### PR TITLE
IPv6 only: Allow IPv4 and IPv6 host-gateway-ip addresses

### DIFF
--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
@@ -354,7 +354,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		return nil, errors.Errorf("network mode %q not supported by buildkit", opt.Options.NetworkMode)
 	}
 
-	extraHosts, err := toBuildkitExtraHosts(opt.Options.ExtraHosts, b.dnsconfig.HostGatewayIP)
+	extraHosts, err := toBuildkitExtraHosts(opt.Options.ExtraHosts, b.dnsconfig.HostGatewayIPs)
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +600,7 @@ func (j *buildJob) SetUpload(ctx context.Context, rc io.ReadCloser) error {
 }
 
 // toBuildkitExtraHosts converts hosts from docker key:value format to buildkit's csv format
-func toBuildkitExtraHosts(inp []string, hostGatewayIP net.IP) (string, error) {
+func toBuildkitExtraHosts(inp []string, hostGatewayIPs []netip.Addr) (string, error) {
 	if len(inp) == 0 {
 		return "", nil
 	}
@@ -611,17 +611,17 @@ func toBuildkitExtraHosts(inp []string, hostGatewayIP net.IP) (string, error) {
 			return "", errors.Errorf("invalid host %s", h)
 		}
 		// If the IP Address is a "host-gateway", replace this value with the
-		// IP address stored in the daemon level HostGatewayIP config variable.
+		// IP address(es) stored in the daemon level HostGatewayIPs config variable.
 		if ip == opts.HostGatewayName {
-			gateway := hostGatewayIP.String()
-			if gateway == "" {
+			if len(hostGatewayIPs) == 0 {
 				return "", fmt.Errorf("unable to derive the IP value for host-gateway")
 			}
-			ip = gateway
-		} else if net.ParseIP(ip) == nil {
-			return "", fmt.Errorf("invalid host %s", h)
+			for _, gip := range hostGatewayIPs {
+				hosts = append(hosts, host+"="+gip.String())
+			}
+		} else {
+			hosts = append(hosts, host+"="+ip)
 		}
-		hosts = append(hosts, host+"="+ip)
 	}
 	return strings.Join(hosts, ","), nil
 }

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -485,6 +485,16 @@ func getLabels(opt Opt, labels map[string]string) map[string]string {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
-	labels[wlabel.HostGatewayIP] = opt.DNSConfig.HostGatewayIP.String()
+	if len(opt.DNSConfig.HostGatewayIPs) > 0 {
+		// TODO(robmry) - buildx has its own version of toBuildkitExtraHosts(), which
+		//   needs to be updated to understand >1 address. For now, take the IPv4 address
+		//   if there is one, else IPv6.
+		for _, gip := range opt.DNSConfig.HostGatewayIPs {
+			labels[wlabel.HostGatewayIP] = gip.String()
+			if gip.Is4() {
+				break
+			}
+		}
+	}
 	return labels
 }

--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -50,7 +50,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IPSliceVar(&conf.DNS, "dns", conf.DNS, "DNS server to use")
 	flags.Var(opts.NewNamedListOptsRef("dns-opts", &conf.DNSOptions, nil), "dns-opt", "DNS options to use")
 	flags.Var(opts.NewListOptsRef(&conf.DNSSearch, opts.ValidateDNSSearch), "dns-search", "DNS search domains to use")
-	flags.IPVar(&conf.HostGatewayIP, "host-gateway-ip", nil, "IP address that the special 'host-gateway' string in --add-host resolves to. Defaults to the IP address of the default bridge")
+	flags.Var(dopts.NewNamedIPListOptsRef("host-gateway-ips", &conf.HostGatewayIPs), "host-gateway-ip", "IP addresses that the special 'host-gateway' string in --add-host resolves to. Defaults to the IP addresses of the default bridge")
 	flags.Var(opts.NewNamedListOptsRef("labels", &conf.Labels, opts.ValidateLabel), "label", "Set key=value labels to the daemon")
 	flags.StringVar(&conf.LogConfig.Type, "log-driver", "json-file", "Default driver for container logs")
 	flags.Var(opts.NewNamedMapOpts("log-opts", conf.LogConfig.Config, nil), "log-opt", "Default log driver options for containers")

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -83,17 +83,19 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 			return nil, err
 		}
 		host, ip, _ := strings.Cut(extraHost, ":")
