### PR TITLE
hack: Add explicit containerd feature to `daemon.json`

### DIFF
--- a/hack/dockerfile/etc/docker/daemon.json
+++ b/hack/dockerfile/etc/docker/daemon.json
@@ -3,5 +3,8 @@
 		"crun": {
 			"path": "/usr/local/bin/crun"
 		}
+	},
+	"features": {
+		"containerd-snapshotter": false
 	}
 }


### PR DESCRIPTION
Just a small quality of life enhancement if you run the dev container a lot for testing the containerd integration.

While it's still turned off by default, it's easier to just flip the `false` to `true` inside the devcontainer.