### PR TITLE
Ignore kernel-assigned LL addrs when selecting "bip6"

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1190,6 +1191,15 @@ func selectBIP(
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "list bridge addresses failed")
 	}
+	// For IPv6, ignore the kernel-assigned link-local address. Remove all
+	// link-local addresses, unless fixed-cidr-v6 has the standard link-local
+	// prefix. (If fixed-cidr-v6 is the standard LL prefix, the kernel-assigned
+	// address is likely to be used instead of an IPAM assigned address.)
+	if family == netlink.FAMILY_V6 && (fCidrIP == nil || !isStandardLL(fCidrIP)) {
+		bridgeNws = slices.DeleteFunc(bridgeNws, func(nlAddr netlink.Addr) bool {
+			return isStandardLL(nlAddr.IP)
+		})
+	}
 	if len(bridgeNws) > 0 {
 		// Pick any address from the bridge as a starting point.
 		nw := bridgeNws[0].IPNet
@@ -1236,6 +1246,16 @@ func selectBIP(
 	}
 
 	return bIP, bIPNet, nil
+}
+
+// isStandardLL returns true if ip is in fe80::/64 (the link local prefix is fe80::/10,
+// but only fe80::/64 is normally used - however, it's possible to ask IPAM for a
+// link-local subnet that's outside that range).
+func isStandardLL(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.Mask(net.CIDRMask(64, 128)).Equal(net.ParseIP("fe80::"))
 }
 
 // Remove default bridge interface if present (--bridge=none use case)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1043,18 +1043,6 @@ func getDefaultBridgeName(cfg config.BridgeConfig) (bridgeName string, userManag
 		// create it, and it is not possible to supply an address using --bip.
 		return cfg.Iface, true
 	}
-	// Without a --bridge, the bridge is "docker0", created and managed by the
-	// daemon. A --bip (cidr) can be supplied to define the bridge's IP address
-	// and the network's subnet.
-	//
-	// Env var DOCKER_TEST_CREATE_DEFAULT_BRIDGE env var modifies the default
-	// bridge name. Unlike '--bridge', the bridge does not need to be created
-	// outside the daemon, and it's still possible to use '--bip'. It is
-	// intended only for use in moby tests; it may be removed, its behaviour
-	// may be modified, and it may not do what you want anyway!
-	if bn := os.Getenv("DOCKER_TEST_CREATE_DEFAULT_BRIDGE"); bn != "" {
-		return bn, false
-	}
 	return bridge.DefaultBridgeName, false
 }
 

--- a/integration/daemon/daemon_linux_test.go
+++ b/integration/daemon/daemon_linux_test.go
@@ -3,43 +3,45 @@ package daemon // import "github.com/docker/docker/integration/daemon"
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/internal/nlwrap"
+	"github.com/docker/docker/internal/testutils/networking"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/vishvananda/netlink"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
 
+// Check that the daemon will start with fixed-cidr set, but no bip.
+// Regression test for https://github.com/moby/moby/issues/45356
 func TestDaemonDefaultBridgeWithFixedCidrButNoBip(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "can't create L3 segment in rootless namespace")
 	ctx := testutil.StartSpan(baseContext, t)
 
-	bridgeName := "ext-bridge1"
-	d := daemon.New(t, daemon.WithEnvVars("DOCKER_TEST_CREATE_DEFAULT_BRIDGE="+bridgeName))
-	defer func() {
-		d.Stop(t)
-		d.Cleanup(t)
-	}()
+	host, cleanup := newHostInL3Seg(t, "fcnobip", "192.168.130.1", "fd69:d2cd:f7df::1")
+	defer cleanup()
 
