### PR TITLE
Accurately reflect the canonical casing of `API-Version` and `OS-Type` headers

### DIFF
--- a/api/server/middleware/version.go
+++ b/api/server/middleware/version.go
@@ -67,8 +67,8 @@ func (e versionUnsupportedError) InvalidParameter() {}
 func (v VersionMiddleware) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		w.Header().Set("Server", fmt.Sprintf("Docker/%s (%s)", v.serverVersion, runtime.GOOS))
-		w.Header().Set("API-Version", v.defaultAPIVersion)
-		w.Header().Set("OSType", runtime.GOOS)
+		w.Header().Set("Api-Version", v.defaultAPIVersion)
+		w.Header().Set("Ostype", runtime.GOOS)
 
 		apiVersion := vars["version"]
 		if apiVersion == "" {

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -140,6 +140,6 @@ func TestVersionMiddlewareWithErrorsReturnsHeaders(t *testing.T) {
 	hdr := resp.Result().Header
 	assert.Check(t, is.Contains(hdr.Get("Server"), "Docker/1.2.3"))
 	assert.Check(t, is.Contains(hdr.Get("Server"), runtime.GOOS))
-	assert.Check(t, is.Equal(hdr.Get("API-Version"), api.DefaultVersion))
-	assert.Check(t, is.Equal(hdr.Get("OSType"), runtime.GOOS))
+	assert.Check(t, is.Equal(hdr.Get("Api-Version"), api.DefaultVersion))
+	assert.Check(t, is.Equal(hdr.Get("Ostype"), runtime.GOOS))
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9626,7 +9626,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9682,7 +9682,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -369,7 +369,7 @@ func TestNegotiateAPIVersionAutomatic(t *testing.T) {
 	var pingVersion string
 	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
 		resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
-		resp.Header.Set("API-Version", pingVersion)
+		resp.Header.Set("Api-Version", pingVersion)
 		resp.Body = io.NopCloser(strings.NewReader("OK"))
 		return resp, nil
 	})

--- a/client/ping.go
+++ b/client/ping.go
@@ -56,8 +56,8 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 		err := cli.checkResponseErr(resp)
 		return ping, errdefs.FromStatusCode(err, resp.statusCode)
 	}
-	ping.APIVersion = resp.header.Get("API-Version")
-	ping.OSType = resp.header.Get("OSType")
+	ping.APIVersion = resp.header.Get("Api-Version")
+	ping.OSType = resp.header.Get("Ostype")
 	if resp.header.Get("Docker-Experimental") == "true" {
 		ping.Experimental = true
 	}

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -24,7 +24,7 @@ func TestPingFail(t *testing.T) {
 			resp := &http.Response{StatusCode: http.StatusInternalServerError}
 			if withHeader {
 				resp.Header = http.Header{}
-				resp.Header.Set("API-Version", "awesome")
+				resp.Header.Set("Api-Version", "awesome")
 				resp.Header.Set("Docker-Experimental", "true")
 				resp.Header.Set("Swarm", "inactive")
 			}
@@ -72,7 +72,7 @@ func TestPingSuccess(t *testing.T) {
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {
 			resp := &http.Response{StatusCode: http.StatusOK}
 			resp.Header = http.Header{}
-			resp.Header.Set("API-Version", "awesome")
+			resp.Header.Set("Api-Version", "awesome")
 			resp.Header.Set("Docker-Experimental", "true")
 			resp.Header.Set("Swarm", "active/manager")
 			resp.Body = io.NopCloser(strings.NewReader("OK"))
@@ -121,7 +121,7 @@ func TestPingHeadFallback(t *testing.T) {
 						resp.StatusCode = tc.status
 					}
 					resp.Header = http.Header{}
-					resp.Header.Add("API-Version", strings.Join(reqs, ", "))
+					resp.Header.Add("Api-Version", strings.Join(reqs, ", "))
 					return resp, nil
 				}),
 			}

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -38,7 +38,7 @@ func TestPingGet(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(b), "OK")
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Check(t, hdr(res, "API-Version") != "")
+	assert.Check(t, hdr(res, "Api-Version") != "")
 }
 
 func TestPingHead(t *testing.T) {
@@ -51,7 +51,7 @@ func TestPingHead(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(b))
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Check(t, hdr(res, "API-Version") != "")
+	assert.Check(t, hdr(res, "Api-Version") != "")
 }
 
 func TestPingSwarmHeader(t *testing.T) {


### PR DESCRIPTION
Go automatically canonicalises HTTP headers, meaning the string `API-Version` passed as a header has always been returned as `Api-Version`. Similarly, `OSType` is returned as `Ostype`.

This commit updates the documentation to reflect this behaviour and modifies the codebase to ensure that input strings are aligned with their canonical output values.

```markdown changelog
Update docs and code to reflect Go’s automatic canonicalisation of Api-Version and Ostype headers.
```

Closes: https://github.com/moby/moby/issues/49046#issuecomment-2525113278
