### PR TITLE
Wait longer for a stable goroutine count in tests

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -302,7 +302,7 @@ func (s *DockerCLILogsSuite) TestLogsFollowGoroutinesWithStdout(c *testing.T) {
 	assert.NilError(c, d.WaitRun(id))
 
 	client := d.NewClientT(c)
-	nroutines := waitForStableGourtineCount(ctx, c, client)
+	nroutines := waitForStableGoroutineCount(ctx, c, client)
 
 	cmd := d.Command("logs", "-f", id)
 	r, w := io.Pipe()
@@ -358,7 +358,7 @@ func (s *DockerCLILogsSuite) TestLogsFollowGoroutinesNoOutput(c *testing.T) {
 	assert.NilError(c, d.WaitRun(id))
 
 	client := d.NewClientT(c)
-	nroutines := waitForStableGourtineCount(ctx, c, client)
+	nroutines := waitForStableGoroutineCount(ctx, c, client)
 	assert.NilError(c, err)
 
 	cmd := d.Command("logs", "-f", id)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3823,7 +3823,7 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 
 	client := d.NewClientT(c)
 
-	nroutines := waitForStableGourtineCount(ctx, c, client)
+	nroutines := waitForStableGoroutineCount(ctx, c, client)
 
 	out, err := d.Cmd(append([]string{"run", "-d", "--name=test", "-p", "8000:8000", "busybox"}, sleepCommandForDaemonPlatform()...)...)
 	assert.NilError(c, err, out)

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -347,7 +347,7 @@ func getGoroutineNumber(ctx context.Context, apiClient client.APIClient) (int, e
 	return info.NGoroutines, nil
 }
 
-func waitForStableGourtineCount(ctx context.Context, t poll.TestingT, apiClient client.APIClient) int {
+func waitForStableGoroutineCount(ctx context.Context, t poll.TestingT, apiClient client.APIClient) int {
 	var out int
 	poll.WaitOn(t, stableGoroutineCount(ctx, apiClient, &out), poll.WithTimeout(30*time.Second))
 	return out

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -349,7 +349,7 @@ func getGoroutineNumber(ctx context.Context, apiClient client.APIClient) (int, e
 
 func waitForStableGoroutineCount(ctx context.Context, t poll.TestingT, apiClient client.APIClient) int {
 	var out int
-	poll.WaitOn(t, stableGoroutineCount(ctx, apiClient, &out), poll.WithTimeout(30*time.Second))
+	poll.WaitOn(t, stableGoroutineCount(ctx, apiClient, &out), poll.WithDelay(time.Second), poll.WithTimeout(30*time.Second))
 	return out
 }
 
@@ -374,7 +374,7 @@ func stableGoroutineCount(ctx context.Context, apiClient client.APIClient, count
 			nRoutines = n
 		}
 
-		if numStable > 3 {
+		if numStable > 6 {
 			*count = n
 			return poll.Success()
 		}


### PR DESCRIPTION
- related: https://github.com/moby/moby/issues/21247

**- What I did**

Test 'TestDockerCLIRunSuite/TestRunAttachFailedNoLeak' does this ...

- start a container that exits immediately, its comment says:
  - "Run a dummy container to ensure all goroutines are up and running before we get a count"
- wait for the number of goroutines to be stable for 400ms, and remember that number
- start a container
- start another container, expecting it to fail with a port-mapping clash
- stop the running container
- wait for up to 30s for the number of goroutines to fall back to the remembered number.

In a CI run - hacking in some debug to count goroutines once a second, before waiting for the number to stablilise for 400ms, showed that the initial (dummy) container run had no immediate effect. But, three more goroutines appeared within a few seconds. For example:

    === RUN   TestDockerCLIRunSuite/TestRunAttachFailedNoLeak
      docker_cli_run_test.go:3822: goroutines before container run: 47 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 47 i 0 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 48 i 1 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 48 i 2 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 48 i 3 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 48 i 4 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 50 i 5 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 50 i 6 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 50 i 7 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 50 i 8 err <nil>
      docker_cli_run_test.go:3830: goroutines after container run: 50 i 9 err <nil>

That means a delay while running the rest of the test risks finding the extra goroutines that are going to start anyway and not go away (regardless of whether more containers are started).

**- How I did it**

So - wait for the goroutine count to be stable for 7s, rather than 400ms.

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

