### PR TITLE
c8d/pull: Show `Extracting` layer status

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -125,7 +125,11 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	})
 	opts = append(opts, containerd.WithImageHandler(h))
 
-	pp := pullProgress{store: i.content, showExists: true}
+	pp := &pullProgress{
+		store:       i.content,
+		snapshotter: i.snapshotterService(i.snapshotter),
+		showExists:  true,
+	}
 	finishProgress := jobs.showProgress(ctx, out, pp)
 
 	defer func() {
@@ -195,6 +199,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 
 	// AppendInfoHandlerWrapper will annotate the image with basic information like manifest and layer digests as labels;
 	// this information is used to enable remote snapshotters like nydus and stargz to query a registry.
+	// This is also needed for the pull progress to detect the `Extracting` status.
 	infoHandler := snapshotters.AppendInfoHandlerWrapper(ref.String())
 	opts = append(opts, containerd.WithImageHandlerWrapper(infoHandler))
 

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -121,7 +121,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 	jobsQueue := newJobs()
 	finishProgress := jobsQueue.showProgress(ctx, out, combinedProgress([]progressUpdater{
 		&pp,
-		pullProgress{showExists: false, store: store},
+		&pullProgress{showExists: false, store: store},
 	}))
 	defer func() {
 		finishProgress()


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/47108

Before this patch, pull progress wouldn't show the `Extracting` layer status which made the pull look like it got stuck when extracting a big layer.

Use the `containerd.io/snapshot/cri.layer-digest` snapshot labels to find a corresponding snapshot and check whether it's `active` or `committed` to set the layer status accordingly.

Despite the `cri.` component in the label name, it's not CRI specific - it only depends on the `snapshotters.AppendInfoHandlerWrapper`.

We _could_ also use the `Usage` snapshot method to query the exact progress of the unpack, but it would be too expensive as the implementation time complexity will be proportional to the snapshot size.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- How to verify it**

`docker pull pawelgronowski465/big` 

https://github.com/user-attachments/assets/06c213d3-5536-4003-a640-33181fef19d2



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Add support for `Extracting` layer status in `docker pull`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

