### PR TITLE
Fix lease management during pull and export

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -55,6 +55,11 @@ func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentIma
 		parentSnapshot = identity.ChainID(diffIDs).String()
 	}
 
+	// TODO: Consider a better way to do this. It is better to have a container directly
+	// reference a snapshot, however, that is not done today because a container may
+	// removed and recreated with nothing holding the snapshot in between. Consider
+	// removing this lease and only temporarily holding a lease on re-create, using
+	// non-expiring leases introduces the possibility of leaking resources.
 	ls := i.client.LeasesService()
 	lease, err := ls.Create(ctx, leases.WithID(id))
 	if err != nil {

--- a/daemon/containerd/leases.go
+++ b/daemon/containerd/leases.go
@@ -1,0 +1,52 @@
+package containerd
+
+import (
+	"context"
+	"time"
+
+	"github.com/containerd/containerd/leases"
+	"github.com/containerd/log"
+)
+
+const (
+	leaseExpireDuration = 8 * time.Hour
+	expireLabel         = "containerd.io/gc.expire" // Copied from containerd
+	pruneLeaseLabel     = "moby/prune.images"
+	pruneLeaseFilter    = `labels."moby/prune.images"`
+)
+
+// withLease is used to prevent content or snapshots from being eligible for
+// garbage collection while they are being used. Leases should always be
+// released when complete to make the resources eligible again.
+// If cancellable is set to true, then the lease will remain if the context
+// is canceled until its expiration or deletion via prune.
+func (i *ImageService) withLease(ctx context.Context, cancellable bool) (context.Context, func(), error) {
+	_, ok := leases.FromContext(ctx)
+	if ok {
+		return ctx, func() {}, nil
+	}
+
+	ls := i.client.LeasesService()
+
+	expireAt := time.Now().Add(leaseExpireDuration)
+	l, err := ls.Create(ctx,
+		leases.WithRandomID(),
+		leases.WithLabels(map[string]string{
+			pruneLeaseLabel: "true",
+			expireLabel:     expireAt.Format(time.RFC3339),
+		}))
+	if err != nil {
+		return ctx, func() {}, err
+	}
+
+	ctx = leases.WithLease(ctx, l.ID)
+	return ctx, func() {
+		if ctx.Err() != nil && cancellable {
+			log.G(ctx).WithFields(log.Fields{"lease": l.ID, "expires_at": expireAt}).Info("Cancel with lease, leased resources will remain until expiration")
+			return
+		}
+		if err := ls.Delete(context.WithoutCancel(ctx), l); err != nil {
+			log.G(ctx).WithError(err).WithFields(log.Fields{"lease": l.ID, "expires_at": expireAt}).Warn("Error deleting lease, leased resources will remain until expiration")
+		}
+	}, nil
+}


### PR DESCRIPTION
Ensure that leases have a reasonable expiration and are cleaned up during prune

Currently it seems some leases could be leaked as they were created with no expiration and their removal could fail due to using a canceled context.

- Fixes #48909


**- Description for the changelog**

```markdown changelog
containerd image-store: fix partially pulled images not being garbage-collected [moby#48910](https://github.com/moby/moby/pull/48910)
```


