### PR TITLE
integration: remove default poll delay and timeouts

### DIFF
--- a/integration/capabilities/capabilities_linux_test.go
+++ b/integration/capabilities/capabilities_linux_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -80,7 +79,7 @@ func TestNoNewPrivileges(t *testing.T) {
 				container.WithSecurityOpt("no-new-privileges=true"),
 			)
 			cid := container.Run(ctx, t, client, opts...)
-			poll.WaitOn(t, container.IsInState(ctx, client, cid, "exited"), poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsInState(ctx, client, cid, "exited"))
 
 			// Assert on outputs
 			logReader, err := client.ContainerLogs(ctx, cid, containertypes.LogsOptions{

--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types/checkpoint"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -105,10 +104,7 @@ func TestCheckpoint(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	poll.WaitOn(t,
-		container.IsInState(ctx, apiClient, cID, "exited"),
-		poll.WithDelay(100*time.Millisecond),
-	)
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"))
 
 	inspect, err = apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -256,7 +256,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 		err = apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
 		assert.NilError(t, err)
 
-		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"))
 
 		checkInspect(t, ctx, name, tc.expected)
 	}
@@ -334,7 +334,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 		err = apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
 		assert.NilError(t, err)
 
-		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"))
 
 		checkInspect(t, ctx, name, tc.expected)
 	}

--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -37,7 +37,7 @@ func TestDiffStoppedContainer(t *testing.T) {
 
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("sh", "-c", `mkdir /foo; echo xyzzy > /foo/bar`))
 
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(60*time.Second))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithTimeout(60*time.Second))
 
 	expected := []containertypes.FilesystemChange{
 		{Kind: containertypes.ChangeAdd, Path: "/foo"},

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
@@ -26,7 +25,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"))
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 
 	reference := "repo/" + strings.ToLower(t.Name()) + ":v1"
 	exportResp, err := apiClient.ContainerExport(ctx, cID)

--- a/integration/container/health_test.go
+++ b/integration/container/health_test.go
@@ -29,7 +29,7 @@ func TestHealthCheckWorkdir(t *testing.T) {
 		}
 	})
 
-	poll.WaitOn(t, pollForHealthStatus(ctx, apiClient, cID, containertypes.Healthy), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctx, apiClient, cID, containertypes.Healthy))
 }
 
 // GitHub #37263
@@ -74,21 +74,21 @@ while true; do sleep 1; done
 
 	ctxPoll, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "healthy"))
 
 	err := apiClient.ContainerKill(ctx, id, "SIGUSR1")
 	assert.NilError(t, err)
 
 	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "unhealthy"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "unhealthy"))
 
 	err = apiClient.ContainerKill(ctx, id, "SIGUSR1")
 	assert.NilError(t, err)
 
 	ctxPoll, cancel = context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "healthy"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, pollForHealthStatus(ctxPoll, apiClient, id, "healthy"))
 }
 
 // TestHealthCheckProcessKilled verifies that health-checks exec get killed on time-out.
@@ -142,7 +142,7 @@ func TestHealthStartInterval(t *testing.T) {
 			return poll.Continue("waiting on container to be ready")
 		}
 		return poll.Success()
-	}, poll.WithDelay(100*time.Millisecond), poll.WithTimeout(time.Until(dl)))
+	}, poll.WithTimeout(time.Until(dl)))
 	cancel()
 
 	ctxPoll, cancel = context.WithTimeout(ctx, 2*time.Minute)

--- a/integration/container/kill_test.go
+++ b/integration/container/kill_test.go
@@ -3,7 +3,6 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"runtime"
 	"testing"
