### PR TITLE
libnet/iptables: deprecate type IPV

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -13,13 +13,19 @@ import (
 )
 
 // IPV defines the table string
-type IPV string
+//
+// Deprecated: use [IPVersion]
+type IPV = IPVersion
 
 const (
 	// Iptables point ipv4 table
-	Iptables IPV = "ipv4"
+	//
+	// Deprecated: use [IPv4].
+	Iptables IPV = IPv4
 	// IP6Tables point to ipv6 table
-	IP6Tables IPV = "ipv6"
+	//
+	// Deprecated: use [IPv6].
+	IP6Tables IPV = IPv6
 )
 
 const (
@@ -169,7 +175,7 @@ func checkRunning() bool {
 }
 
 // Passthrough method simply passes args through to iptables/ip6tables
-func Passthrough(ipv IPV, args ...string) ([]byte, error) {
+func Passthrough(ipv IPVersion, args ...string) ([]byte, error) {
 	var output string
 	log.G(context.TODO()).Debugf("Firewalld passthrough: %s, %s", ipv, args)
 	if err := connection.sysObj.Call(dbusInterface+".direct.passthrough", 0, ipv, args).Store(&output); err != nil {

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -96,7 +96,7 @@ func TestPassthrough(t *testing.T) {
 		"-j", "ACCEPT",
 	}
 
-	_, err := Passthrough(Iptables, append([]string{"-A"}, rule1...)...)
+	_, err := Passthrough(IPv4, append([]string{"-A"}, rule1...)...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -57,9 +57,9 @@ type IPVersion string
 
 const (
 	// IPv4 is version 4.
-	IPv4 IPVersion = "IPV4"
+	IPv4 IPVersion = "ipv4"
 	// IPv6 is version 6.
-	IPv6 IPVersion = "IPV6"
+	IPv6 IPVersion = "ipv6"
 )
 
 var (
@@ -435,14 +435,8 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 // Raw calls 'iptables' system command, passing supplied arguments.
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 	if firewalldRunning {
-		// select correct IP version for firewalld
-		ipv := Iptables
-		if iptable.ipVersion == IPv6 {
-			ipv = IP6Tables
-		}
-
 		startTime := time.Now()
-		output, err := Passthrough(ipv, args...)
+		output, err := Passthrough(iptable.ipVersion, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
 			return filterOutput(startTime, output, args...), err
 		}


### PR DESCRIPTION
**- What I did**

The iptables package has two different types to specify the IP version: IPVersion, used by iptables code, and IPV, used by firewalld code. Both are representing the ip version as a string.

For iptables, the case doesn't matter because the string is never used as-is. However, for firewalld the case matters.

Make the IPV type an alias of IPVersion, and deprecate it. Also change the case used in IPVersion strings to make IPV consts aliases of IPVersion consts.

**- How to verify it**

Existing tests.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
libnetwork/iptables: deprecate `IPV`, `Iptables` and `IP6Tables` types in favor of `IPVersion`, `IPv4`, and `IPv6`. This type and consts will be removed in the next release [moby/moby#49093](https://github.com/moby/moby/pull/49093).
```


