### PR TITLE
Remove function isLinkable

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -85,7 +85,7 @@ func (daemon *Daemon) addLegacyLinks(
 		return nil
 	}
 	for _, child := range children {
-		if !isLinkable(child) {
+		if _, ok := child.NetworkSettings.Networks[network.DefaultNetwork]; !ok {
 			return fmt.Errorf("Cannot link to %s, as it does not belong to the default network", child.Name)
 		}
 	}
@@ -485,12 +485,6 @@ func killProcessDirectly(ctr *container.Container) error {
 		}
 	}
 	return nil
-}
-
-func isLinkable(child *container.Container) bool {
-	// A container is linkable only if it belongs to the default network
-	_, ok := child.NetworkSettings.Networks[network.DefaultNetwork]
-	return ok
 }
 
 // TODO(aker): remove when we make the default bridge network behave like any other network

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -161,10 +161,6 @@ func killProcessDirectly(ctr *container.Container) error {
 	return nil
 }
 
-func isLinkable(child *container.Container) bool {
-	return false
-}
-
 func enableIPOnPredefinedNetwork() bool {
 	return true
 }


### PR DESCRIPTION
**- What I did**

Follow up on:
 - https://github.com/moby/moby/pull/47406#discussion_r1800204237

**- How I did it**

Inlined `isLinkable` to make it less obscure, and removed unused Windows version.

**- How to verify it**

It compiles.

**- Description for the changelog**
```markdown changelog
n/a
```