### PR TITLE
c8d/container/inspect: Return `ImageManifestDescriptor`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,9 @@ RUN /download-frozen-image-v2.sh /build \
         busybox:glibc@sha256:1f81263701cddf6402afe9f33fca0266d9fff379e59b1748f33d3072da71ee85 \
         debian:bookworm-slim@sha256:2bc5c236e9b262645a323e9088dfa3bb1ecb16cc75811daf40a23a824d665be9 \
         hello-world:latest@sha256:d58e752213a51785838f9eed2b7a498ffa1cb3aa7f946dda11af39286c3db9a9 \
-        arm32v7/hello-world:latest@sha256:50b8560ad574c779908da71f7ce370c0a2471c098d44d1c8f6b513c5a55eeeb1
+        arm32v7/hello-world:latest@sha256:50b8560ad574c779908da71f7ce370c0a2471c098d44d1c8f6b513c5a55eeeb1 \
+        hello-world:amd64@sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042 \
+        hello-world:arm64@sha256:963612c5503f3f1674f315c67089dee577d8cc6afc18565e0b4183ae355fb343
 
 # delve
 FROM base AS delve-src

--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -33,6 +33,9 @@ func (c *containerRouter) getContainersByName(ctx context.Context, w http.Respon
 			}
 		}
 	}
+	if versions.LessThan(version, "1.48") {
+		ctr.ImageManifestDescriptor = nil
+	}
 
 	return httputils.WriteJSON(w, http.StatusOK, ctr)
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7266,6 +7266,14 @@ paths:
                 type: "string"
               Platform:
                 type: "string"
+              ImageManifestDescriptor:
+                $ref: "#/definitions/OCIDescriptor"
+                description: |
+                  OCI descriptor of the platform-specific manifest of the image
+                  the container was created from.
+
+                  Note: Only available if the daemon provides a multi-platform
+                  image store.
               MountLabel:
                 type: "string"
               ProcessLabel:

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/storage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // PruneReport contains the response for Engine API:
@@ -171,4 +172,6 @@ type InspectResponse struct {
 	Mounts          []MountPoint
 	Config          *Config
 	NetworkSettings *NetworkSettings
+	// ImageManifestDescriptor is the descriptor of a platform-specific manifest of the image used to create the container.
+	ImageManifestDescriptor *ocispec.Descriptor `json:",omitempty"`
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -151,7 +151,7 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 	if c.Config == nil {
 		c.Config = container.Config
 	}
-	newConfig, err := dockerfile.BuildFromConfig(ctx, c.Config, c.Changes, container.OS)
+	newConfig, err := dockerfile.BuildFromConfig(ctx, c.Config, c.Changes, container.ImagePlatform.OS)
 	if err != nil {
 		return "", err
 	}
@@ -166,7 +166,7 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 		ContainerConfig:     container.Config,
 		ContainerID:         container.ID,
 		ContainerMountLabel: container.MountLabel,
-		ContainerOS:         container.OS,
+		ContainerOS:         container.ImagePlatform.OS,
 		ParentImageID:       string(container.ImageID),
 	})
 	if err != nil {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -23,6 +23,7 @@ import (
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/docker/go-connections/nat"
 	"github.com/moby/sys/signal"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/pkg/errors"
 )
@@ -119,7 +120,7 @@ func (daemon *Daemon) register(ctx context.Context, c *container.Container) erro
 	return c.CheckpointTo(ctx, daemon.containersReplica)
 }
 
