### PR TITLE
integration-cli: don't skip AppArmor tests on SLES

### DIFF
--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -79,9 +79,6 @@ func Network() bool {
 }
 
 func Apparmor() bool {
-	if strings.HasPrefix(testEnv.DaemonInfo.OperatingSystem, "SUSE Linux Enterprise Server ") {
-		return false
-	}
 	buf, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
 	return err == nil && len(buf) > 1 && buf[0] == 'Y'
 }


### PR DESCRIPTION
This partially reverts e440831 ("fix and skip some tests based on
API version"), which caused the integration-cli tests to skip all
AppArmor-related tests on SUSE.

It's not really clear why this was done originally, but I have verified
that on modern SLE 12 and SLE 15 systems the AppArmor tests pass without
any adjustments needed.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>