### PR TITLE
Down with the sickness (AUTO_GOPATH)

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -77,12 +77,6 @@ if [ "$AUTO_GOPATH" ]; then
 	export GOPATH="${PWD}/.gopath"
 fi
 
-if [ ! "$GOPATH" ]; then
-	echo >&2 'error: missing GOPATH; please see https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable'
-	echo >&2 '  alternatively, set AUTO_GOPATH=1'
-	exit 1
-fi
-
 if [ -z "${EXCLUDE_AUTO_BUILDTAG_JOURNALD:-}" ] && ${PKG_CONFIG} 'libsystemd' 2> /dev/null; then
 	DOCKER_BUILDTAGS+=" journald"
 fi


### PR DESCRIPTION
Go has a nice tool to inspect the currently set (or default) `GOPATH` with `go env GOPATH`.
We should do that rather than absolutely requiring people to manually set `GOPATH` or use `AUTO_GOPATH`.

This doesn't actually remove `AUTO_GOPATH`, people can still use it.
