### PR TITLE
api/ping: add support for querying engine features

### DIFF
--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -27,6 +27,7 @@ type DiskUsageOptions struct {
 // Backend is the methods that need to be implemented to provide
 // system specific functionality.
 type Backend interface {
+	SystemCapabilities(context.Context, int) (system.Capabilities, error)
 	SystemInfo(context.Context) (*system.Info, error)
 	SystemVersion(context.Context) (types.Version, error)
 	SystemDiskUsage(ctx context.Context, opts DiskUsageOptions) (*types.DiskUsage, error)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -173,6 +173,36 @@ tags:
     x-displayName: "System"
 
 definitions:
+  Capabilities:
+    x-extendedDiscriminator: _v
+    description: "Represents engine capabilities"
+    type: "object"
+    required:
+      - _v
+    properties:
+      _v:
+        type: "integer"
+      data:
+        type: "object"
+
+  CapabilitiesV1:
+    allOf:
+      - $ref: "#/definitions/Capabilities"
+      - type: "object"
+        properties:
+          _v:
+            type: "integer"
+            enum:
+              - 1
+          data:
+            type: "object"
+            properties:
+              registry-client-auth:
+                description: "Whether the engine supports client auth handling."
+                type: "boolean"
+                x-nullable: true
+                example: true
+
   Port:
     type: "object"
     description: "An open port on a container"
@@ -10155,6 +10185,90 @@ paths:
           description: "server error"
           schema:
             $ref: "#/definitions/ErrorResponse"
+      tags: ["System"]
+  # Using a zero-width character here to define a separate /_ping endpoint to describe the
+  # /_ping?capabilities=1 API since otherwise Swagger won't allow us to define multiple
+  # responses for the same endpoint depending on query parameter.
+  # This is however supported by OpenAPI v3.
+  # See: https://github.com/OAI/OpenAPI-Specification/issues/146
+  # and https://github.com/OAI/OpenAPI-Specification/issues/182
+  /_ping​:
+    get:
+      summary: "/_ping?capabilities=1"
+      description: |
+        This is the same endpoint as `GET /_ping`, but describes the different
+        response when it is called with the `capabilities=1` query parameter.
+
+        In this case, the daemon instead responds with a `Content-Type` of
+        `application/json` and writes a json represenation of the engine's
+        capabilities in the response body.
+      operationId: "SystemPingCapabilities"
+      produces: ["application/json"]
+      parameters:
+        - name: "capabilities"
+          in: "query"
+          description: The capabilities API version being requested.
+          # marked as required since this is a separate endpoint in the swagger yaml.
+          required: true
+          type: "string"
+          enum: ["1"]
+      responses:
+        200:
+          description: "no error"
+          schema:
+            $ref: "#/definitions/Capabilities"
+          headers:
+            Api-Version:
+              type: "string"
+              description: "Max API Version the server supports"
+            Builder-Version:
+              type: "string"
+              description: |
+                Default version of docker image builder
+
+                The default on Linux is version "2" (BuildKit), but the daemon
+                can be configured to recommend version "1" (classic Builder).
+                Windows does not yet support BuildKit for native Windows images,
+                and uses "1" (classic builder) as a default.
+
+                This value is a recommendation as advertised by the daemon, and
+                it is up to the client to choose which builder to use.
+              default: "2"
+            Docker-Experimental:
+              type: "boolean"
+              description: "If the server is running with experimental mode enabled"
+            Swarm:
+              type: "string"
+              enum:
+                [
+                  "inactive",
+                  "pending",
+                  "error",
+                  "locked",
+                  "active/worker",
+                  "active/manager",
+                ]
+              description: |
+                Contains information about Swarm status of the daemon,
+                and if the daemon is acting as a manager or worker node.
+              default: "inactive"
+            Cache-Control:
+              type: "string"
+              default: "no-cache, no-store, must-revalidate"
+            Pragma:
+              type: "string"
+              default: "no-cache"
+        500:
+          description: "server error"
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+          headers:
+            Cache-Control:
+              type: "string"
+              default: "no-cache, no-store, must-revalidate"
+            Pragma:
+              type: "string"
+              default: "no-cache"
       tags: ["System"]
   /commit:
     post:

--- a/api/types/system/capabilities.go
+++ b/api/types/system/capabilities.go
@@ -1,0 +1,72 @@
+package system
+
+import (
+	"fmt"
+)
+
+// CapabilitiesVersion is the current version of the Capabilities API.
+//
+// If a client requests a version N such that N > CapabilitiesVersion
+// with this version. Otherwise, the engine will respond, downgrading
+// if necessary, with the requested version.
+const CapabilitiesVersion = 1
+
+// Capabilities represents a specific version of Capabilities.
+type Capabilities struct {
+	// Version is a natural number representing the version of the
+	// capabilities API this response is for.
+	// The version of the Capabilities is intrinsically tied to
+	// the values contained in Data, and necessary to parse them.
+	//
+	// The capabilities API contract mandates that any client requesting
+	// capabilities version N MUST also accept any capabilities version
+	// M such that 1 < M < N. When handling a capabilities request for
+	// version N, the daemon will pick a version
+	// M = min(DAEMON_CAPABILITIES_VERSION, N) and reply with that
+	// version.
+	Version int `json:"_v"`
+
+	// Data contains the internal representation of the advertised
+	// capabilities.
+	// Values contained therein should not be processed without
+	// taking Version into account, and no inferences about the
+	// capabilities of the engine should be made solely on it.
+	Data map[string]any `json:"data"`
+}
+
+func (b Capabilities) CapabilitiesVersion() int {
+	return b.Version
+}
+
+type ErrBadCapabilities struct {
+	cause error
+}
+
+func (e ErrBadCapabilities) Error() string {
+	return "bad capabilities: " + e.cause.Error()
+}
+
+type ErrUnknownCapabilitiesVersion struct {
+	version int
+}
+
+func (e ErrUnknownCapabilitiesVersion) Error() string {
+	return fmt.Sprintf("can't process unknown capabilities version %d", e.version)
+}
+
+func (b Capabilities) SupportsRegistryClientAuth() (bool, error) {
+	switch b.CapabilitiesVersion() {
+	case 1:
+		v, ok := b.Data["registry-client-auth"]
+		if !ok {
+			return false, ErrBadCapabilities{
+				cause: fmt.Errorf("capabilities version %d must contain `registry-client-auth`", b.CapabilitiesVersion()),
+			}
+		}
+		if b, ok := v.(bool); ok {
+			return b, nil
+		}
+	}
+
+	return false, ErrUnknownCapabilitiesVersion{version: b.CapabilitiesVersion()}
+}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/api/types/volume"
 )
 
@@ -34,6 +35,24 @@ type Ping struct {
 	// should use other ways to get the current swarm status, such as the /swarm
 	// endpoint.
 	SwarmStatus *swarm.Status
+
+	// Capabilities provides information about specific capabilities
+	// the daemon might or might not support.
+	//
+	// Can be nil if capabilities are not requested, or if the client is communicating
+	// with an older daemon that does not support requesting capabilities.
+	Capabilities *system.Capabilities
+}
+
+// PingBody represents the body of the `GET /_ping` endpoint, when
+// it's Content-Type is `application/json`.
+type PingBody struct {
+	Capabilities *system.Capabilities `json:"capabilities,omitempty"`
+}
+
+// PingOptions holds parameters for the Ping endpoint.
+type PingOptions struct {
+	Capabilities bool
 }
 
 // ComponentVersion describes the version information for a specific component.

--- a/client/client.go
+++ b/client/client.go
@@ -289,7 +289,7 @@ func (cli *Client) checkVersion(ctx context.Context) error {
 			return nil
 		}
 
-		ping, err := cli.Ping(ctx)
+		ping, err := cli.Ping(ctx, types.PingOptions{})
 		if err != nil {
 			return err
 		}
@@ -338,7 +338,7 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 		cli.negotiateLock.Lock()
 		defer cli.negotiateLock.Unlock()
 
-		ping, err := cli.Ping(ctx)
+		ping, err := cli.Ping(ctx, types.PingOptions{})
 		if err != nil {
 			// FIXME(thaJeztah): Ping returns an error when failing to connect to the API; we should not swallow the error here, and instead returning it.
 			return

--- a/client/interface.go
+++ b/client/interface.go
@@ -169,8 +169,7 @@ type SystemAPIClient interface {
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options types.DiskUsageOptions) (types.DiskUsage, error)
-	Ping(ctx context.Context) (types.Ping, error)
-	PingWithOptions(ctx context.Context, options types.PingOptions) (types.Ping, error)
+	Ping(ctx context.Context, options types.PingOptions) (types.Ping, error)
 }
 
 // VolumeAPIClient defines API client methods for the volumes

--- a/client/interface.go
+++ b/client/interface.go
@@ -170,6 +170,7 @@ type SystemAPIClient interface {
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options types.DiskUsageOptions) (types.DiskUsage, error)
 	Ping(ctx context.Context) (types.Ping, error)
+	PingWithOptions(ctx context.Context, options types.PingOptions) (types.Ping, error)
 }
 
 // VolumeAPIClient defines API client methods for the volumes

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -73,7 +74,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), types.PingOptions{})
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -88,7 +89,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), types.PingOptions{})
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -102,7 +103,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), types.PingOptions{})
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -116,7 +117,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), types.PingOptions{})
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})
@@ -131,7 +132,7 @@ func TestWithUserAgent(t *testing.T) {
 			})),
 		)
 		assert.Check(t, err)
