### PR TITLE
Dockerfile: remove libapparmor-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -569,7 +569,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             gcc \
             pkg-config \
             dpkg-dev \
-            libapparmor-dev \
             libseccomp-dev \
             libsecret-1-dev \
             libsystemd-dev \
@@ -595,7 +594,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
         xx-apt-get install --no-install-recommends -y \
             dpkg-dev \
             gcc \
-            libapparmor-dev \
             libc6-dev \
             libseccomp-dev \
             libsecret-1-dev \

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		curl \
 		cmake \
 		git \
-		libapparmor-dev \
 		libseccomp-dev \
 		ca-certificates \
 		e2fsprogs \


### PR DESCRIPTION
- relates to https://github.com/opencontainers/runc/pull/1675

I don't think anything uses this dependency, and runc no longer requires it either, since [opencontainers/runc@db093f6] (part of v1.0.0-rc5)

[opencontainers/runc@db093f6]: https://github.com/opencontainers/runc/commit/db093f621f4e6d40feafbe6d7b89a9bee6f6ff85

**- A picture of a cute animal (not mandatory but encouraged)**

