### PR TITLE
api/server/router: fix debug routes, and refactor

### DIFF
--- a/api/server/router/debug/debug.go
+++ b/api/server/router/debug/debug.go
@@ -24,13 +24,13 @@ type debugRouter struct {
 
 func (r *debugRouter) initRoutes() {
 	r.routes = []router.Route{
-		router.NewGetRoute("/vars", frameworkAdaptHandler(expvar.Handler())),
-		router.NewGetRoute("/pprof/", frameworkAdaptHandlerFunc(pprof.Index)),
-		router.NewGetRoute("/pprof/cmdline", frameworkAdaptHandlerFunc(pprof.Cmdline)),
-		router.NewGetRoute("/pprof/profile", frameworkAdaptHandlerFunc(pprof.Profile)),
-		router.NewGetRoute("/pprof/symbol", frameworkAdaptHandlerFunc(pprof.Symbol)),
-		router.NewGetRoute("/pprof/trace", frameworkAdaptHandlerFunc(pprof.Trace)),
-		router.NewGetRoute("/pprof/{name}", handlePprof),
+		router.NewGetRoute("/debug/vars", frameworkAdaptHandler(expvar.Handler())),
+		router.NewGetRoute("/debug/pprof/", frameworkAdaptHandlerFunc(pprof.Index)),
+		router.NewGetRoute("/debug/pprof/cmdline", frameworkAdaptHandlerFunc(pprof.Cmdline)),
+		router.NewGetRoute("/debug/pprof/profile", frameworkAdaptHandlerFunc(pprof.Profile)),
+		router.NewGetRoute("/debug/pprof/symbol", frameworkAdaptHandlerFunc(pprof.Symbol)),
+		router.NewGetRoute("/debug/pprof/trace", frameworkAdaptHandlerFunc(pprof.Trace)),
+		router.NewGetRoute("/debug/pprof/{name}", handlePprof),
 	}
 }
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -83,7 +83,7 @@ func (s *Server) CreateMux(routers ...router.Router) *mux.Router {
 	debugRouter := debug.NewRouter()
 	for _, r := range debugRouter.Routes() {
 		f := s.makeHTTPHandler(r.Handler(), r.Method()+" "+r.Path())
-		m.Path("/debug" + r.Path()).Handler(f)
+		m.Path(r.Path()).Handler(f)
 	}
 
 	notFoundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/middleware"
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/api/server/router/debug"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/dockerversion"
 	"github.com/gorilla/mux"
@@ -80,13 +79,7 @@ func (s *Server) CreateMux(routers ...router.Router) *mux.Router {
 		}
 	}
 
-	debugRouter := debug.NewRouter()
-	for _, r := range debugRouter.Routes() {
-		f := s.makeHTTPHandler(r.Handler(), r.Method()+" "+r.Path())
-		m.Path(versionMatcher + r.Path()).Methods(r.Method()).Handler(f)
-		m.Path(r.Path()).Methods(r.Method()).Handler(f)
-	}
-
+	// Setup handlers for undefined paths and methods
 	notFoundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = httputils.WriteJSON(w, http.StatusNotFound, &types.ErrorResponse{
 			Message: "page not found",

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -83,6 +83,7 @@ func (s *Server) CreateMux(routers ...router.Router) *mux.Router {
 	debugRouter := debug.NewRouter()
 	for _, r := range debugRouter.Routes() {
 		f := s.makeHTTPHandler(r.Handler(), r.Method()+" "+r.Path())
+		m.Path(versionMatcher + r.Path()).Methods(r.Method()).Handler(f)
 		m.Path(r.Path()).Methods(r.Method()).Handler(f)
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -83,7 +83,7 @@ func (s *Server) CreateMux(routers ...router.Router) *mux.Router {
 	debugRouter := debug.NewRouter()
 	for _, r := range debugRouter.Routes() {
 		f := s.makeHTTPHandler(r.Handler(), r.Method()+" "+r.Path())
-		m.Path(r.Path()).Handler(f)
+		m.Path(r.Path()).Methods(r.Method()).Handler(f)
 	}
 
 	notFoundHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/docker/api/server/router/build"
 	checkpointrouter "github.com/docker/docker/api/server/router/checkpoint"
 	"github.com/docker/docker/api/server/router/container"
+	debugrouter "github.com/docker/docker/api/server/router/debug"
 	distributionrouter "github.com/docker/docker/api/server/router/distribution"
 	grpcrouter "github.com/docker/docker/api/server/router/grpc"
 	"github.com/docker/docker/api/server/router/image"
@@ -716,6 +717,7 @@ func buildRouters(opts routerOptions) []router.Router {
 		pluginrouter.NewRouter(opts.daemon.PluginManager()),
 		distributionrouter.NewRouter(opts.daemon.ImageBackend()),
 		network.NewRouter(opts.daemon, opts.cluster),
+		debugrouter.NewRouter(),
 	}
 
 	if opts.buildBackend != nil {

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -307,7 +307,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 	}
 
 	routers := buildRouters(routerOpts)
-	httpServer.Handler = apiServer.CreateMux(routers...)
+	httpServer.Handler = apiServer.CreateMux(ctx, routers...)
 
 	go d.ProcessClusterNotifications(ctx, c.GetWatchStream())
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -58,6 +58,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   the one that sorts first is picked.
 * `GET /containers/json` now returns a `GwPriority` field in `NetworkSettings`
   for each network endpoint.
+* API debug endpoints (`GET /debug/vars`, `GET /debug/pprof/`, `GET /debug/pprof/cmdline`,
+  `GET /debug/pprof/profile`, `GET /debug/pprof/symbol`, `GET /debug/pprof/trace`,
+  `GET /debug/pprof/{name}`) are now also accessible through the versioned-API
+  paths (`/v<API-version>/<endpoint>`).
 
 ## v1.47 API changes
 


### PR DESCRIPTION
### api/server: set /debug prefix as part of debug-router routes

Update the debug-router to include  the prefix, instead of adding it
when registering the routes.

### api/server: Server.CreateMux: register debug endpoints with correct methods

The debug handlers were created for GET methods, but were registered for
any method;

```bash
curl -s -XGET --unix-socket /var/run/docker.sock http://localhost/debug/vars | jq -c .cmdline
["dockerd","--debug"]
curl -s -XPOST --unix-socket /var/run/docker.sock http://localhost/debug/vars | jq -c .cmdline
["dockerd","--debug"]
curl -s -XDELETE --unix-socket /var/run/docker.sock http://localhost/debug/vars | jq -c .cmdline
["dockerd","--debug"]
```

After this patch, they're only registered with the intended method, and a
404 is returned for incorrect ones;

```bash
curl -s -XGET --unix-socket /var/run/docker.sock http://localhost/debug/vars | jq -c .cmdline
["dockerd","--debug"]
curl -s -XPOST --unix-socket /var/run/docker.sock http://localhost/debug/vars
{"message":"page not found"}
curl -s -XDELETE --unix-socket /var/run/docker.sock http://localhost/debug/vars
{"message":"page not found"}
```

### api/server: Server.CreateMux: also register API-version debug endpoints

The debug endpoints are currently only provided non-versioned (e.g. `/debug/vars`).
While this is convenient, we "officially" deprecated non-versioned endpoints
in the API.

This patch also registers the debug-endpoints under the API-versioned paths,
so that they can be used either without version ("latest") and versioned
paths.


### cmd/dockerd: pass debug-router instead of constructing in CreateMux

Now that debug-routes are identical to regular routers, we can pass them
the same as those routers. With this, the daemon also logs those routes
as part of its startup (when in debug mode).

Before this patch, only non-debug endpoints would be logged:

```console
DEBU[2024-12-08T15:24:47.320933959Z] Registering routers
...
DEBU[2024-12-08T15:24:47.324420709Z] Registering POST, /networks/{id:.*}/disconnect
DEBU[2024-12-08T15:24:47.324447251Z] Registering POST, /networks/prune
DEBU[2024-12-08T15:24:47.324460626Z] Registering DELETE, /networks/{id:.*}
INFO[2024-12-08T15:24:47.324828334Z] API listen on /var/run/docker.sock
```

With this patch, debug endpoints are also logged:

```console
DEBU[2024-12-08T15:24:47.320933959Z] Registering routers
...
DEBU[2024-12-08T15:24:47.324420709Z] Registering POST, /networks/{id:.*}/disconnect
DEBU[2024-12-08T15:24:47.324447251Z] Registering POST, /networks/prune
DEBU[2024-12-08T15:24:47.324460626Z] Registering DELETE, /networks/{id:.*}
DEBU[2024-12-08T15:24:47.324486834Z] Registering GET, /debug/vars
DEBU[2024-12-08T15:24:47.324506751Z] Registering GET, /debug/pprof/
DEBU[2024-12-08T15:24:47.324532126Z] Registering GET, /debug/pprof/cmdline
DEBU[2024-12-08T15:24:47.324549293Z] Registering GET, /debug/pprof/profile
DEBU[2024-12-08T15:24:47.324564501Z] Registering GET, /debug/pprof/symbol
DEBU[2024-12-08T15:24:47.324582043Z] Registering GET, /debug/pprof/trace
DEBU[2024-12-08T15:24:47.324604751Z] Registering GET, /debug/pprof/{name}
INFO[2024-12-08T15:24:47.324828334Z] API listen on /var/run/docker.sock
```

### api/server: Server.CreateMux: pass context and use structured logs

Pass the context that's used for logging, and add minimal handling of
context-cancellation. Also update logs to use structured fields.

Before this  patch:

```console
DEBU[2024-12-08T15:24:47.324420709Z] Registering POST, /networks/{id:.*}/disconnect
DEBU[2024-12-08T15:24:47.324447251Z] Registering POST, /networks/prune
DEBU[2024-12-08T15:24:47.324460626Z] Registering DELETE, /networks/{id:.*}
```

With this patch:

```console
DEBU[2024-12-08T15:33:50.408445543Z] Registering route                              method=POST path="/networks/{id:.*}/disconnect"
DEBU[2024-12-08T15:33:50.408484335Z] Registering route                              method=POST path=/networks/prune
DEBU[2024-12-08T15:33:50.408505251Z] Registering route                              method=DELETE path="/networks/{id:.*}"
```

Or in JSON format:

```json
{"level":"debug","method":"POST","msg":"Registering route","path":"/networks/{id:.*}/connect","time":"2024-12-08T15:37:19.235209667Z"}
{"level":"debug","method":"POST","msg":"Registering route","path":"/networks/{id:.*}/disconnect","time":"2024-12-08T15:37:19.235243001>
{"level":"debug","method":"POST","msg":"Registering route","path":"/networks/prune","time":"2024-12-08T15:37:19.235290876Z"}
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
* API debug endpoints (`GET /debug/vars`, `GET /debug/pprof/`, `GET /debug/pprof/cmdline`,
  `GET /debug/pprof/profile`, `GET /debug/pprof/symbol`, `GET /debug/pprof/trace`,
  `GET /debug/pprof/{name}`) are now also accessible through the versioned-API
  paths (`/v<API-version>/<endpoint>`).
```

**- A picture of a cute animal (not mandatory but encouraged)**

