### PR TITLE
daemon: info: remove bridge-nf-call-iptables / ip6tables warnings

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5859,8 +5859,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
       CDISpecDirs:
         description: |
           List of directories where (Container Device Interface) CDI

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -159,12 +159,6 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 	if !v.IPv4Forwarding {
 		v.Warnings = append(v.Warnings, "WARNING: IPv4 forwarding is disabled")
 	}
-	if !v.BridgeNfIptables {
-		v.Warnings = append(v.Warnings, "WARNING: bridge-nf-call-iptables is disabled")
-	}
-	if !v.BridgeNfIP6tables {
-		v.Warnings = append(v.Warnings, "WARNING: bridge-nf-call-ip6tables is disabled")
-	}
 	return nil
 }
 

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -5223,8 +5223,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
 
 
   # PluginsInfo is a temp struct holding Plugins name

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -5360,8 +5360,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
 
 
   # PluginsInfo is a temp struct holding Plugins name

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -5614,8 +5614,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
 
 
   # PluginsInfo is a temp struct holding Plugins name

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -5614,8 +5614,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
 
 
   # PluginsInfo is a temp struct holding Plugins name

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -5647,8 +5647,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
 
 
   # PluginsInfo is a temp struct holding Plugins name

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -5762,8 +5762,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
       CDISpecDirs:
         description: |
           List of directories where (Container Device Interface) CDI

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -5748,8 +5748,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
       CDISpecDirs:
         description: |
           List of directories where (Container Device Interface) CDI

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -5807,8 +5807,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
       CDISpecDirs:
         description: |
           List of directories where (Container Device Interface) CDI

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -5825,8 +5825,6 @@ definitions:
           type: "string"
         example:
           - "WARNING: No memory limit support"
-          - "WARNING: bridge-nf-call-iptables is disabled"
-          - "WARNING: bridge-nf-call-ip6tables is disabled"
       CDISpecDirs:
         description: |
           List of directories where (Container Device Interface) CDI

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -79,6 +79,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   query parameter to `true`.
   WARNING: This is experimental and may change at any time without any backward
   compatibility.
+* `GET /info` no longer includes warnings when `bridge-nf-call-iptables` or
+  `bridge-nf-call-ip6tables` are disabled when the daemon was started. The
+  `br_netfilter` module is now attempted to be loaded when needed, making those
+  warnings inaccurate. This change is not versioned, and affects all API versions
+  if the daemon has this patch.
 
 ## v1.46 API changes
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48492
- https://github.com/moby/moby/pull/48960
- https://github.com/moby/moby/pull/49038



### daemon: info: remove bridge-nf-call-iptables / ip6tables warnings

Historically, the `bridge` network-driver would detect whether netfiltering was enabled in the kernel or, if disabled, try to do a `modprobe` when initializing the driver. This approach became problematic, as loading the module was not always performed  at startup depending on daemon configuration, or the daemon may have failed to load the module. The `/info` response would include a warning  to inform the user that some functionality may not be available;

    WARNING: bridge-nf-call-iptables is disabled
    WARNING: bridge-nf-call-ip6tables is disabled

Starting with db25b0dcd0461802289e962aa0df3abd323d1994, detecting whether netfiltering  is enabled now [happens when needed][1], which was further improved on to not depend  on `modprobe` in 264c15bfc427d1321c5b302e48e16d113b06ef92 and 474082071665314f56f42705eb42114c20ceaf0b.

Because of the above, the `/info` output would now return warnings in any situation where netfiltering was not enabled on the host before the daemon started, which may be either _incorrect_ (i.e., the module may have been loaded afterwards), or irrelevant, because netfiltering is not needed in all situations.

This patch removes the warnings from the `/info` response,

[1]: https://github.com/moby/moby/blob/944e40350259f040950d871d402d848ff2a799bc/libnetwork/drivers/bridge/setup_bridgenetfiltering.go#L16-L77


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
* `docker info` and the corresponding `GET /info` API endpoint no longer include
  warnings when `bridge-nf-call-iptables` or `bridge-nf-call-ip6tables` are
  disabled at the daemon is started. The `br_netfilter` kernel module is now
  attempted to be loaded when needed, which made those warnings inaccurate.
```

**- A picture of a cute animal (not mandatory but encouraged)**

