### PR TITLE
vendor: github.com/containerd/cgroups v3.0.5

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -25,7 +25,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.32.0
 	github.com/aws/smithy-go v1.19.0
 	github.com/cloudflare/cfssl v1.6.4
-	github.com/containerd/cgroups/v3 v3.0.3
+	github.com/containerd/cgroups/v3 v3.0.5
 	github.com/containerd/containerd v1.7.24
 	github.com/containerd/containerd/api v1.7.19
 	github.com/containerd/continuity v0.4.5

--- a/vendor.sum
+++ b/vendor.sum
@@ -107,8 +107,8 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/container-storage-interface/spec v1.5.0 h1:lvKxe3uLgqQeVQcrnL2CPQKISoKjTJxojEs9cBk+HXo=
 github.com/container-storage-interface/spec v1.5.0/go.mod h1:8K96oQNkJ7pFcC2R9Z1ynGGBB1I93kcS6PGg3SsOk8s=
-github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGDJ9kip0=
-github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2WzJmticMgVuz0=
+github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
+github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd v1.7.24 h1:zxszGrGjrra1yYJW/6rhm9cJ1ZQ8rkKBR48brqsa7nA=

--- a/vendor/github.com/containerd/cgroups/v3/Protobuild.toml
+++ b/vendor/github.com/containerd/cgroups/v3/Protobuild.toml
@@ -13,7 +13,7 @@ generators = ["go"]
   # This is the default.
   after = ["/usr/local/include", "/usr/include"]
 
-# Aggregrate the API descriptors to lock down API changes.
+# Aggregate the API descriptors to lock down API changes.
 [[descriptors]]
 prefix = "github.com/containerd/cgroups/cgroup1/stats"
 target = "cgroup1/stats/metrics.pb.txt"

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/cgroup.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/cgroup.go
@@ -196,7 +196,7 @@ func (c *cgroup) AddTask(process Process, subsystems ...Name) error {
 	return c.add(process, cgroupTasks, subsystems...)
 }
 
