### PR TITLE
tests: migrate assertions to be more modern

### DIFF
--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -567,7 +567,7 @@ func TestGetBoolOrDefault(t *testing.T) {
 				assert.Check(t, is.DeepEqual(expected.Value, actual.Value))
 
 				wrappedErr := fmt.Errorf("something went wrong: %w", err)
-				assert.Check(t, errors.Is(wrappedErr, err), "Expected a wrapped error to be detected as invalidFilter")
+				assert.Check(t, is.ErrorIs(wrappedErr, err), "Expected a wrapped error to be detected as invalidFilter")
 			}
 
 			assert.Check(t, is.Equal(tc.expectedValue, value))

--- a/builder/remotecontext/git/gitutils_test.go
+++ b/builder/remotecontext/git/gitutils_test.go
@@ -324,7 +324,7 @@ func TestCheckoutGit(t *testing.T) {
 				assert.Check(t, is.Equal("subcontents", string(b)))
 			} else {
 				_, err := os.Stat(filepath.Join(r, "sub/subfile"))
-				assert.Assert(t, is.ErrorContains(err, ""))
+				assert.ErrorContains(t, err, "")
 				assert.Assert(t, os.IsNotExist(err))
 			}
 
@@ -373,6 +373,8 @@ func TestGitInvalidRef(t *testing.T) {
 	for _, url := range gitUrls {
 		_, err := Clone(url)
 		assert.Assert(t, err != nil)
+		// On Windows, git has different case for the "invalid refspec" error,
+		// so we can't use ErrorContains.
 		assert.Check(t, is.Contains(strings.ToLower(err.Error()), "invalid refspec"))
 	}
 }

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -3,7 +3,6 @@ package client // import "github.com/docker/docker/client"
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -125,7 +124,7 @@ func TestCanceledContext(t *testing.T) {
 
 	_, err := client.sendRequest(ctx, http.MethodGet, testEndpoint, nil, nil, nil)
 	assert.Check(t, is.ErrorType(err, errdefs.IsCancelled))
-	assert.Check(t, errors.Is(err, context.Canceled))
+	assert.Check(t, is.ErrorIs(err, context.Canceled))
 }
 
 func TestDeadlineExceededContext(t *testing.T) {
@@ -145,5 +144,5 @@ func TestDeadlineExceededContext(t *testing.T) {
 
 	_, err := client.sendRequest(ctx, http.MethodGet, testEndpoint, nil, nil, nil)
 	assert.Check(t, is.ErrorType(err, errdefs.IsDeadline))
-	assert.Check(t, errors.Is(err, context.DeadlineExceeded))
+	assert.Check(t, is.ErrorIs(err, context.DeadlineExceeded))
 }

--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -141,7 +141,7 @@ func TestLoadDaemonCliConfigWithoutTLSVerify(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
-	assert.Check(t, loadedConfig.TLS == nil)
+	assert.Check(t, is.Nil(loadedConfig.TLS))
 }
 
 func TestLoadDaemonCliConfigWithLogLevel(t *testing.T) {

--- a/daemon/cluster/convert/volume_test.go
+++ b/daemon/cluster/convert/volume_test.go
@@ -7,6 +7,7 @@ import (
 	swarmapi "github.com/moby/swarmkit/v2/api"
 
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestTopologyFromGRPC(t *testing.T) {
@@ -23,7 +24,7 @@ func TestTopologyFromGRPC(t *testing.T) {
 
 func TestCapacityRangeFromGRPC(t *testing.T) {
 	nilCapacity := capacityRangeFromGRPC(nil)
-	assert.Assert(t, nilCapacity == nil)
+	assert.Assert(t, is.Nil(nilCapacity))
 
 	swarmZeroCapacity := &swarmapi.CapacityRange{}
 	zeroCapacity := capacityRangeFromGRPC(swarmZeroCapacity)

--- a/daemon/list_test.go
+++ b/daemon/list_test.go
@@ -81,7 +81,7 @@ func containerListContainsName(containers []*containertypes.Summary, name string
 
 func TestListInvalidFilter(t *testing.T) {
 	db, err := container.NewViewDB()
-	assert.Assert(t, err == nil)
+	assert.NilError(t, err)
 	d := &Daemon{
 		containersReplica: db,
 	}
@@ -94,7 +94,7 @@ func TestListInvalidFilter(t *testing.T) {
 
 func TestNameFilter(t *testing.T) {
 	db, err := container.NewViewDB()
-	assert.Assert(t, err == nil)
+	assert.NilError(t, err)
 	d := &Daemon{
 		containersReplica: db,
 	}

--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/daemon/logger"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 
@@ -36,7 +35,7 @@ func testDecode(t *testing.T, buf []byte, split int) {
 		assert.NilError(t, err)
 
 		_, err = d.Decode()
-		assert.Assert(t, errors.Is(err, io.EOF))
+		assert.ErrorIs(t, err, io.EOF)
 
 		_, err = fw.Write(buf[split:])
 		assert.NilError(t, err)

--- a/daemon/logger/loggerutils/sharedtemp_test.go
+++ b/daemon/logger/loggerutils/sharedtemp_test.go
@@ -181,7 +181,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 				defer t.Logf("goroutine %v: exit", i)
 				start.Done()
 				_, err := uut.Do(src)
-				assert.Check(t, errors.Is(err, fakeErr), "in goroutine %v", i)
+				assert.Check(t, is.ErrorIs(err, fakeErr), "in goroutine %v", i)
 			}()
 		}
 		done.Wait()
@@ -190,7 +190,7 @@ func TestSharedTempFileConverter(t *testing.T) {
 		// request should retry from scratch.
 		fakeErr = errors.New("another fake error")
 		_, err = uut.Do(src)
-		assert.Check(t, errors.Is(err, fakeErr))
+		assert.Check(t, is.ErrorIs(err, fakeErr))
 
 		fakeErr = nil
 		f, err := uut.Do(src)

--- a/daemon/oci_windows_test.go
+++ b/daemon/oci_windows_test.go
@@ -35,15 +35,15 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 
 		err := daemon.setWindowsCredentialSpec(&container.Container{}, spec)
 		assert.NilError(t, err)
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 
 		err = daemon.setWindowsCredentialSpec(&container.Container{HostConfig: &containertypes.HostConfig{}}, spec)
 		assert.NilError(t, err)
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 
 		err = daemon.setWindowsCredentialSpec(&container.Container{HostConfig: &containertypes.HostConfig{SecurityOpt: []string{}}}, spec)
 		assert.NilError(t, err)
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	dummyContainerID := "dummy-container-ID"
@@ -90,7 +90,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 		err := daemon.setWindowsCredentialSpec(containerFactory(`file://C:\path\to\my\credspec.json`), spec)
 		assert.ErrorContains(t, err, "invalid credential spec: file:// path cannot be absolute")
 
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	t.Run("it's not allowed to use a 'file://' option breaking out of the cred specs' directory", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 		err := daemon.setWindowsCredentialSpec(containerFactory(`file://..\credspec.json`), spec)
 		assert.ErrorContains(t, err, fmt.Sprintf("invalid credential spec: file:// path must be under %s", credSpecsDir))
 
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	t.Run("when using a 'file://' option pointing to a file that doesn't exist, it fails gracefully", func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 		err := daemon.setWindowsCredentialSpec(containerFactory("file://i-dont-exist.json"), spec)
 		assert.Check(t, is.ErrorContains(err, fmt.Sprintf("failed to load credential spec for container %s", dummyContainerID)))
 		assert.Check(t, is.ErrorIs(err, os.ErrNotExist))
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	t.Run("happy path with a 'registry://' option", func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 		err := daemon.setWindowsCredentialSpec(containerFactory("registry://my-cred-spec"), spec)
 		assert.ErrorContains(t, err, fmt.Sprintf("registry key %s could not be opened: %v", credentialSpecRegistryLocation, dummyError))
 
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	t.Run("when using a 'registry://' option pointing to a value that doesn't exist, it fails gracefully", func(t *testing.T) {
@@ -219,7 +219,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 		err := daemon.setWindowsCredentialSpec(containerFactory("config://whatever"), spec)
 		assert.Equal(t, errInvalidCredentialSpecSecOpt, err)
 
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	t.Run("happy path with a 'raw://' option", func(t *testing.T) {
@@ -250,7 +250,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 		err := daemon.setWindowsCredentialSpec(containerFactory("credentialspe=config://whatever"), spec)
 		assert.ErrorContains(t, err, "security option not supported: credentialspe")
 
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	t.Run("it rejects unsupported credentialspec options", func(t *testing.T) {
@@ -259,7 +259,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 		err := daemon.setWindowsCredentialSpec(containerFactory("idontexist://whatever"), spec)
 		assert.Equal(t, errInvalidCredentialSpecSecOpt, err)
 
-		assert.Check(t, spec.Windows == nil)
+		assert.Check(t, is.Nil(spec.Windows))
 	})
 
 	for _, option := range []string{"file", "registry", "config", "raw"} {
@@ -269,7 +269,7 @@ func TestSetWindowsCredentialSpecInSpec(t *testing.T) {
 			err := daemon.setWindowsCredentialSpec(containerFactory(option+"://"), spec)
 			assert.Equal(t, errInvalidCredentialSpecSecOpt, err)
 
-			assert.Check(t, spec.Windows == nil)
+			assert.Check(t, is.Nil(spec.Windows))
 		})
 	}
 }

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -96,7 +96,7 @@ func (s *DockerAPISuite) TestGetContainersWsAttachContainerNotFound(c *testing.T
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	expected := "No such container: doesnotexist"
-	assert.Assert(c, strings.Contains(getErrorMessage(c, b), expected))
+	assert.Assert(c, is.Contains(getErrorMessage(c, b), expected))
 }
 
 func (s *DockerAPISuite) TestPostContainersAttach(c *testing.T) {

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -667,7 +667,7 @@ func (s *DockerAPISuite) TestContainerAPIInvalidPortSyntax(c *testing.T) {
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(b[:]), "invalid port"))
+	assert.Assert(c, is.Contains(string(b[:]), "invalid port"))
 }
 
 func (s *DockerAPISuite) TestContainerAPIRestartPolicyInvalidPolicyName(c *testing.T) {
@@ -687,7 +687,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartPolicyInvalidPolicyName(c *testi
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(b[:]), "invalid restart policy"))
+	assert.Assert(c, is.Contains(string(b[:]), "invalid restart policy"))
 }
 
 func (s *DockerAPISuite) TestContainerAPIRestartPolicyRetryMismatch(c *testing.T) {
@@ -707,7 +707,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartPolicyRetryMismatch(c *testing.T
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(b[:]), "invalid restart policy: maximum retry count can only be used with 'on-failure'"))
+	assert.Assert(c, is.Contains(string(b[:]), "invalid restart policy: maximum retry count can only be used with 'on-failure'"))
 }
 
 func (s *DockerAPISuite) TestContainerAPIRestartPolicyNegativeRetryCount(c *testing.T) {
@@ -727,7 +727,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartPolicyNegativeRetryCount(c *test
 
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(b[:]), "maximum retry count cannot be negative"))
+	assert.Assert(c, is.Contains(string(b[:]), "maximum retry count cannot be negative"))
 }
 
 func (s *DockerAPISuite) TestContainerAPIRestartPolicyDefaultRetryCount(c *testing.T) {
@@ -811,7 +811,7 @@ func (s *DockerAPISuite) TestCreateWithTooLowMemoryLimit(c *testing.T) {
 	assert.Assert(c, err2 == nil)
 
 	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
-	assert.Assert(c, strings.Contains(string(b), "Minimum memory limit allowed is 6MB"))
+	assert.Assert(c, is.Contains(string(b), "Minimum memory limit allowed is 6MB"))
 }
 
 func (s *DockerAPISuite) TestContainerAPIRename(c *testing.T) {
@@ -2032,7 +2032,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsTmpfs(c *testing.T) {
 		assert.NilError(c, err)
 		out := cli.DockerCmd(c, "start", "-a", cName).Combined()
 		for _, option := range x.expectedOptions {
-			assert.Assert(c, strings.Contains(out, option))
+			assert.Assert(c, is.Contains(out, option))
 		}
 	}
 }

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -624,7 +624,7 @@ func (s *DockerAPISuite) TestContainerAPIVerifyHeader(c *testing.T) {
 
 	create := func(ct string) (*http.Response, io.ReadCloser, error) {
 		jsonData := bytes.NewBuffer(nil)
-		assert.Assert(c, json.NewEncoder(jsonData).Encode(config) == nil)
+		assert.NilError(c, json.NewEncoder(jsonData).Encode(config))
 		return request.Post(testutil.GetContext(c), "/containers/create", request.RawContent(io.NopCloser(jsonData)), request.ContentType(ct))
 	}
 
@@ -782,7 +782,7 @@ func (s *DockerAPISuite) TestContainerAPIPostCreateNull(c *testing.T) {
 		ID string
 	}
 	var ctr createResp
-	assert.Assert(c, json.Unmarshal(b, &ctr) == nil)
+	assert.NilError(c, json.Unmarshal(b, &ctr))
 	out := inspectField(c, ctr.ID, "HostConfig.CpusetCpus")
 	assert.Equal(c, out, "")
 
@@ -808,7 +808,7 @@ func (s *DockerAPISuite) TestCreateWithTooLowMemoryLimit(c *testing.T) {
 	res, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.RawString(config), request.JSON)
 	assert.NilError(c, err)
 	b, err2 := request.ReadBody(body)
-	assert.Assert(c, err2 == nil)
+	assert.NilError(c, err2)
 
 	assert.Equal(c, res.StatusCode, http.StatusBadRequest)
 	assert.Assert(c, is.Contains(string(b), "Minimum memory limit allowed is 6MB"))
@@ -856,7 +856,7 @@ func (s *DockerAPISuite) TestContainerAPIRestart(c *testing.T) {
 	err = apiClient.ContainerRestart(testutil.GetContext(c), name, container.StopOptions{Timeout: &timeout})
 	assert.NilError(c, err)
 
-	assert.Assert(c, waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 15*time.Second) == nil)
+	assert.NilError(c, waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 15*time.Second))
 }
 
 func (s *DockerAPISuite) TestContainerAPIRestartNotimeoutParam(c *testing.T) {
@@ -871,7 +871,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartNotimeoutParam(c *testing.T) {
 	err = apiClient.ContainerRestart(testutil.GetContext(c), name, container.StopOptions{})
 	assert.NilError(c, err)
 
-	assert.Assert(c, waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 15*time.Second) == nil)
+	assert.NilError(c, waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 15*time.Second))
 }
 
 func (s *DockerAPISuite) TestContainerAPIStart(c *testing.T) {
@@ -913,7 +913,7 @@ func (s *DockerAPISuite) TestContainerAPIStop(c *testing.T) {
 		Timeout: &timeout,
 	})
 	assert.NilError(c, err)
-	assert.Assert(c, waitInspect(name, "{{ .State.Running  }}", "false", 60*time.Second) == nil)
+	assert.NilError(c, waitInspect(name, "{{ .State.Running  }}", "false", 60*time.Second))
 
 	// second call to start should give 304
 	// maybe add ContainerStartWithRaw to test it
@@ -1075,7 +1075,7 @@ func (s *DockerAPISuite) TestContainerAPIPostContainerStop(c *testing.T) {
 
 	err = apiClient.ContainerStop(testutil.GetContext(c), containerID, container.StopOptions{})
 	assert.NilError(c, err)
-	assert.Assert(c, waitInspect(containerID, "{{ .State.Running  }}", "false", 60*time.Second) == nil)
+	assert.NilError(c, waitInspect(containerID, "{{ .State.Running  }}", "false", 60*time.Second))
 }
 
 // #14170
@@ -1437,7 +1437,7 @@ func (s *DockerAPISuite) TestContainerAPIStatsWithNetworkDisabled(c *testing.T) 
 	case <-time.After(2 * time.Second):
 		c.Fatal("stream was not closed after container was removed")
 	case sr := <-bc:
-		assert.Assert(c, sr.err == nil)
+		assert.NilError(c, sr.err)
 		sr.stats.Body.Close()
 	}
 }

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -215,7 +215,7 @@ func (s *DockerAPISuite) TestGetContainerStatsRmRunning(c *testing.T) {
 	assert.NilError(c, err)
 
 	cli.DockerCmd(c, "rm", "-f", id)
-	assert.Assert(c, <-chErr == nil)
+	assert.Assert(c, is.Nil(<-chErr))
 }
 
 // ChannelBuffer holds a chan of byte array that can be populate in a goroutine.
@@ -1347,7 +1347,7 @@ func (s *DockerAPISuite) TestPostContainersCreateMemorySwappinessHostConfigOmitt
 	containerJSON, err := apiClient.ContainerInspect(testutil.GetContext(c), ctr.ID)
 	assert.NilError(c, err)
 
-	assert.Assert(c, containerJSON.HostConfig.MemorySwappiness == nil)
+	assert.Assert(c, is.Nil(containerJSON.HostConfig.MemorySwappiness))
 }
 
 // check validation is done daemon side and not only in cli

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -163,7 +163,7 @@ func (s *DockerAPISuite) TestExecAPIStartValidCommand(c *testing.T) {
 	var inspectJSON struct{ ExecIDs []string }
 	inspectContainer(ctx, c, name, &inspectJSON)
 
-	assert.Assert(c, inspectJSON.ExecIDs == nil)
+	assert.Assert(c, is.Nil(inspectJSON.ExecIDs))
 }
 
 // #30311
@@ -179,7 +179,7 @@ func (s *DockerAPISuite) TestExecAPIStartInvalidCommand(c *testing.T) {
 	var inspectJSON struct{ ExecIDs []string }
 	inspectContainer(ctx, c, name, &inspectJSON)
 
-	assert.Assert(c, inspectJSON.ExecIDs == nil)
+	assert.Assert(c, is.Nil(inspectJSON.ExecIDs))
 }
 
 func (s *DockerAPISuite) TestExecStateCleanup(c *testing.T) {

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -575,7 +575,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesStateReporting(c *testing.T) {
 	assert.Assert(c, len(containers2) == instances)
 	for i := range containers {
 		if i == toRemove {
-			assert.Assert(c, containers2[i] == nil)
+			assert.Assert(c, is.Nil(containers2[i]))
 		} else {
 			assert.Assert(c, containers2[i] != nil)
 		}
@@ -601,7 +601,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesStateReporting(c *testing.T) {
 	assert.Assert(c, len(containers2) == instances)
 	for i := range containers {
 		if i == toRemove {
-			assert.Assert(c, containers2[i] == nil)
+			assert.Assert(c, is.Nil(containers2[i]))
 		} else {
 			assert.Assert(c, containers2[i] != nil)
 		}

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -19,6 +19,7 @@ import (
 	testdaemon "github.com/docker/docker/testutil/daemon"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
 )
@@ -80,13 +81,13 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *testing.T) {
 	resp, _, err := client.ServiceInspectWithRaw(ctx, id, options)
 	out := fmt.Sprintf("%+v", resp)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, "UpdateConfig"))
+	assert.Assert(c, is.Contains(out, "UpdateConfig"))
 
 	// insertDefaults inserts UpdateConfig when service is fetched by ID
 	resp, _, err = client.ServiceInspectWithRaw(ctx, "top", options)
 	out = fmt.Sprintf("%+v", resp)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, "UpdateConfig"))
+	assert.Assert(c, is.Contains(out, "UpdateConfig"))
 
 	service := d.GetService(ctx, c, id)
 	instances = 5

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -258,7 +258,7 @@ func (s *DockerSwarmSuite) TestAPISwarmPromoteDemote(c *testing.T) {
 	// it anchors the regexp contrary to the documentation, and this makes
 	// it impossible to match something that includes a line break.
 	if !strings.Contains(string(b), "last manager of the swarm") {
-		assert.Assert(c, strings.Contains(string(b), "this would result in a loss of quorum"))
+		assert.Assert(c, is.Contains(string(b), "this would result in a loss of quorum"))
 	}
 	info = d1.SwarmInfo(ctx, c)
 	assert.Equal(c, info.LocalNodeState, swarm.LocalNodeStateActive)

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type DockerAPISuite struct {
@@ -70,7 +71,7 @@ func (s *DockerAPISuite) TestAPIErrorJSON(c *testing.T) {
 	httpResp, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.JSONBody(struct{}{}))
 	assert.NilError(c, err)
 	assert.Equal(c, httpResp.StatusCode, http.StatusBadRequest)
-	assert.Assert(c, strings.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
+	assert.Assert(c, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Equal(c, getErrorMessage(c, b), runconfig.ErrEmptyConfig.Error())
@@ -81,7 +82,7 @@ func (s *DockerAPISuite) TestAPIErrorNotFoundJSON(c *testing.T) {
 	httpResp, body, err := request.Get(testutil.GetContext(c), "/notfound", request.JSON)
 	assert.NilError(c, err)
 	assert.Equal(c, httpResp.StatusCode, http.StatusNotFound)
-	assert.Assert(c, strings.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
+	assert.Assert(c, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	assert.Equal(c, getErrorMessage(c, b), "page not found")

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -166,7 +166,7 @@ func (s *DockerCLIAttachSuite) TestAttachDisconnect(c *testing.T) {
 	stdout, err := cmd.StdoutPipe()
 	assert.NilError(c, err)
 	defer stdout.Close()
-	assert.Assert(c, cmd.Start() == nil)
+	assert.NilError(c, cmd.Start())
 	defer func() {
 		cmd.Process.Kill()
 		cmd.Wait()
@@ -178,7 +178,7 @@ func (s *DockerCLIAttachSuite) TestAttachDisconnect(c *testing.T) {
 	assert.NilError(c, err)
 	assert.Equal(c, strings.TrimSpace(out), "hello")
 
-	assert.Assert(c, stdin.Close() == nil)
+	assert.NilError(c, stdin.Close())
 
 	// Expect container to still be running after stdin is closed
 	running := inspectField(c, id, "State.Running")

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/creack/pty"
 	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 // #9860 Make sure attach ends when container ends (with no errors)
@@ -118,7 +119,7 @@ func (s *DockerCLIAttachSuite) TestAttachAfterDetach(c *testing.T) {
 		c.Fatal("timeout waiting for attach read")
 	}
 
-	assert.Assert(c, strings.Contains(string(bytes[:nBytes]), "/ #"))
+	assert.Assert(c, is.Contains(string(bytes[:nBytes]), "/ #"))
 }
 
 // TestAttachDetach checks that attach in tty mode can be detached using the long container ID

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4554,9 +4554,9 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgEnv(c *testing.T) {
 	out := result.Combined()[i:] // "out" should contain just the warning message now
 
 	// These were specified on a --build-arg but no ARG was in the Dockerfile
-	assert.Assert(c, strings.Contains(out, "FOO7"))
-	assert.Assert(c, strings.Contains(out, "FOO8"))
-	assert.Assert(c, strings.Contains(out, "FOO9"))
+	assert.Assert(c, is.Contains(out, "FOO7"))
+	assert.Assert(c, is.Contains(out, "FOO8"))
+	assert.Assert(c, is.Contains(out, "FOO9"))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgQuotedValVariants(c *testing.T) {
@@ -4632,10 +4632,10 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageArg(c *testing.T) {
 	parentID := imgs[0]
 
 	result = cli.DockerCmd(c, "run", "--rm", parentID, "cat", "/out")
-	assert.Assert(c, strings.Contains(result.Stdout(), "foo=abc"))
+	assert.Assert(c, is.Contains(result.Stdout(), "foo=abc"))
 	result = cli.DockerCmd(c, "run", "--rm", imgName, "cat", "/out")
 	assert.Assert(c, !strings.Contains(result.Stdout(), "foo"))
-	assert.Assert(c, strings.Contains(result.Stdout(), "bar=def"))
+	assert.Assert(c, is.Contains(result.Stdout(), "bar=def"))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildMultiStageGlobalArg(c *testing.T) {
@@ -4664,7 +4664,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageGlobalArg(c *testing.T) {
 	result = cli.DockerCmd(c, "run", "--rm", parentID, "cat", "/out")
 	assert.Assert(c, !strings.Contains(result.Stdout(), "tag"))
 	result = cli.DockerCmd(c, "run", "--rm", imgName, "cat", "/out")
-	assert.Assert(c, strings.Contains(result.Stdout(), "tag=latest"))
+	assert.Assert(c, is.Contains(result.Stdout(), "tag=latest"))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildMultiStageUnusedArg(c *testing.T) {
@@ -4679,8 +4679,8 @@ func (s *DockerCLIBuildSuite) TestBuildMultiStageUnusedArg(c *testing.T) {
 		build.WithDockerfile(dockerfile),
 		cli.WithFlags("--build-arg", "baz=abc"))
 	result.Assert(c, icmd.Success)
-	assert.Assert(c, strings.Contains(result.Combined(), "[Warning]"))
-	assert.Assert(c, strings.Contains(result.Combined(), "[baz] were not consumed"))
+	assert.Assert(c, is.Contains(result.Combined(), "[Warning]"))
+	assert.Assert(c, is.Contains(result.Combined(), "[baz] were not consumed"))
 	result = cli.DockerCmd(c, "run", "--rm", imgName, "cat", "/out")
 	assert.Assert(c, !strings.Contains(result.Stdout(), "bar"))
 	assert.Assert(c, !strings.Contains(result.Stdout(), "baz"))
@@ -5361,9 +5361,9 @@ func (s *DockerCLIBuildSuite) TestBuildStepsWithProgress(c *testing.T) {
 	totalRun := 5
 	result := buildImage(name, build.WithDockerfile("FROM busybox\n"+strings.Repeat("RUN echo foo\n", totalRun)))
 	result.Assert(c, icmd.Success)
-	assert.Assert(c, strings.Contains(result.Combined(), fmt.Sprintf("Step 1/%d : FROM busybox", 1+totalRun)))
+	assert.Assert(c, is.Contains(result.Combined(), fmt.Sprintf("Step 1/%d : FROM busybox", 1+totalRun)))
 	for i := 2; i <= 1+totalRun; i++ {
-		assert.Assert(c, strings.Contains(result.Combined(), fmt.Sprintf("Step %d/%d : RUN echo foo", i, 1+totalRun)))
+		assert.Assert(c, is.Contains(result.Combined(), fmt.Sprintf("Step %d/%d : RUN echo foo", i, 1+totalRun)))
 	}
 }
 
@@ -5374,8 +5374,8 @@ func (s *DockerCLIBuildSuite) TestBuildWithFailure(c *testing.T) {
 	dockerfile := "FROM busybox\nRUN nobody"
 	result := buildImage(name, build.WithDockerfile(dockerfile))
 	assert.Assert(c, result.Error != nil)
-	assert.Assert(c, strings.Contains(result.Stdout(), "Step 1/2 : FROM busybox"))
-	assert.Assert(c, strings.Contains(result.Stdout(), "Step 2/2 : RUN nobody"))
+	assert.Assert(c, is.Contains(result.Stdout(), "Step 1/2 : FROM busybox"))
+	assert.Assert(c, is.Contains(result.Stdout(), "Step 2/2 : RUN nobody"))
 	// Second test case `FFOM` should have been detected before build runs so no steps
 	dockerfile = "FFOM nobody\nRUN nobody"
 	result = buildImage(name, build.WithDockerfile(dockerfile))

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5457,8 +5457,8 @@ func (s *DockerCLIBuildSuite) TestBuildCacheFrom(c *testing.T) {
 
 	var layers1 []string
 	var layers2 []string
-	assert.Assert(c, json.Unmarshal([]byte(layers1Str), &layers1) == nil)
-	assert.Assert(c, json.Unmarshal([]byte(layers2Str), &layers2) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(layers1Str), &layers1))
+	assert.NilError(c, json.Unmarshal([]byte(layers2Str), &layers2))
 
 	assert.Equal(c, len(layers1), len(layers2))
 	for i := 0; i < len(layers1)-1; i++ {

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -619,7 +619,7 @@ func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredManifest(c *testing
 	assert.Assert(c, exitStatus != 0)
 
 	expectedErrorMsg := fmt.Sprintf("image verification failed for digest %s", manifestDigest)
-	assert.Assert(c, strings.Contains(out, expectedErrorMsg))
+	assert.Assert(c, is.Contains(out, expectedErrorMsg))
 }
 
 // TestPullFailsWithAlteredLayer tests that a `docker pull` fails when

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -630,14 +630,14 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *testing.T) {
 	skip.If(c, testEnv.UsingSnapshotter(), "Faked layer is already in the content store, so it won't be fetched from the repository at all.")
 
 	manifestDigest, err := setupImage(c)
-	assert.Assert(c, err == nil)
+	assert.NilError(c, err)
 
 	// Load the target manifest blob.
 	manifestBlob := s.reg.ReadBlobContents(c, manifestDigest)
 
 	var imgManifest schema2.Manifest
 	err = json.Unmarshal(manifestBlob, &imgManifest)
-	assert.Assert(c, err == nil)
+	assert.NilError(c, err)
 
 	// Next, get the digest of one of the layers from the manifest.
 	targetLayerDigest := imgManifest.Layers[0].Digest
@@ -673,14 +673,14 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *testing.T) {
 func (s *DockerSchema1RegistrySuite) TestPullFailsWithAlteredLayer(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	manifestDigest, err := setupImage(c)
-	assert.Assert(c, err == nil)
+	assert.NilError(c, err)
 
 	// Load the target manifest blob.
 	manifestBlob := s.reg.ReadBlobContents(c, manifestDigest)
 
 	var imgManifest schema1.Manifest
 	err = json.Unmarshal(manifestBlob, &imgManifest)
-	assert.Assert(c, err == nil)
+	assert.NilError(c, err)
 
 	// Next, get the digest of one of the layers from the manifest.
 	targetLayerDigest := imgManifest.FSLayers[0].BlobSum

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -63,7 +64,7 @@ func (s *DockerCLICommitSuite) TestCommitPausedContainer(c *testing.T) {
 
 	out := inspectField(c, containerID, "State.Paused")
 	// commit should not unpause a paused container
-	assert.Assert(c, strings.Contains(out, "true"))
+	assert.Assert(c, is.Contains(out, "true"))
 }
 
 func (s *DockerCLICommitSuite) TestCommitNewFile(c *testing.T) {

--- a/integration-cli/docker_cli_cp_utils_test.go
+++ b/integration-cli/docker_cli_cp_utils_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/pkg/archive"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type fileType uint32
@@ -225,12 +226,12 @@ func getTestDir(c *testing.T, label string) (tmpDir string) {
 	return
 }
 
-func isCpDirNotExist(err error) bool {
-	return strings.Contains(err.Error(), archive.ErrDirNotExists.Error())
+func isCpDirNotExist(err error) is.Comparison {
+	return is.ErrorContains(err, archive.ErrDirNotExists.Error())
 }
 
-func isCpCannotCopyDir(err error) bool {
-	return strings.Contains(err.Error(), archive.ErrCannotCopyDir.Error())
+func isCpCannotCopyDir(err error) is.Comparison {
+	return is.ErrorContains(err, archive.ErrCannotCopyDir.Error())
 }
 
 func fileContentEquals(c *testing.T, filename, contents string) error {

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -267,7 +267,7 @@ func (s *DockerCLICreateSuite) TestCreateStopSignal(c *testing.T) {
 	cli.DockerCmd(c, "create", "--name", name, "--stop-signal", "9", "busybox")
 
 	res := inspectFieldJSON(c, name, "Config.StopSignal")
-	assert.Assert(c, strings.Contains(res, "9"))
+	assert.Assert(c, is.Contains(res, "9"))
 }
 
 func (s *DockerCLICreateSuite) TestCreateWithWorkdir(c *testing.T) {
@@ -296,7 +296,7 @@ func (s *DockerCLICreateSuite) TestCreateWithInvalidLogOpts(c *testing.T) {
 	const name = "test-invalidate-log-opts"
 	out, _, err := dockerCmdWithError("create", "--name", name, "--log-opt", "invalid=true", "busybox")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "unknown log opt"))
+	assert.Assert(c, is.Contains(out, "unknown log opt"))
 	assert.Assert(c, is.Contains(out, "unknown log opt"))
 
 	out = cli.DockerCmd(c, "ps", "-a").Stdout()
@@ -344,10 +344,10 @@ func (s *DockerCLICreateSuite) TestCreateStopTimeout(c *testing.T) {
 	cli.DockerCmd(c, "create", "--name", name1, "--stop-timeout", "15", "busybox")
 
 	res := inspectFieldJSON(c, name1, "Config.StopTimeout")
-	assert.Assert(c, strings.Contains(res, "15"))
+	assert.Assert(c, is.Contains(res, "15"))
 	name2 := "test_create_stop_timeout_2"
 	cli.DockerCmd(c, "create", "--name", name2, "busybox")
 
 	res = inspectFieldJSON(c, name2, "Config.StopTimeout")
-	assert.Assert(c, strings.Contains(res, "null"))
+	assert.Assert(c, is.Contains(res, "null"))
 }

--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -36,8 +37,8 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithPluginEnabled(c *testing.T) {
 	if err != nil {
 		c.Fatalf("Could not list plugins: %v %s", err, out)
 	}
-	assert.Assert(c, strings.Contains(out, pName))
-	assert.Assert(c, strings.Contains(out, "true"))
+	assert.Assert(c, is.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, "true"))
 }
 
 // TestDaemonRestartWithPluginDisabled tests state restore for a disabled plugin
@@ -62,8 +63,8 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithPluginDisabled(c *testing.T) {
 	if err != nil {
 		c.Fatalf("Could not list plugins: %v %s", err, out)
 	}
-	assert.Assert(c, strings.Contains(out, pName))
-	assert.Assert(c, strings.Contains(out, "false"))
+	assert.Assert(c, is.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, "false"))
 }
 
 // TestDaemonKillLiveRestoreWithPlugins SIGKILLs daemon started with --live-restore.
@@ -220,8 +221,8 @@ func (s *DockerDaemonSuite) TestVolumePlugin(c *testing.T) {
 	if err != nil {
 		c.Fatalf("Could not list volume: %v %s", err, out)
 	}
-	assert.Assert(c, strings.Contains(out, volName))
-	assert.Assert(c, strings.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, volName))
+	assert.Assert(c, is.Contains(out, pName))
 
 	out, err = s.d.Cmd("run", "--rm", "-v", volName+":"+destDir, "busybox", "touch", destDir+destFile)
 	assert.NilError(c, err, out)
@@ -237,7 +238,7 @@ func (s *DockerDaemonSuite) TestPluginVolumeRemoveOnRestart(c *testing.T) {
 
 	out, err := s.d.Cmd("plugin", "install", "--grant-all-permissions", pName)
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, pName))
 
 	out, err = s.d.Cmd("volume", "create", "--driver", pName, "test")
 	assert.NilError(c, err, out)
@@ -246,7 +247,7 @@ func (s *DockerDaemonSuite) TestPluginVolumeRemoveOnRestart(c *testing.T) {
 
 	out, err = s.d.Cmd("plugin", "disable", pName)
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "in use"))
+	assert.Assert(c, is.Contains(out, "in use"))
 
 	out, err = s.d.Cmd("volume", "rm", "test")
 	assert.NilError(c, err, out)
@@ -278,12 +279,12 @@ func (s *DockerDaemonSuite) TestPluginListFilterEnabled(c *testing.T) {
 
 	out, err = s.d.Cmd("plugin", "ls", "--filter", "enabled=false")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, pName))
-	assert.Assert(c, strings.Contains(out, "false"))
+	assert.Assert(c, is.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, "false"))
 
 	out, err = s.d.Cmd("plugin", "ls")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, pName))
 }
 
 func (s *DockerDaemonSuite) TestPluginListFilterCapability(c *testing.T) {
@@ -302,7 +303,7 @@ func (s *DockerDaemonSuite) TestPluginListFilterCapability(c *testing.T) {
 
 	out, err = s.d.Cmd("plugin", "ls", "--filter", "capability=volumedriver")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, pName))
 
 	out, err = s.d.Cmd("plugin", "ls", "--filter", "capability=authz")
 	assert.NilError(c, err, out)
@@ -310,5 +311,5 @@ func (s *DockerDaemonSuite) TestPluginListFilterCapability(c *testing.T) {
 
 	out, err = s.d.Cmd("plugin", "ls")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, pName))
+	assert.Assert(c, is.Contains(out, pName))
 }

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1578,7 +1578,7 @@ func (s *DockerDaemonSuite) TestDaemonNoSpaceLeftOnDeviceError(c *testing.T) {
 	testDir, err := os.MkdirTemp("", "no-space-left-on-device-test")
 	assert.NilError(c, err)
 	defer os.RemoveAll(testDir)
-	assert.Assert(c, mount.MakeRShared(testDir) == nil)
+	assert.NilError(c, mount.MakeRShared(testDir))
 	defer mount.Unmount(testDir)
 
 	// create a 3MiB image (with a 2MiB ext4 fs) and mount it as storage root
@@ -1828,7 +1828,7 @@ func (s *DockerDaemonSuite) TestCleanupMountsAfterDaemonCrash(c *testing.T) {
 	id := strings.TrimSpace(out)
 
 	// kill the daemon
-	assert.Assert(c, s.d.Kill() == nil)
+	assert.NilError(c, s.d.Kill())
 
 	// Check if there are mounts with container id visible from the host.
 	// If not, those mounts exist in container's own mount ns, and so
@@ -2064,7 +2064,7 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFile(c *testing.T)
 	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentDownloads))
 	err = os.WriteFile(configFilePath, []byte(`{ "max-concurrent-uploads" : 7, "max-concurrent-downloads" : 9 }`), 0o666)
 	assert.NilError(c, err)
-	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 	// unix.Kill(s.d.cmd.Process.Pid, unix.SIGHUP)
 
 	time.Sleep(3 * time.Second)
@@ -2100,7 +2100,7 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *test
 	err = os.WriteFile(configFilePath, []byte(`{ "max-concurrent-uploads" : 1, "max-concurrent-downloads" : null }`), 0o666)
 	assert.NilError(c, err)
 
-	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 	// unix.Kill(s.d.cmd.Process.Pid, unix.SIGHUP)
 
 	time.Sleep(3 * time.Second)
@@ -2114,7 +2114,7 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *test
 	err = os.WriteFile(configFilePath, []byte(`{ "labels":["foo=bar"] }`), 0o666)
 	assert.NilError(c, err)
 
-	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 
 	time.Sleep(3 * time.Second)
 
@@ -2204,7 +2204,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *testing.T) {
 }
 `
 	os.WriteFile(configName, []byte(config), 0o644)
-	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 	// Give daemon time to reload config
 	<-time.After(1 * time.Second)
 
@@ -2231,7 +2231,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *testing.T) {
 }
 `
 	os.WriteFile(configName, []byte(config), 0o644)
-	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 	// Give daemon time to reload config
 	<-time.After(1 * time.Second)
 
@@ -2256,7 +2256,7 @@ func (s *DockerDaemonSuite) TestRunWithRuntimeFromConfigFile(c *testing.T) {
 }
 `
 	os.WriteFile(configName, []byte(config), 0o644)
-	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 	// Give daemon time to reload config
 	<-time.After(1 * time.Second)
 
@@ -2433,7 +2433,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeout(c *testing.T) {
 	_, err := s.d.Cmd("run", "-d", "busybox", "top")
 	assert.NilError(c, err)
 
-	assert.Assert(c, s.d.Signal(unix.SIGINT) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGINT))
 
 	select {
 	case <-s.d.Wait:
@@ -2461,7 +2461,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeoutWithConfigFile(c *testing.T
 	err = os.WriteFile(configFilePath, []byte(`{ "shutdown-timeout" : 5 }`), 0o666)
 	assert.NilError(c, err)
 
-	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
+	assert.NilError(c, s.d.Signal(unix.SIGHUP))
 
 	select {
 	case <-s.d.Wait:

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -340,7 +340,7 @@ func (s *DockerDaemonSuite) TestDaemonIPv6HostMode(c *testing.T) {
 
 	out, err = s.d.Cmd("exec", "hostcnt", "ip", "-6", "addr", "show", "docker0")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(strings.Trim(out, " \r\n'"), "2001:db8:2::1"))
+	assert.Assert(c, is.Contains(strings.Trim(out, " \r\n'"), "2001:db8:2::1"))
 }
 
 func (s *DockerDaemonSuite) TestDaemonLogLevelWrong(c *testing.T) {
@@ -488,7 +488,7 @@ func (s *DockerDaemonSuite) TestDaemonBridgeNone(c *testing.T) {
 	// verify default "bridge" network is not there
 	out, err := d.Cmd("network", "inspect", "bridge")
 	assert.ErrorContains(c, err, "", `"bridge" network should not be present if daemon started with --bridge=none`)
-	assert.Assert(c, strings.Contains(out, "No such network"))
+	assert.Assert(c, is.Contains(out, "No such network"))
 }
 
 func createInterface(c *testing.T, ifType string, ifName string, ipNet string) {
@@ -1036,7 +1036,7 @@ func (s *DockerDaemonSuite) TestDaemonLoggingDriverNoneLogsError(c *testing.T) {
 	out, err = s.d.Cmd("logs", "test")
 	assert.Assert(c, err != nil, "Logs should fail with 'none' driver")
 	expected := `configured logging driver does not support reading`
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerDaemonSuite) TestDaemonLoggingDriverShouldBeIgnoredForBuild(c *testing.T) {
@@ -1414,8 +1414,8 @@ func (s *DockerDaemonSuite) TestDaemonWideLogConfig(c *testing.T) {
 
 	out, err = s.d.Cmd("inspect", "-f", "{{ .HostConfig.LogConfig.Config }}", name)
 	assert.NilError(c, err, "Output: %s", out)
-	assert.Assert(c, strings.Contains(out, "max-size:1k"))
-	assert.Assert(c, strings.Contains(out, "max-file:5"))
+	assert.Assert(c, is.Contains(out, "max-size:1k"))
+	assert.Assert(c, is.Contains(out, "max-file:5"))
 
 	out, err = s.d.Cmd("inspect", "-f", "{{ .HostConfig.LogConfig.Type }}", name)
 	assert.NilError(c, err, "Output: %s", out)
@@ -1467,7 +1467,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartRmVolumeInUse(c *testing.T) {
 
 	out, err = s.d.Cmd("volume", "rm", "test")
 	assert.Assert(c, err != nil, "should not be able to remove in use volume after daemon restart")
-	assert.Assert(c, strings.Contains(out, "in use"))
+	assert.Assert(c, is.Contains(out, "in use"))
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartLocalVolumes(c *testing.T) {
@@ -1932,7 +1932,7 @@ func (s *DockerDaemonSuite) TestRunLinksChanged(c *testing.T) {
 
 	out, err = s.d.Cmd("run", "--name=test2", "--link=test:abc", "busybox", "sh", "-c", "ping -c 1 abc")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, "1 packets transmitted, 1 packets received"))
+	assert.Assert(c, is.Contains(out, "1 packets transmitted, 1 packets received"))
 	out, err = s.d.Cmd("rm", "-f", "test")
 	assert.NilError(c, err, out)
 
@@ -1972,7 +1972,7 @@ func (s *DockerDaemonSuite) TestDaemonStartWithoutColors(c *testing.T) {
 	s.d.Stop(c)
 	// Wait for io.Copy() before checking output
 	<-done
-	assert.Assert(c, strings.Contains(b.String(), infoLog))
+	assert.Assert(c, is.Contains(b.String(), infoLog))
 	b.Reset()
 
 	// "tty" is already closed in prev s.d.Stop(),
@@ -2013,7 +2013,7 @@ func (s *DockerDaemonSuite) TestDaemonDebugLog(c *testing.T) {
 
 	s.d.StartWithLogFile(tty, "--debug")
 	s.d.Stop(c)
-	assert.Assert(c, strings.Contains(b.String(), debugLog))
+	assert.Assert(c, is.Contains(b.String(), debugLog))
 }
 
 // Test for #21956
@@ -2026,7 +2026,7 @@ func (s *DockerDaemonSuite) TestDaemonLogOptions(c *testing.T) {
 
 	out, err = s.d.Cmd("inspect", "--format='{{.HostConfig.LogConfig}}'", id)
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, "{json-file map[]}"))
+	assert.Assert(c, is.Contains(out, "{json-file map[]}"))
 }
 
 // Test case for #20936, #22443
@@ -2039,8 +2039,8 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrency(c *testing.T) {
 	expectedMaxConcurrentDownloads := `level=debug msg="Max Concurrent Downloads: 8"`
 	content, err := s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentUploads))
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentDownloads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentUploads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentDownloads))
 }
 
 // Test case for #20936, #22443
@@ -2060,8 +2060,8 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFile(c *testing.T)
 	expectedMaxConcurrentDownloads := `level=debug msg="Max Concurrent Downloads: 8"`
 	content, err := s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentUploads))
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentDownloads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentUploads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentDownloads))
 	err = os.WriteFile(configFilePath, []byte(`{ "max-concurrent-uploads" : 7, "max-concurrent-downloads" : 9 }`), 0o666)
 	assert.NilError(c, err)
 	assert.Assert(c, s.d.Signal(unix.SIGHUP) == nil)
@@ -2073,8 +2073,8 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFile(c *testing.T)
 	expectedMaxConcurrentDownloads = `level=debug msg="Reset Max Concurrent Downloads: 9"`
 	content, err = s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentUploads))
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentDownloads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentUploads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentDownloads))
 }
 
 // Test case for #20936, #22443
@@ -2095,8 +2095,8 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *test
 	expectedMaxConcurrentDownloads := `level=debug msg="Max Concurrent Downloads: 3"`
 	content, err := s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentUploads))
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentDownloads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentUploads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentDownloads))
 	err = os.WriteFile(configFilePath, []byte(`{ "max-concurrent-uploads" : 1, "max-concurrent-downloads" : null }`), 0o666)
 	assert.NilError(c, err)
 
@@ -2109,8 +2109,8 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *test
 	expectedMaxConcurrentDownloads = `level=debug msg="Reset Max Concurrent Downloads: 3"`
 	content, err = s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentUploads))
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentDownloads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentUploads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentDownloads))
 	err = os.WriteFile(configFilePath, []byte(`{ "labels":["foo=bar"] }`), 0o666)
 	assert.NilError(c, err)
 
@@ -2122,8 +2122,8 @@ func (s *DockerDaemonSuite) TestDaemonMaxConcurrencyWithConfigFileReload(c *test
 	expectedMaxConcurrentDownloads = `level=debug msg="Reset Max Concurrent Downloads: 3"`
 	content, err = s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentUploads))
-	assert.Assert(c, strings.Contains(string(content), expectedMaxConcurrentDownloads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentUploads))
+	assert.Assert(c, is.Contains(string(content), expectedMaxConcurrentDownloads))
 }
 
 func (s *DockerDaemonSuite) TestBuildOnDisabledBridgeNetworkDaemon(c *testing.T) {
@@ -2369,7 +2369,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartSaveContainerExitCode(c *testing.T)
 	errMsg1, err := s.d.Cmd("inspect", "-f", "{{.State.Error}}", containerName)
 	errMsg1 = strings.TrimSpace(errMsg1)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(errMsg1, "executable file not found"))
+	assert.Assert(c, is.Contains(errMsg1, "executable file not found"))
 	// now restart daemon
 	s.d.Restart(c)
 
@@ -2443,7 +2443,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeout(c *testing.T) {
 	expectedMessage := `level=debug msg="daemon configured with a 3 seconds minimum shutdown timeout"`
 	content, err := s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMessage))
+	assert.Assert(c, is.Contains(string(content), expectedMessage))
 }
 
 // Test case for #22471
@@ -2471,7 +2471,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownTimeoutWithConfigFile(c *testing.T
 	expectedMessage := `level=debug msg="Reset Shutdown Timeout: 5"`
 	content, err := s.d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), expectedMessage))
+	assert.Assert(c, is.Contains(string(content), expectedMessage))
 }
 
 // Test case for 29342

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -359,7 +359,7 @@ func (s *DockerCLIEventSuite) TestEventsFilterImageLabels(c *testing.T) {
 	// 2 events from the "docker tag" command, another one is from "docker build"
 	assert.Equal(c, len(events), 3, "Events == %s", events)
 	for _, e := range events {
-		assert.Check(c, strings.Contains(e, "labelfiltertest"))
+		assert.Check(c, is.Contains(e, "labelfiltertest"))
 	}
 }
 
@@ -582,7 +582,7 @@ func (s *DockerCLIEventSuite) TestEventsFilterType(c *testing.T) {
 	// 2 events from the "docker tag" command, another one is from "docker build"
 	assert.Equal(c, len(events), 3, "Events == %s", events)
 	for _, e := range events {
-		assert.Check(c, strings.Contains(e, "labelfiltertest"))
+		assert.Check(c, is.Contains(e, "labelfiltertest"))
 	}
 
 	out = cli.DockerCmd(c,
@@ -693,7 +693,7 @@ func (s *DockerCLIEventSuite) TestEventsSinceInTheFuture(c *testing.T) {
 	out, _, err := dockerCmdWithError("events", "--filter", "image=busybox", "--since", parseEventTime(since), "--until", parseEventTime(until))
 
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "cannot be after `until`"))
+	assert.Assert(c, is.Contains(out, "cannot be after `until`"))
 }
 
 func (s *DockerCLIEventSuite) TestEventsUntilInThePast(c *testing.T) {
@@ -708,7 +708,7 @@ func (s *DockerCLIEventSuite) TestEventsUntilInThePast(c *testing.T) {
 	out := cli.DockerCmd(c, "events", "--filter", "image=busybox", "--since", since, "--until", until).Stdout()
 
 	assert.Assert(c, !strings.Contains(out, "test-container2"))
-	assert.Assert(c, strings.Contains(out, "test-container"))
+	assert.Assert(c, is.Contains(out, "test-container"))
 }
 
 func (s *DockerCLIEventSuite) TestEventsFormat(c *testing.T) {

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -240,12 +240,12 @@ func (s *DockerCLIEventSuite) TestEventsContainerWithMultiNetwork(c *testing.T) 
 
 	// received two network disconnect events
 	assert.Equal(c, len(netEvents), 2)
-	assert.Assert(c, strings.Contains(netEvents[0], "disconnect"))
-	assert.Assert(c, strings.Contains(netEvents[1], "disconnect"))
+	assert.Assert(c, is.Contains(netEvents[0], "disconnect"))
+	assert.Assert(c, is.Contains(netEvents[1], "disconnect"))
 
 	// both networks appeared in the network event output
-	assert.Assert(c, strings.Contains(out, "test-event-network-local-1"))
-	assert.Assert(c, strings.Contains(out, "test-event-network-local-2"))
+	assert.Assert(c, is.Contains(out, "test-event-network-local-1"))
+	assert.Assert(c, is.Contains(out, "test-event-network-local-2"))
 }
 
 func (s *DockerCLIEventSuite) TestEventsStreaming(c *testing.T) {
@@ -371,8 +371,8 @@ func (s *DockerCLIEventSuite) TestEventsFilterVolumeID(c *testing.T) {
 	assert.Equal(c, len(events), 1)
 
 	assert.Equal(c, len(events), 1)
-	assert.Assert(c, strings.Contains(events[0], "test-event-volume-id"))
-	assert.Assert(c, strings.Contains(events[0], "driver=local"))
+	assert.Assert(c, is.Contains(events[0], "test-event-volume-id"))
+	assert.Assert(c, is.Contains(events[0], "driver=local"))
 }
 
 func (s *DockerCLIEventSuite) TestEventsFilterNetworkID(c *testing.T) {
@@ -384,8 +384,8 @@ func (s *DockerCLIEventSuite) TestEventsFilterNetworkID(c *testing.T) {
 	out := cli.DockerCmd(c, "events", "--filter", "network=test-event-network-local", "--since", since, "--until", daemonUnixTime(c)).Stdout()
 	events := strings.Split(strings.TrimSpace(out), "\n")
 	assert.Equal(c, len(events), 1)
-	assert.Assert(c, strings.Contains(events[0], "test-event-network-local"))
-	assert.Assert(c, strings.Contains(events[0], "type=bridge"))
+	assert.Assert(c, is.Contains(events[0], "test-event-network-local"))
+	assert.Assert(c, is.Contains(events[0], "type=bridge"))
 }
 
 func (s *DockerDaemonSuite) TestDaemonEvents(c *testing.T) {
@@ -452,11 +452,11 @@ func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *testing.T) {
 
 	out, err := s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", info.ID))
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", fmt.Sprintf("daemon=%s", info.ID))
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "daemon=foo")
 	assert.NilError(c, err)
@@ -464,7 +464,7 @@ func (s *DockerDaemonSuite) TestDaemonEventsWithFilters(c *testing.T) {
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=daemon")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("daemon reload %s", info.ID)))
 
 	out, err = s.d.Cmd("events", "--since=0", "--until", daemonUnixTime(c), "--filter", "type=container")
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -119,8 +119,8 @@ func (s *DockerCLIExecSuite) TestExecEnv(c *testing.T) {
 
 	out := cli.DockerCmd(c, "exec", "testing", "env").Stdout()
 	assert.Check(c, !strings.Contains(out, "LALA=value1"))
-	assert.Check(c, strings.Contains(out, "LALA=value2"))
-	assert.Check(c, strings.Contains(out, "HOME=/root"))
+	assert.Check(c, is.Contains(out, "LALA=value2"))
+	assert.Check(c, is.Contains(out, "HOME=/root"))
 }
 
 func (s *DockerCLIExecSuite) TestExecSetEnv(c *testing.T) {
@@ -130,8 +130,8 @@ func (s *DockerCLIExecSuite) TestExecSetEnv(c *testing.T) {
 
 	out := cli.DockerCmd(c, "exec", "-e", "HOME=/another", "-e", "ABC=xyz", "testing", "env").Stdout()
 	assert.Check(c, !strings.Contains(out, "HOME=/root"))
-	assert.Check(c, strings.Contains(out, "HOME=/another"))
-	assert.Check(c, strings.Contains(out, "ABC=xyz"))
+	assert.Check(c, is.Contains(out, "HOME=/another"))
+	assert.Check(c, is.Contains(out, "ABC=xyz"))
 }
 
 func (s *DockerCLIExecSuite) TestExecExitStatus(c *testing.T) {
@@ -437,7 +437,7 @@ func (s *DockerCLIExecSuite) TestExecWithUser(c *testing.T) {
 	cli.DockerCmd(c, "run", "-d", "--name", "parent", "busybox", "top")
 
 	out := cli.DockerCmd(c, "exec", "-u", "1", "parent", "id").Stdout()
-	assert.Assert(c, strings.Contains(out, "uid=1(daemon) gid=1(daemon)"))
+	assert.Assert(c, is.Contains(out, "uid=1(daemon) gid=1(daemon)"))
 
 	out = cli.DockerCmd(c, "exec", "-u", "root", "parent", "id").Stdout()
 	assert.Assert(c, strings.Contains(out, "uid=0(root) gid=0(root)"), "exec with user by id expected daemon user got %s", out)
@@ -529,7 +529,7 @@ func (s *DockerCLIExecSuite) TestExecWindowsPathNotWiped(c *testing.T) {
 
 	out = cli.DockerCmd(c, "exec", "testing", "powershell", "write-host", "$env:PATH").Stdout()
 	out = strings.ToLower(strings.Trim(out, "\r\n"))
-	assert.Assert(c, strings.Contains(out, `windowspowershell\v1.0`))
+	assert.Assert(c, is.Contains(out, `windowspowershell\v1.0`))
 }
 
 func (s *DockerCLIExecSuite) TestExecEnvLinksHost(c *testing.T) {

--- a/integration-cli/docker_cli_external_volume_driver_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_test.go
@@ -24,6 +24,7 @@ import (
 	testdaemon "github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/volume"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 const volumePluginName = "test-external-volume-driver"
@@ -282,7 +283,7 @@ func (s *DockerExternalVolumeSuite) TestVolumeCLICreateOptionConflict(c *testing
 
 	out, _, err := dockerCmdWithError("volume", "create", "test", "--driver", volumePluginName)
 	assert.Assert(c, err != nil, "volume create exception name already in use with another driver")
-	assert.Assert(c, strings.Contains(out, "must be unique"))
+	assert.Assert(c, is.Contains(out, "must be unique"))
 	driver := cli.DockerCmd(c, "volume", "inspect", "--format={{ .Driver }}", "test").Stdout()
 	_, _, err = dockerCmdWithError("volume", "create", "test", "--driver", strings.TrimSpace(driver))
 	assert.NilError(c, err)
@@ -294,7 +295,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverNamed(c *testing.T) 
 
 	out, err := s.d.Cmd("run", "--rm", "--name", "test-data", "-v", "external-volume-test:/tmp/external-volume-test", "--volume-driver", volumePluginName, "busybox:latest", "cat", "/tmp/external-volume-test/test")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, s.Server.URL))
+	assert.Assert(c, is.Contains(out, s.Server.URL))
 	_, err = s.d.Cmd("volume", "rm", "external-volume-test")
 	assert.NilError(c, err)
 
@@ -316,7 +317,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverUnnamed(c *testing.T
 
 	out, err := s.d.Cmd("run", "--rm", "--name", "test-data", "-v", "/tmp/external-volume-test", "--volume-driver", volumePluginName, "busybox:latest", "cat", "/tmp/external-volume-test/test")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, s.Server.URL))
+	assert.Assert(c, is.Contains(out, s.Server.URL))
 	assert.Equal(c, s.ec.activations, 1)
 	assert.Equal(c, s.ec.creations, 1)
 	assert.Equal(c, s.ec.removals, 1)
@@ -472,7 +473,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverList(c *testing.T) {
 func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGet(c *testing.T) {
 	out, _, err := dockerCmdWithError("volume", "inspect", "dummy")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "No such volume"))
+	assert.Assert(c, is.Contains(out, "No such volume"))
 	assert.Equal(c, s.ec.gets, 1)
 
 	cli.DockerCmd(c, "volume", "create", "test", "-d", volumePluginName)
@@ -510,7 +511,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGetEmptyResponse(c *
 
 	out, err = s.d.Cmd("volume", "inspect", "abc2")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "No such volume"))
+	assert.Assert(c, is.Contains(out, "No such volume"))
 }
 
 // Ensure only cached paths are used in volume list to prevent N+1 calls to `VolumeDriver.Path`
@@ -566,7 +567,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverOutOfBandDelete(c *t
 
 	out, err = s.d.Cmd("volume", "create", "-d", "local", "--name", "test")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "must be unique"))
+	assert.Assert(c, is.Contains(out, "must be unique"))
 	// simulate out of band volume deletion on plugin level
 	delete(p.vols, "test")
 

--- a/integration-cli/docker_cli_external_volume_driver_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_test.go
@@ -378,10 +378,10 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverLookupNotBlocked(c *
 	cmd1 := exec.Command(dockerBinary, "volume", "create", "-d", "down-driver")
 	cmd2 := exec.Command(dockerBinary, "volume", "create")
 
-	assert.Assert(c, cmd1.Start() == nil)
+	assert.NilError(c, cmd1.Start())
 	defer cmd1.Process.Kill()
 	time.Sleep(100 * time.Millisecond) // ensure API has been called
-	assert.Assert(c, cmd2.Start() == nil)
+	assert.NilError(c, cmd2.Start())
 
 	go func() {
 		cmd1.Wait()
@@ -450,7 +450,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverBindExternalVolume(c
 		Driver string
 	}
 	out := inspectFieldJSON(c, "testing", "Mounts")
-	assert.Assert(c, json.NewDecoder(strings.NewReader(out)).Decode(&mounts) == nil)
+	assert.NilError(c, json.NewDecoder(strings.NewReader(out)).Decode(&mounts))
 	assert.Equal(c, len(mounts), 1, out)
 	assert.Equal(c, mounts[0].Name, "foo")
 	assert.Equal(c, mounts[0].Driver, volumePluginName)
@@ -484,7 +484,7 @@ func (s *DockerExternalVolumeSuite) TestExternalVolumeDriverGet(c *testing.T) {
 	}
 	var st []vol
 
-	assert.Assert(c, json.Unmarshal([]byte(out), &st) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &st))
 	assert.Equal(c, len(st), 1)
 	assert.Equal(c, len(st[0].Status), 1, fmt.Sprintf("%v", st[0]))
 	assert.Equal(c, st[0].Status["Hello"], "world", fmt.Sprintf("%v", st[0].Status))

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type DockerCLIHistorySuite struct {
@@ -65,7 +66,7 @@ LABEL label.Z="Z"`))
 	for i := 0; i < 26; i++ {
 		echoValue := fmt.Sprintf("LABEL label.%s=%s", expectedValues[i], expectedValues[i])
 		actualValue := actualValues[i]
-		assert.Assert(c, strings.Contains(actualValue, echoValue))
+		assert.Assert(c, is.Contains(actualValue, echoValue))
 	}
 }
 
@@ -92,7 +93,7 @@ func (s *DockerCLIHistorySuite) TestHistoryImageWithComment(c *testing.T) {
 	out := cli.DockerCmd(c, "history", name).Combined()
 	outputTabs := strings.Fields(strings.Split(out, "\n")[1])
 	actualValue := outputTabs[len(outputTabs)-1]
-	assert.Assert(c, strings.Contains(actualValue, comment))
+	assert.Assert(c, is.Contains(actualValue, comment))
 }
 
 func (s *DockerCLIHistorySuite) TestHistoryHumanOptionFalse(c *testing.T) {

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -33,7 +33,7 @@ func (s *DockerCLIImagesSuite) OnTimeout(c *testing.T) {
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImageIsListed(c *testing.T) {
 	imagesOut := cli.DockerCmd(c, "images").Stdout()
-	assert.Assert(c, strings.Contains(imagesOut, "busybox"))
+	assert.Assert(c, is.Contains(imagesOut, "busybox"))
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImageWithTagIsListed(c *testing.T) {
@@ -43,15 +43,15 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImageWithTagIsListed(c *testing.T
 	cli.DockerCmd(c, "tag", "busybox", name+":v2")
 
 	imagesOut := cli.DockerCmd(c, "images", name+":v1").Stdout()
-	assert.Assert(c, strings.Contains(imagesOut, name))
-	assert.Assert(c, strings.Contains(imagesOut, "v1"))
+	assert.Assert(c, is.Contains(imagesOut, name))
+	assert.Assert(c, is.Contains(imagesOut, "v1"))
 	assert.Assert(c, !strings.Contains(imagesOut, "v2"))
 	assert.Assert(c, !strings.Contains(imagesOut, "v1v1"))
 	imagesOut = cli.DockerCmd(c, "images", name).Stdout()
-	assert.Assert(c, strings.Contains(imagesOut, name))
-	assert.Assert(c, strings.Contains(imagesOut, "v1"))
-	assert.Assert(c, strings.Contains(imagesOut, "v1v1"))
-	assert.Assert(c, strings.Contains(imagesOut, "v2"))
+	assert.Assert(c, is.Contains(imagesOut, name))
+	assert.Assert(c, is.Contains(imagesOut, "v1"))
+	assert.Assert(c, is.Contains(imagesOut, "v1v1"))
+	assert.Assert(c, is.Contains(imagesOut, "v2"))
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *testing.T) {
@@ -82,7 +82,7 @@ func (s *DockerCLIImagesSuite) TestImagesOrderedByCreationDate(c *testing.T) {
 func (s *DockerCLIImagesSuite) TestImagesErrorWithInvalidFilterNameTest(c *testing.T) {
 	out, _, err := dockerCmdWithError("images", "-f", "FOO=123")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "invalid filter"))
+	assert.Assert(c, is.Contains(out, "invalid filter"))
 }
 
 func (s *DockerCLIImagesSuite) TestImagesFilterLabelMatch(c *testing.T) {
@@ -259,14 +259,14 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *te
 	assert.Assert(c, !strings.Contains(out, imageID))
 	out = cli.DockerCmd(c, "images").Stdout()
 	// docker images still include dangling images
-	assert.Assert(c, strings.Contains(out, imageID))
+	assert.Assert(c, is.Contains(out, imageID))
 }
 
 // FIXME(vdemeester) should be a unit test for `docker image ls`
 func (s *DockerCLIImagesSuite) TestImagesWithIncorrectFilter(c *testing.T) {
 	out, _, err := dockerCmdWithError("images", "-f", "dangling=invalid")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "invalid filter"))
+	assert.Assert(c, is.Contains(out, "invalid filter"))
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureOnlyHeadsImagesShown(c *testing.T) {
@@ -289,7 +289,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureOnlyHeadsImagesShown(c *testing.T
 	// images shouldn't show non-heads images
 	assert.Assert(c, !strings.Contains(out, intermediate))
 	// images should contain final built images
-	assert.Assert(c, strings.Contains(out, stringid.TruncateID(id)))
+	assert.Assert(c, is.Contains(out, stringid.TruncateID(id)))
 }
 
 func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromScratchShown(c *testing.T) {
@@ -304,7 +304,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromScratchShown(c *testing
 
 	out := cli.DockerCmd(c, "images").Stdout()
 	// images should contain images built from scratch
-	assert.Assert(c, strings.Contains(out, stringid.TruncateID(id)))
+	assert.Assert(c, is.Contains(out, stringid.TruncateID(id)))
 }
 
 // For W2W - equivalent to TestImagesEnsureImagesFromScratchShown but Windows
@@ -320,7 +320,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromBusyboxShown(c *testing
 
 	out := cli.DockerCmd(c, "images").Stdout()
 	// images should contain images built from busybox
-	assert.Assert(c, strings.Contains(out, stringid.TruncateID(id)))
+	assert.Assert(c, is.Contains(out, stringid.TruncateID(id)))
 }
 
 // #18181
@@ -328,9 +328,9 @@ func (s *DockerCLIImagesSuite) TestImagesFilterNameWithPort(c *testing.T) {
 	const tag = "a.b.c.d:5000/hello"
 	cli.DockerCmd(c, "tag", "busybox", tag)
 	out := cli.DockerCmd(c, "images", tag).Stdout()
-	assert.Assert(c, strings.Contains(out, tag))
+	assert.Assert(c, is.Contains(out, tag))
 	out = cli.DockerCmd(c, "images", tag+":latest").Stdout()
-	assert.Assert(c, strings.Contains(out, tag))
+	assert.Assert(c, is.Contains(out, tag))
 	out = cli.DockerCmd(c, "images", tag+":no-such-tag").Stdout()
 	assert.Assert(c, !strings.Contains(out, tag))
 }

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type DockerCLIInfoSuite struct {
@@ -74,10 +75,10 @@ func (s *DockerCLIInfoSuite) TestInfoDisplaysRunningContainers(c *testing.T) {
 
 	cli.DockerCmd(c, "run", "-d", "busybox", "top")
 	out := cli.DockerCmd(c, "info").Stdout()
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Containers: %d\n", existing["Containers"]+1)))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Running: %d\n", existing["ContainersRunning"]+1)))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Paused: %d\n", existing["ContainersPaused"])))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Stopped: %d\n", existing["ContainersStopped"])))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("Containers: %d\n", existing["Containers"]+1)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Running: %d\n", existing["ContainersRunning"]+1)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Paused: %d\n", existing["ContainersPaused"])))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Stopped: %d\n", existing["ContainersStopped"])))
 }
 
 func (s *DockerCLIInfoSuite) TestInfoDisplaysPausedContainers(c *testing.T) {
@@ -90,10 +91,10 @@ func (s *DockerCLIInfoSuite) TestInfoDisplaysPausedContainers(c *testing.T) {
 	cli.DockerCmd(c, "pause", id)
 
 	out := cli.DockerCmd(c, "info").Stdout()
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Containers: %d\n", existing["Containers"]+1)))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Running: %d\n", existing["ContainersRunning"])))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Paused: %d\n", existing["ContainersPaused"]+1)))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Stopped: %d\n", existing["ContainersStopped"])))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("Containers: %d\n", existing["Containers"]+1)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Running: %d\n", existing["ContainersRunning"])))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Paused: %d\n", existing["ContainersPaused"]+1)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Stopped: %d\n", existing["ContainersStopped"])))
 }
 
 func (s *DockerCLIInfoSuite) TestInfoDisplaysStoppedContainers(c *testing.T) {
@@ -107,10 +108,10 @@ func (s *DockerCLIInfoSuite) TestInfoDisplaysStoppedContainers(c *testing.T) {
 	cli.DockerCmd(c, "stop", cleanedContainerID)
 
 	out = cli.DockerCmd(c, "info").Stdout()
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Containers: %d\n", existing["Containers"]+1)))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Running: %d\n", existing["ContainersRunning"])))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Paused: %d\n", existing["ContainersPaused"])))
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf(" Stopped: %d\n", existing["ContainersStopped"]+1)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("Containers: %d\n", existing["Containers"]+1)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Running: %d\n", existing["ContainersRunning"])))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Paused: %d\n", existing["ContainersPaused"])))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf(" Stopped: %d\n", existing["ContainersStopped"]+1)))
 }
 
 func existingContainerStates(c *testing.T) map[string]int {

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -132,7 +133,7 @@ func (s *DockerCLIInspectSuite) TestInspectTypeFlagWithInvalidValue(c *testing.T
 	out, exitCode, err := dockerCmdWithError("inspect", "--type=foobar", "busybox")
 	assert.Assert(c, err != nil, "%d", exitCode)
 	assert.Equal(c, exitCode, 1, err)
-	assert.Assert(c, strings.Contains(out, "not a valid value for --type"))
+	assert.Assert(c, is.Contains(out, "not a valid value for --type"))
 }
 
 func (s *DockerCLIInspectSuite) TestInspectImageFilterInt(c *testing.T) {
@@ -298,10 +299,10 @@ func (s *DockerCLIInspectSuite) TestInspectTemplateError(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("inspect", "--type=container", "--format='Format container: {{.ThisDoesNotExist}}'", "container1")
 	assert.Assert(c, err != nil)
-	assert.Assert(c, strings.Contains(out, "Template parsing error"))
+	assert.Assert(c, is.Contains(out, "Template parsing error"))
 	out, _, err = dockerCmdWithError("inspect", "--type=image", "--format='Format container: {{.ThisDoesNotExist}}'", "busybox")
 	assert.Assert(c, err != nil)
-	assert.Assert(c, strings.Contains(out, "Template parsing error"))
+	assert.Assert(c, is.Contains(out, "Template parsing error"))
 }
 
 func (s *DockerCLIInspectSuite) TestInspectJSONFields(c *testing.T) {
@@ -329,16 +330,16 @@ func (s *DockerCLIInspectSuite) TestInspectStopWhenNotFound(c *testing.T) {
 	result := dockerCmdWithResult("inspect", "--type=container", "--format='{{.Name}}'", "busybox1", "busybox2", "missing")
 
 	assert.Assert(c, result.Error != nil)
-	assert.Assert(c, strings.Contains(result.Stdout(), "busybox1"))
-	assert.Assert(c, strings.Contains(result.Stdout(), "busybox2"))
-	assert.Assert(c, strings.Contains(result.Stderr(), "Error: No such container: missing"))
+	assert.Assert(c, is.Contains(result.Stdout(), "busybox1"))
+	assert.Assert(c, is.Contains(result.Stdout(), "busybox2"))
+	assert.Assert(c, is.Contains(result.Stderr(), "Error: No such container: missing"))
 	// test inspect would not fast fail
 	result = dockerCmdWithResult("inspect", "--type=container", "--format='{{.Name}}'", "missing", "busybox1", "busybox2")
 
 	assert.Assert(c, result.Error != nil)
-	assert.Assert(c, strings.Contains(result.Stdout(), "busybox1"))
-	assert.Assert(c, strings.Contains(result.Stdout(), "busybox2"))
-	assert.Assert(c, strings.Contains(result.Stderr(), "Error: No such container: missing"))
+	assert.Assert(c, is.Contains(result.Stdout(), "busybox1"))
+	assert.Assert(c, is.Contains(result.Stdout(), "busybox2"))
+	assert.Assert(c, is.Contains(result.Stderr(), "Error: No such container: missing"))
 }
 
 func (s *DockerCLIInspectSuite) TestInspectHistory(c *testing.T) {
@@ -346,7 +347,7 @@ func (s *DockerCLIInspectSuite) TestInspectHistory(c *testing.T) {
 	cli.DockerCmd(c, "commit", "-m", "test comment", "testcont", "testimg")
 	out, _, err := dockerCmdWithError("inspect", "--format='{{.Comment}}'", "testimg")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, "test comment"))
+	assert.Assert(c, is.Contains(out, "test comment"))
 }
 
 func (s *DockerCLIInspectSuite) TestInspectContainerNetworkDefault(c *testing.T) {
@@ -356,7 +357,7 @@ func (s *DockerCLIInspectSuite) TestInspectContainerNetworkDefault(c *testing.T)
 	cli.DockerCmd(c, "run", "--name", contName, "-d", "busybox", "top")
 	netOut := cli.DockerCmd(c, "network", "inspect", "--format={{.ID}}", "bridge").Stdout()
 	out := inspectField(c, contName, "NetworkSettings.Networks")
-	assert.Assert(c, strings.Contains(out, "bridge"))
+	assert.Assert(c, is.Contains(out, "bridge"))
 	out = inspectField(c, contName, "NetworkSettings.Networks.bridge.NetworkID")
 	assert.Equal(c, strings.TrimSpace(out), strings.TrimSpace(netOut))
 }
@@ -367,7 +368,7 @@ func (s *DockerCLIInspectSuite) TestInspectContainerNetworkCustom(c *testing.T) 
 	netOut := cli.DockerCmd(c, "network", "create", "net1").Stdout()
 	cli.DockerCmd(c, "run", "--name=container1", "--net=net1", "-d", "busybox", "top")
 	out := inspectField(c, "container1", "NetworkSettings.Networks")
-	assert.Assert(c, strings.Contains(out, "net1"))
+	assert.Assert(c, is.Contains(out, "net1"))
 	out = inspectField(c, "container1", "NetworkSettings.Networks.net1.NetworkID")
 	assert.Equal(c, strings.TrimSpace(out), strings.TrimSpace(netOut))
 }
@@ -387,9 +388,9 @@ func (s *DockerCLIInspectSuite) TestInspectAmpersand(c *testing.T) {
 
 	name := "test"
 	out := cli.DockerCmd(c, "run", "--name", name, "--env", `TEST_ENV="soanni&rtr"`, "busybox", "env").Stdout()
-	assert.Assert(c, strings.Contains(out, `soanni&rtr`))
+	assert.Assert(c, is.Contains(out, `soanni&rtr`))
 	out = cli.DockerCmd(c, "inspect", name).Stdout()
-	assert.Assert(c, strings.Contains(out, `soanni&rtr`))
+	assert.Assert(c, is.Contains(out, `soanni&rtr`))
 }
 
 func (s *DockerCLIInspectSuite) TestInspectPlugin(c *testing.T) {
@@ -419,7 +420,7 @@ func (s *DockerCLIInspectSuite) TestInspectPlugin(c *testing.T) {
 
 	out, _, err = dockerCmdWithError("plugin", "remove", pNameWithTag)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, pNameWithTag))
+	assert.Assert(c, is.Contains(out, pNameWithTag))
 }
 
 // Test case for 29185