-		// If the IP Address is a string called "host-gateway", replace this
-		// value with the IP address stored in the daemon level HostGatewayIP
+		// If the IP Address is the literal string "host-gateway", replace this
+		// value with the IP address(es) stored in the daemon level HostGatewayIP
 		// config variable
 		if ip == opts.HostGatewayName {
-			gateway := cfg.HostGatewayIP.String()
-			if gateway == "" {
+			if len(cfg.HostGatewayIPs) == 0 {
 				return nil, fmt.Errorf("unable to derive the IP value for host-gateway")
 			}
-			ip = gateway
+			for _, gip := range cfg.HostGatewayIPs {
+				sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, gip.String()))
+			}
+		} else {
+			sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, ip))
 		}
-		sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, ip))
 	}
 
 	bindings := make(nat.PortMap)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -902,15 +903,18 @@ func configureNetworking(controller *libnetwork.Controller, conf *config.Config)
 
 // setHostGatewayIP sets cfg.HostGatewayIP to the default bridge's IP if it is empty.
 func setHostGatewayIP(controller *libnetwork.Controller, config *config.Config) {
-	if config.HostGatewayIP != nil {
+	if len(config.HostGatewayIPs) > 0 {
 		return
 	}
 	if n, err := controller.NetworkByName(network.NetworkBridge); err == nil {
 		v4Info, v6Info := n.IpamInfo()
 		if len(v4Info) > 0 {
-			config.HostGatewayIP = v4Info[0].Gateway.IP
-		} else if len(v6Info) > 0 {
-			config.HostGatewayIP = v6Info[0].Gateway.IP
+			addr, _ := netip.AddrFromSlice(v4Info[0].Gateway.IP)
+			config.HostGatewayIPs = append(config.HostGatewayIPs, addr)
+		}
+		if len(v6Info) > 0 {
+			addr, _ := netip.AddrFromSlice(v6Info[0].Gateway.IP)
+			config.HostGatewayIPs = append(config.HostGatewayIPs, addr)
 		}
 	}
 }

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -1,0 +1,186 @@
+package network // import "github.com/docker/docker/integration/network"
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/skip"
+)
+
+func TestRunContainerWithBridgeNone(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
+	skip.If(t, testEnv.IsUserNamespace)
+	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "-b", "none")
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+
+	id1 := container.Run(ctx, t, c)
+	defer c.ContainerRemove(ctx, id1, containertypes.RemoveOptions{Force: true})
+
+	result, err := container.Exec(ctx, c, id1, []string{"ip", "l"})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(false, strings.Contains(result.Combined(), "eth0")), "There shouldn't be eth0 in container in default(bridge) mode when bridge network is disabled")
+
+	id2 := container.Run(ctx, t, c, container.WithNetworkMode("bridge"))
+	defer c.ContainerRemove(ctx, id2, containertypes.RemoveOptions{Force: true})
+
+	result, err = container.Exec(ctx, c, id2, []string{"ip", "l"})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(false, strings.Contains(result.Combined(), "eth0")), "There shouldn't be eth0 in container in bridge mode when bridge network is disabled")
+
+	nsCommand := "ls -l /proc/self/ns/net | awk -F '->' '{print $2}'"
+	cmd := exec.Command("sh", "-c", nsCommand)
+	stdout := bytes.NewBuffer(nil)
+	cmd.Stdout = stdout
+	err = cmd.Run()
+	assert.NilError(t, err, "Failed to get current process network namespace: %+v", err)
+
+	id3 := container.Run(ctx, t, c, container.WithNetworkMode("host"))
+	defer c.ContainerRemove(ctx, id3, containertypes.RemoveOptions{Force: true})
+
+	result, err = container.Exec(ctx, c, id3, []string{"sh", "-c", nsCommand})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(stdout.String(), result.Combined()), "The network namespace of container should be the same with host when --net=host and bridge network is disabled")
+}
+
+func TestHostIPv4BridgeLabel(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	d.Start(t)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	ipv4SNATAddr := "172.0.0.172"
+	// Create a bridge network with --opt com.docker.network.host_ipv4=172.0.0.172
+	bridgeName := "hostIPv4Bridge"
+	network.CreateNoError(ctx, t, c, bridgeName,
+		network.WithDriver("bridge"),
+		network.WithOption("com.docker.network.host_ipv4", ipv4SNATAddr),
+		network.WithOption("com.docker.network.bridge.name", bridgeName),
+	)
+	defer network.RemoveNoError(ctx, t, c, bridgeName)
+	out, err := c.NetworkInspect(ctx, bridgeName, networktypes.InspectOptions{Verbose: true})
+	assert.NilError(t, err)
+	assert.Assert(t, len(out.IPAM.Config) > 0)
+	// Make sure the SNAT rule exists
+	testutil.RunCommand(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING", "-s", out.IPAM.Config[0].Subnet, "!", "-o", bridgeName, "-j", "SNAT", "--to-source", ipv4SNATAddr).Assert(t, icmd.Success)
+}
+
+func TestDefaultNetworkOpts(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
+	ctx := testutil.StartSpan(baseContext, t)
+
+	tests := []struct {
+		name       string
+		mtu        int
+		configFrom bool
+		args       []string
+	}{
+		{
+			name: "default value",
+			mtu:  1500,
+			args: []string{},
+		},
+		{
+			name: "cmdline value",
+			mtu:  1234,
+			args: []string{"--default-network-opt", "bridge=com.docker.network.driver.mtu=1234"},
+		},
+		{
+			name:       "config-from value",
+			configFrom: true,
+			mtu:        1233,
+			args:       []string{"--default-network-opt", "bridge=com.docker.network.driver.mtu=1234"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
+			d := daemon.New(t)
+			d.StartWithBusybox(ctx, t, tc.args...)
+			defer d.Stop(t)
+			c := d.NewClientT(t)
+			defer c.Close()
+
+			if tc.configFrom {
+				// Create a new network config
+				network.CreateNoError(ctx, t, c, "from-net", func(create *networktypes.CreateOptions) {
+					create.ConfigOnly = true
+					create.Options = map[string]string{
+						"com.docker.network.driver.mtu": fmt.Sprint(tc.mtu),
+					}
+				})
+				defer c.NetworkRemove(ctx, "from-net")
+			}
+
+			// Create a new network
+			networkName := "testnet"
+			networkId := network.CreateNoError(ctx, t, c, networkName, func(create *networktypes.CreateOptions) {
+				if tc.configFrom {
+					create.ConfigFrom = &networktypes.ConfigReference{
+						Network: "from-net",
+					}
+				}
+			})
+			defer c.NetworkRemove(ctx, networkName)
+
+			// Check the MTU of the bridge itself, before any devices are connected. (The
+			// bridge's MTU will be set to the minimum MTU of anything connected to it, but
+			// it's set explicitly on the bridge anyway - so it doesn't look like the option
+			// was ignored.)
+			cmd := exec.Command("ip", "link", "show", "br-"+networkId[:12])
+			output, err := cmd.CombinedOutput()
+			assert.NilError(t, err)
+			assert.Check(t, is.Contains(string(output), fmt.Sprintf(" mtu %d ", tc.mtu)), "Bridge MTU should have been set to %d", tc.mtu)
+
+			// Start a container to inspect the MTU of its network interface
+			id1 := container.Run(ctx, t, c, container.WithNetworkMode(networkName))
+			defer c.ContainerRemove(ctx, id1, containertypes.RemoveOptions{Force: true})
+
+			result, err := container.Exec(ctx, c, id1, []string{"ip", "l", "show", "eth0"})
+			assert.NilError(t, err)
+			assert.Check(t, is.Contains(result.Combined(), fmt.Sprintf(" mtu %d ", tc.mtu)), "Network MTU should have been set to %d", tc.mtu)
+		})
+	}
+}
+
+func TestForbidDuplicateNetworkNames(t *testing.T) {
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	network.CreateNoError(ctx, t, c, "testnet")
+	defer network.RemoveNoError(ctx, t, c, "testnet")
+
+	_, err := c.NetworkCreate(ctx, "testnet", networktypes.CreateOptions{})
+	assert.Error(t, err, "Error response from daemon: network with name testnet already exists", "2nd NetworkCreate call should have failed")
+}

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -1,69 +1,16 @@
 package network // import "github.com/docker/docker/integration/network"
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os/exec"
-	"strings"
 	"testing"
 
-	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/testutil"
-	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/icmd"
-	"gotest.tools/v3/skip"
 )
