### PR TITLE
cmd/dockerd: ignore some unhandled errors

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -233,7 +233,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 
 	const otelServiceNameEnv = "OTEL_SERVICE_NAME"
 	if _, ok := os.LookupEnv(otelServiceNameEnv); !ok {
-		os.Setenv(otelServiceNameEnv, filepath.Base(os.Args[0]))
+		_ = os.Setenv(otelServiceNameEnv, filepath.Base(os.Args[0]))
 	}
 
 	setOTLPProtoDefault()
@@ -382,10 +382,10 @@ func setOTLPProtoDefault() {
 
 	if os.Getenv(protoEnv) == "" {
 		if os.Getenv(tracesEnv) == "" {
-			os.Setenv(tracesEnv, defaultProto)
+			_ = os.Setenv(tracesEnv, defaultProto)
 		}
 		if os.Getenv(metricsEnv) == "" {
-			os.Setenv(metricsEnv, defaultProto)
+			_ = os.Setenv(metricsEnv, defaultProto)
 		}
 	}
 }


### PR DESCRIPTION
These are unlikely to fail ever, so should be fine to ignore.

