### PR TITLE
Disallow "network generic data" with type options.Generic

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -646,11 +646,6 @@ func parseNetworkGenericOptions(data interface{}) (*networkConfiguration, error)
 			EnableIPMasquerade: true,
 		}
 		err = config.fromLabels(opt)
-	case options.Generic:
-		var opaqueConfig interface{}
-		if opaqueConfig, err = options.GenerateFromModel(opt, config); err == nil {
-			config = opaqueConfig.(*networkConfiguration)
-		}
 	default:
 		err = types.InvalidParameterErrorf("do not recognize network configuration format: %T", opt)
 	}

--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -227,13 +227,6 @@ func parseNetworkGenericOptions(data interface{}) (*configuration, error) {
 		return opt, nil
 	case map[string]string:
 		return newConfigFromLabels(opt), nil
-	case options.Generic:
-		var config *configuration
-		opaqueConfig, err := options.GenerateFromModel(opt, config)
-		if err != nil {
-			return nil, err
-		}
-		return opaqueConfig.(*configuration), nil
 	default:
 		return nil, types.InvalidParameterErrorf("unrecognized network configuration format: %v", opt)
 	}

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -236,13 +236,6 @@ func parseNetworkGenericOptions(data interface{}) (*configuration, error) {
 		return opt, nil
 	case map[string]string:
 		return newConfigFromLabels(opt), nil
-	case options.Generic:
-		var config *configuration
-		opaqueConfig, err := options.GenerateFromModel(opt, config)
-		if err != nil {
-			return nil, err
-		}
-		return opaqueConfig.(*configuration), nil
 	default:
 		return nil, types.InvalidParameterErrorf("unrecognized network configuration format: %v", opt)
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 	"github.com/docker/docker/libnetwork/ipams/null"
 	"github.com/docker/docker/libnetwork/ipamutils"
@@ -170,8 +171,8 @@ func TestNetworkName(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 
@@ -206,8 +207,8 @@ func TestNetworkType(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 
@@ -232,8 +233,8 @@ func TestNetworkID(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 
@@ -256,12 +257,11 @@ func TestDeleteNetworkWithActiveEndpoints(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	netOption := options.Generic{
-		"BridgeName": "testnetwork",
-	}
 	option := options.Generic{
-		netlabel.EnableIPv4:  true,
-		netlabel.GenericData: netOption,
+		netlabel.EnableIPv4: true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
+		},
 	}
 
 	network, err := createTestNetwork(controller, bridgeNetType, "testnetwork", option, nil, nil)
@@ -311,11 +311,10 @@ func TestNetworkConfig(t *testing.T) {
 	}
 
 	// Create supported config network
-	netOption := options.Generic{
-		"EnableICC": false,
-	}
 	option := options.Generic{
-		netlabel.GenericData: netOption,
+		netlabel.GenericData: map[string]string{
+			bridge.EnableICC: "false",
+		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", SubPool: "192.168.100.128/25", Gateway: "192.168.100.1"}}
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "2001:db8:abcd::/64", SubPool: "2001:db8:abcd::ef99/80", Gateway: "2001:db8:abcd::22"}}
@@ -401,12 +400,11 @@ func TestUnknownNetwork(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	netOption := options.Generic{
-		"BridgeName": "testnetwork",
-	}
 	option := options.Generic{
-		netlabel.EnableIPv4:  true,
-		netlabel.GenericData: netOption,
+		netlabel.EnableIPv4: true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
+		},
 	}
 
 	network, err := createTestNetwork(controller, bridgeNetType, "testnetwork", option, nil, nil)
@@ -433,12 +431,11 @@ func TestUnknownEndpoint(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	controller := newController(t)
 
-	netOption := options.Generic{
-		"BridgeName": "testnetwork",
-	}
 	option := options.Generic{
-		netlabel.EnableIPv4:  true,
-		netlabel.GenericData: netOption,
+		netlabel.EnableIPv4: true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
+		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24"}}
 
@@ -478,8 +475,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network1",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network1",
 		},
 	}
 
@@ -552,8 +549,8 @@ func TestNetworkEndpointsWalkers(t *testing.T) {
 	// Create network 2
 	netOption = options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network2",
 		},
 	}
 
@@ -609,8 +606,8 @@ func TestDuplicateEndpoint(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", netOption, nil, nil)
@@ -659,8 +656,8 @@ func TestControllerQuery(t *testing.T) {
 	// Create network 1
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network1",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network1",
 		},
 	}
 	net1, err := createTestNetwork(controller, bridgeNetType, "network1", netOption, nil, nil)
@@ -676,8 +673,8 @@ func TestControllerQuery(t *testing.T) {
 	// Create network 2
 	netOption = options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network2",
 		},
 	}
 	net2, err := createTestNetwork(controller, bridgeNetType, "network2", netOption, nil, nil)
@@ -762,8 +759,8 @@ func TestNetworkQuery(t *testing.T) {
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network1",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network1",
 		},
 	}
 	net1, err := createTestNetwork(controller, bridgeNetType, "network1", netOption, nil, nil)
@@ -848,8 +845,8 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -863,8 +860,8 @@ func TestEndpointDeleteWithActiveContainer(t *testing.T) {
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork2",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -924,8 +921,8 @@ func TestEndpointMultipleJoins(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testmultiple", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testmultiple",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testmultiple",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -998,8 +995,8 @@ func TestLeaveAll(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1014,8 +1011,8 @@ func TestLeaveAll(t *testing.T) {
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork2",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1064,8 +1061,8 @@ func TestContainerInvalidLeave(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1130,8 +1127,8 @@ func TestEndpointUpdateParent(t *testing.T) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1303,8 +1300,8 @@ func makeTestIPv6Network(t *testing.T, c *libnetwork.Controller) *libnetwork.Net
 	netOptions := options.Generic{
 		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}
 	ipamV6ConfList := []*libnetwork.IpamConf{
@@ -1427,10 +1424,10 @@ func TestBridgeIpv6FromMac(t *testing.T) {
 	controller := newController(t)
 
 	netOption := options.Generic{
-		netlabel.GenericData: options.Generic{
-			"BridgeName":         "testipv6mac",
-			"EnableICC":          true,
-			"EnableIPMasquerade": true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName:         "testipv6mac",
+			bridge.EnableICC:          "true",
+			bridge.EnableIPMasquerade: "true",
 		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}
@@ -1504,10 +1501,10 @@ func TestEndpointJoin(t *testing.T) {
 
 	// Create network 1 and add 2 endpoint: ep11, ep12
 	netOption := options.Generic{
-		netlabel.GenericData: options.Generic{
-			"BridgeName":         "testnetwork1",
-			"EnableICC":          true,
-			"EnableIPMasquerade": true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName:         "testnetwork1",
+			bridge.EnableICC:          "true",
+			bridge.EnableIPMasquerade: "true",
 		},
 	}
 	ipamV6ConfList := []*libnetwork.IpamConf{{PreferredPool: "fe90::/64", Gateway: "fe90::22"}}
@@ -1630,8 +1627,8 @@ func TestEndpointJoin(t *testing.T) {
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2",
 		options.Generic{
 			netlabel.EnableIPv4: true,
-			netlabel.GenericData: options.Generic{
-				"BridgeName": "testnetwork2",
+			netlabel.GenericData: map[string]string{
+				bridge.BridgeName: "testnetwork2",
 			},
 		}, nil, nil)
 	if err != nil {
@@ -1681,8 +1678,8 @@ func externalKeyTest(t *testing.T, reexec bool) {
 
 	n, err := createTestNetwork(controller, bridgeNetType, "testnetwork", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1696,8 +1693,8 @@ func externalKeyTest(t *testing.T, reexec bool) {
 
 	n2, err := createTestNetwork(controller, bridgeNetType, "testnetwork2", options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "testnetwork2",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "testnetwork2",
 		},
 	}, nil, nil)
 	if err != nil {
@@ -1994,8 +1991,8 @@ func TestParallel(t *testing.T) {
 
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName": "network",
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName: "network",
 		},
 	}
 
@@ -2056,10 +2053,10 @@ func TestBridge(t *testing.T) {
 	netOption := options.Generic{
 		netlabel.EnableIPv4: true,
 		netlabel.EnableIPv6: true,
-		netlabel.GenericData: options.Generic{
-			"BridgeName":         "testnetwork",
-			"EnableICC":          true,
-			"EnableIPMasquerade": true,
+		netlabel.GenericData: map[string]string{
+			bridge.BridgeName:         "testnetwork",
+			bridge.EnableICC:          "true",
+			bridge.EnableIPMasquerade: "true",
 		},
 	}
 	ipamV4ConfList := []*libnetwork.IpamConf{{PreferredPool: "192.168.100.0/24", Gateway: "192.168.100.1"}}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
@@ -42,7 +43,9 @@ func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network)
 		name := "test_nw_" + strconv.Itoa(i)
 		newOptions := []NetworkOption{
 			NetworkOptionGeneric(options.Generic{
-				netlabel.GenericData: options.Generic{"BridgeName": name},
+				netlabel.GenericData: map[string]string{
+					bridge.BridgeName: name,
+				},
 			}),
 		}
 		newOptions = append(newOptions, opt...)


### PR DESCRIPTION
**- What I did**

Field `generic` in `libnetwork.Network` is used to store driver options, it has type `options.Generic`, which is `map[string]any`.

In that map, there may be a key `netlabel.GenericData` holding options known as "network generic options", used for options like:

    -o com.docker.network.bridge.name=br-foo

The value type for key `netlabel.GenericData` is always `map[string]string` when created via an API request. But, some unit tests use type `options.Generic`

That works because the bridge, ipvlan and macvlan drivers look for type `options.Generic` as well as `map[string]string` If they find `options.Generic` Go reflection is used to map keys to fields of the config struct with the expectation that the value has the same type as that field. But, that's only used in unit tests (so the tests aren't testing the same code path as the API would use).

The `options.Generic` form of the bridge name option is this, because "BridgeName" is the name of the field in the bridge driver's network config struct:

    "BridgeName": "br-foo"

The libnetwork code expects "network generic options" to have type `map[string]string` and makes no provision for `options.Generic`. So, for example, function `Network.DriverOptions` will panic if called when `Network.generic[netlabel.GenericData]` has type `options.Generic`

The type of `Network.generic[netlabel.GenericData]` can't be statically checked, because it's just a field in a `map[string]any`.

**- How I did it**

Removed the driver code that converts "network generic options" from type `options.Generic`, as it's only used in tests and just makes things more confusing.

This should reduce the chances of things appearing to work when the type is wrong, and converting unit tests to use `map[string]string` means they're testing the right thing.

**- How to verify it**

Existing tests.

**- Description for the changelog**
```markdown changelog
n/a
```
