### PR TITLE
vendor: github.com/containerd/typeurl v2.2.3

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -33,7 +33,7 @@ require (
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v0.2.1
-	github.com/containerd/typeurl/v2 v2.2.0
+	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/cpuguy83/tar2go v0.3.1
 	github.com/creack/pty v1.1.21

--- a/vendor.sum
+++ b/vendor.sum
@@ -135,8 +135,8 @@ github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G
 github.com/containerd/stargz-snapshotter/estargz v0.15.1/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
 github.com/containerd/ttrpc v1.2.5 h1:IFckT1EFQoFBMG4c3sMdT8EP3/aKfumK1msY+Ze4oLU=
 github.com/containerd/ttrpc v1.2.5/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
-github.com/containerd/typeurl/v2 v2.2.0 h1:6NBDbQzr7I5LHgp34xAXYF5DOTQDn05X58lsPEmzLso=
-github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfedjS/8UHSPJnX4g=
+github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++dYSw40=
+github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/containernetworking/cni v1.2.2 h1:9IbP6KJQQxVKo4hhnm8r50YcVKrJbJu3Dqw+Rbt1vYk=
 github.com/containernetworking/cni v1.2.2/go.mod h1:DuLgF+aPd3DzcTQTtp/Nvl1Kim23oFKdm2okJzBQA5M=
 github.com/containernetworking/plugins v1.5.1 h1:T5ji+LPYjjgW0QM+KyrigZbLsZ8jaX+E5J/EcKOE4gQ=

--- a/vendor/github.com/containerd/typeurl/v2/README.md
+++ b/vendor/github.com/containerd/typeurl/v2/README.md
@@ -18,3 +18,9 @@ As a containerd sub-project, you will find the:
  * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
 
 information in our [`containerd/project`](https://github.com/containerd/project) repository.
+
+## Optional
+
+By default, support for gogoproto is available along side the standard Google
+protobuf types.
+You can choose to leave gogo support out by using the `!no_gogo` build tag.

--- a/vendor/github.com/containerd/typeurl/v2/types_gogo.go
+++ b/vendor/github.com/containerd/typeurl/v2/types_gogo.go
@@ -1,0 +1,68 @@
+//go:build !no_gogo
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package typeurl
+
+import (
+	"reflect"
+
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+func init() {
+	handlers = append(handlers, gogoHandler{})
+}
+
+type gogoHandler struct{}
+
+func (gogoHandler) Marshaller(v interface{}) func() ([]byte, error) {
+	pm, ok := v.(gogoproto.Message)
+	if !ok {
+		return nil
+	}
+	return func() ([]byte, error) {
+		return gogoproto.Marshal(pm)
+	}
+}
+
+func (gogoHandler) Unmarshaller(v interface{}) func([]byte) error {
+	pm, ok := v.(gogoproto.Message)
+	if !ok {
+		return nil
+	}
+
+	return func(dt []byte) error {
+		return gogoproto.Unmarshal(dt, pm)
+	}
+}
+
+func (gogoHandler) TypeURL(v interface{}) string {
+	pm, ok := v.(gogoproto.Message)
+	if !ok {
+		return ""
+	}
+	return gogoproto.MessageName(pm)
+}
+
+func (gogoHandler) GetType(url string) (reflect.Type, bool) {
+	t := gogoproto.MessageType(url)
+	if t == nil {
+		return nil, false
+	}
+	return t.Elem(), true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -390,7 +390,7 @@ github.com/containerd/stargz-snapshotter/estargz/errorutil
 # github.com/containerd/ttrpc v1.2.5
 ## explicit; go 1.19
 github.com/containerd/ttrpc
-# github.com/containerd/typeurl/v2 v2.2.0
+# github.com/containerd/typeurl/v2 v2.2.3
 ## explicit; go 1.21
 github.com/containerd/typeurl/v2
 # github.com/containernetworking/cni v1.2.2


### PR DESCRIPTION
- add a `no_gogo` build-tag to allow compiling without support for gogoproto (github.com/gogo/protobuf)
- fix panic when type is not found and no handler is hit.

full diff: https://github.com/containerd/typeurl/compare/v2.2.0...v2.2.3


**- A picture of a cute animal (not mandatory but encouraged)**

