### PR TITLE
daemon: Daemon.RegistryHosts: use internal method to get daemon config

### DIFF
--- a/daemon/hosts.go
+++ b/daemon/hosts.go
@@ -33,7 +33,7 @@ func (daemon *Daemon) RegistryHosts(host string) ([]docker.RegistryHost, error) 
 	})(host)
 	if err == nil {
 		// Merge in legacy configuration if provided
-		if cfg := daemon.Config(); len(cfg.Mirrors) > 0 || len(cfg.InsecureRegistries) > 0 {
+		if cfg := daemon.config().Config; len(cfg.Mirrors) > 0 || len(cfg.InsecureRegistries) > 0 {
 			hosts, err = daemon.mergeLegacyConfig(host, hosts)
 		}
 	}


### PR DESCRIPTION
The Daemon.Config() option was added to expose the Config outside of the daemon package. Limit the use of that function to that purpose and use the internal, non-exported functions within the daemon itself; this makes it easier to see if there's still external consumers of the Config() method.


