### PR TITLE
[27.x backport] deprecate pkg/platform and move internal

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -20,11 +20,11 @@ import (
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/internal/platform"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/meminfo"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
-	"github.com/docker/docker/pkg/platform"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/registry"
 	metrics "github.com/docker/go-metrics"
@@ -63,7 +63,7 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*system.Info, error) {
 		OSVersion:          osVersion(ctx),
 		IndexServerAddress: registry.IndexServer,
 		OSType:             runtime.GOOS,
-		Architecture:       platform.Architecture,
+		Architecture:       platform.Architecture(),
 		RegistryConfig:     doWithTrace(ctx, "registry.ServiceConfig", daemon.registryService.ServiceConfig),
 		NCPU:               doWithTrace(ctx, "sysinfo.NumCPU", sysinfo.NumCPU),
 		MemTotal:           memInfo(ctx).MemTotal,

--- a/daemon/stats_windows.go
+++ b/daemon/stats_windows.go
@@ -6,7 +6,7 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/platform"
+	"github.com/docker/docker/internal/platform"
 )
 
 func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsResponse, error) {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"context"
+	"sync"
+
+	"github.com/containerd/log"
+)
+
+var (
+	arch     string
+	onceArch sync.Once
+)
+
+// Architecture returns the runtime architecture of the process.
+//
+// Unlike [runtime.GOARCH] (which refers to the compiler platform),
+// Architecture refers to the running platform.
+//
+// For example, Architecture reports "x86_64" as architecture, even
+// when running a "linux/386" compiled binary on "linux/amd64" hardware.
+func Architecture() string {
+	onceArch.Do(func() {
+		var err error
+		arch, err = runtimeArchitecture()
+		if err != nil {
+			log.G(context.TODO()).WithError(err).Error("Could not read system architecture info")
+		}
+	})
+	return arch
+}

--- a/internal/platform/platform_unix.go
+++ b/internal/platform/platform_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package platform // import "github.com/docker/docker/pkg/platform"
+package platform
 
 import (
 	"golang.org/x/sys/unix"
@@ -13,4 +13,13 @@ func runtimeArchitecture() (string, error) {
 		return "", err
 	}
 	return unix.ByteSliceToString(utsname.Machine[:]), nil
+}
+
+// NumProcs returns the number of processors on the system
+//
+// Deprecated: temporary stub for non-Windows to provide an alias for the deprecated github.com/docker/docker/pkg/platform package.
+//
+// FIXME(thaJeztah): remove once we remove  github.com/docker/docker/pkg/platform
+func NumProcs() uint32 {
+	return 0
 }

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -1,4 +1,4 @@
-package platform // import "github.com/docker/docker/pkg/platform"
+package platform
 
 import (
 	"fmt"

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1,11 +1,11 @@
 // Package platform provides helper function to get the runtime architecture
 // for different platforms.
+//
+// Deprecated: this package is only used internally, and will be removed in the next release.
 package platform // import "github.com/docker/docker/pkg/platform"
 
 import (
-	"context"
-
-	"github.com/containerd/log"
+	"github.com/docker/docker/internal/platform"
 )
 
 // Architecture holds the runtime architecture of the process.
@@ -15,12 +15,13 @@ import (
 //
 // For example, Architecture reports "x86_64" as architecture, even
 // when running a "linux/386" compiled binary on "linux/amd64" hardware.
-var Architecture string
+//
+// Deprecated: this package is only used internally, and will be removed in the next release.
+var Architecture = platform.Architecture()
 
-func init() {
-	var err error
-	Architecture, err = runtimeArchitecture()
-	if err != nil {
-		log.G(context.TODO()).WithError(err).Error("Could not read system architecture info")
-	}
+// NumProcs returns the number of processors on the system
+//
+// Deprecated: this package is only used internally, and will be removed in the next release.
+func NumProcs() uint32 {
+	return platform.NumProcs()
 }


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48862


Functions in this package are only used internally in the daemon for the `/info` endpoint (Architecture), and as part of `stats` (NumProcs).

I was not able to find external consumers, but deprecating the package first, so that we can remove / dismantle the package in a follow-up.


(cherry picked from commit b034dc41a217fbeb2c8a8b58fba3cef7c97611aa)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
deprecate pkg/platform: this package is only used internally, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