-		_, err = c.Ping(context.Background())
+		_, err = c.Ping(context.Background(), types.PingOptions{})
 		assert.Check(t, err)
 		assert.Check(t, c.Close())
 	})

--- a/client/ping.go
+++ b/client/ping.go
@@ -18,7 +18,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (cli *Client) PingWithOptions(ctx context.Context, options types.PingOptions) (types.Ping, error) {
+// Ping pings the server and returns the value of the "Docker-Experimental",
+// "Builder-Version", "OS-Type" & "API-Version" headers. It attempts to use
+// a HEAD request on the endpoint, but falls back to GET if HEAD is not supported
+// by the daemon. It ignores internal server errors returned by the API, which
+// may be returned if the daemon is in an unhealthy state, but returns errors
+// for other non-success status codes, failing to connect to the API, or failing
+// to parse the API response.
+func (cli *Client) Ping(ctx context.Context, options types.PingOptions) (types.Ping, error) {
 	var ping types.Ping
 
 	// If not interested in engine capabilities, do a HEAD request
@@ -56,17 +63,6 @@ func (cli *Client) PingWithOptions(ctx context.Context, options types.PingOption
 		return ping, err
 	}
 	return parsePingResponse(cli, serverResp)
-}
-
-// Ping pings the server and returns the value of the "Docker-Experimental",
-// "Builder-Version", "OS-Type" & "API-Version" headers. It attempts to use
-// a HEAD request on the endpoint, but falls back to GET if HEAD is not supported
-// by the daemon. It ignores internal server errors returned by the API, which
-// may be returned if the daemon is in an unhealthy state, but returns errors
-// for other non-success status codes, failing to connect to the API, or failing
-// to parse the API response.
-func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
-	return cli.PingWithOptions(ctx, types.PingOptions{})
 }
 
 func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {

--- a/client/ping.go
+++ b/client/ping.go
@@ -2,14 +2,61 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
 )
