### PR TITLE
Add --host-gateway-ip to the dockerd manpage

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -36,6 +36,7 @@ dockerd - Enable daemon mode
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
 [**-H**|**--host**[=*[]*]]
+[**--host-gateway-ip**[=*HOST-GATEWAY-IP*]]
 [**--help**]
 [**--http-proxy**[*""*]]
 [**--https-proxy**[*""*]]
@@ -248,6 +249,11 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 unix://[/path/to/socket] to use.
   The socket(s) to bind to in daemon mode specified using one or more
   tcp://host:port, unix:///path/to/socket, fd://\* or fd://socketfd.
+
+**--host-gateway-ip**=[*2001:db8::1234*]
+  Supply host addresses to substitute for the special string host-gateway in
+  --add-host options. Addresses from the docker0 bridge are used by default.
+  Two of these options are allowed, one IPv4 and one IPv6 address.
 
 **--help**
   Print usage statement

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -35,9 +35,9 @@ dockerd - Enable daemon mode
 [**--fixed-cidr**[=*FIXED-CIDR*]]
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
+[**--help**]
 [**-H**|**--host**[=*[]*]]
 [**--host-gateway-ip**[=*HOST-GATEWAY-IP*]]
-[**--help**]
 [**--http-proxy**[*""*]]
 [**--https-proxy**[*""*]]
 [**--icc**[=**true**]]
@@ -245,6 +245,9 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   Group to assign the unix socket specified by -H when running in daemon mode.
   use '' (the empty string) to disable setting of a group. Default is `docker`.
 
+**--help**
+  Print usage statement
+
 **-H**, **--host**=[*unix:///var/run/docker.sock*]: tcp://[host:port] to bind or
 unix://[/path/to/socket] to use.
   The socket(s) to bind to in daemon mode specified using one or more
@@ -254,9 +257,6 @@ unix://[/path/to/socket] to use.
   Supply host addresses to substitute for the special string host-gateway in
   --add-host options. Addresses from the docker0 bridge are used by default.
   Two of these options are allowed, one IPv4 and one IPv6 address.
-
-**--help**
-  Print usage statement
 
 **--http-proxy***""*
   Proxy URL for HTTP requests unless overridden by NoProxy.


### PR DESCRIPTION
**- What I did**

- related to https://github.com/docker/cli/pull/5607

Add `--host-gateway-ip` to moby's copy of the dockerd manpage, and put `--help` before `--host`.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

