### PR TITLE
[27.x backport] Fix lease management during pull and export

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -67,19 +67,14 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 		archive.WithSkipMissing(i.content),
 	}
 
-	leasesManager := i.client.LeasesService()
-	lease, err := leasesManager.Create(ctx, leases.WithRandomID())
+	ctx, done, err := i.withLease(ctx, false)
 	if err != nil {
 		return errdefs.System(err)
 	}
-	defer func() {
-		if err := leasesManager.Delete(ctx, lease); err != nil {
-			log.G(ctx).WithError(err).Warn("cleaning up lease")
-		}
-	}()
+	defer done()
 
 	addLease := func(ctx context.Context, target ocispec.Descriptor) error {
-		return leaseContent(ctx, i.content, leasesManager, lease, target)
+		return i.leaseContent(ctx, i.content, target)
 	}
 
 	exportImage := func(ctx context.Context, target ocispec.Descriptor, ref reference.Named) error {
@@ -206,7 +201,13 @@ func (i *ImageService) ExportImage(ctx context.Context, names []string, outStrea
 
 // leaseContent will add a resource to the lease for each child of the descriptor making sure that it and
 // its children won't be deleted while the lease exists
-func leaseContent(ctx context.Context, store content.Store, leasesManager leases.Manager, lease leases.Lease, desc ocispec.Descriptor) error {
+func (i *ImageService) leaseContent(ctx context.Context, store content.Store, desc ocispec.Descriptor) error {
+	lid, ok := leases.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+	lease := leases.Lease{ID: lid}
+	leasesManager := i.client.LeasesService()
 	return containerdimages.Walk(ctx, containerdimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		_, err := store.Info(ctx, desc.Digest)
 		if err != nil {

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -58,6 +58,11 @@ func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentIma
 		parentSnapshot = identity.ChainID(diffIDs).String()
 	}
 
+	// TODO: Consider a better way to do this. It is better to have a container directly
+	// reference a snapshot, however, that is not done today because a container may
+	// removed and recreated with nothing holding the snapshot in between. Consider
+	// removing this lease and only temporarily holding a lease on re-create, using
+	// non-expiring leases introduces the possibility of leaking resources.
 	ls := i.client.LeasesService()
 	lease, err := ls.Create(ctx, leases.WithID(id))
 	if err != nil {

--- a/daemon/containerd/leases.go
+++ b/daemon/containerd/leases.go
@@ -1,0 +1,52 @@
+package containerd
+
+import (
+	"context"
+	"time"
+
+	"github.com/containerd/containerd/leases"
+	"github.com/containerd/log"
+)
+
+const (
+	leaseExpireDuration = 8 * time.Hour
+	expireLabel         = "containerd.io/gc.expire" // Copied from containerd
+	pruneLeaseLabel     = "moby/prune.images"
+	pruneLeaseFilter    = `labels."moby/prune.images"`
+)
+
+// withLease is used to prevent content or snapshots from being eligible for
+// garbage collection while they are being used. Leases should always be
+// released when complete to make the resources eligible again.
+// If cancellable is set to true, then the lease will remain if the context
+// is canceled until its expiration or deletion via prune.
+func (i *ImageService) withLease(ctx context.Context, cancellable bool) (context.Context, func(), error) {
+	_, ok := leases.FromContext(ctx)
+	if ok {
+		return ctx, func() {}, nil
+	}
+
+	ls := i.client.LeasesService()
+
+	expireAt := time.Now().Add(leaseExpireDuration)
+	l, err := ls.Create(ctx,
+		leases.WithRandomID(),
+		leases.WithLabels(map[string]string{
+			pruneLeaseLabel: "true",
+			expireLabel:     expireAt.Format(time.RFC3339),
+		}))
+	if err != nil {
+		return ctx, func() {}, err
+	}
+
+	ctx = leases.WithLease(ctx, l.ID)
+	return ctx, func() {
+		if ctx.Err() != nil && cancellable {
+			log.G(ctx).WithFields(log.Fields{"lease": l.ID, "expires_at": expireAt}).Info("Cancel with lease, leased resources will remain until expiration")
+			return
+		}
+		if err := ls.Delete(context.WithoutCancel(ctx), l); err != nil {
+			log.G(ctx).WithError(err).WithFields(log.Fields{"lease": l.ID, "expires_at": expireAt}).Warn("Error deleting lease, leased resources will remain until expiration")
+		}
+	}, nil
+}


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48910

---

Ensure that leases have a reasonable expiration and are cleaned up during prune

Currently it seems some leases could be leaked as they were created with no expiration and their removal could fail due to using a canceled context.

- Fixes #48909


**- Description for the changelog**

```markdown changelog
containerd image-store: fix partially pulled images not being garbage-collected [moby#48910](https://github.com/moby/moby/pull/48910)
```


