### PR TITLE
daemon/logger: logDriverError: use WithFields for logs

### DIFF
--- a/daemon/logger/logger_error.go
+++ b/daemon/logger/logger_error.go
@@ -18,9 +18,10 @@ var logErrorLimiter = rate.NewLimiter(333, 333)
 func logDriverError(loggerName, msgLine string, logErr error) {
 	logWritesFailedCount.Inc(1)
 	if logErrorLimiter.Allow() {
-		log.G(context.TODO()).WithError(logErr).
-			WithField("driver", loggerName).
-			WithField("message", msgLine).
-			Errorf("Error writing log message")
+		log.G(context.TODO()).WithFields(log.Fields{
+			"error":   logErr,
+			"driver":  loggerName,
+			"message": msgLine,
+		}).Error("Error writing log message")
 	}
 }


### PR DESCRIPTION
Slightly more performant than multiple `WithField` calls

