### PR TITLE
ci: use edge releases of buildx

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -28,7 +28,7 @@ env:
   DOCKER_EXPERIMENTAL: 1
   DOCKER_GRAPHDRIVER: ${{ inputs.storage == 'snapshotter' && 'overlayfs' || 'overlay2' }}
   TEST_INTEGRATION_USE_SNAPSHOTTER: ${{ inputs.storage == 'snapshotter' && '1' || '' }}
-  SETUP_BUILDX_VERSION: latest
+  SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
 
 jobs:

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -31,7 +31,7 @@ env:
   PLATFORM: Moby Engine - Nightly
   PRODUCT: moby-bin
   PACKAGER_NAME: The Moby Project
-  SETUP_BUILDX_VERSION: latest
+  SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
 
 jobs:

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -24,7 +24,7 @@ on:
 env:
   GO_VERSION: "1.23.3"
   DESTDIR: ./build
-  SETUP_BUILDX_VERSION: latest
+  SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   DESTDIR: ./build
-  SETUP_BUILDX_VERSION: latest
+  SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ env:
   GO_VERSION: "1.23.3"
   GIT_PAGER: "cat"
   PAGER: "cat"
-  SETUP_BUILDX_VERSION: latest
+  SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
 
 jobs:


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/48964#discussion_r1860371031
relates to https://github.com/docker/actions-toolkit/pull/510

This allows to use edge releases of buildx when building (latest stable or latest RC if there is one).