### PR TITLE
client: Client.ImageHistory: don't decorate error twice, and improve tests

### DIFF
--- a/client/image_history.go
+++ b/client/image_history.go
@@ -3,7 +3,6 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/docker/docker/api/types/image"
@@ -19,18 +18,18 @@ func (cli *Client) ImageHistory(ctx context.Context, imageID string, opts image.
 
 		p, err := encodePlatform(opts.Platform)
 		if err != nil {
-			return nil, fmt.Errorf("invalid platform: %v", err)
+			return nil, err
 		}
 		query.Set("platform", p)
 	}
 
-	var history []image.HistoryResponseItem
 	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", query, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
-		return history, err
+		return nil, err
 	}
 
+	var history []image.HistoryResponseItem
 	err = json.NewDecoder(serverResp.body).Decode(&history)
 	return history, err
 }


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48806

### client: Client.ImageHistory: don't decorate error twice

I forgot to include this patch in 96039276b66f1bb48d227d716f55d60a695b2c70,
which introduced the encodePlatform, which already decorates the error to
have a `invalid platform:` prefix.

While updating, also be more explicit on no result being returned on error.

### client: TestImageHistory: use fixture for JSON response

Use a fixture instead of encoding with the current definition of the type,
to make sure we don't regress if any changes are made in the type.

### client: TestImageHistory: add minimal test for platform


**- A picture of a cute animal (not mandatory but encouraged)**

