### PR TITLE
docs/api: version-history.md: fix markdown

### DIFF
--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,7 +17,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.48](https://docs.docker.com/reference/api/engine/version/v1.48/) documentation
 
-# Deprecated: The "allow-nondistributable-artifacts" daemon configuration is
+* Deprecated: The "allow-nondistributable-artifacts" daemon configuration is
   deprecated and enabled by default. The  `AllowNondistributableArtifactsCIDRs`
   and `AllowNondistributableArtifactsHostnames` fields in the `RegistryConfig`
   struct in the `GET /info` response will now always be `null` and will be


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49065

Fixes a typo introduced in 1932091e21b64abc52b42320393b0ac5f6921668


