### PR TITLE
Fix /etc/hosts update for net disconnect

### DIFF
--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -20,6 +20,13 @@ func WithName(name string) func(*TestContainerConfig) {
 	}
 }
 
+// WithHostname sets the hostname of the container
+func WithHostname(name string) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.Config.Hostname = name
+	}
+}
+
 // WithLinks sets the links of the container
 func WithLinks(links ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {

--- a/integration/networking/testdata/TestEtcHostsDisconnect1.golden
+++ b/integration/networking/testdata/TestEtcHostsDisconnect1.golden
@@ -1,0 +1,12 @@
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::	ip6-localnet
+ff00::	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+192.0.2.3	otherhost.invalid
+2001:db8::1234	otherhost.invalid
+192.168.123.2	c1.invalid c1
+fde6:be58:aedf::2	c1.invalid c1
+192.168.124.2	c1.invalid c1
+fdd2:c4e3:c4d5::2	c1.invalid c1

--- a/integration/networking/testdata/TestEtcHostsDisconnect2.golden
+++ b/integration/networking/testdata/TestEtcHostsDisconnect2.golden
@@ -1,0 +1,10 @@
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::	ip6-localnet
+ff00::	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+192.0.2.3	otherhost.invalid
+2001:db8::1234	otherhost.invalid
+192.168.124.2	c1.invalid c1
+fdd2:c4e3:c4d5::2	c1.invalid c1

--- a/integration/networking/testdata/TestEtcHostsDisconnect3.golden
+++ b/integration/networking/testdata/TestEtcHostsDisconnect3.golden
@@ -1,0 +1,12 @@
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::	ip6-localnet
+ff00::	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+192.0.2.3	otherhost.invalid
+2001:db8::1234	otherhost.invalid
+192.168.124.2	c1.invalid c1
+fdd2:c4e3:c4d5::2	c1.invalid c1
+192.168.123.2	c1.invalid c1
+fde6:be58:aedf::2	c1.invalid c1

--- a/integration/networking/testdata/TestEtcHostsDisconnect4.golden
+++ b/integration/networking/testdata/TestEtcHostsDisconnect4.golden
@@ -1,0 +1,10 @@
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::	ip6-localnet
+ff00::	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+192.0.2.3	otherhost.invalid
+2001:db8::1234	otherhost.invalid
+192.168.124.2	c1.invalid c1
+fdd2:c4e3:c4d5::2	c1.invalid c1

--- a/integration/networking/testdata/TestEtcHostsDisconnect5.golden
+++ b/integration/networking/testdata/TestEtcHostsDisconnect5.golden
@@ -1,0 +1,8 @@
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::	ip6-localnet
+ff00::	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+192.0.2.3	otherhost.invalid
+2001:db8::1234	otherhost.invalid

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -199,8 +199,8 @@ func (sb *Sandbox) addHostsEntries(ctx context.Context, ifaceAddrs []netip.Addr)
 	}
 }
 
-func (sb *Sandbox) deleteHostsEntries(recs []etchosts.Record) {
-	if err := etchosts.Delete(sb.config.hostsPath, recs); err != nil {
+func (sb *Sandbox) deleteHostsEntries(ifaceAddrs []netip.Addr) {
+	if err := etchosts.Delete(sb.config.hostsPath, sb.makeHostsRecs(ifaceAddrs)); err != nil {
 		log.G(context.TODO()).Warnf("Failed deleting service host entries to the running container: %v", err)
 	}
 }

--- a/libnetwork/sandbox_dns_windows.go
+++ b/libnetwork/sandbox_dns_windows.go
@@ -5,8 +5,6 @@ package libnetwork
 import (
 	"context"
 	"net/netip"
-
-	"github.com/docker/docker/libnetwork/etchosts"
 )
 
 // Stub implementations for DNS related functions
@@ -23,7 +21,7 @@ func (sb *Sandbox) addHostsEntries(_ context.Context, ifaceIP []netip.Addr) erro
 	return nil
 }
 
-func (sb *Sandbox) deleteHostsEntries(recs []etchosts.Record) {}
+func (sb *Sandbox) deleteHostsEntries(ifaceAddrs []netip.Addr) {}
 
 func (sb *Sandbox) updateDNS(ipv6Enabled bool) error {
 	return nil


### PR DESCRIPTION
**- What I did**

Without these changes ...

Nothing gets deleted if a `--hostname` is used:
```
# docker network create --ipv6 n1
64d05b1267972baec7bd340c0bc354249c67d4bf1899da242fd9f57ccfe79c71
# docker network create --ipv6 n2
0d73e51ca1e91297f4a74d71e8d6ff7b6902f69be3fad61ee6bc1d0c90ed5e49
# docker run --rm -d --network n1 --network n2 --name c1 --hostname c1.invalid busybox sleep infinity
827beffc09a779df35bc8f76d7336accb2e2e468a40e4fa835cfcfb0b5ebcdb4
# docker exec -ti c1 cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::	ip6-localnet
ff00::	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.22.0.2	c1.invalid c1
fda3:534a:4f8:2::2	c1.invalid c1
172.21.0.2	c1.invalid c1
fda3:534a:4f8:1::2	c1.invalid c1

# docker network disconnect n2 c1
# docker exec -ti c1 cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::	ip6-localnet
ff00::	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.22.0.2	c1.invalid c1
fda3:534a:4f8:2::2	c1.invalid c1
172.21.0.2	c1.invalid c1
fda3:534a:4f8:1::2	c1.invalid c1
```

Without a `--hostname`, entries for all networks are removed on the first disconnect:
```
# docker run --rm -d --network n1 --network n2 --name c1 busybox sleep infinity
419d3e77f2d548388cbb54ae0c1726473efc408e0623849a58c65391be75af90
# docker exec -ti c1 cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::	ip6-localnet
ff00::	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
172.21.0.2	419d3e77f2d5
fda3:534a:4f8:1::2	419d3e77f2d5
172.22.0.2	419d3e77f2d5
fda3:534a:4f8:2::2	419d3e77f2d5

# docker network disconnect n2 c1
# docker exec -ti c1 cat /etc/hosts
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
fe00::	ip6-localnet
ff00::	ip6-mcastprefix
ff02::1	ip6-allnodes
ff02::2	ip6-allrouters
```

**- How I did it**

- When deleting entries, match on IP address as well as hostnames.
- Remove the hosts entries by calculating hostnames in the same way as when they were added, rather than digging through DNS records.
- Removed `Network.getSvcRecords` as it was only used for digging into DNS records to get names to delete from `/etc/hosts`, and a unit test ...
- Updated unit test `TestUpdateSvcRecord`.

**- How to verify it**

New integration test.

**- Description for the changelog**
```markdown changelog
- Remove the correct `/etc/hosts` entries when disconnecting a container from a network.
```
