### PR TITLE
[27.x backport] integration-cli: don't skip AppArmor tests on SLES

### DIFF
--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -79,9 +79,6 @@ func Network() bool {
 }
 
 func Apparmor() bool {
-	if strings.HasPrefix(testEnv.DaemonInfo.OperatingSystem, "SUSE Linux Enterprise Server ") {
-		return false
-	}
 	buf, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
 	return err == nil && len(buf) > 1 && buf[0] == 'Y'
 }


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49061

This partially reverts e440831802a5 ("fix and skip some tests based on API version"), which caused the integration-cli tests to skip all AppArmor-related tests on SUSE.

It's not really clear why this was done originally, but I have verified that on modern SLE 12 and SLE 15 systems the AppArmor tests pass without any adjustments needed.


(cherry picked from commit 1a453abfb17203a1f5d683bde5938a31ee069e4f)

