### PR TITLE
pkg/system: deprecate types and functions that are only used internally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,6 +151,12 @@ issues:
       linters:
         - staticcheck
 
+    # FIXME temporarily suppress these until https://github.com/moby/moby/pull/49072 is merged, which removes their use.
+    - text: "SA1019: system\\.(FromStatT|Mkdev|Mknod|StatT)"
+      path: "pkg/archive/"
+      linters:
+        - staticcheck
+
     - text: "ineffectual assignment to ctx"
       source: "ctx[, ].*=.*\\(ctx[,)]"
       linters:

--- a/pkg/system/lstat_unix.go
+++ b/pkg/system/lstat_unix.go
@@ -10,7 +10,9 @@ import (
 // Lstat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //
-// Throws an error if the file does not exist
+// Throws an error if the file does not exist.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Lstat(path string) (*StatT, error) {
 	s := &syscall.Stat_t{}
 	if err := syscall.Lstat(path, s); err != nil {

--- a/pkg/system/lstat_windows.go
+++ b/pkg/system/lstat_windows.go
@@ -4,6 +4,8 @@ import "os"
 
 // Lstat calls os.Lstat to get a fileinfo interface back.
 // This is then copied into our own locally defined structure.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Lstat(path string) (*StatT, error) {
 	fi, err := os.Lstat(path)
 	if err != nil {

--- a/pkg/system/mknod.go
+++ b/pkg/system/mknod.go
@@ -11,6 +11,8 @@ import (
 // Linux device nodes are a bit weird due to backwards compat with 16 bit device nodes.
 // They are, from low to high: the lower 8 bits of the minor, then 12 bits of the major,
 // then the top 12 bits of the minor.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Mkdev(major int64, minor int64) uint32 {
 	return uint32(unix.Mkdev(uint32(major), uint32(minor)))
 }

--- a/pkg/system/mknod_freebsd.go
+++ b/pkg/system/mknod_freebsd.go
@@ -8,6 +8,8 @@ import (
 
 // Mknod creates a filesystem node (file, device special file or named pipe) named path
 // with attributes specified by mode and dev.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Mknod(path string, mode uint32, dev int) error {
 	return unix.Mknod(path, mode, uint64(dev))
 }

--- a/pkg/system/mknod_unix.go
+++ b/pkg/system/mknod_unix.go
@@ -8,6 +8,8 @@ import (
 
 // Mknod creates a filesystem node (file, device special file or named pipe) named path
 // with attributes specified by mode and dev.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Mknod(path string, mode uint32, dev int) error {
 	return unix.Mknod(path, mode, dev)
 }

--- a/pkg/system/stat_linux.go
+++ b/pkg/system/stat_linux.go
@@ -17,6 +17,8 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 
 // FromStatT converts a syscall.Stat_t type to a system.Stat_t type
 // This is exposed on Linux as pkg/archive/changes uses it.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func FromStatT(s *syscall.Stat_t) (*StatT, error) {
 	return fromStatT(s)
 }

--- a/pkg/system/stat_unix.go
+++ b/pkg/system/stat_unix.go
@@ -9,6 +9,8 @@ import (
 
 // StatT type contains status of a file. It contains metadata
 // like permission, owner, group, size, etc about a file.
+//
+// Deprecated: this type is only used internally, and will be removed in the next release.
 type StatT struct {
 	mode uint32
 	uid  uint32
@@ -56,7 +58,9 @@ func (s StatT) IsDir() bool {
 // Stat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //
-// Throws an error if the file does not exist
+// Throws an error if the file does not exist.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Stat(path string) (*StatT, error) {
 	s := &syscall.Stat_t{}
 	if err := syscall.Stat(path, s); err != nil {

--- a/pkg/system/stat_windows.go
+++ b/pkg/system/stat_windows.go
@@ -7,6 +7,8 @@ import (
 
 // StatT type contains status of a file. It contains metadata
 // like permission, size, etc about a file.
+//
+// Deprecated: this type is only used internally, and will be removed in the next release.
 type StatT struct {
 	mode os.FileMode
 	size int64
@@ -31,7 +33,9 @@ func (s StatT) Mtim() time.Time {
 // Stat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //
-// Throws an error if the file does not exist
+// Throws an error if the file does not exist.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func Stat(path string) (*StatT, error) {
 	fi, err := os.Stat(path)
 	if err != nil {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49072


These types and functions are only used internally (through pkg/archive). Deprecate them, and mark them for removal.

This deprecates the `Lstat()`, `Mkdev()`, `Mknod()`, `FromStatT()` and `Stat()` functions, and related `StatT` type.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
pkg/system: deprecate `Lstat()`, `Mkdev()`, `Mknod()`, `FromStatT()` and `Stat()` functions, and related `StatT` types. These were only used internally, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

