### PR TITLE
Try to load kernel modules, without modprobe

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,15 +60,6 @@ pipeline {
                     }
 
                     stages {
-                        stage("Load kernel modules") {
-                            steps {
-                                sh '''
-                                sudo modprobe ip6table_filter
-                                sudo modprobe -va br_netfilter
-                                sudo systemctl restart docker.service
-                                '''
-                            }
-                        }
                         stage("Print info") {
                             steps {
                                 sh 'docker version'

--- a/hack/make/run
+++ b/hack/make/run
@@ -91,19 +91,6 @@ if [ -n "$DOCKER_ROOTLESS" ]; then
 	)
 fi
 
-# On a host using nftables, the ip6_tables kernel module may need to be loaded.
-# This trick is borrowed from the docker (dind) official image ...
-# "modprobe" without modprobe
-#   https://twitter.com/lucabruno/status/902934379835662336
-# This isn't 100% fool-proof, but it'll have a much higher success rate than
-# simply using the "real" modprobe (which isn't installed in the dev container).
-if ! ip6tables -nL > /dev/null 2>&1; then
-	ip link show ip6_tables > /dev/null 2>&1 || true
-	if ! ip6tables -nL > /dev/null 2>&1; then
-		echo >&2 'ip6tables is not available'
-	fi
-fi
-
 set -x
 # shellcheck disable=SC2086
 exec "${dockerd[@]}" "${args[@]}"

--- a/internal/modprobe/modprobe_linux.go
+++ b/internal/modprobe/modprobe_linux.go
@@ -1,0 +1,110 @@
+// Package modprobe attempts to load kernel modules. It may have more success
+// than simply running "modprobe", particularly for docker-in-docker.
+package modprobe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/containerd/log"
+	"golang.org/x/sys/unix"
+)
+
+// LoadModules attempts to load kernel modules, if necessary.
+//
+// isLoaded must be a function that checks whether the modules are loaded. It may
+// be called multiple times. isLoaded must return an error to indicate that the
+// modules still need to be loaded, otherwise nil.
+//
+// For each method of loading modules, LoadModules will attempt the load for each
+// of modNames, then it will call isLoaded to check the result - moving on to try
+// the next method if needed, and there is one.
+//
+// The returned error is the result of the final call to isLoaded.
+func LoadModules(ctx context.Context, isLoaded func() error, modNames ...string) error {
+	if isLoaded() == nil {
+		log.G(ctx).WithFields(log.Fields{
+			"modules": modNames,
+		}).Debug("Modules already loaded")
+		return nil
+	}
+
+	if err := tryLoad(ctx, isLoaded, modNames, ioctlLoader{}); err != nil {
+		return tryLoad(ctx, isLoaded, modNames, modprobeLoader{})
+	}
+	return nil
+}
+
+type loader interface {
+	name() string
+	load(modName string) error
+}
+
+func tryLoad(ctx context.Context, isLoaded func() error, modNames []string, loader loader) error {
+	var loadErrs []error
+	for _, modName := range modNames {
+		if err := loader.load(modName); err != nil {
+			loadErrs = append(loadErrs, err)
+		}
+	}
+
+	if checkResult := isLoaded(); checkResult != nil {
+		log.G(ctx).WithFields(log.Fields{
+			"loader":      loader.name(),
+			"modules":     modNames,
+			"loadErrors":  errors.Join(loadErrs...),
+			"checkResult": checkResult,
+		}).Debug("Modules not loaded")
+		return checkResult
+	}
+
+	log.G(ctx).WithFields(log.Fields{
+		"loader":     loader.name(),
+		"modules":    modNames,
+		"loadErrors": errors.Join(loadErrs...),
+	}).Debug("Modules loaded")
+	return nil
+}
+
+// ioctlLoader attempts to load the module using an ioctl() to get the interface index
+// of a module - it won't have one, but the kernel may load the module. This tends to
+// work in docker-in-docker, where the inner-docker may not have "modprobe" or access
+// to modules in the host's filesystem.
+type ioctlLoader struct{}
+
+func (il ioctlLoader) name() string { return "ioctl" }
+
+func (il ioctlLoader) load(modName string) error {
+	sd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return fmt.Errorf("creating socket for ioctl load of %s: %w", modName, err)
+	}
+	defer unix.Close(sd)
+
+	// This tends to work, if running with CAP_SYS_MODULE, because...
+	//   https://github.com/torvalds/linux/blob/6f7da290413ba713f0cdd9ff1a2a9bb129ef4f6c/net/core/dev_ioctl.c#L457
+	//   https://github.com/torvalds/linux/blob/6f7da290413ba713f0cdd9ff1a2a9bb129ef4f6c/net/core/dev_ioctl.c#L371-L372
+	ifreq, err := unix.NewIfreq(modName)
+	if err != nil {
+		return fmt.Errorf("creating ifreq for %s: %w", modName, err)
+	}
+	// An error is returned even if the module load is successful. So, ignore it.
+	_ = unix.IoctlIfreq(sd, unix.SIOCGIFINDEX, ifreq)
+	return nil
+}
+
+// modprobeLoader attempts to load a kernel module using modprobe.
+type modprobeLoader struct{}
+
+func (ml modprobeLoader) name() string { return "modprobe" }
+
+func (ml modprobeLoader) load(modName string) error {
+	out, err := exec.Command("modprobe", "-va", modName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("modprobe %s failed with message: %q, error: %w", modName, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}


### PR DESCRIPTION
**- What I did**

When running in a container (docker-in-docker), the host may not have required kernel modules loaded.

Try to trigger the module load using an `ioctl()` call, then `modprobe` if that doesn't work.

This should make IPv6 networks work in GitHub Codespaces / devcontainers:
- https://github.com/devcontainers/features/issues/1206

This is based on the DinD official image's [method of loading modules](https://github.com/docker-library/docker/blob/6ce7fe78a5a66dadf37e9226d8485e94e894814f/modprobe.sh) using `ip link show`, which was inspired by https://twitter.com/lucabruno/status/902934379835662336

**- How I did it**

- Replaced existing modprobe calls with the new method, supplying check functions to determine whether the load is necessary, or has been successful.
- Add a modprobe for `ip6_tables`.
- Remove modprobe calls from the moby dev-container's run script, and the Jenkinsfile - added as workarounds in:
  - https://github.com/moby/moby/pull/47960
  - https://github.com/moby/moby/pull/48993

**- How to verify it**

On a Debian 12.5 host, running dockerd `27.3.1`, with systemd ...
- With `ip6_tables` not loaded on the host (the host doesn't need it, because the daemon's`ip6tables` commands use a (deprecated) dbus interface to send raw firewall commands.
- Started a dev container with the updated code, the `ip6_tables` module wasn't loaded.
- Built the new dockerd and ran it, with `ip6tables` enabled by-default.
- The module was loaded on the host, and inner-docker logs showed module was loaded using the `ioctl` method:
  - `DEBU[2024-12-05T11:30:36.095500049Z] Modules loaded                                loadErrors="<nil>" loader=ioctl modules=ip6_tables`
- Restarted the inner docker, no load was attempted:
  -  `DEBU[2024-12-05T11:31:59.533424067Z] Modules already loaded                        modules=ip6_tables`
- Ditto (both times) for the conntrack modules:
  - `DEBU[2024-12-05T11:31:59.590301221Z] Modules already loaded                        modules="nf_conntrack,nf_conntrack_netlink"`

To check error logging, and fallback to modprobe:

```go
if err := modprobe.LoadModules(context.TODO(), func() error {
        return fmt.Errorf("no fruit")
}, "bananas", "apples", "oranges"); err != nil {
        log.G(context.Background()).WithError(err).Debug("Loading breakfast")
}
```

Resulted in:

```
DEBU[2024-12-05T11:55:32.007075924Z] Modules not loaded                            checkResult="no fruit" loadErrors="<nil>" loader=ioctl modules="bananas,apples,oranges"
DEBU[2024-12-05T11:55:32.007147257Z] Modules not loaded                            checkResult="no fruit" loadErrors="modprobe bananas failed with message: \"\", error: exec: \"modprobe\": executable file not found in $PATH\nmodprobe apples failed with message: \"\", error: exec: \"modprobe\": executable file not found in $PATH\nmodprobe oranges failed with message: \"\", error: exec: \"modprobe\": executable file not found in $PATH" loader=modprobe modules="bananas,apples,oranges"
DEBU[2024-12-05T11:55:32.007172382Z] Loading breakfast                             error="no fruit"
```

**- Description for the changelog**
```markdown changelog
- Attempt to load kernel modules, including `ip6_tables` and `br_netfilter` when required, using a
  method that is likely to succeed inside a docker-in-docker container.
```