### PR TITLE
registry: deprecate APIEndpoint.TrimHostname

### DIFF
--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -299,7 +299,7 @@ func TestPullSchema2Config(t *testing.T) {
 				switch {
 				case r.Method == "GET" && r.URL.Path == "/v2":
 					w.WriteHeader(http.StatusOK)
-				case r.Method == "GET" && r.URL.Path == "/v2/docker.io/library/testremotename/blobs/"+expectedDigest.String():
+				case r.Method == "GET" && r.URL.Path == "/v2/library/testremotename/blobs/"+expectedDigest.String():
 					tc.handler(int(callCount.Add(1)), w)
 				default:
 					w.WriteHeader(http.StatusNotFound)

--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -517,7 +517,6 @@ func TestWhenEmptyAuthConfig(t *testing.T) {
 					Scheme: "https",
 					Host:   registrypkg.IndexHostname,
 				},
-				TrimHostname: true,
 			},
 		}
 		pusher.push(context.Background())

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -76,11 +76,8 @@ func newRepository(
 	ctx context.Context, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint,
 	metaHeaders http.Header, authConfig *registrytypes.AuthConfig, actions ...string,
 ) (distribution.Repository, error) {
-	repoName := repoInfo.Name.Name()
-	// If endpoint does not support CanonicalName, use the RemoteName instead
-	if endpoint.TrimHostname {
-		repoName = reference.Path(repoInfo.Name)
-	}
+	// Trim the hostname to form the RemoteName
+	repoName := reference.Path(repoInfo.Name)
 
 	direct := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -131,6 +128,7 @@ func newRepository(
 	}
 	tr := transport.NewTransport(base, modifiers...)
 
+	// FIXME(thaJeztah): should this just take the original repoInfo.Name instead of converting the remote name back to a named reference?
 	repoNameRef, err := reference.WithName(repoName)
 	if err != nil {
 		return nil, fallbackError{

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -40,10 +40,6 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 		t.Fatalf("could not parse url from test server: %v", err)
 	}
 
-	endpoint := registrypkg.APIEndpoint{
-		URL:          uri,
-		TrimHostname: false,
-	}
 	n, _ := reference.ParseNormalizedNamed("testremotename")
 	repoInfo := &registrypkg.RepositoryInfo{
 		Name: n,
@@ -59,7 +55,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 			},
 		},
 	}
-	p := newPuller(endpoint, repoInfo, imagePullConfig, nil)
+	p := newPuller(registrypkg.APIEndpoint{URL: uri}, repoInfo, imagePullConfig, nil)
 	ctx := context.Background()
 	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {

--- a/registry/service.go
+++ b/registry/service.go
@@ -105,7 +105,7 @@ type APIEndpoint struct {
 	URL                            *url.URL
 	AllowNondistributableArtifacts bool
 	Official                       bool
-	TrimHostname                   bool
+	TrimHostname                   bool // Deprecated: hostname is now trimmed unconditionally for remote names. This field will be removed in the next release.
 	TLSConfig                      *tls.Config
 }
 

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -24,17 +24,15 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				return nil, err
 			}
 			endpoints = append(endpoints, APIEndpoint{
-				URL:          mirrorURL,
-				Mirror:       true,
-				TrimHostname: true,
-				TLSConfig:    mirrorTLSConfig,
+				URL:       mirrorURL,
+				Mirror:    true,
+				TLSConfig: mirrorTLSConfig,
 			})
 		}
 		endpoints = append(endpoints, APIEndpoint{
-			URL:          DefaultV2Registry,
-			Official:     true,
-			TrimHostname: true,
-			TLSConfig:    tlsconfig.ServerDefault(),
+			URL:       DefaultV2Registry,
+			Official:  true,
+			TLSConfig: tlsconfig.ServerDefault(),
 
 			AllowNondistributableArtifacts: ana,
 		})
@@ -53,9 +51,9 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "https",
 				Host:   hostname,
 			},
+			TLSConfig: tlsConfig,
+
 			AllowNondistributableArtifacts: ana,
-			TrimHostname:                   true,
-			TLSConfig:                      tlsConfig,
 		},
 	}
 
@@ -65,10 +63,10 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "http",
 				Host:   hostname,
 			},
-			AllowNondistributableArtifacts: ana,
-			TrimHostname:                   true,
 			// used to check if supposed to be secure via InsecureSkipVerify
 			TLSConfig: tlsConfig,
+
+			AllowNondistributableArtifacts: ana,
 		})
 	}
 


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/49004
- [x] depends on / stacked on https://github.com/moby/moby/pull/49015
- relates to https://github.com/moby/moby/pull/13375

### registry: deprecate APIEndpoint.TrimHostname

This field was added in 19515a7ad859b28c474d81e756ac245afcd968e3, but looks
to be always set for endpoints used, so we can trim remote names unconditionally.

This option was added for possible future expansion, allowing registry-
mirrors to get the full reference of the image (including domain-name),
for them to host a mirror for multiple upstreams on the same registry.

That approach will unlikely be implemented, and containerd has a different
approach for this, where the reference to the original registry is passed
through a query parameter instead.

The field is unlikely used outside of our codebased, but deprecating it
before removal just in case.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
registry: deprecate APIEndpoint.TrimHostName; hostname is now trimmed unconditionally for remote names. This field will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

