### PR TITLE
registry: remove deprecated APIEndpoint.Version and APIVersion type

### DIFF
--- a/registry/service.go
+++ b/registry/service.go
@@ -103,7 +103,6 @@ func (s *Service) ResolveRepository(name reference.Named) (*RepositoryInfo, erro
 type APIEndpoint struct {
 	Mirror                         bool
 	URL                            *url.URL
-	Version                        APIVersion // Deprecated: v1 registries are deprecated, and endpoints are always v2.
 	AllowNondistributableArtifacts bool
 	Official                       bool
 	TrimHostname                   bool

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -25,7 +25,6 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 			}
 			endpoints = append(endpoints, APIEndpoint{
 				URL:          mirrorURL,
-				Version:      APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 				Mirror:       true,
 				TrimHostname: true,
 				TLSConfig:    mirrorTLSConfig,
@@ -33,7 +32,6 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 		}
 		endpoints = append(endpoints, APIEndpoint{
 			URL:          DefaultV2Registry,
-			Version:      APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 			Official:     true,
 			TrimHostname: true,
 			TLSConfig:    tlsconfig.ServerDefault(),
@@ -55,7 +53,6 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "https",
 				Host:   hostname,
 			},
-			Version:                        APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 			AllowNondistributableArtifacts: ana,
 			TrimHostname:                   true,
 			TLSConfig:                      tlsConfig,
@@ -68,7 +65,6 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "http",
 				Host:   hostname,
 			},
-			Version:                        APIVersion2, //nolint:staticcheck // ignore SA1019 (Version is deprecated) to allow potential consumers to transition.
 			AllowNondistributableArtifacts: ana,
 			TrimHostname:                   true,
 			// used to check if supposed to be secure via InsecureSkipVerify

--- a/registry/types.go
+++ b/registry/types.go
@@ -5,27 +5,6 @@ import (
 	"github.com/docker/docker/api/types/registry"
 )
 
-// APIVersion is an integral representation of an API version (presently
-// either 1 or 2)
-//
-// Deprecated: v1 registries are deprecated, and endpoints are always v2.
-type APIVersion int
-
-func (av APIVersion) String() string {
-	return apiVersions[av]
-}
-
-// API Version identifiers.
-const (
-	APIVersion1 APIVersion = 1 // Deprecated: v1 registries are deprecated, and endpoints are always v2.
-	APIVersion2 APIVersion = 2 // Deprecated: v1 registries are deprecated, and endpoints are always v2.
-)
-
-var apiVersions = map[APIVersion]string{
-	APIVersion1: "v1",
-	APIVersion2: "v2",
-}
-
 // RepositoryInfo describes a repository
 type RepositoryInfo struct {
 	Name reference.Named


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46359


This field was unused, and support for v1 registries was removed a long time ago. It was deprecated in d43e61758ad95fe71c238434c26a7897cc7248f4 (part of v25.0), and marked for deletion after that release.

This removes the deprecated field and types;

- `registry.APIEndpoint.Version` field
- `registry.APIVersion` type
- `registry.APIVersion1` const
- `registry.APIVersion2` const

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
registry: remove deprecated `APIEndpoint.Version` field, `APIVersion` type, and `APIVersion1` and `APIVersion2` consts. 
```

**- A picture of a cute animal (not mandatory but encouraged)**

