### PR TITLE
fix missing go:build tags

### DIFF
--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package container // import "github.com/docker/docker/api/server/router/container"
 
 import (

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package containerd
 
 import (

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package libnetwork
 
 import (


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48777
- https://github.com/moby/moby/pull/48323
- https://github.com/moby/moby/pull/48672


### daemon/containerd: add missing go:build tag

This was introduced in ba454f573b02922340761c0d44687c0b5daa60a6;

    make BIND_DIR=. shell
    make -C ./internal/gocompat/
    GO111MODULE=on go test -v
    # github.com/docker/docker/daemon/containerd
    ../../daemon/containerd/image_inspect.go:107:18: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    FAIL	gocompat [build failed]

### api/server/router/container: add missing go:build tag

This was introduced in 3f2e9da0100af2ceb3ef0d6431cb2b27dc3e1e49;

    make BIND_DIR=. shell
    make -C ./internal/gocompat/
    GO111MODULE=on go test -v
    # github.com/docker/docker/api/server/router/container
    ../../api/server/router/container/inspect.go:29:18: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    FAIL	gocompat [build failed]


### libnetwork: add missing go:build tag

This was introduced in 18327745c00d4d2e98e5ea7241c1a1ef43b0401b;


    make BIND_DIR=. shell
    make -C ./internal/gocompat/
    GO111MODULE=on go test -v
    # github.com/docker/docker/libnetwork
    ../../libnetwork/sandbox.go:588:6: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    FAIL	gocompat [build failed]



