### PR TITLE
Fix concurrency issue in dind

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -62,10 +62,18 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
 	# otherwise writing subtree_control fails with EBUSY.
 	# An error during moving non-existent process (i.e., "cat") is ignored.
 	mkdir -p /sys/fs/cgroup/init
-	xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
-	# enable controllers
-	sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
-		> /sys/fs/cgroup/cgroup.subtree_control
+	# this happens in a loop because things like "docker exec" on our dind
+	# container will create new processes, which creates a race between our
+	# moving everything to "init" and enabling subtree_control
+	while ! {
+		# move the processes from the root group to the /init group,
+		# otherwise writing subtree_control fails with EBUSY.
+		# An error during moving non-existent process (i.e., "cat") is ignored.
+		xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+		# enable controllers
+		sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+			> /sys/fs/cgroup/cgroup.subtree_control
+	}; do true; done
 fi
 
 # Change mount propagation to shared to make the environment more similar to a


### PR DESCRIPTION
When dind is run alongside with other processes, it might happen that the first xargs call fails (ignored) but then also the call to sed fails. Leading to the following error messages and dind terminating (`set -e`) :

```
echo: write error: No such process
sed: write error
```

This fixes the behavior by ignoring non 0 exit codes from sed

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Start a dind container which spawns some short living processes. Sometimes the call to sed will fail, because the process is already killed.

**- How I did it**
Create a simple Dockerfile and entrypoint:

Dockerfile
```
FROM docker:27.1.2-dind

RUN apk add --no-cache bash

COPY --chmod=755 entrypoint.sh /app/bin/entrypoint.sh
WORKDIR /app/bin
ENTRYPOINT ["/app/bin/entrypoint.sh"]
```


entrypoint.sh
```
#!/bin/bash

WAIT_MAX_RETRIES=60
DOCKER_SOCKET=/var/run/docker.sock

# fork a command
fork() { (setsid "$@" &); }

is_docker_ready() {
    [[ -S "${DOCKER_SOCKET}" ]] && [[ -r "${DOCKER_SOCKET}" ]] && docker stats --no-stream &>/dev/null
}

wait_for(){
    check_function="${1}" && shift

    # Initialize retry counter
    retry_count=0

    # Loop until check_function is ready or max retries is reached
    while ! "${check_function}"; do
        if [[ "${retry_count}" -ge "${WAIT_MAX_RETRIES}" ]]; then
            echo "${check_function} was not ready after ${WAIT_MAX_RETRIES} seconds."
            exit 1
        fi

        echo "Waiting for ${check_function}... Attempt $((retry_count+1))/${WAIT_MAX_RETRIES}"
        sleep 1
        ((retry_count++))
    done

    echo "${check_function} is ready!"
}

#
# Main
#

# Create some short living processes
fork bash -c 'while true; do ls; done &>/dev/null'

# start docker
if ! is_docker_ready; then
    (
        # dockerd-entrypoint always spawns a tini processes
        # which, if TINI_SUBREAPER is not defined, expects to
        # to be PID=1 and hence failes sometimes
        # (possibly due concurrency issues)
        # This is why we tell tini here to register as child
        # subreaper. Which will make tini reap only processes
        # belonging to its subtree and allows it to run
        # as PID!=1. Note this only works on kernel >= 3.4
        #
        # ref:
        # - https://github.com/krallin/tini
        # - https://man7.org/linux/man-pages/man2/pr_set_child_subreaper.2const.html
        export TINI_SUBREAPER=1
        fork bash -x dockerd-entrypoint.sh
    )
fi

wait_for is_docker_ready
```
**- How to verify it**
Build the container
```
docker build -t dind .
```

Run the container in a loop and wait for the error to occur
```
while docker run --privileged dind true; do true; done
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```
ignore non 0 exit codes from sed
```

**- A picture of a cute animal (not mandatory but encouraged)**

