### PR TITLE
pkg/archive: replace uses of pkg/errors for stdlib errors

### DIFF
--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -2,13 +2,13 @@ package archive // import "github.com/docker/docker/pkg/archive"
 
 import (
 	"archive/tar"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/pkg/system"
 	"github.com/moby/sys/userns"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -79,7 +79,7 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 
 		err := unix.Setxattr(dir, opaqueXattrName, []byte{'y'}, 0)
 		if err != nil {
-			return false, errors.Wrapf(err, "setxattr(%q, %s=y)", dir, opaqueXattrName)
+			return false, fmt.Errorf("setxattr('%s', %s=y): %w", dir, opaqueXattrName, err)
 		}
 		// don't write the file itself
 		return false, err
@@ -91,7 +91,7 @@ func (c overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (boo
 		originalPath := filepath.Join(dir, originalBase)
 
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
-			return false, errors.Wrapf(err, "failed to mknod(%q, S_IFCHR, 0)", originalPath)
+			return false, fmt.Errorf("failed to mknod('%s', S_IFCHR, 0): %w", originalPath, err)
 		}
 		if err := os.Chown(originalPath, hdr.Uid, hdr.Gid); err != nil {
 			return false, err


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/49069
- relates to https://github.com/moby/moby/issues/32989


Reducing dependencies in preparation of moving pkg/archive to a separate module.

Most errors were already using stdlib, and only 3 places used pkg/errors, so it was already inconsistent.

**- A picture of a cute animal (not mandatory but encouraged)**