+
+func (cli *Client) PingWithOptions(ctx context.Context, options types.PingOptions) (types.Ping, error) {
+	var ping types.Ping
+
+	// If not interested in engine capabilities, do a HEAD request
+	if !options.Capabilities {
+		// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
+		// because ping requests are used during API version negotiation, so we want
+		// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
+		req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
+		if err != nil {
+			return ping, err
+		}
+		serverResp, err := cli.doRequest(req)
+		if err == nil {
+			defer ensureReaderClosed(serverResp)
+			switch serverResp.statusCode {
+			case http.StatusOK, http.StatusInternalServerError:
+				// Server handled the request, so parse the response
+				return parsePingResponse(cli, serverResp)
+			}
+		} else if IsErrConnectionFailed(err) {
+			return ping, err
+		}
+	}
+
+	// if the HEAD request failed – or we're requesting capabilities –
+	// do a GET request
+	query := url.Values{}
+	if options.Capabilities {
+		query.Set("capabilities", strconv.Itoa(system.CapabilitiesVersion))
+	}
+
+	serverResp, err := cli.get(ctx, path.Join(cli.basePath, "/_ping"), query, nil)
+	defer ensureReaderClosed(serverResp)
+	if err != nil {
+		return ping, err
+	}
+	return parsePingResponse(cli, serverResp)
+}
 
 // Ping pings the server and returns the value of the "Docker-Experimental",
 // "Builder-Version", "OS-Type" & "API-Version" headers. It attempts to use
@@ -19,35 +66,7 @@ import (
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
-	var ping types.Ping
-
-	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
-	// because ping requests are used during API version negotiation, so we want
-	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
-	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
-	if err != nil {
-		return ping, err
-	}
-	serverResp, err := cli.doRequest(req)
-	if err == nil {
-		defer ensureReaderClosed(serverResp)
-		switch serverResp.statusCode {
-		case http.StatusOK, http.StatusInternalServerError:
-			// Server handled the request, so parse the response
-			return parsePingResponse(cli, serverResp)
-		}
-	} else if IsErrConnectionFailed(err) {
-		return ping, err
-	}
-
-	// HEAD failed; fallback to GET.
-	req.Method = http.MethodGet
-	serverResp, err = cli.doRequest(req)
-	defer ensureReaderClosed(serverResp)
-	if err != nil {
-		return ping, err
-	}
-	return parsePingResponse(cli, serverResp)
+	return cli.PingWithOptions(ctx, types.PingOptions{})
 }
 
 func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
@@ -71,6 +90,40 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 			ControlAvailable: role == "manager",
 		}
 	}
+
 	err := cli.checkResponseErr(resp)
-	return ping, errdefs.FromStatusCode(err, resp.statusCode)
+	// if  200 <= statuscode < 400, this will return nil and not read the body
+	if err != nil {
+		return ping, errdefs.FromStatusCode(err, resp.statusCode)
+	}
+
+	// check the body for capabilities if it's not nil and the response was not an error
+	if resp.body != nil {
+		capabilities, err := parseCapabilitiesFromBody(resp.body)
+		if err != nil {
+			return ping, fmt.Errorf("failed to parse ping body: %w", err)
+		}
+		ping.Capabilities = capabilities
+	}
+	return ping, nil
+}
+
+type pingBody struct {
+	Capabilities *system.Capabilities `json:"capabilities"`
+}
+
+func parseCapabilitiesFromBody(responseBody io.Reader) (*system.Capabilities, error) {
+	content, err := io.ReadAll(responseBody)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 || string(content) == "OK" {
+		return nil, nil
+	}
+	var b pingBody
+	err = json.Unmarshal(content, &b)
+	if err != nil {
+		return nil, errors.Errorf("expected capabilities, found '%s'", string(content))
+	}
+	return b.Capabilities, nil
 }

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -35,7 +35,7 @@ func TestPingFail(t *testing.T) {
 		}),
 	}
 
-	ping, err := client.Ping(context.Background())
+	ping, err := client.Ping(context.Background(), types.PingOptions{})
 	assert.Check(t, is.ErrorContains(err, "some error with the server"))
 	assert.Check(t, is.Equal(false, ping.Experimental))
 	assert.Check(t, is.Equal("", ping.APIVersion))
