### PR TITLE
fix(systemd): start Docker engine *after* DNS resolution is ready

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target docker.socket firewalld.service containerd.service time-set.target
+After=network-online.target nss-lookup.target docker.socket firewalld.service containerd.service time-set.target
 Wants=network-online.target containerd.service
 Requires=docker.socket
 


### PR DESCRIPTION
On systems using systemd to autostart Docker on boot, containers might encounter a problem where they will not have any DNS access until the container is restarted manually.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added an additional target for the Docker Engine service: `nss-lookup.target`. This target is reached when DNS resolution is ready (see https://wiki.archlinux.org/title/Systemd#Running_services_after_the_network_is_up, paragraph "If a service needs to perform DNS queries...")
**- How I did it**
Using a text editor.
**- How to verify it**
Check that containers launched during Docker Engine's `systemd` autostart can successfully perform DNS queries.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix DNS queries failing when containers are launched via `systemd` autostart on boot
```

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/user-attachments/assets/8f03f1a1-d353-4a7e-adc6-34eb8c403703)

