### PR TITLE
[27.x backport] registry: deprecate RepositoryInfo.Class

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -123,7 +123,6 @@ func newRepository(
 			Scopes: []auth.Scope{auth.RepositoryScope{
 				Repository: repoName,
 				Actions:    actions,
-				Class:      repoInfo.Class,
 			}},
 			ClientID: registry.AuthClientID,
 		})

--- a/registry/types.go
+++ b/registry/types.go
@@ -37,5 +37,7 @@ type RepositoryInfo struct {
 	Official bool
 	// Class represents the class of the repository, such as "plugin"
 	// or "image".
+	//
+	// Deprecated: this field is no longer used, and will be removed in the next release.
 	Class string
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/49006

relates to:

- https://github.com/distribution/distribution/pull/2067
- https://github.com/moby/moby/pull/28459
- https://github.com/docker/cli/pull/4114
- https://github.com/docker/hub-feedback/issues/2107

The Class field was added in a12b466183e03621bc9e1c1e4deab6db8ec93f0a because Docker Hub registry required a special scope to be set for pulling plugins;

    HTTP/1.1 401 Unauthorized
    ...
    Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository(plugin):vieux/sshfs:pull",error="insufficient_scope"

This is no longer a requirement, and the field is no longer set.

This patch deprecates the field and removes its use.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
registry: deprecate `RepositoryInfo.Class`. This field is no longer used, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