@@ -43,7 +43,7 @@ func TestPingFail(t *testing.T) {
 	assert.Check(t, is.Equal(si, ping.SwarmStatus))
 
 	withHeader = true
-	ping2, err := client.Ping(context.Background())
+	ping2, err := client.Ping(context.Background(), types.PingOptions{})
 	assert.Check(t, is.ErrorContains(err, "some error with the server"))
 	assert.Check(t, is.Equal(true, ping2.Experimental))
 	assert.Check(t, is.Equal("awesome", ping2.APIVersion))
@@ -59,7 +59,7 @@ func TestPingWithError(t *testing.T) {
 		}),
 	}
 
-	ping, err := client.Ping(context.Background())
+	ping, err := client.Ping(context.Background(), types.PingOptions{})
 	assert.Check(t, is.ErrorContains(err, "some connection error"))
 	assert.Check(t, is.Equal(false, ping.Experimental))
 	assert.Check(t, is.Equal("", ping.APIVersion))
@@ -81,7 +81,7 @@ func TestPingSuccess(t *testing.T) {
 			return resp, nil
 		}),
 	}
-	ping, err := client.Ping(context.Background())
+	ping, err := client.Ping(context.Background(), types.PingOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(true, ping.Experimental))
 	assert.Check(t, is.Equal("awesome", ping.APIVersion))
@@ -148,7 +148,7 @@ func TestPingEngineCapabilities(t *testing.T) {
 				}),
 			}
 
-			ping, err := client.PingWithOptions(context.Background(), types.PingOptions{Capabilities: true})
+			ping, err := client.Ping(context.Background(), types.PingOptions{Capabilities: true})
 			if tc.expectedError == "" {
 				assert.NilError(t, err)
 				assert.Check(t, is.Equal("awesome", ping.APIVersion))
@@ -199,7 +199,7 @@ func TestPingHeadFallback(t *testing.T) {
 					return resp, nil
 				}),
 			}
-			ping, _ := client.Ping(context.Background())
+			ping, _ := client.Ping(context.Background(), types.PingOptions{})
 			assert.Check(t, is.Equal(ping.APIVersion, tc.expected))
 		})
 	}

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/system"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -84,6 +86,78 @@ func TestPingSuccess(t *testing.T) {
 	assert.Check(t, is.Equal(true, ping.Experimental))
 	assert.Check(t, is.Equal("awesome", ping.APIVersion))
 	assert.Check(t, is.Equal(swarm.Status{NodeState: "active", ControlAvailable: true}, *ping.SwarmStatus))
+}
+
+func TestPingEngineCapabilities(t *testing.T) {
+	testCases := []struct {
+		doc           string
+		body          string
+		expected      *system.Capabilities
+		expectedError string
+	}{
+		{
+			doc:      "empty",
+			expected: nil,
+		},
+		{
+			doc:      "older daemons",
+			body:     "OK",
+			expected: nil,
+		},
+		{
+			doc:  "valid single",
+			body: `{"capabilities": {"_v":1, "data": { "registry-client-auth": true } } }`,
+			expected: &system.Capabilities{
+				Version: 1,
+				Data: map[string]any{
+					"registry-client-auth": true,
+				},
+			},
+		},
+		{
+			doc:  "known and unknown keys",
+			body: `{"capabilities":  {"_v":1, "data": { "meow": false, "registry-client-auth": true} } }`,
+			expected: &system.Capabilities{
+				Version: 1,
+				Data: map[string]any{
+					"registry-client-auth": true,
+					"meow":                 false,
+				},
+			},
+		},
+		{
+			doc:           "invalid body",
+			body:          "bork",
+			expectedError: "failed to parse ping body: expected capabilities, found 'bork'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.doc, func(t *testing.T) {
+			client := &Client{
+				client: newMockClient(func(req *http.Request) (*http.Response, error) {
+					capabilitiesQuery := req.URL.Query()["capabilities"][0]
+					assert.Equal(t, capabilitiesQuery, "1")
+
+					resp := &http.Response{StatusCode: http.StatusOK}
+					resp.Header = http.Header{}
+					resp.Header.Set("API-Version", "awesome")
+					resp.Body = io.NopCloser(strings.NewReader(tc.body))
+
+					return resp, nil
+				}),
+			}
+
+			ping, err := client.PingWithOptions(context.Background(), types.PingOptions{Capabilities: true})
+			if tc.expectedError == "" {
+				assert.NilError(t, err)
+				assert.Check(t, is.Equal("awesome", ping.APIVersion))
+				assert.DeepEqual(t, tc.expected, ping.Capabilities)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+			}
+		})
+	}
 }
 
 // TestPingHeadFallback tests that the client falls back to GET if HEAD fails.

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -105,7 +106,7 @@ func TestInfiniteError(t *testing.T) {
 		}),
 	}
 
-	_, err := client.Ping(context.Background())
+	_, err := client.Ping(context.Background(), types.PingOptions{})
 	assert.Check(t, is.ErrorContains(err, "request returned Internal Server Error"))
 }
 

