### PR TITLE
[26.1 backport] vendor: github.com/golang-jwt/jwt/v4@v4.5.1

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -160,7 +160,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/certificate-transparency-go v1.1.4 // indirect

--- a/vendor.sum
+++ b/vendor.sum
@@ -283,8 +283,8 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
-github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2 h1:xisWqjiKEff2B0KfFYGpCqc3M3zdTz+OHQHRc09FeYk=
 github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -544,7 +544,7 @@ github.com/gogo/protobuf/sortkeys
 github.com/gogo/protobuf/types
 github.com/gogo/protobuf/vanity
 github.com/gogo/protobuf/vanity/command
-# github.com/golang-jwt/jwt/v4 v4.5.0
+# github.com/golang-jwt/jwt/v4 v4.5.1
 ## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
 # github.com/golang/gddo v0.0.0-20190904175337-72a348e765d2


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48911

(cherry picked from commit 1eccc326deec9e39916c227b2684329b7f010bfd)

**- What I did**
This change vendors `github.com/golang-jwt/jwt/v4@v4.5.1` to resolve **_false positive warnings_** for CVE 2024-51744. The warnings are false positive because the code is not called from buildkit.

The dependency is brought by moby/buildkit which starting in moby/buildkit@v0.18.0 will no longer depend on `github.com/golang-jwt/jwt/v4` module with change https://github.com/moby/buildkit/pull/5529. Until then it is fine to vendor v4.5.1 to silence scanner warnings.

**- How I did it**
```
go get -u github.com/golang-jwt/jwt/v4@v4.5.1
```

**- How to verify it**
Should show no warnings for CVE 2024-51744
```
govulncheck -mode=binary -show verbose bundles/binary/dockerd
```

**- Description for the changelog**
```markdown changelog
Vendor github.com/golang-jwt/jwt/v4@v4.5.1
```

**- A picture of a cute animal (not mandatory but encouraged)**


