### PR TITLE
Use errdefs.System for errors from populateNetworkResources

### DIFF
--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -575,7 +575,7 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 	}()
 
 	if err := sb.populateNetworkResources(ctx, ep); err != nil {
-		return err
+		return errdefs.System(err)
 	}
 
 	if err := addEpToResolver(ctx, n.Name(), ep.Name(), &sb.config, ep.iface, n.Resolvers()); err != nil {


### PR DESCRIPTION
**- What I did**

When a container is connected to an IPv6-enabled network, with IPv6 disabled on the endpoint, and that endpoint is selected as the gateway - the container fails to start because the default route can't be configured.

(Fixing that is a bit involved, because at the moment the IPv6 address has landed in lots of config before the sysctl is applied and the address disappears.)

But, can at-least sort out the API's error response ...

**- How I did it**

Used `errdefs.System`.

**- How to verify it**

Start a container connected to an IPv6-enabled network, but disable IPv6 on the endpoint ...
```
docker network create --ipv6 b46
docker run --rm -ti --network name=b46,driver-opt=com.docker.network.endpoint.sysctls=net.ipv6.conf.IFNAME.disable_ipv6=1 --name c1 -p 8080:80 busybox
```

Before, the daemon logged this ...

```
DEBU[2024-12-09T14:51:02.951470211Z] FIXME: Got an API for which error does not match any expected type!!!  error="failed to set IPv6 gateway while updating gateway: route for the gateway fd15:83f9:f0a9::1 could not be found: network is unreachable" error_type="*errors.errorString" module=api
DEBU[2024-12-09T14:51:02.951492920Z] handling POST request                         error-response="failed to set IPv6 gateway while updating gateway: route for the gateway fd15:83f9:f0a9::1 could not be found: network is unreachable" method=POST module=api request-url=/v1.47/containers/0a4985dcc7af68ff2ee08e12f51469589d2908badd54fcafba94474a8cbd0abe/start spanID=38dd228c74e08a14 status=500 traceID=e57a51157fdbd2414ab83ccf162475cb vars="map[name:0a4985dcc7af68ff2ee08e12f51469589d2908badd54fcafba94474a8cbd0abe version:1.47]"
DEBU[2024-12-09T14:51:02.951541503Z] FIXME: Got an API for which error does not match any expected type!!!  error="failed to set IPv6 gateway while updating gateway: route for the gateway fd15:83f9:f0a9::1 could not be found: network is unreachable" error_type="*errors.errorString" module=api
ERRO[2024-12-09T14:51:02.951555211Z] Handler for POST /v1.47/containers/0a4985dcc7af68ff2ee08e12f51469589d2908badd54fcafba94474a8cbd0abe/start returned error: failed to set IPv6 gateway while updating gateway: route for the gateway fd15:83f9:f0a9::1 could not be found: network is unreachable  spanID=38dd228c74e08a14 traceID=e57a51157fdbd2414ab83ccf162475cb
```

After ...
```
DEBU[2024-12-09T14:51:37.779200172Z] handling POST request                         error-response="failed to set IPv6 gateway while updating gateway: route for the gateway fd15:83f9:f0a9::1 could not be found: network is unreachable" method=POST module=api request-url=/v1.47/containers/9fac7096284d507ce34cd612189241dac457811b77b7885e38c712240942881c/start spanID=6707ef521fae3c13 status=500 traceID=267f0b958ef99467ae92cab40b5962a2 vars="map[name:9fac7096284d507ce34cd612189241dac457811b77b7885e38c712240942881c version:1.47]"
ERRO[2024-12-09T14:51:37.779246547Z] Handler for POST /v1.47/containers/9fac7096284d507ce34cd612189241dac457811b77b7885e38c712240942881c/start returned error: failed to set IPv6 gateway while updating gateway: route for the gateway fd15:83f9:f0a9::1 could not be found: network is unreachable  spanID=6707ef521fae3c13 traceID=267f0b958ef99467ae92cab40b5962a2
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