--- a/daemon/capabilities/manager.go
+++ b/daemon/capabilities/manager.go
@@ -1,0 +1,129 @@
+package capabilities
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/api/types/system"
+)
+
+type Provider interface {
+	UsesSnapshotter() bool
+}
+
+// NewManager returns a new capabilities.Manager.
+// Use this instead of Manager{}.
+func NewManager(p Provider) Manager {
+	cond := sync.NewCond(&sync.Mutex{})
+	return Manager{
+		provider:  p,
+		stateCond: cond,
+	}
+}
+
+type Manager struct {
+	provider Provider
+
+	// cacheReady is not guarded/an atomic type
+	// so that InvalidateCache is fast/doesn't have
+	// to contend with GetCapabilities.
+	cacheReady atomic.Bool
+
+	stateCond         *sync.Cond
+	refreshInProgress bool              // guarded by stateCond
+	cache             capabilitiesCache // guarded by stateCond
+}
+
+// GetCapabilities returns Capabilities according to the requested version.
+// If the requested version N <= CurrentVersion, the requested version is
+// returned. Otherwise, GetCapabilities returns the newest capabilities
+// version (CurrentVersion).
+// Capabilities are cached by the manager, so as long as the cache is valid
+// (and the cache isn't currently being refreshed) GetCapabilities should be
+// quick and have little performance impact. However, changes to daemon
+// configuration/reloads can invalidate the cache. If this happens, the first
+// call to GetCapabilities will launch a goroutine to refresh the cache.
+// Subsequent calls to GetCapabilities will block until the cache has been
+// refreshed.
+func (m *Manager) GetCapabilities(ctx context.Context, requestedVersion int) (system.Capabilities, error) {
+	negotiatedVersion := negotiatedCapabilitiesVersion(requestedVersion)
+
+	// even though cacheReady is a thread-safe type, grab stateCond before
+	// checking it, otherwise we'd introduce a race between checking cacheReady
+	// and updating refreshInProgress (since we'd need to acquire stateCond to)
+	// update refreshInProgress
+	m.stateCond.L.Lock()
+	defer m.stateCond.L.Unlock()
+	// if many threads try to call GetCapabilities while
+	// the cache is dirty, only one should refresh
+	if shouldRefresh := m.cacheReady.CompareAndSwap(false, true); shouldRefresh {
+		// tell other callers that we're going to refresh and they should wait
+		m.refreshInProgress = true
+
+		go func() {
+			newCapabilities := fetchCapabilities(ctx, m.provider)
+
+			m.stateCond.L.Lock()
+			m.cache = newCapabilities
+			m.refreshInProgress = false
+			m.stateCond.L.Unlock()
+			// tell all waiting callers that we're done
+			m.stateCond.Broadcast()
+		}()
+	}
+
+	// wait for any refreshes to be finished
+	// before accessing cache
+	for m.refreshInProgress {
+		m.stateCond.Wait()
+	}
+
+	switch negotiatedVersion {
+	case 1:
+		// 1 is the latest version, and there are no older
+		// versions, so regardless of what is requested,
+		// return v1
+		fallthrough
+	default:
+		return system.Capabilities{
+			Version: 1,
+			Data:    m.cache.v1,
+		}, nil
+	}
+}
+
+// InvalidateCache causes the capabilities cache to be refetched.
+// It should be called whenever daemon configurations change, in
+// order to make sure that capabilities returned by GetCapabilities
+// are accurate to the current state of the daemon.
+// InvalidateCache is not blocking – it does not wait until the cache
+// is rebuilt, just marks it "dirty" – rebuilding happens on the
+// next GetCapabilities call.
+func (m *Manager) InvalidateCache(ctx context.Context) {
+	log.G(ctx).Debug("invalidating cached system capabilities")
+	m.cacheReady.Store(false)
+}
+
+func fetchCapabilities(ctx context.Context, p Provider) capabilitiesCache {
+	log.G(ctx).Debug("fetching system capabilities")
+
+	v1 := map[string]any{}
+	v1["registry-client-auth"] = p.UsesSnapshotter()
+	return capabilitiesCache{
+		v1: v1,
+	}
+}
+
+type capabilitiesCache struct {
+	v1 map[string]any
+}
+
+func negotiatedCapabilitiesVersion(requestVersion int) int {
+	if requestVersion < system.CapabilitiesVersion && requestVersion > 0 {
+		return requestVersion
+	}
+
+	return system.CapabilitiesVersion
+}

