### PR TITLE
libnet/d/bridge: unconditionally error out if LinkSetMTU fails

### DIFF
--- a/libnetwork/drivers/bridge/setup_device_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_device_linux_test.go
@@ -95,6 +95,11 @@ func TestGenerateRandomMAC(t *testing.T) {
 	}
 }
 
+// TestMTUBiggerThan1500 tests that setting an MTU bigger than 1500 succeeds.
+// Since v4.17, the kernel allows setting an MTU bigger than 1500 on a bridge
+// device even if there's no links attached yet. Relevant kernel commit: [1].
+//
+// [1]: https://github.com/torvalds/linux/commit/804b854d374e39f5f8bff9638fd274b9a9ca7d33
 func TestMTUBiggerThan1500(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
@@ -111,6 +116,10 @@ func TestMTUBiggerThan1500(t *testing.T) {
 	assert.NilError(t, setupMTU(config, br))
 }
 
+// TestMTUBiggerThan64K tests that setting an MTU bigger than 64k fails
+// properly. The kernel caps the MTU at this value -- see [1].
+//
+// [1]: https://github.com/torvalds/linux/blob/a446e965a188ee8f745859e63ce046fe98577d45/net/bridge/br_device.c#L527
 func TestMTUBiggerThan64K(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 


### PR DESCRIPTION
- closes https://github.com/moby/moby/issues/47312

Related to:

- https://github.com/moby/moby/pull/47309

**- What I did**

Since 89470a7 we ignore errors returned by `LinkSetMTU` when the MTU is greater than 1500 but lower than 65535 to let CentOS/RHEL 7 users set an MTU in that range (despite their kernel rejecting that value).

We dropped support for those distros, so we can now remove this code and unconditionally error out if `LinkSetMTU` returns an error.

Commit 89470a7 introduced two unit tests - these are kept, and both now have a proper GoDoc describing what they're testing.

**- How to verify it**

Existing unit tests.

