### PR TITLE
hack/make.sh: disable compiling "gogo-protobuf" in typeurl

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -93,7 +93,7 @@ if [ -z "$DOCKER_DEBUG" ]; then
 	LDFLAGS='-w'
 fi
 
-BUILDFLAGS=(${BUILDFLAGS} -tags "netgo osusergo static_build $DOCKER_BUILDTAGS")
+BUILDFLAGS=(${BUILDFLAGS} -tags "netgo osusergo static_build no_gogo $DOCKER_BUILDTAGS")
 LDFLAGS_STATIC="-extldflags -static"
 
 if [ "$(uname -s)" = 'FreeBSD' ]; then

--- a/vendor.mod
+++ b/vendor.mod
@@ -33,7 +33,7 @@ require (
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v0.2.1
-	github.com/containerd/typeurl/v2 v2.2.3
+	github.com/containerd/typeurl/v2 v2.2.3 // TODO(thaJeztah): remove "no_gogo" build-tag from hack/make.sh once we update to v2.3.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/cpuguy83/tar2go v0.3.1
 	github.com/creack/pty v1.1.21


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48827
- relates to https://github.com/containerd/typeurl/pull/50

commit 0af6203b46ac8973fc0c0c7f2a95fa8c2e57132d updated typeurl to v2.2.3, which now provides a `no_gogo` build-tag to allow compiling without gogo- protobuf support. BuildKit v0.17 and above no longer require gogo-protobuf, so we can use this build-tag to disable it.

Note that SwarmKit still uses gogo-protobuf, but doesn't use typeurl, so this change wont affect that code.


**- A picture of a cute animal (not mandatory but encouraged)**

