### PR TITLE
docs/api: document correct case for Api-Version header

### DIFF
--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -5401,7 +5401,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -5434,7 +5434,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -5681,7 +5681,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -5771,7 +5771,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -6781,7 +6781,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -6785,7 +6785,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -6825,7 +6825,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -6855,7 +6855,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -6887,7 +6887,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -6930,7 +6930,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -7001,7 +7001,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -8223,7 +8223,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -8546,7 +8546,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -8585,7 +8585,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -8835,7 +8835,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -8874,7 +8874,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -9100,7 +9100,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9156,7 +9156,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -9118,7 +9118,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9174,7 +9174,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -9287,7 +9287,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9343,7 +9343,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -9267,7 +9267,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9323,7 +9323,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -9401,7 +9401,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9457,7 +9457,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -9538,7 +9538,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9594,7 +9594,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49054

This header is sent in its canonical format; update the docs to reflect this.

Follow-up to 76a5ca1d4d97ad313b8f1f0deb1ae5563a158a40