-func (daemon *Daemon) newContainer(name string, operatingSystem string, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {
+func (daemon *Daemon) newContainer(name string, platform ocispec.Platform, config *containertypes.Config, hostConfig *containertypes.HostConfig, imgID image.ID, managed bool) (*container.Container, error) {
 	var (
 		id  string
 		err error
@@ -153,8 +154,9 @@ func (daemon *Daemon) newContainer(name string, operatingSystem string, config *
 	base.NetworkSettings = &network.Settings{}
 	base.Name = name
 	base.Driver = daemon.imageService.StorageDriver()
-	base.OS = operatingSystem
-	return base, nil
+	base.ImagePlatform = platform
+	base.OS = platform.OS //nolint:staticcheck // ignore SA1019: field is deprecated, but still set for compatibility
+	return base, err
 }
 
 // GetByName returns a container given a name.

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -78,6 +78,14 @@ func (daemon *Daemon) load(id string) (*container.Container, error) {
 	}
 	selinux.ReserveLabel(ctr.ProcessLabel)
 
+	if ctr.ImagePlatform.Architecture == "" {
+		migration := daemonPlatformReader{
+			imageService: daemon.imageService,
+			content:      daemon.containerdClient.ContentStore(),
+		}
+		migrateContainerOS(context.TODO(), migration, ctr)
+	}
+
 	if ctr.ID != id {
 		return ctr, fmt.Errorf("Container %s is stored at %s", ctr.ID, id)
 	}

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -325,7 +325,7 @@ func (i *ImageService) CommitBuildStep(ctx context.Context, c backend.CommitConf
 		return "", fmt.Errorf("container not found: %s", c.ContainerID)
 	}
 	c.ContainerMountLabel = ctr.MountLabel
-	c.ContainerOS = ctr.OS
+	c.ContainerOS = ctr.ImagePlatform.OS
 	c.ParentImageID = string(ctr.ImageID)
 	return i.CommitImage(ctx, c)
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -3,7 +3,6 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"strings"
 	"time"
 
@@ -23,7 +22,7 @@ import (
 	"github.com/docker/docker/runconfig"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/selinux/go-selinux"
-	archvariant "github.com/tonistiigi/go-archvariant"
+	"github.com/tonistiigi/go-archvariant"
 )
 
 type createOpts struct {
@@ -130,7 +129,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		imgManifest *ocispec.Descriptor
 		imgID       image.ID
 		err         error
-		os          = runtime.GOOS
+		platform    = platforms.DefaultSpec()
 	)
 
 	if opts.params.Config.Image != "" {
@@ -148,17 +147,17 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 				return nil, err
 			}
 		}
-		os = img.OperatingSystem()
+		platform = img.Platform()
 		imgID = img.ID()
 	} else if isWindows {
-		os = "linux" // 'scratch' case.
+		platform.OS = "linux" // 'scratch' case.
 	}
 
 	// On WCOW, if are not being invoked by the builder to create this container (where
 	// ignoreImagesArgEscaped will be true) - if the image already has its arguments escaped,
 	// ensure that this is replicated across to the created container to avoid double-escaping
 	// of the arguments/command line when the runtime attempts to run the container.
-	if os == "windows" && !opts.ignoreImagesArgsEscaped && img != nil && img.RunConfig().ArgsEscaped {
+	if platform.OS == "windows" && !opts.ignoreImagesArgsEscaped && img != nil && img.RunConfig().ArgsEscaped {
 		opts.params.Config.ArgsEscaped = true
 	}
 
@@ -170,7 +169,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		return nil, errdefs.InvalidParameter(err)
 	}
 
-	if ctr, err = daemon.newContainer(opts.params.Name, os, opts.params.Config, opts.params.HostConfig, imgID, opts.managed); err != nil {
+	if ctr, err = daemon.newContainer(opts.params.Name, platform, opts.params.Config, opts.params.HostConfig, imgID, opts.managed); err != nil {
 		return nil, err
 	}
 	defer func() {

--- a/daemon/exec_windows.go
+++ b/daemon/exec_windows.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, daemonCfg *config.Config, ec *container.ExecConfig, p *specs.Process) error {
-	if ec.Container.OS == "windows" {
+	if ec.Container.ImagePlatform.OS == "windows" {
 		p.User.Username = ec.User
 	}
 	return nil

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) ContainerExport(ctx context.Context, name string, out io.W
 		return err
 	}
 
-	if isWindows && ctr.OS == "windows" {
+	if isWindows && ctr.ImagePlatform.OS == "windows" {
 		return fmt.Errorf("the daemon on this operating system does not support exporting Windows containers")
 	}
 

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -457,7 +457,7 @@ func getShell(cntr *container.Container) []string {
 	if runtime.GOOS != "windows" {
 		return []string{"/bin/sh", "-c"}
 	}
-	if cntr.OS != runtime.GOOS {
+	if cntr.ImagePlatform.OS != runtime.GOOS {
 		return []string{"/bin/sh", "-c"}
 	}
 	return []string{"cmd", "/S", "/C"}

--- a/daemon/images/image_commit.go
+++ b/daemon/images/image_commit.go
@@ -128,7 +128,7 @@ func (i *ImageService) CommitBuildStep(ctx context.Context, c backend.CommitConf
 		return "", errors.Errorf("container not found: %s", c.ContainerID)
 	}
 	c.ContainerMountLabel = ctr.MountLabel
-	c.ContainerOS = ctr.OS
+	c.ContainerOS = ctr.ImagePlatform.OS
 	c.ParentImageID = string(ctr.ImageID)
 	return i.CommitImage(ctx, c)
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -27,7 +27,7 @@ import (
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/registry"
-	metrics "github.com/docker/go-metrics"
+	"github.com/docker/go-metrics"
 	"github.com/opencontainers/selinux/go-selinux"
 )
 

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -77,11 +77,21 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 		base.SizeRootFs = &sizeRootFs
 	}
 
+	imageManifest := ctr.ImageManifest
+	if imageManifest != nil && imageManifest.Platform == nil {
+		// Copy the image manifest to avoid mutating the original
+		c := *imageManifest
+		imageManifest = &c
+
+		imageManifest.Platform = &ctr.ImagePlatform
+	}
+
 	return &containertypes.InspectResponse{
-		ContainerJSONBase: base,
-		Mounts:            mountPoints,
-		Config:            ctr.Config,
-		NetworkSettings:   networkSettings,
+		ContainerJSONBase:       base,
+		Mounts:                  mountPoints,
+		Config:                  ctr.Config,
+		NetworkSettings:         networkSettings,
+		ImageManifestDescriptor: imageManifest,
 	}, nil
 }
 

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -145,7 +145,7 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, container *contai
 		Name:         container.Name,
 		RestartCount: container.RestartCount,
 		Driver:       container.Driver,
-		Platform:     container.OS,
+		Platform:     container.ImagePlatform.OS,
 		MountLabel:   container.MountLabel,
 		ProcessLabel: container.ProcessLabel,
 		ExecIDs:      container.GetExecIDs(),

--- a/daemon/migration.go
+++ b/daemon/migration.go
@@ -1,0 +1,137 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/internal/multierror"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func migrateContainerOS(ctx context.Context,
+	migration platformReader,
+	ctr *container.Container,
+) {
+	deduced, err := deduceContainerPlatform(ctx, migration, ctr)
+	if err != nil {
+		log.G(ctx).WithFields(log.Fields{
+			"container": ctr.ID,
+			"error":     err,
+		}).Warn("failed to deduce the container architecture")
+		ctr.ImagePlatform.OS = ctr.OS //nolint:staticcheck // ignore SA1019
+		return
+	}
+
+	ctr.ImagePlatform = deduced
+}
+
+type platformReader interface {
+	ReadPlatformFromConfigByImageManifest(ctx context.Context, desc ocispec.Descriptor) (ocispec.Platform, error)
+	ReadPlatformFromImage(ctx context.Context, id image.ID) (ocispec.Platform, error)
+}
+
+// deduceContainerPlatform tries to deduce `ctr`'s platform.
+// If both `ctr.OS` and `ctr.ImageManifest` are empty, assume the image comes
+// from a pre-OS times and use the host platform to match the behavior of
+// [container.FromDisk].
+// Otherwise:
+// - `ctr.ImageManifest.Platform` is used, if it exists and is not empty.
+// - The platform from the manifest's config is used, if `ctr.ImageManifest` exists
+// and we're able to load its config from the content store.
+// - The platform found by loading the image from the image service by ID (using
+// `ctr.ImageID`) is used – this looks for the best *present* matching manifest in
+// the store.
+func deduceContainerPlatform(
+	ctx context.Context,
+	migration platformReader,
+	ctr *container.Container,
+) (ocispec.Platform, error) {
+	if ctr.OS == "" && ctr.ImageManifest == nil { //nolint:staticcheck // ignore SA1019 because we are testing deprecated field migration
+		return platforms.DefaultSpec(), nil
+	}
+
+	var errs []error
+	isValidPlatform := func(p ocispec.Platform) bool {
+		return p.OS != "" && p.Architecture != ""
+	}
+
+	if ctr.ImageManifest != nil {
+		if ctr.ImageManifest.Platform != nil {
+			return *ctr.ImageManifest.Platform, nil
+		}
+
+		if ctr.ImageManifest != nil {
+			p, err := migration.ReadPlatformFromConfigByImageManifest(ctx, *ctr.ImageManifest)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				if isValidPlatform(p) {
+					return p, nil
+				}
+				errs = append(errs, errors.New("malformed image config obtained by ImageManifestDescriptor"))
+			}
+		}
+	}
+
+	if ctr.ImageID != "" {
+		p, err := migration.ReadPlatformFromImage(ctx, ctr.ImageID)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			if isValidPlatform(p) {
+				return p, nil
+			}
+			errs = append(errs, errors.New("malformed image config obtained by image id"))
+		}
+	}
+
+	return ocispec.Platform{}, errors.Wrap(multierror.Join(errs...), "cannot deduce the container platform")
+}
+
+type daemonPlatformReader struct {
+	imageService ImageService
+	content      content.Provider
+}
+
+func (r daemonPlatformReader) ReadPlatformFromConfigByImageManifest(
+	ctx context.Context,
+	desc ocispec.Descriptor,
+) (ocispec.Platform, error) {
+	b, err := content.ReadBlob(ctx, r.content, desc)
+	if err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	var mfst ocispec.Manifest
+	if err := json.Unmarshal(b, &mfst); err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	b, err = content.ReadBlob(ctx, r.content, mfst.Config)
+	if err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	var plat ocispec.Platform
+	if err := json.Unmarshal(b, &plat); err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	return plat, nil
+}
+
+func (r daemonPlatformReader) ReadPlatformFromImage(ctx context.Context, id image.ID) (ocispec.Platform, error) {
+	img, err := r.imageService.GetImage(ctx, id.String(), backend.GetImageOpts{})
+	if err != nil {
+		return ocispec.Platform{}, err
+	}
+
+	return img.Platform(), nil
+}

--- a/daemon/migration_test.go
+++ b/daemon/migration_test.go
@@ -1,0 +1,173 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/containerd/platforms"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+)
+
+type mockPlatformReader struct{}
+
+func (m mockPlatformReader) ReadPlatformFromImage(ctx context.Context, id image.ID) (ocispec.Platform, error) {
+	switch id {
+	case "multiplatform":
+		// This image has multiple platforms, but GetImage will prefer the first one
+		// because the ID points to the full image index, not a specific platform.
+		return platforms.DefaultSpec(), nil
+	case "linux/arm64/v8":
+		return ocispec.Platform{
+			OS:           "linux",
+			Architecture: "arm64",
+			Variant:      "v8",
+		}, nil
+	case "linux/amd64":
+		return ocispec.Platform{
+			OS:           "linux",
+			Architecture: "amd64",
+		}, nil
+	case "windows/amd64":
+		return ocispec.Platform{
+			OS:           "windows",
+			Architecture: "amd64",
+		}, nil
+	default:
+		return ocispec.Platform{}, errors.New("image not found")
+	}
+}
+
+func (m mockPlatformReader) ReadPlatformFromConfigByImageManifest(ctx context.Context, desc ocispec.Descriptor) (ocispec.Platform, error) {
+	return m.ReadPlatformFromImage(ctx, image.ID(desc.Digest))
+}
+
+//nolint:staticcheck // ignore SA1019 because we are testing deprecated field migration
+func TestContainerMigrateOS(t *testing.T) {
+	type Container = container.Container
+
+	var mock mockPlatformReader
+
+	// ImageManifest is nil for containers created with graphdrivers image store
+	var graphdrivers *ocispec.Descriptor = nil
+
+	for _, tc := range []struct {
+		name     string
+		ctr      Container
+		expected ocispec.Platform
+	}{
+		{
+			name: "gd pre-OS container",
+			ctr: Container{
+				ImageManifest: graphdrivers,
+				OS:            "",
+			},
+			expected: platforms.DefaultSpec(),
+		},
+		{
+			name: "gd with linux arm64 image",
+			ctr: Container{
+				ImageManifest: graphdrivers,
+				ImageID:       "linux/arm64/v8",
+				OS:            "linux",
+			},
+			expected: ocispec.Platform{
+				OS:           "linux",
+				Architecture: "arm64",
+				Variant:      "v8",
+			},
+		},
+		{
+			name: "gd with windows image",
+			ctr: Container{
+				ImageManifest: graphdrivers,
+				ImageID:       "windows/amd64",
+				OS:            "windows",
+			},
+			expected: ocispec.Platform{
+				OS:           "windows",
+				Architecture: "amd64",
+			},
+		},
+		{
+			name: "gd with an image thats no longer available",
+			ctr: Container{
+				ImageManifest: graphdrivers,
+				ImageID:       "notfound",
+				OS:            "linux",
+			},
+			expected: platforms.Platform{
+				OS: "linux",
+			},
+		},
+		{
+			name: "c8d with linux arm64 image",
+			ctr: Container{
+				ImageManifest: &ocispec.Descriptor{
+					Digest: "linux/arm64/v8",
+				},
+				OS:      "linux",
+				ImageID: "linux/arm64/v8",
+			},
+			expected: ocispec.Platform{
+				OS:           "linux",
+				Architecture: "arm64",
+				Variant:      "v8",
+			},
+		},
+		{
+			name: "c8d with an image thats no longer available",
+			ctr: Container{
+				ImageManifest: &ocispec.Descriptor{
+					Digest: "notfound",
+				},
+				OS:      "linux",
+				ImageID: "notfound",
+			},
+			expected: platforms.Platform{
+				OS: "linux",
+			},
+		},
+		{
+			name: "c8d with ImageManifest that is no longer available",
+			ctr: Container{
+				ImageManifest: &ocispec.Descriptor{
+					Digest: "notfound",
+				},
+				OS:      "linux",
+				ImageID: "multiplatform",
+			},
+			// Note: This might produce unexpected results, because if the platform-specific manifest
+			// is not available, and the ImageID points to a multi-platform image, then GetImage will
+			// return any available platform with host platform being the priority.
+			// So it will just use whatever platform is returned by GetImage (docker image inspect).
+			expected: platforms.DefaultSpec(),
+		},
+		{
+			name: "ImageManifest has priority over ImageID migration",
+			ctr: Container{
+				ImageManifest: &ocispec.Descriptor{
+					Digest: "linux/arm64/v8",
+				},
+				OS:      "linux",
+				ImageID: "linux/amd64",
+			},
+			expected: ocispec.Platform{
+				OS:           "linux",
+				Architecture: "arm64",
+				Variant:      "v8",
+			},
+		},
+	} {
+		ctr := tc.ctr
+		t.Run(tc.name, func(t *testing.T) {
+			migrateContainerOS(context.Background(), mock, &ctr)
+
+			assert.DeepEqual(t, tc.expected, ctr.ImagePlatform)
+		})
+	}
+
+}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -40,6 +40,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   image store.
   WARNING: This is experimental and may change at any time without any backward
   compatibility.
+* `GET /containers/{name}/json` now returns an `ImageManifestDescriptor` field
+  containing the OCI descriptor of the platform-specific image manifest of the
+  image that was used to create the container.
+  This field is only populated if the daemon provides a multi-platform image
+  store.
 * `POST /networks/create` now has an `EnableIPv4` field. Setting it to `false`
   disables IPv4 IPAM for the network. It can only be set to `false` if the
   daemon has experimental features enabled.

--- a/integration/container/inspect_test.go
+++ b/integration/container/inspect_test.go
@@ -5,11 +5,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/platforms"
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 )
 
 func TestInspectAnnotations(t *testing.T) {
@@ -61,6 +64,81 @@ func TestNetworkAliasesAreEmpty(t *testing.T) {
 			netAliases := inspect.NetworkSettings.Networks[nwMode].Aliases
 
 			assert.Check(t, is.Nil(netAliases))
+		})
+	}
+}
+
+func TestInspectImageManifestPlatform(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, !testEnv.UsingSnapshotter())
+
+	tests := []struct {
+		name             string
+		image            string
+		skipIf           func() bool
+		expectedPlatform platforms.Platform
+	}{
+		{
+			name:  "amd64 only on any host",
+			image: "busybox:latest",
+			expectedPlatform: platforms.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+				Variant:      "",
+			},
+		},
+		{
+			skipIf: func() bool { return runtime.GOARCH != "amd64" },
+			name:   "amd64 image on non-amd64 host",
+
+			image: "hello-world:amd64",
+			expectedPlatform: platforms.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			},
+		},
+		{
+			name:   "arm64 image on non-arm64 host",
+			skipIf: func() bool { return runtime.GOARCH != "arm64" },
+			image:  "hello-world:arm64",
+
+			expectedPlatform: platforms.Platform{
+				OS:           "linux",
+				Architecture: "arm64",
+				Variant:      "",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		if tc.skipIf != nil && tc.skipIf() {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := setupTest(t)
+			apiClient := request.NewAPIClient(t)
+
+			ctr := container.Create(ctx, t, apiClient, container.WithImage(tc.image))
+			defer apiClient.ContainerRemove(ctx, ctr, containertypes.RemoveOptions{Force: true})
+
+			img, _, err := apiClient.ImageInspectWithRaw(ctx, tc.image)
+			assert.NilError(t, err)
+
+			hostPlatform := platforms.Platform{
+				OS:           img.Os,
+				Architecture: img.Architecture,
+				Variant:      img.Variant,
+			}
+			inspect := container.Inspect(ctx, t, apiClient, ctr)
+			assert.Assert(t, inspect.ImageManifestDescriptor != nil)
+			assert.Check(t, is.DeepEqual(*inspect.ImageManifestDescriptor.Platform, hostPlatform))
+
+			t.Run("pre 1.48", func(t *testing.T) {
+				oldClient := request.NewAPIClient(t, client.WithVersion("1.47"))
+				inspect := container.Inspect(ctx, t, oldClient, ctr)
+				assert.Check(t, is.Nil(inspect.ImageManifestDescriptor))
+			})
 		})
 	}
 }

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -15,7 +15,14 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-var frozenImages = []string{"busybox:latest", "busybox:glibc", "hello-world:frozen", "debian:bookworm-slim"}
+var frozenImages = []string{
+	"busybox:latest",
+	"busybox:glibc",
+	"hello-world:frozen",
+	"debian:bookworm-slim",
+	"hello-world:amd64",
+	"hello-world:arm64",
+}
 
 type protectedElements struct {
 	containers map[string]struct{}


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/48841

**- What I did**
- Changed the on-disk representation of the container to store the full OCI platform and not just operating system
- Expose the `ImageManifestDescriptor` when the containerd image store is enabled 

**- How I did it**

**- How to verify it**
TestInspectImageManifestPlatform

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: `GET /containers/{name}/json` now returns an `ImageManifestDescriptor` field containing the OCI descriptor of the platform-specific image manifest of the image that was used to create the container.
```

**- A picture of a cute animal (not mandatory but encouraged)**

