### PR TITLE
c8d/tag: Don't log a warning if the source image is not dangling

### DIFF
--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -68,7 +68,9 @@ func (i *ImageService) TagImage(ctx context.Context, imageID image.ID, newTag re
 
 	// Delete the source dangling image, as it's no longer dangling.
 	if err := i.images.Delete(context.WithoutCancel(ctx), danglingImageName(targetImage.Target.Digest)); err != nil {
-		logger.WithError(err).Warn("unexpected error when deleting dangling image")
+		if !cerrdefs.IsNotFound(err) {
+			logger.WithError(err).Warn("unexpected error when deleting dangling image")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
After the image is tagged, the engine attempts to delete a dangling image of the source image, so the image is no longer dangling.

When the source image is not dangling, the removal errors out (as expected), but a warning is logged to the daemon log:

```
time="2024-12-02T10:44:25.386957553Z" level=warning msg="unexpected error when deleting dangling image" error="NotFound: image \"moby-dangling@sha256:54d8c2251c811295690b53af7767ecaf246f1186c36e4f2b2a63e0bfa42df045\": not found" imageID="sha256:54d8c2251c811295690b53af7767ecaf246f1186c36e4f2b2a63e0bfa42df045" spanID=bd10a21a07830d72 tag="docker.io/library/test:latest" traceID=4cf61671c2dc6da3dc7a09c0c6ac4e16
```

Remove that log as it causes unnecessary confusion, as the failure is expected.


**- What I did**

**- How I did it**

**- How to verify it**
```
$ docker tag <tagged-image> <new-tag>
# Observe daemon logs
```

**- Description for the changelog**
```markdown changelog
containerd image store: Remove a confusing warning log when tagging a non-dangling image.
```

**- A picture of a cute animal (not mandatory but encouraged)**

