### PR TITLE
Remove buildkit init timeout

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -294,16 +294,13 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 
 	log.G(ctx).Info("Daemon has completed initialization")
 
-	routerCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	// Get a the current daemon config, because the daemon sets up config
 	// during initialization. We cannot user the cli.Config for that reason,
 	// as that only holds the config that was set by the user.
 	//
 	// FIXME(thaJeztah): better separate runtime and config data?
 	daemonCfg := d.Config()
-	routerOpts, err := newRouterOptions(routerCtx, &daemonCfg, d, c)
+	routerOpts, err := newRouterOptions(ctx, &daemonCfg, d, c)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/48569
- part of https://github.com/moby/moby/pull/48950
- relates to https://github.com/moby/buildkit/pull/5550


Buildkit *can* take a long time to start, we don't want the daemon to fail to startup because buildkit took too long.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

