### PR TITLE
[27.x] vendor: tags.cncf.io/container-device-interface v0.8.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -118,7 +118,7 @@ require (
 	google.golang.org/protobuf v1.35.1
 	gotest.tools/v3 v3.5.1
 	resenje.org/singleflight v0.4.1
-	tags.cncf.io/container-device-interface v0.7.2
+	tags.cncf.io/container-device-interface v0.8.0
 )
 
 require (
@@ -236,5 +236,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
-	tags.cncf.io/container-device-interface/specs-go v0.7.0 // indirect
+	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )

--- a/vendor.sum
+++ b/vendor.sum
@@ -1075,7 +1075,7 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-tags.cncf.io/container-device-interface v0.7.2 h1:MLqGnWfOr1wB7m08ieI4YJ3IoLKKozEnnNYBtacDPQU=
-tags.cncf.io/container-device-interface v0.7.2/go.mod h1:Xb1PvXv2BhfNb3tla4r9JL129ck1Lxv9KuU6eVOfKto=
-tags.cncf.io/container-device-interface/specs-go v0.7.0 h1:w/maMGVeLP6TIQJVYT5pbqTi8SCw/iHZ+n4ignuGHqg=
-tags.cncf.io/container-device-interface/specs-go v0.7.0/go.mod h1:hMAwAbMZyBLdmYqWgYcKH0F/yctNpV3P35f+/088A80=
+tags.cncf.io/container-device-interface v0.8.0 h1:8bCFo/g9WODjWx3m6EYl3GfUG31eKJbaggyBDxEldRc=
+tags.cncf.io/container-device-interface v0.8.0/go.mod h1:Apb7N4VdILW0EVdEMRYXIDVRZfNJZ+kmEUss2kRRQ6Y=
+tags.cncf.io/container-device-interface/specs-go v0.8.0 h1:QYGFzGxvYK/ZLMrjhvY0RjpUavIn4KcmRmVP/JjdBTA=
+tags.cncf.io/container-device-interface/specs-go v0.8.0/go.mod h1:BhJIkjjPh4qpys+qm4DAYtUyryaTDg9zris+AczXyws=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1613,13 +1613,13 @@ resenje.org/singleflight
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# tags.cncf.io/container-device-interface v0.7.2
+# tags.cncf.io/container-device-interface v0.8.0
 ## explicit; go 1.20
 tags.cncf.io/container-device-interface/internal/validation
 tags.cncf.io/container-device-interface/internal/validation/k8s
 tags.cncf.io/container-device-interface/pkg/cdi
 tags.cncf.io/container-device-interface/pkg/parser
-# tags.cncf.io/container-device-interface/specs-go v0.7.0
+# tags.cncf.io/container-device-interface/specs-go v0.8.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
 # github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.11.7

