### PR TITLE
IPv6 only: not experimental

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -11285,9 +11285,7 @@ paths:
                 description: "Optional custom IP scheme for the network."
                 $ref: "#/definitions/IPAM"
               EnableIPv4:
-                description: |
-                  Enable IPv4 on the network.
-                  To disable IPv4, the daemon must be started with experimental features enabled.
+                description: "Enable IPv4 on the network."
                 type: "boolean"
                 example: true
               EnableIPv6:

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -319,11 +319,6 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.Crea
 			return nil, errdefs.InvalidParameter(fmt.Errorf("driver-opt %q is not a valid bool", netlabel.EnableIPv4))
 		}
 	}
-	if !enableIPv4 && !daemon.config().Experimental && create.ConfigFrom == nil {
-		return nil, errdefs.InvalidParameter(
-			errors.New("IPv4 can only be disabled if experimental features are enabled"),
-		)
-	}
 
 	var enableIPv6 bool
 	if create.EnableIPv6 != nil {

--- a/integration/network/dns_test.go
+++ b/integration/network/dns_test.go
@@ -104,7 +104,6 @@ func TestExtDNSInIPv6OnlyNw(t *testing.T) {
 	// Set up a temp resolv.conf pointing at that DNS server, and a daemon using it.
 	d := daemon.New(t,
 		daemon.WithResolvConf(network.GenResolvConf("127.0.0.1")),
-		daemon.WithExperimental(),
 	)
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)

--- a/integration/network/nat/nat_windows_test.go
+++ b/integration/network/nat/nat_windows_test.go
@@ -16,9 +16,5 @@ func TestWindowsNoDisableIPv4(t *testing.T) {
 		network.WithDriver("nat"),
 		network.WithIPv4(false),
 	)
-	// This error message should change to "IPv4 cannot be disabled on Windows"
-	// when "--experimental" is no longer required to disable IPv4. But, there's
-	// no way to start a second daemon with "--experimental" in Windows CI.
-	assert.Check(t, is.ErrorContains(err,
-		"IPv4 can only be disabled if experimental features are enabled"))
+	assert.Check(t, is.ErrorContains(err, "IPv4 cannot be disabled on Windows"))
 }

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -438,8 +438,7 @@ func TestMixL3IPVlanAndBridge(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 
-			// experimental is needed for a WithIPv4(false) network.
-			d := daemon.New(t, daemon.WithExperimental())
+			d := daemon.New(t)
 			var daemonArgs []string
 			if tc.liveRestore {
 				daemonArgs = append(daemonArgs, "--live-restore")

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -781,7 +781,7 @@ func TestDisableIPv6Addrs(t *testing.T) {
 // IPv4 addresses.
 func TestDisableIPv4(t *testing.T) {
 	ctx := setupTest(t)
-	d := daemon.New(t, daemon.WithExperimental())
+	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
@@ -1126,7 +1126,7 @@ func TestGatewaySelection(t *testing.T) {
 	skip.If(t, testEnv.IsRootless, "proxies run in child namespace")
 
 	ctx := setupTest(t)
-	d := daemon.New(t, daemon.WithExperimental())
+	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 	c := d.NewClientT(t)

--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	net "github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
-	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -122,7 +121,7 @@ func TestSwarmNoDisableIPv4(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	ctx := setupTest(t)
 
-	d := swarm.NewSwarm(ctx, t, testEnv, daemon.WithExperimental())
+	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 	client := d.NewClientT(t)
 	defer client.Close()


### PR DESCRIPTION
**- What I did**

Until the IPv6-only changes were all in place, `--experimental` was required to disable IPv4 ... that's no longer necessary.

**- How I did it**

Removed the restriction.

**- How to verify it**

Tests that set `--experimental` no longer do, and they still work.

**- Description for the changelog**
```markdown changelog

```
