### PR TITLE
[27.x backport] vendor: resenje.org/singleflight v0.4.3

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -117,7 +117,7 @@ require (
 	google.golang.org/grpc v1.66.3
 	google.golang.org/protobuf v1.35.1
 	gotest.tools/v3 v3.5.1
-	resenje.org/singleflight v0.4.1
+	resenje.org/singleflight v0.4.3
 	tags.cncf.io/container-device-interface v0.8.0
 )
 

--- a/vendor.sum
+++ b/vendor.sum
@@ -1069,8 +1069,8 @@ kernel.org/pub/linux/libs/security/libcap/cap v1.2.70 h1:QnLPkuDWWbD5C+3DUA2IUXa
 kernel.org/pub/linux/libs/security/libcap/cap v1.2.70/go.mod h1:/iBwcj9nbLejQitYvUm9caurITQ6WyNHibJk6Q9fiS4=
 kernel.org/pub/linux/libs/security/libcap/psx v1.2.70 h1:HsB2G/rEQiYyo1bGoQqHZ/Bvd6x1rERQTNdPr1FyWjI=
 kernel.org/pub/linux/libs/security/libcap/psx v1.2.70/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
-resenje.org/singleflight v0.4.1 h1:ryGHRaOBwhnZLyf34LMDf4AsTSHrs4hdGPdG/I4Hmac=
-resenje.org/singleflight v0.4.1/go.mod h1:lAgQK7VfjG6/pgredbQfmV0RvG/uVhKo6vSuZ0vCWfk=
+resenje.org/singleflight v0.4.3 h1:l7foFYg8X/VEHPxWs1K/Pw77807RMVzvXgWGb0J1sdM=
+resenje.org/singleflight v0.4.3/go.mod h1:lAgQK7VfjG6/pgredbQfmV0RvG/uVhKo6vSuZ0vCWfk=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1607,7 +1607,7 @@ k8s.io/klog/v2/internal/clock
 k8s.io/klog/v2/internal/dbg
 k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
-# resenje.org/singleflight v0.4.1
+# resenje.org/singleflight v0.4.3
 ## explicit; go 1.18
 resenje.org/singleflight
 # sigs.k8s.io/yaml v1.3.0

--- a/vendor/resenje.org/singleflight/.golangci.yaml
+++ b/vendor/resenje.org/singleflight/.golangci.yaml
@@ -1,0 +1,36 @@
+run:
+  timeout: 10m
+  allow-parallel-runners: true
+
+linters:
+  enable:
+    - errname
+    - stylecheck
+    - importas
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - mirror
+    - staticcheck
+    - tagalign
+    - testifylint
+    - typecheck
+    - unused
+    - unconvert
+    - wastedassign
+    - whitespace
+    - gocritic
+    - exhaustive
+    - noctx
+    - promlinter
+  # TODO these fail on windows
+  # - gofmt
+  # - goimports
+
+linters-settings:
+  govet:
+    enable-all: true
+    disable:
+      - shadow
+      - fieldalignment

--- a/vendor/resenje.org/singleflight/README.md
+++ b/vendor/resenje.org/singleflight/README.md
@@ -3,9 +3,12 @@
 [![GoDoc](https://godoc.org/resenje.org/singleflight?status.svg)](https://godoc.org/resenje.org/singleflight)
 [![Go](https://github.com/janos/singleflight/workflows/Go/badge.svg)](https://github.com/janos/singleflight/actions?query=workflow%3AGo)
 
-Package singleflight provides a duplicate function call suppression
-mechanism similar to golang.org/x/sync/singleflight but with support
-for context cancelation.
+Package singleflight provides a duplicate function call suppression 
+mechanism similar to [golang.org/x/sync/singleflight](https://pkg.go.dev/golang.org/x/sync/singleflight) but with:
+
+- support for context cancelation. The context passed to the callback function is a context that preserves all values
+from the passed context but is cancelled by the singleflight only when all awaiting caller's contexts are cancelled.
+- support for generics.
 
 ## Installation
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48930

full diff: https://resenje.org/singleflight/compare/v0.4.1...v0.4.3

Changes:
- Fix incorrect `Forget` behavior
- Make panic behavior consistent with x/sync package


(cherry picked from commit 1551d957271de7b32ed2630300f88a399fbd28cf)