### PR TITLE
[27.x] vendor: github.com/moby/buildkit 80e01a9dc7c1 (v0.17.3-dev)

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -67,7 +67,7 @@ require (
 	github.com/miekg/dns v1.1.57
 	github.com/mistifyio/go-zfs/v3 v3.0.1
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/moby/buildkit v0.17.2
+	github.com/moby/buildkit v0.17.3-0.20241126095802-80e01a9dc7c1 // v0.17 branch (v0.17.3-dev)
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/locker v1.0.1

--- a/vendor.sum
+++ b/vendor.sum
@@ -469,8 +469,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
-github.com/moby/buildkit v0.17.2 h1:/jgk/MuXbA7jeXMkknOpHYB+Ct4aNvQHkBB7SxD3D4U=
-github.com/moby/buildkit v0.17.2/go.mod h1:vr5vltV8wt4F2jThbNOChfbAklJ0DOW11w36v210hOg=
+github.com/moby/buildkit v0.17.3-0.20241126095802-80e01a9dc7c1 h1:BtPamBN42w+owbk4Uk5o5I5ijE8mGEVzZSd9Zz1Y6b4=
+github.com/moby/buildkit v0.17.3-0.20241126095802-80e01a9dc7c1/go.mod h1:vr5vltV8wt4F2jThbNOChfbAklJ0DOW11w36v210hOg=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/ipvs v1.1.0 h1:ONN4pGaZQgAx+1Scz5RvWV4Q7Gb+mvfRh3NsPS+1XQQ=

--- a/vendor/github.com/moby/buildkit/cache/metadata/metadata.go
+++ b/vendor/github.com/moby/buildkit/cache/metadata/metadata.go
@@ -193,7 +193,7 @@ func (s *Store) Get(id string) (*StorageItem, bool) {
 	}
 
 	var si *StorageItem
-	if err := s.db.Update(func(tx *bolt.Tx) error {
+	if err := s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(mainBucket))
 		if b == nil {
 			return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -711,7 +711,7 @@ github.com/mitchellh/hashstructure/v2
 # github.com/mitchellh/reflectwalk v1.0.2
 ## explicit
 github.com/mitchellh/reflectwalk
-# github.com/moby/buildkit v0.17.2
+# github.com/moby/buildkit v0.17.3-0.20241126095802-80e01a9dc7c1
 ## explicit; go 1.22.0
 github.com/moby/buildkit/api/services/control
 github.com/moby/buildkit/api/types


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/48569

Use view transaction for metadata read to prevent dockerd failing to fully start with a "context deadline exceeded error" with containerd snapshotter and many builds/images.

full diff: https://github.com/moby/buildkit/compare/v0.17.2...80e01a9dc7c1f5bab680bab7b43059ad7a413301

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Fix dockerd failing to fully start with a "context deadline exceeded error" with containerd snapshotter and many builds/images.
```

**- A picture of a cute animal (not mandatory but encouraged)**