-// writeCgroupsProcs writes to the file, but retries on EINVAL.
+// writeCgroupProcs writes to the file, but retries on EINVAL.
 func writeCgroupProcs(path string, content []byte, perm fs.FileMode) error {
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, perm)
 	if err != nil {

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/memory.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/memory.go
@@ -433,7 +433,7 @@ func getMemorySettings(resources *specs.LinuxResources) []memorySettings {
 		},
 		{
 			name:  "kmem.limit_in_bytes",
-			value: mem.Kernel,
+			value: mem.Kernel, //nolint:staticcheck // SA1019: mem.Kernel is deprecated
 		},
 		{
 			name:  "kmem.tcp.limit_in_bytes",

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/opts.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/opts.go
@@ -62,11 +62,19 @@ func RequireDevices(s Subsystem, _ Path, _ error) error {
 	return ErrIgnoreSubsystem
 }
 
-// WithHiearchy sets a list of cgroup subsystems.
+// WithHierarchy sets a list of cgroup subsystems.
 // The default list is coming from /proc/self/mountinfo.
-func WithHiearchy(h Hierarchy) InitOpts {
+func WithHierarchy(h Hierarchy) InitOpts {
 	return func(c *InitConfig) error {
 		c.hierarchy = h
 		return nil
 	}
+}
+
+// WithHiearchy sets a list of cgroup subsystems. It is just kept for backward
+// compatibility and will be removed in v4.
+//
+// Deprecated: use WithHierarchy instead.
+func WithHiearchy(h Hierarchy) InitOpts {
+	return WithHierarchy(h)
 }

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/pids.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/pids.go
@@ -66,13 +66,13 @@ func (p *pidsController) Stat(path string, stats *v1.Metrics) error {
 	if err != nil {
 		return err
 	}
-	max, err := readUint(filepath.Join(p.Path(path), "pids.max"))
+	pidsMax, err := readUint(filepath.Join(p.Path(path), "pids.max"))
 	if err != nil {
 		return err
 	}
 	stats.Pids = &v1.PidsStat{
 		Current: current,
-		Limit:   max,
+		Limit:   pidsMax,
 	}
 	return nil
 }

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/subsystem.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/subsystem.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containerd/cgroups/v3"
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	"github.com/moby/sys/userns"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -60,7 +60,7 @@ func Subsystems() []Name {
 		Blkio,
 		Rdma,
 	}
-	if !cgroups.RunningInUserNS() {
+	if !userns.RunningInUserNS() {
 		n = append(n, Devices)
 	}
 	if _, err := os.Stat("/sys/kernel/mm/hugepages"); err == nil {

--- a/vendor/github.com/containerd/cgroups/v3/cgroup1/utils.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup1/utils.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/containerd/cgroups/v3"
 	units "github.com/docker/go-units"
+	"github.com/moby/sys/userns"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -53,7 +54,7 @@ func defaults(root string) ([]Subsystem, error) {
 	}
 	// only add the devices cgroup if we are not in a user namespace
 	// because modifications are not allowed
-	if !cgroups.RunningInUserNS() {
+	if !userns.RunningInUserNS() {
 		s = append(s, NewDevices(root))
 	}
 	// add the hugetlb cgroup if error wasn't due to missing hugetlb
@@ -196,7 +197,7 @@ func parseKV(raw string) (string, uint64, error) {
 // The resulting map does not have an element for cgroup v2 unified hierarchy.
 // Use [cgroups.ParseCgroupFileUnified] to get the unified path.
 func ParseCgroupFile(path string) (map[string]string, error) {
-	x, _, err := ParseCgroupFileUnified(path)
+	x, _, err := cgroups.ParseCgroupFileUnified(path)
 	return x, err
 }
 
@@ -236,9 +237,9 @@ func getCgroupDestination(subsystem string) (string, error) {
 	return "", ErrNoCgroupMountDestination
 }
 
-func pathers(subystems []Subsystem) []pather {
+func pathers(subsystems []Subsystem) []pather {
 	var out []pather
-	for _, s := range subystems {
+	for _, s := range subsystems {
 		if p, ok := s.(pather); ok {
 			out = append(out, p)
 		}

--- a/vendor/github.com/containerd/cgroups/v3/cgroup2/devicefilter.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup2/devicefilter.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Devicefilter containes eBPF device filter program
+// Devicefilter contains eBPF device filter program
 //
 // The implementation is based on https://github.com/containers/crun/blob/0.10.2/src/libcrun/ebpf.c
 //

--- a/vendor/github.com/containerd/cgroups/v3/cgroup2/manager.go
+++ b/vendor/github.com/containerd/cgroups/v3/cgroup2/manager.go
@@ -31,10 +31,10 @@ import (
 
 	"github.com/containerd/cgroups/v3/cgroup2/stats"
 
+	"github.com/containerd/log"
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -242,8 +242,10 @@ func setResources(path string, resources *Resources) error {
 type CgroupType string
 
 const (
-	Domain   CgroupType = "domain"
-	Threaded CgroupType = "threaded"
+	Domain         CgroupType = "domain"
+	DomainThreaded CgroupType = "domain threaded"
+	DomainInvalid  CgroupType = "domain invalid"
+	Threaded       CgroupType = "threaded"
 )
 
 func (c *Manager) GetType() (CgroupType, error) {
@@ -317,7 +319,7 @@ func (c *Manager) ToggleControllers(controllers []string, t ControllerToggle) er
 		}
 		filePath := filepath.Join(f, subtreeControl)
 		if err := c.writeSubtreeControl(filePath, controllers, t); err != nil {
-			// When running as rootless, the user may face EPERM on parent groups, but it is neglible when the
+			// When running as rootless, the user may face EPERM on parent groups, but it is negligible when the
 			// controller is already written.
 			// So we only return the last error.
 			lastErr = fmt.Errorf("failed to write subtree controllers %+v to %q: %w", controllers, filePath, err)
@@ -401,7 +403,7 @@ func (c *Manager) Kill() error {
 	if err == nil {
 		return nil
 	}
-	logrus.Warnf("falling back to slower kill implementation: %s", err)
+	log.L.Warnf("falling back to slower kill implementation: %s", err)
 	// Fallback to slow method.
 	return c.fallbackKill()
 }
@@ -414,13 +416,15 @@ func (c *Manager) Kill() error {
 //
 // https://github.com/opencontainers/runc/blob/8da0a0b5675764feaaaaad466f6567a9983fcd08/libcontainer/init_linux.go#L523-L529
 func (c *Manager) fallbackKill() error {
+	logger := log.G(context.TODO()).WithFields(log.Fields{"path": c.path})
+
 	if err := c.Freeze(); err != nil {
-		logrus.Warn(err)
+		logger.WithError(err).Warn("freezing cgroup2.manager")
 	}
 	pids, err := c.Procs(true)
 	if err != nil {
 		if err := c.Thaw(); err != nil {
-			logrus.Warn(err)
+			logger.WithError(err).Warn("thawing cgroup2.manager")
 		}
 		return err
 	}
@@ -428,16 +432,16 @@ func (c *Manager) fallbackKill() error {
 	for _, pid := range pids {
 		p, err := os.FindProcess(int(pid))
 		if err != nil {
-			logrus.Warn(err)
+			logger.WithFields(log.Fields{"error": err, "pid": int(pid)}).Warnf("finding process")
 			continue
 		}
 		procs = append(procs, p)
 		if err := p.Signal(unix.SIGKILL); err != nil {
-			logrus.Warn(err)
+			logger.WithFields(log.Fields{"error": err, "pid": int(pid)}).Warnf("signaling process")
 		}
 	}
 	if err := c.Thaw(); err != nil {
-		logrus.Warn(err)
+		logger.WithError(err).Warn("thawing cgroup2.manager")
 	}
 
 	subreaper, err := getSubreaper()
@@ -459,7 +463,7 @@ func (c *Manager) fallbackKill() error {
 		if subreaper == 0 {
 			if _, err := p.Wait(); err != nil {
 				if !errors.Is(err, unix.ECHILD) {
-					logrus.Warnf("wait on pid %d failed: %s", p.Pid, err)
+					logger.WithFields(log.Fields{"error": err, "pid": p.Pid}).Warn("waiting on process")
 				}
 			}
 		}
@@ -468,13 +472,29 @@ func (c *Manager) fallbackKill() error {
 }
 
 func (c *Manager) Delete() error {
-	// kernel prevents cgroups with running process from being removed, check the tree is empty
-	processes, err := c.Procs(true)
+	// Kernel prevents cgroups with running process from being removed,
+	// check the tree is empty.
+	//
+	// Pick the right file to read based on the cgs type.
+	cgType, err := c.GetType()
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	var tasks []uint64
+	switch cgType {
+	case Threaded, DomainThreaded:
+		tasks, err = c.Threads(true)
+	default:
+		tasks, err = c.Procs(true)
+	}
 	if err != nil {
 		return err
 	}
-	if len(processes) > 0 {
-		return fmt.Errorf("cgroups: unable to remove path %q: still contains running processes", c.path)
+	if len(tasks) > 0 {
+		return fmt.Errorf("cgroups: unable to remove path %q: still contains running tasks", c.path)
 	}
 	return remove(c.path)
 }
@@ -692,7 +712,7 @@ func (c *Manager) MemoryEventFD() (int, uint32, error) {
 	fpath := filepath.Join(c.path, "memory.events")
 	fd, err := unix.InotifyInit()
 	if err != nil {
-		return 0, 0, errors.New("failed to create inotify fd")
+		return 0, 0, fmt.Errorf("failed to create inotify fd: %w", err)
 	}
 	wd, err := unix.InotifyAddWatch(fd, fpath, unix.IN_MODIFY)
 	if err != nil {
@@ -928,24 +948,27 @@ func startUnit(conn *systemdDbus.Conn, group string, properties []systemdDbus.Pr
 		}
 	}
 
+	systemdStartUnitTimeout := 30 * time.Second
 	select {
 	case s := <-statusChan:
 		if s != "done" {
 			attemptFailedUnitReset(conn, group)
 			return fmt.Errorf("error creating systemd unit `%s`: got `%s`", group, s)
 		}
-	case <-time.After(30 * time.Second):
-		logrus.Warnf("Timed out while waiting for StartTransientUnit(%s) completion signal from dbus. Continuing...", group)
+	case <-time.After(systemdStartUnitTimeout):
+		attemptFailedUnitReset(conn, group)
+		return fmt.Errorf("timed out while waiting for StartTransientUnit(%s) completion signal from dbus after %v", group, systemdStartUnitTimeout)
 	}
 
 	return nil
 }
 
 func attemptFailedUnitReset(conn *systemdDbus.Conn, group string) {
-	err := conn.ResetFailedUnitContext(context.TODO(), group)
+	ctx := context.TODO()
+	err := conn.ResetFailedUnitContext(ctx, group)
 
 	if err != nil {
-		logrus.Warnf("Unable to reset failed unit: %v", err)
+		log.G(ctx).Warnf("Unable to reset failed unit: %v", err)
 	}
 }
 

--- a/vendor/github.com/containerd/cgroups/v3/utils.go
+++ b/vendor/github.com/containerd/cgroups/v3/utils.go
@@ -25,12 +25,11 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/moby/sys/userns"
 	"golang.org/x/sys/unix"
 )
 
 var (
-	nsOnce    sync.Once
-	inUserNS  bool
 	checkMode sync.Once
 	cgMode    CGMode
 )
@@ -77,35 +76,10 @@ func Mode() CGMode {
 
 // RunningInUserNS detects whether we are currently running in a user namespace.
 // Copied from github.com/lxc/lxd/shared/util.go
+//
+// Deprecated: use [userns.RunningInUserNS].
 func RunningInUserNS() bool {
-	nsOnce.Do(func() {
-		file, err := os.Open("/proc/self/uid_map")
-		if err != nil {
-			// This kernel-provided file only exists if user namespaces are supported
-			return
-		}
-		defer file.Close()
-
-		buf := bufio.NewReader(file)
-		l, _, err := buf.ReadLine()
-		if err != nil {
-			return
-		}
-
-		line := string(l)
-		var a, b, c int64
-		fmt.Sscanf(line, "%d %d %d", &a, &b, &c)
-
-		/*
-		 * We assume we are in the initial user namespace if we have a full
-		 * range - 4294967295 uids starting at uid 0.
-		 */
-		if a == 0 && b == 0 && c == 4294967295 {
-			return
-		}
-		inUserNS = true
-	})
-	return inUserNS
+	return userns.RunningInUserNS()
 }
 
 // ParseCgroupFileUnified returns legacy subsystem paths as the first value,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -246,8 +246,8 @@ github.com/cloudflare/cfssl/signer/local
 # github.com/container-storage-interface/spec v1.5.0
 ## explicit; go 1.16
 github.com/container-storage-interface/spec/lib/go/csi
-# github.com/containerd/cgroups/v3 v3.0.3
-## explicit; go 1.18
+# github.com/containerd/cgroups/v3 v3.0.5
+## explicit; go 1.22.0
 github.com/containerd/cgroups/v3
 github.com/containerd/cgroups/v3/cgroup1
 github.com/containerd/cgroups/v3/cgroup1/stats


### PR DESCRIPTION
- [x] depends on https://github.com/moby/moby/pull/49030
- [x] depends on https://github.com/moby/moby/pull/49031

----

### vendor: github.com/containerd/cgroups v3.0.4

full diff: https://github.com/containerd/cgroups/compare/v3.0.3...v3.0.4

notable changes:

- chore: don't log ENOTSUP during parsing PSI files 
- Add EOPNOTSUPP to err filter for PSI data
- cg2: Don't read cgroup.procs when deleting threaded cg
- Added cgroup type "domain threaded" and "domain invalid"
- switch to github.com/containerd/log
- go.mod: update to go1.22 as minimum
- deprecate RunningInUserNS()
- dont ignore failure to create cgroup after timeout
- cgroup2: Manager.Delete: handle both "threaded" and "domain threaded"
