### PR TITLE
api/ping: add support for querying engine features

### DIFF
--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -27,6 +27,7 @@ type DiskUsageOptions struct {
 // Backend is the methods that need to be implemented to provide
 // system specific functionality.
 type Backend interface {
+	SystemCapabilities(context.Context) (system.Capabilities, error)
 	SystemInfo(context.Context) (*system.Info, error)
 	SystemVersion(context.Context) (types.Version, error)
 	SystemDiskUsage(ctx context.Context, opts DiskUsageOptions) (*types.DiskUsage, error)

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -32,7 +32,8 @@ func (s *systemRouter) pingHandler(ctx context.Context, w http.ResponseWriter, r
 	w.Header().Add("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Header().Add("Pragma", "no-cache")
 
-	builderVersion := build.BuilderVersion(s.features())
+	features := s.features()
+	builderVersion := build.BuilderVersion(features)
 	if bv := builderVersion; bv != "" {
 		w.Header().Set("Builder-Version", string(bv))
 	}
@@ -44,6 +45,17 @@ func (s *systemRouter) pingHandler(ctx context.Context, w http.ResponseWriter, r
 		w.Header().Set("Content-Length", "0")
 		return nil
 	}
+
+	if queryFeatures := r.FormValue("features"); queryFeatures == "v1" {
+		w.Header().Set("Content-Type", "application/json")
+		featuresJson, err := json.Marshal(features)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(featuresJson)
+		return err
+	}
+
 	_, err := w.Write([]byte{'O', 'K'})
 	return err
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9642,6 +9642,15 @@ paths:
                 This value is a recommendation as advertised by the daemon, and
                 it is up to the client to choose which builder to use.
               default: "2"
+            Engine-Features:
+              type: "string"
+              description: |
+                List of engine features and whether they are enabled or not, containing
+                elements of the `features` field of the daemon's configuration file, as
+                well as features enabled via command line arguments when starting the daemon.
+
+                Represented as a comma separated (,) list of key-value pairs (`some-feature=true|false`),
+                e.g. `containerd-snapshotter=true,other-feature=false`.
             Docker-Experimental:
               type: "boolean"
               description: "If the server is running with experimental mode enabled"
@@ -9708,6 +9717,90 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
+      tags: ["System"]
+  # Using a zero-width character here to define a separate /_ping endpoint to describe the
+  # /_ping?features=v1 API since otherwise Swagger won't allow us to define multiple
+  # responses for the same endpoint depending on query parameter.
+  # This is however supported by OpenAPI v3.
+  # See: https://github.com/OAI/OpenAPI-Specification/issues/146
+  # and https://github.com/OAI/OpenAPI-Specification/issues/182
+  /_ping​:
+    get:
+      summary: "/_ping?features=v1"
+      description: |
+        This is the same endpoint as `GET /_ping`, but describes the different
+        response when it is called with the `features=v1` query parameter.
+
+        In this case, the daemon instead responds with a `Content-Type` of
+        `application/json` and writes a json map corresponding to the engine's
+        configured features in the response body.
+      operationId: "SystemPingFeatures"
+      produces: ["application/json"]
+      parameters:
+        - name: "features"
+          in: "query"
+          description: |
+            The name of the plugin. The `:latest` tag is optional, and is the
+            default if omitted.
+          # marked as required since this is a separate endpoint in the swagger yaml.
+          required: true
+          type: "string"
+          enum: ["v1"]
+      responses:
+        200:
+          description: "no error"
+          schema:
+            # map of strings to booleans
+            type: "object"
+            additionalProperties:
+              type: boolean
+            example:
+              containerd-snapshotter: true
+              other-feature: false
+          headers:
+            API-Version:
+              type: "string"
+              description: "Max API Version the server supports"
+            Builder-Version:
+              type: "string"
+              description: |
+                Default version of docker image builder
+
+                The default on Linux is version "2" (BuildKit), but the daemon
+                can be configured to recommend version "1" (classic Builder).
+                Windows does not yet support BuildKit for native Windows images,
+                and uses "1" (classic builder) as a default.
+
+                This value is a recommendation as advertised by the daemon, and
+                it is up to the client to choose which builder to use.
+              default: "2"
+            Docker-Experimental:
+              type: "boolean"
+              description: "If the server is running with experimental mode enabled"
+            Swarm:
+              type: "string"
+              enum: ["inactive", "pending", "error", "locked", "active/worker", "active/manager"]
+              description: |
+                Contains information about Swarm status of the daemon,
+                and if the daemon is acting as a manager or worker node.
+              default: "inactive"
+            Cache-Control:
+              type: "string"
+              default: "no-cache, no-store, must-revalidate"
+            Pragma:
+              type: "string"
+              default: "no-cache"
+        500:
+          description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+          headers:
+            Cache-Control:
+              type: "string"
+              default: "no-cache, no-store, must-revalidate"
+            Pragma:
+              type: "string"
+              default: "no-cache"
       tags: ["System"]
   /commit:
     post:

--- a/api/types/system/capabilities.go
+++ b/api/types/system/capabilities.go
@@ -1,0 +1,5 @@
+package system
+
+type Capabilities struct {
+	RegistryClientAuth bool `json:"registry-client-auth"`
+}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/api/types/volume"
 )
 
@@ -35,7 +36,11 @@ type Ping struct {
 	// endpoint.
 	SwarmStatus *swarm.Status
 
-	EngineFeatures map[string]bool
+	// Capabilities provides information about specific capabilities
+	// the daemon might or might not support.
+	//
+	// Can be nil if talking to an older engine.
+	Capabilities *system.Capabilities
 }
 
 // ComponentVersion describes the version information for a specific component.

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -34,6 +34,8 @@ type Ping struct {
 	// should use other ways to get the current swarm status, such as the /swarm
 	// endpoint.
 	SwarmStatus *swarm.Status
+
+	EngineFeatures map[string]bool
 }
 
 // ComponentVersion describes the version information for a specific component.

--- a/client/client.go
+++ b/client/client.go
@@ -289,7 +289,7 @@ func (cli *Client) checkVersion(ctx context.Context) error {
 			return nil
 		}
 
-		ping, err := cli.Ping(ctx)
+		ping, err := cli.Ping(ctx, false)
 		if err != nil {
 			return err
 		}
@@ -338,7 +338,7 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 		cli.negotiateLock.Lock()
 		defer cli.negotiateLock.Unlock()
 
-		ping, err := cli.Ping(ctx)
+		ping, err := cli.Ping(ctx, false)
 		if err != nil {
 			// FIXME(thaJeztah): Ping returns an error when failing to connect to the API; we should not swallow the error here, and instead returning it.
 			return

--- a/client/interface.go
+++ b/client/interface.go
@@ -169,7 +169,7 @@ type SystemAPIClient interface {
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options types.DiskUsageOptions) (types.DiskUsage, error)
-	Ping(ctx context.Context) (types.Ping, error)
+	Ping(ctx context.Context, requestFeatures bool) (types.Ping, error)
 }
 
 // VolumeAPIClient defines API client methods for the volumes

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -73,7 +73,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), false)
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -88,7 +88,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), false)
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -102,7 +102,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), false)
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -116,7 +116,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), false)
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -131,7 +131,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), false)
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})

