### PR TITLE
[27.x backport] vendor: github.com/containerd/continuity v0.4.5

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -32,7 +32,7 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.3
 	github.com/containerd/containerd v1.7.23
 	github.com/containerd/containerd/api v1.7.19
-	github.com/containerd/continuity v0.4.4
+	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v0.3.0
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/log v0.1.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -148,8 +148,8 @@ github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZG
 github.com/containerd/containerd v1.7.23/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
 github.com/containerd/containerd/api v1.7.19 h1:VWbJL+8Ap4Ju2mx9c9qS1uFSB1OVYr5JJrW2yT5vFoA=
 github.com/containerd/containerd/api v1.7.19/go.mod h1:fwGavl3LNwAV5ilJ0sbrABL44AQxmNjDRcwheXDb6Ig=
-github.com/containerd/continuity v0.4.4 h1:/fNVfTJ7wIl/YPMHjf+5H32uFhl63JucB34PlCpMKII=
-github.com/containerd/continuity v0.4.4/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
+github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
+github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=
 github.com/containerd/errdefs v0.3.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=

--- a/vendor/github.com/containerd/continuity/fs/stat_darwinbsd.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_darwinbsd.go
@@ -19,9 +19,35 @@
 package fs
 
 import (
+	"fmt"
+	"io/fs"
 	"syscall"
 	"time"
 )
+
+func Atime(st fs.FileInfo) (time.Time, error) {
+	stSys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
+	}
+	return time.Unix(stSys.Atimespec.Unix()), nil
+}
+
+func Ctime(st fs.FileInfo) (time.Time, error) {
+	stSys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
+	}
+	return time.Unix(stSys.Ctimespec.Unix()), nil
+}
+
+func Mtime(st fs.FileInfo) (time.Time, error) {
+	stSys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
+	}
+	return time.Unix(stSys.Mtimespec.Unix()), nil
+}
 
 // StatAtime returns the access time from a stat struct
 func StatAtime(st *syscall.Stat_t) syscall.Timespec {

--- a/vendor/github.com/containerd/continuity/fs/stat_unix.go
+++ b/vendor/github.com/containerd/continuity/fs/stat_unix.go
@@ -30,7 +30,7 @@ func Atime(st fs.FileInfo) (time.Time, error) {
 	if !ok {
 		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
 	}
-	return StatATimeAsTime(stSys), nil
+	return time.Unix(stSys.Atim.Unix()), nil
 }
 
 func Ctime(st fs.FileInfo) (time.Time, error) {
@@ -38,7 +38,7 @@ func Ctime(st fs.FileInfo) (time.Time, error) {
 	if !ok {
 		return time.Time{}, fmt.Errorf("expected st.Sys() to be *syscall.Stat_t, got %T", st.Sys())
 	}
-	return time.Unix(stSys.Atim.Unix()), nil
+	return time.Unix(stSys.Ctim.Unix()), nil
 }
 
 func Mtime(st fs.FileInfo) (time.Time, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -362,7 +362,7 @@ github.com/containerd/containerd/api/services/version/v1
 github.com/containerd/containerd/api/types
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/api/types/transfer
-# github.com/containerd/continuity v0.4.4
+# github.com/containerd/continuity v0.4.5
 ## explicit; go 1.21
 github.com/containerd/continuity/devices
 github.com/containerd/continuity/driver


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48925

full diff: https://github.com/containerd/continuity/compare/v0.4.4...v0.4.5


(cherry picked from commit d23bc11b97efa7ccc927d578267e4857bfec279a)

**- A picture of a cute animal (not mandatory but encouraged)**