--- a/vendor/tags.cncf.io/container-device-interface/pkg/cdi/oci.go
+++ b/vendor/tags.cncf.io/container-device-interface/pkg/cdi/oci.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2021 The CDI Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdi
+
+import (
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// toOCI returns the opencontainers runtime Spec Hook for this Hook.
+func (h *Hook) toOCI() spec.Hook {
+	return spec.Hook{
+		Path:    h.Path,
+		Args:    h.Args,
+		Env:     h.Env,
+		Timeout: h.Timeout,
+	}
+}
+
+// toOCI returns the opencontainers runtime Spec Mount for this Mount.
+func (m *Mount) toOCI() spec.Mount {
+	return spec.Mount{
+		Source:      m.HostPath,
+		Destination: m.ContainerPath,
+		Options:     m.Options,
+		Type:        m.Type,
+	}
+}
+
+// toOCI returns the opencontainers runtime Spec LinuxDevice for this DeviceNode.
+func (d *DeviceNode) toOCI() spec.LinuxDevice {
+	return spec.LinuxDevice{
+		Path:     d.Path,
+		Type:     d.Type,
+		Major:    d.Major,
+		Minor:    d.Minor,
+		FileMode: d.FileMode,
+		UID:      d.UID,
+		GID:      d.GID,
+	}
+}
+
+// toOCI returns the opencontainers runtime Spec LinuxIntelRdt for this IntelRdt config.
+func (i *IntelRdt) toOCI() *spec.LinuxIntelRdt {
+	return &spec.LinuxIntelRdt{
+		ClosID:        i.ClosID,
+		L3CacheSchema: i.L3CacheSchema,
+		MemBwSchema:   i.MemBwSchema,
+		EnableCMT:     i.EnableCMT,
+		EnableMBM:     i.EnableMBM,
+	}
+}

--- a/vendor/tags.cncf.io/container-device-interface/pkg/cdi/version.go
+++ b/vendor/tags.cncf.io/container-device-interface/pkg/cdi/version.go
@@ -40,6 +40,7 @@ const (
 	v050 version = "v0.5.0"
 	v060 version = "v0.6.0"
 	v070 version = "v0.7.0"
+	v080 version = "v0.8.0"
 
 	// vEarliest is the earliest supported version of the CDI specification
 	vEarliest version = v030
@@ -56,6 +57,7 @@ var validSpecVersions = requiredVersionMap{
 	v050: requiresV050,
 	v060: requiresV060,
 	v070: requiresV070,
+	v080: requiresV080,
 }
 
 // MinimumRequiredVersion determines the minimum spec version for the input spec.
@@ -118,6 +120,13 @@ func (r requiredVersionMap) requiredVersion(spec *cdi.Spec) version {
 	}
 
 	return minVersion
+}
+
+// requiresV080 returns true if the spec uses v0.8.0 features.
+// Since the v0.8.0 spec bump was due to the removed .ToOCI functions on the
+// spec types, there are explicit spec changes.
+func requiresV080(_ *cdi.Spec) bool {
+	return false
 }
 
 // requiresV070 returns true if the spec uses v0.7.0 features

--- a/vendor/tags.cncf.io/container-device-interface/specs-go/config.go
+++ b/vendor/tags.cncf.io/container-device-interface/specs-go/config.go
@@ -3,7 +3,7 @@ package specs
 import "os"
 
 // CurrentVersion is the current version of the Spec.
-const CurrentVersion = "0.7.0"
+const CurrentVersion = "0.8.0"
 
 // Spec is the base configuration for CDI
 type Spec struct {

--- a/vendor/tags.cncf.io/container-device-interface/specs-go/oci.go
+++ b/vendor/tags.cncf.io/container-device-interface/specs-go/oci.go
@@ -1,49 +1,56 @@
+/*
+Copyright © 2021 The CDI Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package specs
 
-import (
-	spec "github.com/opencontainers/runtime-spec/specs-go"
-)
+import "errors"
+
+// errDeprecated is returned for the ToOCI functions below.
+// This should provide better guidance for user when migrating from the API
+// below to the APIs provided in the cdi package.
+var errDeprecated = errors.New("deprecated; Use cdi package functions instead")
 
 // ToOCI returns the opencontainers runtime Spec Hook for this Hook.
-func (h *Hook) ToOCI() spec.Hook {
-	return spec.Hook{
-		Path:    h.Path,
-		Args:    h.Args,
-		Env:     h.Env,
-		Timeout: h.Timeout,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.Hook.toOCI
+// and made private.
+func (h *Hook) ToOCI() error {
+	return errDeprecated
 }
 
 // ToOCI returns the opencontainers runtime Spec Mount for this Mount.
-func (m *Mount) ToOCI() spec.Mount {
-	return spec.Mount{
-		Source:      m.HostPath,
-		Destination: m.ContainerPath,
-		Options:     m.Options,
-		Type:        m.Type,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.Mount.toOCI
+// and made private.
+func (m *Mount) ToOCI() error {
+	return errDeprecated
 }
 
 // ToOCI returns the opencontainers runtime Spec LinuxDevice for this DeviceNode.
-func (d *DeviceNode) ToOCI() spec.LinuxDevice {
-	return spec.LinuxDevice{
-		Path:     d.Path,
-		Type:     d.Type,
-		Major:    d.Major,
-		Minor:    d.Minor,
-		FileMode: d.FileMode,
-		UID:      d.UID,
-		GID:      d.GID,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.DeviceNode.toOCI
+// and made private.
+func (d *DeviceNode) ToOCI() error {
+	return errDeprecated
 }
 
 // ToOCI returns the opencontainers runtime Spec LinuxIntelRdt for this IntelRdt config.
-func (i *IntelRdt) ToOCI() *spec.LinuxIntelRdt {
-	return &spec.LinuxIntelRdt{
-		ClosID:        i.ClosID,
-		L3CacheSchema: i.L3CacheSchema,
-		MemBwSchema:   i.MemBwSchema,
-		EnableCMT:     i.EnableCMT,
-		EnableMBM:     i.EnableMBM,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.IntelRdt.toOCI
+// and made private.
+func (i *IntelRdt) ToOCI() error {
+	return errDeprecated
 }


### PR DESCRIPTION
Align with docker/cli, which uses v0.8.0

- backport: https://github.com/moby/moby/pull/48371

---

Breaking change: The .ToOCI() functions in the specs-go package have been removed. This removes the dependency on the OCI runtime specification from the CDI specification definition itself.

What's Changed

- Add workflow to mark prs and issues as stale
- Remove the ToOCI functions from the specs-go package
- docs: add a pointer to community meetings in our docs.
- Bump spec version to v0.8.0
- Update spec version in README

Full diff:  https://github.com/cncf-tags/container-device-interface/compare/v0.7.2...v0.8.0


(cherry picked from commit 2f0180934d5420001e90c71133435d92822edc8b)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