--- a/daemon/capabilities/manager_test.go
+++ b/daemon/capabilities/manager_test.go
@@ -1,0 +1,356 @@
+package capabilities
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/system"
+	"gotest.tools/v3/assert"
+)
+
+type mockDaemon struct {
+	usesSnapshotter func() bool
+}
+
+func (m *mockDaemon) UsesSnapshotter() bool {
+	return m.usesSnapshotter()
+}
+
+func TestGetCapabilities(t *testing.T) {
+	t.Run("V1 returns expected values", func(t *testing.T) {
+		t.Run("if snapshotter enabled", func(t *testing.T) {
+			mockDaemon := &mockDaemon{}
+			mockDaemon.usesSnapshotter = func() bool {
+				return true
+			}
+			manager := NewManager(mockDaemon)
+
+			caps, err := manager.GetCapabilities(context.Background(), 1)
+			assert.NilError(t, err)
+
+			result, err := caps.SupportsRegistryClientAuth()
+			assert.NilError(t, err)
+			assert.Equal(t, true, result, "registry-client-auth should be true if snapshotter enabled")
+		})
+
+		t.Run("if snapshotter disabled", func(t *testing.T) {
+			mockDaemon := &mockDaemon{}
+			mockDaemon.usesSnapshotter = func() bool {
+				return false
+			}
+			manager := NewManager(mockDaemon)
+
+			caps, err := manager.GetCapabilities(context.Background(), 1)
+			assert.NilError(t, err)
+
+			result, err := caps.SupportsRegistryClientAuth()
+			assert.NilError(t, err)
+			assert.Equal(t, false, result, "registry-client-auth should be false if snapshotter disabled ")
+		})
+	})
+}
+
+func TestVersionNegotiation(t *testing.T) {
+	t.Run("assume latest version when requested version is", func(t *testing.T) {
+		testCases := []struct {
+			doc              string
+			requestedVersion int
+		}{
+			{
+				doc:              "same as the daemon's",
+				requestedVersion: system.CapabilitiesVersion,
+			},
+			{
+				doc:              "newer than the daemon's",
+				requestedVersion: 1000,
+			},
+			{
+				doc:              "unknown/looks malformed",
+				requestedVersion: -1,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.doc, func(t *testing.T) {
+				mockDaemon := &mockDaemon{}
+				mockDaemon.usesSnapshotter = func() bool {
+					return true
+				}
+				manager := NewManager(mockDaemon)
+
+				capabilities, err := manager.GetCapabilities(context.Background(), tc.requestedVersion)
+				assert.NilError(t, err)
+
+				assert.Equal(t, capabilities.CapabilitiesVersion(), system.CapabilitiesVersion)
+			})
+		}
+	})
+}
+
+func TestManagerInvalidateCache(t *testing.T) {
+	t.Run("if the manager does not have cache", func(t *testing.T) {
+		t.Run("invalidate does not cause cache to be fetched multiple times", func(t *testing.T) {
+			mockDaemon := &mockDaemon{}
+			var called int
+			mockDaemon.usesSnapshotter = func() bool {
+				called++
+				return true
+			}
+			manager := NewManager(mockDaemon)
+			ctx := context.Background()
+
+			assert.Equal(t, 0, called)
+			manager.InvalidateCache(ctx)
+			assert.Equal(t, 0, called)
+
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 1, called)
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 1, called)
+		})
+	})
+
+	t.Run("if the manager already has cache", func(t *testing.T) {
+		t.Run("invalidate causes cache to be fetched again", func(t *testing.T) {
+			mockDaemon := &mockDaemon{}
+			var called int
+			mockDaemon.usesSnapshotter = func() bool {
+				called++
+				return true
+			}
+			manager := NewManager(mockDaemon)
+			manager.cache.v1 = map[string]any{
+				"registry-client-auth": false,
+			}
+			manager.cacheReady.Store(true)
+			ctx := context.Background()
+
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 0, called)
+
+			manager.InvalidateCache(ctx)
+
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 1, called)
+		})
+
+		t.Run("invalidate causes cache to be fetched again multiple times", func(t *testing.T) {
+			mockDaemon := &mockDaemon{}
+			var called int
+			mockDaemon.usesSnapshotter = func() bool {
+				called++
+				return true
+			}
+			manager := NewManager(mockDaemon)
+			manager.cache.v1 = map[string]any{
+				"registry-client-auth": false,
+			}
+			manager.cacheReady.Store(true)
+
+			ctx := context.Background()
+
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 0, called)
+
+			manager.InvalidateCache(ctx)
+
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 1, called)
+
+			manager.InvalidateCache(ctx)
+
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 2, called)
+
+			manager.InvalidateCache(ctx)
+
+			_, _ = manager.GetCapabilities(ctx, system.CapabilitiesVersion)
+			assert.Equal(t, 3, called)
+		})
+	})
+
+	// TODO(laurazard): can probably clean up this test
+	t.Run("doesn't lock if there are many concurrent GetCapabilities calls", func(t *testing.T) {
+		mockDaemon := &mockDaemon{}
+		mockDaemon.usesSnapshotter = func() bool {
+			time.Sleep(2 * time.Second)
+			return true
+		}
+		manager := NewManager(mockDaemon)
+		manager.cache = capabilitiesCache{
+			v1: map[string]any{
+				"registry-client-auth": false,
+			},
+		}
+		manager.cacheReady.Store(true)
+
+		ctx := context.Background()
+		stop := make(chan struct{})
+		capC := make(chan system.Capabilities)
+		errC := make(chan error)
+		// keep launching goroutines to call GetCapabilities until we
+		// receive on stop
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+
+				go func() {
+					c, err := manager.GetCapabilities(ctx, 1)
+					if err != nil {
+						errC <- err
+						return
+					}
+					capC <- c
+				}()
+				time.Sleep(time.Millisecond)
+			}
+		}()
+
+	A:
+		for {
+			select {
+			case c := <-capC:
+				regClientAuth, err := c.SupportsRegistryClientAuth()
+				assert.NilError(t, err)
+				assert.Check(t, !regClientAuth, "c.RegistryClientAuth should be false before cache invalidation")
+				break A
+			case err := <-errC:
+				t.Fatal(err)
+			}
+		}
+
+		done := make(chan struct{})
+		go func() {
+			manager.InvalidateCache(ctx)
+			done <- struct{}{}
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Millisecond):
+			t.Fatal("took too long!")
+		}
+
+	B:
+		for {
+			select {
+			case caps := <-capC:
+				regClientAuth, err := caps.SupportsRegistryClientAuth()
+				assert.NilError(t, err)
+				if regClientAuth == true {
+					break B
+				}
+			case err := <-errC:
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
+func TestManagerConcurrency(t *testing.T) {
+	t.Run("many concurrent calls while cache dirty only results in single refresh", func(t *testing.T) {
+		mockDaemon := &mockDaemon{}
+		var timesCalled int
+		mockDaemon.usesSnapshotter = func() bool {
+			timesCalled++
+			time.Sleep(2 * time.Second)
+			return true
+		}
+		manager := NewManager(mockDaemon)
+
+		ctx := context.Background()
+		concurrentCalls := 10000
+		done := make(chan error, 5)
+		for i := 0; i < concurrentCalls; i++ {
+			go func() {
+				_, err := manager.GetCapabilities(ctx, 1)
+				done <- err
+			}()
+		}
+
+		for i := 0; i < concurrentCalls; i++ {
+			err := <-done
+			assert.NilError(t, err)
+		}
+
+		assert.Equal(t, 1, timesCalled)
+	})
+
+	t.Run("cache invalidation during concurrent calls to GetCapabilities", func(t *testing.T) {
+		mockDaemon := &mockDaemon{}
+		mockDaemon.usesSnapshotter = func() bool {
+			time.Sleep(2 * time.Second)
+			return true
+		}
+		manager := NewManager(mockDaemon)
+		manager.cache = capabilitiesCache{
+			v1: map[string]any{
+				"registry-client-auth": false,
+			},
+		}
+		manager.cacheReady.Store(true)
+
+		ctx := context.Background()
+		stop := make(chan struct{})
+		capC := make(chan system.Capabilities)
+		errC := make(chan error)
+		// keep launching goroutines to call GetCapabilities until we
+		// receive on stop
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+
+				go func() {
+					caps, err := manager.GetCapabilities(ctx, 1)
+					if err != nil {
+						errC <- errors.New("failed to cast caps to capabilitiesV1")
+						return
+					}
+					capC <- caps
+				}()
+				time.Sleep(time.Millisecond)
+			}
+		}()
+
+	A:
+		for {
+			select {
+			case caps := <-capC:
+				regClientAuth, err := caps.SupportsRegistryClientAuth()
+				assert.NilError(t, err)
+				assert.Check(t, !regClientAuth, "caps.RegistryClientAuth should be false before cache invalidation")
+				break A
+			case err := <-errC:
+				t.Fatal(err)
+			}
+		}
+
+		manager.InvalidateCache(ctx)
+
+	B:
+		for {
+			select {
+			case caps := <-capC:
+				regClientAuth, err := caps.SupportsRegistryClientAuth()
+				assert.NilError(t, err)
+				if regClientAuth == true {
+					break B
+				}
+			case err := <-errC:
+				t.Fatal(err)
+			}
+		}
+
+		stop <- struct{}{}
+	})
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -36,9 +36,11 @@ import (
 	networktypes "github.com/docker/docker/api/types/network"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
+	systemtypes "github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/container"
+	"github.com/docker/docker/daemon/capabilities"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	"github.com/docker/docker/daemon/config"
 	ctrd "github.com/docker/docker/daemon/containerd"
@@ -148,6 +150,8 @@ type Daemon struct {
 	mdDB *bbolt.DB
 
 	usesSnapshotter bool
+
+	capabilitiesManager capabilities.Manager
 }
 
 // ID returns the daemon id
@@ -200,6 +204,10 @@ func (daemon *Daemon) Features() map[string]bool {
 // UsesSnapshotter returns true if feature flag to use containerd snapshotter is enabled
 func (daemon *Daemon) UsesSnapshotter() bool {
 	return daemon.usesSnapshotter
+}
+
+func (daemon *Daemon) SystemCapabilities(ctx context.Context, requestedVersion int) (systemtypes.Capabilities, error) {
+	return daemon.capabilitiesManager.GetCapabilities(ctx, requestedVersion)
 }
 
 func (daemon *Daemon) restore(cfg *configStore) error {
@@ -838,6 +846,8 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		Runtimes: rts,
 	}
 	d.configStore.Store(cfgStore)
+
+	d.capabilitiesManager = capabilities.NewManager(d)
 
 	// TEST_INTEGRATION_USE_SNAPSHOTTER is used for integration tests only.
 	if os.Getenv("TEST_INTEGRATION_USE_SNAPSHOTTER") != "" {

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -126,8 +126,10 @@ func (daemon *Daemon) Reload(conf *config.Config) error {
 			NoProxy:    config.MaskCredentials(newCfg.NoProxy),
 		},
 	})
-	log.G(context.TODO()).Infof("Reloaded configuration: %s", jsonString)
+	ctx := context.TODO()
+	log.G(ctx).Infof("Reloaded configuration: %s", jsonString)
 	daemon.configStore.Store(newCfg)
+	daemon.capabilitiesManager.InvalidateCache(ctx)
 	daemon.LogDaemonEventWithAttributes(events.ActionReload, attributes)
 	return txn.Commit()
 }

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -71,6 +71,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   `GET /debug/pprof/profile`, `GET /debug/pprof/symbol`, `GET /debug/pprof/trace`,
   `GET /debug/pprof/{name}`) are now also accessible through the versioned-API
   paths (`/v<API-version>/<endpoint>`).
