### PR TITLE
api: add GwPriority field to EndpointSettings

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -643,6 +643,14 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		}
 	}
 
+	if versions.LessThan(version, "1.48") {
+		for _, epConfig := range networkingConfig.EndpointsConfig {
+			// Before 1.48, all endpoints had the same priority, so
+			// reinitialize this field.
+			epConfig.GwPriority = 0
+		}
+	}
+
 	var warnings []string
 	if warn := handleVolumeDriverBC(version, hostConfig); warn != "" {
 		warnings = append(warnings, warn)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2927,6 +2927,16 @@ definitions:
         example:
           com.example.some-label: "some-value"
           com.example.some-other-label: "some-other-value"
+      GwPriority:
+        description: |
+          This property determines which endpoint will provide the default
+          gateway for a container. The endpoint with the highest priority will
+          be used. If multiple endpoints have the same priority, endpoints are
+          lexicographically sorted based on their network name, and the one
+          that sorts first is picked.
+        type: "number"
+        example:
+          - 10
 
       # Operational data
       NetworkID:
@@ -10910,6 +10920,7 @@ paths:
                   IPv4Address: "172.24.56.89"
                   IPv6Address: "2001:db8::5689"
                 MacAddress: "02:42:ac:12:05:02"
+                Priority: 100
       tags: ["Network"]
 
   /networks/{id}/disconnect:

--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -19,6 +19,7 @@ type EndpointSettings struct {
 	// generated address).
 	MacAddress string
 	DriverOpts map[string]string
+	GwPriority int
 	// Operational data
 	NetworkID           string
 	EndpointID          string

--- a/container/view.go
+++ b/container/view.go
@@ -377,6 +377,7 @@ func (v *View) transform(ctr *Container) *Snapshot {
 				GlobalIPv6PrefixLen: netw.GlobalIPv6PrefixLen,
 				MacAddress:          netw.MacAddress,
 				NetworkID:           netw.NetworkID,
+				GwPriority:          netw.GwPriority,
 			}
 			if netw.IPAMConfig != nil {
 				networks[name].IPAMConfig = &network.EndpointIPAMConfig{

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1120,7 +1120,10 @@ func buildJoinOptions(settings *network.Settings, n interface{ Name() string }) 
 		return []libnetwork.EndpointOption{}, nil
 	}
 
-	var joinOptions []libnetwork.EndpointOption
+	joinOptions := []libnetwork.EndpointOption{
+		libnetwork.JoinOptionPriority(epConfig.GwPriority),
+	}
+
 	for _, str := range epConfig.Links {
 		name, alias, err := opts.ParseLink(str)
 		if err != nil {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1115,18 +1115,21 @@ func buildEndpointInfo(networkSettings *network.Settings, n *libnetwork.Network,
 
 // buildJoinOptions builds endpoint Join options from a given network.
 func buildJoinOptions(settings *network.Settings, n interface{ Name() string }) ([]libnetwork.EndpointOption, error) {
+	epConfig, ok := settings.Networks[n.Name()]
+	if !ok {
+		return []libnetwork.EndpointOption{}, nil
+	}
+
 	var joinOptions []libnetwork.EndpointOption
-	if epConfig, ok := settings.Networks[n.Name()]; ok {
-		for _, str := range epConfig.Links {
-			name, alias, err := opts.ParseLink(str)
-			if err != nil {
-				return nil, err
-			}
-			joinOptions = append(joinOptions, libnetwork.CreateOptionAlias(name, alias))
+	for _, str := range epConfig.Links {
+		name, alias, err := opts.ParseLink(str)
+		if err != nil {
+			return nil, err
 		}
-		for k, v := range epConfig.DriverOpts {
-			joinOptions = append(joinOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
-		}
+		joinOptions = append(joinOptions, libnetwork.CreateOptionAlias(name, alias))
+	}
+	for k, v := range epConfig.DriverOpts {
+		joinOptions = append(joinOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
 	}
 
 	return joinOptions, nil

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -50,6 +50,14 @@ keywords: "API, Docker, rcli, REST, documentation"
   daemon has experimental features enabled.
 * `GET /networks/{id}` now returns an `EnableIPv4` field showing whether the
   network has IPv4 IPAM enabled.
+* `POST /networks/{id}/connect` and `POST /containers/create` now accept a
+  `GwPriority` field in `EndpointsConfig`. This value is used to determine which
+  network endpoint provides the default gateway for the container. The endpoint
+  with the highest priority is selected. If multiple endpoints have the same
+  priority, endpoints are sorted lexicographically by their network name, and
+  the one that sorts first is picked.
+* `GET /containers/json` now returns a `GwPriority` field in `NetworkSettings`
+  for each network endpoint.
 
 ## v1.47 API changes
 


### PR DESCRIPTION
Fixes:

- fixes https://github.com/moby/moby/issues/48868
- fixes https://github.com/moby/moby/issues/20179
- fixes https://github.com/moby/libnetwork/issues/2093

Supersedes:

- supersedes, closes https://github.com/moby/moby/pull/46036

**- What I did**

1st commit is just a minor refactoring.

2nd commit adds a new `GwPriority` field to `EndpointSettings`. It can be specified both during initial `ContainerCreate` or during subsequent `NetworkConnect`. This field is passed as is to libnetwork. Libnet already supports this property -- it'll use it to determine which endpoint should provide the default gateway for a container. If two endpoints have the same priority, they're sorted in lexicographic order, and the one sorted first is picked.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

```markdown changelog
- Add a way to specify which network should provide the default gateway for a container.
```
