### PR TITLE
pkg/jsonmessage: should return early on context cancellation

### DIFF
--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -75,7 +75,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	defer resp.Body.Close()
 
 	buf := bytes.NewBuffer(nil)
-	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, buf, 0, false, nil)
+	err = jsonmessage.DisplayJSONMessagesStream(ctx, resp.Body, buf, 0, false, nil)
 	assert.NilError(t, err)
 
 	reader, err := clientUserRemap.ImageSave(ctx, []string{imageTag}, image.SaveOptions{})
@@ -112,7 +112,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	assert.NilError(t, err, "failed to load image tar file")
 	defer loadResp.Body.Close()
 	buf = bytes.NewBuffer(nil)
-	err = jsonmessage.DisplayJSONMessagesStream(loadResp.Body, buf, 0, false, nil)
+	err = jsonmessage.DisplayJSONMessagesStream(ctx, loadResp.Body, buf, 0, false, nil)
 	assert.NilError(t, err)
 
 	cid := container.Run(ctx, t, clientNoUserRemap,

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -154,7 +154,7 @@ func TestCopyFromContainer(t *testing.T) {
 	defer resp.Body.Close()
 
 	var imageID string
-	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
+	err = jsonmessage.DisplayJSONMessagesStream(ctx, resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
 		var r types.BuildResult
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -141,7 +141,7 @@ func TestPluginInstall(t *testing.T) {
 		buf := &strings.Builder{}
 		assert.NilError(t, err)
 		var digest string
-		assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(rdr, buf, 0, false, func(j jsonmessage.JSONMessage) {
+		assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(ctx, rdr, buf, 0, false, func(j jsonmessage.JSONMessage) {
 			if j.Aux != nil {
 				var r types.PushResult
 				assert.NilError(t, json.Unmarshal(*j.Aux, &r))
@@ -335,7 +335,7 @@ func TestPluginBackCompatMediaTypes(t *testing.T) {
 	defer rdr.Close()
 
 	buf := &strings.Builder{}
-	assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(rdr, buf, 0, false, nil), buf)
+	assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(ctx, rdr, buf, 0, false, nil), buf)
 
 	// Use custom header here because older versions of the registry do not
 	// parse the accept header correctly and does not like the accept header

--- a/testutil/fixtures/load/frozen.go
+++ b/testutil/fixtures/load/frozen.go
@@ -117,7 +117,7 @@ func loadFrozenImages(ctx context.Context, client client.APIClient) error {
 	}
 	defer resp.Body.Close()
 	fd, isTerminal := term.GetFdInfo(os.Stdout)
-	return jsonmessage.DisplayJSONMessagesStream(resp.Body, os.Stdout, fd, isTerminal, nil)
+	return jsonmessage.DisplayJSONMessagesStream(ctx, resp.Body, os.Stdout, fd, isTerminal, nil)
 }
 
 func pullImages(ctx context.Context, client client.APIClient, images []string) error {
@@ -168,7 +168,7 @@ func pullTagAndRemove(ctx context.Context, client client.APIClient, ref string, 
 	}
 	defer resp.Close()
 	fd, isTerminal := term.GetFdInfo(os.Stdout)
-	if err := jsonmessage.DisplayJSONMessagesStream(resp, os.Stdout, fd, isTerminal, nil); err != nil {
+	if err := jsonmessage.DisplayJSONMessagesStream(ctx, resp, os.Stdout, fd, isTerminal, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This patch makes the `jsonmessage.DisplayJSONMessagesToStream` and `jsonmessage.DisplayJSONMessagesStream` context aware and allows them to return early upon receiving a context.Cancellation.

The current behavior of `jsonmessage.DisplayJSONMessagesToStream` and `jsonmessage.DisplayJSONMessagesStream` are to continue to read the response object for as long as the reponse remains open.

Since these functions do not return an error upon closing the response object it is impossible to know if the `jsonmessage.DisplayJSONMessagesToStream` and `jsonmessage.DisplayJSONMessagesStream` functions completed successfully or if the function returned early due the response object being closed early.

For example, when using `http.NewRequestWithContext`, the request will be cancelled when the context is cancelled. This usually closes the `response` object, causing an `io.EOF`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

