### PR TITLE
[27.4] libnet: don't put external DNS answers in OTel spans

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -600,9 +600,7 @@ func (r *Resolver) forwardExtDNS(ctx context.Context, proto string, remoteAddr n
 			r.log(ctx).Debugf("[resolver] external DNS %s:%s returned response with no answers:\n%s", proto, extDNS.IPStr, resp)
 		}
 		resp.Compress = true
-		span.AddEvent("response from upstream server", trace.WithAttributes(
-			attribute.String("libnet.resolver.resp", resp.String()),
-		))
+		span.AddEvent("response from upstream server")
 		return resp
 	}
 


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/issues/48644

This PR is opened against the 27.x branch as it's a quick fix. It seems there might be a memory leak related to OTel lying around, although that needs further investigation. This commit should be cherry-picked into `master` if we conclude that there's no leak.

**- What I did**

When containers make DNS resolution, and the domain name they're trying to resolve doesn't match any running container, the DNS query is forwarded to upstream servers. In that case, when we receive a response, we put it in an OTel spans.

This was useful to debug DNS resolution on GHA, but it leads to excessive memory usage when DNS resolution happen in a tight loop. So, keep the OTel event signaling that a response was received, but drop the answer from the OTel span.

**- Description for the changelog**

```markdown changelog
- Fix an issue that caused excessive memory usage when DNS resolution was made in a tight loop
```

