### PR TITLE
registry: some optimizations to reduce network connections  and DNS lookups if not needed

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -77,12 +77,12 @@ func loginV2(authConfig *registry.AuthConfig, endpoint APIEndpoint, userAgent st
 
 	log.G(context.TODO()).Debugf("attempting v2 login to registry endpoint %s", endpointStr)
 
-	loginClient, err := v2AuthHTTPClient(endpoint.URL, authTransport, modifiers, creds, nil)
+	req, err := http.NewRequest(http.MethodGet, endpointStr, nil)
 	if err != nil {
 		return "", "", err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, endpointStr, nil)
+	loginClient, err := v2AuthHTTPClient(endpoint.URL, authTransport, modifiers, creds, nil)
 	if err != nil {
 		return "", "", err
 	}

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -133,12 +133,13 @@ func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifi
 // files).
 func ConvertToHostname(url string) string {
 	stripped := url
-	if strings.HasPrefix(url, "http://") {
-		stripped = strings.TrimPrefix(url, "http://")
-	} else if strings.HasPrefix(url, "https://") {
-		stripped = strings.TrimPrefix(url, "https://")
+	if strings.HasPrefix(stripped, "http://") {
+		stripped = strings.TrimPrefix(stripped, "http://")
+	} else if strings.HasPrefix(stripped, "https://") {
+		stripped = strings.TrimPrefix(stripped, "https://")
 	}
-	return strings.SplitN(stripped, "/", 2)[0]
+	stripped, _, _ = strings.Cut(stripped, "/")
+	return stripped
 }
 
 // ResolveAuthConfig matches an auth configuration to a server address or a URL

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -7,27 +7,30 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
-func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
+func (s *Service) lookupV2Endpoints(hostname string, includeMirrors bool) ([]APIEndpoint, error) {
 	ana := s.config.allowNondistributableArtifacts(hostname)
 
+	var endpoints []APIEndpoint
 	if hostname == DefaultNamespace || hostname == IndexHostname {
-		for _, mirror := range s.config.Mirrors {
-			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
-				mirror = "https://" + mirror
+		if includeMirrors {
+			for _, mirror := range s.config.Mirrors {
+				if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
+					mirror = "https://" + mirror
+				}
+				mirrorURL, err := url.Parse(mirror)
+				if err != nil {
+					return nil, invalidParam(err)
+				}
+				mirrorTLSConfig, err := newTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
+				if err != nil {
+					return nil, err
+				}
+				endpoints = append(endpoints, APIEndpoint{
+					URL:       mirrorURL,
+					Mirror:    true,
+					TLSConfig: mirrorTLSConfig,
+				})
 			}
-			mirrorURL, err := url.Parse(mirror)
-			if err != nil {
-				return nil, invalidParam(err)
-			}
-			mirrorTLSConfig, err := newTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
-			if err != nil {
-				return nil, err
-			}
-			endpoints = append(endpoints, APIEndpoint{
-				URL:       mirrorURL,
-				Mirror:    true,
-				TLSConfig: mirrorTLSConfig,
-			})
 		}
 		endpoints = append(endpoints, APIEndpoint{
 			URL:       DefaultV2Registry,


### PR DESCRIPTION
- note: this will conflict with https://github.com/moby/moby/pull/49005
- relates to https://github.com/moby/moby/pull/48999

### registry: loginV2: don't contact registry when failing to construct request

Reverse the order in which we call v2AuthHTTPClient and http.NewRequest.
This is mostly theoretical, but v2AuthHTTPClient makes a network connection
to ping the registry, but loginV2 may fail after this if http.NewRequest
fails. Put the (lightweight) http.NewRequest first, so that we can return
early before trying to contact the registry.


### registry: loginV2: move variables closer to where they're used

Also rename a variable that shadowed a package type.

### registry: Service.lookupV2Endpoints: add arg to skip mirrors

This function unconditionally constructed endpoints for mirrors when
requesting endpoints for the default (Docker Hub) registry. Doing so
involves validating the config, which involves;

- parsing the hostname
- constructing TLS config
- performing a DNS lookup to resolve the host's IP address and matching
  it against CIDR masks for insecure registries.

When looking up push endpoints or endpoints to consider for authentication,
mirror endpoints were discarded to prevent sending credentials of the upstream
registry to a mirror.

This patch adds a "includeMirrors" argument to skip constructing endpoints
for mirrors when not needed.

### registry: ConvertToHostname: use strings.Cut to reduce allocations

Slight refactor to use strings.Cut, which doesn't do allocations






**- A picture of a cute animal (not mandatory but encouraged)**

