### PR TITLE
[27.x] Revert "Fix br_netfilter module loading logic"

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
+	"os/exec"
 	"strconv"
 	"sync"
 
@@ -478,6 +480,14 @@ func (d *driver) configure(option map[string]interface{}) error {
 		// No GenericData option set. Use defaults.
 	default:
 		return &ErrInvalidDriverConfig{}
+	}
+
+	if config.EnableIPTables || config.EnableIP6Tables {
+		if _, err := os.Stat("/proc/sys/net/bridge"); err != nil {
+			if out, err := exec.Command("modprobe", "-va", "bridge", "br_netfilter").CombinedOutput(); err != nil {
+				log.G(context.TODO()).Warnf("Running modprobe bridge br_netfilter failed with message: %s, error: %v", out, err)
+			}
+		}
 	}
 
 	if config.EnableIPTables {

--- a/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
+++ b/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
@@ -45,22 +45,13 @@ func setupIPv6BridgeNetFiltering(config *networkConfiguration, _ *bridgeInterfac
 	return nil
 }
 
-func loadBridgeNetFilterModule(fullPath string) error {
-	// br_netfilter implictly loads bridge module upon modprobe
-	modName := "br_netfilter"
-	if _, err := os.Stat(fullPath); err != nil {
-		if out, err := exec.Command("modprobe", "-va", modName).CombinedOutput(); err != nil {
-			log.G(context.TODO()).WithError(err).Errorf("Running modprobe %s failed with message: %s", modName, out)
-			return fmt.Errorf("cannot restrict inter-container communication: modprobe %s failed: %w", modName, err)
-		}
-	}
-	return nil
-}
-
 // Enable bridge net filtering if not already enabled. See GitHub issue #11404
 func enableBridgeNetFiltering(nfParam string) error {
-	if err := loadBridgeNetFilterModule(nfParam); err != nil {
-		return fmt.Errorf("loadBridgeNetFilterModule failed: %s", err)
+	if _, err := os.Stat("/proc/sys/net/bridge"); err != nil {
+		if out, err := exec.Command("modprobe", "-va", "bridge", "br_netfilter").CombinedOutput(); err != nil {
+			log.G(context.TODO()).WithError(err).Errorf("Running modprobe bridge br_netfilter failed with message: %s", out)
+			return fmt.Errorf("cannot restrict inter-container communication: modprobe br_netfilter failed: %w", err)
+		}
 	}
 	enabled, err := getKernelBoolParam(nfParam)
 	if err != nil {

--- a/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
+++ b/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"syscall"
 
 	"github.com/containerd/log"
@@ -47,12 +46,6 @@ func setupIPv6BridgeNetFiltering(config *networkConfiguration, _ *bridgeInterfac
 
 // Enable bridge net filtering if not already enabled. See GitHub issue #11404
 func enableBridgeNetFiltering(nfParam string) error {
-	if _, err := os.Stat("/proc/sys/net/bridge"); err != nil {
-		if out, err := exec.Command("modprobe", "-va", "bridge", "br_netfilter").CombinedOutput(); err != nil {
-			log.G(context.TODO()).WithError(err).Errorf("Running modprobe bridge br_netfilter failed with message: %s", out)
-			return fmt.Errorf("cannot restrict inter-container communication: modprobe br_netfilter failed: %w", err)
-		}
-	}
 	enabled, err := getKernelBoolParam(nfParam)
 	if err != nil {
 		var pathErr *os.PathError


### PR DESCRIPTION
- revert https://github.com/moby/moby/pull/48966
- revert https://github.com/moby/moby/pull/48511
- relates to https://github.com/moby/moby/pull/48988#issuecomment-2508234241


This reverts commit 052f7d6461bfebe721a5fb58dd1806a2a1acfdd6.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

