### PR TITLE
daemon/&container/: enable `--security-opt writable-cgroups=true|false` as an option

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -127,6 +127,7 @@ type SecurityOptions struct {
 	AppArmorProfile string
 	SeccompProfile  string
 	NoNewPrivileges bool
+	WritableCgroups bool
 }
 
 type localLogCacheMeta struct {

--- a/container/container.go
+++ b/container/container.go
@@ -127,7 +127,7 @@ type SecurityOptions struct {
 	AppArmorProfile string
 	SeccompProfile  string
 	NoNewPrivileges bool
-	WritableCgroups bool
+	WritableCgroups *bool
 }
 
 type localLogCacheMeta struct {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -256,7 +256,7 @@ func parseSecurityOpt(securityOptions *container.SecurityOptions, config *contai
 			if err != nil {
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}
-			securityOptions.WritableCgroups = writableCgroups
+			securityOptions.WritableCgroups = &writableCgroups
 		default:
 			return fmt.Errorf("invalid --security-opt 2: %q", opt)
 		}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -251,6 +251,12 @@ func parseSecurityOpt(securityOptions *container.SecurityOptions, config *contai
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}
 			securityOptions.NoNewPrivileges = nnp
+		case "writable-cgroups":
+			writableCgroups, err := strconv.ParseBool(v)
+			if err != nil {
+				return fmt.Errorf("invalid --security-opt 2: %q", opt)
+			}
+			securityOptions.WritableCgroups = writableCgroups
 		default:
 			return fmt.Errorf("invalid --security-opt 2: %q", opt)
 		}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -221,6 +221,11 @@ func parseSecurityOpt(securityOptions *container.SecurityOptions, config *contai
 			securityOptions.NoNewPrivileges = true
 			continue
 		}
+		if opt == "writable-cgroups" {
+			trueVal := true
+			securityOptions.WritableCgroups = &trueVal
+			continue
+		}
 		if opt == "disable" {
 			labelOpts = append(labelOpts, "disable")
 			continue

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -161,6 +161,13 @@ func TestParseSecurityOpt(t *testing.T) {
 		})
 		assert.Error(t, err, `invalid --security-opt 2: "unknown=something"`)
 	})
