### PR TITLE
c8d/list: Return `Descriptor`

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -397,6 +397,7 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 
 	useNone := versions.LessThan(version, "1.43")
 	withVirtualSize := versions.LessThan(version, "1.44")
+	noDescriptor := versions.LessThan(version, "1.48")
 	for _, img := range images {
 		if useNone {
 			if len(img.RepoTags) == 0 && len(img.RepoDigests) == 0 {
@@ -413,6 +414,9 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		}
 		if withVirtualSize {
 			img.VirtualSize = img.Size //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
+		}
+		if noDescriptor {
+			img.Descriptor = nil
 		}
 	}
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2278,6 +2278,18 @@ definitions:
         x-omitempty: true
         items:
           $ref: "#/definitions/ImageManifestSummary"
+      Descriptor:
+        description: |
+          Descriptor is an OCI descriptor of the image target.
+          In case of a multi-platform image, this descriptor points to the OCI index
+          or a manifest list.
+
+          This field is only present if the daemon provides a multi-platform image store.
+
+          WARNING: This is experimental and may change at any time without any backward
+          compatibility.
+        x-nullable: true
+        $ref: "#/definitions/OCIDescriptor"
 
   AuthConfig:
     type: "object"

--- a/api/types/image/summary.go
+++ b/api/types/image/summary.go
@@ -1,5 +1,7 @@
 package image
 
+import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 type Summary struct {
 
 	// Number of containers using this image. Includes both stopped and running
@@ -41,6 +43,13 @@ type Summary struct {
 	//
 	// Required: true
 	ParentID string `json:"ParentId"`
+
+	// Descriptor is the OCI descriptor of the image target.
+	// It's only set if the daemon provides a multi-platform image store.
+	//
+	// WARNING: This is experimental and may change at any time without any backward
+	// compatibility.
+	Descriptor *ocispec.Descriptor `json:"Descriptor,omitempty"`
 
 	// Manifests is a list of image manifests available in this image.  It
 	// provides a more detailed view of the platform-specific image manifests or

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -393,6 +393,7 @@ func (i *ImageService) imageSummary(ctx context.Context, img images.Image, platf
 			// consider both "0" and "nil" to be "empty".
 			SharedSize: -1,
 			Containers: -1,
+			Descriptor: &target,
 		}, nil, nil
 	}
 
@@ -402,6 +403,8 @@ func (i *ImageService) imageSummary(ctx context.Context, img images.Image, platf
 	}
 	image.Size = totalSize
 	image.Manifests = manifestSummaries
+	target := img.Target
+	image.Descriptor = &target
 
 	if opts.ContainerCount {
 		image.Containers = containersCount

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -187,20 +187,18 @@ func TestImageList(t *testing.T) {
 
 	blobsDir := t.TempDir()
 
-	multilayer, err := specialimage.MultiLayer(blobsDir)
-	assert.NilError(t, err)
+	toContainerdImage := func(t *testing.T, imageFunc specialimage.SpecialImageFunc) images.Image {
+		idx, err := imageFunc(blobsDir)
+		assert.NilError(t, err)
 
-	twoplatform, err := specialimage.TwoPlatform(blobsDir)
-	assert.NilError(t, err)
+		return imagesFromIndex(idx)[0]
+	}
 
-	emptyIndex, err := specialimage.EmptyIndex(blobsDir)
-	assert.NilError(t, err)
-
-	configTarget, err := specialimage.ConfigTarget(blobsDir)
-	assert.NilError(t, err)
-
-	textplain, err := specialimage.TextPlain(blobsDir)
-	assert.NilError(t, err)
+	multilayer := toContainerdImage(t, specialimage.MultiLayer)
+	twoplatform := toContainerdImage(t, specialimage.TwoPlatform)
+	emptyIndex := toContainerdImage(t, specialimage.EmptyIndex)
+	configTarget := toContainerdImage(t, specialimage.ConfigTarget)
+	textplain := toContainerdImage(t, specialimage.TextPlain)
 
 	cs := &blobsDirContentStore{blobs: filepath.Join(blobsDir, "blobs/sha256")}
 
@@ -213,11 +211,14 @@ func TestImageList(t *testing.T) {
 	}{
 		{
 			name:   "one multi-layer image",
-			images: imagesFromIndex(multilayer),
+			images: []images.Image{multilayer},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 1))
 
-				assert.Check(t, is.Equal(all[0].ID, multilayer.Manifests[0].Digest.String()))
+				if assert.Check(t, all[0].Descriptor != nil) {
+					assert.Check(t, is.DeepEqual(*all[0].Descriptor, multilayer.Target))
+				}
+				assert.Check(t, is.Equal(all[0].ID, multilayer.Target.Digest.String()))
 				assert.Check(t, is.DeepEqual(all[0].RepoTags, []string{"multilayer:latest"}))
 
 				assert.Check(t, is.Len(all[0].Manifests, 1))
@@ -227,11 +228,15 @@ func TestImageList(t *testing.T) {
 		},
 		{
 			name:   "one image with two platforms is still one entry",
-			images: imagesFromIndex(twoplatform),
+			images: []images.Image{twoplatform},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 1))
 
-				assert.Check(t, is.Equal(all[0].ID, twoplatform.Manifests[0].Digest.String()))
+				if assert.Check(t, all[0].Descriptor != nil) {
+					assert.Check(t, is.DeepEqual(*all[0].Descriptor, twoplatform.Target))
+				}
+				assert.Check(t, is.Equal(all[0].ID, twoplatform.Target.Digest.String()))
+
 				assert.Check(t, is.DeepEqual(all[0].RepoTags, []string{"twoplatform:latest"}))
 
 				i := all[0]
@@ -249,14 +254,22 @@ func TestImageList(t *testing.T) {
 		},
 		{
 			name:   "two images are two entries",
-			images: imagesFromIndex(multilayer, twoplatform),
+			images: []images.Image{multilayer, twoplatform},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 2))
 
-				assert.Check(t, is.Equal(all[0].ID, multilayer.Manifests[0].Digest.String()))
+				if assert.Check(t, all[0].Descriptor != nil) {
+					assert.Check(t, is.DeepEqual(*all[0].Descriptor, multilayer.Target))
+				}
+				assert.Check(t, is.Equal(all[0].ID, multilayer.Target.Digest.String()))
+
 				assert.Check(t, is.DeepEqual(all[0].RepoTags, []string{"multilayer:latest"}))
 
-				assert.Check(t, is.Equal(all[1].ID, twoplatform.Manifests[0].Digest.String()))
+				if assert.Check(t, all[1].Descriptor != nil) {
+					assert.Check(t, is.DeepEqual(*all[1].Descriptor, twoplatform.Target))
+				}
+				assert.Check(t, is.Equal(all[1].ID, twoplatform.Target.Digest.String()))
+
 				assert.Check(t, is.DeepEqual(all[1].RepoTags, []string{"twoplatform:latest"}))
 
 				assert.Check(t, is.Len(all[0].Manifests, 1))
@@ -270,14 +283,14 @@ func TestImageList(t *testing.T) {
 		},
 		{
 			name:   "three images, one is an empty index",
-			images: imagesFromIndex(multilayer, emptyIndex, twoplatform),
+			images: []images.Image{multilayer, emptyIndex, twoplatform},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 3))
 			},
 		},
 		{
 			name:   "one good image, second has config as a target",
-			images: imagesFromIndex(multilayer, configTarget),
+			images: []images.Image{multilayer, configTarget},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 2))
 
