### PR TITLE
registry: isCIDRMatch: avoid performing DNS lookups if not needed

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -58,9 +58,6 @@ var (
 	emptyServiceConfig, _ = newServiceConfig(ServiceOptions{})
 	validHostPortRegex    = regexp.MustCompile(`^` + reference.DomainRegexp.String() + `$`)
 
-	// for mocking in unit tests
-	lookupIP = net.LookupIP
-
 	// certsDir is used to override defaultCertsDir.
 	certsDir string
 )
@@ -284,6 +281,9 @@ func (config *serviceConfig) isSecureIndex(indexName string) bool {
 
 	return !isCIDRMatch(config.InsecureRegistryCIDRs, indexName)
 }
+
+// for mocking in unit tests.
+var lookupIP = net.LookupIP
 
 // isCIDRMatch returns true if URLHost matches an element of cidrs. URLHost is a URL.Host (`host:port` or `host`)
 // where the `host` part can be either a domain name or an IP address. If it is a domain name, then it will be

--- a/registry/config.go
+++ b/registry/config.go
@@ -289,6 +289,10 @@ func (config *serviceConfig) isSecureIndex(indexName string) bool {
 // where the `host` part can be either a domain name or an IP address. If it is a domain name, then it will be
 // resolved to IP addresses for matching. If resolution fails, false is returned.
 func isCIDRMatch(cidrs []*registry.NetIPNet, URLHost string) bool {
+	if len(cidrs) == 0 {
+		return false
+	}
+
 	host, _, err := net.SplitHostPort(URLHost)
 	if err != nil {
 		// Assume URLHost is of the form `host` without the port and go on.

--- a/registry/config.go
+++ b/registry/config.go
@@ -295,24 +295,24 @@ func isCIDRMatch(cidrs []*registry.NetIPNet, URLHost string) bool {
 
 	host, _, err := net.SplitHostPort(URLHost)
 	if err != nil {
-		// Assume URLHost is of the form `host` without the port and go on.
+		// Assume URLHost is a host without port and go on.
 		host = URLHost
 	}
 
-	addrs, err := lookupIP(host)
-	if err != nil {
-		ip := net.ParseIP(host)
-		if ip != nil {
-			addrs = []net.IP{ip}
+	var addresses []net.IP
+	if ip := net.ParseIP(host); ip != nil {
+		// Host is an IP-address.
+		addresses = append(addresses, ip)
+	} else {
+		// Try to resolve the host's IP-address.
+		addresses, err = lookupIP(host)
+		if err != nil {
+			// We failed to resolve the host; assume there's no match.
+			return false
 		}
-
-		// if ip == nil, then `host` is neither an IP nor it could be looked up,
-		// either because the index is unreachable, or because the index is behind an HTTP proxy.
-		// So, len(addrs) == 0 and we're not aborting.
 	}
 
-	// Try CIDR notation only if addrs has any elements, i.e. if `host`'s IP could be determined.
-	for _, addr := range addrs {
+	for _, addr := range addresses {
 		for _, ipnet := range cidrs {
 			// check if the addr falls in the subnet
 			if (*net.IPNet)(ipnet).Contains(addr) {

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -35,25 +35,14 @@ func init() {
 
 	// override net.LookupIP
 	lookupIP = func(host string) ([]net.IP, error) {
-		if host == "127.0.0.1" {
-			// I believe in future Go versions this will fail, so let's fix it later
-			return net.LookupIP(host)
-		}
 		mockHosts := map[string][]net.IP{
 			"":            {net.ParseIP("0.0.0.0")},
 			"localhost":   {net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 			"example.com": {net.ParseIP("42.42.42.42")},
 			"other.com":   {net.ParseIP("43.43.43.43")},
 		}
-		for h, addrs := range mockHosts {
-			if host == h {
-				return addrs, nil
-			}
-			for _, addr := range addrs {
-				if addr.String() == host {
-					return []net.IP{addr}, nil
-				}
-			}
+		if addrs, ok := mockHosts[host]; ok {
+			return addrs, nil
 		}
 		return nil, errors.New("lookup: no such host")
 	}

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -3,9 +3,7 @@ package registry // import "github.com/docker/docker/registry"
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,20 +30,6 @@ func init() {
 
 	testHTTPServer = httptest.NewServer(handlerAccessLog(r))
 	testHTTPSServer = httptest.NewTLSServer(handlerAccessLog(r))
-
-	// override net.LookupIP
-	lookupIP = func(host string) ([]net.IP, error) {
-		mockHosts := map[string][]net.IP{
-			"":            {net.ParseIP("0.0.0.0")},
-			"localhost":   {net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-			"example.com": {net.ParseIP("42.42.42.42")},
-			"other.com":   {net.ParseIP("43.43.43.43")},
-		}
-		if addrs, ok := mockHosts[host]; ok {
-			return addrs, nil
-		}
-		return nil, errors.New("lookup: no such host")
-	}
 }
 
 func handlerAccessLog(handler http.Handler) http.Handler {


### PR DESCRIPTION
A colleague found that isCIDRMatch (called indirectly through ParseRepositoryInfo), is performing DNS lookups. These lookups are related to it assuming is being run as part of the docker engine, and has to check whether the registry is marked as "insecure" in daemon config.

A consequence of this was that tests were slow as they were using `foo.example.com` (and similar) domains.

This is a first set of changes to avoid performing DNS lookups; the core problem lies in `newRegistryInfo` (which is called as part of the above) always tries to propagate all information, including whether the registry is marked "secure". This information is not used in any way for getting the key to use for storing auth, but requires some additional changes to remove (which I'll do in follow-ups); https://github.com/moby/moby/blob/321f9c2d1c3551eb3e842b604c79d1f748b881a2/registry/config.go#L386-L405

