### PR TITLE
api/types/network: add godoc for EndpointSettings.GwPriority

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -19,6 +19,11 @@ type EndpointSettings struct {
 	// generated address).
 	MacAddress string
 	DriverOpts map[string]string
+
+	// GwPriority determines which endpoint will provide the default gateway
+	// for the container. The endpoint with the highest priority will be used.
+	// If multiple endpoints have the same priority, they are lexicographically
+	// sorted based on their network name, and the one that sorts first is picked.
 	GwPriority int
 	// Operational data
 	NetworkID           string


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48936

This field was introduced in 5b752fab327c0c9871d3c7df369ccbaed7ad62db, which added documentation in the API documentation (swagger), but did not document the field in the API go types.

This patch adds documentation, using a variant of the description used in swagger.