-	defer func() {
-		// No need to clean up when running this test in rootless mode, as the
-		// interface is deleted when the daemon is stopped and the netns
-		// reclaimed by the kernel.
-		if !testEnv.IsRootless() {
-			deleteInterface(t, bridgeName)
-		}
-	}()
-	d.StartWithBusybox(ctx, t, "--bridge", bridgeName, "--fixed-cidr", "192.168.130.0/24")
+	host.Do(t, func() {
+		// Run without OTel because there's no routing from this netns for it - which
+		// means the daemon doesn't shut down cleanly, causing the test to fail.
+		d := daemon.New(t, daemon.WithEnvVars("OTEL_EXPORTER_OTLP_ENDPOINT="))
+		d.StartWithBusybox(ctx, t, "--fixed-cidr", "192.168.130.0/24")
+		defer func() {
+			d.Stop(t)
+			d.Cleanup(t)
+		}()
+	})
 }
 
 // Test fixed-cidr and bip options, with various addresses on the bridge
 // before the daemon starts.
 func TestDaemonDefaultBridgeIPAM_Docker0(t *testing.T) {
-	skip.If(t, testEnv.IsRootless, "can't create test bridge in rootless namespace")
+	skip.If(t, testEnv.IsRootless, "can't create L3 segment in rootless namespace")
 	ctx := testutil.StartSpan(baseContext, t)
 
 	testcases := []defaultBridgeIPAMTestCase{
@@ -168,6 +170,7 @@ func TestDaemonDefaultBridgeIPAM_Docker0(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
+		tc.bridgeName = "docker0"
 		testDefaultBridgeIPAM(ctx, t, tc)
 	}
 }
@@ -175,7 +178,7 @@ func TestDaemonDefaultBridgeIPAM_Docker0(t *testing.T) {
 // Like TestDaemonUserDefaultBridgeIPAMDocker0, but with a user-defined/supplied
 // bridge, instead of docker0.
 func TestDaemonDefaultBridgeIPAM_UserBr(t *testing.T) {
-	skip.If(t, testEnv.IsRootless, "can't create test bridge in rootless namespace")
+	skip.If(t, testEnv.IsRootless, "can't create L3 segment in rootless namespace")
 	ctx := testutil.StartSpan(baseContext, t)
 
 	testcases := []defaultBridgeIPAMTestCase{
@@ -301,6 +304,7 @@ func TestDaemonDefaultBridgeIPAM_UserBr(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
+		tc.bridgeName = "br-dbi"
 		tc.userDefinedBridge = true
 		testDefaultBridgeIPAM(ctx, t, tc)
 	}
@@ -308,6 +312,7 @@ func TestDaemonDefaultBridgeIPAM_UserBr(t *testing.T) {
 
 type defaultBridgeIPAMTestCase struct {
 	name               string
+	bridgeName         string
 	userDefinedBridge  bool
 	initialBridgeAddrs []string
 	daemonArgs         []string
@@ -319,51 +324,75 @@ type defaultBridgeIPAMTestCase struct {
 func testDefaultBridgeIPAM(ctx context.Context, t *testing.T, tc defaultBridgeIPAMTestCase) {
 	t.Run(tc.name, func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
-		const bridgeName = "br-dbi"
 
-		createBridge(t, bridgeName, tc.initialBridgeAddrs)
-		defer deleteInterface(t, bridgeName)
+		// Run this test in its own network namespace because it messes with the default
+		// bridge and, for example, iptables rules for the default bridge aren't deleted
+		// because the network can't be deleted. Then, rules with old addresses may break
+		// unrelated tests.
+		host, cleanup := newHostInL3Seg(t, "defbripam", "192.168.131.1", "fdf9:2eb5:ba8c::1")
+		defer cleanup()
 
-		var dOpts []daemon.Option
-		var dArgs []string
-		if !tc.ipv4Only {
-			dArgs = append(tc.daemonArgs, "--ipv6")
-		}
-		if tc.userDefinedBridge {
-			// If a bridge is supplied by the user, the daemon should use its addresses
-			// to infer --bip (which cannot be specified).
-			dArgs = append(dArgs, "--bridge", bridgeName)
-		} else {
-			// The bridge is created and managed by docker, it's always called "docker0",
-			// unless this test-only env var is set - to avoid conflict with the docker0
-			// belonging to the daemon started in CI runs.
-			dOpts = append(dOpts, daemon.WithEnvVars("DOCKER_TEST_CREATE_DEFAULT_BRIDGE="+bridgeName))
-		}
+		host.Do(t, func() {
+			createBridge(t, tc.bridgeName, tc.initialBridgeAddrs)
 
-		d := daemon.New(t, dOpts...)
-		defer func() {
-			d.Stop(t)
-			d.Cleanup(t)
-		}()
+			var dArgs []string
+			if !tc.ipv4Only {
+				dArgs = append(tc.daemonArgs, "--ipv6")
+			}
+			if tc.userDefinedBridge {
+				// If a bridge is supplied by the user, the daemon should use its addresses
+				// to infer --bip (which cannot be specified).
+				dArgs = append(dArgs, "--bridge", tc.bridgeName)
+			}
 
-		if tc.expStartErr {
-			err := d.StartWithError(dArgs...)
-			assert.Check(t, is.ErrorContains(err, "daemon exited during startup"))
-			return
-		}
+			// Run without OTel because there's no routing from this netns for it - which
+			// means the daemon doesn't shut down cleanly, causing the test to fail.
+			d := daemon.New(t, daemon.WithEnvVars("OTEL_EXPORTER_OTLP_ENDPOINT="))
+			defer func() {
+				d.Stop(t)
+				d.Cleanup(t)
+			}()
 
-		d.Start(t, dArgs...)
-		c := d.NewClientT(t)
-		defer c.Close()
+			if tc.expStartErr {
+				err := d.StartWithError(dArgs...)
+				assert.Check(t, is.ErrorContains(err, "daemon exited during startup"))
+				return
+			}
 
-		insp, err := c.NetworkInspect(ctx, network.NetworkBridge, network.InspectOptions{})
-		assert.NilError(t, err)
-		assert.Check(t, is.DeepEqual(insp.IPAM.Config, tc.expIPAMConfig))
+			d.Start(t, dArgs...)
+			c := d.NewClientT(t)
+			defer c.Close()
+
+			insp, err := c.NetworkInspect(ctx, network.NetworkBridge, network.InspectOptions{})
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(insp.IPAM.Config, tc.expIPAMConfig))
+		})
 	})
+}
+
+func newHostInL3Seg(t *testing.T, name, ip4, ip6 string) (networking.Host, func()) {
+	// Set up a netns for each test to avoid sysctl and iptables pollution.
+	addr4 := netip.MustParseAddr(ip4)
+	addr6 := netip.MustParseAddr(ip6)
+	l3 := networking.NewL3Segment(t, "test-"+name,
+		netip.PrefixFrom(addr4, 24),
+		netip.PrefixFrom(addr6, 64),
+	)
+	hostname := "host-" + name
+	l3.AddHost(t, hostname, "ns-"+name, "eth0",
+		netip.PrefixFrom(addr4.Next(), 24),
+		netip.PrefixFrom(addr6.Next(), 64),
+	)
+	return l3.Hosts[hostname], func() { l3.Destroy(t) }
 }
 
 func createBridge(t *testing.T, ifName string, addrs []string) {
 	t.Helper()
+
+	// Get a netlink handle in this netns.
+	nlh, err := nlwrap.NewHandle()
+	assert.NilError(t, err)
+	defer nlh.Close()
 
 	link := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
@@ -371,19 +400,13 @@ func createBridge(t *testing.T, ifName string, addrs []string) {
 		},
 	}
 
-	err := netlink.LinkAdd(link)
+	err = nlh.LinkAdd(link)
 	assert.NilError(t, err)
 	for _, addr := range addrs {
 		ip, ipNet, err := net.ParseCIDR(addr)
 		assert.NilError(t, err)
 		ipNet.IP = ip
-		err = netlink.AddrAdd(link, &netlink.Addr{IPNet: ipNet})
+		err = nlh.AddrAdd(link, &netlink.Addr{IPNet: ipNet})
 		assert.NilError(t, err)
 	}
-}
-
-func deleteInterface(t *testing.T, ifName string) {
-	icmd.RunCommand("ip", "link", "delete", ifName).Assert(t, icmd.Success)
-	icmd.RunCommand("iptables", "-t", "nat", "--flush").Assert(t, icmd.Success)
-	icmd.RunCommand("iptables", "--flush").Assert(t, icmd.Success)
 }

--- a/libnetwork/drivers/bridge/setup_device_linux.go
+++ b/libnetwork/drivers/bridge/setup_device_linux.go
@@ -15,15 +15,7 @@ import (
 
 // SetupDevice create a new bridge interface/
 func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
-	// We only attempt to create the bridge when the requested device name is
-	// the default one. The default bridge name can be overridden with the
-	// DOCKER_TEST_CREATE_DEFAULT_BRIDGE env var. It should be used only for
-	// test purpose.
-	var defaultBridgeName string
-	if defaultBridgeName = os.Getenv("DOCKER_TEST_CREATE_DEFAULT_BRIDGE"); defaultBridgeName == "" {
-		defaultBridgeName = DefaultBridgeName
-	}
-	if config.BridgeName != defaultBridgeName && config.DefaultBridge {
+	if config.BridgeName != DefaultBridgeName && config.DefaultBridge {
 		return NonDefaultBridgeExistError(config.BridgeName)
 	}
 


### PR DESCRIPTION
**- What I did**

Noticed that, sometimes (under conditions I've not managed to repro reliably) when enabling IPv6 on the default bridge without specifying a `fixed-cidr-v6`, `docker0` wasn't assigned an address from the daemon's implicit ULA subnet - it only got an IPv4 address and the kernel-assigned link local address.

Commit facb2323 (https://github.com/moby/moby/pull/48319 - not shipped) aligned the way the default bridge's IPv6 subnet and gateway addresses are selected with IPv4.

Part of that involved looking at addresses already on the bridge, along with daemon config options. But, for IPv6, the kernel will assign a link-local address to the bridge - and that was confusing things.

**- How I did it**

_**Run tests that change docker0 in their own netns**_

These tests create iptables rules for different addresses on `docker0` but, unlike tests that do that for user-defined bridges, those rules aren't removed when the test deletes the network, because the default bridge network can't be deleted.

Because of this, adding tests for LL addresses in the third commit in this PR caused `TestAccessPublishedPortFromHost` to fail - it uses a custom bridge and wasn't affected by the daemon change in this PR, but NAT rules left behind by the new tests broke it.

So, use (abuse) the `L3Segment` code to run the tests in their own network namespace.

A minor drawback is that `TestDaemonDefaultBridgeWithFixedCidrButNoBip` can no longer run in rootless mode, because the `L3Segment` can't be created in rootlesskit's netns. But the test isn't looking at anything specific to rootless mode.

_**Remove test env var DOCKER_TEST_CREATE_DEFAULT_BRIDGE**_

Env var `DOCKER_TEST_CREATE_DEFAULT_BRIDGE` could be set to override the name of the default bridge - without the bridge being user-managed (unlike the `--bridge` daemon option).

It was needed by tests looking at docker0 behaviour, using their own instance of the daemon, without breaking the
docker0 instance belonging to CI's daemon. Now, those tests run in their own netns using the name docker0.

So, remove the unused env var.

_**Ignore kernel-assigned LL addrs when selecting "bip6"**_

Make sure the kernel-assigned LL address is ignored when selecting "bip6" (when bip6 is not explicitly specified).

This is made slightly complicated because we allow `fixed-cidr-v6` to be a link-local subnet (either the standard "fe80::/64", or any other non-overlapping LL subnet in "fe80::/10").

Following this change, if fixed-cidr-v6 is (or is included by) "fe80::/64", the bridge's kernel-assigned LL address may be used as the network's gateway address - even though it may also get an IPAM-assigned LL address.

**- How to verify it**

Updated the integration tests to make sure the bridge always has a kernel-assigned LL address - and added test cases for link-local subnets.

Without the fix, two of the updated tests fail ...

```
Running /go/src/github.com/docker/docker/integration/daemon (arm64.integration.daemon) flags=-test.v -test.timeout=10m -test.run TestDaemonDefaultBridgeIPAM
INFO: Testing against a local daemon
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/no_config
    daemon_linux_test.go:421: assertion failed:
        --- insp.IPAM.Config
        +++ expIPAMConfig
          []network.IPAMConfig{
          	{
        - 		Subnet:     "fe80::/64",
        + 		Subnet:     "192.168.176.0/24",
          		IPRange:    "",
        - 		Gateway:    "fe80::5448:e2ff:fe6a:4500",
        + 		Gateway:    "192.168.176.1",
          		AuxAddress: nil,
          	},
          	{
        - 		Subnet:     "192.168.176.0/24",
        + 		Subnet:     "fdd1:8161:2d2c::/64",
          		IPRange:    "",
        - 		Gateway:    "192.168.176.1",
        + 		Gateway:    "fdd1:8161:2d2c::1/64",
          		AuxAddress: nil,
          	},
          }

=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/fixed-cidr_only
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/bip_only
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/existing_bridge_address_only
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/fixed-cidr_within_old_bridge_subnet
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/link-local_fixed-cidr-v6
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/nonstandard_link-local_fixed-cidr-v6
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/fixed-cidr_within_old_bridge_subnet_with_new_bip
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/old_bridge_subnet_within_fixed-cidr
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/old_bridge_subnet_outside_fixed-cidr
=== RUN   TestDaemonDefaultBridgeIPAM_Docker0/old_bridge_subnet_outside_fixed-cidr_with_bip
--- FAIL: TestDaemonDefaultBridgeIPAM_Docker0 (6.55s)
    --- FAIL: TestDaemonDefaultBridgeIPAM_Docker0/no_config (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/fixed-cidr_only (0.59s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/bip_only (0.59s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/existing_bridge_address_only (0.59s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/fixed-cidr_within_old_bridge_subnet (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/link-local_fixed-cidr-v6 (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/nonstandard_link-local_fixed-cidr-v6 (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/fixed-cidr_within_old_bridge_subnet_with_new_bip (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/old_bridge_subnet_within_fixed-cidr (0.59s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/old_bridge_subnet_outside_fixed-cidr (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_Docker0/old_bridge_subnet_outside_fixed-cidr_with_bip (0.60s)
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/bridge_only
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_only
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.378304680Z" level=debug msg="/usr/sbin/ip6tables, [--wait -t filter -C DOCKER-USER -j RETURN]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.378768055Z" level=debug msg="/usr/sbin/ip6tables, [--wait -t filter -C FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.379219805Z" level=debug msg="/usr/sbin/ip6tables, [--wait -D FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.379704430Z" level=debug msg="/usr/sbin/ip6tables, [--wait -I FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.380792555Z" level=debug msg="/usr/sbin/iptables, [--wait -t filter -n -L DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.381250055Z" level=debug msg="/usr/sbin/iptables, [--wait -t filter -C DOCKER-USER -j RETURN]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.381705305Z" level=debug msg="/usr/sbin/iptables, [--wait -t filter -C FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.382163430Z" level=debug msg="/usr/sbin/iptables, [--wait -D FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.382651096Z" level=debug msg="/usr/sbin/iptables, [--wait -I FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.383120971Z" level=debug msg="/usr/sbin/ip6tables, [--wait -t filter -n -L DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.383612430Z" level=debug msg="/usr/sbin/ip6tables, [--wait -t filter -C DOCKER-USER -j RETURN]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.384440888Z" level=debug msg="/usr/sbin/ip6tables, [--wait -t filter -C FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.384975930Z" level=debug msg="/usr/sbin/ip6tables, [--wait -D FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.385480846Z" level=debug msg="/usr/sbin/ip6tables, [--wait -I FORWARD -j DOCKER-USER]"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.386415763Z" level=debug msg="daemon configured with a 15 seconds minimum shutdown timeout"
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.386447055Z" level=debug msg="start clean shutdown of all containers with a 15 seconds timeout..."
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.386827471Z" level=debug msg="Unix socket /tmp/dxr/daf4351ff91cf/libnetwork/940813862d38.sock was closed. The external key listener will stop."
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.387220346Z" level=debug msg="Cleaning up old mountid : start."
    daemon.go:318: [daf4351ff91cf] time="2024-12-03T17:58:32.387999721Z" level=debug msg="Cleaning up old mountid : done."
    daemon.go:318: [daf4351ff91cf] failed to start daemon: Error initializing network controller: fixed-cidr-v6=fdd1:8161:2d2c::/64 is outside any subnet implied by addresses on the user-managed default bridge
    daemon_linux_test.go:409: [daf4351ff91cf] failed to start daemon with arguments [--data-root /go/src/github.com/docker/docker/bundles/test-integration/TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_only/daf4351ff91cf/root --exec-root /tmp/dxr/daf4351ff91cf --pidfile /go/src/github.com/docker/docker/bundles/test-integration/TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_only/daf4351ff91cf/docker.pid --userland-proxy=true --containerd-namespace daf4351ff91cf --containerd-plugins-namespace daf4351ff91cfp --containerd /var/run/docker/containerd/containerd.sock --host unix:///tmp/docker-integration/daf4351ff91cf.sock --debug --storage-driver vfs --fixed-cidr 192.168.176.0/24 --fixed-cidr-v6 fdd1:8161:2d2c::/64 --ipv6 --bridge br-dbi] : [daf4351ff91cf] daemon exited during startup: exit status 1
    daemon_linux_test.go:399: [daf4351ff91cf] daemon is not started
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/fcidr_in_bridge_subnet_and_bridge_ip_in_fcidr
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/fcidr_in_bridge_subnet_and_bridge_ip_not_in_fcidr
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/link-local_fixed-cidr-v6
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/nonstandard_link-local_fixed-cidr-v6
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_bigger_than_bridge_subnet
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/no_bridge_ip_within_fixed-cidr
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_contains_bridge_subnet
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr-v6_bigger_than_bridge_subnet
    daemon_linux_test.go:399: [d77287f8daafc] daemon is not started
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/no_bridge_ip_within_fixed-cidr-v6
    daemon_linux_test.go:399: [dff5af1a1a58e] daemon is not started
=== RUN   TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr-v6_contains_bridge_subnet
    daemon_linux_test.go:399: [d47d53e1bbe3d] daemon is not started
--- FAIL: TestDaemonDefaultBridgeIPAM_UserBr (7.09s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/bridge_only (0.60s)
    --- FAIL: TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_only (0.56s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/fcidr_in_bridge_subnet_and_bridge_ip_in_fcidr (0.61s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/fcidr_in_bridge_subnet_and_bridge_ip_not_in_fcidr (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/link-local_fixed-cidr-v6 (0.59s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/nonstandard_link-local_fixed-cidr-v6 (0.60s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_bigger_than_bridge_subnet (0.59s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/no_bridge_ip_within_fixed-cidr (0.62s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr_contains_bridge_subnet (0.59s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr-v6_bigger_than_bridge_subnet (0.58s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/no_bridge_ip_within_fixed-cidr-v6 (0.58s)
    --- PASS: TestDaemonDefaultBridgeIPAM_UserBr/fixed-cidr-v6_contains_bridge_subnet (0.58s)
FAIL
```

**- Description for the changelog**
```markdown changelog
n/a
```
