### PR TITLE
fix vendor of github.com/containerd/containerd

### DIFF
--- a/vendor/github.com/containerd/containerd/remotes/docker/config/hosts.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/config/hosts.go
@@ -32,10 +32,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd/remotes/docker"
-	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/pelletier/go-toml"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/remotes/docker"
 )
 
 // UpdateClientFunc is a function that lets you to amend http Client behavior used by registry clients.


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/pull/47380
- https://github.com/moby/moby/pull/48544


The github.com/containerd/containerd/remotes/docker/config package was vendored incorrectly due to 5f39567e560515088f2ab293d20e95f8da319796 (update to containerd v1.7.23) being merged from an outdated branch that missed the changes from 8b4cb6f58cf2addbb62313392c7b3dbab204e958 that brought in the dependency on the config package.


**- A picture of a cute animal (not mandatory but encouraged)**

