### PR TITLE
[27.x backport] daemon/graphdriver/zfs: ignore non-existent dataset on removal

### DIFF
--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -353,6 +353,17 @@ func (d *Driver) Remove(id string) error {
 	name := d.zfsPath(id)
 	dataset := zfs.Dataset{Name: name}
 	err := dataset.Destroy(zfs.DestroyRecursive)
+	if err != nil {
+		var errZfs *zfs.Error
+		isZfsError := errors.As(err, &errZfs)
+		if isZfsError && strings.HasSuffix(strings.TrimSpace(errZfs.Stderr), "dataset does not exist") {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":          err,
+				"storage-driver": "zfs",
+			}).Warnf("Tried to destroy inexistent dataset %q", name)
+			err = nil
+		}
+	}
 	if err == nil {
 		d.Lock()
 		delete(d.filesystemsCache, name)


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48520
- fixes https://github.com/moby/moby/issues/43080

----

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I updated the Remove function to ignore the "dataset does not exist" error

**- How I did it**

Doing a strings.Contains of "dataset does not exist" in err

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Ignores "dataset does not exist" error when removing dataset on ZFS (#43080)
```

![image](https://github.com/user-attachments/assets/962b0a7f-3bfa-4db4-837a-0769b472e2eb)