@@ -427,6 +428,6 @@ func (s *DockerCLIInspectSuite) TestInspectUnknownObject(c *testing.T) {
 	// This test should work on both Windows and Linux
 	out, _, err := dockerCmdWithError("inspect", "foobar")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Error: No such object: foobar"))
+	assert.Assert(c, is.Contains(out, "Error: No such object: foobar"))
 	assert.ErrorContains(c, err, "Error: No such object: foobar")
 }

--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type DockerCLILoginSuite struct {
@@ -38,7 +38,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLoginToPrivateRegistry(c *testing.
 	// wrong credentials
 	out, _, err := dockerCmdWithError("login", "-u", s.reg.Username(), "-p", "WRONGPASSWORD", privateRegistryURL)
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "401 Unauthorized"))
+	assert.Assert(c, is.Contains(out, "401 Unauthorized"))
 
 	// now it's fine
 	cli.DockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)

--- a/integration-cli/docker_cli_logout_test.go
+++ b/integration-cli/docker_cli_logout_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *testing.T) {
@@ -45,7 +46,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *testing.
 	b, err := os.ReadFile(configPath)
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(string(b), `"auth":`))
-	assert.Assert(c, strings.Contains(string(b), privateRegistryURL))
+	assert.Assert(c, is.Contains(string(b), privateRegistryURL))
 
 	_, err = s.d.Cmd("--config", tmp, "tag", "busybox", imgRepoName)
 	assert.NilError(c, err)
