### PR TITLE
[27.x backport] docs/api: document correct case for Api-Version header

### DIFF
--- a/api/server/middleware/version.go
+++ b/api/server/middleware/version.go
@@ -67,8 +67,8 @@ func (e versionUnsupportedError) InvalidParameter() {}
 func (v VersionMiddleware) WrapHandler(handler func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error) func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		w.Header().Set("Server", fmt.Sprintf("Docker/%s (%s)", v.serverVersion, runtime.GOOS))
-		w.Header().Set("API-Version", v.defaultAPIVersion)
-		w.Header().Set("OSType", runtime.GOOS)
+		w.Header().Set("Api-Version", v.defaultAPIVersion)
+		w.Header().Set("Ostype", runtime.GOOS)
 
 		apiVersion := vars["version"]
 		if apiVersion == "" {

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -141,6 +141,6 @@ func TestVersionMiddlewareWithErrorsReturnsHeaders(t *testing.T) {
 	hdr := resp.Result().Header
 	assert.Check(t, is.Contains(hdr.Get("Server"), "Docker/1.2.3"))
 	assert.Check(t, is.Contains(hdr.Get("Server"), runtime.GOOS))
-	assert.Check(t, is.Equal(hdr.Get("API-Version"), api.DefaultVersion))
-	assert.Check(t, is.Equal(hdr.Get("OSType"), runtime.GOOS))
+	assert.Check(t, is.Equal(hdr.Get("Api-Version"), api.DefaultVersion))
+	assert.Check(t, is.Equal(hdr.Get("Ostype"), runtime.GOOS))
 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9561,7 +9561,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9617,7 +9617,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -371,7 +371,7 @@ func TestNegotiateAPIVersionAutomatic(t *testing.T) {
 	var pingVersion string
 	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
 		resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
-		resp.Header.Set("API-Version", pingVersion)
+		resp.Header.Set("Api-Version", pingVersion)
 		resp.Body = io.NopCloser(strings.NewReader("OK"))
 		return resp, nil
 	})

--- a/client/ping.go
+++ b/client/ping.go
@@ -56,8 +56,8 @@ func parsePingResponse(cli *Client, resp serverResponse) (types.Ping, error) {
 		err := cli.checkResponseErr(resp)
 		return ping, errdefs.FromStatusCode(err, resp.statusCode)
 	}
-	ping.APIVersion = resp.header.Get("API-Version")
-	ping.OSType = resp.header.Get("OSType")
+	ping.APIVersion = resp.header.Get("Api-Version")
+	ping.OSType = resp.header.Get("Ostype")
 	if resp.header.Get("Docker-Experimental") == "true" {
 		ping.Experimental = true
 	}

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -24,7 +24,7 @@ func TestPingFail(t *testing.T) {
 			resp := &http.Response{StatusCode: http.StatusInternalServerError}
 			if withHeader {
 				resp.Header = http.Header{}
-				resp.Header.Set("API-Version", "awesome")
+				resp.Header.Set("Api-Version", "awesome")
 				resp.Header.Set("Docker-Experimental", "true")
 				resp.Header.Set("Swarm", "inactive")
 			}
@@ -72,7 +72,7 @@ func TestPingSuccess(t *testing.T) {
 		client: newMockClient(func(req *http.Request) (*http.Response, error) {
 			resp := &http.Response{StatusCode: http.StatusOK}
 			resp.Header = http.Header{}
-			resp.Header.Set("API-Version", "awesome")
+			resp.Header.Set("Api-Version", "awesome")
 			resp.Header.Set("Docker-Experimental", "true")
 			resp.Header.Set("Swarm", "active/manager")
 			resp.Body = io.NopCloser(strings.NewReader("OK"))
@@ -122,7 +122,7 @@ func TestPingHeadFallback(t *testing.T) {
 						resp.StatusCode = tc.status
 					}
 					resp.Header = http.Header{}
-					resp.Header.Add("API-Version", strings.Join(reqs, ", "))
+					resp.Header.Add("Api-Version", strings.Join(reqs, ", "))
 					return resp, nil
 				}),
 			}

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -5401,7 +5401,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -5434,7 +5434,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -5681,7 +5681,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -5771,7 +5771,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -6809,7 +6809,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -6813,7 +6813,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -6853,7 +6853,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -6883,7 +6883,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -6915,7 +6915,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -6958,7 +6958,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -7029,7 +7029,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Docker-Experimental:

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -8251,7 +8251,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -8574,7 +8574,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -8613,7 +8613,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -8863,7 +8863,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -8902,7 +8902,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -9128,7 +9128,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9184,7 +9184,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -9146,7 +9146,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9202,7 +9202,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -9315,7 +9315,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9371,7 +9371,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -9295,7 +9295,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9351,7 +9351,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -9429,7 +9429,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9485,7 +9485,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -9566,7 +9566,7 @@ paths:
             type: "string"
             example: "OK"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:
@@ -9622,7 +9622,7 @@ paths:
             type: "string"
             example: "(empty)"
           headers:
-            API-Version:
+            Api-Version:
               type: "string"
               description: "Max API Version the server supports"
             Builder-Version:

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -38,7 +38,7 @@ func TestPingGet(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(b), "OK")
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Check(t, hdr(res, "API-Version") != "")
+	assert.Check(t, hdr(res, "Api-Version") != "")
 }
 
 func TestPingHead(t *testing.T) {
@@ -51,7 +51,7 @@ func TestPingHead(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(b))
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Check(t, hdr(res, "API-Version") != "")
+	assert.Check(t, hdr(res, "Api-Version") != "")
 }
 
 func TestPingSwarmHeader(t *testing.T) {


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49054
- backport https://github.com/moby/moby/pull/49103
- closes https://github.com/moby/moby/issues/49046


