### PR TITLE
Dockerfile: remove dpkg-dev, libudev-dev, libsecret-1-dev, libbtrfs-dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -400,7 +400,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-crun-aptlib,target=/var/lib/apt \
             libseccomp-dev \
             libsystemd-dev \
             libtool \
-            libudev-dev \
             libyajl-dev \
             python3 \
             ;
@@ -570,7 +569,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             libseccomp-dev \
             libsecret-1-dev \
             libsystemd-dev \
-            libudev-dev \
             yamllint
 COPY --link --from=dockercli             /build/ /usr/local/cli
 COPY --link --from=dockercli-integration /build/ /usr/local/cli-integration
@@ -595,7 +593,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
             libseccomp-dev \
             libsecret-1-dev \
             libsystemd-dev \
-            libudev-dev \
             pkg-config
 ARG DOCKER_BUILDTAGS
 ARG DOCKER_DEBUG

--- a/Dockerfile
+++ b/Dockerfile
@@ -210,7 +210,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-containerd-aptlib,target=/var/lib/
         apt-get update && xx-apt-get install -y --no-install-recommends \
             gcc \
             libbtrfs-dev \
-            libsecret-1-dev \
             pkg-config
 ARG DOCKER_STATIC
 RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
@@ -567,7 +566,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             gcc \
             pkg-config \
             libseccomp-dev \
-            libsecret-1-dev \
             libsystemd-dev \
             yamllint
 COPY --link --from=dockercli             /build/ /usr/local/cli
@@ -591,7 +589,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
             gcc \
             libc6-dev \
             libseccomp-dev \
-            libsecret-1-dev \
             libsystemd-dev \
             pkg-config
 ARG DOCKER_BUILDTAGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -299,7 +299,6 @@ ARG TARGETPLATFORM
 RUN --mount=type=cache,sharing=locked,id=moby-runc-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-runc-aptcache,target=/var/cache/apt \
         apt-get update && xx-apt-get install -y --no-install-recommends \
-            dpkg-dev \
             gcc \
             libc6-dev \
             libseccomp-dev \
@@ -568,7 +567,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
         apt-get update && apt-get install --no-install-recommends -y \
             gcc \
             pkg-config \
-            dpkg-dev \
             libseccomp-dev \
             libsecret-1-dev \
             libsystemd-dev \
@@ -592,7 +590,6 @@ ARG TARGETPLATFORM
 RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=moby-build-aptcache,target=/var/cache/apt \
         xx-apt-get install --no-install-recommends -y \
-            dpkg-dev \
             gcc \
             libc6-dev \
             libseccomp-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -209,7 +209,6 @@ RUN --mount=type=cache,sharing=locked,id=moby-containerd-aptlib,target=/var/lib/
     --mount=type=cache,sharing=locked,id=moby-containerd-aptcache,target=/var/cache/apt \
         apt-get update && xx-apt-get install -y --no-install-recommends \
             gcc \
-            libbtrfs-dev \
             pkg-config
 ARG DOCKER_STATIC
 RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \


### PR DESCRIPTION
- [x] follow-up to / stacked on https://github.com/moby/moby/pull/49066

### Dockerfile: remove dpkg-dev dependency

We don't build .deb packages as part of the Dockerfiles in this
repository, so we can remove this dependency.


### Dockerfile: remove libudev-dev dependency

It was introduced in e89a5e5e91476102a471797fc2a81aa2f0f2b3fb, and probably
used for devicemapper, which we no longer support, so likely unused.

### Dockerfile: remove libsecret-1-dev dependency

This dependency was added in 81d704d15d69015c2c661ea600be8aab74957ba1, but
I could not find a reference to it, and we may not need it.

### Dockerfile: remove libbtrfs-dev dependency

Starting with [containerd@52f82ac] (containerd 1.7), this dependency is no
longer needed for building containerd.

[containerd@52f82ac]: https://github.com/containerd/containerd/commit/52f82acb7b3984fcb143af50c29a0ac0ceb5dc5d

**- A picture of a cute animal (not mandatory but encouraged)**