+* `GET` `/_ping` endpoint now optionally supports a `capabilities` query parameter 
+  (e.g. `GET /_ping?capabilities=1`). If set, instead of the response body containing
+  `OK`, the daemon responds with a JSON Content-Type instead of `text/plain`, and
+  includes the engine capabilities in the response.
 
 ## v1.47 API changes
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -2703,7 +2703,7 @@ func (s *DockerDaemonSuite) TestFailedPluginRemove(c *testing.T) {
 	d.Restart(c)
 	ctx, cancel = context.WithTimeout(testutil.GetContext(c), 30*time.Second)
 	defer cancel()
-	_, err = apiClient.Ping(ctx)
+	_, err = apiClient.Ping(ctx, types.PingOptions{})
 	assert.NilError(c, err)
 
 	_, _, err = apiClient.PluginInspectWithRaw(ctx, name)

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -69,7 +69,7 @@ func TestPingSwarmHeader(t *testing.T) {
 
 	t.Run("before swarm init", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
-		p, err := apiClient.Ping(ctx)
+		p, err := apiClient.Ping(ctx, types.PingOptions{})
 		assert.NilError(t, err)
 		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateInactive)
 		assert.Equal(t, p.SwarmStatus.ControlAvailable, false)
@@ -80,7 +80,7 @@ func TestPingSwarmHeader(t *testing.T) {
 
 	t.Run("after swarm init", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
-		p, err := apiClient.Ping(ctx)
+		p, err := apiClient.Ping(ctx, types.PingOptions{})
 		assert.NilError(t, err)
 		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateActive)
 		assert.Equal(t, p.SwarmStatus.ControlAvailable, true)
@@ -91,7 +91,7 @@ func TestPingSwarmHeader(t *testing.T) {
 
 	t.Run("after swarm leave", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
-		p, err := apiClient.Ping(ctx)
+		p, err := apiClient.Ping(ctx, types.PingOptions{})
 		assert.NilError(t, err)
 		assert.Equal(t, p.SwarmStatus.NodeState, swarm.LocalNodeStateInactive)
 		assert.Equal(t, p.SwarmStatus.ControlAvailable, false)
@@ -117,7 +117,7 @@ func TestPingBuilderHeader(t *testing.T) {
 			expected = types.BuilderV1
 		}
 
-		p, err := apiClient.Ping(ctx)
+		p, err := apiClient.Ping(ctx, types.PingOptions{})
 		assert.NilError(t, err)
 		assert.Equal(t, p.BuilderVersion, expected)
 	})
@@ -131,7 +131,7 @@ func TestPingBuilderHeader(t *testing.T) {
 		defer d.Stop(t)
 
 		expected := types.BuilderV1
-		p, err := apiClient.Ping(ctx)
+		p, err := apiClient.Ping(ctx, types.PingOptions{})
 		assert.NilError(t, err)
 		assert.Equal(t, p.BuilderVersion, expected)
 	})
@@ -181,7 +181,7 @@ func TestPingCapabilities(t *testing.T) {
 			d.Start(t, "--config-file", cfg)
 			defer d.Stop(t)
 
-			p, err := apiClient.PingWithOptions(ctx, types.PingOptions{
+			p, err := apiClient.Ping(ctx, types.PingOptions{
 				Capabilities: true,
 			})
 			assert.NilError(t, err)
@@ -200,7 +200,7 @@ func TestPingCapabilities(t *testing.T) {
 			d.Start(t, "--config-file", cfg)
 			defer d.Stop(t)
 
-			p, err := apiClient.PingWithOptions(ctx, types.PingOptions{
+			p, err := apiClient.Ping(ctx, types.PingOptions{
 				Capabilities: true,
 			})
 			assert.NilError(t, err)


### PR DESCRIPTION
Supercedes/close: https://github.com/moby/moby/pull/48944

**- What I did**

With moving towards using the containerd image store (as opposed to the "legacy" graphdrivers), some new daemon features will only be implemented for the containerd image store.

A client wanting to make use of new features would find it useful to be able to know what features are available without having to attempt to use them, getting an error back, and having to do another roundtrip.

Address this by adding a new query parameter to the `/_ping` endpoint to allow clients to query supported features.

**- How I did it**

Adds a new query parameter to the (`GET`) Ping endpoint `/_ping?capabilities=1` that, if set, prompts the daemon to reply with a JSON representation of it's configured features.

Since clients will generally already by hitting the `/_ping` endpoint in order to negotiate API versions, this provides a way for clients to know which features are supported without extra roundtrips.

Also updated swagger and API docs.

**- How to verify it**

```console
$ curl -s --unix-socket /var/run/docker.sock http://localhost/_ping?capabilities=1 | jq
{
  "capabilities": {
    "_v": 1,
    "data": {
      "registry-client-auth": true
    }
  }
}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Added `capabilities` query parameter to the `/_ping` endpoint to request daemon capabilities.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="594" alt="Screenshot 2024-11-21 at 12 14 16" src="https://github.com/user-attachments/assets/3fed59ec-6078-45e6-9082-6ca0407c6001">
