### PR TITLE
Deprecate BridgeNfIptables and BridgeNfIp6tables fields

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5546,13 +5546,28 @@ definitions:
         type: "boolean"
         example: true
       BridgeNfIptables:
-        description: "Indicates if `bridge-nf-call-iptables` is available on the host."
+        description: |
+          Indicates if `bridge-nf-call-iptables` is available on the host when
+          the daemon was started.
+
+          <p><br /></p>
+
+          > **Deprecated**: netfilter module is now loaded on-demand and no longer
+          > during daemon startup, making this field obsolete. This field is always
+          > `false` and will be removed in a API v1.49.
         type: "boolean"
-        example: true
+        example: false
       BridgeNfIp6tables:
-        description: "Indicates if `bridge-nf-call-ip6tables` is available on the host."
+        description: |
+          Indicates if `bridge-nf-call-ip6tables` is available on the host.
+
+          <p><br /></p>
+
+          > **Deprecated**: netfilter module is now loaded on-demand, and no longer
+          > during daemon startup, making this field obsolete. This field is always
+          > `false` and will be removed in a API v1.49.
         type: "boolean"
-        example: true
+        example: false
       Debug:
         description: |
           Indicates if the daemon is running in debug-mode / with debug-level

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -29,8 +29,8 @@ type Info struct {
 	CPUSet             bool
 	PidsLimit          bool
 	IPv4Forwarding     bool
-	BridgeNfIptables   bool
-	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"`
+	BridgeNfIptables   bool `json:"BridgeNfIptables"`  // Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
+	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"` // Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
 	Debug              bool
 	NFd                int
 	OomKillDisable     bool

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -53,8 +53,6 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*system.Info, error) {
 		ID:                 daemon.id,
 		Images:             daemon.imageService.CountImages(ctx),
 		IPv4Forwarding:     !sysInfo.IPv4ForwardingDisabled,
-		BridgeNfIptables:   !sysInfo.BridgeNFCallIPTablesDisabled,
-		BridgeNfIP6tables:  !sysInfo.BridgeNFCallIP6TablesDisabled,
 		Name:               hostName(ctx),
 		SystemTime:         time.Now().Format(time.RFC3339Nano),
 		LoggingDriver:      daemon.defaultLogConfig.Type,

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -5512,7 +5512,11 @@ definitions:
         type: "boolean"
         example: true
       BridgeNfIptables:
-        description: "Indicates if `bridge-nf-call-iptables` is available on the host."
+        description: |
+          Indicates if `bridge-nf-call-iptables` is available on the host when
+          the daemon was started.
+
+          The `br_netfilter`
         type: "boolean"
         example: true
       BridgeNfIp6tables:

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -22,6 +22,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   and `AllowNondistributableArtifactsHostnames` fields in the `RegistryConfig`
   struct in the `GET /info` response will now always be `null` and will be
   omitted in API v1.49.
+* Deprecated: The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the 
+  `GET /info` response are now always be `false` and will be omitted in API
+  v1.49. The netfilter module is now loaded on-demand, and no longer during
+  daemon startup, making these fields obsolete.
 * `GET /images/{name}/history` now supports a `platform` parameter (JSON
   encoded OCI Platform type) that allows to specify a platform to show the
   history of.

--- a/integration-cli/requirements_unix_test.go
+++ b/integration-cli/requirements_unix_test.go
@@ -64,7 +64,8 @@ func seccompEnabled() bool {
 }
 
 func bridgeNfIptables() bool {
-	return !sysInfo.BridgeNFCallIPTablesDisabled
+	content, err := os.ReadFile("/proc/sys/net/bridge/bridge-nf-call-iptables")
+	return err == nil && strings.TrimSpace(string(content)) == "1"
 }
 
 func unprivilegedUsernsClone() bool {

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -27,9 +27,13 @@ type SysInfo struct {
 	IPv4ForwardingDisabled bool
 
 	// Whether bridge-nf-call-iptables is supported or not
+	//
+	// Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
 	BridgeNFCallIPTablesDisabled bool
 
 	// Whether bridge-nf-call-ip6tables is supported or not
+	//
+	// Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
 	BridgeNFCallIP6TablesDisabled bool
 
 	// Whether the cgroup has the mountpoint of "devices" or not

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -267,8 +267,6 @@ func applyDevicesCgroupInfo(info *SysInfo) {
 // applyNetworkingInfo adds networking information to the info.
 func applyNetworkingInfo(info *SysInfo) {
 	info.IPv4ForwardingDisabled = !readProcBool("/proc/sys/net/ipv4/ip_forward")
-	info.BridgeNFCallIPTablesDisabled = !readProcBool("/proc/sys/net/bridge/bridge-nf-call-iptables")
-	info.BridgeNFCallIP6TablesDisabled = !readProcBool("/proc/sys/net/bridge/bridge-nf-call-ip6tables")
 }
 
 // applyAppArmorInfo adds whether AppArmor is enabled to the info.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49089

The netfilter module is now loaded on-demand, and no longer during daemon startup, making these fields obsolete. These fields are now always `false` and will be removed in the next relase.

This patch deprecates:

- the `BridgeNfIptables` field in `api/types/system.Info`
- the `BridgeNfIp6tables` field in `api/types/system.Info`
- the `BridgeNFCallIPTablesDisabled` field in `pkg/sysinfo.SysInfo`
- the `BridgeNFCallIP6TablesDisabled` field in `pkg/sysinfo.SysInfo`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Go SDK: the `BridgeNfIptables` field in `api/types/system.Info` is deprecated and will be removed in the next release
- Go SDK: the `BridgeNfIp6tables` field in `api/types/system.Info`  is deprecated and will be removed in the next release
- Go SDK: the `BridgeNFCallIPTablesDisabled` field in `pkg/sysinfo.SysInfo` is deprecated and will be removed in the next release
- Go SDK: the `BridgeNFCallIP6TablesDisabled` field in `pkg/sysinfo.SysInfo`  is deprecated and will be removed in the next release

- API: Deprecated: The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the 
  `GET /info` response are now always be `false` and will be omitted in API
  v1.49. The netfilter module is now loaded on-demand, and no longer during
  daemon startup, making these fields obsolete.
```

**- A picture of a cute animal (not mandatory but encouraged)**

