### PR TITLE
🚧 WIP daemon/exec: fix race preventing exec clean up

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -178,8 +178,9 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 		"execID": ec.ID,
 	})
 
+	var started bool
 	defer func() {
-		if err != nil {
+		if err != nil && !started {
 			ec.Lock()
 			ec.Container.ExecCommands.Delete(ec.ID)
 			ec.Running = false
@@ -294,6 +295,8 @@ func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, optio
 		return setExitCodeFromError(ec.SetExitCode, err)
 	}
 	ec.Unlock()
+
+	started = true
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes https://github.com/moby/moby/issues/48908

**- What I did**

When an exec start fails and returns an error (particularly, due to context cancellation, but this can happen in other cases as well) one of two things can happen:
- either it fails in a way that containerd does not actually get to starting the process, and as such no exit event is published for the exec,
- or it fails but containerd has already started the process, in which case it will still publish an exit event.

In the latter case, the `defer`red block in `daemon.ContainerExecStart`: https://github.com/moby/moby/blob/431e829f5053746b7b40a24fd13be2a846f16af4/daemon/exec.go#L181-L197 will race against `daemon.ProcessEvent`:
https://github.com/moby/moby/blob/431e829f5053746b7b40a24fd13be2a846f16af4/daemon/monitor.go#L179-L222 (which processes exit events) to handle the exit.

This happens because the original `defer`red block deletes the exec from the container's store:
https://github.com/moby/moby/blob/431e829f5053746b7b40a24fd13be2a846f16af4/daemon/exec.go#L184 which is where `daemon.ProcessEvent` gets the exec from for deleting: https://github.com/moby/moby/blob/431e829f5053746b7b40a24fd13be2a846f16af4/daemon/monitor.go#L179

We've known about this for a while: https://github.com/moby/moby/blob/431e829f5053746b7b40a24fd13be2a846f16af4/daemon/monitor.go#L203-L210

However, this is also the root cause for PID files accumulating in `/run/containerd/io.containerd.runtime.v2.task/moby/xxxxxx`, since when the `daemon.ContainerExecStart` deletes the exec from the container's store before `daemon.ProcessEvent` gets to it, `daemon.ProcessEvent` can't cleanup the exec, so the daemon can't call into containerd to delete the process, which would normally cleanup the PID file:

https://github.com/containerd/containerd/blob/c11645039862bd517016eeed6400738c0fa156e5/pkg/process/exec.go#L116

**- How I did it**

This (WIP) commit shows that preventing the race condition here fixes the pid file issue.

**- How to verify it**

From https://github.com/moby/moby/issues/48908:

- run a container:
```console
$ docker run -d \
    --name fail_timeout \
    --health-cmd='sleep 10' \
    --health-timeout=1s \
    --health-retries=1 \
    --health-interval=1s \
    --restart=always \
     alpine tail -f /dev/null
```

In another terminal, watch the PID files increasing:
```console
$ watch -n .2 "ls /var/run/docker/containerd/daemon/io.containerd.runtime.v2.task/moby/{CONTAINER ID}/ | wc -l"
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fixed issue causing PID files for execs to sometimes not be cleaned up and accumulate in the file system.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="564" alt="Screenshot 2024-11-27 at 14 16 58" src="https://github.com/user-attachments/assets/f245128f-a4f1-4230-aeb8-7d7229ed9f1a">
