### PR TITLE
Return an error for nonexistent or duplicate network connections to not started containers

### DIFF
--- a/integration/service/network_test.go
+++ b/integration/service/network_test.go
@@ -32,9 +32,7 @@ func TestDockerNetworkConnectAliasPreV144(t *testing.T) {
 
 	cID1 := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
-			EndpointsConfig: map[string]*network.EndpointSettings{
-				name: {},
-			},
+			EndpointsConfig: map[string]*network.EndpointSettings{},
 		}
 	})
 
@@ -55,9 +53,7 @@ func TestDockerNetworkConnectAliasPreV144(t *testing.T) {
 
 	cID2 := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
-			EndpointsConfig: map[string]*network.EndpointSettings{
-				name: {},
-			},
+			EndpointsConfig: map[string]*network.EndpointSettings{},
 		}
 	})
 
@@ -94,9 +90,7 @@ func TestDockerNetworkReConnect(t *testing.T) {
 
 	c1 := container.Create(ctx, t, client, func(c *container.TestContainerConfig) {
 		c.NetworkingConfig = &network.NetworkingConfig{
-			EndpointsConfig: map[string]*network.EndpointSettings{
-				name: {},
-			},
+			EndpointsConfig: map[string]*network.EndpointSettings{},
 		}
 	})
 


### PR DESCRIPTION
When the container is started, the necessary checks are performed when we want to connect a network to it or disconnect it from it. 

Even when the container is stopped, the necessary checks for disconnecting a network are performed, but not for connecting a network. 

This can lead to a situation where we connect a network to a stopped container that does not exist, and then if we try to start that container, we encounter an error, and the container fails to start.