@@ -61,7 +62,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithExternalAuth(c *testing.
 	// check I cannot pull anymore
 	out, err := s.d.Cmd("--config", tmp, "pull", imgRepoName)
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "no basic auth credentials"))
+	assert.Assert(c, is.Contains(out, "no basic auth credentials"))
 }
 
 // #23100
@@ -93,8 +94,8 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithWrongHostnamesStored(c *
 
 	b, err := os.ReadFile(configPath)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(b), fmt.Sprintf(`"https://%s": {}`, privateRegistryURL)))
-	assert.Assert(c, strings.Contains(string(b), fmt.Sprintf(`"%s": {}`, privateRegistryURL)))
+	assert.Assert(c, is.Contains(string(b), fmt.Sprintf(`"https://%s": {}`, privateRegistryURL)))
+	assert.Assert(c, is.Contains(string(b), fmt.Sprintf(`"%s": {}`, privateRegistryURL)))
 
 	cli.DockerCmd(c, "--config", tmp, "logout", privateRegistryURL)
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/testutil"
 	testdaemon "github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -186,7 +187,7 @@ func (s *DockerCLILogsSuite) TestLogsSince(c *testing.T) {
 		result := icmd.RunCommand(dockerBinary, cmd...)
 		result.Assert(c, icmd.Success)
 		for _, v := range expected {
-			assert.Check(c, strings.Contains(result.Combined(), v))
+			assert.Check(c, is.Contains(result.Combined(), v))
 		}
 	}
 }