@@ -285,19 +298,29 @@ func TestImageList(t *testing.T) {
 					return slices.Contains(all[i].RepoTags, "multilayer:latest")
 				})
 
-				assert.Check(t, is.Equal(all[0].ID, multilayer.Manifests[0].Digest.String()))
+				if assert.Check(t, all[0].Descriptor != nil) {
+					assert.Check(t, is.DeepEqual(*all[0].Descriptor, multilayer.Target))
+				}
+				assert.Check(t, is.Equal(all[0].ID, multilayer.Target.Digest.String()))
+
 				assert.Check(t, is.Len(all[0].Manifests, 1))
 
-				assert.Check(t, is.Equal(all[1].ID, configTarget.Manifests[0].Digest.String()))
+				if assert.Check(t, all[1].Descriptor != nil) {
+					assert.Check(t, is.DeepEqual(*all[1].Descriptor, configTarget.Target))
+				}
 				assert.Check(t, is.Len(all[1].Manifests, 0))
 			},
 		},
 		{
 			name:   "a non-container image manifest",
-			images: imagesFromIndex(textplain),
+			images: []images.Image{textplain},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 1))
-				assert.Check(t, is.Equal(all[0].ID, textplain.Manifests[0].Digest.String()))
+
+				if assert.Check(t, all[0].Descriptor != nil) {
+					assert.Check(t, is.DeepEqual(*all[0].Descriptor, textplain.Target))
+				}
+				assert.Check(t, is.Equal(all[0].ID, textplain.Target.Digest.String()))
 
 				assert.Assert(t, is.Len(all[0].Manifests, 0))
 			},

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -34,6 +34,12 @@ keywords: "API, Docker, rcli, REST, documentation"
   and will be omitted in API v1.49.
 * `Sysctls` in `HostConfig` (top level `--sysctl` settings) for `eth0` are
   no longer migrated to `DriverOpts`, as described in the changes for v1.46.