-
-func TestRunContainerWithBridgeNone(t *testing.T) {
-	skip.If(t, testEnv.IsRemoteDaemon, "cannot start daemon on remote test run")
-	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
-	skip.If(t, testEnv.IsUserNamespace)
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
-
-	ctx := testutil.StartSpan(baseContext, t)
-
-	d := daemon.New(t)
-	d.StartWithBusybox(ctx, t, "-b", "none")
-	defer d.Stop(t)
-
-	c := d.NewClientT(t)
-
-	id1 := container.Run(ctx, t, c)
-	defer c.ContainerRemove(ctx, id1, containertypes.RemoveOptions{Force: true})
-
-	result, err := container.Exec(ctx, c, id1, []string{"ip", "l"})
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(false, strings.Contains(result.Combined(), "eth0")), "There shouldn't be eth0 in container in default(bridge) mode when bridge network is disabled")
-
-	id2 := container.Run(ctx, t, c, container.WithNetworkMode("bridge"))
-	defer c.ContainerRemove(ctx, id2, containertypes.RemoveOptions{Force: true})
-
-	result, err = container.Exec(ctx, c, id2, []string{"ip", "l"})
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(false, strings.Contains(result.Combined(), "eth0")), "There shouldn't be eth0 in container in bridge mode when bridge network is disabled")
-
-	nsCommand := "ls -l /proc/self/ns/net | awk -F '->' '{print $2}'"
-	cmd := exec.Command("sh", "-c", nsCommand)
-	stdout := bytes.NewBuffer(nil)
-	cmd.Stdout = stdout
-	err = cmd.Run()
-	assert.NilError(t, err, "Failed to get current process network namespace: %+v", err)
-
-	id3 := container.Run(ctx, t, c, container.WithNetworkMode("host"))
-	defer c.ContainerRemove(ctx, id3, containertypes.RemoveOptions{Force: true})
-
-	result, err = container.Exec(ctx, c, id3, []string{"sh", "-c", nsCommand})
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(stdout.String(), result.Combined()), "The network namespace of container should be the same with host when --net=host and bridge network is disabled")
-}
 
 // TestNetworkInvalidJSON tests that POST endpoints that expect a body return
 // the correct error when sending invalid JSON requests.
