### PR TITLE
Use `getsubids` tool for subid validation if possible

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -228,8 +228,13 @@ init() {
 		fi
 	fi
 
-	# instructions: validate subuid/subgid files for current user
-	if ! grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subuid 2> /dev/null; then
+	# instructions: validate subuid for current user
+	if command -v "getsubids" > /dev/null 2>&1; then
+		getsubids "$USERNAME" > /dev/null 2>&1 || getsubids "$(id -u)" > /dev/null 2>&1
+	else
+		grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subuid 2> /dev/null
+	fi
+	if [ $? -ne 0 ]; then
 		instructions=$(
 			cat <<- EOI
 				${instructions}
@@ -238,7 +243,14 @@ init() {
 			EOI
 		)
 	fi
-	if ! grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subgid 2> /dev/null; then
+
+	# instructions: validate subgid for current user
+	if command -v "getsubids" > /dev/null 2>&1; then
+		getsubids -g "$USERNAME" > /dev/null 2>&1 || getsubids -g "$(id -u)" > /dev/null 2>&1
+	else
+		grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subgid 2> /dev/null
+	fi
+	if [ $? -ne 0 ]; then
 		instructions=$(
 			cat <<- EOI
 				${instructions}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Use `getsubids` tool instead of parsing `/etc/subuid` and `/etc/subgid` for subid ownership validation.

**- How I did it**
`getsubids` tool is includes within `uidmap` package that is required for running rootless Docker. It supports NSS module in addition to `/etc/subuid` and `/etc/subgid` files. As the latter is a default, existing users that pass the test shouldn't be affected.

**- How to verify it**
Use an NSS-based or traditional file-based `subid` backend and run `dockerd-rootless-setuptools.sh install`. It would  no longer fail for the NSS case.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix rootless Docker setup with `subid` backed by NSS modules
```

**- A picture of a cute animal (not mandatory but encouraged)**

