### PR TITLE
libnetwork: endpointJoinInfo.UnmarshalJSON: fix shadowed variable (go…

### DIFF
--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -455,7 +455,6 @@ func (epj *endpointJoinInfo) UnmarshalJSON(b []byte) error {
 	var tStaticRoute []types.StaticRoute
 	if v, ok := epMap["StaticRoutes"]; ok {
 		tb, _ := json.Marshal(v)
-		var tStaticRoute []types.StaticRoute
 		// TODO(cpuguy83): Linter caught that we aren't checking errors here
 		// I don't know why we aren't other than potentially the data is not always expected to be right?
 		// This is why I'm not adding the error check.


### PR DESCRIPTION
…vet)

looks like this was added in [libnetwork@be153a1], but not spotted.

    libnetwork/endpoint_info.go:467:20: nilness: range of nil slice (govet)
        for _, r := range tStaticRoute {
                          ^

[libnetwork@be153a1]: https://github.com/moby/libnetwork/commit/be153a13e43f2509c75d86e7f2a7de55ce5ec76c

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