+* `GET /images/json` response now includes `Descriptor` field, which contains
+  an OCI descriptor of the image target.
+  The new field will only be populated if the daemon provides a multi-platform
+  image store.
+  WARNING: This is experimental and may change at any time without any backward
+  compatibility.
 
 ## v1.47 API changes
 


### PR DESCRIPTION
While the endpoint returns a detailed information about its children, it doesn't actually expose the descriptor of the root OCI index/manifest list.

This commits adds the target description to the returned JSON.

**- How to verify it**

unit test: TestImageList

manual:
```bash
$  docker pull alpine # multi-platform index image
Using default tag: latest
latest: Pulling from library/alpine
9986a736f7d3: Download complete 
Digest: sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a
Status: Downloaded newer image for alpine:latest
docker.io/library/alpine:latest

$ docker pull arm64v8/alpine:3.20.0 # single-platform manifest image
3.20.0: Pulling from arm64v8/alpine
94747bd81234: Download complete 
Digest: sha256:1c3b93ed450e26eac89b471d6d140e2f99488f489739b8b8ea5e8202dd086f82
Status: Downloaded newer image for arm64v8/alpine:3.20.0
docker.io/arm64v8/alpine:3.20.0

$ curl -s --unix-socket /var/run/docker.sock localhost/images/json | jq
[
  {
    "Containers": -1,
    "Created": 1725624336,
    "Id": "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
    "Labels": null,
    "ParentId": "",
    "Descriptor": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
      "size": 9218
    },
    "RepoDigests": [
      "alpine@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a"
    ],
    "RepoTags": [
      "alpine:latest"
    ],
    "SharedSize": -1,
    "Size": 13575703
  },
  {
    "Containers": -1,
    "Created": 1716401848,
    "Id": "sha256:1c3b93ed450e26eac89b471d6d140e2f99488f489739b8b8ea5e8202dd086f82",
    "Labels": null,
    "ParentId": "",
    "Descriptor": {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "digest": "sha256:1c3b93ed450e26eac89b471d6d140e2f99488f489739b8b8ea5e8202dd086f82",
      "size": 528
    },
    "RepoDigests": [
      "arm64v8/alpine@sha256:1c3b93ed450e26eac89b471d6d140e2f99488f489739b8b8ea5e8202dd086f82"
    ],
    "RepoTags": [
      "arm64v8/alpine:3.20.0"
    ],
    "SharedSize": -1,
    "Size": 13575127
  }
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: `GET /images/json` response now includes `Descriptor` field, which contains an OCI descriptor of the image target.
```

**- A picture of a cute animal (not mandatory but encouraged)**

