### PR TITLE
EnableIPv4 will be in API 1.48, not 1.47

### DIFF
--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -214,8 +214,8 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 
 	version := httputils.VersionFromContext(ctx)
 
-	// EnableIPv4 was introduced in API 1.47.
-	if versions.LessThan(version, "1.47") {
+	// EnableIPv4 was introduced in API 1.48.
+	if versions.LessThan(version, "1.48") {
 		create.EnableIPv4 = nil
 	}
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -40,16 +40,16 @@ keywords: "API, Docker, rcli, REST, documentation"
   image store.
   WARNING: This is experimental and may change at any time without any backward
   compatibility.
-
-## v1.47 API changes
-
-[Docker Engine API v1.47](https://docs.docker.com/reference/api/engine/version/v1.47/) documentation
-
 * `POST /networks/create` now has an `EnableIPv4` field. Setting it to `false`
   disables IPv4 IPAM for the network. It can only be set to `false` if the
   daemon has experimental features enabled.
 * `GET /networks/{id}` now returns an `EnableIPv4` field showing whether the
   network has IPv4 IPAM enabled.
+
+## v1.47 API changes
+
+[Docker Engine API v1.47](https://docs.docker.com/reference/api/engine/version/v1.47/) documentation
+
 * `GET /images/json` response now includes `Manifests` field, which contains
   information about the sub-manifests included in the image index. This
   includes things like platform-specific manifests and build attestations.


### PR DESCRIPTION
**- What I did**

API field `EnableIPv4`, needed to create an IPv6-only network, will be in moby 28.0 ... which will have API 1.48, not 1.47.

Numbering has changed since https://github.com/moby/moby/pull/48271 (commit d4d86111642916149b54aa99ef4e48d6665465cc).

(None of this is in the 27.x branch, its `version-history.md` is fine.)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

