### PR TITLE
libnetwork/iptables: remove deprecated IPV, Iptables, IP6Tables, Passthrough()

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -158,13 +158,6 @@ func checkRunning() bool {
 	return err == nil
 }
 
-// Passthrough method simply passes args through to iptables/ip6tables.
-//
-// Deprecated: this function is only used internally and will be removed in the next release.
-func Passthrough(ipv IPVersion, args ...string) ([]byte, error) {
-	return passthrough(ipv, args...)
-}
-
 // passthrough method simply passes args through to iptables/ip6tables
 func passthrough(ipv IPVersion, args ...string) ([]byte, error) {
 	var output string

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -12,22 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// IPV defines the table string
-//
-// Deprecated: use [IPVersion]
-type IPV = IPVersion
-
-const (
-	// Iptables point ipv4 table
-	//
-	// Deprecated: use [IPv4].
-	Iptables IPV = IPv4
-	// IP6Tables point to ipv6 table
-	//
-	// Deprecated: use [IPv6].
-	IP6Tables IPV = IPv6
-)
-
 const (
 	dbusInterface   = "org.fedoraproject.FirewallD1"
 	dbusPath        = "/org/fedoraproject/FirewallD1"


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49093
- follow-up to https://github.com/moby/moby/pull/49115


### libnetwork/iptables: remove deprecated IPV, Iptables, IP6Tables

This was deprecated in 27deff4da1c90259ccf53befbc1ee1a1620f1fa0, and has
no known external users. The deprecation was included in the 27.4.1
release, so we can remove it from master.

This patch removes the deprecated `IPV`, and `Iptables` and `IP6Tables`
consts.

### libnetwork/iptables: remove deprecated Passthrough()

This was deprecated in d688389f4ac921d2239bf076d2af17acbe279ece, and has
no known external users. The deprecation was included in the 27.4.1
release, so we can remove it from master.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- libnetwork/iptables: remove deprecated `IPV`, `Iptables`, `IP6Tables`.
- libnetwork/iptables: remove deprecated `Passthrough()`
```

**- A picture of a cute animal (not mandatory but encouraged)**