@@ -382,7 +383,7 @@ func (s *DockerCLILogsSuite) TestLogsCLIContainerNotFound(c *testing.T) {
 	name := "testlogsnocontainer"
 	out, _, _ := dockerCmdWithError("logs", name)
 	message := fmt.Sprintf("No such container: %s\n", name)
-	assert.Assert(c, strings.Contains(out, message))
+	assert.Assert(c, is.Contains(out, message))
 }
 
 func (s *DockerCLILogsSuite) TestLogsWithDetails(c *testing.T) {

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/runconfig"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 // GH14530. Validates combinations of --net= with other options
@@ -41,58 +42,58 @@ func (s *DockerCLINetmodeSuite) TestNetHostnameWithNetHost(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	out := cli.DockerCmd(c, "run", "--net=host", "busybox", "ps").Stdout()
-	assert.Assert(c, strings.Contains(out, stringCheckPS))
+	assert.Assert(c, is.Contains(out, stringCheckPS))
 }
 
 func (s *DockerCLINetmodeSuite) TestNetHostname(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	out := cli.DockerCmd(c, "run", "-h=name", "busybox", "ps").Stdout()
-	assert.Assert(c, strings.Contains(out, stringCheckPS))
+	assert.Assert(c, is.Contains(out, stringCheckPS))
 	out = cli.DockerCmd(c, "run", "-h=name", "--net=bridge", "busybox", "ps").Stdout()
-	assert.Assert(c, strings.Contains(out, stringCheckPS))
+	assert.Assert(c, is.Contains(out, stringCheckPS))
 	out = cli.DockerCmd(c, "run", "-h=name", "--net=none", "busybox", "ps").Stdout()
-	assert.Assert(c, strings.Contains(out, stringCheckPS))
+	assert.Assert(c, is.Contains(out, stringCheckPS))
 	out = dockerCmdWithFail(c, "run", "-h=name", "--net=container:other", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkHostname.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictNetworkHostname.Error()))
 	out = dockerCmdWithFail(c, "run", "--net=container", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, "invalid container format container:<name|id>"))
+	assert.Assert(c, is.Contains(out, "invalid container format container:<name|id>"))
 	out = dockerCmdWithFail(c, "run", "--net=weird", "busybox", "ps")