--- a/client/ping.go
+++ b/client/ping.go
@@ -2,13 +2,18 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
 )
 
 // Ping pings the server and returns the value of the "Docker-Experimental",
@@ -18,31 +23,39 @@ import (
 // may be returned if the daemon is in an unhealthy state, but returns errors
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
-func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
+func (cli *Client) Ping(ctx context.Context, requestFeatures bool) (types.Ping, error) {
 	var ping types.Ping
 
-	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
-	// because ping requests are used during API version negotiation, so we want
-	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
-	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
-	if err != nil {
-		return ping, err
-	}
-	serverResp, err := cli.doRequest(req)
-	if err == nil {
-		defer ensureReaderClosed(serverResp)
-		switch serverResp.statusCode {
-		case http.StatusOK, http.StatusInternalServerError:
-			// Server handled the request, so parse the response
-			return parsePingResponse(cli, serverResp)
+	// If not interested in engine features, do a HEAD request
+	if !requestFeatures {
+		// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
+		// because ping requests are used during API version negotiation, so we want
+		// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
+		req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
+		if err != nil {
+			return ping, err
 		}
-	} else if IsErrConnectionFailed(err) {
-		return ping, err
+		serverResp, err := cli.doRequest(req)
+		if err == nil {
+			defer ensureReaderClosed(serverResp)
+			switch serverResp.statusCode {
+			case http.StatusOK, http.StatusInternalServerError:
+				// Server handled the request, so parse the response
+				return parsePingResponse(cli, serverResp)
+			}
+		} else if IsErrConnectionFailed(err) {
+			return ping, err
+		}
 	}
 
-	// HEAD failed; fallback to GET.
-	req.Method = http.MethodGet
-	serverResp, err = cli.doRequest(req)
+	// if the HEAD request failed – or we're requesting features –
+	// do a GET request
+	query := url.Values{}
+	if requestFeatures {
+		query.Set("features", "v1")
+	}
+
+	serverResp, err := cli.get(ctx, path.Join(cli.basePath, "/_ping"), query, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return ping, err
@@ -71,6 +84,36 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 			ControlAvailable: role == "manager",
 		}
 	}
+
 	err := cli.checkResponseErr(resp)
-	return ping, errdefs.FromStatusCode(err, resp.statusCode)
+	// if  200 <= statuscode < 400, this will return nil and not read the body
+	if err != nil {
+		return ping, errdefs.FromStatusCode(err, resp.statusCode)
+	}
+
+	// check the body for features if it's not nil and the response was not an error
+	if resp.body != nil {
+		featuresMap, err := parseFeaturesFromPingBody(resp.body)
+		if err != nil {
+			return ping, fmt.Errorf("failed to parse ping body: %w", err)
+		}
+		ping.EngineFeatures = featuresMap
+	}
+	return ping, nil
+}
+
+func parseFeaturesFromPingBody(pingBody io.Reader) (map[string]bool, error) {
+	content, err := io.ReadAll(pingBody)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 || string(content) == "OK" {
+		return nil, nil
+	}
+	features := make(map[string]bool)
+	err = json.Unmarshal(content, &features)
+	if err != nil {
+		return nil, errors.Errorf("expected features, found '%s'", string(content))
+	}
+	return features, nil
 }

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -105,7 +105,7 @@ func TestInfiniteError(t *testing.T) {
 		}),
 	}
 
