### PR TITLE
builder: fall back to defaultKeepStorage if keepStorage is unset for GC policy

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -437,7 +437,7 @@ func getGCPolicy(conf config.BuilderConfig, root string) ([]client.PruneInfo, er
 		if conf.GC.DefaultKeepStorage != "" {
 			defaultKeepStorage, err = units.RAMInBytes(conf.GC.DefaultKeepStorage)
 			if err != nil {
-				return nil, errors.Wrapf(err, "could not parse '%s' as Builder.GC.DefaultKeepStorage config", conf.GC.DefaultKeepStorage)
+				return nil, errors.Wrapf(err, "failed to parse defaultKeepStorage")
 			}
 		}
 
@@ -446,9 +446,12 @@ func getGCPolicy(conf config.BuilderConfig, root string) ([]client.PruneInfo, er
 		} else {
 			gcPolicy = make([]client.PruneInfo, len(conf.GC.Policy))
 			for i, p := range conf.GC.Policy {
-				b, err := units.RAMInBytes(p.KeepStorage)
-				if err != nil {
-					return nil, err
+				var b int64
+				if p.KeepStorage != "" {
+					b, err = units.RAMInBytes(p.KeepStorage)
+					if err != nil {
+						return nil, errors.Wrapf(err, "failed to parse keepStorage")
+					}
 				}
 				if b == 0 {
 					b = defaultKeepStorage


### PR DESCRIPTION
**- What I did**

Builder GC policies without a `keepStorage` option set should fall back to using the `defaultKeepStorage` value. But currently, the policy's `keepStorage` is parsed unconditionally, meaning that if it's unset, an error occurs:

```
could not get builder GC policy: invalid size: ''
```

The only way to get a policy to use `defaultKeepStorage` limit for GC would be to set it to `"0"`.

This patch is to make sure policy `keepStorage` is conditionally parsed, if set, otherwise the `defaultKeepStorage` is used.

I also modified related error messages:

```
could not get builder GC policy: failed to parse defaultKeepStorage: invalid size: 'foo'
could not get builder GC policy: failed to parse keepStorage: invalid size: 'bar'
```

**- How I did it**

**- How to verify it**

Tested manually;

```json
{
        "builder": {
                "gc": {
                        "enabled": true,
                        "defaultKeepStorage": "10GB",
                        "policy": [ { "filter": ["unused-for=2200h"] } ] 
                }
        }
}
```

```console
$ docker buildx inspect
...
GC Policy rule#0:
 All:            false
 Filters:        
 Keep Duration:  2200h0m0.5074347s
 Reserved Space: 10GiB
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Builder GC policies without a `keepStorage` value now inherit the `defaultKeepStorage` limit as intended.
```

**- A picture of a cute animal (not mandatory but encouraged)**

