### PR TITLE
Dockerfile: make sure modprobe is available in dev-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -540,6 +540,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             iproute2 \
             iptables \
             jq \
+            kmod \
             libcap2-bin \
             libnet1 \
             libnl-3-200 \


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48492
- relates to https://github.com/moby/moby/pull/48960


Depending on the host configuration, the `br_netfilter` module may not be loaded by default. In this situation, docker will try to load the module through `modprobe`.

Older versions of docker would silently ignore failing to do so, log a message, and continue;

    time="2024-11-29T20:04:58.538404376Z" level=warning msg="Running modprobe bridge br_netfilter failed with message: , error: exec: \"modprobe\": executable file not found in $PATH"

However, starting with db25b0dcd0461802289e962aa0df3abd323d1994 and 264c15bfc427d1321c5b302e48e16d113b06ef92, we now produce an error, which in our CI situation caused tests to fail:

    === FAIL: libnetwork/drivers/bridge TestCreateFullOptions (0.04s)
    time="2024-11-29T19:03:44Z" level=error msg="Running modprobe br_netfilter failed with message: " error="exec: \"modprobe\": executable file not found in $PATH"
        bridge_linux_test.go:280: Failed to create bridge: loadBridgeNetFilterModule failed: cannot restrict inter-container communication: modprobe br_netfilter failed: exec: "modprobe": executable file not found in $PATH

This patch updates the Dockerfile to make sure `modprobe` is available in the dev-container, which is the environment in which we run out tests.

Following this, we should;

- Check our packaging to make sure `kmod` / `modprobe` is listed as a dependency
- Look for alternatives / fallbacks for situations where `modprobe` is not available.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

