### PR TITLE
⚠️ WIP ⚠️  Enable forwarding auth challenges to client

### DIFF
--- a/client/image_pull_opts.go
+++ b/client/image_pull_opts.go
@@ -19,6 +19,16 @@ type ImagePullOptions struct {
 	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
 	PrivilegeFunc func(context.Context) (string, error)
 
+	// ChallengeHandlerFunc is a function that a client can supply to handle
+	// challenges returned by the registry.
+	// If ChallengeHandlerFunc is not nil, the engine will not attempt to handle
+	// any challenges returned by the registry. Instead, the engine will return
+	// a 401 response to the client, including the WWW-Authenticate header, and
+	// the client will call ChallengeHandlerFunc to handle the challenge.
+	// This function returns the registry authentication header value (in base64
+	// encoded format).
+	ChallengeHandlerFunc func(context.Context, string) (string, error)
+
 	// Platforms selects the platforms to pull. Multiple platforms can be
 	// specified if the image ia a multi-platform image.
 	Platforms []ocispec.Platform

--- a/client/image_push_opts.go
+++ b/client/image_push_opts.go
@@ -19,6 +19,16 @@ type ImagePushOptions struct {
 	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
 	PrivilegeFunc func(context.Context) (string, error)
 
+	// ChallengeHandlerFunc is a function that a client can supply to handle
+	// challenges returned by the registry.
+	// If ChallengeHandlerFunc is not nil, the engine will not attempt to handle
+	// any challenges returned by the registry. Instead, the engine will return
+	// a 401 response to the client, including the WWW-Authenticate header, and
+	// the client will call ChallengeHandlerFunc to handle the challenge.
+	// This function returns the registry authentication header value (in base64
+	// encoded format).
+	ChallengeHandlerFunc func(context.Context, string) (string, error)
+
 	// Platform is an optional field that selects a specific platform to push
 	// when the image is a multi-platform image.
 	// Using this will only push a single platform-specific manifest.

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -56,7 +56,7 @@ func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, o
 	}
 
 	if !reference.IsNameOnly(baseRef) {
-		return i.pullTag(ctx, baseRef, platform, options.MetaHeaders, options.AuthConfig, out)
+		return i.pullTag(ctx, baseRef, platform, options.MetaHeaders, options.AuthConfig, out, options.ClientAuth)
 	}
 
 	tags, err := distribution.Tags(ctx, baseRef, &distribution.Config{
@@ -78,7 +78,7 @@ func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, o
 			continue
 		}
 
-		if err := i.pullTag(ctx, ref, platform, options.MetaHeaders, options.AuthConfig, out); err != nil {
+		if err := i.pullTag(ctx, ref, platform, options.MetaHeaders, options.AuthConfig, out, options.ClientAuth); err != nil {
 			return fmt.Errorf("error pulling %s: %w", ref, err)
 		}
 	}
@@ -86,13 +86,13 @@ func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, o
 	return nil
 }
 
-func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output) error {
+func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output, clientAuth bool) error {
 	var opts []containerd.RemoteOpt
 	if platform != nil {
 		opts = append(opts, containerd.WithPlatform(platforms.FormatAll(*platform)))
 	}
 
-	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig, ref, metaHeaders)
+	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig, ref, metaHeaders, clientAuth)
 	opts = append(opts, containerd.WithResolver(resolver))
 
 	oldImage, err := i.resolveImage(ctx, ref.String())