-	assert.Assert(c, strings.Contains(strings.ToLower(out), "not found"))
+	assert.Assert(c, is.Contains(strings.ToLower(out), "not found"))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictContainerNetworkAndLinks(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	out := dockerCmdWithFail(c, "run", "--net=container:other", "--link=zip:zap", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictContainerNetworkAndLinks.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictContainerNetworkAndLinks.Error()))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictContainerNetworkHostAndLinks(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	out := dockerCmdWithFail(c, "run", "--net=host", "--link=zip:zap", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictHostNetworkAndLinks.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictHostNetworkAndLinks.Error()))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictNetworkModeNetHostAndOptions(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 
 	out := dockerCmdWithFail(c, "run", "--net=host", "--mac-address=92:d0:c6:0a:29:33", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictContainerNetworkAndMac.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictContainerNetworkAndMac.Error()))
 }
 
 func (s *DockerCLINetmodeSuite) TestConflictNetworkModeAndOptions(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	out := dockerCmdWithFail(c, "run", "--net=container:other", "--dns=8.8.8.8", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkAndDNS.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictNetworkAndDNS.Error()))
 	out = dockerCmdWithFail(c, "run", "--net=container:other", "--add-host=name:8.8.8.8", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkHosts.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictNetworkHosts.Error()))
 	out = dockerCmdWithFail(c, "run", "--net=container:other", "-P", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkPublishPorts.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictNetworkPublishPorts.Error()))
 	out = dockerCmdWithFail(c, "run", "--net=container:other", "-p", "8080", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkPublishPorts.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictNetworkPublishPorts.Error()))
 	out = dockerCmdWithFail(c, "run", "--net=container:other", "--expose", "8000-9000", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNetworkExposePorts.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictNetworkExposePorts.Error()))
 }

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -320,7 +320,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkCreateHostBind(c *testing.T) {
 	id := runSleepingContainer(c, "--net=testbind", "-p", "5000:5000")
 	cli.WaitRun(c, id)
 	out := cli.DockerCmd(c, "ps").Stdout()
-	assert.Assert(c, strings.Contains(out, "192.168.10.1:5000->5000/tcp"))
+	assert.Assert(c, is.Contains(out, "192.168.10.1:5000->5000/tcp"))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkRmPredefined(c *testing.T) {
@@ -435,7 +435,7 @@ func (s *DockerCLINetworkSuite) TestDockerNetworkDeleteMultiple(c *testing.T) {
 	// err should not be nil due to deleting testDelMulti2 failed.
 	assert.Assert(c, err != nil, "out: %s", out)
 	// testDelMulti2 should fail due to network has active endpoints
-	assert.Assert(c, strings.Contains(out, "has active endpoints"))
+	assert.Assert(c, is.Contains(out, "has active endpoints"))
 	assertNwNotAvailable(c, "testDelMulti0")
 	assertNwNotAvailable(c, "testDelMulti1")
 	// testDelMulti2 can't be deleted, so it should exist
@@ -804,9 +804,9 @@ func (s *DockerNetworkSuite) TestDockerPluginV2NetworkDriver(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("plugin", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, npName))
-	assert.Assert(c, strings.Contains(out, npTag))
-	assert.Assert(c, strings.Contains(out, "true"))
+	assert.Assert(c, is.Contains(out, npName))
+	assert.Assert(c, is.Contains(out, npTag))
+	assert.Assert(c, is.Contains(out, "true"))
 	cli.DockerCmd(c, "network", "create", "-d", npNameWithTag, "v2net")
 	assertNwIsAvailable(c, "v2net")
 	cli.DockerCmd(c, "network", "rm", "v2net")
@@ -967,9 +967,9 @@ func (s *DockerNetworkSuite) TestDockerNetworkOverlayPortMapping(c *testing.T) {
 	unpPort2 := fmt.Sprintf("%d/tcp", port2)
 	out := cli.DockerCmd(c, "ps", "-n=1").Stdout()
 	// Missing unpublished ports in docker ps output
-	assert.Assert(c, strings.Contains(out, unpPort1))
+	assert.Assert(c, is.Contains(out, unpPort1))
 	// Missing unpublished ports in docker ps output
-	assert.Assert(c, strings.Contains(out, unpPort2))
+	assert.Assert(c, is.Contains(out, unpPort2))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkDriverUngracefulRestart(c *testing.T) {
@@ -1155,7 +1155,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectToHostFromOtherNetwork(c *t
 	cli.DockerCmd(c, "network", "disconnect", "bridge", "container1")
 	out, _, err := dockerCmdWithError("network", "connect", "host", "container1")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictHostNetwork.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictHostNetwork.Error()))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkDisconnectFromHost(c *testing.T) {
@@ -1163,7 +1163,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkDisconnectFromHost(c *testing.T) {
 	cli.WaitRun(c, "container1")
 	out, _, err := dockerCmdWithError("network", "disconnect", "host", "container1")
 	assert.Assert(c, err != nil, "Should err out disconnect from host")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictHostNetwork.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictHostNetwork.Error()))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectWithPortMapping(c *testing.T) {
@@ -1324,7 +1324,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIP(c *testing.T) {
 	// Still it should fail to connect to the default network with a specified IP (whatever ip)
 	out, _, err := dockerCmdWithError("network", "connect", "--ip", "172.21.55.44", "bridge", "c0")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndIP.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrUnsupportedNetworkAndIP.Error()))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectPreferredIPStoppedContainer(c *testing.T) {
@@ -1362,10 +1362,10 @@ func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedRequiredIP(c *testing.T
 
 	out, _, err := dockerCmdWithError("run", "-d", "--ip", "172.28.99.88", "--net", "n0", "busybox", "top")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkNoSubnetAndIP.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrUnsupportedNetworkNoSubnetAndIP.Error()))
 	out, _, err = dockerCmdWithError("run", "-d", "--ip6", "2001:db8:1234::9988", "--net", "n0", "busybox", "top")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkNoSubnetAndIP.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrUnsupportedNetworkNoSubnetAndIP.Error()))
 	cli.DockerCmd(c, "network", "rm", "n0")
 	assertNwNotAvailable(c, "n0")
 }
@@ -1373,7 +1373,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedRequiredIP(c *testing.T
 func checkUnsupportedNetworkAndIP(c *testing.T, nwMode string) {
 	out, _, err := dockerCmdWithError("run", "-d", "--net", nwMode, "--ip", "172.28.99.88", "--ip6", "2001:db8:1234::9988", "busybox", "top")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndIP.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrUnsupportedNetworkAndIP.Error()))
 }
 
 func verifyIPAddressConfig(c *testing.T, cName, nwname, ipv4, ipv6 string) {
@@ -1512,7 +1512,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectWithAliasOnDefaultNetworks(
 	for _, nw := range defaults {
 		res, _, err := dockerCmdWithError("network", "connect", "--alias", "alias"+nw, nw, containerID)
 		assert.ErrorContains(c, err, "")
-		assert.Assert(c, strings.Contains(res, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
+		assert.Assert(c, is.Contains(res, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
 	}
 }
 
@@ -1563,11 +1563,11 @@ func (s *DockerCLINetworkSuite) TestUserDefinedNetworkConnectDisconnectAlias(c *
 	// verify the alias option is rejected when running on predefined network
 	out, _, err := dockerCmdWithError("run", "--rm", "--name=any", "--net-alias=any", "busybox:glibc", "true")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
 	// verify the alias option is rejected when connecting to predefined network
 	out, _, err = dockerCmdWithError("network", "connect", "--alias=any", "bridge", "first")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
 }
 
 func (s *DockerCLINetworkSuite) TestUserDefinedNetworkConnectivity(c *testing.T) {

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -991,7 +991,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkDriverUngracefulRestart(c *testing
 	assert.NilError(c, err)
 
 	// Kill daemon and restart
-	assert.Assert(c, s.d.Kill() == nil)
+	assert.NilError(c, s.d.Kill())
 
 	server.Close()
 
@@ -1106,7 +1106,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkMultipleNetworksUngracefulDaemonRe
 	verifyContainerIsConnectedToNetworks(c, s.d, cName, nwList)
 
 	// Kill daemon and restart
-	assert.Assert(c, s.d.Kill() == nil)
+	assert.NilError(c, s.d.Kill())
 	s.d.Restart(c)
 
 	// Restart container
@@ -1139,7 +1139,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 	}
 
 	// Kill daemon ungracefully and restart
-	assert.Assert(c, s.d.Kill() == nil)
+	assert.NilError(c, s.d.Kill())
 	s.d.Restart(c)
 
 	// make sure all the containers are up and running

--- a/integration-cli/docker_cli_plugins_logdriver_test.go
+++ b/integration-cli/docker_cli_plugins_logdriver_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type DockerCLIPluginLogDriverSuite struct {
@@ -57,6 +58,6 @@ func (s *DockerCLIPluginLogDriverSuite) TestPluginLogDriverInfoList(c *testing.T
 	assert.NilError(c, err)
 
 	drivers := strings.Join(info.Plugins.Log, " ")
-	assert.Assert(c, strings.Contains(drivers, "json-file"))
+	assert.Assert(c, is.Contains(drivers, "json-file"))
 	assert.Assert(c, !strings.Contains(drivers, pluginName))
 }

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -251,9 +251,9 @@ func (s *DockerCLIPortSuite) TestUnpublishedPortsInPsOutput(c *testing.T) {
 	unpPort2 := fmt.Sprintf("%d/tcp", port2)
 	out := cli.DockerCmd(c, "ps", "-n=1").Stdout()
 	// Missing unpublished ports in docker ps output
-	assert.Assert(c, strings.Contains(out, unpPort1))
+	assert.Assert(c, is.Contains(out, unpPort1))
 	// Missing unpublished ports in docker ps output
-	assert.Assert(c, strings.Contains(out, unpPort2))
+	assert.Assert(c, is.Contains(out, unpPort2))
 	// Run the container forcing to publish the exposed ports
 	cli.DockerCmd(c, "run", "-d", "-P", expose1, expose2, "busybox", "sleep", "5")
 
@@ -279,9 +279,9 @@ func (s *DockerCLIPortSuite) TestUnpublishedPortsInPsOutput(c *testing.T) {
 	expBnd2 := fmt.Sprintf("0.0.0.0:%d->%s", offset+port2, unpPort2)
 	out = cli.DockerCmd(c, "ps", "-n=1").Stdout()
 	// Cannot find expected port binding (expBnd1) in docker ps output
-	assert.Assert(c, strings.Contains(out, expBnd1))
+	assert.Assert(c, is.Contains(out, expBnd1))
 	// Cannot find expected port binding (expBnd2) in docker ps output
-	assert.Assert(c, strings.Contains(out, expBnd2))
+	assert.Assert(c, is.Contains(out, expBnd2))
 	// Remove container now otherwise it will interfere with next test
 	stopRemoveContainer(id, c)
 
@@ -292,9 +292,9 @@ func (s *DockerCLIPortSuite) TestUnpublishedPortsInPsOutput(c *testing.T) {
 	// Check docker ps o/p for last created container reports the specified port mappings
 	out = cli.DockerCmd(c, "ps", "-n=1").Stdout()
 	// Cannot find expected port binding (expBnd1) in docker ps output
-	assert.Assert(c, strings.Contains(out, expBnd1))
+	assert.Assert(c, is.Contains(out, expBnd1))
 	// Cannot find expected port binding (expBnd2) in docker ps output
-	assert.Assert(c, strings.Contains(out, expBnd2))
+	assert.Assert(c, is.Contains(out, expBnd2))
 	// Remove container now otherwise it will interfere with next test
 	stopRemoveContainer(id, c)
 
@@ -304,9 +304,9 @@ func (s *DockerCLIPortSuite) TestUnpublishedPortsInPsOutput(c *testing.T) {
 	// Check docker ps o/p for last created container reports the specified unpublished port and port mapping
 	out = cli.DockerCmd(c, "ps", "-n=1").Stdout()
 	// Missing unpublished exposed ports (unpPort1) in docker ps output
-	assert.Assert(c, strings.Contains(out, unpPort1))
+	assert.Assert(c, is.Contains(out, unpPort1))
 	// Missing port binding (expBnd2) in docker ps output
-	assert.Assert(c, strings.Contains(out, expBnd2))
+	assert.Assert(c, is.Contains(out, expBnd2))
 }
 
 func (s *DockerCLIPortSuite) TestPortHostBinding(c *testing.T) {

--- a/integration-cli/docker_cli_prune_unix_test.go
+++ b/integration-cli/docker_cli_prune_unix_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
 )
@@ -104,16 +105,16 @@ func (s *DockerDaemonSuite) TestPruneImageDangling(c *testing.T) {
 
 	out, err := s.d.Cmd("images", "-q", "--no-trunc")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id))
 	out, err = s.d.Cmd("image", "prune", "--force")
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id))
 	out, err = s.d.Cmd("images", "-q", "--no-trunc")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id))
 	out, err = s.d.Cmd("image", "prune", "--force", "--all")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id))
 	out, err = s.d.Cmd("images", "-q", "--no-trunc")
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id))
@@ -131,11 +132,11 @@ func (s *DockerCLIPruneSuite) TestPruneContainerUntil(c *testing.T) {
 	cli.WaitExited(c, id2, 5*time.Second)
 
 	out = cli.DockerCmd(c, "container", "prune", "--force", "--filter", "until="+until).Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
 }
 
 func (s *DockerCLIPruneSuite) TestPruneContainerLabel(c *testing.T) {
@@ -168,29 +169,29 @@ func (s *DockerCLIPruneSuite) TestPruneContainerLabel(c *testing.T) {
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id4))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id4))
 
 	out = cli.DockerCmd(c, "container", "prune", "--force", "--filter", "label=foo").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
 
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id3))
 
 	out = cli.DockerCmd(c, "container", "prune", "--force", "--filter", "label!=bar").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id3))
 
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
 
 	// With config.json label=foobar and CLI label!=foobar, CLI label!=foobar supersede
 	out = cli.DockerCmd(c, "--config", d, "container", "prune", "--force", "--filter", "label!=foobar").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
 
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
@@ -226,29 +227,29 @@ func (s *DockerCLIPruneSuite) TestPruneVolumeLabel(c *testing.T) {
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id4))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id4))
 
 	out = cli.DockerCmd(c, "volume", "prune", "--force", "--filter", "label=foo").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
 
 	out = cli.DockerCmd(c, "volume", "ls", "--format", "{{.Name}}").Stdout()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id3))
 
 	out = cli.DockerCmd(c, "volume", "prune", "--force", "--filter", "label!=bar").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id3))
 
 	out = cli.DockerCmd(c, "volume", "ls", "--format", "{{.Name}}").Stdout()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id3))
 
 	// With config.json label=foobar and CLI label!=foobar, CLI label!=foobar supersede
 	out = cli.DockerCmd(c, "--config", d, "volume", "prune", "--force", "--filter", "label!=foobar").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
 	out = cli.DockerCmd(c, "volume", "ls", "--format", "{{.Name}}").Stdout()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 }
@@ -259,18 +260,18 @@ func (s *DockerCLIPruneSuite) TestPruneNetworkLabel(c *testing.T) {
 	cli.DockerCmd(c, "network", "create", "n3")
 
 	out := cli.DockerCmd(c, "network", "prune", "--force", "--filter", "label=foo").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "n1"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "n1"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n2"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n3"))
 
 	out = cli.DockerCmd(c, "network", "prune", "--force", "--filter", "label!=bar").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n1"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n2"))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "n3"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "n3"))
 
 	out = cli.DockerCmd(c, "network", "prune", "--force").Combined()
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n1"))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "n2"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "n2"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), "n3"))
 }
 
@@ -287,7 +288,7 @@ func (s *DockerDaemonSuite) TestPruneImageLabel(c *testing.T) {
 	id1 := strings.TrimSpace(result.Combined())
 	out, err := s.d.Cmd("images", "-q", "--no-trunc")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id1))
 	result = cli.BuildCmd(c, "test2", cli.Daemon(s.d),
 		build.WithDockerfile(`FROM busybox
                  LABEL bar=foo`),
@@ -298,11 +299,11 @@ func (s *DockerDaemonSuite) TestPruneImageLabel(c *testing.T) {
 
 	out, err = s.d.Cmd("images", "-q", "--no-trunc")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
 
 	out, err = s.d.Cmd("image", "prune", "--force", "--all", "--filter", "label=foo=bar")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id1))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id2))
 
 	out, err = s.d.Cmd("image", "prune", "--force", "--all", "--filter", "label!=bar=foo")
@@ -313,5 +314,5 @@ func (s *DockerDaemonSuite) TestPruneImageLabel(c *testing.T) {
 	out, err = s.d.Cmd("image", "prune", "--force", "--all", "--filter", "label=bar=foo")
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), id1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -444,8 +444,8 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterLabel(c *testing.T) {
 	// filter containers by exact key
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match").Stdout()
 	containerOut = strings.TrimSpace(out)
-	assert.Assert(c, strings.Contains(containerOut, firstID))
-	assert.Assert(c, strings.Contains(containerOut, secondID))
+	assert.Assert(c, is.Contains(containerOut, firstID))
+	assert.Assert(c, is.Contains(containerOut, secondID))
 	assert.Assert(c, !strings.Contains(containerOut, thirdID))
 }
 
@@ -469,13 +469,13 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterExited(c *testing.T) {
 
 	// filter containers by exited=0
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=exited=0").Stdout()
-	assert.Assert(c, strings.Contains(out, strings.TrimSpace(firstZero)))
-	assert.Assert(c, strings.Contains(out, strings.TrimSpace(secondZero)))
+	assert.Assert(c, is.Contains(out, strings.TrimSpace(firstZero)))
+	assert.Assert(c, is.Contains(out, strings.TrimSpace(secondZero)))
 	assert.Assert(c, !strings.Contains(out, strings.TrimSpace(firstNonZero)))
 	assert.Assert(c, !strings.Contains(out, strings.TrimSpace(secondNonZero)))
 	out = cli.DockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=exited=1").Stdout()
-	assert.Assert(c, strings.Contains(out, strings.TrimSpace(firstNonZero)))
-	assert.Assert(c, strings.Contains(out, strings.TrimSpace(secondNonZero)))
+	assert.Assert(c, is.Contains(out, strings.TrimSpace(firstNonZero)))
+	assert.Assert(c, is.Contains(out, strings.TrimSpace(secondNonZero)))
 	assert.Assert(c, !strings.Contains(out, strings.TrimSpace(firstZero)))
 	assert.Assert(c, !strings.Contains(out, strings.TrimSpace(secondZero)))
 }
