### PR TITLE
[25.0 backport] Dockerfile: update containerd v1.7.24, runc v1.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -283,7 +283,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.1.14
+ARG RUNC_VERSION=v1.2.2
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -198,7 +198,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.7.22
+ARG CONTAINERD_VERSION=v1.7.24
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -164,7 +164,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.22.9
 ARG GOTESTSUM_VERSION=v1.8.2
 ARG GOWINRES_VERSION=v0.3.1
-ARG CONTAINERD_VERSION=v1.7.22
+ARG CONTAINERD_VERSION=v1.7.24
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.7.22}"
+: "${CONTAINERD_VERSION:=v1.7.24}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.1.14}"
+: "${RUNC_VERSION:=v1.2.2}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
**- What I did**

Backports runtime updates in CI to 25.0 branch.
* containerd v1.7.24: https://github.com/moby/moby/pull/48918
* runc v1.2.2: https://github.com/moby/moby/pull/47666

**- How I did it**

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Upgrade `runc` to [v1.2.2](https://github.com/opencontainers/runc/releases/tag/v1.2.2)
Upgrade `containerd` (static binaries only) to [v1.7.24](https://github.com/containerd/containerd/releases/tag/v1.7.24)
```

**- A picture of a cute animal (not mandatory but encouraged)**
