### PR TITLE
[27.x backport] libnetwork/drivers/bridge: setupIPChains: fix defer checking wrong err

### DIFF
--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -66,7 +66,7 @@ func setupIPChains(config configuration, version iptables.IPVersion) (natChain *
 		return nil, nil, nil, nil, fmt.Errorf("failed to create FILTER chain %s: %v", DockerChain, err)
 	}
 	defer func() {
-		if err != nil {
+		if retErr != nil {
 			if err := iptable.RemoveExistingChain(DockerChain, iptables.Filter); err != nil {
 				log.G(context.TODO()).Warnf("failed on removing iptables FILTER chain %s on cleanup: %v", DockerChain, err)
 			}


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49109
- introduced in https://github.com/moby/moby/pull/46236

The output variable was renamed in 0503cf2510ba77563ae4f731cc9ca599d45b7e3a, but that commit failed to change this defer, which was now checking the wrong error.


(cherry picked from commit 01a55860c62d2ddeb03fbd3d7a931a757d29f2da)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
networking: fixed a bug that could result in a iptables DOCKER FILTER chain not being cleaned up on failure [moby/moby#49109](ttps://github.com/moby/moby/pull/49109)
```

**- A picture of a cute animal (not mandatory but encouraged)**