-	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
@@ -23,12 +22,12 @@ func TestKillContainerInvalidSignal(t *testing.T) {
 	err := apiClient.ContainerKill(ctx, id, "0")
 	assert.ErrorContains(t, err, "Error response from daemon:")
 	assert.ErrorContains(t, err, "nvalid signal: 0") // match "(I|i)nvalid" case-insensitive to allow testing against older daemons.
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "running"))
 
 	err = apiClient.ContainerKill(ctx, id, "SIG42")
 	assert.ErrorContains(t, err, "Error response from daemon:")
 	assert.ErrorContains(t, err, "nvalid signal: SIG42") // match "(I|i)nvalid" case-insensitive to allow testing against older daemons.
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "running"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "running"))
 }
 
 func TestKillContainer(t *testing.T) {
@@ -143,7 +142,7 @@ func TestKillDifferentUserContainer(t *testing.T) {
 
 	err := apiClient.ContainerKill(ctx, id, "SIGKILL")
 	assert.NilError(t, err)
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, id, "exited"))
 }
 
 func TestInspectOomKilledTrue(t *testing.T) {
@@ -159,7 +158,7 @@ func TestInspectOomKilledTrue(t *testing.T) {
 		c.HostConfig.Resources.Memory = 32 * 1024 * 1024
 	})
 
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"))
 
 	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
@@ -174,7 +173,7 @@ func TestInspectOomKilledFalse(t *testing.T) {
 
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("sh", "-c", "echo hello world"))
 
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"))
 
 	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -137,9 +137,7 @@ func testLogs(t *testing.T, logDriver string) {
 			)
 			defer apiClient.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
 
-			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id),
-				poll.WithDelay(time.Millisecond*100),
-				poll.WithTimeout(pollTimeout))
+			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id), poll.WithTimeout(pollTimeout))
 
 			logs, err := apiClient.ContainerLogs(ctx, id, tc.logOps)
 			assert.NilError(t, err)

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/api"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -271,7 +270,7 @@ func TestContainerBindMountNonRecursive(t *testing.T) {
 	}
 
 	for _, c := range containers {
-		poll.WaitOn(t, container.IsSuccessful(ctx, apiClient, c), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, container.IsSuccessful(ctx, apiClient, c))
 	}
 }
 