-	_, err := client.Ping(context.Background())
+	_, err := client.Ping(context.Background(), false)
 	assert.Check(t, is.ErrorContains(err, "request returned Internal Server Error"))
 }
 

--- a/daemon/capabilities.go
+++ b/daemon/capabilities.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/api/types/system"
+)
+
+func (d *Daemon) SystemCapabilities(ctx context.Context) (system.Capabilities, error) {
+	return capManager.getCapabilities(ctx, d)
+}
+
+type capabilitiesProvider interface {
+	UsesSnapshotter() bool
+}
+
+// Daemon must implement capabilitiesProvider
+var _ capabilitiesProvider = &Daemon{}
+
+var capManager = &capabilitiesManager{}
+
+type capabilitiesManager struct {
+	sync.RWMutex
+	cacheValid         bool
+	cachedCapabilities system.Capabilities
+}
+
+func (m *capabilitiesManager) getCapabilities(ctx context.Context, p capabilitiesProvider) (system.Capabilities, error) {
+	m.RLock()
+	if m.cacheValid {
+		defer m.RUnlock()
+		return m.cachedCapabilities, nil
+	}
+	m.RUnlock()
+
+	m.Lock()
+	defer m.Unlock()
+	m.cachedCapabilities = m.fetchCapabilities(ctx, p)
+	m.cacheValid = true
+	return m.cachedCapabilities, nil
+}
+
+func (m *capabilitiesManager) invalidateCache(ctx context.Context) {
+	log.G(ctx).Debug("invalidating cached system capabilities")
+	m.Lock()
+	defer m.Unlock()
+
+	m.cacheValid = false
+}
+
+func (m *capabilitiesManager) fetchCapabilities(ctx context.Context, p capabilitiesProvider) system.Capabilities {
+	log.G(ctx).Debug("fetching system capabilities")
+	var registryClientAuth bool
+	if p.UsesSnapshotter() {
+		registryClientAuth = true
+	}
+	return system.Capabilities{
+		RegistryClientAuth: registryClientAuth,
+	}
+}

