### PR TITLE
otel: Avoid excessive memory allocations if not configured

### DIFF
--- a/api/server/router/grpc/grpc.go
+++ b/api/server/router/grpc/grpc.go
@@ -12,11 +12,11 @@ import (
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/router"
+	"github.com/docker/docker/internal/otelutil"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/moby/buildkit/util/stack"
 	"github.com/moby/buildkit/util/tracing"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 )
@@ -29,8 +29,9 @@ type grpcRouter struct {
 
 // NewRouter initializes a new grpc http router
 func NewRouter(backends ...Backend) router.Router {
+	tp, _ := otelutil.NewTracerProvider(context.Background(), false)
 	opts := []grpc.ServerOption{
-		grpc.StatsHandler(tracing.ServerStatsHandler(otelgrpc.WithTracerProvider(otel.GetTracerProvider()))),
+		grpc.StatsHandler(tracing.ServerStatsHandler(otelgrpc.WithTracerProvider(tp))),
 		grpc.ChainUnaryInterceptor(unaryInterceptor, grpcerrors.UnaryServerInterceptor),
 		grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
 		grpc.MaxRecvMsgSize(defaults.DefaultMaxRecvMsgSize),

--- a/integration/build/build_traces_test.go
+++ b/integration/build/build_traces_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/util/progress/progressui"
-	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/poll"
@@ -80,8 +80,9 @@ func TestBuildkitHistoryTracePropagation(t *testing.T) {
 		return
 	}
 
+	tp := sdktrace.NewTracerProvider()
 	// Split this into a new span so it doesn't clutter up the trace reporting GUI.
-	ctx, span := otel.Tracer("").Start(ctx, "Wait for trace to propagate to history record")
+	ctx, span := tp.Tracer("").Start(ctx, "Wait for trace to propagate to history record")
 	defer span.End()
 
 	t.Log("Waiting for trace to be available")

--- a/internal/otelutil/provider.go
+++ b/internal/otelutil/provider.go
@@ -1,0 +1,36 @@
+package otelutil
+
+import (
+	"context"
+
+	"github.com/containerd/log"
+	"github.com/moby/buildkit/util/tracing/detect"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func NewTracerProvider(ctx context.Context, allowNoop bool) (trace.TracerProvider, func(context.Context) error) {
+	noopShutdown := func(ctx context.Context) error { return nil }
+
+	exp, err := detect.NewSpanExporter(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("Failed to initialize tracing, skipping")
+		if allowNoop {
+			return noop.NewTracerProvider(), noopShutdown
+		}
+	}
+
+	if allowNoop && detect.IsNoneSpanExporter(exp) {
+		log.G(ctx).Info("OTEL tracing is not configured, using no-op tracer provider")
+		return noop.NewTracerProvider(), noopShutdown
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithResource(resource.Default()),
+		sdktrace.WithSyncer(detect.Recorder),
+		sdktrace.WithBatcher(exp),
+	)
+	return tp, tp.Shutdown
+}

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/trace/noop"
 	"gotest.tools/v3/icmd"
 )
 
@@ -43,6 +44,7 @@ func ConfigureTracing() func(context.Context) {
 	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" {
 		// No OTLP endpoint configured, so don't bother setting up tracing.
 		// Since we are not using a batch exporter we don't want tracing to block up tests.
+		otel.SetTracerProvider(noop.NewTracerProvider())
 		return func(context.Context) {}
 	}
 	var tp *trace.TracerProvider


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/49075
- relates to https://github.com/moby/moby/pull/47983

Use noop tracer provider if the OTEL exporter is not configured. This makes the OTEL tracing avoid doing unneeded memory allocations for spans which aren't going to be exported anywhere anyway.

**- How to verify it**
```bash
#!/bin/sh

docker run -d --rm -it --name leak alpine sh -c 'while true; do date; done'

for i in $(seq 0 4); do
    docker logs -f leak >/dev/null &
done


watch -d ps -C dockerd -o rss=

docker rm -f leak

wait
```

Before this patch, the RSS grows significantly over time, in proportion to the amount of running `docker logs -f`.
After the patch, the RSS stays around the same level.

**- Description for the changelog**
```markdown changelog
Fix excessive memory allocations when OTEL is not configured.
```

**- A picture of a cute animal (not mandatory but encouraged)**

