### PR TITLE
Dockerfile: update containerd v1.7.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.7.22
+ARG CONTAINERD_VERSION=v1.7.24
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -164,7 +164,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.23.3
 ARG GOTESTSUM_VERSION=v1.8.2
 ARG GOWINRES_VERSION=v0.3.1
-ARG CONTAINERD_VERSION=v1.7.22
+ARG CONTAINERD_VERSION=v1.7.24
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.7.22}"
+: "${CONTAINERD_VERSION:=v1.7.24}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
**- What I did**
This change updates containerd v1.7.24 in CI.
* https://github.com/containerd/containerd/releases/tag/v1.7.23
* https://github.com/containerd/containerd/releases/tag/v1.7.24

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Upgrade `containerd` (static binaries only) to [v1.7.24](https://github.com/containerd/containerd/releases/tag/v1.7.24)
```

**- A picture of a cute animal (not mandatory but encouraged)**