@@ -816,9 +816,9 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterPorts(c *testing.T) {
 	id3 := strings.TrimSpace(out)
 
 	out = cli.DockerCmd(c, "ps", "--no-trunc", "-q").Stdout()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id2))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), id3))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), id3))
 
 	out = cli.DockerCmd(c, "ps", "--no-trunc", "-q", "--filter", "publish=80-8080/udp").Stdout()
 	assert.Assert(c, strings.TrimSpace(out) != id1)

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
@@ -455,7 +456,7 @@ func (s *DockerRegistrySuite) TestRunImplicitPullWithNoTag(c *testing.T) {
 	cli.DockerCmd(c, "rmi", repoTag2)
 
 	out := cli.DockerCmd(c, "run", imgRepo).Combined()
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Unable to find image '%s:latest' locally", imgRepo)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("Unable to find image '%s:latest' locally", imgRepo)))
 	// There should be only one line for repo, the one with repo:latest
 	outImageCmd := cli.DockerCmd(c, "images", imgRepo).Stdout()
 	splitOutImageCmd := strings.Split(strings.TrimSpace(outImageCmd), "\n")

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -34,7 +34,7 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistry(c *testing.T) {
 
 	assert.Assert(c, strings.Contains(out, "Using default tag: latest"), "expected the 'latest' tag to be automatically assumed")
 	assert.Assert(c, strings.Contains(out, "Pulling from library/hello-world"), "expected the 'library/' prefix to be automatically assumed")
-	assert.Assert(c, strings.Contains(out, "Downloaded newer image for hello-world:latest"))
+	assert.Assert(c, is.Contains(out, "Downloaded newer image for hello-world:latest"))
 
 	matches := regexp.MustCompile(`Digest: (.+)\n`).FindAllStringSubmatch(out, -1)
 	assert.Equal(c, len(matches), 1, "expected exactly one image digest in the output")
@@ -109,7 +109,7 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistryImplicitRefParts(c *test
 			s.Cmd(c, "rmi", ref)
 			s.Cmd(c, "tag", "hello-world-backup", "hello-world")
 		}
-		assert.Assert(c, strings.Contains(out, "Image is up to date for hello-world:latest"))
+		assert.Assert(c, is.Contains(out, "Image is up to date for hello-world:latest"))
 	}
 
 	s.Cmd(c, "rmi", "hello-world-backup")
@@ -127,7 +127,7 @@ func (s *DockerHubPullSuite) TestPullScratchNotAllowed(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	out, err := s.CmdWithError("pull", "scratch")
 	assert.ErrorContains(c, err, "", "expected pull of scratch to fail")
-	assert.Assert(c, strings.Contains(out, "'scratch' is a reserved name"))
+	assert.Assert(c, is.Contains(out, "'scratch' is a reserved name"))
 	assert.Assert(c, !strings.Contains(out, "Pulling repository scratch"))
 }
 

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -195,7 +195,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	assert.NilError(c, err, "pushing the image to the private registry has failed: %s", out2)
 
 	// ensure that layers were mounted from the first repo during push
-	assert.Assert(c, strings.Contains(out2, "Mounted from crossrepopush/busybox"))
+	assert.Assert(c, is.Contains(out2, "Mounted from crossrepopush/busybox"))
 
 	digest2 := reference.DigestRegexp.FindString(out2)
 	assert.Assert(c, len(digest2) > 0, "no digest found for pushed manifest")
@@ -222,7 +222,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestPushNoCredentialsNoRetry(c *testin
 	out, _, err := dockerCmdWithError("push", imgRepo)
 	assert.ErrorContains(c, err, "", out)
 	assert.Assert(c, !strings.Contains(out, "Retrying"))
-	assert.Assert(c, strings.Contains(out, "no basic auth credentials"))
+	assert.Assert(c, is.Contains(out, "no basic auth credentials"))
 }
 
 // This may be flaky but it's needed not to regress on unauthorized push, see #21054

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -128,7 +128,7 @@ func (s *DockerCLIRestartSuite) TestRestartPolicyAlways(c *testing.T) {
 func (s *DockerCLIRestartSuite) TestRestartPolicyOnFailure(c *testing.T) {
 	out, _, err := dockerCmdWithError("create", "--restart=on-failure:-1", "busybox")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "maximum retry count cannot be negative"))
+	assert.Assert(c, is.Contains(out, "maximum retry count cannot be negative"))
 
 	id := cli.DockerCmd(c, "create", "--restart=on-failure:1", "busybox").Stdout()
 	id = strings.TrimSpace(id)

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
@@ -43,7 +44,7 @@ func (s *DockerCLIRmiSuite) TestRmiWithContainerFails(c *testing.T) {
 	// make sure it didn't delete the busybox name
 	images := cli.DockerCmd(c, "images").Stdout()
 	// The name 'busybox' should not have been removed from images
-	assert.Assert(c, strings.Contains(images, "busybox"))
+	assert.Assert(c, is.Contains(images, "busybox"))
 }
 
 func (s *DockerCLIRmiSuite) TestRmiTag(c *testing.T) {
@@ -163,7 +164,7 @@ func (s *DockerCLIRmiSuite) TestRmiImageIDForceWithRunningContainersAndMultipleT
 	out, _, err := dockerCmdWithError("rmi", "-f", imgID)
 	// rmi -f should not delete image with running containers
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "(cannot be forced) - image is being used by running container"))
+	assert.Assert(c, is.Contains(out, "(cannot be forced) - image is being used by running container"))
 }
 
 func (s *DockerCLIRmiSuite) TestRmiTagWithExistingContainers(c *testing.T) {
@@ -203,7 +204,7 @@ func (s *DockerCLIRmiSuite) TestRmiWithMultipleRepositories(c *testing.T) {
 	cli.DockerCmd(c, "commit", "test", newTag)
 
 	out := cli.DockerCmd(c, "rmi", newTag).Combined()
-	assert.Assert(c, strings.Contains(out, "Untagged: "+newTag))
+	assert.Assert(c, is.Contains(out, "Untagged: "+newTag))
 }
 
 func (s *DockerCLIRmiSuite) TestRmiForceWithMultipleRepositories(c *testing.T) {
@@ -216,7 +217,7 @@ func (s *DockerCLIRmiSuite) TestRmiForceWithMultipleRepositories(c *testing.T) {
 	cli.DockerCmd(c, "tag", tag1, tag2)
 
 	out := cli.DockerCmd(c, "rmi", "-f", tag2).Combined()
-	assert.Assert(c, strings.Contains(out, "Untagged: "+tag2))
+	assert.Assert(c, is.Contains(out, "Untagged: "+tag2))
 	assert.Assert(c, !strings.Contains(out, "Untagged: "+tag1))
 	// Check built image still exists
 	images := cli.DockerCmd(c, "images", "-a").Stdout()
@@ -294,12 +295,12 @@ RUN echo 2 #layer2
 	out, _, err := dockerCmdWithError("rmi", newTag)
 	// should not be untagged without the -f flag
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, cID[:12]))
+	assert.Assert(c, is.Contains(out, cID[:12]))
 	assert.Assert(c, strings.Contains(out, "(must force)") || strings.Contains(out, "(must be forced)"))
 	// Add the -f flag and test again.
 	out = cli.DockerCmd(c, "rmi", "-f", newTag).Combined()
 	// should be allowed to untag with the -f flag
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("Untagged: %s:latest", newTag)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("Untagged: %s:latest", newTag)))
 }
 
 func (*DockerCLIRmiSuite) TestRmiParentImageFail(c *testing.T) {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3588,7 +3588,7 @@ func (s *DockerCLIRunSuite) TestRunStdinBlockedAfterContainerExit(c *testing.T) 
 	stdout := bytes.NewBuffer(nil)
 	cmd.Stdout = stdout
 	cmd.Stderr = stdout
-	assert.Assert(c, cmd.Start() == nil)
+	assert.NilError(c, cmd.Start())
 
 	waitChan := make(chan error, 1)
 	go func() {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/moby/sys/mountinfo"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
@@ -291,7 +292,7 @@ func (s *DockerCLIRunSuite) TestRunWithNetAliasOnDefaultNetworks(c *testing.T) {
 	for _, nw := range defaults {
 		out, _, err := dockerCmdWithError("run", "-d", "--net", nw, "--net-alias", "alias_"+nw, "busybox", "top")
 		assert.ErrorContains(c, err, "")
-		assert.Assert(c, strings.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
+		assert.Assert(c, is.Contains(out, runconfig.ErrUnsupportedNetworkAndAlias.Error()))
 	}
 }
 
@@ -305,14 +306,14 @@ func (s *DockerCLIRunSuite) TestUserDefinedNetworkAlias(c *testing.T) {
 	// Check if default short-id alias is added automatically
 	id := strings.TrimSpace(cid1)
 	aliases := inspectField(c, id, "NetworkSettings.Networks.net1.Aliases")
-	assert.Assert(c, strings.Contains(aliases, stringid.TruncateID(id)))
+	assert.Assert(c, is.Contains(aliases, stringid.TruncateID(id)))
 	cid2 := cli.DockerCmd(c, "run", "-d", "--net=net1", "--name=second", "busybox:glibc", "top").Stdout()
 	cli.WaitRun(c, "second")
 
 	// Check if default short-id alias is added automatically
 	id = strings.TrimSpace(cid2)
 	aliases = inspectField(c, id, "NetworkSettings.Networks.net1.Aliases")
-	assert.Assert(c, strings.Contains(aliases, stringid.TruncateID(id)))
+	assert.Assert(c, is.Contains(aliases, stringid.TruncateID(id)))
 	// ping to first and its network-scoped aliases
 	_, _, err := dockerCmdWithError("exec", "second", "ping", "-c", "1", "first")
 	assert.NilError(c, err)
@@ -344,7 +345,7 @@ func (s *DockerCLIRunSuite) TestUserDefinedNetworkAlias(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunWithDaemonFlags(c *testing.T) {
 	out, _, err := dockerCmdWithError("--exec-opt", "foo=bar", "run", "-i", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "unknown flag: --exec-opt"))
+	assert.Assert(c, is.Contains(out, "unknown flag: --exec-opt"))
 }
 
 // Regression test for #4979
@@ -2282,7 +2283,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughExpose(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunExposePort(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--expose", "80000", "busybox")
 	assert.Assert(c, err != nil, "--expose with an invalid port should error out")
-	assert.Assert(c, strings.Contains(out, "invalid range format for --expose"))
+	assert.Assert(c, is.Contains(out, "invalid range format for --expose"))
 }
 
 func (s *DockerCLIRunSuite) TestRunModeIpcHost(c *testing.T) {
@@ -2443,7 +2444,7 @@ func (s *DockerCLIRunSuite) TestRunModeUTSHost(c *testing.T) {
 	}
 
 	out = dockerCmdWithFail(c, "run", "-h=name", "--uts=host", "busybox", "ps")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictUTSHostname.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictUTSHostname.Error()))
 }
 
 func (s *DockerCLIRunSuite) TestRunTLSVerify(c *testing.T) {
@@ -2683,7 +2684,7 @@ func testReadOnlyFile(c *testing.T, testPriv bool, filenames ...string) {
 
 	for _, f := range filenames {
 		expected := "touch: " + f + ": Read-only file system"
-		assert.Assert(c, strings.Contains(out, expected))
+		assert.Assert(c, is.Contains(out, expected))
 	}
 
 	if !testPriv {
@@ -2695,7 +2696,7 @@ func testReadOnlyFile(c *testing.T, testPriv bool, filenames ...string) {
 
 	for _, f := range filenames {
 		expected := "touch: " + f + ": Read-only file system"
-		assert.Assert(c, strings.Contains(out, expected))
+		assert.Assert(c, is.Contains(out, expected))
 	}
 }
 
@@ -3554,7 +3555,7 @@ func (s *DockerCLIRunSuite) TestContainerWithConflictingSharedNetwork(c *testing
 	// Connecting to the user defined network must fail
 	out, _, err := dockerCmdWithError("network", "connect", "testnetwork1", "second")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictSharedNetwork.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictSharedNetwork.Error()))
 }
 
 func (s *DockerCLIRunSuite) TestContainerWithConflictingNoneNetwork(c *testing.T) {
@@ -3568,7 +3569,7 @@ func (s *DockerCLIRunSuite) TestContainerWithConflictingNoneNetwork(c *testing.T
 	// Connecting to the user defined network must fail
 	out, _, err := dockerCmdWithError("network", "connect", "testnetwork1", "first")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, runconfig.ErrConflictNoNetwork.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictNoNetwork.Error()))
 	// create a container connected to testnetwork1
 	cli.DockerCmd(c, "run", "-d", "--net=testnetwork1", "--name=second", "busybox", "top")
 	cli.WaitRun(c, "second")
@@ -3737,7 +3738,7 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumesMountedAsShared(c *testing.T) {
 	testRequires(c, DaemonIsLinux, NotUserNamespace)
 	out, exitCode, _ := dockerCmdWithError("run", "-v", "foo:/test:shared", "busybox", "touch", "/test/somefile")
 	assert.Assert(c, exitCode != 0)
-	assert.Assert(c, strings.Contains(out, "invalid mount config"))
+	assert.Assert(c, is.Contains(out, "invalid mount config"))
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolumeCopyImageData(c *testing.T) {
@@ -3762,13 +3763,13 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumeNotRemoved(c *testing.T) {
 	cli.DockerCmd(c, "run", "--rm", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
 	cli.DockerCmd(c, "volume", "inspect", "test")
 	out := cli.DockerCmd(c, "volume", "ls", "-q").Combined()
-	assert.Assert(c, strings.Contains(out, "test"))
+	assert.Assert(c, is.Contains(out, "test"))
 
 	cli.DockerCmd(c, "run", "--name=test", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true")
 	cli.DockerCmd(c, "rm", "-fv", "test")
 	cli.DockerCmd(c, "volume", "inspect", "test")
 	out = cli.DockerCmd(c, "volume", "ls", "-q").Combined()
-	assert.Assert(c, strings.Contains(out, "test"))
+	assert.Assert(c, is.Contains(out, "test"))
 }
 
 func (s *DockerCLIRunSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
@@ -3798,7 +3799,7 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
 	cli.DockerCmd(c, "rm", "-fv", "child")
 	cli.DockerCmd(c, "volume", "inspect", "test")
 	out := cli.DockerCmd(c, "volume", "ls", "-q").Combined()
-	assert.Assert(c, strings.Contains(out, "test"))
+	assert.Assert(c, is.Contains(out, "test"))
 	assert.Assert(c, !strings.Contains(strings.TrimSpace(out), vname))
 }
 
@@ -4018,7 +4019,7 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *testing.T) {
 
 	out, err := d.Cmd("inspect", "--format", "{{.HostConfig.Ulimits}}", name)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, "[nofile=65535:65535]"))
+	assert.Assert(c, is.Contains(out, "[nofile=65535:65535]"))
 	name = "test-B"
 	_, err = d.Cmd("run", "--name", name, "--ulimit=nofile=42", "-d", "busybox", "top")
 	assert.NilError(c, err)
@@ -4026,7 +4027,7 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *testing.T) {
 
 	out, err = d.Cmd("inspect", "--format", "{{.HostConfig.Ulimits}}", name)
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, "[nofile=42:42]"))
+	assert.Assert(c, is.Contains(out, "[nofile=42:42]"))
 }
 
 func (s *DockerCLIRunSuite) TestRunStoppedLoggingDriverNoLeak(c *testing.T) {
@@ -4075,8 +4076,8 @@ func (s *DockerCLIRunSuite) TestRunCredentialSpecWellFormed(c *testing.T) {
 		// controller handy
 		out := cli.DockerCmd(c, "run", "--rm", "--security-opt=credentialspec="+value, minimalBaseImage(), "nltest", "/PARENTDOMAIN").Combined()
 
-		assert.Assert(c, strings.Contains(out, "hyperv.local."))
-		assert.Assert(c, strings.Contains(out, "The command completed successfully"))
+		assert.Assert(c, is.Contains(out, "hyperv.local."))
+		assert.Assert(c, is.Contains(out, "The command completed successfully"))
 	}
 }
 
@@ -4095,9 +4096,9 @@ func (s *DockerCLIRunSuite) TestRunDuplicateMount(c *testing.T) {
 	name := "test"
 	out := cli.DockerCmd(c, "run", "--name", name, "-v", "/tmp:/tmp", "-v", "/tmp:/tmp", "busybox", "sh", "-c", "cat "+tmpFile.Name()+" && ls /").Combined()
 	assert.Assert(c, !strings.Contains(out, "tmp:"))
-	assert.Assert(c, strings.Contains(out, data))
+	assert.Assert(c, is.Contains(out, data))
 	out = inspectFieldJSON(c, name, "Config.Volumes")
-	assert.Assert(c, strings.Contains(out, "null"))
+	assert.Assert(c, is.Contains(out, "null"))
 }
 
 func (s *DockerCLIRunSuite) TestRunWindowsWithCPUCount(c *testing.T) {
@@ -4134,9 +4135,9 @@ func (s *DockerCLIRunSuite) TestRunProcessIsolationWithCPUCountCPUSharesAndCPUPe
 	testRequires(c, DaemonIsWindows, testEnv.DaemonInfo.Isolation.IsProcess)
 
 	out := cli.DockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU shares on Windows Server Containers. CPU shares discarded"))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU percent on Windows Server Containers. CPU percent discarded"))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "testing"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU shares on Windows Server Containers. CPU shares discarded"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "WARNING: Conflicting options: CPU count takes priority over CPU percent on Windows Server Containers. CPU percent discarded"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "testing"))
 	out = inspectField(c, "test", "HostConfig.CPUCount")
 	assert.Equal(c, out, "1")
 
@@ -4151,7 +4152,7 @@ func (s *DockerCLIRunSuite) TestRunHypervIsolationWithCPUCountCPUSharesAndCPUPer
 	testRequires(c, DaemonIsWindows, testEnv.DaemonInfo.Isolation.IsHyperV)
 
 	out := cli.DockerCmd(c, "run", "--cpu-count=1", "--cpu-shares=1000", "--cpu-percent=80", "--name", "test", "busybox", "echo", "testing").Combined()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "testing"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "testing"))
 	out = inspectField(c, "test", "HostConfig.CPUCount")
 	assert.Equal(c, out, "1")
 
@@ -4170,15 +4171,15 @@ func (s *DockerCLIRunSuite) TestRunEmptyEnv(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("run", "-e", "", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, expectedOutput))
+	assert.Assert(c, is.Contains(out, expectedOutput))
 
 	out, _, err = dockerCmdWithError("run", "-e", "=", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, expectedOutput))
+	assert.Assert(c, is.Contains(out, expectedOutput))
 
 	out, _, err = dockerCmdWithError("run", "-e", "=foo", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, expectedOutput))
+	assert.Assert(c, is.Contains(out, expectedOutput))
 }
 
 // #28658
@@ -4229,7 +4230,7 @@ func (s *DockerCLIRunSuite) TestRunMountReadOnlyDevShm(c *testing.T) {
 		"-v", fmt.Sprintf("%s:/dev/shm:ro", emptyDir),
 		"busybox", "touch", "/dev/shm/foo")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, strings.Contains(out, "Read-only file system"))
+	assert.Assert(c, is.Contains(out, "Read-only file system"))
 }
 
 func (s *DockerCLIRunSuite) TestRunMount(c *testing.T) {
@@ -4418,7 +4419,7 @@ func (s *DockerCLIRunSuite) TestRunHostnameFQDN(c *testing.T) {
 
 	out = cli.DockerCmd(c, "run", "--hostname=foobar.example.com", "busybox", "sh", "-c", `cat /etc/hosts`).Combined()
 	expectedOutput = "foobar.example.com foobar"
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), expectedOutput))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), expectedOutput))
 }
 
 // Test case for 29129

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/docker/testutil"
 	"github.com/moby/sys/mount"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -138,8 +139,8 @@ func (s *DockerCLIRunSuite) TestRunAttachDetach(c *testing.T) {
 
 	out = cli.DockerCmd(c, "events", "--since=0", "--until", daemonUnixTime(c), "-f", "container="+name).Stdout()
 	// attach and detach event should be monitored
-	assert.Assert(c, strings.Contains(out, "attach"))
-	assert.Assert(c, strings.Contains(out, "detach"))
+	assert.Assert(c, is.Contains(out, "attach"))
+	assert.Assert(c, is.Contains(out, "detach"))
 }
 
 // TestRunAttachDetachFromFlag checks attaching and detaching with the escape sequence specified via flags.
