### PR TITLE
Fix health check timing logic for StartPeriod and Interval

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -262,14 +262,23 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 	started := c.State.StartedAt
 	c.Unlock()
 
+	// Ensures that if the StartPeriod ends before the next scheduled probeInterval
+	// The next health check runs immediately after the StartPeriod.
 	getInterval := func() time.Duration {
-		if time.Since(started) >= startPeriod {
+		elapsed := time.Since(started)
+		if elapsed >= startPeriod {
 			return probeInterval
 		}
+	
+		remainingStartPeriod := startPeriod - elapsed
+		if remainingStartPeriod < probeInterval {
+			return remainingStartPeriod
+		}
+	
 		c.Lock()
 		status := c.Health.Health.Status
 		c.Unlock()
-
+	
 		if status == containertypes.Starting {
 			return startInterval
 		}

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -263,7 +263,7 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 	c.Unlock()
 
 	// Ensures that if the StartPeriod ends before the next scheduled probeInterval
-	// The next health check runs immediately after the StartPeriod.
+	// The next health check runs immediately after the StartPeriod
 	getInterval := func() time.Duration {
 		elapsed := time.Since(started)
 		if elapsed >= startPeriod {


### PR DESCRIPTION
Fixes: #46747
How I did it

Updated the monitor function in health.go to correctly calculate the interval after the StartPeriod ends.
Ensured that the health checks respect the configured HealthStartPeriod and HealthInterval.
Added logic to dynamically adjust the scheduling of health checks based on elapsed time and configuration.

How to verify it

Run a container with the following health check configuration:
docker run -d --name health-test \
  --health-cmd "/bin/false" \
  --health-interval=2s \
  --health-start-period=2s \
  --health-retries=1 \
  alpine:latest sleep 60
  
Inspect the health check logs with:
docker inspect --format='{{json .State.Health}}' health-test

Confirm that the first health check occurs immediately after the StartPeriod ends.
Confirm subsequent checks occur at the configured HealthInterval.
Verify the container's health status transitions to "unhealthy" after a failing health check.

Description for the changelog:

Fixed health check timing to ensure probes begin immediately after the `StartPeriod` ends, adhering to the configured interval.
  
Signed-off-by: Karim Turfah <kturfah02@gmail.com>