### PR TITLE
[master forward-port] libnet: don't put external DNS answers in OTel spans

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -589,9 +589,7 @@ func (r *Resolver) forwardExtDNS(ctx context.Context, proto string, remoteAddr n
 			r.log(ctx).Debugf("[resolver] external DNS %s:%s returned response with no answers:\n%s", proto, extDNS.IPStr, resp)
 		}
 		resp.Compress = true
-		span.AddEvent("response from upstream server", trace.WithAttributes(
-			attribute.String("libnet.resolver.resp", resp.String()),
-		))
+		span.AddEvent("response from upstream server")
 		return resp
 	}
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/48840
- related to https://github.com/moby/moby/issues/48644

**- What I did**

When containers make DNS resolution, and the domain name they're trying to resolve doesn't match any running container, the DNS query is forwarded to upstream servers. In that case, when we receive a response, we put it in an OTel spans.

This was useful to debug DNS resolution on GHA, but it leads to excessive memory usage when DNS resolution happen in a tight loop. So, keep the OTel event signaling that a response was received, but drop the answer from the OTel span.

(cherry picked from commit 173a9f20910eb620223a589c0d5a5e387b3daf62)


**- Description for the changelog**

```markdown changelog
- Fix an issue that caused excessive memory usage when DNS resolution was made in a tight loop
```