@@ -479,15 +480,15 @@ func (s *DockerCLIRunSuite) TestRunWithInvalidCpuPeriod(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--cpu-period", "900", "busybox", "true")
 	assert.ErrorContains(c, err, "")
 	expected := "CPU cfs period can not be less than 1ms (i.e. 1000) or larger than 1s (i.e. 1000000)"
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 
 	out, _, err = dockerCmdWithError("run", "--cpu-period", "2000000", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 
 	out, _, err = dockerCmdWithError("run", "--cpu-period", "-3", "busybox", "true")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerCLIRunSuite) TestRunWithCPUShares(c *testing.T) {
@@ -548,7 +549,7 @@ func (s *DockerCLIRunSuite) TestRunWithInvalidBlkioWeight(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--blkio-weight", "5", "busybox", "true")
 	assert.ErrorContains(c, err, "", out)
 	expected := "Range of blkio weight is from 10 to 1000"
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerCLIRunSuite) TestRunWithInvalidPathforBlkioWeightDevice(c *testing.T) {
@@ -687,7 +688,7 @@ func (s *DockerCLIRunSuite) TestRunSwapLessThanMemoryLimit(c *testing.T) {
 	expected := "Minimum memoryswap limit should be larger than memory limit"
 	assert.ErrorContains(c, err, "")
 
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerCLIRunSuite) TestRunInvalidCpusetCpusFlagValue(c *testing.T) {
@@ -706,7 +707,7 @@ func (s *DockerCLIRunSuite) TestRunInvalidCpusetCpusFlagValue(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--cpuset-cpus", strconv.Itoa(invalid), "busybox", "true")
 	assert.ErrorContains(c, err, "")
 	expected := fmt.Sprintf("Error response from daemon: Requested CPUs are not available - requested %s, available: %s", strconv.Itoa(invalid), sysInfo.Cpus)
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerCLIRunSuite) TestRunInvalidCpusetMemsFlagValue(c *testing.T) {
@@ -725,7 +726,7 @@ func (s *DockerCLIRunSuite) TestRunInvalidCpusetMemsFlagValue(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--cpuset-mems", strconv.Itoa(invalid), "busybox", "true")
 	assert.ErrorContains(c, err, "")
 	expected := fmt.Sprintf("Error response from daemon: Requested memory nodes are not available - requested %s, available: %s", strconv.Itoa(invalid), sysInfo.Mems)
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerCLIRunSuite) TestRunInvalidCPUShares(c *testing.T) {
@@ -733,17 +734,17 @@ func (s *DockerCLIRunSuite) TestRunInvalidCPUShares(c *testing.T) {
 	out, _, err := dockerCmdWithError("run", "--cpu-shares", "1", "busybox", "echo", "test")
 	assert.ErrorContains(c, err, "", out)
 	expected := "minimum allowed cpu-shares is 2"
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 
 	out, _, err = dockerCmdWithError("run", "--cpu-shares", "-1", "busybox", "echo", "test")
 	assert.ErrorContains(c, err, "", out)
 	expected = "shares: invalid argument"
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 
 	out, _, err = dockerCmdWithError("run", "--cpu-shares", "99999999", "busybox", "echo", "test")
 	assert.ErrorContains(c, err, "", out)
 	expected = "maximum allowed cpu-shares is"
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerCLIRunSuite) TestRunWithDefaultShmSize(c *testing.T) {
@@ -777,7 +778,7 @@ func (s *DockerCLIRunSuite) TestRunTmpfsMountsEnsureOrdered(c *testing.T) {
 	assert.NilError(c, err)
 	defer tmpFile.Close()
 	out := cli.DockerCmd(c, "run", "--tmpfs", "/run", "-v", tmpFile.Name()+":/run/test", "busybox", "ls", "/run").Combined()
-	assert.Assert(c, strings.Contains(out, "test"))
+	assert.Assert(c, is.Contains(out, "test"))
 }
 
 func (s *DockerCLIRunSuite) TestRunTmpfsMounts(c *testing.T) {
@@ -819,25 +820,25 @@ func (s *DockerCLIRunSuite) TestRunTmpfsMountsWithOptions(c *testing.T) {
 	expectedOptions := []string{"rw", "nosuid", "nodev", "noexec", "relatime"}
 	out := cli.DockerCmd(c, "run", "--tmpfs", "/tmp", "busybox", "sh", "-c", "mount | grep 'tmpfs on /tmp'").Combined()
 	for _, option := range expectedOptions {
-		assert.Assert(c, strings.Contains(out, option))
+		assert.Assert(c, is.Contains(out, option))
 	}
 	assert.Assert(c, !strings.Contains(out, "size="))
 	expectedOptions = []string{"rw", "nosuid", "nodev", "noexec", "relatime"}
 	out = cli.DockerCmd(c, "run", "--tmpfs", "/tmp:rw", "busybox", "sh", "-c", "mount | grep 'tmpfs on /tmp'").Combined()
 	for _, option := range expectedOptions {
-		assert.Assert(c, strings.Contains(out, option))
+		assert.Assert(c, is.Contains(out, option))
 	}
 	assert.Assert(c, !strings.Contains(out, "size="))
 	expectedOptions = []string{"rw", "nosuid", "nodev", "relatime", "size=8192k"}
 	out = cli.DockerCmd(c, "run", "--tmpfs", "/tmp:rw,exec,size=8192k", "busybox", "sh", "-c", "mount | grep 'tmpfs on /tmp'").Combined()
 	for _, option := range expectedOptions {
-		assert.Assert(c, strings.Contains(out, option))
+		assert.Assert(c, is.Contains(out, option))
 	}
 
 	expectedOptions = []string{"rw", "nosuid", "nodev", "noexec", "relatime", "size=4096k"}
 	out = cli.DockerCmd(c, "run", "--tmpfs", "/tmp:rw,size=8192k,exec,size=4096k,noexec", "busybox", "sh", "-c", "mount | grep 'tmpfs on /tmp'").Combined()
 	for _, option := range expectedOptions {
-		assert.Assert(c, strings.Contains(out, option))
+		assert.Assert(c, is.Contains(out, option))
 	}
 
 	// We use debian:bookworm-slim as there is no findmnt in busybox. Also the output will be in the format of
@@ -847,7 +848,7 @@ func (s *DockerCLIRunSuite) TestRunTmpfsMountsWithOptions(c *testing.T) {
 	expectedOptions = []string{"shared"}
 	out = cli.DockerCmd(c, "run", "--tmpfs", "/tmp:shared", "debian:bookworm-slim", "findmnt", "-o", "TARGET,PROPAGATION", "/tmp").Combined()
 	for _, option := range expectedOptions {
-		assert.Assert(c, strings.Contains(out, option))
+		assert.Assert(c, is.Contains(out, option))
 	}
 }
 
@@ -1416,7 +1417,7 @@ func (s *DockerCLIRunSuite) TestRunUserDeviceAllowed(c *testing.T) {
 
 	const file = "/sys/fs/cgroup/devices/devices.list"
 	out := cli.DockerCmd(c, "run", "--device", "/dev/snd/timer:w", "busybox", "cat", file).Combined()
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("c %d:%d w", stat.Rdev/256, stat.Rdev%256)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("c %d:%d w", stat.Rdev/256, stat.Rdev%256)))
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNewFormat(c *testing.T) {
@@ -1442,7 +1443,7 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNewFormat(c *testing.T) {
 
 	out, err := s.d.Cmd("run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "777", ".")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Operation not permitted"))
+	assert.Assert(c, is.Contains(out, "Operation not permitted"))
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNoNameAndNames(c *testing.T) {
@@ -1469,7 +1470,7 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoNameAndNames(c *testing.T) {
 
 	out, err := s.d.Cmd("run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "777", ".")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "use either 'name' or 'names'"))
+	assert.Assert(c, is.Contains(out, "use either 'name' or 'names'"))
 }
 
 func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *testing.T) {
@@ -1507,7 +1508,7 @@ func (s *DockerDaemonSuite) TestRunSeccompJSONNoArchAndArchMap(c *testing.T) {
 
 	out, err := s.d.Cmd("run", "--security-opt", "seccomp="+tmpFile.Name(), "busybox", "chmod", "777", ".")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "use either 'architectures' or 'archMap'"))
+	assert.Assert(c, is.Contains(out, "use either 'architectures' or 'archMap'"))
 }
 
 func (s *DockerDaemonSuite) TestRunWithDaemonDefaultSeccompProfile(c *testing.T) {
@@ -1544,7 +1545,7 @@ func (s *DockerDaemonSuite) TestRunWithDaemonDefaultSeccompProfile(c *testing.T)
 
 	out, err := s.d.Cmd("run", "busybox", "chmod", "777", ".")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Operation not permitted"))
+	assert.Assert(c, is.Contains(out, "Operation not permitted"))
 }
 
 func (s *DockerCLIRunSuite) TestRunWithNanoCPUs(c *testing.T) {
@@ -1568,5 +1569,5 @@ func (s *DockerCLIRunSuite) TestRunWithNanoCPUs(c *testing.T) {
 
 	out, _, err = dockerCmdWithError("run", "--cpus", "0.5", "--cpu-quota", "50000", "--cpu-period", "100000", "busybox", "sh")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Conflicting options: Nano CPUs and CPU Period cannot both be set"))
+	assert.Assert(c, is.Contains(out, "Conflicting options: Nano CPUs and CPU Period cannot both be set"))
 }

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -202,7 +202,7 @@ func (s *DockerCLISaveLoadSuite) TestSaveWithNoExistImage(c *testing.T) {
 
 	out, _, err := dockerCmdWithError("save", "-o", "test-img.tar", imgName)
 	assert.ErrorContains(c, err, "", "save image should fail for non-existing image")
-	assert.Assert(c, strings.Contains(out, fmt.Sprintf("No such image: %s", imgName)))
+	assert.Assert(c, is.Contains(out, fmt.Sprintf("No such image: %s", imgName)))
 }
 
 func (s *DockerCLISaveLoadSuite) TestSaveMultipleNames(c *testing.T) {
@@ -295,14 +295,14 @@ func (s *DockerCLISaveLoadSuite) TestSaveLoadNoTag(c *testing.T) {
 
 	// Should not show 'name' but should show the image ID during the load
 	assert.Assert(c, !strings.Contains(out, "Loaded image: "))
-	assert.Assert(c, strings.Contains(out, "Loaded image ID:"))
-	assert.Assert(c, strings.Contains(out, id))
+	assert.Assert(c, is.Contains(out, "Loaded image ID:"))
+	assert.Assert(c, is.Contains(out, id))
 	// Test to make sure that save by name shows that name during load
 	out, err = RunCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "save", name),
 		exec.Command(dockerBinary, "load"))
 	assert.NilError(c, err, "failed to save and load repo: %s, %v", out, err)
 
-	assert.Assert(c, strings.Contains(out, "Loaded image: "+name+":latest"))
+	assert.Assert(c, is.Contains(out, "Loaded image: "+name+":latest"))
 	assert.Assert(c, !strings.Contains(out, "Loaded image ID:"))
 }

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
@@ -89,7 +90,7 @@ func (s *DockerCLISaveLoadSuite) TestSaveAndLoadWithProgressBar(c *testing.T) {
 	cli.DockerCmd(c, "tag", "busybox", name)
 	out := cli.DockerCmd(c, "load", "-i", tmptar).Combined()
 	expected := fmt.Sprintf("The image %s:latest already exists, renaming the old one with ID", name)
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 // fail because load didn't receive data from stdin
@@ -108,5 +109,5 @@ func (s *DockerCLISaveLoadSuite) TestLoadNoStdinFail(c *testing.T) {
 
 	n, err := p.Read(buf)
 	assert.NilError(c, err) // could not read tty output
-	assert.Assert(c, strings.Contains(string(buf[:n]), "requested load from stdin, but stdin is empty"))
+	assert.Assert(c, is.Contains(string(buf[:n]), "requested load from stdin, but stdin is empty"))
 }

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -45,7 +45,7 @@ func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	var mountConfig []mount.Mount
-	assert.Assert(c, json.Unmarshal([]byte(out), &mountConfig) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &mountConfig))
 	assert.Equal(c, len(mountConfig), 1)
 
 	assert.Equal(c, mountConfig[0].Source, "foo")
@@ -59,7 +59,7 @@ func (s *DockerSwarmSuite) TestServiceCreateMountVolume(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	var mounts []container.MountPoint
-	assert.Assert(c, json.Unmarshal([]byte(out), &mounts) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &mounts))
 	assert.Equal(c, len(mounts), 1)
 
 	assert.Equal(c, mounts[0].Type, mount.TypeVolume)
@@ -89,7 +89,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSimple(c *testing.T) {
 	assert.NilError(c, err)
 
 	var refs []swarm.SecretReference
-	assert.Assert(c, json.Unmarshal([]byte(out), &refs) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &refs))
 	assert.Equal(c, len(refs), 1)
 
 	assert.Equal(c, refs[0].SecretName, testName)
@@ -139,7 +139,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretSourceTargetPaths(c *testi
 	assert.NilError(c, err)
 
 	var refs []swarm.SecretReference
-	assert.Assert(c, json.Unmarshal([]byte(out), &refs) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &refs))
 	assert.Equal(c, len(refs), len(testPaths))
 
 	var tasks []swarm.Task
@@ -190,7 +190,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithSecretReferencedTwice(c *testing
 	assert.NilError(c, err)
 
 	var refs []swarm.SecretReference
-	assert.Assert(c, json.Unmarshal([]byte(out), &refs) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &refs))
 	assert.Equal(c, len(refs), 2)
 
 	var tasks []swarm.Task
@@ -240,7 +240,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigSimple(c *testing.T) {
 	assert.NilError(c, err)
 
 	var refs []swarm.ConfigReference
-	assert.Assert(c, json.Unmarshal([]byte(out), &refs) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &refs))
 	assert.Equal(c, len(refs), 1)
 
 	assert.Equal(c, refs[0].ConfigName, testName)
@@ -289,7 +289,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigSourceTargetPaths(c *testi
 	assert.NilError(c, err)
 
 	var refs []swarm.ConfigReference
-	assert.Assert(c, json.Unmarshal([]byte(out), &refs) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &refs))
 	assert.Equal(c, len(refs), len(testPaths))
 
 	var tasks []swarm.Task
@@ -340,7 +340,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithConfigReferencedTwice(c *testing
 	assert.NilError(c, err)
 
 	var refs []swarm.ConfigReference
-	assert.Assert(c, json.Unmarshal([]byte(out), &refs) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &refs))
 	assert.Equal(c, len(refs), 2)
 
 	var tasks []swarm.Task
@@ -395,7 +395,7 @@ func (s *DockerSwarmSuite) TestServiceCreateMountTmpfs(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	var mountConfig []mount.Mount
-	assert.Assert(c, json.Unmarshal([]byte(out), &mountConfig) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &mountConfig))
 	assert.Equal(c, len(mountConfig), 1)
 
 	assert.Equal(c, mountConfig[0].Source, "")
@@ -409,7 +409,7 @@ func (s *DockerSwarmSuite) TestServiceCreateMountTmpfs(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	var mounts []container.MountPoint
-	assert.Assert(c, json.Unmarshal([]byte(out), &mounts) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &mounts))
 	assert.Equal(c, len(mounts), 1)
 
 	assert.Equal(c, mounts[0].Type, mount.TypeTmpfs)
@@ -453,7 +453,7 @@ func (s *DockerSwarmSuite) TestServiceCreateWithNetworkAlias(c *testing.T) {
 
 	// Make sure the only alias seen is the container-id
 	var aliases []string
-	assert.Assert(c, json.Unmarshal([]byte(out), &aliases) == nil)
+	assert.NilError(c, json.Unmarshal([]byte(out), &aliases))
 	assert.Equal(c, len(aliases), 1)
 
 	assert.Assert(c, is.Contains(task.Status.ContainerStatus.ContainerID, aliases[0]))

--- a/integration-cli/docker_cli_service_create_test.go
+++ b/integration-cli/docker_cli_service_create_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
 )
 
@@ -419,7 +420,7 @@ func (s *DockerSwarmSuite) TestServiceCreateMountTmpfs(c *testing.T) {
 	out, err = s.nodeCmd(c, task.NodeID, "logs", task.Status.ContainerStatus.ContainerID)
 	assert.NilError(c, err, out)
 	assert.Assert(c, strings.HasPrefix(strings.TrimSpace(out), "tmpfs on /foo type tmpfs"))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "size=1024k"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "size=1024k"))
 }
 
 func (s *DockerSwarmSuite) TestServiceCreateWithNetworkAlias(c *testing.T) {
@@ -455,5 +456,5 @@ func (s *DockerSwarmSuite) TestServiceCreateWithNetworkAlias(c *testing.T) {
 	assert.Assert(c, json.Unmarshal([]byte(out), &aliases) == nil)
 	assert.Equal(c, len(aliases), 1)
 
-	assert.Assert(c, strings.Contains(task.Status.ContainerStatus.ContainerID, aliases[0]))
+	assert.Assert(c, is.Contains(task.Status.ContainerStatus.ContainerID, aliases[0]))
 }

--- a/integration-cli/docker_cli_service_logs_test.go
+++ b/integration-cli/docker_cli_service_logs_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
 )
@@ -94,7 +95,7 @@ func (s *DockerSwarmSuite) TestServiceLogsCompleteness(c *testing.T) {
 	// mis-ordered. If this test fails, then possibly that's what causing the
 	// failure.
 	for i, line := range lines {
-		assert.Assert(c, strings.Contains(line, fmt.Sprintf("log test %v", i)))
+		assert.Assert(c, is.Contains(line, fmt.Sprintf("log test %v", i)))
 	}
 }
 
@@ -119,7 +120,7 @@ func (s *DockerSwarmSuite) TestServiceLogsTail(c *testing.T) {
 
 	for i, line := range lines {
 		// doing i+5 is hacky but not too fragile, it's good enough. if it flakes something else is wrong
-		assert.Assert(c, strings.Contains(line, fmt.Sprintf("log test %v", i+5)))
+		assert.Assert(c, is.Contains(line, fmt.Sprintf("log test %v", i+5)))
 	}
 }
 
@@ -205,7 +206,7 @@ func (s *DockerSwarmSuite) TestServiceLogsFollow(c *testing.T) {
 	for i := 0; i < 3; i++ {
 		msg := <-ch
 		assert.NilError(c, msg.err)
-		assert.Assert(c, strings.Contains(string(msg.data), "log test"))
+		assert.Assert(c, is.Contains(string(msg.data), "log test"))
 	}
 	close(done)
 
@@ -259,9 +260,9 @@ func (s *DockerSwarmSuite) TestServiceLogsTaskLogs(c *testing.T) {
 		c.Logf("checking messages for %v", taskID)
 		for i, line := range lines {
 			// make sure the message is in order
-			assert.Assert(c, strings.Contains(line, fmt.Sprintf("log test %v", i)))
+			assert.Assert(c, is.Contains(line, fmt.Sprintf("log test %v", i)))
 			// make sure it contains the task id
-			assert.Assert(c, strings.Contains(line, taskID))
+			assert.Assert(c, is.Contains(line, taskID))
 		}
 	}
 }

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/integration-cli/cli"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -94,7 +95,7 @@ func (s *DockerCLIStartSuite) TestStartRecordError(c *testing.T) {
 	assert.Assert(c, err != nil, "out: %s", out)
 
 	stateErr = inspectField(c, "test2", "State.Error")
-	assert.Assert(c, strings.Contains(stateErr, "port is already allocated"))
+	assert.Assert(c, is.Contains(stateErr, "port is already allocated"))
 	// Expect the conflict to be resolved when we stop the initial container
 	cli.DockerCmd(c, "stop", "test")
 	cli.DockerCmd(c, "start", "test2")
@@ -115,7 +116,7 @@ func (s *DockerCLIStartSuite) TestStartPausedContainer(c *testing.T) {
 	// an error should have been shown that you cannot start paused container
 	assert.Assert(c, err != nil, "out: %s", out)
 	// an error should have been shown that you cannot start paused container
-	assert.Assert(c, strings.Contains(strings.ToLower(out), "cannot start a paused container, try unpause instead"))
+	assert.Assert(c, is.Contains(strings.ToLower(out), "cannot start a paused container, try unpause instead"))
 }
 
 func (s *DockerCLIStartSuite) TestStartMultipleContainers(c *testing.T) {
@@ -171,7 +172,7 @@ func (s *DockerCLIStartSuite) TestStartAttachMultipleContainers(c *testing.T) {
 		// err shouldn't be nil because start will fail
 		assert.Assert(c, err != nil, "out: %s", out)
 		// output does not correspond to what was expected
-		assert.Assert(c, strings.Contains(out, "you cannot start and attach multiple containers at once"))
+		assert.Assert(c, is.Contains(out, "you cannot start and attach multiple containers at once"))
 	}
 
 	// confirm the state of all the containers be stopped

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -123,7 +123,7 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *testing.T) {
 	assert.Equal(c, spec.CAConfig.ExternalCAs[0].CACert, "")
 	assert.Equal(c, spec.CAConfig.ExternalCAs[1].CACert, string(expected))
 
-	assert.Assert(c, d.SwarmLeave(ctx, c, true) == nil)
+	assert.NilError(c, d.SwarmLeave(ctx, c, true))
 	cli.Docker(cli.Args("swarm", "init"), cli.Daemon(d)).Assert(c, icmd.Success)
 
 	spec = getSpec()
@@ -443,7 +443,7 @@ func (s *DockerSwarmSuite) TestOverlayAttachableOnSwarmLeave(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	// Leave the swarm
-	assert.Assert(c, d.SwarmLeave(ctx, c, true) == nil)
+	assert.NilError(c, d.SwarmLeave(ctx, c, true))
 
 	// Check the container is disconnected
 	out, err = d.Cmd("inspect", "c1", "--format", "{{.NetworkSettings.Networks."+nwName+"}}")

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/moby/swarmkit/v2/ca/keyutils"
 	"github.com/vishvananda/netlink"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/fs"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
@@ -56,7 +57,7 @@ func (s *DockerSwarmSuite) TestSwarmUpdate(c *testing.T) {
 	// setting anything under 30m for cert-expiry is not allowed
 	out, err = d.Cmd("swarm", "update", "--cert-expiry", "15m")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "minimum certificate expiry time"))
+	assert.Assert(c, is.Contains(out, "minimum certificate expiry time"))
 	spec = getSpec()
 	assert.Equal(c, spec.CAConfig.NodeCertExpiry, 30*time.Hour)
 
@@ -142,7 +143,7 @@ func (s *DockerSwarmSuite) TestSwarmInitIPv6(c *testing.T) {
 		cli.Daemon(d2)).Assert(c, icmd.Success)
 
 	out := cli.Docker(cli.Args("info"), cli.Daemon(d2)).Assert(c, icmd.Success).Combined()
-	assert.Assert(c, strings.Contains(out, "Swarm: active"))
+	assert.Assert(c, is.Contains(out, "Swarm: active"))
 }
 
 func (s *DockerSwarmSuite) TestSwarmInitUnspecifiedAdvertiseAddr(c *testing.T) {
@@ -150,7 +151,7 @@ func (s *DockerSwarmSuite) TestSwarmInitUnspecifiedAdvertiseAddr(c *testing.T) {
 	d := s.AddDaemon(ctx, c, false, false)
 	out, err := d.Cmd("swarm", "init", "--advertise-addr", "0.0.0.0")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "advertise address must be a non-zero IP address"))
+	assert.Assert(c, is.Contains(out, "advertise address must be a non-zero IP address"))
 }
 
 func (s *DockerSwarmSuite) TestSwarmIncompatibleDaemon(c *testing.T) {
@@ -166,7 +167,7 @@ func (s *DockerSwarmSuite) TestSwarmIncompatibleDaemon(c *testing.T) {
 	assert.ErrorContains(c, err, "")
 	content, err := d.ReadLogFile()
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(string(content), "--live-restore daemon configuration is incompatible with swarm mode"))
+	assert.Assert(c, is.Contains(string(content), "--live-restore daemon configuration is incompatible with swarm mode"))
 	// restart for teardown
 	d.StartNode(c)
 }
@@ -1661,7 +1662,7 @@ func (s *DockerSwarmSuite) TestSwarmInitWithDrain(c *testing.T) {
 
 	out, err = d.Cmd("node", "ls")
 	assert.NilError(c, err)
-	assert.Assert(c, strings.Contains(out, "Drain"))
+	assert.Assert(c, is.Contains(out, "Drain"))
 }
 
 func (s *DockerSwarmSuite) TestSwarmReadonlyRootfs(c *testing.T) {

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func (s *DockerCLIUpdateSuite) TearDownTest(ctx context.Context, c *testing.T) {
@@ -118,7 +119,7 @@ func (s *DockerCLIUpdateSuite) TestUpdateContainerInvalidValue(c *testing.T) {
 	out, _, err := dockerCmdWithError("update", "-m", "2M", name)
 	assert.ErrorContains(c, err, "")
 	expected := "Minimum memory limit allowed is 6MB"
-	assert.Assert(c, strings.Contains(out, expected))
+	assert.Assert(c, is.Contains(out, expected))
 }
 
 func (s *DockerCLIUpdateSuite) TestUpdateContainerWithoutFlags(c *testing.T) {
@@ -209,7 +210,7 @@ func (s *DockerCLIUpdateSuite) TestUpdateMemoryWithSwapMemory(c *testing.T) {
 	cli.DockerCmd(c, "run", "-d", "--name", name, "--memory", "300M", "busybox", "top")
 	out, _, err := dockerCmdWithError("update", "--memory", "800M", name)
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Memory limit should be smaller than already set memoryswap limit"))
+	assert.Assert(c, is.Contains(out, "Memory limit should be smaller than already set memoryswap limit"))
 
 	cli.DockerCmd(c, "update", "--memory", "800M", "--memory-swap", "1000M", name)
 }
@@ -267,7 +268,7 @@ func (s *DockerCLIUpdateSuite) TestUpdateWithNanoCPUs(c *testing.T) {
 
 	out, _, err = dockerCmdWithError("update", "--cpu-quota", "80000", "top")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "Conflicting options: CPU Quota cannot be updated as NanoCPUs has already been set"))
+	assert.Assert(c, is.Contains(out, "Conflicting options: CPU Quota cannot be updated as NanoCPUs has already been set"))
 
 	cli.DockerCmd(c, "update", "--cpus", "0.8", "top")
 	inspect, err = clt.ContainerInspect(testutil.GetContext(c), "top")

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -72,9 +73,9 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIInspectMulti(c *testing.T) {
 	})
 
 	out := result.Stdout()
-	assert.Assert(c, strings.Contains(out, "test1"))
-	assert.Assert(c, strings.Contains(out, "test2"))
-	assert.Assert(c, strings.Contains(out, "test3"))
+	assert.Assert(c, is.Contains(out, "test1"))
+	assert.Assert(c, is.Contains(out, "test2"))
+	assert.Assert(c, is.Contains(out, "test3"))
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLILs(c *testing.T) {
@@ -182,13 +183,13 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLILsFilterDangling(c *testing.T) {
 func (s *DockerCLIVolumeSuite) TestVolumeCLILsErrorWithInvalidFilterName(c *testing.T) {
 	out, _, err := dockerCmdWithError("volume", "ls", "-f", "FOO=123")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "invalid filter"))
+	assert.Assert(c, is.Contains(out, "invalid filter"))
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLILsWithIncorrectFilterValue(c *testing.T) {
 	out, _, err := dockerCmdWithError("volume", "ls", "-f", "dangling=invalid")
 	assert.ErrorContains(c, err, "")
-	assert.Assert(c, strings.Contains(out, "invalid filter"))
+	assert.Assert(c, is.Contains(out, "invalid filter"))
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLIRm(c *testing.T) {
@@ -227,7 +228,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLINoArgs(c *testing.T) {
 	out := cli.DockerCmd(c, "volume").Combined()
 	// no args should produce the cmd usage output
 	usage := "Usage:	docker volume COMMAND"
-	assert.Assert(c, strings.Contains(out, usage))
+	assert.Assert(c, is.Contains(out, usage))
 	// invalid arg should error and show the command usage on stderr
 	icmd.RunCommand(dockerBinary, "volume", "somearg").Assert(c, icmd.Expected{
 		ExitCode: 1,
@@ -242,7 +243,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLINoArgs(c *testing.T) {
 		Error:    "exit status 125",
 		Err:      usage,
 	})
-	assert.Assert(c, strings.Contains(result.Stderr(), "unknown flag: --no-such-flag"))
+	assert.Assert(c, is.Contains(result.Stderr(), "unknown flag: --no-such-flag"))
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLIInspectTmplError(c *testing.T) {
@@ -252,7 +253,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIInspectTmplError(c *testing.T) {
 	out, exitCode, err := dockerCmdWithError("volume", "inspect", "--format='{{ .FooBar }}'", name)
 	assert.Assert(c, err != nil, "Output: %s", out)
 	assert.Equal(c, exitCode, 1, fmt.Sprintf("Output: %s", out))
-	assert.Assert(c, strings.Contains(out, "Template parsing error"))
+	assert.Assert(c, is.Contains(out, "Template parsing error"))
 }
 
 func (s *DockerCLIVolumeSuite) TestVolumeCLICreateWithOpts(c *testing.T) {
@@ -271,8 +272,8 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLICreateWithOpts(c *testing.T) {
 			assert.Equal(c, info[0], "tmpfs")
 			assert.Equal(c, info[2], "/foo")
 			assert.Equal(c, info[4], "tmpfs")
-			assert.Assert(c, strings.Contains(info[5], "uid=1000"))
-			assert.Assert(c, strings.Contains(info[5], "size=1024k"))
+			assert.Assert(c, is.Contains(info[5], "uid=1000"))
+			assert.Assert(c, is.Contains(info[5], "size=1024k"))
 			break
 		}
 	}
@@ -404,7 +405,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIRmForce(c *testing.T) {
 	assert.Assert(c, !strings.Contains(out, name))
 	cli.DockerCmd(c, "volume", "create", name)
 	out = cli.DockerCmd(c, "volume", "ls").Stdout()
-	assert.Assert(c, strings.Contains(out, name))
+	assert.Assert(c, is.Contains(out, name))
 }
 
 // TestVolumeCLIRmForceInUse verifies that repeated `docker volume rm -f` calls does not remove a volume
@@ -423,7 +424,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIRmForceInUse(c *testing.T) {
 	assert.ErrorContains(c, err, "")
 	assert.ErrorContains(c, err, "volume is in use")
 	out := cli.DockerCmd(c, "volume", "ls").Stdout()
-	assert.Assert(c, strings.Contains(out, name))
+	assert.Assert(c, is.Contains(out, name))
 	// The original issue did not _remove_ the volume from the list
 	// the first time. But a second call to `volume rm` removed it.
 	// Calling `volume rm` a second time to confirm it's not removed
@@ -432,7 +433,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIRmForceInUse(c *testing.T) {
 	assert.ErrorContains(c, err, "")
 	assert.ErrorContains(c, err, "volume is in use")
 	out = cli.DockerCmd(c, "volume", "ls").Stdout()
-	assert.Assert(c, strings.Contains(out, name))
+	assert.Assert(c, is.Contains(out, name))
 	// Verify removing the volume after the container is removed works
 	e := cli.DockerCmd(c, "rm", cid).ExitCode
 	assert.Equal(c, e, 0)
@@ -452,7 +453,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCliInspectWithVolumeOpts(c *testing.T) 
 	name := "test1"
 	cli.DockerCmd(c, "volume", "create", "-d", "local", name)
 	out := cli.DockerCmd(c, "volume", "inspect", "--format={{ .Options }}", name).Stdout()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), "map[]"))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), "map[]"))
 	// With options
 	name = "test2"
 	k1, v1 := "type", "tmpfs"
@@ -460,9 +461,9 @@ func (s *DockerCLIVolumeSuite) TestVolumeCliInspectWithVolumeOpts(c *testing.T) 
 	k3, v3 := "o", "size=1m,uid=1000"
 	cli.DockerCmd(c, "volume", "create", "-d", "local", name, "--opt", fmt.Sprintf("%s=%s", k1, v1), "--opt", fmt.Sprintf("%s=%s", k2, v2), "--opt", fmt.Sprintf("%s=%s", k3, v3))
 	out = cli.DockerCmd(c, "volume", "inspect", "--format={{ .Options }}", name).Stdout()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), fmt.Sprintf("%s:%s", k1, v1)))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), fmt.Sprintf("%s:%s", k2, v2)))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), fmt.Sprintf("%s:%s", k3, v3)))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), fmt.Sprintf("%s:%s", k1, v1)))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), fmt.Sprintf("%s:%s", k2, v2)))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), fmt.Sprintf("%s:%s", k3, v3)))
 }
 
 // Test case (1) for 21845: duplicate targets for --volumes-from
