### PR TITLE
[26.1 backport] integration: add wait

### DIFF
--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/testutil/fakecontext"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -85,6 +86,8 @@ func TestBuildSquashParent(t *testing.T) {
 		container.WithImage(name),
 		container.WithCmd("/bin/sh", "-c", "cat /hello"),
 	)
+
+	poll.WaitOn(t, container.IsStopped(ctx, client, cid))
 	reader, err := client.ContainerLogs(ctx, cid, containertypes.LogsOptions{
 		ShowStdout: true,
 	})

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/docker/docker/testutil/fixtures/load"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -117,6 +118,8 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 		container.WithImage(imageTag),
 		container.WithCmd("/sbin/getcap", "-n", "/bin/sleep"),
 	)
+
+	poll.WaitOn(t, container.IsStopped(ctx, clientNoUserRemap, cid))
 	logReader, err := clientNoUserRemap.ContainerLogs(ctx, cid, containertypes.LogsOptions{
 		ShowStdout: true,
 	})

--- a/integration/container/cdi_test.go
+++ b/integration/container/cdi_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -54,6 +55,7 @@ func TestCreateWithCDIDevices(t *testing.T) {
 	}
 	assert.Check(t, is.DeepEqual(inspect.HostConfig.DeviceRequests, expectedRequests))
 
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, id))
 	reader, err := apiClient.ContainerLogs(ctx, id, containertypes.LogsOptions{
 		ShowStdout: true,
 	})

--- a/integration/container/diff_test.go
+++ b/integration/container/diff_test.go
@@ -23,6 +23,7 @@ func TestDiff(t *testing.T) {
 		{Kind: containertypes.ChangeAdd, Path: "/foo/bar"},
 	}
 
+	poll.WaitOn(t, container.IsStopped(ctx, apiClient, cID))
 	items, err := apiClient.ContainerDiff(ctx, cID)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, items)

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -25,13 +26,25 @@ func TestNetworkNat(t *testing.T) {
 
 	ctx := setupTest(t)
 
-	msg := "it works"
-	startServerContainer(ctx, t, msg, 8080)
+	const msg = "it works"
+	const port = 8080
+	startServerContainer(ctx, t, msg, port)
 
 	endpoint := getExternalAddress(t)
-	conn, err := net.Dial("tcp", net.JoinHostPort(endpoint.String(), "8080"))
-	assert.NilError(t, err)
-	defer conn.Close()
+
+	var conn net.Conn
+	addr := net.JoinHostPort(endpoint.String(), strconv.Itoa(port))
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		var err error
+		conn, err = net.Dial("tcp", addr)
+		if err != nil {
+			return poll.Continue("waiting for %s to be accessible: %v", addr, err)
+		}
+		return poll.Success()
+	})
+	defer func() {
+		assert.Check(t, conn.Close())
+	}()
 
 	data, err := io.ReadAll(conn)
 	assert.NilError(t, err)
@@ -43,12 +56,23 @@ func TestNetworkLocalhostTCPNat(t *testing.T) {
 
 	ctx := setupTest(t)
 
-	msg := "hi yall"
-	startServerContainer(ctx, t, msg, 8081)
+	const msg = "hi yall"
+	const port = 8081
+	startServerContainer(ctx, t, msg, port)
 
-	conn, err := net.Dial("tcp", "localhost:8081")
-	assert.NilError(t, err)
-	defer conn.Close()
+	var conn net.Conn
+	addr := net.JoinHostPort("localhost", strconv.Itoa(port))
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		var err error
+		conn, err = net.Dial("tcp", addr)
+		if err != nil {
+			return poll.Continue("waiting for %s to be accessible: %v", addr, err)
+		}
+		return poll.Success()
+	})
+	defer func() {
+		assert.Check(t, conn.Close())
+	}()
 
 	data, err := io.ReadAll(conn)
 	assert.NilError(t, err)

--- a/integration/image/commit_test.go
+++ b/integration/image/commit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -61,7 +62,8 @@ func TestUsernsCommit(t *testing.T) {
 	clientUserRemap := dUserRemap.NewClientT(t)
 	defer clientUserRemap.Close()
 
-	container.Run(ctx, t, clientUserRemap, container.WithName(t.Name()), container.WithImage("busybox"), container.WithCmd("sh", "-c", "echo hello world > /hello.txt && chown 1000:1000 /hello.txt"))
+	cID := container.Run(ctx, t, clientUserRemap, container.WithName(t.Name()), container.WithImage("busybox"), container.WithCmd("sh", "-c", "echo hello world > /hello.txt && chown 1000:1000 /hello.txt"))
+	poll.WaitOn(t, container.IsStopped(ctx, clientUserRemap, cID))
 	img, err := clientUserRemap.ContainerCommit(ctx, t.Name(), containertypes.CommitOptions{})
 	assert.NilError(t, err)
 

--- a/integration/plugin/logging/read_test.go
+++ b/integration/plugin/logging/read_test.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	testContainer "github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
 )
 
 // TestReadPluginNoRead tests that reads are supported even if the plugin isn't capable.
@@ -65,6 +67,7 @@ func TestReadPluginNoRead(t *testing.T) {
 			err = client.ContainerStart(ctx, c.ID, container.StartOptions{})
 			assert.Assert(t, err)
 
+			poll.WaitOn(t, testContainer.IsStopped(ctx, client, c.ID))
 			logs, err := client.ContainerLogs(ctx, c.ID, container.LogsOptions{ShowStdout: true})
 			if !test.logsSupported {
 				assert.Assert(t, err != nil)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Backports https://github.com/moby/moby/pull/48940 to 26.1 branch

Cherry-picked several WIP commits from
https://github.com/moby/moby/commits/b0a592798f4d9d7162f8aedca89ada3a29d60e2c/

Originally-authored-by: Rodrigo Campos <rodrigoca@microsoft.com>

(cherry picked from commit fb6e650ab9dec7f9e8a67b278104881f03f63d08)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