--- a/daemon/capabilities_test.go
+++ b/daemon/capabilities_test.go
@@ -1,0 +1,100 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+type mockDaemon struct {
+	usesSnapshotter func() bool
+}
+
+func (m *mockDaemon) UsesSnapshotter() bool {
+	return m.usesSnapshotter()
+}
+
+func TestGetCapabilities(t *testing.T) {
+	t.Run("snapshotter enabled", func(t *testing.T) {
+		manager := capabilitiesManager{}
+		mockDaemon := &mockDaemon{}
+		mockDaemon.usesSnapshotter = func() bool {
+			return true
+		}
+
+		capabilities, err := manager.getCapabilities(context.Background(), mockDaemon)
+		assert.NilError(t, err)
+
+		assert.Equal(t, true, capabilities.RegistryClientAuth)
+	})
+
+	t.Run("snapshotter disabled", func(t *testing.T) {
+		manager := capabilitiesManager{}
+		mockDaemon := &mockDaemon{}
+		mockDaemon.usesSnapshotter = func() bool {
+			return false
+		}
+
+		capabilities, err := manager.getCapabilities(context.Background(), mockDaemon)
+		assert.NilError(t, err)
+
+		assert.Equal(t, false, capabilities.RegistryClientAuth)
+	})
+}
+
+func TestCache(t *testing.T) {
+	t.Run("first call", func(t *testing.T) {
+		manager := capabilitiesManager{}
+		mockDaemon := &mockDaemon{}
+		var called int
+		mockDaemon.usesSnapshotter = func() bool {
+			called++
+			return true
+		}
+
+		_, _ = manager.getCapabilities(context.Background(), mockDaemon)
+
+		assert.Equal(t, 1, called)
+	})
+
+	t.Run("no invalidate", func(t *testing.T) {
+		manager := capabilitiesManager{}
+		mockDaemon := &mockDaemon{}
+		var called int
+		mockDaemon.usesSnapshotter = func() bool {
+			called++
+			return true
+		}
+
+		_, _ = manager.getCapabilities(context.Background(), mockDaemon)
+
+		assert.Equal(t, 1, called)
+
+		_, _ = manager.getCapabilities(context.Background(), mockDaemon)
+
+		assert.Equal(t, 1, called)
+	})
+
+	t.Run("invalidate fetches again", func(t *testing.T) {
+		manager := capabilitiesManager{}
+		mockDaemon := &mockDaemon{}
+		var called int
+		mockDaemon.usesSnapshotter = func() bool {
+			called++
+			return true
+		}
+		ctx := context.Background()
+
+		_, _ = manager.getCapabilities(ctx, mockDaemon)
+		assert.Equal(t, 1, called)
+
+		_, _ = manager.getCapabilities(ctx, mockDaemon)
+		assert.Equal(t, 1, called)
+
+		manager.invalidateCache(ctx)
+
+		_, _ = manager.getCapabilities(ctx, mockDaemon)
+		assert.Equal(t, 2, called)
+	})
+}

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -437,6 +437,8 @@ func MergeDaemonConfigurations(flagsConfig *Config, flags *pflag.FlagSet, config
 		return nil, err
 	}
 