@@ -317,7 +316,7 @@ func TestContainerVolumesMountedAsShared(t *testing.T) {
 
 	apiClient := testEnv.APIClient()
 	containerID := container.Run(ctx, t, apiClient, container.WithPrivileged(true), container.WithMount(sharedMount), container.WithCmd(bindMountCmd...))
-	poll.WaitOn(t, container.IsSuccessful(ctx, apiClient, containerID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsSuccessful(ctx, apiClient, containerID))
 
 	// Make sure a bind mount under a shared volume propagated to host.
 	if mounted, _ := mountinfo.Mounted(tmpDir1Mnt); !mounted {
@@ -634,7 +633,7 @@ func TestContainerBindMountRecursivelyReadOnly(t *testing.T) {
 	}
 
 	for _, c := range containers {
-		poll.WaitOn(t, container.IsSuccessful(ctx, apiClient, c), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, container.IsSuccessful(ctx, apiClient, c))
 	}
 }
 

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"strings"
 	"testing"
-	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
@@ -76,7 +75,7 @@ func TestNetworkLoopbackNat(t *testing.T) {
 		container.WithNetworkMode("container:"+serverContainerID),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 
 	body, err := apiClient.ContainerLogs(ctx, cID, containertypes.LogsOptions{
 		ShowStdout: true,

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -3,7 +3,6 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"io"
 	"testing"
-	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -72,7 +71,7 @@ func TestPauseStopPausedContainer(t *testing.T) {
 	err = apiClient.ContainerStop(ctx, cID, containertypes.StopOptions{})
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 }
 
 func getEventActions(t *testing.T, messages <-chan events.Message, errs <-chan error) []events.Action {

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -3,7 +3,6 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"os"
 	"testing"
-	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -37,7 +36,7 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 	defer tempDir.Remove()
 
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithBind(tempDir.Path(), prefix+slash+"test"))
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"))
 
 	err := os.RemoveAll(tempDir.Path())
 	assert.NilError(t, err)
@@ -60,7 +59,7 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"))
 
 	insp, _, err := apiClient.ContainerInspectWithRaw(ctx, cID, true)
 	assert.NilError(t, err)

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -2,7 +2,6 @@ package container // import "github.com/docker/docker/integration/container"
 
 import (
 	"testing"
-	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -145,7 +144,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 		}
 		c.HostConfig.NetworkMode = containertypes.NetworkMode(networkName)
 	}, container.WithCmd("ping", count, "1", container1Name))
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"))
 
 	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -109,7 +109,7 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 						err = apiClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
 						assert.NilError(t, err)
 						if tc.xHealthCheck {
-							poll.WaitOn(t, pollForHealthStatus(ctx, apiClient, resp.ID, container.Healthy), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(30*time.Second))
+							poll.WaitOn(t, pollForHealthStatus(ctx, apiClient, resp.ID, container.Healthy), poll.WithTimeout(30*time.Second))
 							testContainer.ExecT(ctx, t, apiClient, resp.ID, []string{"touch", "/tmp/unhealthy"}).AssertSuccess(t)
 						}
 					}
@@ -123,7 +123,7 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 						expected = tc.xRunningLiveRestore
 					}
 
-					poll.WaitOn(t, testContainer.RunningStateFlagIs(ctx, apiClient, resp.ID, expected), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(30*time.Second))
+					poll.WaitOn(t, testContainer.RunningStateFlagIs(ctx, apiClient, resp.ID, expected), poll.WithTimeout(30*time.Second))
 
 					if tc.xHealthCheck {
 						// We have arranged to have the container's health probes fail until we tell it
@@ -131,10 +131,10 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 						// the container's health state is Starting before we have to worry about racing
 						// the health monitor.
 						assert.Equal(t, testContainer.Inspect(ctx, t, apiClient, resp.ID).State.Health.Status, container.Starting)
-						poll.WaitOn(t, pollForNewHealthCheck(ctx, apiClient, startTime, resp.ID), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(30*time.Second))
+						poll.WaitOn(t, pollForNewHealthCheck(ctx, apiClient, startTime, resp.ID), poll.WithTimeout(30*time.Second))
 
 						testContainer.ExecT(ctx, t, apiClient, resp.ID, []string{"rm", "/tmp/unhealthy"}).AssertSuccess(t)
-						poll.WaitOn(t, pollForHealthStatus(ctx, apiClient, resp.ID, container.Healthy), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(30*time.Second))
+						poll.WaitOn(t, pollForHealthStatus(ctx, apiClient, resp.ID, container.Healthy), poll.WithTimeout(30*time.Second))
 					}
 					// TODO(cpuguy83): test pause states... this seems to be rather undefined currently
 				})

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
@@ -185,7 +184,7 @@ func TestRunConsoleSize(t *testing.T) {
 		container.WithConsoleSize(57, 123),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 
 	out, err := apiClient.ContainerLogs(ctx, cID, containertypes.LogsOptions{ShowStdout: true})
 	assert.NilError(t, err)
@@ -230,7 +229,7 @@ func TestRunWithAlternativeContainerdShim(t *testing.T) {
 		container.WithRuntime("io.containerd.realfake.v42"),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 
 	out, err := apiClient.ContainerLogs(ctx, cID, containertypes.LogsOptions{ShowStdout: true})
 	assert.NilError(t, err)
@@ -250,7 +249,7 @@ func TestRunWithAlternativeContainerdShim(t *testing.T) {
 		container.WithCmd("sh", "-c", `echo 'Hello, world!'`),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 
 	out, err = apiClient.ContainerLogs(ctx, cID, containertypes.LogsOptions{ShowStdout: true})
 	assert.NilError(t, err)
@@ -314,7 +313,7 @@ func TestStaticIPOutsideSubpool(t *testing.T) {
 		container.WithIPv4(netname, "10.42.1.3"),
 	)
 
-	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID), poll.WithDelay(100*time.Millisecond))
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 
 	out, err := apiClient.ContainerLogs(ctx, cID, containertypes.LogsOptions{ShowStdout: true})
 	assert.NilError(t, err)

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -63,8 +63,7 @@ func TestStopContainerWithTimeout(t *testing.T) {
 			err := apiClient.ContainerStop(ctx, id, containertypes.StopOptions{Timeout: &tc.timeout})
 			assert.NilError(t, err)
 
-			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id),
-				poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id))
 
 			inspect, err := apiClient.ContainerInspect(ctx, id)
 			assert.NilError(t, err)

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -27,7 +27,7 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 	}
 
 	for _, name := range names {
-		poll.WaitOn(t, container.IsInState(ctx, apiClient, name, "running", "restarting"), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, container.IsInState(ctx, apiClient, name, "running", "restarting"))
 	}
 
 	for _, name := range names {
@@ -36,6 +36,6 @@ func TestStopContainerWithRestartPolicyAlways(t *testing.T) {
 	}
 
 	for _, name := range names {
-		poll.WaitOn(t, container.IsStopped(ctx, apiClient, name), poll.WithDelay(100*time.Millisecond))
+		poll.WaitOn(t, container.IsStopped(ctx, apiClient, name))
 	}
 }

