### PR TITLE
daemon/config: add validation of exec-config options

### DIFF
--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -245,6 +245,20 @@ func validatePlatformConfig(conf *Config) error {
 	return verifyDefaultCgroupNsMode(conf.CgroupNamespaceMode)
 }
 
+// validatePlatformExecOpt validates if the given exec-opt and value are valid
+// for the current platform.
+func validatePlatformExecOpt(opt, value string) error {
+	switch opt {
+	case "isolation":
+		return fmt.Errorf("option '%s' is only supported on windows", opt)
+	case "native.cgroupdriver":
+		// TODO(thaJeztah): add validation that's currently in daemon.verifyCgroupDriver
+		return nil
+	default:
+		return fmt.Errorf("unknown option: '%s'", opt)
+	}
+}
+
 // verifyUserlandProxyConfig verifies if a valid userland-proxy path
 // is configured if userland-proxy is enabled.
 func verifyUserlandProxyConfig(conf *Config) error {

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -2,6 +2,7 @@ package config // import "github.com/docker/docker/daemon/config"
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -88,4 +89,18 @@ func validatePlatformConfig(conf *Config) error {
 		log.G(context.TODO()).Warn(`WARNING: MTU for the default network is not configurable on Windows, and this option will be ignored.`)
 	}
 	return nil
+}
+
+// validatePlatformExecOpt validates if the given exec-opt and value are valid
+// for the current platform.
+func validatePlatformExecOpt(opt, value string) error {
+	switch opt {
+	case "isolation":
+		// TODO(thaJeztah): add validation that's currently in Daemon.setDefaultIsolation()
+		return nil
+	case "native.cgroupdriver":
+		return fmt.Errorf("option '%s' is only supported on linux", opt)
+	default:
+		return fmt.Errorf("unknown option: '%s'", opt)
+	}
 }


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/48985

### daemon/config: add basic validation of exec-opt options

Validate if options are passed in the right format and if the given option
is supported on the current platform.

Before this patch, no validation would happen until the daemon was started,
and unknown options as well as incorrectly formatted options would be silently
ignored on Linux;

    dockerd --exec-opt =value-only --validate
    configuration OK
    
    dockerd --exec-opt unknown-opt=unknown-value --validate
    configuration OK
    
    dockerd --exec-opt unknown-opt=unknown-value --validate
    ...
    INFO[2024-11-28T12:07:44.255942174Z] Daemon has completed initialization
    INFO[2024-11-28T12:07:44.361412049Z] API listen on /var/run/docker.sock

With this patch, exec-opts are included in the validation before the daemon
is started/created, and errors are produced when trying to use an option
that's either unknown or not supported by the platform;

    dockerd --exec-opt =value-only --validate
    unable to configure the Docker daemon with file /etc/docker/daemon.json: merged configuration validation from file and command line flags failed: invalid exec-opt (=value-only): must be formatted 'opt=value'
    
    dockerd --exec-opt isolation=default --validate
    unable to configure the Docker daemon with file /etc/docker/daemon.json: merged configuration validation from file and command line flags failed: invalid exec-opt (isolation=default): 'isolation' option is only supported on windows
    
    dockerd --exec-opt unknown-opt=unknown-value --validate
    unable to configure the Docker daemon with file /etc/docker/daemon.json: merged configuration validation from file and command line flags failed: invalid exec-opt (unknown-opt=unknown-value): unknown option: 'unknown-opt'


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Improve validation of "exec-opts" in daemon configuration
```

**- A picture of a cute animal (not mandatory but encouraged)**

