### PR TITLE
distribution: verifySchema1Manifest: pass through context

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -514,7 +514,7 @@ func (p *puller) pullSchema1(ctx context.Context, ref reference.Reference, unver
 	}
 
 	var verifiedManifest *schema1.Manifest
-	verifiedManifest, err = verifySchema1Manifest(unverifiedManifest, ref)
+	verifiedManifest, err = verifySchema1Manifest(ctx, unverifiedManifest, ref)
 	if err != nil {
 		return "", "", err
 	}
@@ -996,7 +996,7 @@ func schema2ManifestDigest(ref reference.Named, mfst distribution.Manifest) (dig
 	return digest.FromBytes(canonical), nil
 }
 
-func verifySchema1Manifest(signedManifest *schema1.SignedManifest, ref reference.Reference) (m *schema1.Manifest, err error) {
+func verifySchema1Manifest(ctx context.Context, signedManifest *schema1.SignedManifest, ref reference.Reference) (*schema1.Manifest, error) {
 	// If pull by digest, then verify the manifest digest. NOTE: It is
 	// important to do this first, before any other content validation. If the
 	// digest cannot be verified, don't even bother with those other things.
@@ -1007,12 +1007,12 @@ func verifySchema1Manifest(signedManifest *schema1.SignedManifest, ref reference
 		}
 		if !verifier.Verified() {
 			err := fmt.Errorf("image verification failed for digest %s", digested.Digest())
-			log.G(context.TODO()).Error(err)
+			log.G(ctx).Error(err)
 			return nil, err
 		}
 	}
-	m = &signedManifest.Manifest
 
+	m := &signedManifest.Manifest
 	if m.SchemaVersion != 1 {
 		return nil, fmt.Errorf("unsupported schema version %d for %q", m.SchemaVersion, reference.FamiliarString(ref))
 	}

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/containerd/log/logtest"
 	"github.com/distribution/reference"
 	"github.com/docker/distribution/manifest/schema1"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -123,6 +124,9 @@ func TestValidateManifest(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Needs fixing on Windows")
 	}
+	ctx := context.TODO()
+	ctx = logtest.WithT(ctx, t)
+
 	expectedDigest, err := reference.ParseNormalizedNamed("repo@sha256:02fee8c3220ba806531f606525eceb83f4feb654f62b207191b1c9209188dedd")
 	if err != nil {
 		t.Fatal("could not parse reference")
@@ -142,7 +146,7 @@ func TestValidateManifest(t *testing.T) {
 		t.Fatal("error unmarshaling manifest:", err)
 	}
 
-	verifiedManifest, err := verifySchema1Manifest(&goodSignedManifest, expectedDigest)
+	verifiedManifest, err := verifySchema1Manifest(ctx, &goodSignedManifest, expectedDigest)
 	if err != nil {
 		t.Fatal("validateManifest failed:", err)
 	}
@@ -164,7 +168,7 @@ func TestValidateManifest(t *testing.T) {
 		t.Fatal("error unmarshaling manifest:", err)
 	}
 
-	verifiedManifest, err = verifySchema1Manifest(&extraDataSignedManifest, expectedDigest)
+	verifiedManifest, err = verifySchema1Manifest(ctx, &extraDataSignedManifest, expectedDigest)
 	if err != nil {
 		t.Fatal("validateManifest failed:", err)
 	}
@@ -186,7 +190,7 @@ func TestValidateManifest(t *testing.T) {
 		t.Fatal("error unmarshaling manifest:", err)
 	}
 
-	_, err = verifySchema1Manifest(&badSignedManifest, expectedDigest)
+	_, err = verifySchema1Manifest(ctx, &badSignedManifest, expectedDigest)
 	if err == nil || !strings.HasPrefix(err.Error(), "image verification failed for digest") {
 		t.Fatal("expected validateManifest to fail with digest error")
 	}


### PR DESCRIPTION
Before this patch:

    go test -run TestValidateManifest
    ERRO[0000] image verification failed for digest sha256:02fee8c3220ba806531f606525eceb83f4feb654f62b207191b1c9209188dedd
    PASS
    ok  	github.com/docker/docker/distribution	0.008s

With this patch:

    go test -run TestValidateManifest
    PASS
    ok  	github.com/docker/docker/distribution	0.010s

Note that in verbose mode, the logs are still printed, but through t.Log;

    go test -run TestValidateManifest -v
    === RUN   TestValidateManifest
        log_hook.go:47: time="2024-12-03T13:41:19.308383552Z" level=error msg="image verification failed for digest sha256:02fee8c3220ba806531f606525eceb83f4feb654f62b207191b1c9209188dedd" func=distribution.verifySchema1Manifest file="/go/src/github.com/docker/docker/distribution/pull_v2.go:1010" testcase=TestValidateManifest
    --- PASS: TestValidateManifest (0.00s)
    PASS
    ok  	github.com/docker/docker/distribution	0.011s

