### PR TITLE
Release IPv6 address if IPv6 is disabled on an interface

### DIFF
--- a/daemon/libnetwork/driverapi/driverapi.go
+++ b/daemon/libnetwork/driverapi/driverapi.go
@@ -107,6 +107,15 @@ type ExtConner interface {
 	ProgramExternalConnectivity(ctx context.Context, nid, eid string, gw4Id, gw6Id string) error
 }
 
+// IPv6Releaser is an optional interface for a network driver.
+type IPv6Releaser interface {
+	// ReleaseIPv6 tells the driver that an endpoint has no IPv6 address, even
+	// if the options passed to Driver.CreateEndpoint specified an address. This
+	// happens when, for example, sysctls applied after configuring the interface
+	// disable IPv6.
+	ReleaseIPv6(ctx context.Context, nid, eid string) error
+}
+
 // GwAllocChecker is an optional interface for a network driver.
 type GwAllocChecker interface {
 	// GetSkipGwAlloc returns true if the opts describe a network

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -548,17 +548,6 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 		ep.joinInfo.gw6 = nil
 	}
 
-	if !n.getController().isAgent() {
-		if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
-			n.updateSvcRecord(context.WithoutCancel(ctx), ep, true)
-		}
-	}
-
-	sb.addHostsEntries(ctx, ep.getEtcHostsAddrs())
-	if err := sb.updateDNS(n.enableIPv6); err != nil {
-		return err
-	}
-
 	// Current endpoint(s) providing external connectivity for the Sandbox.
 	// If ep is selected as a gateway endpoint once it's been added to the Sandbox,
 	// these are the endpoints that need to be un-gateway'd.

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -1268,15 +1268,6 @@ func (n *Network) createEndpoint(ctx context.Context, name string, options ...En
 		}
 	}()
 
-	if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
-		n.updateSvcRecord(context.WithoutCancel(ctx), ep, true)
-		defer func() {
-			if err != nil {
-				n.updateSvcRecord(context.WithoutCancel(ctx), ep, false)
-			}
-		}()
-	}
-
 	return ep, nil
 }
 

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -1240,7 +1240,7 @@ func (n *Network) createEndpoint(ctx context.Context, name string, options ...En
 	}
 	defer func() {
 		if err != nil {
-			ep.releaseAddress()
+			ep.releaseIPAddresses()
 		}
 	}()
 