--- a/integration/container/stop_windows_test.go
+++ b/integration/container/stop_windows_test.go
@@ -3,7 +3,6 @@ package container // import "github.com/docker/docker/integration/container"
 import (
 	"strconv"
 	"testing"
-	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
@@ -58,8 +57,7 @@ func TestStopContainerWithTimeout(t *testing.T) {
 			err := apiClient.ContainerStop(ctx, id, containertypes.StopOptions{Timeout: &d.timeout})
 			assert.NilError(t, err)
 
-			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id),
-				poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsStopped(ctx, apiClient, id))
 
 			inspect, err := apiClient.ContainerInspect(ctx, id)
 			assert.NilError(t, err)

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -35,7 +35,7 @@ func TestUpdateRestartPolicy(t *testing.T) {
 		timeout = 180 * time.Second
 	}
 
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(timeout))
+	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, "exited"), poll.WithTimeout(timeout))
 
 	inspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -42,7 +42,7 @@ func TestWaitNonBlocked(t *testing.T) {
 
 			ctx := testutil.StartSpan(ctx, t)
 			containerID := container.Run(ctx, t, cli, container.WithCmd("sh", "-c", tc.cmd))
-			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "exited"), poll.WithTimeout(30*time.Second), poll.WithDelay(100*time.Millisecond))
+			poll.WaitOn(t, container.IsInState(ctx, cli, containerID, "exited"), poll.WithTimeout(30*time.Second))
 
 			waitResC, errC := cli.ContainerWait(ctx, containerID, "")
 			select {

--- a/integration/network/dns_test.go
+++ b/integration/network/dns_test.go
@@ -2,7 +2,6 @@ package network // import "github.com/docker/docker/integration/network"
 
 import (
 	"testing"
-	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
@@ -33,7 +32,7 @@ func TestDaemonDNSFallback(t *testing.T) {
 	cid := container.Run(ctx, t, c, container.WithNetworkMode("test"), container.WithCmd("nslookup", "docker.com"))
 	defer c.ContainerRemove(ctx, cid, containertypes.RemoveOptions{Force: true})
 
-	poll.WaitOn(t, container.IsSuccessful(ctx, c, cid), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(10*time.Second))
+	poll.WaitOn(t, container.IsSuccessful(ctx, c, cid))
 }
 
 // Check that, when the internal DNS server's address is supplied as an external


### PR DESCRIPTION
The default delay is 100ms and default timeout is 10s, so we can remove cases where we are setting the defaults;

https://github.com/moby/moby/blob/d8fa0581eeeb1caa5d7f2bef4ac58c0366f92a11/vendor/gotest.tools/v3/poll/poll.go#L115 https://github.com/moby/moby/blob/d8fa0581eeeb1caa5d7f2bef4ac58c0366f92a11/vendor/gotest.tools/v3/poll/poll.go#L39-L40

**- A picture of a cute animal (not mandatory but encouraged)**

