### PR TITLE
daemon: remove Daemon.NetworkControllerEnabled

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -715,14 +715,11 @@ func buildRouters(opts routerOptions) []router.Router {
 		swarmrouter.NewRouter(opts.cluster),
 		pluginrouter.NewRouter(opts.daemon.PluginManager()),
 		distributionrouter.NewRouter(opts.daemon.ImageBackend()),
+		network.NewRouter(opts.daemon, opts.cluster),
 	}
 
 	if opts.buildBackend != nil {
 		routers = append(routers, grpcrouter.NewRouter(opts.buildBackend))
-	}
-
-	if opts.daemon.NetworkControllerEnabled() {
-		routers = append(routers, network.NewRouter(opts.daemon, opts.cluster))
 	}
 
 	if opts.daemon.HasExperimental() {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -44,12 +44,6 @@ func (pnr PredefinedNetworkError) Error() string {
 // Forbidden denotes the type of this error
 func (pnr PredefinedNetworkError) Forbidden() {}
 
-// NetworkControllerEnabled checks if the networking stack is enabled.
-// This feature depends on OS primitives and it's disabled in systems like Windows.
-func (daemon *Daemon) NetworkControllerEnabled() bool {
-	return daemon.netController != nil
-}
-
 // NetworkController returns the network controller created by the daemon.
 func (daemon *Daemon) NetworkController() *libnetwork.Controller {
 	return daemon.netController
@@ -506,7 +500,7 @@ func (daemon *Daemon) DisconnectContainerFromNetwork(containerName string, netwo
 // GetNetworkDriverList returns the list of plugins drivers
 // registered for network.
 func (daemon *Daemon) GetNetworkDriverList(ctx context.Context) []string {
-	if !daemon.NetworkControllerEnabled() {
+	if daemon.netController == nil {
 		return nil
 	}
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/17128


This function was added in eb982e7c00192c8306f9c420fb469f087c7b161d, at which time networking was not yet implemented for Windows, resulting in a panic when trying to call network-related endpoints.

That's no longer the case, so we should be able to add network-endpoints unconditionally.

