### PR TITLE
Only masquerade access to own published ports for userland-proxy=false

### DIFF
--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -111,7 +111,6 @@ And the corresponding nat table:
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
     2        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
-    3        0     0 MASQUERADE  6    --  *      *       192.0.2.2            192.0.2.2            tcp dpt:80
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -132,7 +131,6 @@ And the corresponding nat table:
     -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
     -A POSTROUTING -s 192.0.2.0/24 ! -o bridge1 -j MASQUERADE
     -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
-    -A POSTROUTING -s 192.0.2.2/32 -d 192.0.2.2/32 -p tcp -m tcp --dport 80 -j MASQUERADE
     -A DOCKER -i bridge1 -j RETURN
     -A DOCKER -i docker0 -j RETURN
     -A DOCKER ! -i bridge1 -p tcp -m tcp --dport 8080 -j DNAT --to-destination 192.0.2.2:80

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
@@ -138,6 +138,8 @@ Differences from [running with the proxy][0] are:
     [ProgramChain][1].
   - The "SKIP DNAT" RETURN rule for packets routed to the bridge is omitted from
     the DOCKER chain [setupIPTablesInternal][2].
+  - A MASQUERADE rule is added for packets sent from the container to one of its
+    own published ports on the host.
   - A MASQUERADE rule for packets from a LOCAL source address is included in
     POSTROUTING [setupIPTablesInternal][3].
   - In the DOCKER chain's DNAT rule, there's no destination bridge [setPerPortNAT][4].

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -123,7 +123,6 @@ And the corresponding nat table:
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
     2        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
-    3        0     0 MASQUERADE  6    --  *      *       192.0.2.2            192.0.2.2            tcp dpt:80
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -144,7 +143,6 @@ And the corresponding nat table:
     -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
     -A POSTROUTING -s 192.0.2.0/24 ! -o bridge1 -j MASQUERADE
     -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
-    -A POSTROUTING -s 192.0.2.2/32 -d 192.0.2.2/32 -p tcp -m tcp --dport 80 -j MASQUERADE
     -A DOCKER -i bridge1 -j RETURN
     -A DOCKER -i docker0 -j RETURN
     -A DOCKER ! -i bridge1 -p tcp -m tcp --dport 8080 -j DNAT --to-destination 192.0.2.2:80

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-noproxy.md
@@ -36,6 +36,8 @@ Differences from [running with the proxy][0] are:
     [ProgramChain][1].
   - The "SKIP DNAT" RETURN rule for packets routed to the bridge is omitted from
     the DOCKER chain [setupIPTablesInternal][2].
+  - A MASQUERADE rule is added for packets sent from the container to one of its
+    own published ports on the host.
   - A MASQUERADE rule for packets from a LOCAL source address is included in
     POSTROUTING [setupIPTablesInternal][3].
   - In the DOCKER chain's DNAT rule, there's no destination bridge [setPerPortNAT][4].

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -821,7 +821,7 @@ func setPerPortNAT(b portBinding, ipv iptables.IPVersion, proxyPath string, brid
 		"-j", "MASQUERADE",
 	}
 	rule = iptRule{ipv: ipv, table: iptables.Nat, chain: "POSTROUTING", args: args}
-	if err := appendOrDelChainRule(rule, "MASQUERADE", enable); err != nil {
+	if err := appendOrDelChainRule(rule, "MASQUERADE", hairpinMode && enable); err != nil {
 		return err
 	}
 

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -905,7 +905,7 @@ func TestAddPortMappings(t *testing.T) {
 				masqRule := fmt.Sprintf("-s %s -d %s -p %s -m %s --dport %d -j MASQUERADE",
 					addrM, addrM, expPB.Proto, expPB.Proto, expPB.Port)
 				ir := iptRule{ipv: ipv, table: iptables.Nat, chain: "POSTROUTING", args: strings.Split(masqRule, " ")}
-				if disableNAT {
+				if disableNAT || tc.proxyPath != "" {
 					assert.Check(t, !ir.Exists(), fmt.Sprintf("unexpected rule %s", ir))
 				} else {
 					assert.Check(t, ir.Exists(), fmt.Sprintf("expected rule %s", ir))


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/12632

 When a container sends a packet to one of its own published ports on the host, it's normally picked up by the userland proxy and sent back.

When the userland proxy is disabled, a masquerade rule is needed in order for responses to the container to have the host's source address. When the proxy is enabled, the masquerade rule is not hit.

The masquerade rule matches the container's address as source and dest, and the published port as the dest. It's only used for the no-proxy case.

**- How I did it**

When the userland proxy is enabled, don't create the masquerade rule.

**- How to verify it**

Modified `TestAccessPublishedPortFromCtr` to test access to the container's own published port. With docker-proxy disabled, and the masquerade rule manually deleted, the test fails.

**- Description for the changelog**
```markdown changelog
- Do not create iptables nat-POSTROUTING masquerade rules for a container's own published ports, when the userland proxy is enabled.
```