### PR TITLE
[23.0 backport] Jenkinsfile: modprobe br_netfilter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,15 @@ pipeline {
                     }
 
                     stages {
+                        stage("Load kernel modules") {
+                            steps {
+                                sh '''
+                                sudo modprobe ip6table_filter
+                                sudo modprobe -va br_netfilter
+                                sudo systemctl restart docker.service
+                                '''
+                            }
+                        }
                         stage("Print info") {
                             steps {
                                 sh 'docker version'
@@ -78,9 +87,6 @@ pipeline {
                         }
                         stage("Unit tests") {
                             steps {
-                                sh '''
-                                sudo modprobe ip6table_filter
-                                '''
                                 sh '''
                                 docker run --rm -t --privileged \
                                   -v "$WORKSPACE/bundles:/go/src/github.com/docker/docker/bundles" \


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48993


Make sure the module is loaded, as we're not able to load it from within the dev-container;

    time="2024-11-29T20:40:42Z" level=error msg="Running modprobe br_netfilter failed with message: modprobe: WARNING: Module br_netfilter not found in directory /lib/modules/5.15.0-1072-aws\n" error="exit status 1"

Also moving these steps _before_ the "print info" step, so that docker info doesn't show warnings that bridge-nf-call-iptables and bridge-nf-call-ip6tables are not loaded.


(cherry picked from commit cce5dfe1e748525184e45ee28651843e2bcdf1e9)


