### PR TITLE
daemon/config: some refactor and  deprecate Config.ValidatePlatformConfig

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -740,7 +740,7 @@ func Validate(config *Config) error {
 	}
 
 	// validate platform-specific settings
-	return config.ValidatePlatformConfig()
+	return validatePlatformConfig(config)
 }
 
 // MaskCredentials masks credentials that are in an URL.

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -180,7 +180,7 @@ func verifyDefaultIpcMode(mode string) error {
 func verifyDefaultCgroupNsMode(mode string) error {
 	cm := container.CgroupnsMode(mode)
 	if !cm.Valid() {
-		return fmt.Errorf(`default cgroup namespace mode (%v) is invalid; use "host" or "private"`, cm)
+		return fmt.Errorf(`invalid default cgroup namespace (%v): use "host" or "private"`, cm)
 	}
 
 	return nil

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -129,30 +129,10 @@ func (conf *Config) IsSwarmCompatible() error {
 }
 
 // ValidatePlatformConfig checks if any platform-specific configuration settings are invalid.
+//
+// Deprecated: this function was only used internally and is no longer used. Use [Validate] instead.
 func (conf *Config) ValidatePlatformConfig() error {
-	if conf.EnableUserlandProxy {
-		if conf.UserlandProxyPath == "" {
-			return errors.New("invalid userland-proxy-path: userland-proxy is enabled, but userland-proxy-path is not set")
-		}
-		if !filepath.IsAbs(conf.UserlandProxyPath) {
-			return errors.New("invalid userland-proxy-path: must be an absolute path: " + conf.UserlandProxyPath)
-		}
-		// Using exec.LookPath here, because it also produces an error if the
-		// given path is not a valid executable or a directory.
-		if _, err := exec.LookPath(conf.UserlandProxyPath); err != nil {
-			return errors.Wrap(err, "invalid userland-proxy-path")
-		}
-	}
-
-	if err := verifyDefaultIpcMode(conf.IpcMode); err != nil {
-		return err
-	}
-
-	if err := bridge.ValidateFixedCIDRV6(conf.FixedCIDRv6); err != nil {
-		return errors.Wrap(err, "invalid fixed-cidr-v6")
-	}
-
-	return verifyDefaultCgroupNsMode(conf.CgroupNamespaceMode)
+	return validatePlatformConfig(conf)
 }
 
 // IsRootless returns conf.Rootless on Linux but false on Windows
@@ -247,6 +227,33 @@ func lookupBinPath(binary string) (string, error) {
 
 	// if we checked all the "libexec" directories and found no matches, fall back to PATH
 	return exec.LookPath(binary)
+}
+
+// validatePlatformConfig checks if any platform-specific configuration settings are invalid.
+func validatePlatformConfig(conf *Config) error {
+	if conf.EnableUserlandProxy {
+		if conf.UserlandProxyPath == "" {
+			return errors.New("invalid userland-proxy-path: userland-proxy is enabled, but userland-proxy-path is not set")
+		}
+		if !filepath.IsAbs(conf.UserlandProxyPath) {
+			return errors.New("invalid userland-proxy-path: must be an absolute path: " + conf.UserlandProxyPath)
+		}
+		// Using exec.LookPath here, because it also produces an error if the
+		// given path is not a valid executable or a directory.
+		if _, err := exec.LookPath(conf.UserlandProxyPath); err != nil {
+			return errors.Wrap(err, "invalid userland-proxy-path")
+		}
+	}
+
+	if err := verifyDefaultIpcMode(conf.IpcMode); err != nil {
+		return err
+	}
+
+	if err := bridge.ValidateFixedCIDRV6(conf.FixedCIDRv6); err != nil {
+		return errors.Wrap(err, "invalid fixed-cidr-v6")
+	}
+
+	return verifyDefaultCgroupNsMode(conf.CgroupNamespaceMode)
 }
 
 func verifyDefaultIpcMode(mode string) error {

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -64,11 +64,10 @@ func (conf *Config) IsSwarmCompatible() error {
 }
 
 // ValidatePlatformConfig checks if any platform-specific configuration settings are invalid.
+//
+// Deprecated: this function was only used internally and is no longer used. Use [Validate] instead.
 func (conf *Config) ValidatePlatformConfig() error {
-	if conf.MTU != 0 && conf.MTU != DefaultNetworkMtu {
-		log.G(context.TODO()).Warn(`WARNING: MTU for the default network is not configurable on Windows, and this option will be ignored.`)
-	}
-	return nil
+	return validatePlatformConfig(conf)
 }
 
 // IsRootless returns conf.Rootless on Linux but false on Windows
@@ -80,5 +79,13 @@ func setPlatformDefaults(cfg *Config) error {
 	cfg.Root = filepath.Join(os.Getenv("programdata"), "docker")
 	cfg.ExecRoot = filepath.Join(os.Getenv("programdata"), "docker", "exec-root")
 	cfg.Pidfile = filepath.Join(cfg.Root, "docker.pid")
+	return nil
+}
+
+// validatePlatformConfig checks if any platform-specific configuration settings are invalid.
+func validatePlatformConfig(conf *Config) error {
+	if conf.MTU != 0 && conf.MTU != DefaultNetworkMtu {
+		log.G(context.TODO()).Warn(`WARNING: MTU for the default network is not configurable on Windows, and this option will be ignored.`)
+	}
 	return nil
 }


### PR DESCRIPTION

### daemon/config: verifyDefaultCgroupNsMode: update error message for consistency

Most validation errors have the "invalid xxxxx" prefix; format this error
to be consitent with other errors.


### daemon/config: move utility-functions separate from Config methods

### daemon/config: deprecate Config.ValidatePlatformConfig

This method was only used internally as part of config.Validate; deprecate
it in favor of config.Validate and make it a non-exported function.

### daemon/config: extract validation of userland-proxy config




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Deprecate daemon/config.Config.ValidatePlatformConfig(). This method was used as helper for config.Validate, which should be used instead.
```

**- A picture of a cute animal (not mandatory but encouraged)**