@@ -223,6 +223,12 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 			// https://github.com/containerd/containerd/blob/v2.1.1/core/remotes/docker/authorizer.go#L201-L203
 			if strings.Contains(err.Error(), "no basic auth credentials") {
 				return err
+			}
+			var authChallengeErr *ErrAuthenticationChallenge
+			if errors.As(err, &authChallengeErr) {
+				// Return immediately if the request return an auth challenge
+				// so that we can surface that to the client.
+				return authChallengeErr
 			}
 			return errdefs.NotFound(fmt.Errorf("pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(ref)))
 		}

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -24,6 +24,9 @@ import (
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
 func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, options imagebackend.PullOptions) error {
+	if options.ClientAuth {
+		return cerrdefs.ErrNotImplemented.WithMessage("engine is using the graphdriver image store, which does not support client auth handling")
+	}
 	if len(options.Platforms) > 1 {
 		// TODO(thaJeztah): add support for pulling multiple platforms
 		return cerrdefs.ErrInvalidArgument.WithMessage("multiple platforms is not supported")

--- a/daemon/images/image_push.go
+++ b/daemon/images/image_push.go
@@ -18,6 +18,9 @@ import (
 // PushImage initiates a push operation on the repository named localName.
 // func (i *ImageService) PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
 func (i *ImageService) PushImage(ctx context.Context, ref reference.Named, options imagebackend.PushOptions) error {
+	if options.ClientAuth {
+		return cerrdefs.ErrNotImplemented.WithMessage("engine is using the graphdriver image store, which does not support client auth handling")
+	}
 	if len(options.Platforms) > 1 {
 		// TODO(thaJeztah): add support for pushing multiple platforms
 		return cerrdefs.ErrInvalidArgument.WithMessage("multiple platforms is not supported")

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -16,6 +16,7 @@ type PullOptions struct {
 	Platforms   []ocispec.Platform
 	MetaHeaders http.Header
 	AuthConfig  *registry.AuthConfig
+	ClientAuth  bool
 	OutStream   io.Writer
 }
 
@@ -23,6 +24,7 @@ type PushOptions struct {
 	Platforms   []ocispec.Platform
 	MetaHeaders http.Header
 	AuthConfig  *registry.AuthConfig
+	ClientAuth  bool
 	OutStream   io.Writer
 }
 

--- a/vendor/github.com/moby/moby/client/image_pull_opts.go
+++ b/vendor/github.com/moby/moby/client/image_pull_opts.go
@@ -19,6 +19,16 @@ type ImagePullOptions struct {
 	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
 	PrivilegeFunc func(context.Context) (string, error)
 
+	// ChallengeHandlerFunc is a function that a client can supply to handle
+	// challenges returned by the registry.
+	// If ChallengeHandlerFunc is not nil, the engine will not attempt to handle
+	// any challenges returned by the registry. Instead, the engine will return
+	// a 401 response to the client, including the WWW-Authenticate header, and
+	// the client will call ChallengeHandlerFunc to handle the challenge.
+	// This function returns the registry authentication header value (in base64
+	// encoded format).
+	ChallengeHandlerFunc func(context.Context, string) (string, error)
+
 	// Platforms selects the platforms to pull. Multiple platforms can be
 	// specified if the image ia a multi-platform image.
 	Platforms []ocispec.Platform

--- a/vendor/github.com/moby/moby/client/image_push_opts.go
+++ b/vendor/github.com/moby/moby/client/image_push_opts.go
@@ -19,6 +19,16 @@ type ImagePushOptions struct {
 	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
 	PrivilegeFunc func(context.Context) (string, error)
 
+	// ChallengeHandlerFunc is a function that a client can supply to handle
+	// challenges returned by the registry.
+	// If ChallengeHandlerFunc is not nil, the engine will not attempt to handle
+	// any challenges returned by the registry. Instead, the engine will return
+	// a 401 response to the client, including the WWW-Authenticate header, and
+	// the client will call ChallengeHandlerFunc to handle the challenge.
+	// This function returns the registry authentication header value (in base64
+	// encoded format).
+	ChallengeHandlerFunc func(context.Context, string) (string, error)
+
 	// Platform is an optional field that selects a specific platform to push
 	// when the image is a multi-platform image.
 	// Using this will only push a single platform-specific manifest.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Implement client auth protocol – as discussed in https://github.com/moby/moby/issues/38591.

With this change, a client can **opt-in** to the new client auth flow by including a `clientAuth` URL parameter set to a non-falsy value (`"0"`, `"false"`, `"[empty]"`).

If a client opts in, any `401` response with a `WWW-Authenticate` header returned by the registry causes the pull to fail and a `401` response with the unaltered `WWW-Authenticate` header to be returned to the client.

The client can then handle this challenge any way it sees fit, and initiate another request with the relevant auth configuration.

---------------------

Consider an OAuth authentication scenario: previously, a client could make use of the `IdentityToken` https://github.com/moby/moby/blob/48e43eb8601e5edaec3b4b88926413ef786e2913/api/types/registry/authconfig.go#L43 and `RegistryToken` https://github.com/moby/moby/blob/48e43eb8601e5edaec3b4b88926413ef786e2913/api/types/registry/authconfig.go#L46 fields in the `AuthConfig` struct to send along a bearer and refresh token to be used for the registry.

When using the `IdentityToken` field, on any `401` response from the registry with an `WWW-Authenticate` header, the engine would attempt to use the refresh token passed here against the `realm` from the challenge to fetch an access token to use for authentication. After fetching the new credentials, the engine does not send them back to the client, which means the client cannot store the new, refreshed credentials.

On top of that, OAuth tenants frequently implement refresh token rotation – with this practice, each time that a client refreshes it's credentials with a refresh token flow, it receives a new access token **AND** a new refresh token, which it's expected to store and use for future refresh flows. When this is done, each individual refresh token has a shorter lifetime, after which it cannot be used. This is fine if a client stores the new refresh token every time it does a refresh flow, since the new refresh token has a fresh lifetime. However, given that the engine does not forward the new access + refresh tokens to the client, this flow is incompatible with the current engine auth implementations.

With the new client auth protocol implemented in this patch, instead of the client sending along a refresh token with the pull request, the client instead initiates the pull request, receives a `401` back from the engine with the auth challenge, refreshes it's credentials (and can store the new – rotated – refresh token), and then restarts the pull request with the relevant credentials for authentication.

**- How I did it**

Add a `clientAuth` flag to the `/images/create` endpoint, which toggles the client auth handling flow.

Also added a `ChallengeHandlerFunc` field to the API `PullOptions` struct, which is used to pass along "challenge handling closure" to be used by the API client.

If the client auth flow is used, then a new `clientChallengeAuthorizer` is used when initiating the request, which returns the new error type `ErrAuthenticationChallenge` if any challenge is received. This new `ErrAuthenticationChallenge` is bubbled up to the API handler, which handles it by responding with a `401` with the returned `WWW-Authenticate` header.

**- How to verify it**

Check the CLI PR implementing this – https://github.com/docker/cli/pull/5606.

> [!NOTE]  
> While working at this, I first implemented something more akin to https://github.com/moby/moby/compare/master...simonferquel:auth-streaming – i.e. negotiate credentials by streaming the auth requests while the pull is ongoing instead of responding to the `/images/create` request with a `401` and having the client handle the challenge and start the pull again. I can push this if it makes sense, but I prefer this more conventional/less complex approach.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Add support for forwarding auth challenges during registry operations to the client initiating the registry operation.
```

**- A picture of a cute animal (not mandatory but encouraged)**