+	PopulateFeatures(fileConfig.Features)
+
 	// validate the merged fileConfig and flagsConfig
 	if err := Validate(fileConfig); err != nil {
 		return nil, errors.Wrap(err, "merged configuration validation from file and command line flags failed")

--- a/daemon/config/features.go
+++ b/daemon/config/features.go
@@ -1,0 +1,37 @@
+package config
+
+import "errors"
+
+// DefaultFeatures maps features the engine supports to
+// their default value.
+// When a features becomes on by default, update this.
+var DefaultFeatures = map[string]bool{
+	"containerd-snapshotter": false,
+}
+
+// PopulateFeatures adds all the features the engine is aware of
+// to features, set to their current default value.
+//
+// This is used to populate the daemon config features map, so that
+// instead of this map not including features that are off by default
+// and not enabled – or on by default and not disabled – it contains
+// all features the engine is are of.
+// This prevents older clients from assuming that engine features are
+// disabled when communicating with newer daemons where the feature is
+// now enabled by default.
+func PopulateFeatures(features map[string]bool) error {
+	if features == nil {
+		return errors.New("features cannot be nil")
+	}
+	if DefaultFeatures == nil {
+		return errors.New("DefaultFeatures cannot be nil")
+	}
+
+	for k, v := range DefaultFeatures {
+		if _, exists := features[k]; !exists {
+			features[k] = v
+		}
+	}
+
+	return nil
+}

--- a/daemon/config/features_test.go
+++ b/daemon/config/features_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPopulateFeatures(t *testing.T) {
+	testCases := []struct {
+		doc             string
+		in              map[string]bool
+		defaultFeatures map[string]bool
+		expected        map[string]bool
+		expectedError   string
+	}{
+		{
+			doc:             "empty",
+			in:              map[string]bool{},
+			defaultFeatures: map[string]bool{},
+			expected:        map[string]bool{},
+		},
+		{
+			doc: "no default",
+			in: map[string]bool{
+				"foo": true,
+			},
+			defaultFeatures: map[string]bool{},
+			expected: map[string]bool{
+				"foo": true,
+			},
+		},
+		{
+			doc: "just defaults",
+			in:  map[string]bool{},
+			defaultFeatures: map[string]bool{
+				"foo": false,
+			},
+			expected: map[string]bool{
+				"foo": false,
+			},
+		},
+		{
+			doc: "multiple defaults",
+			in:  map[string]bool{},
+			defaultFeatures: map[string]bool{
+				"foo": false,
+				"bar": true,
+			},
+			expected: map[string]bool{
+				"foo": false,
+				"bar": true,
+			},
+		},
+		{
+			doc: "defaults don't overwrite config",
+			in: map[string]bool{
+				"foo": false,
+				"bar": false,
+			},
+			defaultFeatures: map[string]bool{
+				"foo": true,
+				"bar": true,
+			},
+			expected: map[string]bool{
+				"foo": false,
+				"bar": false,
+			},
+		},
+		{
+			doc: "config + defaults",
+			in: map[string]bool{
+				"foo": false,
+			},
+			defaultFeatures: map[string]bool{
+				"bar": true,
+			},
+			expected: map[string]bool{
+				"foo": false,
+				"bar": true,
+			},
+		},
+		{
+			doc: "nil features",
+			in:  nil,
+			defaultFeatures: map[string]bool{
+				"bar": true,
+			},
+			expectedError: "features cannot be nil",
+		},
+		{
+			doc: "nil defaults",
+			in: map[string]bool{
+				"foo": true,
+			},
+			defaultFeatures: nil,
+			expectedError:   "DefaultFeatures cannot be nil",
+		},
+		{
+			doc:             "both nil",
+			in:              nil,
+			defaultFeatures: nil,
+			expectedError:   "features cannot be nil",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.doc, func(t *testing.T) {
+			features := tc.in
+			DefaultFeatures = tc.defaultFeatures
+
+			err := PopulateFeatures(features)
+
+			if tc.expectedError == "" {
+				assert.DeepEqual(t, features, tc.expected)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+			}
+		})
+	}
+}

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -126,8 +126,10 @@ func (daemon *Daemon) Reload(conf *config.Config) error {
 			NoProxy:    config.MaskCredentials(newCfg.NoProxy),
 		},
 	})
-	log.G(context.TODO()).Infof("Reloaded configuration: %s", jsonString)
+	ctx := context.TODO()
+	log.G(ctx).Infof("Reloaded configuration: %s", jsonString)
 	daemon.configStore.Store(newCfg)