+	t.Run("invalid cgroup option", func(t *testing.T) {
+		secOpts := &container.SecurityOptions{}
+		err := parseSecurityOpt(secOpts, &containertypes.HostConfig{
+			SecurityOpt: []string{"writable-cgroups=dang"},
+		})
+		assert.Error(t, err, `invalid --security-opt 2: "writable-cgroups=dang"`)
+	})
 }
 
 func TestParseNNPSecurityOptions(t *testing.T) {

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -666,7 +666,7 @@ func withMounts(daemon *Daemon, daemonCfg *configStore, c *container.Container, 
 
 		// TODO: until a kernel/mount solution exists for handling remount in a user namespace,
 		// we must clear the readonly flag for the cgroups mount (@mrunalp concurs)
-		if uidMap := daemon.idMapping.UIDMaps; uidMap != nil || c.HostConfig.Privileged {
+		if uidMap := daemon.idMapping.UIDMaps; uidMap != nil || c.HostConfig.Privileged || c.WritableCgroups {
 			for i, m := range s.Mounts {
 				if m.Type == "cgroup" {
 					clearReadOnly(&s.Mounts[i])

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -664,9 +664,21 @@ func withMounts(daemon *Daemon, daemonCfg *configStore, c *container.Container, 
 			}
 		}
 
+		// if the user didn't specify otherwise, default to the value of privileged
+		writableCgroups := c.HostConfig.Privileged
+		if c.WritableCgroups != nil {
+			if daemonCfg.Rootless || daemon.idMapping.UIDMaps != nil {
+				// error if the user requested a configuration we can't explicitly support
+				return errors.New("option WritableCgroups conflicts with user namespaces and rootless mode")
+			}
+			writableCgroups = *c.WritableCgroups
+		}
 		// TODO: until a kernel/mount solution exists for handling remount in a user namespace,
 		// we must clear the readonly flag for the cgroups mount (@mrunalp concurs)
-		if uidMap := daemon.idMapping.UIDMaps; uidMap != nil || c.HostConfig.Privileged || c.WritableCgroups {
+		if daemon.idMapping.UIDMaps != nil {
+			writableCgroups = true
+		}
+		if writableCgroups {
 			for i, m := range s.Mounts {
 				if m.Type == "cgroup" {
 					clearReadOnly(&s.Mounts[i])

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -402,6 +402,7 @@ func TestSeccomp(t *testing.T) {
 
 func TestCgroupRW(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRootless, "can't test writable cgroups in rootless (permission denied)")
 	skip.If(t, testEnv.IsUserNamespace, "can't test writable cgroups in user namespaces (permission denied)")
 
 	ctx := setupTest(t)

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -407,54 +407,65 @@ func TestCgroupRW(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	type testCase struct {
+		name             string
 		ops              []func(*container.TestContainerConfig)
 		expectedErrMsg   string
 		expectedExitCode int
 	}
 	testCases := []testCase{
 		{
-			ops: nil,
-			// no err msg, so, success
+			name: "nil",
+			ops:  nil,
+			// no err msg, because disabled-by-default
+			expectedExitCode: 1,
 		},
 		{
-			ops: []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=true")},
+			name: "writable=true",
+			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=true")},
 			// no err msg, because this is correct key=value
 			expectedExitCode: 0,
 		},
 		{
-			ops: []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=false")},
+			name: "writable=false",
+			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=false")},
 			// no err msg, because this is correct key=value
 			expectedExitCode: 1,
 		},
 		{
+			name:           "writeable=true",
 			ops:            []func(*container.TestContainerConfig){container.WithSecurityOpt("writeable-cgroups=true")},
 			expectedErrMsg: `Error response from daemon: invalid --security-opt 2: "writeable-cgroups=true"`,
 		},
 		{
+			name:           "writable=1",
 			ops:            []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=1")},
 			expectedErrMsg: `Error response from daemon: invalid --security-opt 2: "writable-cgroups=1"`,
 		},
 		{
+			name:           "writable=potato",
 			ops:            []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=potato")},
 			expectedErrMsg: `Error response from daemon: invalid --security-opt 2: "writable-cgroups=potato"`,
 		},
 	}
 	for _, tc := range testCases {
-		config := container.NewTestConfig(tc.ops...)
-		resp, err := container.CreateFromConfig(ctx, apiClient, config)
-		if err != nil {
-			assert.Equal(t, tc.expectedErrMsg, err.Error())
-			continue
-		}
-		// TODO check if ro or not
-		err = apiClient.ContainerStart(ctx, resp.ID, containertypes.StartOptions{})
-		assert.NilError(t, err)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			config := container.NewTestConfig(tc.ops...)
+			resp, err := container.CreateFromConfig(ctx, apiClient, config)
+			if err != nil {
+				assert.Equal(t, tc.expectedErrMsg, err.Error())
+				return
+			}
+			// TODO check if ro or not
+			err = apiClient.ContainerStart(ctx, resp.ID, containertypes.StartOptions{})
+			assert.NilError(t, err)
 
-		res, err := container.Exec(ctx, apiClient, resp.ID, []string{"mkdir", "/sys/fs/cgroup/foo"})
-		assert.NilError(t, err)
-		assert.Equal(t, tc.expectedExitCode, res.ExitCode)
-		if tc.expectedExitCode != 0 {
-			assert.Check(t, is.Contains(res.Stderr(), "Read-only file system"))
-		}
+			res, err := container.Exec(ctx, apiClient, resp.ID, []string{"mkdir", "/sys/fs/cgroup/foo"})
+			assert.NilError(t, err)
+			assert.Equal(t, tc.expectedExitCode, res.ExitCode)
+			if tc.expectedExitCode != 0 {
+				assert.Check(t, is.Contains(res.Stderr(), "Read-only file system"))
+			}
+		})
 	}
 }

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -456,7 +456,6 @@ func TestCgroupRW(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			config := container.NewTestConfig(tc.ops...)
 			resp, err := container.CreateFromConfig(ctx, apiClient, config)

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -422,6 +422,12 @@ func TestCgroupRW(t *testing.T) {
 			expectedExitCode: 1,
 		},
 		{
+			name: "writable",
+			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups")},
+			// no err msg, because this is correct key=bool
+			expectedExitCode: 0,
+		},
+		{
 			name: "writable=true",
 			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=true")},
 			// no err msg, because this is correct key=value


### PR DESCRIPTION
Fixes #42040
Fixes #42275
Closes #42043

Rather than making cgroups read-write by default, instead have a flag for making it possible.

Since these security options are passed through the cli to daemon API, no changes are needed to docker-cli.

Since this is currently only a single toggle, I also considered making it a `bool` like `cgroups-rw=true`. I could go either way. It being a string makes the intuitive value kindof hidden to users even moreso than the args to --security-opt already are.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Summoned the strong desire to run systemd inside a container. Particularly a docker container, not podman.
Sought out what is blocking it.
Talked to fine humans like @tianon.

**- How I did it**

wrote the code.

**- How to verify it**

- build and run this branch of `dockerd`. Nothing special.
- run:
```shell
vbatts@jungle:~$ docker run -it --rm --security-opt cgroups=rw debian:testing findmnt | grep cgroup.*rw
| `-/sys/fs/cgroup   cgroup                          cgroup2 rw,nosuid,nodev,noe
```

Further, with a base container like:

```Dockerfile
FROM debian:testing
RUN apt update && \
    apt install -y --no-install-recommends systemd && \
    rm -rf /var/lib/apt/lists/*
ENTRYPOINT ["/usr/lib/systemd/systemd"]
```

![image](https://github.com/user-attachments/assets/23744369-77d5-42b6-ac49-faa26b08c55e)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
 `POST /containers/create` now accepts a `writable-cgroups=true` option in `HostConfig.SecurityOpt`
  to mount the container's cgroups writable. This provides a more granular
  approach than `HostConfig.Privileged`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/e2592645-6b3e-4939-8384-9d2727b47c69)