@@ -155,132 +102,4 @@ func TestNetworkList(t *testing.T) {
 			assert.Assert(t, len(nws) > 0)
 		})
 	}
-}
-
-func TestHostIPv4BridgeLabel(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
-	ctx := testutil.StartSpan(baseContext, t)
-
-	d := daemon.New(t)
-	d.Start(t)
-	defer d.Stop(t)
-	c := d.NewClientT(t)
-	defer c.Close()
-
-	ipv4SNATAddr := "172.0.0.172"
-	// Create a bridge network with --opt com.docker.network.host_ipv4=172.0.0.172
-	bridgeName := "hostIPv4Bridge"
-	network.CreateNoError(ctx, t, c, bridgeName,
-		network.WithDriver("bridge"),
-		network.WithOption("com.docker.network.host_ipv4", ipv4SNATAddr),
-		network.WithOption("com.docker.network.bridge.name", bridgeName),
-	)
-	defer network.RemoveNoError(ctx, t, c, bridgeName)
-	out, err := c.NetworkInspect(ctx, bridgeName, networktypes.InspectOptions{Verbose: true})
-	assert.NilError(t, err)
-	assert.Assert(t, len(out.IPAM.Config) > 0)
-	// Make sure the SNAT rule exists
-	testutil.RunCommand(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING", "-s", out.IPAM.Config[0].Subnet, "!", "-o", bridgeName, "-j", "SNAT", "--to-source", ipv4SNATAddr).Assert(t, icmd.Success)
-}
-
-func TestDefaultNetworkOpts(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, testEnv.IsRemoteDaemon)
-	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
-	ctx := testutil.StartSpan(baseContext, t)
-
-	tests := []struct {
-		name       string
-		mtu        int
-		configFrom bool
-		args       []string
-	}{
-		{
-			name: "default value",
-			mtu:  1500,
-			args: []string{},
-		},
-		{
-			name: "cmdline value",
-			mtu:  1234,
-			args: []string{"--default-network-opt", "bridge=com.docker.network.driver.mtu=1234"},
-		},
-		{
-			name:       "config-from value",
-			configFrom: true,
-			mtu:        1233,
-			args:       []string{"--default-network-opt", "bridge=com.docker.network.driver.mtu=1234"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := testutil.StartSpan(ctx, t)
-			d := daemon.New(t)
-			d.StartWithBusybox(ctx, t, tc.args...)
-			defer d.Stop(t)
-			c := d.NewClientT(t)
-			defer c.Close()
-
-			if tc.configFrom {
-				// Create a new network config
-				network.CreateNoError(ctx, t, c, "from-net", func(create *networktypes.CreateOptions) {
-					create.ConfigOnly = true
-					create.Options = map[string]string{
-						"com.docker.network.driver.mtu": fmt.Sprint(tc.mtu),
-					}
-				})
-				defer c.NetworkRemove(ctx, "from-net")
-			}
-
-			// Create a new network
-			networkName := "testnet"
-			networkId := network.CreateNoError(ctx, t, c, networkName, func(create *networktypes.CreateOptions) {
-				if tc.configFrom {
-					create.ConfigFrom = &networktypes.ConfigReference{
-						Network: "from-net",
-					}
-				}
-			})
-			defer c.NetworkRemove(ctx, networkName)
-
-			// Check the MTU of the bridge itself, before any devices are connected. (The
-			// bridge's MTU will be set to the minimum MTU of anything connected to it, but
-			// it's set explicitly on the bridge anyway - so it doesn't look like the option
-			// was ignored.)
-			cmd := exec.Command("ip", "link", "show", "br-"+networkId[:12])
-			output, err := cmd.CombinedOutput()
-			assert.NilError(t, err)
-			assert.Check(t, is.Contains(string(output), fmt.Sprintf(" mtu %d ", tc.mtu)), "Bridge MTU should have been set to %d", tc.mtu)
-
-			// Start a container to inspect the MTU of its network interface
-			id1 := container.Run(ctx, t, c, container.WithNetworkMode(networkName))
-			defer c.ContainerRemove(ctx, id1, containertypes.RemoveOptions{Force: true})
-
-			result, err := container.Exec(ctx, c, id1, []string{"ip", "l", "show", "eth0"})
-			assert.NilError(t, err)
-			assert.Check(t, is.Contains(result.Combined(), fmt.Sprintf(" mtu %d ", tc.mtu)), "Network MTU should have been set to %d", tc.mtu)
-		})
-	}
-}
-
-func TestForbidDuplicateNetworkNames(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-
-	ctx := testutil.StartSpan(baseContext, t)
-
-	d := daemon.New(t)
-	d.StartWithBusybox(ctx, t)
-	defer d.Stop(t)
-
-	c := d.NewClientT(t)
-	defer c.Close()
-
-	network.CreateNoError(ctx, t, c, "testnet")
-	defer network.RemoveNoError(ctx, t, c, "testnet")
-
-	_, err := c.NetworkCreate(ctx, "testnet", networktypes.CreateOptions{})
-	assert.Error(t, err, "Error response from daemon: network with name testnet already exists", "2nd NetworkCreate call should have failed")
 }