@@ -487,8 +488,8 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFrom(c *testing
 
 	// Both volume should exist
 	out := cli.DockerCmd(c, "volume", "ls", "-q").Stdout()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), data1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), data2))
 	out, _, err := dockerCmdWithError("run", "--name=app", "--volumes-from=data1", "--volumes-from=data2", "-d", "busybox", "top")
 	assert.Assert(c, err == nil, "Out: %s", out)
 
@@ -528,8 +529,8 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFromAndBind(c *
 
 	// Both volume should exist
 	out := cli.DockerCmd(c, "volume", "ls", "-q").Stdout()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), data1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), data2))
 	// /tmp/data is automatically created, because we are not using the modern mount API here
 	out, _, err := dockerCmdWithError("run", "--name=app", "--volumes-from=data1", "--volumes-from=data2", "-v", "/tmp/data:/tmp/data", "-d", "busybox", "top")
 	assert.Assert(c, err == nil, "Out: %s", out)
@@ -570,8 +571,8 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFromAndMounts(c
 
 	// Both volume should exist
 	out := cli.DockerCmd(c, "volume", "ls", "-q").Stdout()
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data1))
-	assert.Assert(c, strings.Contains(strings.TrimSpace(out), data2))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), data1))
+	assert.Assert(c, is.Contains(strings.TrimSpace(out), data2))
 	err := os.MkdirAll("/tmp/data", 0o755)
 	assert.NilError(c, err)
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -177,7 +177,7 @@ func buildImage(name string, cmdOperators ...cli.CmdOperator) *icmd.Result {
 func writeFile(dst, content string, c *testing.T) {
 	c.Helper()
 	// Create subdirectories if necessary
-	assert.Assert(c, os.MkdirAll(path.Dir(dst), 0o700) == nil)
+	assert.NilError(c, os.MkdirAll(path.Dir(dst), 0o700))
 	f, err := os.OpenFile(dst, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
 	assert.NilError(c, err)
 	defer f.Close()
@@ -408,7 +408,7 @@ func waitForGoroutines(ctx context.Context, t poll.TestingT, apiClient client.AP
 func getErrorMessage(c *testing.T, body []byte) string {
 	c.Helper()
 	var resp types.ErrorResponse
-	assert.Assert(c, json.Unmarshal(body, &resp) == nil)
+	assert.NilError(c, json.Unmarshal(body, &resp))
 	return strings.TrimSpace(resp.Message)
 }
 

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -627,7 +627,7 @@ func TestBuildWithEmptyDockerfile(t *testing.T) {
 					ForceRemove: true,
 				})
 
-			assert.Check(t, is.Contains(err.Error(), tc.expectedErr))
+			assert.Check(t, is.ErrorContains(err, tc.expectedErr))
 		})
 	}
 }

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -46,7 +46,7 @@ func TestCopyFromContainerPathIsNotDir(t *testing.T) {
 		expected = "The filename, directory name, or volume label syntax is incorrect."
 	}
 	_, _, err := apiClient.CopyFromContainer(ctx, cid, path)
-	assert.Assert(t, is.ErrorContains(err, expected))
+	assert.ErrorContains(t, err, expected)
 }
 
 func TestCopyToContainerPathDoesNotExist(t *testing.T) {

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -96,5 +96,5 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, inspect.NetworkSettings.SandboxID == "")
 	assert.Assert(t, inspect.NetworkSettings.SandboxKey == "")
-	assert.Assert(t, inspect.NetworkSettings.Ports["80/tcp"] == nil)
+	assert.Assert(t, is.Nil(inspect.NetworkSettings.Ports["80/tcp"]))
 }

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -126,8 +126,8 @@ func TestKillStoppedContainer(t *testing.T) {
 	apiClient := testEnv.APIClient()
 	id := container.Create(ctx, t, apiClient)
 	err := apiClient.ContainerKill(ctx, id, "SIGKILL")
-	assert.Assert(t, is.ErrorContains(err, ""))
-	assert.Assert(t, is.Contains(err.Error(), "is not running"))
+	assert.ErrorContains(t, err, "")
+	assert.ErrorContains(t, err, "is not running")
 }
 
 func TestKillDifferentUserContainer(t *testing.T) {

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -69,7 +69,7 @@ func TestImageInspectDescriptor(t *testing.T) {
 	assert.NilError(t, err)
 
 	if !testEnv.UsingSnapshotter() {
-		assert.Check(t, inspect.Descriptor == nil)
+		assert.Check(t, is.Nil(inspect.Descriptor))
 		return
 	}
 

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -452,7 +452,7 @@ func testIpvlanExperimentalV4Only(t *testing.T, ctx context.Context, client dcli
 		net.WithIPv4(false),
 	)
 	defer client.NetworkRemove(ctx, "testnet")
-	assert.Assert(t, is.ErrorContains(err, "IPv4 can only be disabled if experimental features are enabled"))
+	assert.ErrorContains(t, err, "IPv4 can only be disabled if experimental features are enabled")
 }
 
 // Check that an ipvlan interface with '--ipv6=false' doesn't get kernel-assigned

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -180,7 +180,7 @@ func testIpvlanL2InternalMode(t *testing.T, ctx context.Context, client dclient.
 	id2 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
 
 	result, _ := container.Exec(ctx, client, id1, []string{"ping", "-c", "1", "8.8.8.8"})
-	assert.Check(t, strings.Contains(result.Combined(), "Network is unreachable"))
+	assert.Check(t, is.Contains(result.Combined(), "Network is unreachable"))
 
 	_, err := container.Exec(ctx, client, id2, []string{"ping", "-c", "1", id1})
 	assert.NilError(t, err)
@@ -228,7 +228,7 @@ func testIpvlanL3InternalMode(t *testing.T, ctx context.Context, client dclient.
 	)
 
 	result, _ := container.Exec(ctx, client, id1, []string{"ping", "-c", "1", "8.8.8.8"})
-	assert.Check(t, strings.Contains(result.Combined(), "Network is unreachable"))
+	assert.Check(t, is.Contains(result.Combined(), "Network is unreachable"))
 
 	_, err := container.Exec(ctx, client, id2, []string{"ping", "-c", "1", id1})
 	assert.NilError(t, err)

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -128,7 +128,7 @@ func testMacvlanOverlapParent(t *testing.T, ctx context.Context, client client.A
 	_, err := net.Create(ctx, client, overlapNetName,
 		net.WithMacvlan(parentName),
 	)
-	assert.Check(t, err == nil)
+	assert.Check(t, err)
 
 	// delete the second network while preserving the parent link
 	err = client.NetworkRemove(ctx, overlapNetName)
@@ -217,7 +217,7 @@ func testMacvlanOverlapDeleteCreatedSecond(t *testing.T, ctx context.Context, cl
 	_, err := net.Create(ctx, client, overlapNetName,
 		net.WithMacvlan(parentName),
 	)
-	assert.Check(t, err == nil)
+	assert.Check(t, err)
 
 	// delete the original network while preserving the parent link
 	err = client.NetworkRemove(ctx, netName)
@@ -252,7 +252,7 @@ func testMacvlanOverlapKeepExisting(t *testing.T, ctx context.Context, client cl
 	_, err := net.Create(ctx, client, overlapNetName,
 		net.WithMacvlan(master),
 	)
-	assert.Check(t, err == nil)
+	assert.Check(t, err)
 
 	err = client.NetworkRemove(ctx, overlapNetName)
 	assert.NilError(t, err)
@@ -298,7 +298,7 @@ func testMacvlanNilParent(t *testing.T, ctx context.Context, client client.APICl
 	id2 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
 
 	_, err := container.Exec(ctx, client, id2, []string{"ping", "-c", "1", id1})
-	assert.Check(t, err == nil)
+	assert.Check(t, err)
 }
 
 func testMacvlanInternalMode(t *testing.T, ctx context.Context, client client.APIClient) {
@@ -317,7 +317,7 @@ func testMacvlanInternalMode(t *testing.T, ctx context.Context, client client.AP
 	assert.Check(t, is.Contains(result.Combined(), "Network is unreachable"))
 
 	_, err := container.Exec(ctx, client, id2, []string{"ping", "-c", "1", id1})
-	assert.Check(t, err == nil)
+	assert.Check(t, err)
 }
 
 func testMacvlanMultiSubnetWithParent(t *testing.T, ctx context.Context, client client.APIClient) {

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -314,7 +314,7 @@ func testMacvlanInternalMode(t *testing.T, ctx context.Context, client client.AP
 	id2 := container.Run(ctx, t, client, container.WithNetworkMode(netName))
 
 	result, _ := container.Exec(ctx, client, id1, []string{"ping", "-c", "1", "8.8.8.8"})
-	assert.Check(t, strings.Contains(result.Combined(), "Network is unreachable"))
+	assert.Check(t, is.Contains(result.Combined(), "Network is unreachable"))
 
 	_, err := container.Exec(ctx, client, id2, []string{"ping", "-c", "1", id1})
 	assert.Check(t, err == nil)
@@ -432,11 +432,11 @@ func testMacvlanAddressing(t *testing.T, ctx context.Context, client client.APIC
 	// Validate macvlan bridge mode defaults gateway sets the default IPAM next-hop inferred from the subnet
 	result, err := container.Exec(ctx, client, id1, []string{"ip", "route"})
 	assert.NilError(t, err)
-	assert.Check(t, strings.Contains(result.Combined(), "default via 172.28.130.1 dev eth0"))
+	assert.Check(t, is.Contains(result.Combined(), "default via 172.28.130.1 dev eth0"))
 	// Validate macvlan bridge mode sets the v6 gateway to the user specified default gateway/next-hop
 	result, err = container.Exec(ctx, client, id1, []string{"ip", "-6", "route"})
 	assert.NilError(t, err)
-	assert.Check(t, strings.Contains(result.Combined(), "default via 2001:db8:abca::254 dev eth0"))
+	assert.Check(t, is.Contains(result.Combined(), "default via 2001:db8:abca::254 dev eth0"))
 }
 
 // Check that '--ipv4=false' is only allowed with '--experimental'.

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -448,7 +448,7 @@ func testMacvlanExperimentalV4Only(t *testing.T, ctx context.Context, client cli
 		net.WithIPv4(false),
 	)
 	defer client.NetworkRemove(ctx, "testnet")
-	assert.Assert(t, is.ErrorContains(err, "IPv4 can only be disabled if experimental features are enabled"))
+	assert.ErrorContains(t, err, "IPv4 can only be disabled if experimental features are enabled")
 }
 
 // Check that a macvlan interface with '--ipv6=false' doesn't get kernel-assigned

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -16,6 +15,7 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/requirement"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -72,7 +72,7 @@ func TestAuthZPluginV2Disable(t *testing.T) {
 
 	_, err = c.VolumeCreate(ctx, volume.CreateOptions{Driver: "local"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 
 	// disable the plugin
 	err = c.PluginDisable(ctx, authzPluginNameWithTag, types.PluginDisableOptions{})
@@ -98,24 +98,24 @@ func TestAuthZPluginV2RejectVolumeRequests(t *testing.T) {
 
 	_, err = c.VolumeCreate(ctx, volume.CreateOptions{Driver: "local"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 
 	_, err = c.VolumeList(ctx, volume.ListOptions{})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 
 	// The plugin will block the command before it can determine the volume does not exist
 	err = c.VolumeRemove(ctx, "test", false)
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 
 	_, err = c.VolumeInspect(ctx, "test")
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 
 	_, err = c.VolumesPrune(ctx, filters.Args{})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, strings.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
 }
 
 func TestAuthZPluginV2BadManifestFailsDaemonStart(t *testing.T) {

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/requirement"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -72,7 +71,7 @@ func TestAuthZPluginV2Disable(t *testing.T) {
 
 	_, err = c.VolumeCreate(ctx, volume.CreateOptions{Driver: "local"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
 	// disable the plugin
 	err = c.PluginDisable(ctx, authzPluginNameWithTag, types.PluginDisableOptions{})
@@ -98,24 +97,24 @@ func TestAuthZPluginV2RejectVolumeRequests(t *testing.T) {
 
 	_, err = c.VolumeCreate(ctx, volume.CreateOptions{Driver: "local"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
 	_, err = c.VolumeList(ctx, volume.ListOptions{})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
 	// The plugin will block the command before it can determine the volume does not exist
 	err = c.VolumeRemove(ctx, "test", false)
 	assert.Assert(t, err != nil)
-	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
 	_, err = c.VolumeInspect(ctx, "test")
 	assert.Assert(t, err != nil)
-	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
 	_, err = c.VolumesPrune(ctx, filters.Args{})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, is.Contains(err.Error(), fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag)))
+	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 }
 
 func TestAuthZPluginV2BadManifestFailsDaemonStart(t *testing.T) {

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -50,7 +50,7 @@ func testServiceCreateInit(ctx context.Context, daemonEnabled bool) func(t *test
 		poll.WaitOn(t, swarm.RunningTasksCount(ctx, client, serviceID, 1), swarm.ServicePoll)
 		i := inspectServiceContainer(ctx, t, client, serviceID)
 		// HostConfig.Init == nil means that it delegates to daemon configuration
-		assert.Check(t, i.HostConfig.Init == nil)
+		assert.Check(t, is.Nil(i.HostConfig.Init))
 
 		serviceID = swarm.CreateService(ctx, t, d, swarm.ServiceWithInit(&booleanTrue))
 		poll.WaitOn(t, swarm.RunningTasksCount(ctx, client, serviceID, 1), swarm.ServicePoll)

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -261,7 +261,7 @@ func TestBindHostPortsError(t *testing.T) {
 	}
 	pbs, err := bindHostPorts(context.Background(), cfg, "")
 	assert.Check(t, is.Error(err, "port binding mismatch 80/tcp:8080-8080, 80/tcp:8080-8081"))
-	assert.Check(t, pbs == nil)
+	assert.Check(t, is.Nil(pbs))
 }
 
 func newIPNet(t *testing.T, cidr string) *net.IPNet {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1255,7 +1254,7 @@ func TestXGlobalNoParent(t *testing.T) {
 
 	_, err = os.Lstat(filepath.Join(tmpDir, "foo"))
 	assert.Check(t, err != nil)
-	assert.Check(t, errors.Is(err, os.ErrNotExist))
+	assert.Check(t, is.ErrorIs(err, os.ErrNotExist))
 }
 
 // TestImpliedDirectoryPermissions ensures that directories implied by paths in the tar file, but without their own

--- a/pkg/authorization/middleware_unix_test.go
+++ b/pkg/authorization/middleware_unix_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/pkg/plugingetter"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestMiddlewareWrapHandler(t *testing.T) {
@@ -47,7 +46,7 @@ func TestMiddlewareWrapHandler(t *testing.T) {
 			Msg:   "Server Auth Not Allowed",
 		}
 		if err := mdHandler(ctx, resp, req, map[string]string{}); err == nil {
-			assert.Assert(t, is.ErrorContains(err, ""))
+			assert.ErrorContains(t, err, "")
 		}
 	})
 

--- a/quota/projectquota_test.go
+++ b/quota/projectquota_test.go
@@ -61,7 +61,7 @@ func testBiggerThanQuota(t *testing.T, ctrl *Control, homeDir, testDir, testSubD
 
 	biggerThanQuotaFile := filepath.Join(testSubDir, "bigger-than-quota")
 	err := os.WriteFile(biggerThanQuotaFile, make([]byte, testQuotaSize+1), 0o644)
-	assert.Assert(t, is.ErrorContains(err, ""))
+	assert.ErrorContains(t, err, "")
 	if err == io.ErrShortWrite {
 		assert.NilError(t, os.Remove(biggerThanQuotaFile))
 	}

--- a/volume/service/db_test.go
+++ b/volume/service/db_test.go
@@ -8,7 +8,6 @@ import (
 
 	bolt "go.etcd.io/bbolt"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestSetGetMeta(t *testing.T) {
@@ -25,7 +24,7 @@ func TestSetGetMeta(t *testing.T) {
 	defer store.Shutdown()
 
 	_, err = store.getMeta("test")
-	assert.Assert(t, is.ErrorContains(err, ""))
+	assert.ErrorContains(t, err, "")
 
 	err = db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucket(volumeBucketName)

--- a/volume/service/service_test.go
+++ b/volume/service/service_test.go
@@ -149,7 +149,7 @@ func TestServiceGet(t *testing.T) {
 	_, err = service.Get(ctx, "test", opts.WithGetDriver("notarealdriver"))
 	assert.Assert(t, errdefs.IsConflict(err), err)
 	v, err = service.Get(ctx, "test", opts.WithGetDriver("d1"))
-	assert.Assert(t, err == nil)
+	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(created, v))
 
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d2"), "d2"))

--- a/volume/service/service_test.go
+++ b/volume/service/service_test.go
@@ -132,7 +132,7 @@ func TestServiceGet(t *testing.T) {
 
 	v, err := service.Get(ctx, "notexist")
 	assert.Assert(t, IsNotExist(err))
-	assert.Check(t, v == nil)
+	assert.Check(t, is.Nil(v))
 
 	created, err := service.Create(ctx, "test", "d1")
 	assert.NilError(t, err)

--- a/volume/service/store_test.go
+++ b/volume/service/store_test.go
@@ -15,7 +15,6 @@ import (
 	volumetestutils "github.com/docker/docker/volume/testutils"
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestCreate(t *testing.T) {
@@ -300,7 +299,7 @@ func TestRefDerefRemove(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = s.Remove(ctx, v)
-	assert.Assert(t, is.ErrorContains(err, ""))
+	assert.ErrorContains(t, err, "")
 	assert.Equal(t, errVolumeInUse, err.(*OpErr).Err)
 
 	s.Release(ctx, v.Name(), "test-ref")
@@ -318,7 +317,7 @@ func TestGet(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s.Get(ctx, "not-exist")
-	assert.Assert(t, is.ErrorContains(err, ""))
+	assert.ErrorContains(t, err, "")
 	assert.Equal(t, errNoSuchVolume, err.(*OpErr).Err)
 
 	v1, err := s.Create(ctx, "test", driverName, opts.WithCreateLabels(map[string]string{"a": "1"}))
@@ -345,7 +344,7 @@ func TestGetWithReference(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s.Get(ctx, "not-exist", opts.WithGetDriver(driverName), opts.WithGetReference("test-ref"))
-	assert.Assert(t, is.ErrorContains(err, ""))
+	assert.ErrorContains(t, err, "")
 
 	v1, err := s.Create(ctx, "test", driverName, opts.WithCreateLabels(map[string]string{"a": "1"}))
 	assert.NilError(t, err)
@@ -355,7 +354,7 @@ func TestGetWithReference(t *testing.T) {
 	assert.DeepEqual(t, v1, v2, cmpVolume)
 
 	err = s.Remove(ctx, v2)
-	assert.Assert(t, is.ErrorContains(err, ""))
+	assert.ErrorContains(t, err, "")
 	assert.Equal(t, errVolumeInUse, err.(*OpErr).Err)
 
 	s.Release(ctx, v2.Name(), "test-ref")


### PR DESCRIPTION
Quite a lot of tests (especially in `integration-cli`) use boolean assertions which don't provide any useful information about why a comparison failed. This is already kind of annoying when debugging a failing test, but when running the integration suite on an actual machine (where the source code parsing doesn't work) this makes it almost impossible to figure out what the actual error is.

A lot of this is due to limitations of `gotest.tools` (see https://github.com/gotestyourself/gotest.tools/issues/147 for instance) but we can work around most of these issues.

**NOTE**: I've only tackled the "easy" cases for now. All of the transformations were done using `gofmt -r` or `golang.org/x/tools/cmd/eg`, which should make it easier to verify that the tests weren't subtly broken by these changes.

Future work:
- [ ] Fix all of the assertions that have help messages (these are less critical because usually the message gives you some kind of information). Unfortunately, `gofmt` cannot handle these automatically, and we would need to run `gofmt` for every number of arguments used. We could use `sed` but this could lead to bugs, and `eg` seems to be able to do this but it is incredibly poorly documented.
- [x] Migrate `assert.Assert(t, errors.Is(...))` to `assert.ErrorIs` or `is.ErrorIs`.
- [x] Migrate `assert.Assert(t, is.Contains(err.Error(), ...)` to `assert.ErrorContains`.
- [ ] Fix inverse comparisons. `integration-cli/checker` doesn't help with this entirely (see https://github.com/gotestyourself/gotest.tools/issues/147) -- we will instead need to create a new `cmpext` package that will let us create a generic inverter that has useful error messages. This will then let us tackle these issues:
  - [ ] `assert.Assert(t, a != nil)`
  - [ ] `assert.Assert(t, !strings.Contains(...))`
  - [ ] ...