### PR TITLE
c8d/image/inspect: Return `Descriptor`

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -352,6 +352,9 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 		imageInspect.Container = ""        //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
 		imageInspect.ContainerConfig = nil //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
 	}
+	if versions.LessThan(version, "1.48") {
+		imageInspect.Descriptor = nil
+	}
 	return httputils.WriteJSON(w, http.StatusOK, imageInspect)
 }
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1991,6 +1991,18 @@ definitions:
         type: "string"
         x-nullable: false
         example: "sha256:ec3f0931a6e6b6855d76b2d7b0be30e81860baccd891b2e243280bf1cd8ad710"
+      Descriptor:
+        description: |
+          Descriptor is an OCI descriptor of the image target.
+          In case of a multi-platform image, this descriptor points to the OCI index
+          or a manifest list.
+
+          This field is only present if the daemon provides a multi-platform image store.
+
+          WARNING: This is experimental and may change at any time without any backward
+          compatibility.
+        x-nullable: true
+        $ref: "#/definitions/OCIDescriptor"
       RepoTags:
         description: |
           List of image names/tags in the local image cache that reference this

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -3,6 +3,7 @@ package image
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/storage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // RootFS returns Image's RootFS description including the layer IDs.
@@ -119,4 +120,11 @@ type InspectResponse struct {
 	//
 	// This information is local to the daemon, and not part of the image itself.
 	Metadata Metadata
+
+	// Descriptor is the OCI descriptor of the image target.
+	// It's only set if the daemon provides a multi-platform image store.
+	//
+	// WARNING: This is experimental and may change at any time without any backward
+	// compatibility.
+	Descriptor *ocispec.Descriptor `json:"Descriptor,omitempty"`
 }

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -45,7 +45,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backe
 	if err != nil {
 		return nil, err
 	}
-	imgDgst := tagged[0].Target.Digest
+	target := tagged[0].Target
 
 	repoTags := make([]string, 0, len(tagged))
 	repoDigests := make([]string, 0, len(tagged))
@@ -78,7 +78,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backe
 			continue
 		}
 
-		digested, err := reference.WithDigest(reference.TrimNamed(name), imgDgst)
+		digested, err := reference.WithDigest(reference.TrimNamed(name), target.Digest)
 		if err != nil {
 			// This could only happen if digest is invalid, but considering that
 			// we get it from the Descriptor it's highly unlikely.
@@ -107,6 +107,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backe
 	return &imagetypes.InspectResponse{
 		ID:            img.ImageID(),
 		RepoTags:      repoTags,
+		Descriptor:    &target,
 		RepoDigests:   sliceutil.Dedup(repoDigests),
 		Parent:        img.Parent.String(),
 		Comment:       comment,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -34,8 +34,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   and will be omitted in API v1.49.
 * `Sysctls` in `HostConfig` (top level `--sysctl` settings) for `eth0` are
   no longer migrated to `DriverOpts`, as described in the changes for v1.46.
-* `GET /images/json` response now includes `Descriptor` field, which contains
-  an OCI descriptor of the image target.
+* `GET /images/json` and `GET /images/{name}/json` responses now include
+  `Descriptor` field, which contains an OCI descriptor of the image target.
   The new field will only be populated if the daemon provides a multi-platform
   image store.
   WARNING: This is experimental and may change at any time without any backward

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -59,3 +59,21 @@ func TestImageInspectUniqueRepoDigests(t *testing.T) {
 
 	assert.Check(t, is.Len(after.RepoDigests, len(before.RepoDigests)))
 }
+
+func TestImageInspectDescriptor(t *testing.T) {
+	ctx := setupTest(t)
+
+	client := testEnv.APIClient()
+
+	inspect, _, err := client.ImageInspectWithRaw(ctx, "busybox")
+	assert.NilError(t, err)
+
+	if !testEnv.UsingSnapshotter() {
+		assert.Check(t, inspect.Descriptor == nil)
+		return
+	}
+
+	assert.Assert(t, inspect.Descriptor != nil)
+	assert.Check(t, inspect.Descriptor.Digest.String() == inspect.ID)
+	assert.Check(t, inspect.Descriptor.Size > 0)
+}


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/48861

Add the image target descriptor to the image inspect response.


**- How to verify it**
```bash
$ docker pull alpine
$ curl -s --unix-socket /var/run/docker.sock localhost/images/alpine/json | jq
{
  "Id": "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
  "RepoTags": [
    "alpine:latest"
  ],
  "RepoDigests": [
    "alpine@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a"
  ],
  "Parent": "",
  "Comment": "buildkit.dockerfile.v0",
  "Created": "2024-09-06T12:05:36Z",
...
  "Descriptor": {
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "digest": "sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a",
    "size": 9218
  }
}
```
```bash
$ docker pull arm64v8/alpine:3.10

$ curl -s --unix-socket /var/run/docker.sock localhost/images/arm64v8/alpine:3.10/json | jq

{
  "Id": "sha256:f73072b1ae04902f4d7511b834a1ea2d0475ddf6f87bd81f06e2b4590974a2e5",
  "RepoTags": [
    "arm64v8/alpine:3.10"
  ],
  "RepoDigests": [
    "arm64v8/alpine@sha256:f73072b1ae04902f4d7511b834a1ea2d0475ddf6f87bd81f06e2b4590974a2e5"
  ],
  "Parent": "",
  "Comment": "",
  "Created": "2021-04-14T18:43:17.827903143Z",
...
  "Descriptor": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:f73072b1ae04902f4d7511b834a1ea2d0475ddf6f87bd81f06e2b4590974a2e5",
    "size": 528
  }

```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
# Merge with the `GET /images/json`
containerd image store: `GET /images/json` and `GET /images/{name}/json` response now includes `Descriptor` field, which contains an OCI descriptor of the image target. The new field will only be populated if the daemon provides a multi-platform image store.
```

**- A picture of a cute animal (not mandatory but encouraged)**
![Untitled](https://github.com/user-attachments/assets/bd52adce-ed2a-4af4-bcf2-88da9990eba6)