--- a/daemon/libnetwork/network_unix.go
+++ b/daemon/libnetwork/network_unix.go
@@ -3,7 +3,6 @@
 package libnetwork
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -19,16 +18,6 @@ type platformNetwork struct{} //nolint:nolintlint,unused // only populated on wi
 // Stub implementations for DNS related functions
 
 func (n *Network) startResolver() {
-}
-
-func addEpToResolver(
-	ctx context.Context,
-	netName, epName string,
-	config *containerConfig,
-	epIface *EndpointInterface,
-	resolvers []*Resolver,
-) error {
-	return nil
 }
 
 func deleteEpFromResolver(epName string, epIface *EndpointInterface, resolvers []*Resolver) error {

--- a/daemon/libnetwork/osl/namespace_linux.go
+++ b/daemon/libnetwork/osl/namespace_linux.go
@@ -249,7 +249,8 @@ func (n *Namespace) Interfaces() []*Interface {
 	return ifaces
 }
 
-func (n *Namespace) ifaceBySrcName(srcName string) *Interface {
+// InterfaceBySrcName returns a pointer to the Interface with a matching srcName, else nil.
+func (n *Namespace) InterfaceBySrcName(srcName string) *Interface {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	for _, iface := range n.iFaces {
@@ -505,7 +506,6 @@ func (n *Namespace) IPv6LoEnabled() bool {
 func (n *Namespace) RefreshIPv6LoEnabled() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-
 	// If anything goes wrong, assume no-IPv6.
 	n.ipv6LoEnabledCached = false
 	iface, err := n.nlHandle.LinkByName("lo")

--- a/daemon/libnetwork/osl/route_linux.go
+++ b/daemon/libnetwork/osl/route_linux.go
@@ -240,7 +240,7 @@ func (n *Namespace) SetDefaultRouteIPv6(srcName string) error {
 }
 
 func (n *Namespace) setDefaultRoute(srcName string, routeMatcher func(*net.IPNet) bool) error {
-	iface := n.ifaceBySrcName(srcName)
+	iface := n.InterfaceBySrcName(srcName)
 	if iface == nil {
 		return errors.New("no interface")
 	}
@@ -308,7 +308,7 @@ func (n *Namespace) unsetDefaultRoute(srcName string, routeMatcher func(*net.IPN
 		return nil
 	}
 
-	iface := n.ifaceBySrcName(srcName)
+	iface := n.InterfaceBySrcName(srcName)
 	if iface == nil {
 		return nil
 	}

--- a/daemon/libnetwork/sandbox_dns_windows.go
+++ b/daemon/libnetwork/sandbox_dns_windows.go
@@ -17,10 +17,4 @@ func (sb *Sandbox) restoreHostsPath() {}
 
 func (sb *Sandbox) restoreResolvConfPath() {}
 
-func (sb *Sandbox) addHostsEntries(_ context.Context, ifaceIP []netip.Addr) {}
-
 func (sb *Sandbox) deleteHostsEntries(ifaceAddrs []netip.Addr) {}
-
-func (sb *Sandbox) updateDNS(ipv6Enabled bool) error {
-	return nil
-}

--- a/daemon/libnetwork/sandbox_dns_windows.go
+++ b/daemon/libnetwork/sandbox_dns_windows.go
@@ -17,9 +17,7 @@ func (sb *Sandbox) restoreHostsPath() {}
 
 func (sb *Sandbox) restoreResolvConfPath() {}
 
-func (sb *Sandbox) addHostsEntries(_ context.Context, ifaceIP []netip.Addr) error {
-	return nil
-}
+func (sb *Sandbox) addHostsEntries(_ context.Context, ifaceIP []netip.Addr) {}
 
 func (sb *Sandbox) deleteHostsEntries(ifaceAddrs []netip.Addr) {}
 

--- a/daemon/libnetwork/sandbox_linux.go
+++ b/daemon/libnetwork/sandbox_linux.go
@@ -432,6 +432,12 @@ func (sb *Sandbox) populateNetworkResourcesOS(ctx context.Context, ep *Endpoint)
 		}
 	}
 
+	sb.addHostsEntries(ctx, ep.getEtcHostsAddrs())
+	// Make sure /etc/resolv.conf is set up.
+	if err := sb.updateDNS(ep.getNetwork().enableIPv6); err != nil {
+		return err
+	}
+
 	// Populate load balancer only after updating all the other
 	// information including gateway and other routes so that
 	// loadbalancers are populated all the network state is in

--- a/daemon/libnetwork/sandbox_linux.go
+++ b/daemon/libnetwork/sandbox_linux.go
@@ -10,9 +10,6 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/netutils"
 	"github.com/moby/moby/v2/daemon/libnetwork/osl"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Linux-specific container configuration flags.
@@ -330,9 +327,6 @@ func (sb *Sandbox) finishEndpointConfig(ctx context.Context) error {
 		if err := sb.populateNetworkResources(ctx, ep); err != nil {
 			return err
 		}
-		if err := ep.populateNetworkResources(ctx, sb); err != nil {
-			return err
-		}
 	}
 
 	gwep4, gwep6 := sb.getGatewayEndpoint()
@@ -355,11 +349,7 @@ func (sb *Sandbox) canPopulateNetworkResources() bool {
 	return sb.osSbox != nil
 }
 
-func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) error {
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.Sandbox.populateNetworkResources", trace.WithAttributes(
-		attribute.String("endpoint.Name", ep.Name())))
-	defer span.End()
-
+func (sb *Sandbox) populateNetworkResourcesOS(ctx context.Context, ep *Endpoint) error {
 	sb.mu.Lock()
 	if sb.osSbox == nil {
 		sb.mu.Unlock()

--- a/daemon/libnetwork/sandbox_windows.go
+++ b/daemon/libnetwork/sandbox_windows.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/moby/moby/v2/daemon/libnetwork/osl"
+	"github.com/moby/moby/v2/errdefs"
 )
 
 func releaseOSSboxResources(*osl.Namespace, *Endpoint) {}
@@ -37,8 +38,11 @@ func (sb *Sandbox) canPopulateNetworkResources() bool {
 	return true
 }
 
-func (sb *Sandbox) populateNetworkResources(context.Context, *Endpoint) error {
-	// not implemented on Windows (Sandbox.osSbox is always nil)
+func (sb *Sandbox) populateNetworkResourcesOS(ctx context.Context, ep *Endpoint) error {
+	n := ep.getNetwork()
+	if err := addEpToResolver(ctx, n.Name(), ep.Name(), &sb.config, ep.iface, n.Resolvers()); err != nil {
+		return errdefs.System(err)
+	}
 	return nil
 }
 

--- a/daemon/libnetwork/sandbox_windows.go
+++ b/daemon/libnetwork/sandbox_windows.go
@@ -33,6 +33,10 @@ func (sb *Sandbox) NetnsPath() (path string, ok bool) {
 	return "", false
 }
 
+func (sb *Sandbox) canPopulateNetworkResources() bool {
+	return true
+}
+
 func (sb *Sandbox) populateNetworkResources(context.Context, *Endpoint) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)
 	return nil

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1117,6 +1117,10 @@ func buildEndpointInfo(networkSettings *network.Settings, n *libnetwork.Network,
 		onesv6, _ := iface.AddressIPv6().Mask.Size()
 		networkSettings.Networks[nwName].GlobalIPv6Address = iface.AddressIPv6().IP.String()
 		networkSettings.Networks[nwName].GlobalIPv6PrefixLen = onesv6
+	} else {
+		// If IPv6 was disabled on the interface, and its address was removed, remove it here too.
+		networkSettings.Networks[nwName].GlobalIPv6Address = ""
+		networkSettings.Networks[nwName].GlobalIPv6PrefixLen = 0
 	}
 
 	return nil


### PR DESCRIPTION
**- What I did**

When running:
```
  docker network create --ipv6 b46
  docker run --rm -ti \
    --network name=b46,driver-opt=com.docker.network.endpoint.sysctls=net.ipv6.conf.IFNAME.disable_ipv6=1 \
     busybox
```

IPv6 is enabled in the container and the network, so an IPv6 address will be allocated for the endpoint.

But, when the sysctl is applied, the IPv6 address will be removed from the interface ... so, no unsolicited neighbour advertisement should be (or can be) sent and, the endpoint should not be treated as dual-stack when selecting a gateway endpoint and, if it is selected as the gateway endpoint, setting up an IPv6 route via the network will fail.

In 27.x (the release that added per-endpoint sysctls), the error is ...

```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running prestart hook #0: exit status 1, stdout: , stderr: failed to set IPv6 gateway while updating gateway: route for the gateway fd4b:b3cd:ce0c::1 could not be found: network is unreachable: unknown.
```

In 28.0 (because the `SetKey` hook isn't used any more, in this case), it's ...

```
docker: Error response from daemon: failed to set up container networking: failed to add interface veth3368cd8 to sandbox: failed to advertise addresses: write ip ::1->ff02::1: sendmsg: invalid argument
```

**- How I did it**

See the individual commit messages ... refactoring, with the bug fix in the final commit.

The refactoring means Sandbox and Endpoint config happens in the same order, whether or not the OS Sandbox has been created when the Endpoint is added.

**- How to verify it**

Exiting and new integration tests.

**- Description for the changelog**
```markdown changelog
- Fix an issue preventing container startup or selection of its network gateway when IPv6 is only disabled on a specific interface.
```
