### PR TITLE
libnet/iptables: remove mutex-based serialization

### DIFF
--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -65,10 +65,7 @@ const (
 var (
 	iptablesPath  string
 	ip6tablesPath string
-	supportsXlock = false
-	// used to lock iptables commands if xtables lock is not supported
-	bestEffortLock sync.Mutex
-	initOnce       sync.Once
+	initOnce      sync.Once
 )
 
 // IPTable defines struct with [IPVersion].
@@ -113,14 +110,6 @@ func detectIptables() {
 		return
 	}
 	iptablesPath = path
-
-	// The --wait flag was added in iptables v1.6.0.
-	// TODO remove this check once we drop support for CentOS/RHEL 7, which uses an older version of iptables
-	if out, err := exec.Command(path, "--wait", "-L", "-n").CombinedOutput(); err != nil {
-		log.G(context.TODO()).WithError(err).Infof("unable to detect if iptables supports xlock: 'iptables --wait -L -n': `%s`", strings.TrimSpace(string(out)))
-	} else {
-		supportsXlock = true
-	}
 
 	path, err = exec.LookPath("ip6tables")
 	if err != nil {
@@ -464,13 +453,7 @@ func (iptable IPTable) raw(args ...string) ([]byte, error) {
 		commandName = "ip6tables"
 	}
 
-	if supportsXlock {
-		args = append([]string{"--wait"}, args...)
-	} else {
-		bestEffortLock.Lock()
-		defer bestEffortLock.Unlock()
-	}
-
+	args = append([]string{"--wait"}, args...)
 	log.G(context.TODO()).Debugf("%s, %v", path, args)
 
 	startTime := time.Now()

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -128,25 +128,10 @@ func TestOutput(t *testing.T) {
 	}
 }
 
-func TestConcurrencyWithWait(t *testing.T) {
-	RunConcurrencyTest(t, true)
-}
-
-func TestConcurrencyNoWait(t *testing.T) {
-	RunConcurrencyTest(t, false)
-}
-
 // Runs 10 concurrent rule additions. This will fail if iptables
 // is actually invoked simultaneously without --wait.
-// Note that if iptables does not support the xtable lock on this
-// system, then allowXlock has no effect -- it will always be off.
-func RunConcurrencyTest(t *testing.T, allowXlock bool) {
+func TestConcurrencyWithWait(t *testing.T) {
 	_, natChain, _ := createNewChain(t)
-
-	if !allowXlock && supportsXlock {
-		supportsXlock = false
-		defer func() { supportsXlock = true }()
-	}
 
 	ip := net.ParseIP("192.168.1.1")
 	port := 1234


### PR DESCRIPTION
**- What I did**

All distros we support now ship a version of iptables that support the `--wait` flag.

**- How I did it**

**- How to verify it**

Existing tests.