--- a/internal/opts/host_gateway_opts.go
+++ b/internal/opts/host_gateway_opts.go
@@ -1,0 +1,25 @@
+package opts
+
+import (
+	"errors"
+	"net/netip"
+)
+
+// ValidateHostGatewayIPs makes sure the addresses are valid, and there's at-most one IPv4 and one IPv6 address.
+func ValidateHostGatewayIPs(hostGatewayIPs []netip.Addr) error {
+	var have4, have6 bool
+	for _, ip := range hostGatewayIPs {
+		if ip.Is4() {
+			if have4 {
+				return errors.New("only one IPv4 host gateway IP address can be specified")
+			}
+			have4 = true
+		} else {
+			if have6 {
+				return errors.New("only one IPv6 host gateway IP address can be specified")
+			}
+			have6 = true
+		}
+	}
+	return nil
+}

--- a/internal/opts/named_iplist_opts.go
+++ b/internal/opts/named_iplist_opts.go
@@ -1,0 +1,48 @@
+package opts
+
+import (
+	"fmt"
+	"net/netip"
+)
+
+// NamedIPListOpts appends to an underlying []netip.Addr.
+type NamedIPListOpts struct {
+	name string
+	ips  *[]netip.Addr
+}
+
+// NewNamedIPListOptsRef constructs a NamedIPListOpts and returns its address.
+func NewNamedIPListOptsRef(name string, values *[]netip.Addr) *NamedIPListOpts {
+	return &NamedIPListOpts{
+		name: name,
+		ips:  values,
+	}
+}
+
+// String returns a string representation of the addresses in the underlying []netip.Addr.
+func (o *NamedIPListOpts) String() string {
+	if len(*o.ips) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%v", *o.ips)
+}
+
+// Set converts value to a netip.Addr and appends it to the underlying []netip.Addr.
+func (o *NamedIPListOpts) Set(value string) error {
+	ip, err := netip.ParseAddr(value)
+	if err != nil {
+		return err
+	}
+	*o.ips = append(*o.ips, ip)
+	return nil
+}
+
+// Type returns a string name for this Option type
+func (o *NamedIPListOpts) Type() string {
+	return "list"
+}
+
+// Name returns the name of the NamedIPListOpts in the configuration.
+func (o *NamedIPListOpts) Name() string {
+	return o.name
+}


