### PR TITLE
Makefile: don't automatically inherit graph-driver from host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 DOCKER ?= docker
 BUILDX ?= $(DOCKER) buildx
 
-# set the graph driver as the current graphdriver if not set
-DOCKER_GRAPHDRIVER := $(if $(DOCKER_GRAPHDRIVER),$(DOCKER_GRAPHDRIVER),$(shell docker info -f '{{ .Driver }}' 2>&1))
-export DOCKER_GRAPHDRIVER
-
 DOCKER_GITCOMMIT := $(shell git rev-parse HEAD)
 export DOCKER_GITCOMMIT
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/21474
- relates to https://github.com/moby/moby/pull/48860#issuecomment-2474063777

This was originally added in 54aa3a3c210cd16b687f0e6b6356888d90215752, when there was still a wide variety of storage-drivers used, and some hosts would be running aufs of devicemapper. Let's return to make this an explicit override if needed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

