### PR TITLE
api/ping: include engine features in headers

### DIFF
--- a/api/server/router/system/system_routes_test.go
+++ b/api/server/router/system/system_routes_test.go
@@ -1,8 +1,6 @@
 package system
 
 import (
-	"fmt"
-	"strconv"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -10,10 +8,9 @@ import (
 
 func TestBuildEngineFeaturesHeader(t *testing.T) {
 	testCases := []struct {
-		doc           string
-		in            map[string]bool
-		expected      string
-		expectedError string
+		doc      string
+		in       map[string]bool
+		expected string
 	}{
 		{
 			doc:      "no features",
@@ -50,70 +47,14 @@ func TestBuildEngineFeaturesHeader(t *testing.T) {
 			},
 			expected: "a?test/=true,another-+test=false",
 		},
-		{
-			doc: "invalid feature key – equals '='",
-			in: map[string]bool{
-				"foo=bar": true,
-			},
-			expectedError: "invalid feature – key cannot contain '=': foo=bar",
-		},
-		{
-			doc: "invalid feature key – comma ','",
-			in: map[string]bool{
-				"a,comma": true,
-			},
-			expectedError: "invalid feature – key cannot contain ',': a,comma",
-		},
-		{
-			doc: "valid and invalid features",
-			in: map[string]bool{
-				"bork":         true,
-				"invalid=meow": false,
-			},
-			expectedError: "invalid feature – key cannot contain '=': invalid=meow",
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.doc, func(t *testing.T) {
 			actual, err := buildEngineFeaturesHeader(tc.in)
 
-			if tc.expectedError == "" {
-				assert.NilError(t, err)
-				assert.Equal(t, tc.expected, actual)
-			} else {
-				assert.ErrorContains(t, err, tc.expectedError)
-				assert.Equal(t, actual, "")
-			}
+			assert.NilError(t, err)
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
-}
-
-func TestBuildEngineFeaturesHeaderSizeLimits(t *testing.T) {
-	t.Run("feature key too long", func(t *testing.T) {
-		const longFeatureName = "1234567890123456789012345678901234567890"
-		in := map[string]bool{
-			longFeatureName: true,
-		}
-
-		actual, err := buildEngineFeaturesHeader(in)
-
-		expectedError := fmt.Sprintf("feature name length cannot be over %d: %s", maxFeatureKeyLen, longFeatureName)
-		assert.ErrorContains(t, err, expectedError)
-		assert.Equal(t, actual, "")
-	})
-
-	t.Run("too many features", func(t *testing.T) {
-		in := make(map[string]bool)
-		for i := 0; i < 101; i++ {
-			featureName := strconv.Itoa(i)
-			in[featureName] = true
-		}
-
-		actual, err := buildEngineFeaturesHeader(in)
-
-		expectedError := fmt.Sprintf("too many features – expected max %d, found %d", maxFeatures, 101)
-		assert.ErrorContains(t, err, expectedError)
-		assert.Equal(t, actual, "")
-	})
 }

--- a/api/server/router/system/system_routes_test.go
+++ b/api/server/router/system/system_routes_test.go
@@ -1,0 +1,119 @@
+package system
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestBuildEngineFeaturesHeader(t *testing.T) {
+	testCases := []struct {
+		doc           string
+		in            map[string]bool
+		expected      string
+		expectedError string
+	}{
+		{
+			doc:      "no features",
+			in:       map[string]bool{},
+			expected: "",
+		},
+		{
+			doc: "single true",
+			in: map[string]bool{
+				"bork": true,
+			},
+			expected: "bork=true",
+		},
+		{
+			doc: "single false",
+			in: map[string]bool{
+				"bork": false,
+			},
+			expected: "bork=false",
+		},
+		{
+			doc: "multiple features",
+			in: map[string]bool{
+				"bork": true,
+				"meow": false,
+			},
+			expected: "bork=true,meow=false",
+		},
+		{
+			doc: "valid symbols",
+			in: map[string]bool{
+				"a?test/":       true,
+				"another-+test": false,
+			},
+			expected: "a?test/=true,another-+test=false",
+		},
+		{
+			doc: "invalid feature key – equals '='",
+			in: map[string]bool{
+				"foo=bar": true,
+			},
+			expectedError: "invalid feature – key cannot contain '=': foo=bar",
+		},
+		{
+			doc: "invalid feature key – comma ','",
+			in: map[string]bool{
+				"a,comma": true,
+			},
+			expectedError: "invalid feature – key cannot contain ',': a,comma",
+		},
+		{
+			doc: "valid and invalid features",
+			in: map[string]bool{
+				"bork":         true,
+				"invalid=meow": false,
+			},
+			expectedError: "invalid feature – key cannot contain '=': invalid=meow",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.doc, func(t *testing.T) {
+			actual, err := buildEngineFeaturesHeader(tc.in)
+
+			if tc.expectedError == "" {
+				assert.NilError(t, err)
+				assert.Equal(t, tc.expected, actual)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+				assert.Equal(t, actual, "")
+			}
+		})
+	}
+}
+
+func TestBuildEngineFeaturesHeaderSizeLimits(t *testing.T) {
+	t.Run("feature key too long", func(t *testing.T) {
+		const longFeatureName = "1234567890123456789012345678901234567890"
+		in := map[string]bool{
+			longFeatureName: true,
+		}
+
+		actual, err := buildEngineFeaturesHeader(in)
+
+		expectedError := fmt.Sprintf("feature name length cannot be over %d: %s", maxFeatureKeyLen, longFeatureName)
+		assert.ErrorContains(t, err, expectedError)
+		assert.Equal(t, actual, "")
+	})
+
+	t.Run("too many features", func(t *testing.T) {
+		in := make(map[string]bool)
+		for i := 0; i < 101; i++ {
+			featureName := strconv.Itoa(i)
+			in[featureName] = true
+		}
+
+		actual, err := buildEngineFeaturesHeader(in)
+
+		expectedError := fmt.Sprintf("too many features – expected max %d, found %d", maxFeatures, 101)
+		assert.ErrorContains(t, err, expectedError)
+		assert.Equal(t, actual, "")
+	})
+}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9632,6 +9632,15 @@ paths:
                 This value is a recommendation as advertised by the daemon, and
                 it is up to the client to choose which builder to use.
               default: "2"
+            Engine-Features:
+              type: "string"
+              description: |
+                List of engine features and whether they are enabled or not, containing
+                elements of the `features` field of the daemon's configuration file, as
+                well as features enabled via command line arguments when starting the daemon.
+
+                Represented as a comma separated (,) list of key-value pairs (`some-feature=true|false`),
+                e.g. `containerd-snapshotter=true,other-feature=false`.
             Docker-Experimental:
               type: "boolean"
               description: "If the server is running with experimental mode enabled"

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -34,6 +34,8 @@ type Ping struct {
 	// should use other ways to get the current swarm status, such as the /swarm
 	// endpoint.
 	SwarmStatus *swarm.Status
+
+	EngineFeatures map[string]bool
 }
 
 // ComponentVersion describes the version information for a specific component.

--- a/client/ping.go
+++ b/client/ping.go
@@ -2,13 +2,16 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
 )
 
 // Ping pings the server and returns the value of the "Docker-Experimental",
@@ -71,6 +74,62 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 			ControlAvailable: role == "manager",
 		}
 	}
+	if engineFeatureHeaders := resp.header.Values("Engine-Features"); len(engineFeatureHeaders) > 0 {
+		featuresMap, err := parseEngineFeaturesHeader(engineFeatureHeaders)
+		if err != nil {
+			return ping, fmt.Errorf("failed to parse Engine-Features header: %w", err)
+		}
+		ping.EngineFeatures = featuresMap
+	}
 	err := cli.checkResponseErr(resp)
 	return ping, errdefs.FromStatusCode(err, resp.statusCode)
+}
+
+// Prevent a malicious engine from blowing up clients by sending
+// a huge number of engine features.
+const maxNumEngineFeatures = 100
+
+func parseEngineFeaturesHeader(headers []string) (map[string]bool, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+
+	var totalNumFeatures int
+	featuresMap := make(map[string]bool)
+	for _, h := range headers {
+		if h == "" {
+			continue
+		}
+
+		totalNumFeatures += numFeatures(h)
+		if totalNumFeatures > maxNumEngineFeatures {
+			return nil, errors.Errorf("too many features: expected max %d, found %d", maxNumEngineFeatures, totalNumFeatures)
+		}
+
+		features := strings.Split(h, ",")
+		for _, featureValue := range features {
+			k, v, found := strings.Cut(featureValue, "=")
+			if !found {
+				return nil, fmt.Errorf("feature '%s' is missing '='", featureValue)
+			}
+			if _, alreadyExists := featuresMap[k]; alreadyExists {
+				return nil, fmt.Errorf("duplicate feature '%s'", k)
+			}
+			// TODO(laurazard): unnecessary, would be caught by strconv.ParseBool, maybe we should remove it
+			if strings.Contains(v, "=") {
+				return nil, fmt.Errorf("feature '%s' has too many '='", featureValue)
+			}
+			enabled, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, fmt.Errorf("feature '%s': - %w", featureValue, err)
+			}
+			featuresMap[k] = enabled
+		}
+	}
+
+	return featuresMap, nil
+}
+
+func numFeatures(header string) int {
+	return strings.Count(header, ",") + 1
 }

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -84,6 +85,173 @@ func TestPingSuccess(t *testing.T) {
 	assert.Check(t, is.Equal(true, ping.Experimental))
 	assert.Check(t, is.Equal("awesome", ping.APIVersion))
 	assert.Check(t, is.Equal(swarm.Status{NodeState: "active", ControlAvailable: true}, *ping.SwarmStatus))
+}
+
+func TestPingParseEngineFeatures(t *testing.T) {
+	tooManyFeaturesHeader := ""
+	for i := 0; i < 101; i++ {
+		tooManyFeaturesHeader += strconv.Itoa(i) + "=true,"
+	}
+	tooManyFeaturesHeader = tooManyFeaturesHeader[:len(tooManyFeaturesHeader)-1]
+	testCases := []struct {
+		doc           string
+		in            string
+		expected      map[string]bool
+		expectedError string
+	}{
+		{
+			doc:      "empty",
+			in:       "",
+			expected: map[string]bool{},
+		},
+		{
+			doc: "valid single",
+			in:  "foo=true",
+			expected: map[string]bool{
+				"foo": true,
+			},
+		},
+		{
+			doc: "valid multiple",
+			in:  "bork=false,meow-snapshotter=true",
+			expected: map[string]bool{
+				"bork":             false,
+				"meow-snapshotter": true,
+			},
+		},
+		{
+			doc:           "invalid: missing '='",
+			in:            "bork",
+			expectedError: "failed to parse Engine-Features header: feature 'bork' is missing '='",
+		},
+		{
+			doc:           "invalid: too many '='",
+			in:            "bork=meow=false",
+			expectedError: "failed to parse Engine-Features header: feature 'bork=meow=false' has too many '='",
+		},
+		{
+			doc:           "multiple invalid",
+			in:            "bork=meow=false,foo",
+			expectedError: "failed to parse Engine-Features header: feature 'bork=meow=false' has too many '='",
+		},
+		{
+			doc:           "valid + invalid features",
+			in:            "foo=true,bar",
+			expectedError: "failed to parse Engine-Features header: feature 'bar' is missing '='",
+		},
+		{
+			doc:           "duplicate key",
+			in:            "foo=false,foo=true",
+			expectedError: "failed to parse Engine-Features header: duplicate feature 'foo'",
+		},
+		{
+			doc:           "too many features",
+			in:            tooManyFeaturesHeader,
+			expectedError: "failed to parse Engine-Features header: too many features: expected max 100, found 101",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.doc, func(t *testing.T) {
+			client := &Client{
+				client: newMockClient(func(req *http.Request) (*http.Response, error) {
+					resp := &http.Response{StatusCode: http.StatusOK}
+					resp.Header = http.Header{}
+					resp.Header.Set("API-Version", "awesome")
+					resp.Header.Set("Engine-Features", tc.in)
+					resp.Body = io.NopCloser(strings.NewReader("OK"))
+					return resp, nil
+				}),
+			}
+			ping, err := client.Ping(context.Background())
+			if tc.expectedError == "" {
+				assert.NilError(t, err)
+				assert.Check(t, is.Equal("awesome", ping.APIVersion))
+				assert.DeepEqual(t, tc.expected, ping.EngineFeatures)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestParseEngineFeaturesHeaderMultipleHeaders(t *testing.T) {
+	tooManyFeaturesHeader := ""
+	for i := 0; i < 51; i++ {
+		tooManyFeaturesHeader += strconv.Itoa(i) + "=true,"
+	}
+	tooManyFeaturesHeader = tooManyFeaturesHeader[:len(tooManyFeaturesHeader)-1]
+	tooManyFeaturesHeader2 := ""
+	for i := 51; i < 102; i++ {
+		tooManyFeaturesHeader2 += strconv.Itoa(i) + "=true,"
+	}
+	tooManyFeaturesHeader2 = tooManyFeaturesHeader2[:len(tooManyFeaturesHeader2)-1]
+	testCases := []struct {
+		doc           string
+		in            string
+		in2           string
+		expected      map[string]bool
+		expectedError string
+	}{
+		{
+			doc:      "empty",
+			in:       "",
+			in2:      "",
+			expected: map[string]bool{},
+		},
+		{
+			doc: "single + empty",
+			in:  "foo=true",
+			in2: "",
+			expected: map[string]bool{
+				"foo": true,
+			},
+		},
+		{
+			doc: "empty + single",
+			in:  "",
+			in2: "bork=false",
+			expected: map[string]bool{
+				"bork": false,
+			},
+		},
+		{
+			doc:           "duplicate features in separate headers",
+			in:            "foo=true",
+			in2:           "foo=false",
+			expectedError: "failed to parse Engine-Features header: duplicate feature 'foo'",
+		},
+		{
+			doc:           "too many features",
+			in:            tooManyFeaturesHeader,
+			in2:           tooManyFeaturesHeader2,
+			expectedError: "failed to parse Engine-Features header: too many features: expected max 100, found 102",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.doc, func(t *testing.T) {
+			client := &Client{
+				client: newMockClient(func(req *http.Request) (*http.Response, error) {
+					resp := &http.Response{StatusCode: http.StatusOK}
+					resp.Header = http.Header{}
+					resp.Header.Set("API-Version", "awesome")
+					resp.Header.Set("Engine-Features", tc.in)
+					resp.Header.Add("Engine-Features", tc.in2)
+					resp.Body = io.NopCloser(strings.NewReader("OK"))
+					return resp, nil
+				}),
+			}
+			ping, err := client.Ping(context.Background())
+			if tc.expectedError == "" {
+				assert.NilError(t, err)
+				assert.Check(t, is.Equal("awesome", ping.APIVersion))
+				assert.DeepEqual(t, tc.expected, ping.EngineFeatures)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+			}
+		})
+	}
 }
 
 // TestPingHeadFallback tests that the client falls back to GET if HEAD fails.

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -72,6 +72,13 @@ const (
 // Features get serialized into the `Engine-Features` header by the `/_ping` handler,
 // so we need some limits to ensure that we can serialize them into the header.
 const (
+	// The HTTP spec does not define size limits for headers, but clients usually set limits.
+	// The Go default HTTP client has a default of 1MB:
+	// https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/net/http/server.go;l=916
+	// but other clients and proxies usually have lower limits. To be safe, we should try to
+	// set a conservative limit.
+	// 100*(30 +1 (=) +1 (,) +5 (false/true)) = 3700 which is under 4K.
+
 	// MaxFeatures is the maximum number of configured daemon features.
 	MaxFeatures = 100
 	// MaxFeatureKeyLen is the maximum length for feature names.

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -352,6 +352,28 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			},
 			expectedErr: "invalid logging level: foobar",
 		},
+		{
+			name: "with invalid features (equals '=')",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					Features: map[string]bool{
+						"foo=bar": true,
+					},
+				},
+			},
+			expectedErr: "invalid feature – key cannot contain '=': foo=bar",
+		},
+		{
+			name: "with invalid features (equals ',')",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					Features: map[string]bool{
+						"foo,bar": false,
+					},
+				},
+			},
+			expectedErr: "invalid feature – key cannot contain ',': foo,bar",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -50,6 +50,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   daemon has experimental features enabled.
 * `GET /networks/{id}` now returns an `EnableIPv4` field showing whether the
   network has IPv4 IPAM enabled.
+* `GET|POST` `/_ping` responses now include an `Engine-Features` header (comma
+  separated `,` key-value pairs e.g. `containerd-snapshotter=true`) representing
+  features configured in the daemon's `CommonConfig.Features` field.
 
 ## v1.47 API changes
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add a header to the engine's `/_ping` response to let clients know about relevant features in use/supported by the engine.

Currently this is only used to advertise whether the containerd image store integration is enabled or not – this is useful for situations like the CLI's `docker images --tree` (although in this case the output is ultimately mostly fine even if it doesn't include any manifests) or for things such as the client auth handling, which would only be implemented for pushing/pulling with the containerd store.

**- How I did it**

Add an `Engine-Features` header to the `/_ping` response, representing the features such as:
```console
FEATURE-NAME=(TRUE|FALSE)[,OTHER-FEATURE-NAME=...]
```

Due to this syntax, feature names cannot contain `,` (comma) or `=` (equals) runes, so added validation for the `daemon.json` `features` config for these rules, as well as checks in the `/_ping` handler.

Also added some limits (feature number, and feature name length) to ensure that the header doesn't become too large which could pose problems with some HTTP clients and proxies.

Added an `EngineFeatures` field to the `Ping` API type, and added logic to parse this header to the `client` package.

On the client side, added a max number of features (`,` in the header) to prevent malicious hosts from abusing this header to break clients.

**- How to verify it**

```console
curl -v --unix-socket /var/run/docker.sock http://localhost/_ping
*   Trying /var/run/docker.sock:0...
* Connected to localhost (/var/run/docker.sock) port 80 (#0)
> GET /_ping HTTP/1.1
> Host: localhost
> User-Agent: curl/7.88.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Api-Version: 1.48
...
< Engine-Features: containerd-snapshotter=true,other-feature=false
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Added `Engine-Headers` header to the `/_ping` endpoint response to indicate features the engine supports.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="594" alt="Screenshot 2024-11-21 at 12 14 16" src="https://github.com/user-attachments/assets/3fed59ec-6078-45e6-9082-6ca0407c6001">