### PR DESCRIPTION
**- What I did**

Running a container with `--add-host blah:host-gateway` adds an `/etc/hosts` entry for host `blah` and an address on the docker host - to give the container a convenient way of reaching the host.

If no `--host-gateway-ip` option is supplied, the IPv4 address of the default bridge is used - and that's been fine until now, it's a host address we know will exist. But, in a container that's only connected to IPv6-only networks, that doesn't work.

So:
- if the default bridge has an IPv6 address, create an additional `/etc/hosts` entry with that address
- allow two `--host-gateway-ip` options
  - at most one IPv4 and one IPv6 address
- in daemon.json, allow a JSON array value `--host-gateway-ips` (plural).
  - for a single address, a JSON string is also allowed

For example:
  `--host-gateway-ip 192.0.2.1 --host-gateway-ip 2001:db8::1111`
And the daemon.json version would be:
  `"host-gateway-ips": ["192.0.2.1", "2001:db8::1111"]`
But, this is also still valid:
  `"host-gateway-ip": "192.0.2.1"`

**- How I did it**

Notes:
- The `/etc/hosts` entries follow the usual rules...
  - If IPv6 is disabled in a container (by sysctl, or lack of kernel support), IPv6 addresses are not included in the file.
  - In other cases, IPv4 and IPv6 addresses will both be included, whether or not the container currently has network endpoints that support IPv4 or IPv6.
- buildx has its own code to interpret the host-gateway-ip option.
  - When it's updated to understand two addresses, moby will need to pass it both. For now, it passes an IPv4 address if there is one, else IPv6.

**- How to verify it**

**- Description for the changelog**
```markdown changelog
- Modifications to `host-gateway`, for compatibility with IPv6-only networks.
  - When special value `host-gateway` is used in an `--add-host` option in place of an address, it's
    replaced by an address on the docker host to make it possible to refer to the host by name.
    The address used belongs to the default bridge (normally `docker0`). Until now it's always been
    an IPv4 address, because all containers on bridge networks had IPv4 addresses.
  - Now, if IPv6 is enabled on the default bridge network, `/etc/hosts` entries will be created for
    IPv4 and IPv6 addresses. So, it's possible for a container that's only connected to IPv6-only
    networks to access the host by name.
  - The `--host-gateway-ip` option overrides the address used to replace `host-gateway`. Two of
    these options are now allowed on the command line, for one IPv4 gateway and one IPv6.
    - In the `daemon.json` file, to provide two addresses, use a JSON array in the `"host-gateway-ips"`
      field. For example, `"host-gateway-ips": ["192.0.2.1", "2001:db8::1111"]`.
```
