### PR TITLE
libnet/iptables: split ProgramChain and move to bridge driver

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1165,7 +1165,7 @@ func TestCleanupIptableRules(t *testing.T) {
 	assert.NilError(t, setupHashNetIpset(ipsetExtBridges6, unix.AF_INET6))
 
 	for _, version := range ipVersions {
-		_, _, _, _, err := setupIPChains(configs[version], version)
+		err := setupIPChains(configs[version], version)
 		assert.NilError(t, err, "version:%s", version)
 
 		iptable := iptables.GetIptable(version)

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -158,13 +158,13 @@ func assertChainConfig(d *driver, t *testing.T) {
 
 	err = setupHashNetIpset(ipsetExtBridges4, unix.AF_INET)
 	assert.NilError(t, err)
-	d.natChain, d.filterChain, d.isolationChain1, d.isolationChain2, err = setupIPChains(d.config, iptables.IPv4)
+	err = setupIPChains(d.config, iptables.IPv4)
 	assert.NilError(t, err)
 
 	if d.config.EnableIP6Tables {
 		err = setupHashNetIpset(ipsetExtBridges6, unix.AF_INET6)
 		assert.NilError(t, err)
-		d.natChainV6, d.filterChainV6, d.isolationChain1V6, d.isolationChain2V6, err = setupIPChains(d.config, iptables.IPv6)
+		err = setupIPChains(d.config, iptables.IPv6)
 		assert.NilError(t, err)
 	}
 }
@@ -492,7 +492,7 @@ func TestMirroredWSL2Workaround(t *testing.T) {
 				config.UserlandProxyPath = "some-proxy"
 				config.EnableUserlandProxy = true
 			}
-			_, _, _, _, err := setupIPChains(config, iptables.IPv4)
+			err := setupIPChains(config, iptables.IPv4)
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(mirroredWSL2Rule().Exists(), tc.expLoopback0Rule))
 		})

--- a/libnetwork/iptables/iptables_test.go
+++ b/libnetwork/iptables/iptables_test.go
@@ -25,16 +25,8 @@ func createNewChain(t *testing.T) (*IPTable, *ChainInfo, *ChainInfo) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = iptable.ProgramChain(natChain, bridgeName, false, true)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	filterChain, err := iptable.NewChain(chainName, Filter)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = iptable.ProgramChain(filterChain, bridgeName, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**- What I did**

The `ProgramChain` method was called exclusively by the bridge driver to insert totally unrelated ipt rules in two different table-chains.

Break down this method into two functions, and move them into the bridge pkg.

The new function `addNATJumpRules` inserts rules that aren't related to any specific network, and depends solely on the driver config. Call it during driver configuration instead of during network setup.

**- How I did it**

**- How to verify it**

Existing tests, and particularly `iptablesdoc`, should pass.

