### PR TITLE
Add export local volume data route

### DIFF
--- a/api/server/router/volume/backend.go
+++ b/api/server/router/volume/backend.go
@@ -17,7 +17,14 @@ type Backend interface {
 	Create(ctx context.Context, name, driverName string, opts ...opts.CreateOption) (*volume.Volume, error)
 	Remove(ctx context.Context, name string, opts ...opts.RemoveOption) error
 	Prune(ctx context.Context, pruneFilters filters.Args) (*volume.PruneReport, error)
-	Export(ctx context.Context, name string, out io.Writer) error
+	Export(
+		ctx context.Context,
+		name string,
+		out io.Writer,
+		pauseContainerFn func(string) error,
+		unpauseContainerFn func(string) error,
+		pause bool,
+	) error
 }
 
 // ClusterBackend is the backend used for Swarm Cluster Volumes. Regular

--- a/api/server/router/volume/backend.go
+++ b/api/server/router/volume/backend.go
@@ -2,6 +2,7 @@ package volume // import "github.com/docker/docker/api/server/router/volume"
 
 import (
 	"context"
+	"io"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
@@ -16,6 +17,7 @@ type Backend interface {
 	Create(ctx context.Context, name, driverName string, opts ...opts.CreateOption) (*volume.Volume, error)
 	Remove(ctx context.Context, name string, opts ...opts.RemoveOption) error
 	Prune(ctx context.Context, pruneFilters filters.Args) (*volume.PruneReport, error)
+	Export(ctx context.Context, name string, out io.Writer) error
 }
 
 // ClusterBackend is the backend used for Swarm Cluster Volumes. Regular

--- a/api/server/router/volume/volume.go
+++ b/api/server/router/volume/volume.go
@@ -1,19 +1,24 @@
 package volume // import "github.com/docker/docker/api/server/router/volume"
 
-import "github.com/docker/docker/api/server/router"
+import (
+	"github.com/docker/docker/api/server/router"
+	"github.com/docker/docker/api/server/router/container"
+)
 
 // volumeRouter is a router to talk with the volumes controller
 type volumeRouter struct {
-	backend Backend
-	cluster ClusterBackend
-	routes  []router.Route
+	backend          Backend
+	cluster          ClusterBackend
+	routes           []router.Route
+	containerBackend container.Backend
 }
 
 // NewRouter initializes a new volume router
-func NewRouter(b Backend, cb ClusterBackend) router.Router {
+func NewRouter(b Backend, cb ClusterBackend, ctrb container.Backend) router.Router {
 	r := &volumeRouter{
-		backend: b,
-		cluster: cb,
+		backend:          b,
+		cluster:          cb,
+		containerBackend: ctrb,
 	}
 	r.initRoutes()
 	return r

--- a/api/server/router/volume/volume.go
+++ b/api/server/router/volume/volume.go
@@ -27,6 +27,7 @@ func (r *volumeRouter) Routes() []router.Route {
 func (r *volumeRouter) initRoutes() {
 	r.routes = []router.Route{
 		// GET
+		router.NewGetRoute("/volumes/{name:.*}/export", r.getVolumeExport),
 		router.NewGetRoute("/volumes", r.getVolumesList),
 		router.NewGetRoute("/volumes/{name:.*}", r.getVolumeByName),
 		// POST

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -208,3 +208,7 @@ func (v *volumeRouter) postVolumesPrune(ctx context.Context, w http.ResponseWrit
 	}
 	return httputils.WriteJSON(w, http.StatusOK, pruneReport)
 }
+
+func (v *volumeRouter) getVolumeExport(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	return v.backend.Export(ctx, vars["name"], w)
+}

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -210,5 +210,20 @@ func (v *volumeRouter) postVolumesPrune(ctx context.Context, w http.ResponseWrit
 }
 
 func (v *volumeRouter) getVolumeExport(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	return v.backend.Export(ctx, vars["name"], w)
+	if err := httputils.ParseForm(r); err != nil {
+		return err
+	}
+
+	if err := httputils.CheckForJSON(r); err != nil {
+		return err
+	}
+
+	return v.backend.Export(
+		ctx,
+		vars["name"],
+		w,
+		v.containerBackend.ContainerPause,
+		v.containerBackend.ContainerUnpause,
+		httputils.BoolValueOrDefault(r, "pause", true),
+	)
 }

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -640,7 +640,14 @@ func (b *fakeVolumeBackend) Prune(_ context.Context, _ filters.Args) (*volume.Pr
 	return nil, nil
 }
 
-func (b *fakeVolumeBackend) Export(_ context.Context, name string, out io.Writer) error {
+func (b *fakeVolumeBackend) Export(
+	_ context.Context,
+	name string,
+	out io.Writer,
+	_ func(string) error,
+	_ func(string) error,
+	_ bool,
+) error {
 	v, ok := b.volumes[name]
 	if !ok {
 		return errdefs.NotFound(fmt.Errorf("volume %s not found", name))

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -641,7 +641,7 @@ func (b *fakeVolumeBackend) Prune(_ context.Context, _ filters.Args) (*volume.Pr
 }
 
 func (b *fakeVolumeBackend) Export(_ context.Context, name string, out io.Writer) error {
-	v, ok := b.volumes[name] 
+	v, ok := b.volumes[name]
 	if !ok {
 		return errdefs.NotFound(fmt.Errorf("volume %s not found", name))
 	}

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -637,6 +638,17 @@ func (b *fakeVolumeBackend) Remove(_ context.Context, name string, o ...opts.Rem
 
 func (b *fakeVolumeBackend) Prune(_ context.Context, _ filters.Args) (*volume.PruneReport, error) {
 	return nil, nil
+}
+
+func (b *fakeVolumeBackend) Export(_ context.Context, name string, out io.Writer) error {
+	v, ok := b.volumes[name] 
+	if !ok {
+		return errdefs.NotFound(fmt.Errorf("volume %s not found", name))
+	}
+
+	_, err := out.Write([]byte(fmt.Sprintf("%s exported", v.Name)))
+
+	return err
 }
 
 type fakeClusterBackend struct {

--- a/api/types/volume/volume.go
+++ b/api/types/volume/volume.go
@@ -51,6 +51,8 @@ type Volume struct {
 
 	// usage data
 	UsageData *UsageData `json:"UsageData,omitempty"`
+
+	IsExporting bool `json:"IsExporting,omitempty"`
 }
 
 // UsageData Usage details about the volume. This information is used by the

--- a/client/interface.go
+++ b/client/interface.go
@@ -179,7 +179,7 @@ type VolumeAPIClient interface {
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (volume.Volume, []byte, error)
 	VolumeList(ctx context.Context, options volume.ListOptions) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
-	VolumeExport(ctx context.Context, volumeID string) (io.ReadCloser, error)
+	VolumeExport(ctx context.Context, volumeID string, pause bool) (io.ReadCloser, error)
 	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (volume.PruneReport, error)
 	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -179,6 +179,7 @@ type VolumeAPIClient interface {
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (volume.Volume, []byte, error)
 	VolumeList(ctx context.Context, options volume.ListOptions) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
+	VolumeExport(ctx context.Context, volumeID string) (io.ReadCloser, error)
 	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (volume.PruneReport, error)
 	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
 }

--- a/client/volume_export.go
+++ b/client/volume_export.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"io"
 	"net/url"
+	"strconv"
 )
 
 // VolumeExport export a local volume from the docker host.
-func (cli *Client) VolumeExport(ctx context.Context, volumeID string) (io.ReadCloser, error) {
-	serverResp, err := cli.get(ctx, "/volumes/"+volumeID+"/export", url.Values{}, nil)
+func (cli *Client) VolumeExport(ctx context.Context, volumeID string, pause bool) (io.ReadCloser, error) {
+	serverResp, err := cli.get(ctx, "/volumes/"+volumeID+"/export?pause="+strconv.FormatBool(pause), url.Values{}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/volume_export.go
+++ b/client/volume_export.go
@@ -1,0 +1,17 @@
+package client // import "github.com/docker/docker/client"
+
+import (
+	"context"
+	"io"
+	"net/url"
+)
+
+// VolumeExport export a local volume from the docker host.
+func (cli *Client) VolumeExport(ctx context.Context, volumeID string) (io.ReadCloser, error) {
+	serverResp, err := cli.get(ctx, "/volumes/"+volumeID+"/export", url.Values{}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return serverResp.body, nil
+}

--- a/client/volume_export_test.go
+++ b/client/volume_export_test.go
@@ -1,0 +1,52 @@
+package client // import "github.com/docker/docker/client"
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/errdefs"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestVolumeExportError(t *testing.T) {
+	client := &Client{
+		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	}
+
+	_, err := client.VolumeExport(context.Background(), "nothing")
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
+}
+
+func TestVolumeExport(t *testing.T) {
+	expectedURL := "/volumes/local_volume/export"
+	client := &Client{
+		client: newMockClient(func(r *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(r.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, r.URL)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte("response"))),
+			}, nil
+		}),
+	}
+	body, err := client.VolumeExport(context.Background(), "local_volume")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer body.Close()
+	content, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "response" {
+		t.Fatalf("expected response to contain 'response', got %s", string(content))
+	}
+}

--- a/client/volume_export_test.go
+++ b/client/volume_export_test.go
@@ -19,7 +19,7 @@ func TestVolumeExportError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.VolumeExport(context.Background(), "nothing")
+	_, err := client.VolumeExport(context.Background(), "nothing", true)
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -37,7 +37,7 @@ func TestVolumeExport(t *testing.T) {
 			}, nil
 		}),
 	}
-	body, err := client.VolumeExport(context.Background(), "local_volume")
+	body, err := client.VolumeExport(context.Background(), "local_volume", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -712,7 +712,7 @@ func (opts routerOptions) Build() []router.Router {
 			opts.daemon.ImageService().DistributionServices().LayerStore,
 		),
 		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.buildkit, opts.daemon.Features),
-		volume.NewRouter(opts.daemon.VolumesService(), opts.cluster),
+		volume.NewRouter(opts.daemon.VolumesService(), opts.cluster, opts.daemon),
 		build.NewRouter(opts.buildBackend, opts.daemon),
 		sessionrouter.NewRouter(opts.sessionManager),
 		swarmrouter.NewRouter(opts.cluster),

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -327,3 +327,11 @@ func (v *volumeWrapper) Status() map[string]interface{} {
 func (v *volumeWrapper) LiveRestoreVolume(ctx context.Context, ref string) error {
 	return v.s.LiveRestoreVolume(ctx, v.v, ref)
 }
+
+func (v *volumeWrapper) IsExporting() bool {
+	return v.v.IsExporting
+}
+
+func (v *volumeWrapper) SetExporting(exporting bool) {
+	v.v.IsExporting = exporting
+}

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -339,3 +339,17 @@ VOLUME ` + volDest
 	assert.NilError(t, err)
 	assert.Assert(t, is.Contains(pruneReport.VolumesDeleted, volumeName))
 }
+
+func TestVolumeExport(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot export volumes on Windows")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+
+	ctx := setupTest(t)
+	client := testEnv.APIClient()
+
+	v, err := client.VolumeCreate(ctx, volume.CreateOptions{})
+	assert.NilError(t, err)
+
+	_, err = client.VolumeExport(ctx, v.Name)
+	assert.NilError(t, err)
+}

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -350,6 +350,6 @@ func TestVolumeExport(t *testing.T) {
 	v, err := client.VolumeCreate(ctx, volume.CreateOptions{})
 	assert.NilError(t, err)
 
-	_, err = client.VolumeExport(ctx, v.Name)
+	_, err = client.VolumeExport(ctx, v.Name, true)
 	assert.NilError(t, err)
 }

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -113,13 +113,14 @@ func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 }
 
 type volumeAdapter struct {
-	proxy      volumeDriver
-	name       string
-	scopePath  func(string) string
-	driverName string
-	eMount     string    // ephemeral host volume path
-	createdAt  time.Time // time the directory was created
-	status     map[string]interface{}
+	proxy       volumeDriver
+	name        string
+	scopePath   func(string) string
+	driverName  string
+	eMount      string    // ephemeral host volume path
+	createdAt   time.Time // time the directory was created
+	status      map[string]interface{}
+	isExporting bool
 }
 
 type proxyVolume struct {
@@ -173,4 +174,12 @@ func (a *volumeAdapter) Status() map[string]interface{} {
 		out[k] = v
 	}
 	return out
+}
+
+func (a *volumeAdapter) IsExporting() bool {
+	return a.isExporting
+}
+
+func (a *volumeAdapter) SetExporting(exporting bool) {
+	a.isExporting = exporting
 }

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -279,6 +279,8 @@ type localVolume struct {
 	active activeMount
 	// reference to Root instances quotaCtl
 	quotaCtl *quota.Control
+	// isExporting is true if the volume is being exported
+	isExporting bool
 }
 
 // Name returns the name of the given Volume.
@@ -361,6 +363,14 @@ func (v *localVolume) Unmount(id string) error {
 
 func (v *localVolume) Status() map[string]interface{} {
 	return nil
+}
+
+func (v *localVolume) IsExporting() bool {
+	return v.isExporting
+}
+
+func (v *localVolume) SetExporting(exporting bool) {
+	v.isExporting = exporting
 }
 
 func (v *localVolume) loadOpts() error {

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -2,6 +2,8 @@ package service // import "github.com/docker/docker/volume/service"
 
 import (
 	"context"
+	"io"
+	"runtime"
 	"strconv"
 	"sync/atomic"
 
@@ -11,6 +13,7 @@ import (
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/directory"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/stringid"
@@ -274,6 +277,45 @@ func (s *VolumesService) List(ctx context.Context, filter filters.Args) (volumes
 	}
 
 	return s.volumesToAPI(ctx, volumes, useCachedPath(true)), warnings, nil
+}
+
+// Export export a local volume to a tarball.
+// An error is returned if the volume is not exists.
+func (s *VolumesService) Export(ctx context.Context, name string, out io.Writer) error {
+	if runtime.GOOS == "windows" {
+		return errors.New("exporting volumes is not supported on Windows")
+	}
+
+	v, err := s.vs.Get(ctx, name)
+	if err != nil {
+		if IsNotExist(err) {
+			err = errdefs.NotFound(err)
+		}
+		return err
+	}
+
+	if v.DriverName() != volume.DefaultDriverName {
+		return errors.Errorf("exporting volumes is not supported for driver %s", v.DriverName())
+	}
+
+	c, err := archive.Tar(v.Path(), archive.Uncompressed)
+	if err != nil {
+		return errors.Wrap(err, "error while creating volume tar stream")
+	}
+
+	defer func() {
+		if err := c.Close(); err != nil {
+			log.G(ctx).WithError(err).Error("error while closing volume tar stream")
+		}
+	}()
+
+	_, err = io.Copy(out, c)
+	if err != nil {
+		return errors.Wrap(err, "error while copying volume tar stream")
+	}
+
+	s.eventLogger.LogVolumeEvent(name, events.ActionExport, nil)
+	return nil
 }
 
 // Shutdown shuts down the image service and dependencies

--- a/volume/testutils/testutils.go
+++ b/volume/testutils/testutils.go
@@ -37,16 +37,23 @@ func (NoopVolume) Status() map[string]interface{} { return nil }
 // CreatedAt provides the time the volume (directory) was created at
 func (NoopVolume) CreatedAt() (time.Time, error) { return time.Now(), nil }
 
+// IsExporting returns true if the volume is currently being exported
+func (NoopVolume) IsExporting() bool { return false }
+
+// SetExporting sets the exporting status of the volume
+func (NoopVolume) SetExporting(_ bool) { /* no-operation */ }
+
 // FakeVolume is a fake volume with a random name
 type FakeVolume struct {
-	name       string
-	driverName string
-	createdAt  time.Time
+	name        string
+	driverName  string
+	createdAt   time.Time
+	isExporting bool
 }
 
 // NewFakeVolume creates a new fake volume for testing
 func NewFakeVolume(name string, driverName string) volume.Volume {
-	return FakeVolume{name: name, driverName: driverName, createdAt: time.Now()}
+	return FakeVolume{name: name, driverName: driverName, createdAt: time.Now(), isExporting: false}
 }
 
 // Name is the name of the volume
@@ -63,6 +70,14 @@ func (FakeVolume) Mount(_ string) (string, error) { return "fake", nil }
 
 // Unmount unmounts the volume from the container
 func (FakeVolume) Unmount(_ string) error { return nil }
+
+// IsExporting returns true if the volume is currently being exported
+func (f FakeVolume) IsExporting() bool { return f.isExporting }
+
+// SetExporting sets the exporting status of the volume
+func (f FakeVolume) SetExporting(exporting bool) {
+	f.isExporting = exporting
+}
 
 // Status provides low-level details about the volume
 func (FakeVolume) Status() map[string]interface{} {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -59,6 +59,10 @@ type Volume interface {
 	CreatedAt() (time.Time, error)
 	// Status returns low-level status information about a volume
 	Status() map[string]interface{}
+	// IsExporting returns true if the volume is currently being exported
+	IsExporting() bool
+	// SetExporting sets the exporting status of the volume
+	SetExporting(exporting bool)
 }
 
 // LiveRestorer is an optional interface that can be implemented by a volume driver


### PR DESCRIPTION
Implement a new route in the Docker API that enables users to export the contents of `local` volumes as a `.tar` archive. This feature offers a convenient way to generate compressed backups of `local` volume data, making it easier to store, transfer, and restore volume contents efficiently.