### PR TITLE
remove logentries check and migration code

### DIFF
--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -209,10 +209,6 @@ func (sr *swarmRouter) createService(ctx context.Context, w http.ResponseWriter,
 	if err := httputils.ReadJSON(r, &service); err != nil {
 		return err
 	}
-	// TODO(thaJeztah): remove logentries check and migration code in release v26.0.0.
-	if service.TaskTemplate.LogDriver != nil && service.TaskTemplate.LogDriver.Name == "logentries" {
-		return errdefs.InvalidParameter(errors.New("the logentries logging driver has been deprecated and removed"))
-	}
 
 	// Get returns "" if the header does not exist
 	encodedAuth := r.Header.Get(registry.AuthHeader)
@@ -240,10 +236,6 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 	var service types.ServiceSpec
 	if err := httputils.ReadJSON(r, &service); err != nil {
 		return err
-	}
-	// TODO(thaJeztah): remove logentries check and migration code in release v26.0.0.
-	if service.TaskTemplate.LogDriver != nil && service.TaskTemplate.LogDriver.Name == "logentries" {
-		return errdefs.InvalidParameter(errors.New("the logentries logging driver has been deprecated and removed"))
 	}
 
 	rawVersion := r.URL.Query().Get("version")

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -61,10 +61,6 @@ func (daemon *Daemon) containerCreate(ctx context.Context, daemonCfg *configStor
 	if opts.params.Config == nil {
 		return containertypes.CreateResponse{}, errdefs.InvalidParameter(runconfig.ErrEmptyConfig)
 	}
-	// TODO(thaJeztah): remove logentries check and migration code in release v26.0.0.
-	if opts.params.HostConfig != nil && opts.params.HostConfig.LogConfig.Type == "logentries" {
-		return containertypes.CreateResponse{}, errdefs.InvalidParameter(fmt.Errorf("the logentries logging driver has been deprecated and removed"))
-	}
 
 	// Normalize some defaults. Doing this "ad-hoc" here for now, as there's
 	// only one field to migrate, but we should consider having a better

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -46,7 +46,6 @@ import (
 	_ "github.com/docker/docker/daemon/graphdriver/register" // register graph drivers
 	"github.com/docker/docker/daemon/images"
 	dlogger "github.com/docker/docker/daemon/logger"
-	"github.com/docker/docker/daemon/logger/local"
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/daemon/snapshotter"
 	"github.com/docker/docker/daemon/stats"
@@ -322,18 +321,6 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 					baseLogger.Debug("migrated restart-policy")
 					c.HostConfig.RestartPolicy.Name = containertypes.RestartPolicyDisabled
 					c.HostConfig.RestartPolicy.MaximumRetryCount = 0
-				}
-
-				// Migrate containers that use the deprecated (and now non-functional)
-				// logentries driver. Update them to use the "local" logging driver
-				// instead.
-				//
-				// TODO(thaJeztah): remove logentries check and migration code in release v26.0.0.
-				if c.HostConfig.LogConfig.Type == "logentries" {
-					baseLogger.Warn("migrated deprecated logentries logging driver")
-					c.HostConfig.LogConfig = containertypes.LogConfig{
-						Type: local.Name,
-					}
 				}
 
 				// Normalize the "default" network mode into the network mode


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46926

This code was added in 3b1d9f1a26de1d1be89c8e7f7d700954e12b6228 when the logentries logging-driver was removed in v25.0.0. The logentries service was already defunct, so unlikely to have any consumers, so let's remove this code.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Remove migration code and errors for the deprecated "logentries" logging driver.
```

**- A picture of a cute animal (not mandatory but encouraged)**

