### PR TITLE
libnetwork/iptables: deprecate Passthrough

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -174,8 +174,15 @@ func checkRunning() bool {
 	return err == nil
 }
 
-// Passthrough method simply passes args through to iptables/ip6tables
+// Passthrough method simply passes args through to iptables/ip6tables.
+//
+// Deprecated: this function is only used internally and will be removed in the next release.
 func Passthrough(ipv IPVersion, args ...string) ([]byte, error) {
+	return passthrough(ipv, args...)
+}
+
+// passthrough method simply passes args through to iptables/ip6tables
+func passthrough(ipv IPVersion, args ...string) ([]byte, error) {
 	var output string
 	log.G(context.TODO()).Debugf("Firewalld passthrough: %s, %s", ipv, args)
 	if err := connection.sysObj.Call(dbusInterface+".direct.passthrough", 0, ipv, args).Store(&output); err != nil {

--- a/libnetwork/iptables/firewalld_test.go
+++ b/libnetwork/iptables/firewalld_test.go
@@ -96,7 +96,7 @@ func TestPassthrough(t *testing.T) {
 		"-j", "ACCEPT",
 	}
 
-	_, err := Passthrough(IPv4, append([]string{"-A"}, rule1...)...)
+	_, err := passthrough(IPv4, append([]string{"-A"}, rule1...)...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -425,7 +425,7 @@ func filterOutput(start time.Time, output []byte, args ...string) []byte {
 func (iptable IPTable) Raw(args ...string) ([]byte, error) {
 	if firewalldRunning {
 		startTime := time.Now()
-		output, err := Passthrough(iptable.ipVersion, args...)
+		output, err := passthrough(iptable.ipVersion, args...)
 		if err == nil || !strings.Contains(err.Error(), "was not provided by any .service files") {
 			return filterOutput(startTime, output, args...), err
 		}


### PR DESCRIPTION

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
libnetwork/iptables: deprecate Passthrough. This function was only used internally, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