+	capManager.invalidateCache(ctx)
 	daemon.LogDaemonEventWithAttributes(events.ActionReload, attributes)
 	return txn.Commit()
 }

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -58,6 +58,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   the one that sorts first is picked.
 * `GET /containers/json` now returns a `GwPriority` field in `NetworkSettings`
   for each network endpoint.
+* `GET` `/_ping` endpoint now supports a `features` query parameter (currently only
+  takes a constant `v1`, e.g. `GET /_ping?features=v1`). If set, instead of the
+  response body containing `OK`, the daemon responds with with a json map
+  containing the features configured in the daemon's `CommonConfig.Features` field.
 
 ## v1.47 API changes
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2740,7 +2740,7 @@ func (s *DockerDaemonSuite) TestFailedPluginRemove(c *testing.T) {
 	d.Restart(c)
 	ctx, cancel = context.WithTimeout(testutil.GetContext(c), 30*time.Second)
 	defer cancel()
-	_, err = apiClient.Ping(ctx)
+	_, err = apiClient.Ping(ctx, false)
 	assert.NilError(c, err)
 
 	_, _, err = apiClient.PluginInspectWithRaw(ctx, name)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Supercedes/closes: https://github.com/moby/moby/pull/48904

**- What I did**

With moving towards using the containerd image store (as opposed to the "legacy" graphdrivers), some new daemon features will only be implemented for the containerd image store.

A client wanting to make use of new features would find it useful to be able to know what features are available without having to attempt to use them, getting an error back, and having to do another roundtrip.

Address this by adding a new query parameter to the `/_ping` endpoint to allow clients to query supported features.

**- How I did it**

dacfc1649d:

Since the features included in the response correspond to the features present in the daemon's config `features` field, and many features eventually become on-by-default – therefore no longer requiring that they be explicitly configured in the daemon's config – it's possible that older clients communicating with newer daemons would  infer that some features are not supported (since they wouldn't be explicitly configured) when in reality they are now on-by-default. 

We'd normally address an issue like this by conditionally adding older features that are now on-by-default to responses based on the API version the client is using, but since the `/_ping` endpoint isn't versioned, this is not a viable solution.

To address this, this patch also adds a `DefaultFeatures` var to `daemon/config` that keeps track of supported daemon features and their default value, and uses this to update the daemon's config field `Features` to explicitly add features + their default value if they are not explicitly configured, so that we can keep including these in the features list when queried even after they are on-by-default.

3f5ab841ae:

Add some validation to features:
- key length <= 100
- alphanumeric + `.` and `-`

Features not conforming to these constraints are stripped (with a debug-level log) from the config, but do not prevent engine startup. It's noteworthy that (like @tianon) some users might be adding "features" that are actually just comments, to serve as documentation, so we should be careful not breaking this.

Also added a maximum limit of 100 features, checked _after_ stripping all invalid/comment type features.

6864b6066b:

Adds a new query parameter to the (`GET`) Ping endpoint `/_ping?features=v1` that, if set, prompts the daemon to reply with a JSON representation of it's configured features.

Since clients will generally already by hitting the `/_ping` endpoint in order to negotiate API versions, this provides a way for clients to know which features are supported without extra roundtrips.

Currently this is only used to advertise whether the containerd image store integration is enabled or not – this is useful for situations like the CLI's `docker images --tree` (although in this case the output is ultimately mostly fine even if it doesn't include any manifests) or for things such as the client auth handling, which would only be implemented for pushing/pulling with the containerd store – without this, a client would have to attempt to use the new features, get a "not implemented" error back, and retry.

36d9646fa2: update API docs (swagger and version history)

**- How to verify it**

```console
curl -s --unix-socket /var/run/docker.sock http://localhost/_ping?features=v1 | jq
{
  "containerd-snapshotter": false
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Added `features` query parameter to the `/_ping` endpoint to request daemon features.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="594" alt="Screenshot 2024-11-21 at 12 14 16" src="https://github.com/user-attachments/assets/3fed59ec-6078-45e6-9082-6ca0407c6001">
