### PR TITLE
libnet/osl: drop netns path GC

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1333,43 +1333,6 @@ func (s *DockerDaemonSuite) TestDaemonRestartWithContainerRunning(t *testing.T) 
 	}
 }
 
-func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *testing.T) {
-	s.d.StartWithBusybox(testutil.GetContext(c), c)
-	out, err := s.d.Cmd("run", "--name", "netns", "-d", "busybox", "top")
-	if err != nil {
-		c.Fatal(out, err)
-	}
-
-	// Get sandbox key via inspect
-	out, err = s.d.Cmd("inspect", "--format", "'{{.NetworkSettings.SandboxKey}}'", "netns")
-	if err != nil {
-		c.Fatalf("Error inspecting container: %s, %v", out, err)
-	}
-	fileName := strings.Trim(out, " \r\n'")
-
-	if out, err := s.d.Cmd("stop", "netns"); err != nil {
-		c.Fatal(out, err)
-	}
-
-	// Test if the file still exists
-	icmd.RunCommand("stat", "-c", "%n", fileName).Assert(c, icmd.Expected{
-		Out: fileName,
-	})
-
-	// Remove the container and restart the daemon
-	if out, err := s.d.Cmd("rm", "netns"); err != nil {
-		c.Fatal(out, err)
-	}
-
-	s.d.Restart(c)
-
-	// Test again and see now the netns file does not exist
-	icmd.RunCommand("stat", "-c", "%n", fileName).Assert(c, icmd.Expected{
-		Err:      "No such file or directory",
-		ExitCode: 1,
-	})
-}
-
 // tests regression detailed in #13964 where DOCKER_TLS_VERIFY env is ignored
 func (s *DockerDaemonSuite) TestDaemonTLSVerifyIssue13964(c *testing.T) {
 	host := "tcp://localhost:4271"

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1105,7 +1105,6 @@ func (c *Controller) getIPAMDriver(name string) (ipamapi.Ipam, *ipamapi.Capabili
 func (c *Controller) Stop() {
 	c.store.Close()
 	c.stopExternalKeyListener()
-	osl.GC()
 }
 
 // StartDiagnostic starts the network diagnostic server listening on port.

--- a/libnetwork/endpoint_unix_test.go
+++ b/libnetwork/endpoint_unix_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/ipams/defaultipam"
-	"github.com/docker/docker/libnetwork/osl"
 )
 
 func TestHostsEntries(t *testing.T) {
@@ -71,6 +70,4 @@ fe90::2	somehost.example.com somehost
 	if len(ctrlr.sandboxes) != 0 {
 		t.Fatalf("controller sandboxes is not empty. len = %d", len(ctrlr.sandboxes))
 	}
-
-	osl.GC()
 }

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -1737,7 +1737,6 @@ func externalKeyTest(t *testing.T, reexec bool) {
 		if err := cnt.Delete(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		osl.GC()
 	}()
 
 	// Join endpoint to sandbox before SetKey

--- a/libnetwork/osl/namespace_unsupported.go
+++ b/libnetwork/osl/namespace_unsupported.go
@@ -6,11 +6,6 @@ type Namespace struct{}
 
 func (n *Namespace) Destroy() error { return nil }
 
-// GC triggers garbage collection of namespace path right away
-// and waits for it.
-func GC() {
-}
-
 // GetSandboxForExternalKey returns sandbox object for the supplied path
 func GetSandboxForExternalKey(path string, key string) (*Namespace, error) {
 	return nil, nil

--- a/libnetwork/osl/namespace_windows.go
+++ b/libnetwork/osl/namespace_windows.go
@@ -19,7 +19,3 @@ func NewSandbox(key string, osCreate, isRestore bool) (*Namespace, error) {
 func GetSandboxForExternalKey(path string, key string) (*Namespace, error) {
 	return nil, nil
 }
-
-// GC triggers garbage collection of namespace path right away
-// and waits for it.
-func GC() {}

--- a/libnetwork/osl/sandbox_freebsd.go
+++ b/libnetwork/osl/sandbox_freebsd.go
@@ -21,8 +21,3 @@ func NewSandbox(key string, osCreate, isRestore bool) (*Namespace, error) {
 func GetSandboxForExternalKey(path string, key string) (*Namespace, error) {
 	return nil, nil
 }
-
-// GC triggers garbage collection of namespace path right away
-// and waits for it.
-func GC() {
-}

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
-	"github.com/docker/docker/libnetwork/osl"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -111,8 +110,6 @@ func TestSandboxAddEmpty(t *testing.T) {
 	if len(ctrlr.sandboxes) != 0 {
 		t.Fatalf("controller sandboxes is not empty. len = %d", len(ctrlr.sandboxes))
 	}
-
-	osl.GC()
 }
 
 // // If different priorities are specified, internal option and ipv6 addresses mustn't influence endpoint order
@@ -205,8 +202,6 @@ func TestSandboxAddMultiPrio(t *testing.T) {
 	if len(ctrlr.sandboxes) != 0 {
 		t.Fatalf("controller sandboxes is not empty. len = %d", len(ctrlr.sandboxes))
 	}
-
-	osl.GC()
 }
 
 func TestSandboxAddSamePrio(t *testing.T) {
@@ -308,6 +303,4 @@ func TestSandboxAddSamePrio(t *testing.T) {
 	if len(ctrlr.sandboxes) != 0 {
 		t.Fatalf("controller containers is not empty. len = %d", len(ctrlr.sandboxes))
 	}
-
-	osl.GC()
 }


### PR DESCRIPTION
- relates to https://github.com/moby/libnetwork/commit/05462c27b2d9ea9574549bbc8ddcfd83b06ebd0e / https://github.com/moby/libnetwork/pull/223
- relates to https://github.com/torvalds/linux/commit/8f502d5b9e3362971f58dad5d468f070340336e1 (fix in kernel 4.1)


**- What I did**

Commit 3ec19ff62bfa32dc5991105ab3d185ce4bf63008 introduced a GC goroutine to delete files where netns were mounted. It was primarly added to work around a race in kernel 3.18-4.0.1. Since no distros we support are using such old kernels, there's no need to keep this code around.

**- How to verify it**

Existing tests.