### PR TITLE
update go:build tags to use go1.22, and enable copyloopvar linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,19 @@
 linters:
   enable:
     - depguard
-    - dupword         # Checks for duplicate words in the source code.
+    - dupword       # Detects duplicate words.
     - goimports
-    - gosec
+    - gosec         # Detects security problems.
     - gosimple
     - govet
     - forbidigo
     - importas
     - ineffassign
-    - misspell
-    - revive
+    - misspell      # Detects commonly misspelled English words in comments.
+    - revive        # Metalinter; drop-in replacement for golint.
     - staticcheck
     - typecheck
-    - unconvert
+    - unconvert     # Detects unnecessary type conversions.
     - unused
 
   disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - copyloopvar   # Detects places where loop variables are copied.
     - depguard
     - dupword       # Detects duplicate words.
     - goimports

--- a/api/server/httputils/form_test.go
+++ b/api/server/httputils/form_test.go
@@ -149,7 +149,6 @@ func TestUint32Value(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.value, func(t *testing.T) {
 			r, _ := http.NewRequest(http.MethodPost, "", nil)
 			r.Form = url.Values{}

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -56,7 +56,6 @@ func TestNewVersionMiddlewareValidation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			_, err := NewVersionMiddleware("1.2.3", tc.defaultVersion, tc.minVersion)
 			if tc.expectedErr == "" {

--- a/api/server/router/grpc/grpc.go
+++ b/api/server/router/grpc/grpc.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package grpc // import "github.com/docker/docker/api/server/router/grpc"
 

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package system // import "github.com/docker/docker/api/server/router/system"
 

--- a/api/types/container/hostconfig_test.go
+++ b/api/types/container/hostconfig_test.go
@@ -91,7 +91,6 @@ func TestValidateRestartPolicy(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateRestartPolicy(tc.input)
 			if tc.expectedErr == "" {

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -540,7 +540,6 @@ func TestGetBoolOrDefault(t *testing.T) {
 			expectedValue: false,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewArgs()
 

--- a/api/types/network/endpoint_test.go
+++ b/api/types/network/endpoint_test.go
@@ -23,7 +23,7 @@ func (stub subnetStub) Contains(addr net.IP) bool {
 }
 
 func TestEndpointIPAMConfigWithOutOfRangeAddrs(t *testing.T) {
-	testcases := []struct {
+	tests := []struct {
 		name           string
 		ipamConfig     *EndpointIPAMConfig
 		v4Subnets      []NetworkSubnet
@@ -80,8 +80,7 @@ func TestEndpointIPAMConfigWithOutOfRangeAddrs(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -105,7 +104,7 @@ func TestEndpointIPAMConfigWithOutOfRangeAddrs(t *testing.T) {
 }
 
 func TestEndpointIPAMConfigWithInvalidConfig(t *testing.T) {
-	testcases := []struct {
+	tests := []struct {
 		name           string
 		ipamConfig     *EndpointIPAMConfig
 		expectedErrors []string
@@ -162,8 +161,7 @@ func TestEndpointIPAMConfigWithInvalidConfig(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/api/types/network/ipam_test.go
+++ b/api/types/network/ipam_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNetworkWithInvalidIPAM(t *testing.T) {
-	testcases := []struct {
+	tests := []struct {
 		name           string
 		ipam           IPAM
 		ipv6           bool
@@ -123,8 +123,7 @@ func TestNetworkWithInvalidIPAM(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package containerimage
 

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -113,7 +113,6 @@ func TestParseRemoteURL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			repo, err := parseRemoteURL(tc.url)
 			assert.NilError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -88,7 +88,6 @@ func TestNewClientWithOpsFromEnv(t *testing.T) {
 
 	env.PatchAll(t, nil)
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			env.PatchAll(t, tc.envs)
 			client, err := NewClientWithOpts(FromEnv)
@@ -323,7 +322,6 @@ func TestNegotiateAPIVersion(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			opts := make([]Opt, 0)
 			if tc.clientVersion != "" {
@@ -478,7 +476,6 @@ func TestClientRedirect(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.httpMethod, func(t *testing.T) {
 			req, err := http.NewRequest(tc.httpMethod, "/redirectme", nil)
 			assert.Check(t, err)

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -180,7 +180,6 @@ func TestImageListWithSharedSize(t *testing.T) {
 		{name: "set after 1.42, if requested", version: "1.42", options: image.ListOptions{SharedSize: true}, sharedSize: "1"},
 		{name: "unset before 1.42, even if requested", version: "1.41", options: image.ListOptions{SharedSize: true}},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			var query url.Values

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -160,7 +160,6 @@ func TestImagePushWithoutErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s,all-tags=%t", tc.reference, tc.all), func(t *testing.T) {
 			client := &Client{
 				client: newMockClient(func(req *http.Request) (*http.Response, error) {

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -47,7 +47,6 @@ func TestImageTagInvalidSourceImageName(t *testing.T) {
 
 	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "aa/asdf$$^/aa"}
 	for _, repo := range invalidRepos {
-		repo := repo
 		t.Run("invalidRepo/"+repo, func(t *testing.T) {
 			t.Parallel()
 			err := client.ImageTag(ctx, "busybox", repo)
@@ -58,7 +57,6 @@ func TestImageTagInvalidSourceImageName(t *testing.T) {
 	longTag := testutil.GenerateRandomAlphaOnlyString(121)
 	invalidTags := []string{"repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3", "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..", longTag}
 	for _, repotag := range invalidTags {
-		repotag := repotag
 		t.Run("invalidTag/"+repotag, func(t *testing.T) {
 			t.Parallel()
 			err := client.ImageTag(ctx, "busybox", repotag)

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -111,7 +111,6 @@ func TestPingHeadFallback(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(http.StatusText(tc.status), func(t *testing.T) {
 			var reqs []string
 			client := &Client{

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -50,7 +50,6 @@ func TestSetHostHeader(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.host, func(t *testing.T) {
 			hostURL, err := ParseHostURL(tc.host)
 			assert.Check(t, err)

--- a/container/view.go
+++ b/container/view.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package container // import "github.com/docker/docker/container"
 

--- a/daemon/cluster/convert/service_test.go
+++ b/daemon/cluster/convert/service_test.go
@@ -236,7 +236,7 @@ func TestServiceConvertFromGRPCIsolation(t *testing.T) {
 }
 
 func TestServiceConvertToGRPCCredentialSpec(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name        string
 		from        swarmtypes.CredentialSpec
 		to          swarmapi.Privileges_CredentialSpec
@@ -308,22 +308,21 @@ func TestServiceConvertToGRPCCredentialSpec(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			s := swarmtypes.ServiceSpec{
 				TaskTemplate: swarmtypes.TaskSpec{
 					ContainerSpec: &swarmtypes.ContainerSpec{
 						Privileges: &swarmtypes.Privileges{
-							CredentialSpec: &c.from,
+							CredentialSpec: &tc.from,
 						},
 					},
 				},
 			}
 
 			res, err := ServiceSpecToGRPC(s)
-			if c.expectedErr != "" {
-				assert.Error(t, err, c.expectedErr)
+			if tc.expectedErr != "" {
+				assert.Error(t, err, tc.expectedErr)
 				return
 			}
 
@@ -332,13 +331,13 @@ func TestServiceConvertToGRPCCredentialSpec(t *testing.T) {
 			if !ok {
 				t.Fatal("expected type swarmapi.TaskSpec_Container")
 			}
-			assert.DeepEqual(t, c.to, *v.Container.Privileges.CredentialSpec)
+			assert.DeepEqual(t, tc.to, *v.Container.Privileges.CredentialSpec)
 		})
 	}
 }
 
 func TestServiceConvertFromGRPCCredentialSpec(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name string
 		from swarmapi.Privileges_CredentialSpec
 		to   *swarmtypes.CredentialSpec
@@ -371,9 +370,7 @@ func TestServiceConvertFromGRPCCredentialSpec(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		tc := tc
-
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gs := swarmapi.Service{
 				Spec: swarmapi.ServiceSpec{

--- a/daemon/cluster/convert/volume_test.go
+++ b/daemon/cluster/convert/volume_test.go
@@ -61,7 +61,6 @@ func TestVolumeAvailabilityFromGRPC(t *testing.T) {
 			expected: volumetypes.AvailabilityDrain,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			actual := volumeAvailabilityFromGRPC(tc.in)
 			assert.Equal(t, actual, tc.expected)
@@ -113,7 +112,6 @@ func TestAccessModeFromGRPC(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			out := accessModeFromGRPC(tc.in)
 			assert.DeepEqual(t, tc.expected, out)

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -446,7 +446,6 @@ func (c *containerAdapter) remove(ctx context.Context) error {
 func (c *containerAdapter) createVolumes(ctx context.Context) error {
 	// Create plugin volumes that are embedded inside a Mount
 	for _, mount := range c.container.task.Spec.GetContainer().Mounts {
-		mount := mount
 		if mount.Type != api.MountTypeVolume {
 			continue
 		}

--- a/daemon/cluster/executor/container/container_test.go
+++ b/daemon/cluster/executor/container/container_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIsolationConversion(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name string
 		from swarmapi.ContainerSpec_Isolation
 		to   container.Isolation
@@ -20,14 +20,14 @@ func TestIsolationConversion(t *testing.T) {
 		{name: "process", from: swarmapi.ContainerIsolationProcess, to: container.IsolationProcess},
 		{name: "hyperv", from: swarmapi.ContainerIsolationHyperV, to: container.IsolationHyperV},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			task := swarmapi.Task{
 				Spec: swarmapi.TaskSpec{
 					Runtime: &swarmapi.TaskSpec_Container{
 						Container: &swarmapi.ContainerSpec{
 							Image:     "alpine:latest",
-							Isolation: c.from,
+							Isolation: tc.from,
 						},
 					},
 				},
@@ -36,7 +36,7 @@ func TestIsolationConversion(t *testing.T) {
 			// NOTE(dperny): you shouldn't ever pass nil outside of testing,
 			// because if there are CSI volumes, the code will panic. However,
 			// in testing. this is acceptable.
-			assert.Equal(t, c.to, config.hostConfig(nil).Isolation)
+			assert.Equal(t, tc.to, config.hostConfig(nil).Isolation)
 		})
 	}
 }
@@ -87,7 +87,7 @@ func TestContainerLabels(t *testing.T) {
 }
 
 func TestCredentialSpecConversion(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name string
 		from swarmapi.Privileges_CredentialSpec
 		to   []string
@@ -120,15 +120,14 @@ func TestCredentialSpecConversion(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			task := swarmapi.Task{
 				Spec: swarmapi.TaskSpec{
 					Runtime: &swarmapi.TaskSpec_Container{
 						Container: &swarmapi.ContainerSpec{
 							Privileges: &swarmapi.Privileges{
-								CredentialSpec: &c.from,
+								CredentialSpec: &tc.from,
 							},
 						},
 					},
@@ -138,13 +137,13 @@ func TestCredentialSpecConversion(t *testing.T) {
 			// NOTE(dperny): you shouldn't ever pass nil outside of testing,
 			// because if there are CSI volumes, the code will panic. However,
 			// in testing. this is acceptable.
-			assert.DeepEqual(t, c.to, config.hostConfig(nil).SecurityOpt)
+			assert.DeepEqual(t, tc.to, config.hostConfig(nil).SecurityOpt)
 		})
 	}
 }
 
 func TestTmpfsConversion(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name string
 		from []swarmapi.Mount
 		to   []mount.Mount
@@ -197,20 +196,20 @@ func TestTmpfsConversion(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			task := swarmapi.Task{
 				Spec: swarmapi.TaskSpec{
 					Runtime: &swarmapi.TaskSpec_Container{
 						Container: &swarmapi.ContainerSpec{
 							Image:  "alpine:latest",
-							Mounts: c.from,
+							Mounts: tc.from,
 						},
 					},
 				},
 			}
 			config := containerConfig{task: &task}
-			assert.Check(t, is.DeepEqual(c.to, config.hostConfig(nil).Mounts))
+			assert.Check(t, is.DeepEqual(tc.to, config.hostConfig(nil).Mounts))
 		})
 	}
 }

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -164,8 +164,6 @@ func TestDaemonConfigurationFeatures(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := New()
 			assert.NilError(t, err)

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -547,7 +547,6 @@ func TestValidateMinAPIVersion(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			err := ValidateMinAPIVersion(tc.input)
 			if tc.expectedErr != "" {
@@ -578,7 +577,6 @@ func TestConfigInvalidDNS(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			var cfg Config
 			err := json.Unmarshal([]byte(tc.input), &cfg)

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/containerd/image_delete_test.go
+++ b/daemon/containerd/image_delete_test.go
@@ -219,7 +219,6 @@ func TestImageDelete(t *testing.T) {
 			err: dimages.ErrImageDoesNotExist{Ref: nameDigest("repoanddigestzerocase", digestFor(16))},
 		},
 	} {
-		tc := tc
 		t.Run(tc.ref, func(t *testing.T) {
 			t.Parallel()
 			ctx := logtest.WithT(ctx, t)

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -159,7 +159,6 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 	}
 
 	for _, img := range uniqueImages {
-		img := img
 		eg.Go(func() error {
 			image, allChainsIDs, err := i.imageSummary(egCtx, img, platformMatcher, opts, tagsByDigest)
 			if err != nil {

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -86,7 +86,6 @@ func BenchmarkImageList(b *testing.B) {
 	}
 
 	for _, count := range []int{10, 100, 1000} {
-		count := count
 		csDir := b.TempDir()
 
 		ctx := namespaces.WithNamespace(context.TODO(), "testing-"+strconv.Itoa(count))
@@ -96,16 +95,16 @@ func BenchmarkImageList(b *testing.B) {
 			overhead: 500 * time.Microsecond,
 		}
 
-		is := fakeImageService(b, ctx, cs)
+		imgSvc := fakeImageService(b, ctx, cs)
 
 		// Every generated image has a 10% chance to spawn up to 5 containers
 		const containerChance = 10
 		const maxContainerCount = 5
-		populateStore(ctx, is, csDir, count, containerChance, maxContainerCount)
+		populateStore(ctx, imgSvc, csDir, count, containerChance, maxContainerCount)
 
 		b.Run(strconv.Itoa(count)+"-images", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := is.Images(ctx, imagetypes.ListOptions{All: true})
+				_, err := imgSvc.Images(ctx, imagetypes.ListOptions{All: true})
 				assert.NilError(b, err)
 			}
 		})
@@ -303,7 +302,6 @@ func TestImageList(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := logtest.WithT(ctx, t)
 			service := fakeImageService(t, ctx, cs)

--- a/daemon/containerd/image_push_test.go
+++ b/daemon/containerd/image_push_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package containerd
 

--- a/daemon/containerd/image_test.go
+++ b/daemon/containerd/image_test.go
@@ -142,7 +142,6 @@ func TestLookup(t *testing.T) {
 			all:    []images.Image{shortNameIsHashAlgorithm},
 		},
 	} {
-		tc := tc
 		t.Run(tc.lookup, func(t *testing.T) {
 			t.Parallel()
 			img, all, err := service.resolveAllReferences(ctx, tc.lookup)

--- a/daemon/containerd/platform_matchers_test.go
+++ b/daemon/containerd/platform_matchers_test.go
@@ -128,10 +128,7 @@ func testOnlyAndOnlyStrict(t *testing.T, daemonPlatform platforms.MatchComparer,
 		indexTc := indexTc
 		idx := indexTc.index
 		for _, tc := range indexTc.tc {
-			tc := tc
-
 			for _, strict := range []bool{false, true} {
-				strict := strict
 				s := "non-strict"
 				if strict {
 					s = "strict"
@@ -156,7 +153,6 @@ func testOnlyAndOnlyStrict(t *testing.T, daemonPlatform platforms.MatchComparer,
 
 					var first *ocispec.Platform
 					for _, p := range idx {
-						p := p
 						if !pm.Match(p) {
 							continue
 						}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 // Package daemon exposes the functions that occur on the host server
 // that the Docker daemon is running.

--- a/daemon/daemon_unix_test.go
+++ b/daemon/daemon_unix_test.go
@@ -274,7 +274,6 @@ func TestVerifyPlatformContainerResources(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			warnings, err := verifyPlatformContainerResources(&tc.resources, &tc.sysInfo, tc.update)

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -68,7 +68,6 @@ func TestContainerDelete(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			c := tc.initContainer()
 			d, cleanup := newDaemonWithTmpRoot(t)

--- a/daemon/exec_linux_test.go
+++ b/daemon/exec_linux_test.go
@@ -62,7 +62,6 @@ func TestExecSetPlatformOptAppArmor(t *testing.T) {
 	// both give the same result.
 	for _, execPrivileged := range []bool{false, true} {
 		for _, tc := range tests {
-			tc := tc
 			doc := tc.doc
 			if !appArmorEnabled {
 				// no profile should be set if the host does not support AppArmor

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/info_unix_test.go
+++ b/daemon/info_unix_test.go
@@ -50,17 +50,16 @@ func TestParseInitVersion(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		test := test
-		t.Run(test.output, func(t *testing.T) {
-			version, commit, err := parseInitVersion(test.output)
-			if test.invalid {
+	for _, tc := range tests {
+		t.Run(tc.output, func(t *testing.T) {
+			version, commit, err := parseInitVersion(tc.output)
+			if tc.invalid {
 				assert.Check(t, is.ErrorContains(err, ""))
 			} else {
 				assert.Check(t, err)
 			}
-			assert.Equal(t, test.version, version)
-			assert.Equal(t, test.commit, commit)
+			assert.Equal(t, tc.version, version)
+			assert.Equal(t, tc.commit, commit)
 		})
 	}
 }
@@ -117,15 +116,15 @@ spec: 1.0.0
 		},
 	}
 
-	for _, test := range tests {
-		runtime, version, commit, err := parseRuntimeVersion(test.output)
-		if test.invalid {
+	for _, tc := range tests {
+		runtime, version, commit, err := parseRuntimeVersion(tc.output)
+		if tc.invalid {
 			assert.Check(t, is.ErrorContains(err, ""))
 		} else {
 			assert.Check(t, err)
 		}
-		assert.Equal(t, test.runtime, runtime)
-		assert.Equal(t, test.version, version)
-		assert.Equal(t, test.commit, commit)
+		assert.Equal(t, tc.runtime, runtime)
+		assert.Equal(t, tc.version, version)
+		assert.Equal(t, tc.commit, commit)
 	}
 }

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/logger/fluentd/fluentd_test.go
+++ b/daemon/logger/fluentd/fluentd_test.go
@@ -169,7 +169,6 @@ func TestValidateLogOptAddress(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		if len(tc.ports) == 0 {
 			tc.ports = map[string]int{"": tc.expected.port}
 		}

--- a/daemon/logger/loggertest/logreader.go
+++ b/daemon/logger/loggertest/logreader.go
@@ -169,7 +169,7 @@ func (tr Reader) testTailEmptyLogs(t *testing.T, live bool) {
 	}
 	defer func() { assert.NilError(t, l.Close()) }()
 
-	for _, tt := range []struct {
+	for _, tc := range []struct {
 		name string
 		cfg  logger.ReadConfig
 	}{
@@ -180,8 +180,7 @@ func (tr Reader) testTailEmptyLogs(t *testing.T, live bool) {
 		{name: "Until", cfg: logger.ReadConfig{Until: time.Date(2100, time.January, 1, 1, 1, 1, 0, time.UTC)}},
 		{name: "SinceAndUntil", cfg: logger.ReadConfig{Since: time.Unix(1, 0), Until: time.Date(2100, time.January, 1, 1, 1, 1, 0, time.UTC)}},
 	} {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			lw := l.(logger.LogReader).ReadLogs(context.TODO(), logger.ReadConfig{})
 			defer lw.ConsumerGone()
@@ -198,7 +197,6 @@ func (tr Reader) TestFollow(t *testing.T) {
 	// Reader sends all logs and closes after logger is closed
 	// - Starting from empty log (like run)
 	for i, tail := range []int{-1, 0, 1, 42} {
-		i, tail := i, tail
 		t.Run(fmt.Sprintf("FromEmptyLog/Tail=%d", tail), func(t *testing.T) {
 			t.Parallel()
 			l := tr.Factory(t, logger.Info{

--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -806,7 +806,6 @@ func tailFiles(ctx context.Context, files []fileOpener, watcher *logger.LogWatch
 	}()
 
 	for _, ra := range readers {
-		ra := ra
 		select {
 		case <-watcher.WatchConsumerGone():
 			return false

--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loggerutils // import "github.com/docker/docker/daemon/logger/loggerutils"
 

--- a/daemon/logger/loggerutils/sharedtemp_test.go
+++ b/daemon/logger/loggerutils/sharedtemp_test.go
@@ -114,7 +114,6 @@ func TestSharedTempFileConverter(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(3)
 		for i := 0; i < 3; i++ {
-			i := i
 			go func() {
 				defer wg.Done()
 				t.Logf("goroutine %v: enter", i)
@@ -176,7 +175,6 @@ func TestSharedTempFileConverter(t *testing.T) {
 		var done sync.WaitGroup
 		done.Add(3)
 		for i := 0; i < 3; i++ {
-			i := i
 			go func() {
 				defer done.Done()
 				t.Logf("goroutine %v: enter", i)

--- a/daemon/logger/syslog/syslog_test.go
+++ b/daemon/logger/syslog/syslog_test.go
@@ -110,7 +110,6 @@ func TestValidateSyslogAddress(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		if tc.skipOn == runtime.GOOS {
 			continue
 		}

--- a/daemon/runtime_unix_test.go
+++ b/daemon/runtime_unix_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestSetupRuntimes(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		name      string
 		config    *config.Config
 		expectErr string
@@ -169,8 +169,7 @@ func TestSetupRuntimes(t *testing.T) {
 			},
 		},
 	}
-	for _, tc := range cases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := config.New()
 			assert.NilError(t, err)
@@ -251,7 +250,7 @@ func TestGetRuntime(t *testing.T) {
 		Opts: configdOpts,
 	}
 
-	for _, tt := range []struct {
+	for _, tc := range []struct {
 		name, runtime string
 		want          *shimConfig
 	}{
@@ -330,13 +329,12 @@ func TestGetRuntime(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			shim, opts, err := runtimes.Get(tt.runtime)
-			if tt.want != nil {
+		t.Run(tc.name, func(t *testing.T) {
+			shim, opts, err := runtimes.Get(tc.runtime)
+			if tc.want != nil {
 				assert.Check(t, err)
 				got := &shimConfig{Shim: shim, Opts: opts}
-				assert.Check(t, is.DeepEqual(got, tt.want,
+				assert.Check(t, is.DeepEqual(got, tc.want,
 					cmpopts.IgnoreUnexported(runtimeoptions_v1.Options{}),
 					cmpopts.IgnoreUnexported(v2runcoptions.Options{}),
 				))

--- a/daemon/seccomp_linux_test.go
+++ b/daemon/seccomp_linux_test.go
@@ -24,7 +24,7 @@ func TestWithSeccomp(t *testing.T) {
 		comment string
 	}
 
-	for _, x := range []expected{
+	for _, tc := range []expected{
 		{
 			comment: "unconfined seccompProfile runs unconfined",
 			daemon: &Daemon{
@@ -191,14 +191,13 @@ func TestWithSeccomp(t *testing.T) {
 			}(),
 		},
 	} {
-		x := x
-		t.Run(x.comment, func(t *testing.T) {
-			opts := WithSeccomp(x.daemon, x.c)
-			err := opts(nil, nil, nil, &x.inSpec)
+		t.Run(tc.comment, func(t *testing.T) {
+			opts := WithSeccomp(tc.daemon, tc.c)
+			err := opts(nil, nil, nil, &tc.inSpec)
 
-			assert.DeepEqual(t, x.inSpec, x.outSpec)
-			if x.err != "" {
-				assert.Error(t, err, x.err)
+			assert.DeepEqual(t, tc.inSpec, tc.outSpec)
+			if tc.err != "" {
+				assert.Error(t, err, tc.err)
 			} else {
 				assert.NilError(t, err)
 			}

--- a/daemon/top_unix_test.go
+++ b/daemon/top_unix_test.go
@@ -85,7 +85,6 @@ func TestContainerTopParsePSOutput(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(string(tc.output), func(t *testing.T) {
 			_, err := parsePSOutput(tc.output, tc.pids)
 			if tc.errExpected && err == nil {

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -286,9 +286,8 @@ func TestPullSchema2Config(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			var callCount atomic.Uint64
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				t.Logf("HTTP %s %s", r.Method, r.URL.Path)
@@ -297,7 +296,7 @@ func TestPullSchema2Config(t *testing.T) {
 				case r.Method == "GET" && r.URL.Path == "/v2":
 					w.WriteHeader(http.StatusOK)
 				case r.Method == "GET" && r.URL.Path == "/v2/docker.io/library/testremotename/blobs/"+expectedDigest.String():
-					tt.handler(int(callCount.Add(1)), w)
+					tc.handler(int(callCount.Add(1)), w)
 				default:
 					w.WriteHeader(http.StatusNotFound)
 				}
@@ -307,7 +306,7 @@ func TestPullSchema2Config(t *testing.T) {
 			p := testNewPuller(t, ts.URL)
 
 			config, err := p.pullSchema2Config(ctx, expectedDigest)
-			if tt.expectError == "" {
+			if tc.expectError == "" {
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -318,15 +317,15 @@ func TestPullSchema2Config(t *testing.T) {
 				}
 			} else {
 				if err == nil {
-					t.Fatalf("expected error to contain %q", tt.expectError)
+					t.Fatalf("expected error to contain %q", tc.expectError)
 				}
-				if !strings.Contains(err.Error(), tt.expectError) {
-					t.Fatalf("expected error=%q to contain %q", err, tt.expectError)
+				if !strings.Contains(err.Error(), tc.expectError) {
+					t.Fatalf("expected error=%q to contain %q", err, tc.expectError)
 				}
 			}
 
-			if cc := callCount.Load(); cc != tt.expectAttempts {
-				t.Fatalf("got callCount=%d but expected=%d", cc, tt.expectAttempts)
+			if cc := callCount.Load(); cc != tc.expectAttempts {
+				t.Fatalf("got callCount=%d but expected=%d", cc, tc.expectAttempts)
 			}
 		})
 	}

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -391,7 +391,6 @@ func TestMaxDownloadAttempts(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}

--- a/image/cache/compare_test.go
+++ b/image/cache/compare_test.go
@@ -192,7 +192,6 @@ func TestPlatformCompare(t *testing.T) {
 			expected: false,
 		},
 	} {
-		tc := tc
 		// OSVersion comparison is only performed by containerd platform
 		// matcher if built on Windows.
 		if (tc.image.OSVersion != "" || tc.builder.OSVersion != "") && runtime.GOOS != "windows" {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6200,7 +6200,6 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 		{buildkit: false},
 		{buildkit: true},
 	} {
-		builder := builder
 		for _, tc := range []struct {
 			name  string
 			args  []string
@@ -6224,7 +6223,6 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 				},
 			},
 		} {
-			tc := tc
 			t.Run(fmt.Sprintf("buildkit=%v/%s", builder.buildkit, tc.name), func(t *testing.T) {
 				skip.If(t, DaemonIsWindows, "Buildkit is not supported on Windows")
 

--- a/integration/capabilities/capabilities_linux_test.go
+++ b/integration/capabilities/capabilities_linux_test.go
@@ -70,7 +70,6 @@ func TestNoNewPrivileges(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -108,7 +108,6 @@ func TestConfigList(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			entries, err = c.ConfigList(ctx, types.ConfigListOptions{

--- a/integration/container/attach_test.go
+++ b/integration/container/attach_test.go
@@ -36,7 +36,6 @@ func TestAttach(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/container/container_test.go
+++ b/integration/container/container_test.go
@@ -25,7 +25,6 @@ func TestContainerInvalidJSON(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
-		ep := ep
 		t.Run(ep[1:], func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -54,7 +54,6 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
@@ -117,7 +116,6 @@ func TestCreateWithInvalidEnv(t *testing.T) {
 	}
 
 	for index, tc := range testCases {
-		tc := tc
 		t.Run(strconv.Itoa(index), func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
@@ -221,7 +219,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 		maskedPaths, ok := cfg["MaskedPaths"].([]interface{})
 		assert.Check(t, is.Equal(true, ok), name)
 
-		var mps = make([]string, 0, len(maskedPaths))
+		mps := make([]string, 0, len(maskedPaths))
 		for _, mp := range maskedPaths {
 			mps = append(mps, mp.(string))
 		}
@@ -302,7 +300,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 		readonlyPaths, ok := cfg["ReadonlyPaths"].([]interface{})
 		assert.Check(t, is.Equal(true, ok), name)
 
-		var rops = make([]string, 0, len(readonlyPaths))
+		rops := make([]string, 0, len(readonlyPaths))
 		for _, rop := range readonlyPaths {
 			rops = append(rops, rop.(string))
 		}
@@ -403,7 +401,6 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
@@ -580,7 +577,6 @@ func TestCreateInvalidHostConfig(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -215,7 +215,6 @@ func TestExecResize(t *testing.T) {
 			},
 		}
 		for _, tc := range sizes {
-			tc := tc
 			t.Run(tc.doc, func(t *testing.T) {
 				// Manually creating a request here, as the APIClient would invalidate
 				// these values before they're sent.

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -67,7 +67,6 @@ func TestKillContainer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			skip.If(t, testEnv.DaemonInfo.OSType == tc.skipOs, "Windows does not support SIGWINCH")
 			ctx := testutil.StartSpan(ctx, t)
@@ -107,7 +106,6 @@ func TestKillWithStopSignalAndRestartPolicies(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			id := container.Run(ctx, t, apiClient,

--- a/integration/container/overlayfs_linux_test.go
+++ b/integration/container/overlayfs_linux_test.go
@@ -23,7 +23,7 @@ func TestNoOverlayfsWarningsAboutUndefinedBehaviors(t *testing.T) {
 
 	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", `while true; do echo $RANDOM >>/file; sleep 0.1; done`))
 
-	testCases := []struct {
+	tests := []struct {
 		name      string
 		operation func(t *testing.T) error
 	}{
@@ -55,8 +55,7 @@ func TestNoOverlayfsWarningsAboutUndefinedBehaviors(t *testing.T) {
 		}},
 	}
 
-	for _, tc := range testCases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			prev := dmesgLines(256)
 

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -41,7 +41,7 @@ func TestResize(t *testing.T) {
 
 		const valueNotSet = "unset"
 
-		sizes := []struct {
+		tests := []struct {
 			doc, height, width, expErr string
 		}{
 			{
@@ -103,8 +103,7 @@ func TestResize(t *testing.T) {
 				expErr: `invalid resize width "4294967296": value out of range`,
 			},
 		}
-		for _, tc := range sizes {
-			tc := tc
+		for _, tc := range tests {
 			t.Run(tc.doc, func(t *testing.T) {
 				// Manually creating a request here, as the APIClient would invalidate
 				// these values before they're sent.

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -75,7 +75,6 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 			} {
 				tc := tc
 				liveRestoreEnabled := liveRestoreEnabled
-				stopDaemon := stopDaemon
 				t.Run(fmt.Sprintf("live-restore=%v/%s/%s", liveRestoreEnabled, tc.desc, fnName), func(t *testing.T) {
 					t.Parallel()
 
@@ -185,7 +184,6 @@ func TestContainerWithAutoRemoveCanBeRestarted(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			testutil.StartSpan(ctx, t)
 			cID := testContainer.Run(ctx, t, apiClient,

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -338,7 +338,6 @@ func TestWorkingDirNormalization(t *testing.T) {
 		{name: "trailing slash", workdir: "/tmp/"},
 		{name: "no trailing slash", workdir: "/tmp"},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -19,7 +19,7 @@ func TestWaitNonBlocked(t *testing.T) {
 
 	cli := request.NewAPIClient(t)
 
-	testCases := []struct {
+	tests := []struct {
 		doc          string
 		cmd          string
 		expectedCode int64
@@ -36,8 +36,7 @@ func TestWaitNonBlocked(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 
@@ -63,7 +62,7 @@ func TestWaitBlocked(t *testing.T) {
 	ctx := setupTest(t)
 	cli := request.NewAPIClient(t)
 
-	testCases := []struct {
+	tests := []struct {
 		doc          string
 		cmd          string
 		expectedCode int64
@@ -79,8 +78,7 @@ func TestWaitBlocked(t *testing.T) {
 			expectedCode: 99,
 		},
 	}
-	for _, tc := range testCases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
@@ -106,7 +104,7 @@ func TestWaitConditions(t *testing.T) {
 	ctx := setupTest(t)
 	cli := request.NewAPIClient(t)
 
-	testCases := []struct {
+	tests := []struct {
 		doc      string
 		waitCond containertypes.WaitCondition
 		runOpts  []func(*container.TestContainerConfig)
@@ -129,8 +127,7 @@ func TestWaitConditions(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
@@ -181,7 +178,7 @@ func TestWaitRestartedContainer(t *testing.T) {
 	ctx := setupTest(t)
 	cli := request.NewAPIClient(t)
 
-	testCases := []struct {
+	tests := []struct {
 		doc      string
 		waitCond containertypes.WaitCondition
 	}{
@@ -201,8 +198,7 @@ func TestWaitRestartedContainer(t *testing.T) {
 	// We can't catch the SIGTERM in the Windows based busybox image
 	isWindowDaemon := testEnv.DaemonInfo.OSType == "windows"
 
-	for _, tc := range testCases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -112,7 +112,6 @@ func TestDaemonConfigValidation(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_ = testutil.StartSpan(ctx, t)
@@ -158,7 +157,6 @@ func TestConfigDaemonSeccompProfiles(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			_ = testutil.StartSpan(ctx, t)
 
@@ -231,7 +229,6 @@ func TestDaemonConfigFeatures(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_ = testutil.StartSpan(ctx, t)

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -104,7 +104,6 @@ func TestImportWithCustomPlatform(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		tc := tc
 		t.Run(tc.platform, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			reference := "import-with-platform:tc-" + strconv.Itoa(i)
@@ -171,7 +170,6 @@ func TestImportWithCustomPlatformReject(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		tc := tc
 		t.Run(tc.platform, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			reference := "import-with-platform:tc-" + strconv.Itoa(i)

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -186,7 +186,6 @@ func TestAPIImagesFilters(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -73,7 +73,7 @@ func TestPruneLexographicalOrder(t *testing.T) {
 
 	id := inspect.ID
 
-	var tags = []string{"h", "a", "j", "o", "s", "q", "w", "e", "r", "t"}
+	tags := []string{"h", "a", "j", "o", "s", "q", "w", "e", "r", "t"}
 	for _, tag := range tags {
 		err = apiClient.ImageTag(ctx, id, "busybox:"+tag)
 		assert.NilError(t, err)
@@ -190,7 +190,6 @@ func TestPruneDontDeleteUsedImage(t *testing.T) {
 				},
 			},
 		} {
-			tc := tc
 			t.Run(env.name+"/"+tc.name, func(t *testing.T) {
 				ctx := testutil.StartSpan(ctx, t)
 				d := daemon.New(t)

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -174,7 +174,6 @@ func TestImagePullNonExisting(t *testing.T) {
 		"library/asdfasdf",
 		"library/asdfasdf:latest",
 	} {
-		ref := ref
 		all := strings.Contains(ref, ":")
 		t.Run(ref, func(t *testing.T) {
 			t.Parallel()

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -133,7 +133,6 @@ func TestSaveOCI(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.image, func(t *testing.T) {
 			// Get information about the original image.
 			inspect, _, err := client.ImageInspectWithRaw(ctx, tc.image)

--- a/integration/image/tag_test.go
+++ b/integration/image/tag_test.go
@@ -41,7 +41,6 @@ func TestTagValidPrefixedRepo(t *testing.T) {
 	validRepos := []string{"fooo/bar", "fooaa/test", "foooo:t", "HOSTNAME.DOMAIN.COM:443/foo/bar"}
 
 	for _, repo := range validRepos {
-		repo := repo
 		t.Run(repo, func(t *testing.T) {
 			t.Parallel()
 			err := client.ImageTag(ctx, "busybox", repo)
@@ -74,7 +73,6 @@ func TestTagOfficialNames(t *testing.T) {
 	}
 
 	for _, name := range names {
-		name := name
 		t.Run("tag from busybox to "+name, func(t *testing.T) {
 			err := client.ImageTag(ctx, "busybox", name+":latest")
 			assert.NilError(t, err)

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -139,7 +139,7 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 	ctx := setupTest(t)
 	c := testEnv.APIClient()
 
-	testcases := []struct {
+	tests := []struct {
 		name       string
 		subnet     string
 		ipRange    string
@@ -173,8 +173,7 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			const netName = "test64bl"
@@ -213,7 +212,7 @@ func TestFilterForwardPolicy(t *testing.T) {
 	)
 	t.Cleanup(func() { l3.Destroy(t) })
 
-	testcases := []struct {
+	tests := []struct {
 		name           string
 		initForwarding string
 		daemonArgs     []string
@@ -248,7 +247,7 @@ func TestFilterForwardPolicy(t *testing.T) {
 		},
 	}
 
-	for i, tc := range testcases {
+	for i, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -74,7 +74,6 @@ func TestInspectNetwork(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			nw, err := c.NetworkInspect(ctx, tc.network, tc.opts)

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -464,7 +464,7 @@ func TestIpvlanIPAM(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	testcases := []struct {
+	tests := []struct {
 		name       string
 		apiVersion string
 		enableIPv4 bool
@@ -495,8 +495,7 @@ func TestIpvlanIPAM(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 
@@ -582,7 +581,7 @@ func TestIPVlanDNS(t *testing.T) {
 
 	const netName = "ipvlan-dns-net"
 
-	testcases := []struct {
+	tests := []struct {
 		name     string
 		parent   string
 		internal bool
@@ -607,7 +606,7 @@ func TestIPVlanDNS(t *testing.T) {
 	}
 
 	for _, mode := range []string{"l2", "l3"} {
-		for _, tc := range testcases {
+		for _, tc := range tests {
 			name := fmt.Sprintf("Mode=%v/HasParent=%v/Internal=%v", mode, tc.parent != "", tc.internal)
 			t.Run(name, func(t *testing.T) {
 				ctx := testutil.StartSpan(ctx, t)

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -94,7 +94,6 @@ func TestDockerNetworkMacvlan(t *testing.T) {
 			test: testMacvlanExperimentalV4Only,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			testutil.StartSpan(ctx, t)
 
@@ -493,7 +492,6 @@ func TestMacvlanIPAM(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -78,7 +78,6 @@ func TestNetworkInvalidJSON(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
-		ep := ep
 		t.Run(ep[1:], func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
@@ -140,7 +139,6 @@ func TestNetworkList(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
-		ep := ep
 		t.Run(ep, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			t.Parallel()
@@ -218,7 +216,6 @@ func TestDefaultNetworkOpts(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			d := daemon.New(t)

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -628,7 +628,7 @@ func TestDisableIPv4(t *testing.T) {
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
-	testcases := []struct {
+	tests := []struct {
 		name       string
 		apiVersion string
 		expIPv4    bool
@@ -644,8 +644,7 @@ func TestDisableIPv4(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := d.NewClientT(t, client.WithVersion(tc.apiVersion))
 

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -43,7 +43,6 @@ func TestPluginInvalidJSON(t *testing.T) {
 	}
 
 	for _, ep := range endpoints {
-		ep := ep
 		t.Run(ep[1:], func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -287,7 +287,6 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 		service   swarmtypes.Service
 	)
 	for i, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			if i == 0 {

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -258,7 +258,6 @@ func TestDiskUsage(t *testing.T) {
 					},
 				},
 			} {
-				tc := tc
 				t.Run(tc.doc, func(t *testing.T) {
 					ctx := testutil.StartSpan(ctx, t)
 					// TODO: Run in parallel once https://github.com/moby/moby/pull/42560 is merged.

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -199,7 +199,6 @@ func TestVolumesInvalidJSON(t *testing.T) {
 	endpoints := []string{"/volumes/create"}
 
 	for _, ep := range endpoints {
-		ep := ep
 		t.Run(ep[1:], func(t *testing.T) {
 			t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)

--- a/internal/mod/mod_test.go
+++ b/internal/mod/mod_test.go
@@ -58,15 +58,14 @@ dep	github.com/moby/buildkit	v0.10.7-0.20230306143919-70f2ad56d3e5	h1:JZvvWzulcn
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			bi, err := debug.ParseBuildInfo(tt.biContent)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bi, err := debug.ParseBuildInfo(tc.biContent)
 			if err != nil {
 				t.Fatalf("failed to parse build info: %v", err)
 			}
-			if gotVersion := moduleVersion(tt.module, bi); gotVersion != tt.wantVersion {
-				t.Errorf("moduleVersion() = %v, want %v", gotVersion, tt.wantVersion)
+			if gotVersion := moduleVersion(tc.module, bi); gotVersion != tc.wantVersion {
+				t.Errorf("moduleVersion() = %v, want %v", gotVersion, tc.wantVersion)
 			}
 		})
 	}

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package sliceutil
 

--- a/internal/testutils/specialimage/partial.go
+++ b/internal/testutils/specialimage/partial.go
@@ -38,7 +38,6 @@ func PartialMultiPlatform(dir string, imageRef string, opts PartialOpts) (*ocisp
 		platformStr := platforms.FormatAll(platform)
 		dgst := digest.FromBytes([]byte(platformStr))
 
-		platform := platform
 		descs = append(descs, ocispec.Descriptor{
 			MediaType: ocispec.MediaTypeImageManifest,
 			Size:      128,

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -448,7 +448,6 @@ func (t *task) CreateCheckpoint(ctx context.Context, checkpointDir string, exit 
 
 	var cpDesc *ocispec.Descriptor
 	for _, m := range index.Manifests {
-		m := m
 		if m.MediaType == images.MediaTypeContainerd1Checkpoint {
 			cpDesc = &m //nolint:gosec
 			break

--- a/libnetwork/bitmap/sequence_test.go
+++ b/libnetwork/bitmap/sequence_test.go
@@ -1200,17 +1200,16 @@ func TestMarshalJSON(t *testing.T) {
 		t.Errorf("MarshalJSON() output differs from golden. Please add a new golden case to this test.")
 	}
 
-	for _, tt := range []struct {
+	for _, tc := range []struct {
 		name string
 		data []byte
 	}{
 		{name: "Live", data: marshaled},
 		{name: "Golden-v0", data: []byte(goldenV0)},
 	} {
-		tt := tt
-		t.Run("UnmarshalJSON="+tt.name, func(t *testing.T) {
+		t.Run("UnmarshalJSON="+tc.name, func(t *testing.T) {
 			hnd2 := New(0)
-			if err := hnd2.UnmarshalJSON(tt.data); err != nil {
+			if err := hnd2.UnmarshalJSON(tc.data); err != nil {
 				t.Errorf("UnmarshalJSON() err = %v", err)
 			}
 

--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package config
 

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1076,7 +1076,6 @@ func TestValidateFixedCIDRV6(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			err := ValidateFixedCIDRV6(tc.input)
 			if tc.expectedErr == "" {

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package bridge
 

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -760,7 +760,6 @@ func TestAddPortMappings(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			defer netnsutils.SetupTestOSContext(t)()
 

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -679,7 +679,6 @@ func clearEncryptionStates() {
 		log.G(context.TODO()).Warnf("Failed to retrieve SA list for cleanup: %v", err)
 	}
 	for _, sp := range spList {
-		sp := sp
 		if sp.Mark != nil && sp.Mark.Value == spMark.Value {
 			if err := nlh.XfrmPolicyDel(&sp); err != nil {
 				log.G(context.TODO()).Warnf("Failed to delete stale SP %s: %v", sp, err)
@@ -689,7 +688,6 @@ func clearEncryptionStates() {
 		}
 	}
 	for _, sa := range saList {
-		sa := sa
 		if sa.Reqid == mark {
 			if err := nlh.XfrmStateDel(&sa); err != nil {
 				log.G(context.TODO()).Warnf("Failed to delete stale SA %s: %v", sa, err)

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21 && linux
+//go:build go1.22 && linux
 
 package overlay
 

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -131,7 +131,6 @@ func (d *driver) peerDbNetworkWalk(nid string, f func(*peerKey, *peerEntry) bool
 
 	for pKeyStr, pEntry := range mp {
 		var pKey peerKey
-		pEntry := pEntry
 		if _, err := fmt.Sscan(pKeyStr, &pKey); err != nil {
 			log.G(context.TODO()).Warnf("Peer key scan on network %s failed: %v", nid, err)
 		}

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package libnetwork
 

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -464,7 +464,6 @@ func (epj *endpointJoinInfo) UnmarshalJSON(b []byte) error {
 	}
 	var StaticRoutes []*types.StaticRoute
 	for _, r := range tStaticRoute {
-		r := r
 		StaticRoutes = append(StaticRoutes, &r)
 	}
 	epj.StaticRoutes = StaticRoutes

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -49,7 +49,6 @@ func TestUserChain(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(fmt.Sprintf("iptables=%v,insert=%v", tc.iptables, tc.insert), func(t *testing.T) {
 			defer netnsutils.SetupTestOSContext(t)()
 			defer resetIptables(t)

--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 // Package resolvconf is used to generate a container's /etc/resolv.conf file.
 //

--- a/libnetwork/internal/setmatrix/setmatrix.go
+++ b/libnetwork/internal/setmatrix/setmatrix.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package setmatrix
 

--- a/libnetwork/ipams/defaultipam/address_space.go
+++ b/libnetwork/ipams/defaultipam/address_space.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package defaultipam
 

--- a/libnetwork/ipams/defaultipam/parallel_test.go
+++ b/libnetwork/ipams/defaultipam/parallel_test.go
@@ -227,15 +227,14 @@ func release(t *testing.T, tctx *testContext, mode releaseMode, parallel int64) 
 	parallelExec := semaphore.NewWeighted(parallel)
 	ch := make(chan *net.IPNet, len(ipIndex))
 	group := new(errgroup.Group)
-	for index := range ipIndex {
-		index := index
+	for i := range ipIndex {
 		group.Go(func() error {
 			parallelExec.Acquire(context.Background(), 1)
-			err := tctx.a.ReleaseAddress(tctx.pid, tctx.ipList[index].IP)
+			err := tctx.a.ReleaseAddress(tctx.pid, tctx.ipList[i].IP)
 			if err != nil {
 				return fmt.Errorf("routine %d got %v", id, err)
 			}
-			ch <- tctx.ipList[index]
+			ch <- tctx.ipList[i]
 			parallelExec.Release(1)
 			return nil
 		})

--- a/libnetwork/ipamutils/utils.go
+++ b/libnetwork/ipamutils/utils.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 // Package ipamutils provides utility functions for ipam management
 package ipamutils

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -400,7 +400,6 @@ func TestUpdateSvcRecord(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			defer netnsutils.SetupTestOSContext(t)()
 			ctrlr, err := New(config.OptionDataDir(t.TempDir()))

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -2042,7 +2042,6 @@ func TestParallel(t *testing.T) {
 
 	var eg errgroup.Group
 	for i := first; i <= last; i++ {
-		i := i
 		eg.Go(func() error { return pt.Do(t, i) })
 	}
 	if err := eg.Wait(); err != nil {
@@ -2162,7 +2161,6 @@ func TestNullIpam(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.networkType, func(t *testing.T) {
 			_, err := controller.NewNetwork(tc.networkType, "tnet1-"+tc.networkType, "",
 				libnetwork.NetworkOptionEnableIPv4(true),

--- a/libnetwork/netutils/utils_linux.go
+++ b/libnetwork/netutils/utils_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21 && linux
+//go:build go1.22 && linux
 
 package netutils
 

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package libnetwork
 

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package networkdb
 

--- a/libnetwork/options/options.go
+++ b/libnetwork/options/options.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 // Package options provides a way to pass unstructured sets of options to a
 // component expecting a strongly-typed configuration structure.

--- a/libnetwork/portallocator/portallocator.go
+++ b/libnetwork/portallocator/portallocator.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package portallocator
 

--- a/libnetwork/service.go
+++ b/libnetwork/service.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package libnetwork
 

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -154,7 +154,6 @@ func TestAppendDevicePermissionsFromCgroupRules(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			out, err := AppendDevicePermissionsFromCgroupRules([]specs.LinuxDeviceCgroup{}, []string{tc.rule})
 			if tc.expectedErr != "" {

--- a/opts/env_test.go
+++ b/opts/env_test.go
@@ -104,7 +104,6 @@ func TestValidateEnv(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.value, func(t *testing.T) {
 			actual, err := ValidateEnv(tc.value)
 

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -69,7 +69,6 @@ func TestValidateIPAddress(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			actualOut, actualErr := ValidateIPAddress(tc.input)
 			assert.Check(t, is.Equal(tc.expectedOut, actualOut))
@@ -226,7 +225,7 @@ func TestValidateDNSSearch(t *testing.T) {
 }
 
 func TestValidateLabel(t *testing.T) {
-	testCases := []struct {
+	tests := []struct {
 		name           string
 		label          string
 		expectedResult string
@@ -299,18 +298,17 @@ func TestValidateLabel(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
-			result, err := ValidateLabel(testCase.label)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ValidateLabel(tc.label)
 
-			if testCase.expectedErr != "" {
-				assert.Error(t, err, testCase.expectedErr)
+			if tc.expectedErr != "" {
+				assert.Error(t, err, tc.expectedErr)
 			} else {
 				assert.NilError(t, err)
 			}
-			if testCase.expectedResult != "" {
-				assert.Check(t, is.Equal(result, testCase.expectedResult))
+			if tc.expectedResult != "" {
+				assert.Check(t, is.Equal(result, tc.expectedResult))
 			}
 		})
 	}

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -805,7 +805,7 @@ func TestTarWithOptionsChownOptsAlwaysOverridesIdPair(t *testing.T) {
 		},
 	}
 
-	cases := []struct {
+	tests := []struct {
 		opts        *TarOptions
 		expectedUID int
 		expectedGID int
@@ -816,8 +816,7 @@ func TestTarWithOptionsChownOptsAlwaysOverridesIdPair(t *testing.T) {
 		{&TarOptions{ChownOpts: &idtools.Identity{UID: 1, GID: 1}, NoLchown: true}, 1, 1},
 		{&TarOptions{ChownOpts: &idtools.Identity{UID: 1000, GID: 1000}, NoLchown: true}, 1000, 1000},
 	}
-	for _, tc := range cases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
 			reader, err := TarWithOptions(filePath, tc.opts)
 			assert.NilError(t, err)
@@ -853,7 +852,7 @@ func TestTarWithOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cases := []struct {
+	tests := []struct {
 		opts       *TarOptions
 		numChanges int
 	}{
@@ -863,14 +862,14 @@ func TestTarWithOptions(t *testing.T) {
 		{&TarOptions{IncludeFiles: []string{"1", "1"}}, 2},
 		{&TarOptions{IncludeFiles: []string{"1"}, RebaseNames: map[string]string{"1": "test"}}, 4},
 	}
-	for _, testCase := range cases {
-		changes, err := tarUntar(t, origin, testCase.opts)
+	for _, tc := range tests {
+		changes, err := tarUntar(t, origin, tc.opts)
 		if err != nil {
 			t.Fatalf("Error tar/untar when testing inclusion/exclusion: %s", err)
 		}
-		if len(changes) != testCase.numChanges {
+		if len(changes) != tc.numChanges {
 			t.Errorf("Expected %d changes, got %d for %+v:",
-				testCase.numChanges, len(changes), testCase.opts)
+				tc.numChanges, len(changes), tc.opts)
 		}
 	}
 }
@@ -1308,7 +1307,7 @@ func TestImpliedDirectoryPermissions(t *testing.T) {
 
 func TestReplaceFileTarWrapper(t *testing.T) {
 	filesInArchive := 20
-	testcases := []struct {
+	tests := []struct {
 		doc       string
 		filename  string
 		modifier  TarModifierFunc
@@ -1345,16 +1344,16 @@ func TestReplaceFileTarWrapper(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range testcases {
+	for _, tc := range tests {
 		sourceArchive, cleanup := buildSourceArchive(t, filesInArchive)
 		defer cleanup()
 
 		resultArchive := ReplaceFileTarWrapper(
 			sourceArchive,
-			map[string]TarModifierFunc{testcase.filename: testcase.modifier})
+			map[string]TarModifierFunc{tc.filename: tc.modifier})
 
-		actual := readFileFromArchive(t, resultArchive, testcase.filename, testcase.fileCount, testcase.doc)
-		assert.Check(t, is.Equal(testcase.expected, actual), testcase.doc)
+		actual := readFileFromArchive(t, resultArchive, tc.filename, tc.fileCount, tc.doc)
+		assert.Check(t, is.Equal(tc.expected, actual), tc.doc)
 	}
 }
 

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -185,7 +185,6 @@ func TestMkdirAllAndChownNewRelative(t *testing.T) {
 	const expectedUIDGID = 101
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.in, func(t *testing.T) {
 			for _, p := range tc.out {
 				_, err := os.Stat(p)

--- a/pkg/plugins/client_test.go
+++ b/pkg/plugins/client_test.go
@@ -105,7 +105,6 @@ func TestBackoff(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(fmt.Sprintf("retries: %v", tc.retries), func(t *testing.T) {
 			s := tc.expTimeOff * time.Second
 			if d := backoff(tc.retries); d != s {
@@ -129,7 +128,6 @@ func TestAbortRetry(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(fmt.Sprintf("duration: %v", tc.timeOff), func(t *testing.T) {
 			s := tc.timeOff * time.Second
 			if a := abort(time.Now(), s, 0); a != tc.expAbort {

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package v2 // import "github.com/docker/docker/plugin/v2"
 

--- a/profiles/seccomp/kernel_linux_test.go
+++ b/profiles/seccomp/kernel_linux_test.go
@@ -49,7 +49,6 @@ func TestParseRelease(t *testing.T) {
 		{in: "3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "3.-8": expected integer`)},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.in, func(t *testing.T) {
 			version, err := parseRelease(tc.in)
 			if tc.expectedErr != nil {
@@ -108,7 +107,6 @@ func TestKernelGreaterEqualThan(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc+": "+tc.in.String(), func(t *testing.T) {
 			ok, err := kernelGreaterEqualThan(tc.in)
 			if err != nil {

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -132,7 +132,6 @@ func TestLoadProfileValidation(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		rs := createSpec()
 		t.Run(tc.doc, func(t *testing.T) {
 			_, err := LoadProfile(tc.profile, &rs)
@@ -220,7 +219,6 @@ func TestMarshalUnmarshalFilter(t *testing.T) {
 		{in: `{"arches":["s390x"],"minKernel":"4.15"}`, out: `{"arches":["s390x"],"minKernel":"4.15"}`},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.in, func(t *testing.T) {
 			var filter Filter
 			err := json.Unmarshal([]byte(tc.in), &filter)
@@ -262,7 +260,6 @@ func TestLoadConditional(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			rs := createSpec(tc.cap)
 			p, err := LoadProfile(string(f), &rs)

--- a/registry/search_endpoint_v1_test.go
+++ b/registry/search_endpoint_v1_test.go
@@ -137,7 +137,6 @@ func TestV1EndpointParse(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.address, func(t *testing.T) {
 			ep, err := newV1EndpointFromStr(tc.address, nil, nil)
 			if tc.expectedErr != "" {

--- a/registry/search_test.go
+++ b/registry/search_test.go
@@ -131,7 +131,6 @@ func TestSearchErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range errorCases {
-		tc := tc
 		t.Run(tc.expectedError, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if !tc.shouldReturnError {
@@ -394,7 +393,6 @@ func TestSearch(t *testing.T) {
 		},
 	}
 	for _, tc := range successCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-type", "application/json")

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -22,27 +22,26 @@ type f struct {
 
 func TestDecodeContainerConfig(t *testing.T) {
 	var (
-		fixtures []f
-		imgName  string
+		tests   []f
+		imgName string
 	)
 
 	// FIXME (thaJeztah): update fixtures for more current versions.
 	if runtime.GOOS != "windows" {
 		imgName = "ubuntu"
-		fixtures = []f{
+		tests = []f{
 			{"fixtures/unix/container_config_1_19.json", strslice.StrSlice{"bash"}},
 		}
 	} else {
 		imgName = "windows"
-		fixtures = []f{
+		tests = []f{
 			{"fixtures/windows/container_config_1_19.json", strslice.StrSlice{"cmd"}},
 		}
 	}
 
-	for _, f := range fixtures {
-		f := f
-		t.Run(f.file, func(t *testing.T) {
-			b, err := os.ReadFile(f.file)
+	for _, tc := range tests {
+		t.Run(tc.file, func(t *testing.T) {
+			b, err := os.ReadFile(tc.file)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -56,8 +55,8 @@ func TestDecodeContainerConfig(t *testing.T) {
 				t.Fatalf("Expected %s image, found %s", imgName, c.Image)
 			}
 
-			if len(c.Entrypoint) != len(f.entrypoint) {
-				t.Fatalf("Expected %v, found %v", f.entrypoint, c.Entrypoint)
+			if len(c.Entrypoint) != len(tc.entrypoint) {
+				t.Fatalf("Expected %v, found %v", tc.entrypoint, c.Entrypoint)
 			}
 
 			if h != nil && h.Memory != 1000 {

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package testutil // import "github.com/docker/docker/testutil"
 

--- a/volume/local/local_linux_test.go
+++ b/volume/local/local_linux_test.go
@@ -229,7 +229,6 @@ func TestVolCreateValidation(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			if tc.name == "" {
 				tc.name = "vol-" + strconv.Itoa(i)
@@ -313,7 +312,6 @@ func TestVolMountOpts(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			dev, opts, err := getMountOptions(&tc.opts, resolveIP)
 

--- a/volume/mounts/lcow_parser_test.go
+++ b/volume/mounts/lcow_parser_test.go
@@ -102,7 +102,7 @@ func TestLCOWParseMountRaw(t *testing.T) {
 }
 
 func TestLCOWParseMountRawSplit(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		bind     string
 		driver   string
 		expected *MountPoint
@@ -256,8 +256,7 @@ func TestLCOWParseMountRawSplit(t *testing.T) {
 		p.fi = mockFiProvider{}
 	}
 
-	for _, tc := range cases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.bind, func(t *testing.T) {
 			m, err := parser.ParseMountRaw(tc.bind, tc.driver)
 			if tc.expErr != "" {

--- a/volume/mounts/linux_parser_test.go
+++ b/volume/mounts/linux_parser_test.go
@@ -100,7 +100,7 @@ func TestLinuxParseMountRaw(t *testing.T) {
 }
 
 func TestLinuxParseMountRawSplit(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		bind     string
 		driver   string
 		expected *MountPoint
@@ -249,8 +249,7 @@ func TestLinuxParseMountRawSplit(t *testing.T) {
 		p.fi = mockFiProvider{}
 	}
 
-	for _, tc := range cases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.bind, func(t *testing.T) {
 			m, err := parser.ParseMountRaw(tc.bind, tc.driver)
 			if tc.expErr != "" {

--- a/volume/mounts/parser_test.go
+++ b/volume/mounts/parser_test.go
@@ -48,7 +48,7 @@ func TestParseMountSpec(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 	parser := NewParser()
-	cases := []struct {
+	tests := []struct {
 		input    mount.Mount
 		expected MountPoint
 	}{
@@ -78,8 +78,7 @@ func TestParseMountSpec(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
 			mp, err := parser.ParseMountSpec(tc.input)
 			assert.NilError(t, err)

--- a/volume/mounts/validate_test.go
+++ b/volume/mounts/validate_test.go
@@ -56,7 +56,6 @@ func TestValidateMount(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			err := parser.ValidateMountConfig(&tc.input)
 			if tc.expected != nil {
@@ -114,7 +113,6 @@ func TestValidateLCOWMount(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			err := parser.ValidateMountConfig(&tc.input)
 			if tc.expected != nil {

--- a/volume/mounts/windows_parser_test.go
+++ b/volume/mounts/windows_parser_test.go
@@ -109,7 +109,7 @@ func TestWindowsParseMountRaw(t *testing.T) {
 }
 
 func TestWindowsParseMountRawSplit(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
 		bind     string
 		driver   string
 		expected *MountPoint
@@ -279,8 +279,7 @@ func TestWindowsParseMountRawSplit(t *testing.T) {
 		p.fi = mockFiProvider{}
 	}
 
-	for _, tc := range cases {
-		tc := tc
+	for _, tc := range tests {
 		t.Run(tc.bind, func(t *testing.T) {
 			m, err := parser.ParseMountRaw(tc.bind, tc.driver)
 			if tc.expErr != "" {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48824

### update go:build tags to use go1.22

commit a0807e7cfe0ac30dc37d50d5ad63259c897fa90f configured golangci-lint
to use go1.23 semantics, which alowed linters like `copyloopvar` to lint
using thee correct semantics.

go1.22 now creates a copy of variables when assigned in a loop; make sure we
don't have files that may downgrade semantics to go1.21 in case that also means
disabling that feature; https://go.dev/ref/spec#Go_1.22

### golanci-lint: sync comments with docker/cli

Using the same descriptions as used in docker/cli to make it
easier to compare configurations between both repositories.


### golangci-lint: enable copyloopvar linter

go1.22 now creates a copy of variables when assigned in a loop; enable the
copyloopvar linter to find locations where we capture loop vars that are
now redundant; https://go.dev/ref/spec#Go_1.22


**- A picture of a cute animal (not mandatory but encouraged)**

