### PR TITLE
[26.1 backport] gha: more limits, update alpine version, and some minor improvements

### DIFF
--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   run:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 10 # guardrails timeout for the whole job
     steps:
       -
         name: Checkout

--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -40,10 +40,12 @@ jobs:
         name: Validate
         run: |
           docker run --rm \
-            -v "$(pwd):/workspace" \
+            --quiet \
+            -v ./:/workspace \
+            -w /workspace \
             -e VALIDATE_REPO \
             -e VALIDATE_BRANCH \
-            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && cd /workspace && hack/validate/dco'
+            alpine:${{ env.ALPINE_VERSION }} sh -c 'apk add --no-cache -q bash git openssh-client && git config --system --add safe.directory /workspace && hack/validate/dco'
         env:
           VALIDATE_REPO: ${{ github.server_url }}/${{ github.repository }}.git
           VALIDATE_BRANCH: ${{ steps.base-ref.outputs.result }}

--- a/.github/workflows/.dco.yml
+++ b/.github/workflows/.dco.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 
 env:
-  ALPINE_VERSION: 3.16
+  ALPINE_VERSION: "3.20"
 
 jobs:
   run:

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -194,7 +194,7 @@ jobs:
           retention-days: 1
 
   unit-test-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     if: always()
     needs:
@@ -221,7 +221,7 @@ jobs:
           find /tmp/artifacts -type f -name '*-go-test-report.json' -exec teststat -markdown {} \+ >> $GITHUB_STEP_SUMMARY
 
   integration-test-prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     outputs:
       matrix: ${{ steps.tests.outputs.matrix }}
@@ -515,7 +515,7 @@ jobs:
           retention-days: 1
 
   integration-test-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ inputs.storage == 'snapshotter' && github.event_name != 'pull_request' }}
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           find ${{ env.DESTDIR }} -type f -exec file -e ascii -- {} +
 
   prepare-cross:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
   validate-prepare:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 10 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -94,7 +94,7 @@ jobs:
 
   validate:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 30 # guardrails timeout for the whole job
     needs:
       - validate-prepare
       - build-dev
@@ -128,7 +128,7 @@ jobs:
 
   smoke-prepare:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 10 # guardrails timeout for the whole job
     needs:
       - validate-dco
     outputs:
@@ -150,7 +150,7 @@ jobs:
 
   smoke:
     runs-on: ubuntu-20.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - smoke-prepare
     strategy:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Backports https://github.com/moby/moby/pull/48654 to 26.1 branch

### gha: dco: limit to 10 minutes

Regular runs are under a minute.

### gha: build (binary), build (dynbinary): limit to 20 minutes

Regular runs are under 5 minutes.

### gha: dco: update ALPINE_VERSION to 3.20

Alpine 3.16 has been EOL for some time. Update to the latest version.

### gha: dco: small tweaks to running the container

- add `--quiet` to suppress pull progress output
- use `./` instead of `$(pwd)` now that relative paths are supported
- set the working directory on the container, so that we don't have to `cd`

### gha: use "ubuntu-24.04" instead of "ubuntu-latest"

To be more explicit on what we're using.

### gha: shorter time limits for smoke, validate

- validate-prepare and smoke-prepare took 10 seconds; limiting to 10 minutes
- smoke tests took less than 3 minutes; limiting to 10 minutes
- validate: most took under a minute, but "deprecate-integration-cli" took
  14 minutes; limiting to 30 minutes 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

