### PR TITLE
[27.x backport] Update containerd to v1.7.24

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -30,7 +30,7 @@ require (
 	github.com/aws/smithy-go v1.19.0
 	github.com/cloudflare/cfssl v1.6.4
 	github.com/containerd/cgroups/v3 v3.0.3
-	github.com/containerd/containerd v1.7.23
+	github.com/containerd/containerd v1.7.24
 	github.com/containerd/containerd/api v1.7.19
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v0.3.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -144,8 +144,8 @@ github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGD
 github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2WzJmticMgVuz0=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
-github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZGBNYOOwQ=
-github.com/containerd/containerd v1.7.23/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
+github.com/containerd/containerd v1.7.24 h1:zxszGrGjrra1yYJW/6rhm9cJ1ZQ8rkKBR48brqsa7nA=
+github.com/containerd/containerd v1.7.24/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
 github.com/containerd/containerd/api v1.7.19 h1:VWbJL+8Ap4Ju2mx9c9qS1uFSB1OVYr5JJrW2yT5vFoA=
 github.com/containerd/containerd/api v1.7.19/go.mod h1:fwGavl3LNwAV5ilJ0sbrABL44AQxmNjDRcwheXDb6Ig=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=

--- a/vendor/github.com/containerd/containerd/Vagrantfile
+++ b/vendor/github.com/containerd/containerd/Vagrantfile
@@ -104,7 +104,7 @@ EOF
   config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
     sh.upload_path = "/tmp/vagrant-install-golang"
     sh.env = {
-        'GO_VERSION': ENV['GO_VERSION'] || "1.22.8",
+        'GO_VERSION': ENV['GO_VERSION'] || "1.22.9",
     }
     sh.inline = <<~SHELL
         #!/usr/bin/env bash

--- a/vendor/github.com/containerd/containerd/containerd.service
+++ b/vendor/github.com/containerd/containerd/containerd.service
@@ -15,7 +15,7 @@
 [Unit]
 Description=containerd container runtime
 Documentation=https://containerd.io
-After=network.target local-fs.target
+After=network.target local-fs.target dbus.service
 
 [Service]
 #uncomment to enable the experimental sbservice (sandboxed) version of containerd/cri integration

--- a/vendor/github.com/containerd/containerd/content/local/store.go
+++ b/vendor/github.com/containerd/containerd/content/local/store.go
@@ -67,6 +67,8 @@ type LabelStore interface {
 type store struct {
 	root string
 	ls   LabelStore
+
+	ensureIngestRootOnce func() error
 }
 
 // NewStore returns a local content store
@@ -80,14 +82,13 @@ func NewStore(root string) (content.Store, error) {
 // require labels and should use `NewStore`. `NewLabeledStore` is primarily
 // useful for tests or standalone implementations.
 func NewLabeledStore(root string, ls LabelStore) (content.Store, error) {
-	if err := os.MkdirAll(filepath.Join(root, "ingest"), 0777); err != nil {
-		return nil, err
-	}
-
-	return &store{
+	s := &store{
 		root: root,
 		ls:   ls,
-	}, nil
+	}
+
+	s.ensureIngestRootOnce = sync.OnceValue(s.ensureIngestRoot)
+	return s, nil
 }
 
 func (s *store) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
@@ -294,6 +295,9 @@ func (s *store) Status(ctx context.Context, ref string) (content.Status, error) 
 func (s *store) ListStatuses(ctx context.Context, fs ...string) ([]content.Status, error) {
 	fp, err := os.Open(filepath.Join(s.root, "ingest"))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -344,6 +348,9 @@ func (s *store) ListStatuses(ctx context.Context, fs ...string) ([]content.Statu
 func (s *store) WalkStatusRefs(ctx context.Context, fn func(string) error) error {
 	fp, err := os.Open(filepath.Join(s.root, "ingest"))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -545,6 +552,11 @@ func (s *store) writer(ctx context.Context, ref string, total int64, expected di
 	)
 
 	foundValidIngest := false
+
+	if err := s.ensureIngestRootOnce(); err != nil {
+		return nil, err
+	}
+
 	// ensure that the ingest path has been created.
 	if err := os.Mkdir(path, 0755); err != nil {
 		if !os.IsExist(err) {
@@ -653,6 +665,10 @@ func (s *store) ingestPaths(ref string) (string, string, string) {
 	)
 
 	return fp, rp, dp
+}
+
+func (s *store) ensureIngestRoot() error {
+	return os.MkdirAll(filepath.Join(s.root, "ingest"), 0777)
 }
 
 func readFileString(path string) (string, error) {

--- a/vendor/github.com/containerd/containerd/remotes/docker/resolver_unix.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/resolver_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 /*
    Copyright The containerd Authors.
 
@@ -14,21 +16,13 @@
    limitations under the License.
 */
 
-package version
+package docker
 
-import "runtime"
-
-var (
-	// Package is filled at linking time
-	Package = "github.com/containerd/containerd"
-
-	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.24+unknown"
-
-	// Revision is filled with the VCS (e.g. git) revision being used to build
-	// the program at linking time.
-	Revision = ""
-
-	// GoVersion is Go tree's version.
-	GoVersion = runtime.Version()
+import (
+	"errors"
+	"syscall"
 )
+
+func isConnError(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}

--- a/vendor/github.com/containerd/containerd/remotes/docker/resolver_windows.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/resolver_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 /*
    Copyright The containerd Authors.
 
@@ -14,21 +16,15 @@
    limitations under the License.
 */
 
-package version
+package docker
 
-import "runtime"
+import (
+	"errors"
+	"syscall"
 
-var (
-	// Package is filled at linking time
-	Package = "github.com/containerd/containerd"
-
-	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.7.24+unknown"
-
-	// Revision is filled with the VCS (e.g. git) revision being used to build
-	// the program at linking time.
-	Revision = ""
-
-	// GoVersion is Go tree's version.
-	GoVersion = runtime.Version()
+	"golang.org/x/sys/windows"
 )
+
+func isConnError(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, windows.WSAECONNREFUSED)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -258,7 +258,7 @@ github.com/containerd/cgroups/v3/cgroup2/stats
 # github.com/containerd/console v1.0.4
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/containerd v1.7.23
+# github.com/containerd/containerd v1.7.24
 ## explicit; go 1.21
 github.com/containerd/containerd
 github.com/containerd/containerd/archive


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48917
- ☝️ needed if we want to update to BuildKit v0.18 (TBD)

(cherry picked from commit a650dbd951a6edd4bb1d897baa6a1382bf5f3a45)

Diff is slightly different in this branch, because we don't use all the same packages in 27.x