### PR TITLE
Fix br_netfilter module loading logic

### DIFF
--- a/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
+++ b/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
@@ -45,13 +45,22 @@ func setupIPv6BridgeNetFiltering(config *networkConfiguration, _ *bridgeInterfac
 	return nil
 }
 
+func loadBridgeNetFilterModule(fullPath string) error {
+	// br_netfilter implictly loads bridge module upon modprobe
+	modName := "br_netfilter"
+	if _, err := os.Stat(fullPath); err != nil {
+		if out, err := exec.Command("modprobe", "-va", modName).CombinedOutput(); err != nil {
+			log.G(context.TODO()).WithError(err).Errorf("Running modprobe %s failed with message: %s", modName, out)
+			return fmt.Errorf("cannot restrict inter-container communication: modprobe %s failed: %w", modName, err)
+		}
+	}
+	return nil
+}
+
 // Enable bridge net filtering if not already enabled. See GitHub issue #11404
 func enableBridgeNetFiltering(nfParam string) error {
-	if _, err := os.Stat("/proc/sys/net/bridge"); err != nil {
-		if out, err := exec.Command("modprobe", "-va", "bridge", "br_netfilter").CombinedOutput(); err != nil {
-			log.G(context.TODO()).WithError(err).Errorf("Running modprobe bridge br_netfilter failed with message: %s", out)
-			return fmt.Errorf("cannot restrict inter-container communication: modprobe br_netfilter failed: %w", err)
-		}
+	if err := loadBridgeNetFilterModule(nfParam); err != nil {
+		return fmt.Errorf("loadBridgeNetFilterModule failed: %s", err)
 	}
 	enabled, err := getKernelBoolParam(nfParam)
 	if err != nil {


### PR DESCRIPTION
Checking for `/proc/sys/net/bridge` directory alone is not enough to decide if bridge, br_netfilter module to be loaded. Check for specific file for each bridge & br_netfilter module and then do modprobe if the file is not found in `/proc/sys/net/bridge`

Fixes: https://github.com/moby/moby/issues/48948

Please provide the following information:
-->

**- What I did**
Fix loading of bridge and br_netfilter kernel modules

**- How I did it**
By check for presence of specific files for each module in procfs

**- How to verify it**
```
systemctl restart docker
lsmod | grep br_netfilter
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix loading of `bridge` and `br_netfilter` kernel modules.
```

**- A picture of a cute animal (not mandatory but encouraged)**

