### PR TITLE
IPv6 only: use random MAC addresses

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -309,25 +309,6 @@ func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDR(c *testing.T) {
 	assert.Equal(c, strings.Trim(out, " \r\n'"), "2001:db8:2::100", "Container should have a global IPv6 gateway")
 }
 
-// TestDaemonIPv6FixedCIDRAndMac checks that when the daemon is started with ipv6 fixed CIDR
-// the running containers are given an IPv6 address derived from the MAC address and the ipv6 fixed CIDR
-func (s *DockerDaemonSuite) TestDaemonIPv6FixedCIDRAndMac(c *testing.T) {
-	// IPv6 setup is messing with local bridge address.
-	testRequires(c, testEnv.IsLocalDaemon)
-	// Delete the docker0 bridge if its left around from previous daemon. It has to be recreated with
-	// ipv6 enabled
-	deleteInterface(c, "docker0")
-
-	s.d.StartWithBusybox(testutil.GetContext(c), c, "--ipv6", "--fixed-cidr-v6=2001:db8:1::/64")
-
-	out, err := s.d.Cmd("run", "-d", "--name=ipv6test", "--mac-address", "AA:BB:CC:DD:EE:FF", "busybox", "top")
-	assert.NilError(c, err, out)
-
-	out, err = s.d.Cmd("inspect", "--format", "{{.NetworkSettings.Networks.bridge.GlobalIPv6Address}}", "ipv6test")
-	assert.NilError(c, err, out)
-	assert.Equal(c, strings.Trim(out, " \r\n'"), "2001:db8:1::aabb:ccdd:eeff")
-}
-
 // TestDaemonIPv6HostMode checks that when the running a container with
 // network=host the host ipv6 addresses are not removed
 func (s *DockerDaemonSuite) TestDaemonIPv6HostMode(c *testing.T) {

--- a/integration/internal/network/l2disco_linux.go
+++ b/integration/internal/network/l2disco_linux.go
@@ -1,0 +1,217 @@
+package network
+
+// Collect and decode broadcast ARP and unsolicited ICMP6 Neighbour Advertisement messages...
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/internal/nlwrap"
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+)
+
+// TimestampedPkt has a Data slice representing a packet, ReceivedAt is a timestamp
+// set after the packet was received in user-space.
+type TimestampedPkt struct {
+	ReceivedAt time.Time
+	Data       []byte
+}
+
+// CollectBcastARPs collects broadcast ARPs from interface ifname.
+// It returns a stop function, to stop collection and return a slice of collected packets (with
+// timestamps added when they were received in userspace).
+func CollectBcastARPs(t *testing.T, ifname string) (stop func() []TimestampedPkt) {
+	sd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, int(htons(unix.ETH_P_ARP)))
+	assert.NilError(t, err)
+	assert.Assert(t, sd >= 0)
+
+	link, err := nlwrap.LinkByName(ifname)
+	assert.NilError(t, err)
+
+	err = unix.Bind(sd, &unix.SockaddrLinklayer{
+		Protocol: htons(unix.ETH_P_ARP),
+		Pkttype:  unix.PACKET_BROADCAST,
+		Ifindex:  link.Attrs().Index,
+	})
+	assert.NilError(t, err)
+
+	return collectPackets(t, sd, "ARP")
+}
+
+// From https://github.com/mdlayher/packet/blob/f9999b41d9cfb0586e75467db1c81cfde4f965ba/packet_linux.go#L238-L248
+func htons(i uint16) uint16 {
+	var bigEndian [2]byte
+	binary.BigEndian.PutUint16(bigEndian[:], i)
+	return binary.NativeEndian.Uint16(bigEndian[:])
+}
+
+// CollectICMP6 collects ICMP6 packets sent to the all nodes address.
+// It returns a stop function, to stop collection and return a slice of collected packets (with
+// timestamps added when they were received in userspace).
+func CollectICMP6(t *testing.T, ifname string) (stop func() []TimestampedPkt) {
+	sd, err := unix.Socket(unix.AF_INET6, unix.SOCK_RAW|unix.SOCK_CLOEXEC, unix.IPPROTO_ICMPV6)
+	assert.NilError(t, err)
+	assert.Assert(t, sd >= 0)
+
+	link, err := nlwrap.LinkByName(ifname)
+	assert.NilError(t, err)
+
+	mreq := &unix.IPv6Mreq{
+		Interface: uint32(link.Attrs().Index),
+	}
+	copy(mreq.Multiaddr[:], net.IPv6linklocalallnodes)
+	err = unix.SetsockoptIPv6Mreq(sd, unix.IPPROTO_IPV6, unix.IPV6_JOIN_GROUP, mreq)
+	assert.NilError(t, err)
+
+	return collectPackets(t, sd, "ICMP6")
+}
+
+func collectPackets(t *testing.T, sd int, what string) (stop func() []TimestampedPkt) {
+	err := unix.SetsockoptTimeval(sd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 1})
+	assert.NilError(t, err)
+
+	stopC := make(chan struct{})
+	stoppedC := make(chan struct{})
+	var pkts []TimestampedPkt
+	go func() {
+		defer close(stoppedC)
+		defer unix.Close(sd)
+		for {
+			buf := make([]byte, 50)
+			// Blocking read, if no packet is received it'll return an EWOULDBLOCK after a timeout.
+			n, err := unix.Read(sd, buf)
+			// If the stop function has been called, return. That closes stoppedC to confirm that
+			// nothing else will be added to pkts. (Read() probably hit its timeout but, even
+			// if it read a packet, it was racing the stop and the packet can just be dropped.)
+			select {
+			case <-stopC:
+				return
+			default:
+			}
+			if err != nil {
+				if errors.Is(err, unix.EINTR) || errors.Is(err, unix.EWOULDBLOCK) {
+					continue
+				}
+				t.Log(what, "read error:", err, "sd", sd)
+				return
+			}
+			pkts = append(pkts, TimestampedPkt{
+				ReceivedAt: time.Now(),
+				Data:       buf[:n],
+			})
+		}
+	}()
+
+	// Return a stop function - packet collection will continue until this is called.
+	return func() []TimestampedPkt {
+		select {
+		case <-stopC:
+		default:
+			close(stopC)
+		}
+		// Wait for confirmation that packet collection has stopped, to be sure the
+		// pkts slice won't change after the return.
+		<-stoppedC
+		return pkts
+	}
+}
+
+// UnpackUnsolARP checks the packet is a valid Ethernet unsolicited/broadcast ARP
+// request packet. It returns sender hardware and protocol addresses,
+// and true if it is - else, an error.
+func UnpackUnsolARP(pkt TimestampedPkt) (sh net.HardwareAddr, sp netip.Addr, err error) {
+	if len(pkt.Data) != 28 {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("packet size %d", len(pkt.Data))
+	}
+	// Hardware type (1)
+	if pkt.Data[0] != 0 || pkt.Data[1] != 1 {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("hardware type %v", pkt.Data[0:2])
+	}
+	// Protocol type (0x800).
+	if pkt.Data[2] != 8 || pkt.Data[3] != 0 {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("protocol type %v", pkt.Data[2:4])
+	}
+	// Hardware length (6)
+	if pkt.Data[4] != 6 {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("hardware length %v", pkt.Data[4])
+	}
+	// Protocol length (4)
+	if pkt.Data[5] != 4 {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("protocol length %v", pkt.Data[5])
+	}
+	// Operation (1=request, 2=reply)
+	if pkt.Data[6] != 0 || pkt.Data[7] != 1 {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("operation %v", pkt.Data[6:8])
+	}
+
+	// Sender hardware address
+	sh = make(net.HardwareAddr, 6)
+	copy(sh, pkt.Data[8:14])
+	// Sender protocol address
+	sp, _ = netip.AddrFromSlice(pkt.Data[14:18])
+
+	// Target hardware address
+	if slices.Compare(pkt.Data[18:24], net.HardwareAddr{0, 0, 0, 0, 0, 0}) != 0 {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("nonzero target mac address %s", hex.EncodeToString(pkt.Data[18:24]))
+	}
+
+	// Target protocol address
+	if tp, _ := netip.AddrFromSlice(pkt.Data[24:28]); tp != sp {
+		return net.HardwareAddr{}, netip.Addr{}, fmt.Errorf("sender and target IP addresses differ, %s/%s", sp, tp)
+	}
+
+	return sh, sp, nil
+}
+
+// UnpackUnsolNA returns the hardware (MAC) and protocol (IP) addresses from the
+// packet, if it is an unsolicited Neighbour Advertisement message with a
+// link address option. Otherwise, it returns an error.
+func UnpackUnsolNA(pkt TimestampedPkt) (th net.HardwareAddr, tp netip.Addr, err error) {
+	// Treat the packet as invalid unless it's sized for a NA message
+	// with a link address option.
+	if len(pkt.Data) != 32 {
+		return th, tp, fmt.Errorf("packet size %d", len(pkt.Data))
+	}
+	// Type (136=NA)
+	if pkt.Data[0] != 136 {
+		return th, tp, fmt.Errorf("type %d", pkt.Data[0])
+	}
+	// Code
+	if pkt.Data[1] != 0 {
+		return th, tp, fmt.Errorf("code %d", pkt.Data[1])
+	}
+	// Checksum pkt.Data[2:4].
+	// - calculated by the kernel on packets sent by dockerd, not checking that calc here.
+	// Router flag (not sent by a router)
+	if pkt.Data[4]&0x80 != 0 {
+		return th, tp, errors.New("flag Router is set")
+	}
+	// Solicited flag (unsolicited)
+	if pkt.Data[4]&0x40 != 0 {
+		return th, tp, errors.New("flag Solicited is set")
+	}
+	// Override flag (SHOULD be set in an unsolicited advertisement)
+	if pkt.Data[4]&0x20 == 0 {
+		return th, tp, errors.New("flag Override is not set")
+	}
+	// Reserved pkt.Data[4:8]
+	// Target address
+	tp, _ = netip.AddrFromSlice(pkt.Data[8:24])
+	// Options (02=link address, 01=length 8)
+	if pkt.Data[24] != 2 || pkt.Data[25] != 1 {
+		return th, tp, fmt.Errorf("option %d length %d", pkt.Data[24], pkt.Data[25])
+	}
+	// Link address
+	th = make(net.HardwareAddr, 6)
+	copy(th, pkt.Data[26:32])
+
+	return th, tp, nil
+}

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -2,11 +2,15 @@ package networking
 
 import (
 	"context"
+	"encoding/hex"
 	"flag"
 	"fmt"
+	"math"
 	"net"
+	"net/netip"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -1251,4 +1255,287 @@ func checkProxies(ctx context.Context, t *testing.T, c *client.Client, daemonPid
 	}
 
 	assert.DeepEqual(t, gotProxies, wantProxies)
+}
+
+// Check that a gratuitous ARP / neighbour advertisement is sent for a new
+// container's addresses.
+// - start ctr1, ctr2
+// - ping ctr2 from ctr1, ctr1's arp/neighbour caches learns ctr2's addresses.
+// - restart ctr2 with the same IP addresses, it should get new random MAC addresses.
+// - check that ctr1's arp/neighbour caches are updated.
+func TestAdvertiseAddresses(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "can't listen for ARP/NA messages in rootlesskit's namespace")
+
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	testcases := []struct {
+		name            string
+		netOpts         []func(*networktypes.CreateOptions)
+		ipv6LinkLocal   bool
+		stopCtr2After   time.Duration
+		expNetCreateErr string
+		expNoMACUpdate  bool
+		expNMsgs        int
+		expInterval     time.Duration
+	}{
+		{
+			name:        "defaults",
+			expNMsgs:    3,
+			expInterval: time.Second,
+		},
+		{
+			name: "disable advertise addrs",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrNMsgs, "0"),
+			},
+			expNoMACUpdate: true,
+		},
+		{
+			name: "single message",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrNMsgs, "1"),
+			},
+			expNMsgs: 1,
+		},
+		{
+			name: "min interval",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "100"),
+			},
+			expNMsgs:    3,
+			expInterval: 100 * time.Millisecond,
+		},
+		{
+			name: "cancel",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "2000"),
+			},
+			stopCtr2After: 200 * time.Millisecond,
+			expNMsgs:      1,
+		},
+		{
+			name:          "ipv6 link local subnet",
+			ipv6LinkLocal: true,
+			expNMsgs:      3,
+			expInterval:   time.Second,
+		},
+		{
+			name: "interval too short",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "99"),
+			},
+			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_ms must be in the range 100 to 2000",
+		},
+		{
+			name: "interval too long",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "2001"),
+			},
+			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_ms must be in the range 100 to 2000",
+		},
+		{
+			name: "nonsense interval",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "nonsense"),
+			},
+			expNetCreateErr: `Error response from daemon: value for option com.docker.network.advertise_addr_ms "nonsense" must be integer milliseconds`,
+		},
+		{
+			name: "negative msg count",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrNMsgs, "-1"),
+			},
+			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_nmsgs must be in the range 0 to 3",
+		},
+		{
+			name: "too many msgs",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrNMsgs, "4"),
+			},
+			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_nmsgs must be in the range 0 to 3",
+		},
+		{
+			name: "nonsense msg count",
+			netOpts: []func(*networktypes.CreateOptions){
+				network.WithOption(netlabel.AdvertiseAddrNMsgs, "nonsense"),
+			},
+			expNetCreateErr: `Error response from daemon: value for option com.docker.network.advertise_addr_nmsgs "nonsense" must be an integer`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
+
+			const netName = "dsnet"
+			const brName = "br-advaddr"
+			netOpts := append([]func(*networktypes.CreateOptions){
+				network.WithOption(bridge.BridgeName, brName),
+				network.WithIPv6(),
+				network.WithIPAM("172.22.22.0/24", "172.22.22.1"),
+			}, tc.netOpts...)
+			if tc.ipv6LinkLocal {
+				netOpts = append(netOpts, network.WithIPAM("fe80:1234::/64", "fe80:1234::1"))
+			} else {
+				netOpts = append(netOpts, network.WithIPAM("fd3c:e70a:962c::/64", "fd3c:e70a:962c::1"))
+			}
+			_, err := network.Create(ctx, c, netName, netOpts...)
+			if tc.expNetCreateErr != "" {
+				assert.ErrorContains(t, err, tc.expNetCreateErr)
+				return
+			}
+			defer network.RemoveNoError(ctx, t, c, netName)
+
+			stopARPListen := network.CollectBcastARPs(t, brName)
+			defer stopARPListen()
+			stopICMP6Listen := network.CollectICMP6(t, brName)
+			defer stopICMP6Listen()
+
+			ctr1Id := container.Run(ctx, t, c, container.WithName("ctr1"), container.WithNetworkMode(netName))
+			defer c.ContainerRemove(ctx, ctr1Id, containertypes.RemoveOptions{Force: true})
+
+			const ctr2Name = "ctr2"
+			const ctr2Addr4 = "172.22.22.22"
+			ctr2Addr6 := "fd3c:e70a:962c::2222"
+			if tc.ipv6LinkLocal {
+				ctr2Addr6 = "fe80:1234::2222"
+			}
+			ctr2Id := container.Run(ctx, t, c,
+				container.WithName(ctr2Name),
+				container.WithNetworkMode(netName),
+				container.WithIPv4(netName, ctr2Addr4),
+				container.WithIPv6(netName, ctr2Addr6),
+			)
+			// Defer a closure so the updated ctr2Id is used after the container's restarted.
+			defer func() {
+				if ctr2Id != "" {
+					c.ContainerRemove(ctx, ctr2Id, containertypes.RemoveOptions{Force: true})
+				}
+			}()
+
+			ctr2OrigMAC := container.Inspect(ctx, t, c, ctr2Id).NetworkSettings.Networks[netName].MacAddress
+
+			// Ping from ctr1 to ctr2 using both IPv4 and IPv6, to populate ctr1's arp/neighbour caches.
+			pingRes := container.ExecT(ctx, t, c, ctr1Id, []string{"ping", "-4", "-c1", ctr2Name})
+			assert.Assert(t, is.Equal(pingRes.ExitCode, 0))
+			pingRes = container.ExecT(ctx, t, c, ctr1Id, []string{"ping", "-6", "-c1", ctr2Name})
+			assert.Assert(t, is.Equal(pingRes.ExitCode, 0))
+
+			// Search the output from "ip neigh show" for entries for ip, return
+			// the associated MAC address.
+			findNeighMAC := func(neighOut, ip string) string {
+				t.Helper()
+				for _, line := range strings.Split(neighOut, "\n") {
+					// Lines look like ...
+					// 172.22.22.22 dev eth0 lladdr 36:bc:ce:67:f3:e4 ref 1 used 0/7/0 probes 1 DELAY
+					fields := strings.Fields(line)
+					if len(fields) >= 5 && fields[0] == ip {
+						return fields[4]
+					}
+				}
+				t.Fatalf("No entry for %s in '%s'", ip, neighOut)
+				return ""
+			}
+
+			// ctr1 should now have arp/neighbour entries for ctr2
+			ctr1Neighs := container.ExecT(ctx, t, c, ctr1Id, []string{"ip", "neigh", "show"})
+			assert.Assert(t, is.Equal(ctr1Neighs.ExitCode, 0))
+			t.Logf("ctr1 initial neighbours:\n%s", ctr1Neighs.Combined())
+			macBefore := findNeighMAC(ctr1Neighs.Stdout(), ctr2Addr4)
+			assert.Equal(t, macBefore, findNeighMAC(ctr1Neighs.Stdout(), ctr2Addr6))
+
+			// Stop ctr2, start a new container with the same addresses.
+			c.ContainerRemove(ctx, ctr2Id, containertypes.RemoveOptions{Force: true})
+			ctr1Neighs = container.ExecT(ctx, t, c, ctr1Id, []string{"ip", "neigh", "show"})
+			assert.Assert(t, is.Equal(ctr1Neighs.ExitCode, 0))
+			t.Logf("ctr1 neighbours after ctr2 stop:\n%s", ctr1Neighs.Combined())
+			ctr2Id = container.Run(ctx, t, c,
+				container.WithName(ctr2Name),
+				container.WithNetworkMode(netName),
+				container.WithIPv4(netName, ctr2Addr4),
+				container.WithIPv6(netName, ctr2Addr6),
+			)
+			// The original defer will stop ctr2Id.
+
+			ctr2NewMAC := container.Inspect(ctx, t, c, ctr2Id).NetworkSettings.Networks[netName].MacAddress
+			assert.Check(t, ctr2OrigMAC != ctr2NewMAC, "expected restarted ctr2 to have a different MAC address")
+
+			ctr1Neighs = container.ExecT(ctx, t, c, ctr1Id, []string{"ip", "neigh", "show"})
+			assert.Assert(t, is.Equal(ctr1Neighs.ExitCode, 0))
+			t.Logf("ctr1 neighbours after ctr2 restart:\n%s", ctr1Neighs.Combined())
+			macAfter := findNeighMAC(ctr1Neighs.Stdout(), ctr2Addr4)
+			assert.Check(t, is.Equal(macAfter, findNeighMAC(ctr1Neighs.Stdout(), ctr2Addr6)))
+			if tc.expNoMACUpdate {
+				// The neighbour table shouldn't have changed.
+				assert.Check(t, macBefore == macAfter, "Expected ctr1's ARP/ND cache not to have updated")
+			} else {
+				// The new ctr2's interface should have a new random MAC address, and ctr1's
+				// arp/neigh caches should have been updated by ctr2's gratuitous ARP/NA.
+				assert.Check(t, macBefore != macAfter, "Expected ctr1's ARP/ND cache to have updated")
+			}
+
+			if tc.stopCtr2After > 0 {
+				time.Sleep(tc.stopCtr2After)
+				c.ContainerRemove(ctx, ctr2Id, containertypes.RemoveOptions{Force: true})
+				ctr2Id = ""
+			}
+
+			t.Log("Sleeping for 5s to collect ARP/NA messages...")
+			time.Sleep(5 * time.Second)
+
+			// Check ARP/NA messages received for ctr2's new address (all unsolicited).
+
+			ctr2NewHwAddr, err := net.ParseMAC(ctr2NewMAC)
+			assert.NilError(t, err)
+
+			checkPkts := func(pktDesc string, pkts []network.TimestampedPkt, matchIP netip.Addr, unpack func(pkt network.TimestampedPkt) (sh net.HardwareAddr, sp netip.Addr, err error)) {
+				t.Helper()
+				var count int
+				var lastTimestamp time.Time
+
+				// Find the packets of-interest, and check the intervals between them.
+				for i, p := range pkts {
+					ha, pa, err := unpack(p)
+					if err != nil {
+						t.Logf("%s %d: %s: %s: %s",
+							pktDesc, i+1, p.ReceivedAt.Format("15:04:05.000"), hex.EncodeToString(p.Data), err)
+						continue
+					}
+					t.Logf("%s %d: %s '%s' is at '%s'", pktDesc, i+1, p.ReceivedAt.Format("15:04:05.000"), pa, ha)
+					if pa != matchIP || slices.Compare(ha, ctr2NewHwAddr) != 0 {
+						continue
+					}
+					count += 1
+					var interval time.Duration
+					if !lastTimestamp.IsZero() {
+						interval = p.ReceivedAt.Sub(lastTimestamp)
+						// For test pass/fail, arbitrary limit on how early or late ARP/NA messages can be.
+						// They should never be sent early, but if there's a delay in receiving one packet
+						// the interval to the next may be shorted than the configured interval.
+						// Send variance should be a lot less than this but, this is enough to check that
+						// the interval is configurable, while (hopefully) avoiding flakiness on a busy host ...
+						const okIntervalDelta = 100 * time.Millisecond
+						assert.Check(t, time.Duration(math.Abs(float64(interval-tc.expInterval))) < okIntervalDelta,
+							"interval %s is expected to be within %s of configured interval %s",
+							interval, okIntervalDelta, tc.expInterval)
+					}
+					t.Logf("---> found %s %d, interval:%s", pktDesc, count, interval)
+					lastTimestamp = p.ReceivedAt
+				}
+
+				assert.Check(t, is.Equal(count, tc.expNMsgs), pktDesc+" message count")
+			}
+
+			arps := stopARPListen()
+			checkPkts("ARP", arps, netip.MustParseAddr(ctr2Addr4), network.UnpackUnsolARP)
+
+			icmps := stopICMP6Listen()
+			checkPkts("ICMP6", icmps, netip.MustParseAddr(ctr2Addr6), network.UnpackUnsolNA)
+		})
+	}
 }

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"net"
-	"net/netip"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -540,17 +539,6 @@ func TestDefaultBridgeIPv6(t *testing.T) {
 			const networkName = "bridge"
 			inspect := container.Inspect(ctx, t, c, cID)
 			gIPv6 := inspect.NetworkSettings.Networks[networkName].GlobalIPv6Address
-
-			// The container's MAC and IPv6 addresses should be derived from the
-			// IPAM-allocated IPv4 address.
-			addr4, err := netip.ParseAddr(inspect.NetworkSettings.Networks[networkName].IPAddress)
-			assert.NilError(t, err)
-			mac, err := net.ParseMAC(inspect.NetworkSettings.Networks[networkName].MacAddress)
-			assert.NilError(t, err)
-			assert.Check(t, is.DeepEqual(addr4.AsSlice(), []byte(mac)[2:]))
-			addr6, err := netip.ParseAddr(gIPv6)
-			assert.NilError(t, err)
-			assert.Check(t, is.DeepEqual(addr4.AsSlice(), addr6.AsSlice()[12:]))
 
 			attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()

--- a/internal/nlwrap/nlwrap_linux.go
+++ b/internal/nlwrap/nlwrap_linux.go
@@ -160,6 +160,17 @@ func LinkList() (links []netlink.Link, err error) {
 	return links, discardErrDumpInterrupted(err)
 }
 
+// LinkSubscribeWithOptions calls netlink.LinkSubscribeWithOptions, retrying if necessary.
+// Close the done channel when done (rather than just sending on it), so that goroutines
+// started by the netlink package are all stopped.
+func LinkSubscribeWithOptions(ch chan<- netlink.LinkUpdate, done <-chan struct{}, options netlink.LinkSubscribeOptions) (err error) {
+	retryOnIntr(func() error {
+		err = netlink.LinkSubscribeWithOptions(ch, done, options) //nolint:forbidigo
+		return err
+	})
+	return err
+}
+
 // RouteList calls nlh.Handle.RouteList, retrying if necessary.
 func (nlh Handle) RouteList(link netlink.Link, family int) (routes []netlink.Route, err error) {
 	retryOnIntr(func() error {

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1250,6 +1250,10 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	if err = d.linkUp(ctx, host); err != nil {
 		return fmt.Errorf("could not set link up for host interface %s: %v", hostIfName, err)
 	}
+	log.G(ctx).WithFields(log.Fields{
+		"hostifname": host.Attrs().Name,
+		"ifi":        host.Attrs().Index,
+	}).Debug("bridge endpoint host link is up")
 
 	// Generate a MAC-address-based IPv6 address, which may be used by the default
 	// bridge network instead of an IPAM allocated address.

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -30,12 +30,12 @@ func TestLinkCreate(t *testing.T) {
 	}
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
+	ipd6List := getIPv6Data(t)
+	err := d.CreateNetwork("dummy", option, nil, ipdList, ipd6List)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
-
-	te := newTestEndpoint(ipdList[0].Pool, 10)
+	te := newTestEndpoint46(ipdList[0].Pool, ipd6List[0].Pool, 10)
 	err = d.CreateEndpoint(context.Background(), "dummy", "", te.Interface(), nil)
 	if err != nil {
 		if _, ok := err.(InvalidEndpointIDError); !ok {

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -141,12 +141,13 @@ func TestPortMappingV6Config(t *testing.T) {
 	netOptions[netlabel.GenericData] = netConfig
 
 	ipdList4 := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", netOptions, nil, ipdList4, getIPv6Data(t))
+	ipdList6 := getIPv6Data(t)
+	err := d.CreateNetwork("dummy", netOptions, nil, ipdList4, ipdList6)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	te := newTestEndpoint(ipdList4[0].Pool, 11)
+	te := newTestEndpoint46(ipdList4[0].Pool, ipdList6[0].Pool, 11)
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep1", te.Interface(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create the endpoint: %s", err.Error())

--- a/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -32,13 +32,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		mac:    ifInfo.MacAddress(),
 	}
 	if ep.mac == nil {
-		if ep.addr != nil {
-			ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)
-		} else {
-			// TODO(robmry) - generate an unsolicited Neighbor Advertisement to
-			//  associate this MAC address with the IP.
-			ep.mac = netutils.GenerateRandomMAC()
-		}
+		ep.mac = netutils.GenerateRandomMAC()
 		if err := ifInfo.SetMacAddress(ep.mac); err != nil {
 			return err
 		}

--- a/libnetwork/internal/l2disco/unsol_arp_linux.go
+++ b/libnetwork/internal/l2disco/unsol_arp_linux.go
@@ -1,0 +1,82 @@
+package l2disco
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"slices"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	arpTemplate = []byte{
+		0x00, 0x01, // Hardware type
+		0x08, 0x00, // Protocol
+		0x06,       // Hardware address length
+		0x04,       // IPv4 address length
+		0x00, 0x01, // ARP request
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Sender MAC
+		0x00, 0x00, 0x00, 0x00, // Sender IP
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Target MAC (always zeros)
+		0x00, 0x00, 0x00, 0x00, // Target IP
+	}
+	bcastMAC = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+)
+
+type UnsolARP struct {
+	pkt []byte
+	sd  int
+	sa  *unix.SockaddrLinklayer
+}
+
+// NewUnsolARP returns a pointer to an object that can send unsolicited ARPs on
+// the interface with ifIndex, for ip and mac.
+func NewUnsolARP(_ context.Context, ip net.IP, mac net.HardwareAddr, ifIndex int) (*UnsolARP, error) {
+	sd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("create socket: %w", err)
+	}
+
+	pkt := slices.Clone(arpTemplate)
+	copy(pkt[8:14], mac)
+	copy(pkt[14:18], ip)
+	copy(pkt[24:28], ip)
+
+	sa := &unix.SockaddrLinklayer{
+		Protocol: htons(unix.ETH_P_ARP),
+		Ifindex:  ifIndex,
+		Hatype:   unix.ARPHRD_ETHER,
+		Halen:    uint8(len(bcastMAC)),
+	}
+	copy(sa.Addr[:], bcastMAC)
+
+	return &UnsolARP{
+		pkt: pkt,
+		sd:  sd,
+		sa:  sa,
+	}, nil
+}
+
+// Send sends an unsolicited ARP message.
+func (ua *UnsolARP) Send() error {
+	return unix.Sendto(ua.sd, ua.pkt, 0, ua.sa)
+}
+
+// Close releases resources.
+func (ua *UnsolARP) Close() error {
+	if ua.sd >= 0 {
+		err := unix.Close(ua.sd)
+		ua.sd = -1
+		return err
+	}
+	return nil
+}
+
+// From https://github.com/mdlayher/packet/blob/f9999b41d9cfb0586e75467db1c81cfde4f965ba/packet_linux.go#L238-L248
+func htons(i uint16) uint16 {
+	var bigEndian [2]byte
+	binary.BigEndian.PutUint16(bigEndian[:], i)
+	return binary.NativeEndian.Uint16(bigEndian[:])
+}

--- a/libnetwork/internal/l2disco/unsol_na_linux.go
+++ b/libnetwork/internal/l2disco/unsol_na_linux.go
@@ -1,0 +1,91 @@
+package l2disco
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+
+	"github.com/containerd/log"
+	"golang.org/x/net/ipv6"
+)
+
+var naTemplate = []byte{
+	0x88,       // Type (136=NA)
+	0x00,       // Code (always 0)
+	0x00, 0x00, // Checksum (filled in by the kernel)
+	0x20,             // Flags, Router=0, Solicited=0, Override=1
+	0x00, 0x00, 0x00, // Reserved
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Target IP
+	0x02,                               // Option - target link layer address
+	0x01,                               // Option length (32)
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Target MAC
+}
+
+type UnsolNA struct {
+	pkt []byte
+	pc  *ipv6.PacketConn
+	cm  *ipv6.ControlMessage
+}
+
+// NewUnsolNA returns a pointer to an object that can send unsolicited Neighbour
+// Advertisements for ip and mac.
+// https://datatracker.ietf.org/doc/html/rfc4861#section-4.4
+func NewUnsolNA(ctx context.Context, ip net.IP, mac net.HardwareAddr, ifIndex int) (*UnsolNA, error) {
+	// Open a socket ... it'll be bound to an address but the address doesn't matter,
+	// no packets are to be received, and a source address is supplied when sending.
+	netPC, err := net.ListenPacket("ip6:ipv6-icmp", "::1")
+	if err != nil {
+		return nil, err
+	}
+	pc := ipv6.NewPacketConn(netPC)
+
+	// Block incoming packets.
+	f := ipv6.ICMPFilter{}
+	f.SetAll(true)
+	if err := pc.SetICMPFilter(&f); err != nil {
+		log.G(ctx).WithError(err).Errorf("failed to set ICMP filter")
+	}
+
+	cm := &ipv6.ControlMessage{
+		// https://datatracker.ietf.org/doc/html/rfc4861#section-3.1
+		//  By setting the Hop Limit to 255, Neighbor Discovery is immune to
+		//  off-link senders that accidentally or intentionally send ND
+		//  messages.
+		HopLimit: 255,
+		Src:      ip,
+		IfIndex:  ifIndex,
+	}
+
+	pkt := slices.Clone(naTemplate)
+	copy(pkt[8:24], ip)
+	copy(pkt[26:32], mac)
+
+	return &UnsolNA{
+		pkt: pkt,
+		pc:  pc,
+		cm:  cm,
+	}, nil
+}
+
+// Send sends an unsolicited ARP message.
+func (un *UnsolNA) Send() error {
+	n, err := un.pc.WriteTo(un.pkt, un.cm, &net.IPAddr{IP: net.IPv6linklocalallnodes})
+	if err != nil {
+		return err
+	}
+	if n != len(un.pkt) {
+		return fmt.Errorf("failed to send packet: len:%d sent:%d", len(un.pkt), n)
+	}
+	return nil
+}
+
+// Close releases resources.
+func (un *UnsolNA) Close() error {
+	if un.pc != nil {
+		err := un.pc.Close()
+		un.pc = nil
+		return err
+	}
+	return nil
+}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -1,7 +1,6 @@
 package libnetwork_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1418,59 +1417,6 @@ func TestHost(t *testing.T) {
 	}
 }
 
-// Testing IPV6 from MAC address
-func TestBridgeIpv6FromMac(t *testing.T) {
-	defer netnsutils.SetupTestOSContext(t)()
-	controller := newController(t)
-
-	netOption := options.Generic{
-		netlabel.GenericData: map[string]string{
-			bridge.BridgeName:         "testipv6mac",
-			bridge.EnableICC:          "true",
-			bridge.EnableIPMasquerade: "true",
-		},
-	}
-	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
-	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
-
-	network, err := controller.NewNetwork(bridgeNetType, "testipv6mac", "",
-		libnetwork.NetworkOptionGeneric(netOption),
-		libnetwork.NetworkOptionEnableIPv4(true),
-		libnetwork.NetworkOptionEnableIPv6(true),
-		libnetwork.NetworkOptionIpam(defaultipam.DriverName, "", ipamV4ConfList, ipamV6ConfList, nil),
-		libnetwork.NetworkOptionDeferIPv6Alloc(true))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
-	epOption := options.Generic{netlabel.MacAddress: mac}
-
-	ep, err := network.CreateEndpoint(context.Background(), "testep", libnetwork.EndpointOptionGeneric(epOption))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	iface := ep.Info().Iface()
-	if !bytes.Equal(iface.MacAddress(), mac) {
-		t.Fatalf("Unexpected mac address: %v", iface.MacAddress())
-	}
-
-	ip, expIP, _ := net.ParseCIDR("fe90::aabb:ccdd:eeff/64")
-	expIP.IP = ip
-	if !types.CompareIPNet(expIP, iface.AddressIPv6()) {
-		t.Fatalf("Expected %v. Got: %v", expIP, iface.AddressIPv6())
-	}
-
-	if err := ep.Delete(context.Background(), false); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := network.Delete(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func checkSandbox(t *testing.T, info libnetwork.EndpointInfo) {
 	key := info.Sandbox().Key()
 	sbNs, err := netns.GetFromPath(key)
@@ -1513,7 +1459,7 @@ func TestEndpointJoin(t *testing.T) {
 		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam(defaultipam.DriverName, "", nil, ipamV6ConfList, nil),
-		libnetwork.NetworkOptionDeferIPv6Alloc(true))
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/netlabel/labels.go
+++ b/libnetwork/netlabel/labels.go
@@ -39,6 +39,14 @@ const (
 	// DriverMTU constant represents the MTU size for the network driver
 	DriverMTU = DriverPrefix + ".mtu"
 
+	// AdvertiseAddrNMsgs is the number of unsolicited ARP/NA messages that will be sent to
+	// advertise an interface's IP and MAC addresses.
+	AdvertiseAddrNMsgs = Prefix + ".advertise_addr_nmsgs"
+
+	// AdvertiseAddrIntervalMs is the minimum interval between ARP/NA advertisements for
+	// an interface's IP and MAC addresses (in milliseconds).
+	AdvertiseAddrIntervalMs = Prefix + ".advertise_addr_ms"
+
 	// OverlayVxlanIDList constant represents a list of VXLAN Ids as csv
 	OverlayVxlanIDList = DriverPrefix + ".overlay.vxlanid_list"
 

--- a/libnetwork/netutils/utils.go
+++ b/libnetwork/netutils/utils.go
@@ -14,7 +14,9 @@ import (
 	"github.com/containerd/log"
 )
 
-func genMAC(ip net.IP) net.HardwareAddr {
+// GenerateMACFromIP returns a locally administered MAC address where the 4 least
+// significant bytes are derived from the IPv4 address.
+func GenerateMACFromIP(ip net.IP) net.HardwareAddr {
 	hw := make(net.HardwareAddr, 6)
 	// The first byte of the MAC address has to comply with these rules:
 	// 1. Unicast: Set the least-significant bit to 0.
@@ -34,14 +36,13 @@ func genMAC(ip net.IP) net.HardwareAddr {
 }
 
 // GenerateRandomMAC returns a new 6-byte(48-bit) hardware address (MAC)
+// that is not multicast and has the local assignment bit set.
 func GenerateRandomMAC() net.HardwareAddr {
-	return genMAC(nil)
-}
-
-// GenerateMACFromIP returns a locally administered MAC address where the 4 least
-// significant bytes are derived from the IPv4 address.
-func GenerateMACFromIP(ip net.IP) net.HardwareAddr {
-	return genMAC(ip)
+	hw := make(net.HardwareAddr, 6)
+	rand.Read(hw)
+	hw[0] &= 0xfe // Unicast: clear multicast bit
+	hw[0] |= 0x02 // Locally administered: set local assignment bit
+	return hw
 }
 
 // GenerateRandomName returns a string of the specified length, created by joining the prefix to random hex characters.

--- a/libnetwork/network_unix.go
+++ b/libnetwork/network_unix.go
@@ -4,6 +4,12 @@ package libnetwork
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/osl"
 
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 )
@@ -31,4 +37,37 @@ func deleteEpFromResolver(epName string, epIface *EndpointInterface, resolvers [
 
 func defaultIpamForNetworkType(networkType string) string {
 	return defaultipam.DriverName
+}
+
+func (n *Network) validatedAdvertiseAddrNMsgs() (*int, error) {
+	nMsgsStr, ok := n.DriverOptions()[netlabel.AdvertiseAddrNMsgs]
+	if !ok {
+		return nil, nil
+	}
+	nMsgs, err := strconv.Atoi(nMsgsStr)
+	if err != nil {
+		return nil, fmt.Errorf("value for option "+netlabel.AdvertiseAddrNMsgs+" %q must be an integer", nMsgsStr)
+	}
+	if nMsgs < osl.AdvertiseAddrNMsgsMin || nMsgs > osl.AdvertiseAddrNMsgsMax {
+		return nil, fmt.Errorf(netlabel.AdvertiseAddrNMsgs+" must be in the range %d to %d",
+			osl.AdvertiseAddrNMsgsMin, osl.AdvertiseAddrNMsgsMax)
+	}
+	return &nMsgs, nil
+}
+
+func (n *Network) validatedAdvertiseAddrInterval() (*time.Duration, error) {
+	intervalStr, ok := n.DriverOptions()[netlabel.AdvertiseAddrIntervalMs]
+	if !ok {
+		return nil, nil
+	}
+	msecs, err := strconv.Atoi(intervalStr)
+	if err != nil {
+		return nil, fmt.Errorf("value for option "+netlabel.AdvertiseAddrIntervalMs+" %q must be integer milliseconds", intervalStr)
+	}
+	interval := time.Duration(msecs) * time.Millisecond
+	if interval < osl.AdvertiseAddrIntervalMin || interval > osl.AdvertiseAddrIntervalMax {
+		return nil, fmt.Errorf(netlabel.AdvertiseAddrIntervalMs+" must be in the range %d to %d",
+			osl.AdvertiseAddrIntervalMin/time.Millisecond, osl.AdvertiseAddrIntervalMax/time.Millisecond)
+	}
+	return &interval, nil
 }

--- a/libnetwork/network_windows.go
+++ b/libnetwork/network_windows.go
@@ -240,3 +240,11 @@ func defaultIpamForNetworkType(networkType string) string {
 	}
 	return defaultipam.DriverName
 }
+
+func (n *Network) validatedAdvertiseAddrNMsgs() (*int, error) {
+	return nil, nil
+}
+
+func (n *Network) validatedAdvertiseAddrInterval() (*time.Duration, error) {
+	return nil, nil
+}

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -337,8 +337,9 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 
 	// If the interface is up, send unsolicited ARP/NA messages if necessary.
 	if up {
-		// TODO(robmry) - treat this as an error once ARP/NA message-sending can be disabled.
-		_ = n.advertiseAddrs(ctx, iface.Attrs().Index, i, nlh)
+		if err := n.advertiseAddrs(ctx, iface.Attrs().Index, i, nlh); err != nil {
+			return fmt.Errorf("failed to advertise addresses: %w", err)
+		}
 	}
 
 	n.mu.Lock()

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -1,7 +1,9 @@
 package osl
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/internal/nlwrap"
+	"github.com/docker/docker/libnetwork/internal/l2disco"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
@@ -19,12 +22,14 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sys/unix"
 )
 
 // newInterface creates a new interface in the given namespace using the
 // provided options.
 func newInterface(ns *Namespace, srcName, dstPrefix string, options ...IfaceOption) (*Interface, error) {
 	i := &Interface{
+		stopCh:  make(chan struct{}),
 		srcName: srcName,
 		dstName: dstPrefix,
 		ns:      ns,
@@ -52,6 +57,7 @@ func newInterface(ns *Namespace, srcName, dstPrefix string, options ...IfaceOpti
 // host namespace to DstName in a different net namespace with the appropriate
 // network settings.
 type Interface struct {
+	stopCh      chan struct{} // stopCh is closed before the interface is deleted.
 	srcName     string
 	dstName     string
 	master      string
@@ -162,20 +168,19 @@ func (n *Namespace) findDst(srcName string, isBridge bool) string {
 	return ""
 }
 
-func moveLink(ctx context.Context, nlhHost nlwrap.Handle, iface netlink.Link, i *Interface, path string) error {
+func moveLink(ctx context.Context, nlhHost nlwrap.Handle, iface netlink.Link, i *Interface, path string) (netns.NsHandle, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.osl.moveLink", trace.WithAttributes(
 		attribute.String("ifaceName", i.DstName())))
 	defer span.End()
 
 	newNs, err := netns.GetFromPath(path)
 	if err != nil {
-		return fmt.Errorf("failed get network namespace %q: %v", path, err)
+		return netns.None(), fmt.Errorf("failed get network namespace %q: %v", path, err)
 	}
-	defer newNs.Close()
 	if err := nlhHost.LinkSetNsFd(iface, int(newNs)); err != nil {
-		return fmt.Errorf("failed to set namespace on link %q: %v", i.srcName, err)
+		return netns.None(), fmt.Errorf("failed to set namespace on link %q: %v", i.srcName, err)
 	}
-	return nil
+	return newNs, nil
 }
 
 // AddInterface adds an existing Interface to the sandbox. The operation will rename
@@ -208,6 +213,8 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 	nlhHost := ns.NlHandle()
 	n.mu.Unlock()
 
+	newNs := netns.None()
+
 	// If it is a bridge interface we have to create the bridge inside
 	// the namespace so don't try to lookup the interface using srcName
 	if i.bridge {
@@ -229,9 +236,12 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 		// namespace only if the namespace is not a default
 		// type
 		if !isDefault {
-			if err := moveLink(ctx, nlhHost, iface, i, path); err != nil {
+			var err error
+			newNs, err = moveLink(ctx, nlhHost, iface, i, path)
+			if err != nil {
 				return err
 			}
+			defer newNs.Close()
 		}
 	}
 
@@ -275,10 +285,23 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 	if err != nil {
 		return fmt.Errorf("failed to set link up: %v", err)
 	}
+	log.G(ctx).Debug("link has been set to up")
 
 	// Set the routes on the interface. This can only be done when the interface is up.
 	if err := setInterfaceRoutes(ctx, nlh, iface, i); err != nil {
 		return fmt.Errorf("error setting interface %q routes to %q: %v", iface.Attrs().Name, i.Routes(), err)
+	}
+
+	// Wait for the interface to be up and running (or a timeout).
+	up, err := waitForIfUpped(ctx, newNs, iface.Attrs().Index)
+	if err != nil {
+		return err
+	}
+
+	// If the interface is up, send unsolicited ARP/NA messages if necessary.
+	if up {
+		// TODO(robmry) - treat this as an error once ARP/NA message-sending can be disabled.
+		_ = n.advertiseAddrs(ctx, iface.Attrs().Index, i, nlh)
 	}
 
 	n.mu.Lock()
@@ -288,9 +311,214 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 	return nil
 }
 
+func waitForIfUpped(ctx context.Context, ns netns.NsHandle, ifIndex int) (bool, error) {
+	update := make(chan netlink.LinkUpdate, 100)
+	upped := make(chan struct{})
+	opts := netlink.LinkSubscribeOptions{
+		ListExisting: true, // in case the link is already up
+		ErrorCallback: func(err error) {
+			select {
+			case <-upped:
+				// Ignore errors sent after the upped channel is closed, the netlink
+				// package sends an EAGAIN after it closes its netlink socket when it
+				// sees this channel is closed. (No message is ever sent on upped.)
+				return
+			default:
+			}
+			log.G(ctx).WithFields(log.Fields{
+				"ifi":   ifIndex,
+				"error": err,
+			}).Info("netlink error while waiting for interface up")
+		},
+	}
+	if ns.IsOpen() {
+		opts.Namespace = &ns
+	}
+	if err := nlwrap.LinkSubscribeWithOptions(update, upped, opts); err != nil {
+		return false, fmt.Errorf("failed to subscribe to link updates: %w", err)
+	}
+
+	// When done (interface upped, or timeout), stop the LinkSubscribe and drain
+	// the result channel. If the result channel isn't closed after a timeout,
+	// log a warning to note the goroutine leak.
+	defer func() {
+		close(upped)
+		drainTimerC := time.After(3 * time.Second)
+		for {
+			select {
+			case _, ok := <-update:
+				if !ok {
+					return
+				}
+			case <-drainTimerC:
+				log.G(ctx).Warn("timeout while waiting for LinkSubscribe to terminate")
+			}
+		}
+	}()
+
+	timerC := time.After(5 * time.Second)
+	for {
+		select {
+		case <-timerC:
+			return false, nil
+		case u, ok := <-update:
+			if !ok {
+				// The netlink package failed to read from its netlink socket. It will
+				// already have called the ErrorCallback, so the issue has been logged.
+				return false, nil
+			}
+			if u.Attrs().Index != ifIndex {
+				continue
+			}
+			log.G(ctx).WithFields(log.Fields{
+				"iface": u.Attrs().Name,
+				"ifi":   u.Attrs().Index,
+				"flags": deviceFlags(u.Flags),
+			}).Debug("link update")
+			if u.Flags&unix.IFF_UP == unix.IFF_UP {
+				return true, nil
+			}
+		}
+	}
+}
+
+// advertiseAddrs triggers send gratuitous ARP and Neighbour Advertisement
+// messages, so that caches are updated with the MAC address currently associated
+// with the interface's IP addresses.
+//
+// IP addresses are recycled quickly when endpoints are dropped on network
+// disconnect or container stop. A new MAC address may have been generated, so
+// this is necessary to avoid packets sent to the old MAC address getting dropped
+// until the ARP/Neighbour cache entries expire.
+//
+// Note that the kernel's arp_notify sysctl setting is not respected.
+func (n *Namespace) advertiseAddrs(ctx context.Context, ifIndex int, i *Interface, nlh nlwrap.Handle) error {
+	mac := i.MacAddress()
+	address4 := i.Address()
+	address6 := i.AddressIPv6()
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
+		"iface": i.dstName,
+		"ifi":   ifIndex,
+		"mac":   mac.String(),
+		"ip4":   address4,
+		"ip6":   address6,
+	}))
+
+	if address4 == nil && address6 == nil {
+		// Nothing to do - for example, a bridge with no configured addresses.
+		log.G(ctx).Debug("No IP addresses to advertise")
+		return nil
+	}
+	if mac == nil {
+		// Nothing to do - for example, a layer-3 ipvlan.
+		log.G(ctx).Debug("No MAC address to advertise")
+		return nil
+	}
+
+	arpSender, naSender := n.prepAdvertiseAddrs(ctx, i, ifIndex)
+	if arpSender == nil && naSender == nil {
+		return nil
+	}
+	cleanup := func() {
+		if arpSender != nil {
+			arpSender.Close()
+		}
+		if naSender != nil {
+			naSender.Close()
+		}
+	}
+	stillSending := false
+	defer func() {
+		if !stillSending {
+			cleanup()
+		}
+	}()
+
+	send := func(ctx context.Context) error {
+		link, err := nlh.LinkByIndex(ifIndex)
+		if err != nil {
+			return fmt.Errorf("failed to refresh link attributes: %w", err)
+		}
+		if curMAC := link.Attrs().HardwareAddr; !bytes.Equal(curMAC, mac) {
+			log.G(ctx).WithFields(log.Fields{"newMAC": curMAC.String()}).Warn("MAC address changed")
+			return fmt.Errorf("MAC address changed, got %s, expected %s", curMAC, mac.String())
+		}
+		log.G(ctx).Debug("Sending unsolicited ARP/NA")
+		var errs []error
+		if arpSender != nil {
+			if err := arpSender.Send(); err != nil {
+				log.G(ctx).WithError(err).Warn("Failed to send unsolicited ARP")
+				errs = append(errs, err)
+			}
+		}
+		if naSender != nil {
+			if err := naSender.Send(); err != nil {
+				log.G(ctx).WithError(err).Warn("Failed to send unsolicited NA")
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	}
+
+	// Send an initial message. If it fails, skip the resends.
+	if err := send(ctx); err != nil {
+		return err
+	}
+	// Don't clean up on return from this function, there are more ARPs/NAs to send.
+	stillSending = true
+
+	// Send the rest in the background.
+	go func() {
+		defer cleanup()
+		ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "libnetwork.osl.advertiseAddrs")
+		defer span.End()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for c := range 2 {
+			select {
+			case <-i.stopCh:
+				log.G(ctx).Debug("Unsolicited ARP/NA sends cancelled")
+				return
+			case <-ticker.C:
+				if send(log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{"n": c + 1}))) != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (n *Namespace) prepAdvertiseAddrs(ctx context.Context, i *Interface, ifIndex int) (*l2disco.UnsolARP, *l2disco.UnsolNA) {
+	var ua *l2disco.UnsolARP
+	var un *l2disco.UnsolNA
+	if err := n.InvokeFunc(func() {
+		if address4 := i.Address(); address4 != nil {
+			var err error
+			ua, err = l2disco.NewUnsolARP(ctx, address4.IP, i.MacAddress(), ifIndex)
+			if err != nil {
+				log.G(ctx).WithError(err).Warn("Failed to prepare unsolicited ARP")
+			}
+		}
+		if address6 := i.AddressIPv6(); address6 != nil {
+			var err error
+			un, err = l2disco.NewUnsolNA(ctx, address6.IP, i.MacAddress(), ifIndex)
+			if err != nil {
+				log.G(ctx).WithError(err).Warn("Failed to prepare unsolicited NA")
+			}
+		}
+	}); err != nil {
+		log.G(ctx).WithError(err).Warn("Failed to prepare unsolicited ARP/NA messages")
+		return nil, nil
+	}
+	return ua, un
+}
+
 // RemoveInterface removes an interface from the namespace by renaming to
 // original name and moving it out of the sandbox.
 func (n *Namespace) RemoveInterface(i *Interface) error {
+	close(i.stopCh)
 	n.mu.Lock()
 	isDefault := n.isDefault
 	nlh := n.nlHandle

--- a/libnetwork/osl/netlinkutil_linux.go
+++ b/libnetwork/osl/netlinkutil_linux.go
@@ -1,0 +1,54 @@
+package osl
+
+import (
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+type deviceFlags uint32
+
+var deviceFlagStrings = map[deviceFlags]string{
+	unix.IFF_UP:          "IFF_UP",
+	unix.IFF_BROADCAST:   "IFF_BROADCAST",
+	unix.IFF_DEBUG:       "IFF_DEBUG",
+	unix.IFF_LOOPBACK:    "IFF_LOOPBACK",
+	unix.IFF_POINTOPOINT: "IFF_POINTOPOINT",
+	unix.IFF_RUNNING:     "IFF_RUNNING",
+	unix.IFF_NOARP:       "IFF_NOARP",
+	unix.IFF_PROMISC:     "IFF_PROMISC",
+	unix.IFF_NOTRAILERS:  "IFF_NOTRAILERS",
+	unix.IFF_ALLMULTI:    "IFF_ALLMULTI",
+	unix.IFF_MASTER:      "IFF_MASTER",
+	unix.IFF_SLAVE:       "IFF_SLAVE",
+	unix.IFF_MULTICAST:   "IFF_MULTICAST",
+	unix.IFF_PORTSEL:     "IFF_PORTSEL",
+	unix.IFF_AUTOMEDIA:   "IFF_AUTOMEDIA",
+	unix.IFF_DYNAMIC:     "IFF_DYNAMIC",
+	unix.IFF_LOWER_UP:    "IFF_LOWER_UP",
+	unix.IFF_DORMANT:     "IFF_DORMANT",
+	unix.IFF_ECHO:        "IFF_ECHO",
+}
+
+func (d deviceFlags) String() string {
+	var (
+		flags   []string
+		unknown uint32
+	)
+
+	for i := uint(0); i < 32; i++ {
+		if d&(1<<i) != 0 {
+			if s, ok := deviceFlagStrings[deviceFlags(1<<i)]; ok {
+				flags = append(flags, s)
+			} else {
+				unknown |= 1 << i
+			}
+		}
+	}
+	if unknown != 0 {
+		flags = append(flags, "0x"+strconv.FormatUint(uint64(unknown), 16))
+	}
+
+	return "deviceFlags(" + strings.Join(flags, " | ") + ")"
+}

--- a/libnetwork/osl/options_linux.go
+++ b/libnetwork/osl/options_linux.go
@@ -1,6 +1,10 @@
 package osl
 
-import "net"
+import (
+	"fmt"
+	"net"
+	"time"
+)
 
 func (nh *neigh) processNeighOptions(options ...NeighOption) {
 	for _, opt := range options {
@@ -86,6 +90,32 @@ func WithRoutes(routes []*net.IPNet) IfaceOption {
 func WithSysctls(sysctls []string) IfaceOption {
 	return func(i *Interface) error {
 		i.sysctls = sysctls
+		return nil
+	}
+}
+
+// WithAdvertiseAddrNMsgs sets the number of unsolicited ARP/NA messages that will
+// be sent to advertise a network interface's addresses.
+func WithAdvertiseAddrNMsgs(nMsgs int) IfaceOption {
+	return func(i *Interface) error {
+		if nMsgs < AdvertiseAddrNMsgsMin || nMsgs > AdvertiseAddrNMsgsMax {
+			return fmt.Errorf("AdvertiseAddrNMsgs %d is not in the range %d to %d",
+				nMsgs, AdvertiseAddrNMsgsMin, AdvertiseAddrNMsgsMax)
+		}
+		i.advertiseAddrNMsgs = nMsgs
+		return nil
+	}
+}
+
+// WithAdvertiseAddrInterval sets the interval between unsolicited ARP/NA messages
+// sent to advertise a network interface's addresses.
+func WithAdvertiseAddrInterval(interval time.Duration) IfaceOption {
+	return func(i *Interface) error {
+		if interval < AdvertiseAddrIntervalMin || interval > AdvertiseAddrIntervalMax {
+			return fmt.Errorf("AdvertiseAddrNMsgs %d is not in the range %v to %v milliseconds",
+				interval, AdvertiseAddrIntervalMin, AdvertiseAddrIntervalMax)
+		}
+		i.advertiseAddrInterval = interval
 		return nil
 	}
 }

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -384,7 +384,9 @@ func TestSandboxCreate(t *testing.T) {
 		err = s.AddInterface(context.Background(), i.SrcName(), i.DstName(),
 			WithIsBridge(i.Bridge()),
 			WithIPv4Address(i.Address()),
-			WithIPv6Address(i.AddressIPv6()))
+			WithIPv6Address(i.AddressIPv6()),
+			WithAdvertiseAddrNMsgs(0), // Made-up IP addresses, can't sent ARP/NA messages.
+		)
 		if err != nil {
 			t.Fatalf("Failed to add interfaces to sandbox: %v", err)
 		}
@@ -482,6 +484,7 @@ func TestAddRemoveInterface(t *testing.T) {
 			WithIsBridge(i.Bridge()),
 			WithIPv4Address(i.Address()),
 			WithIPv6Address(i.AddressIPv6()),
+			WithAdvertiseAddrNMsgs(0), // Made-up IP addresses, can't sent ARP/NA messages.
 		)
 		if err != nil {
 			t.Fatalf("Failed to add interfaces to sandbox: %v", err)
@@ -502,6 +505,7 @@ func TestAddRemoveInterface(t *testing.T) {
 		WithIsBridge(i.Bridge()),
 		WithIPv4Address(i.Address()),
 		WithIPv6Address(i.AddressIPv6()),
+		WithAdvertiseAddrNMsgs(0), // Made-up IP addresses, can't sent ARP/NA messages.
 	)
 	if err != nil {
 		t.Fatalf("Failed to add interfaces to sandbox: %v", err)

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -340,6 +340,14 @@ func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) e
 		if sysctls := ep.getSysctls(); len(sysctls) > 0 {
 			ifaceOptions = append(ifaceOptions, osl.WithSysctls(sysctls))
 		}
+		if n := ep.getNetwork(); n != nil {
+			if nMsgs, ok := n.advertiseAddrNMsgs(); ok {
+				ifaceOptions = append(ifaceOptions, osl.WithAdvertiseAddrNMsgs(nMsgs))
+			}
+			if interval, ok := n.advertiseAddrInterval(); ok {
+				ifaceOptions = append(ifaceOptions, osl.WithAdvertiseAddrInterval(interval))
+			}
+		}
 
 		if err := sb.osSbox.AddInterface(ctx, i.srcName, i.dstPrefix, ifaceOptions...); err != nil {
 			return fmt.Errorf("failed to add interface %s to sandbox: %v", i.srcName, err)


### PR DESCRIPTION
**- What I did**

In a bridge network with IPv4 enabled, when no MAC address is explicitly configured for a container, the MAC address was generated from the IPv4 address. So, when the container was stopped and its IP addresses were quickly recycled for another container, ARP/neighbour caches were still correct because there was a fixed relationship between MAC and IP addresses.

It's not possible to generate a unique MAC address from an IPv6 address (at least, not with a prefix length of fewer than 80 bits, and the prefix length should normally be at-least 64-bits).

So, for a container in an IPv6-only network, a new scheme is needed or when an IPv6 address gets recycled for another container the neighbour cache will contain the wrong mapping from that IPv6 address to a MAC address.

- Also, fixes https://github.com/moby/moby/issues/48082
  - An issue with Portainer setting a MAC address but no IP address when restarting containers, resulting in duplicate MAC addresses derived from recycled IP addresses. Now, the old random MAC address won't be recycled along with the IP address.

**- How I did it**

- Abandoned the fixed mapping from IPv4 address to MAC address.
  - Now, container interfaces on a bridge network always have a randomly generated MAC address.
  - Send an unsolicited ARP or Neighbour Advertisement when bringing up a new interface, to update caches.

Some of this was written as prototype by @corhere, I've picked up some changes from [this branch](https://github.com/moby/moby/compare/master...corhere:moby:libn/gratuitous-arp). However, setting sysctl `arp_notify` to have the kernel send the unsolicited ARP/NA messages didn't work out ...
- the kernel didn't send an ARP/NA when the interface came up
  - https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1989187
- as a workaround, we tried triggering the ARP/NA by setting the interface's MAC address
  - that was fine for a single initial message, but
  - setting the MAC address again later to trigger ARP/NA resends, flushed entries from the ARP/neighbour caches.

So, the ARP/NA messages are now sent from user space.

The number of unsolicited ARP/NA messages, and the interval between them, are configurable:
- The default is to send 3 messages at 1s intervals.
- That can be overridden in "docker network create" using:
    `-o com.docker.network.advertise_addr_nmsgs=3`
    `-o com.docker.network.advertise_addr_ms=1000`
- Or, in daemon.json for each driver:
    ```
        "default-network-opts": {
          "bridge": {
            "com.docker.network.advertise_addr_nmsgs": "3",
            "com.docker.network.advertise_addr_ms": "1000"
          }
        }
    ```
- The allowed range is 0-3 for count, and 100-2000ms for the interval.
- Setting count to 0 disables the unsolicited ARP/NA messages.
- The default bridge will always use the built-in defaults, it cannot be configured.

Note that random MAC addresses are now used on the default bridge network.
- Until now, as a special case for the default bridge network, IPv6 addresses have been based on the MAC address rather than being IPAM-assigned. So, as the MAC address was based on the IPv4 address unless it was specifically configured, there was a fixed mapping from IPv4 to MAC to IPv6 address. That no longer holds. But, all three addresses can be explicitly configured.

**- How to verify it**

New integration test to check that ARP/NA messages are sent.

Also tested while running `iperf` ...
- In a moby dev container, running in DD on an M2 Macbook.
- `iperf -s` in one container on a bridge, and `iperf -c <addr>` on another -> ~115Gbps TCP
- In one of the containers, pinged a third container's v4 and v6 addresses, to populate the neighbour cache.
  - Restarted the third container a few times, with the same IP address.
  - Used `ip neigh show` to check the iperf container's neighbour cache was immediately updated each time.
- Repeated that, but pinging from the other iperf container.
- Just to be sure, checked that with `nmsgs=0`, the neighbour cache wasn't updated when the third container restarted.

To check for goroutine leaks ...
- Started a bunch of containers running a 4s sleep (so that all three ARP and NA messages would be sent)...
  - `i=0; while [ $i -lt 500 ]; do ( docker run --rm -d --network b46 busybox sleep 4 & ); i=$((i+1)); done`
- Then the same again, but with a 1s sleep so that the ARP/NA goroutine would be cancelled.
- `docker info` reported that it got back to 49 goroutines.

**- Description for the changelog**
```markdown changelog
- Container interfaces in bridge networks now use randomly generated MAC addresses.
  - Unsolicited ARP / Neighbour Advertisement messages will be sent when the interfaces are started
    so that, when IP addresses are reused, they're associated with the newly generated MAC address.
  - IPv6 addresses in the default bridge network are now IPAM-assigned, rather than being derived
    from the MAC address.
  - Driver option "com.docker.network.advertise_addr_nmsgs" can be used to set the number of
    unsolicited ARP and NA packets sent for each address, from 0 to 3, the default is 3.
  - Driver option "com.docker.network.advertise_addr_ms" can be used to set the interval between
    unsolicited ARP and NA packets sent for each address, from 100 to 2000ms, the default is 1000ms.
```
