### PR TITLE
Remove use of `pkg/pools` in archive

### DIFF
--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"compress/gzip"
 	"context"
 	"os"
@@ -66,7 +65,7 @@ func (s *DockerCLIImportSuite) TestImportFile(c *testing.T) {
 
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "export", "test-import"},
-		Stdout:  bufio.NewWriter(temporaryFile),
+		Stdout:  temporaryFile,
 	}).Assert(c, icmd.Success)
 
 	out := cli.DockerCmd(c, "import", temporaryFile.Name()).Combined()
@@ -110,7 +109,7 @@ func (s *DockerCLIImportSuite) TestImportFileWithMessage(c *testing.T) {
 
 	icmd.RunCmd(icmd.Cmd{
 		Command: []string{dockerBinary, "export", "test-import"},
-		Stdout:  bufio.NewWriter(temporaryFile),
+		Stdout:  temporaryFile,
 	}).Assert(c, icmd.Success)
 
 	message := "Testing commit message"
@@ -144,7 +143,7 @@ func (s *DockerCLIImportSuite) TestImportWithQuotedChanges(c *testing.T) {
 	assert.Assert(c, err == nil, "failed to create temporary file")
 	defer os.Remove(temporaryFile.Name())
 
-	cli.Docker(cli.Args("export", "test-import"), cli.WithStdout(bufio.NewWriter(temporaryFile))).Assert(c, icmd.Success)
+	cli.Docker(cli.Args("export", "test-import"), cli.WithStdout(temporaryFile)).Assert(c, icmd.Success)
 
 	result := cli.DockerCmd(c, "import", "-c", `ENTRYPOINT ["/bin/sh", "-c"]`, temporaryFile.Name())
 	imgRef := strings.TrimSpace(result.Stdout())

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -693,7 +693,7 @@ func tarUntar(t *testing.T, origin string, options *TarOptions) ([]Change, error
 	defer archive.Close()
 
 	buf := make([]byte, 10)
-	if _, err := archive.Read(buf); err != nil {
+	if _, err := io.ReadFull(archive, buf); err != nil {
 		return nil, err
 	}
 	wrap := io.MultiReader(bytes.NewReader(buf), archive)

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/pools"
 )
 
 // ChangeType represents the change type.
@@ -388,9 +387,6 @@ func ExportChanges(dir string, changes []Change, idMap idtools.IdentityMapping) 
 	reader, writer := io.Pipe()
 	go func() {
 		ta := newTarAppender(idMap, writer, nil)
-
-		// this buffer is needed for the duration of this piped stream
-		defer pools.BufioWriter32KPool.Put(ta.Buffer)
 
 		sort.Sort(changesByPath(changes))
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
-	"github.com/docker/docker/pkg/pools"
 )
 
 // UnpackLayer unpack `layer` to a `dest`. The stream `layer` can be
@@ -19,8 +18,6 @@ import (
 // Returns the size in bytes of the contents of the layer.
 func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64, err error) {
 	tr := tar.NewReader(layer)
-	trBuf := pools.BufioReader32KPool.Get(tr)
-	defer pools.BufioReader32KPool.Put(trBuf)
 
 	var dirs []*tar.Header
 	unpackedPaths := make(map[string]struct{})
@@ -159,8 +156,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				}
 			}
 
-			trBuf.Reset(tr)
-			srcData := io.Reader(trBuf)
+			srcData := io.Reader(tr)
 			srcHdr := hdr
 
 			// Hard links into /.wh..wh.plnk don't work, as we don't extract that directory, so

--- a/pkg/chrootarchive/archive_unix_test.go
+++ b/pkg/chrootarchive/archive_unix_test.go
@@ -67,6 +67,8 @@ func TestUntarWithMaliciousSymlinks(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(hostData), "I am a host file")
 
+	io.Copy(io.Discard, tee)
+
 	// Now test by chrooting to an attacker controlled path
 	// This should succeed as is and overwrite a "host" file
 	// Note that this would be a mis-use of this function.


### PR DESCRIPTION
Removes unnecessary use of pooling and prefers use of buffer pool on copy rather than pooling bufio. In some cases the bufio was used and the pool copy was still used which unnecessarily got a buffer which would not be used.