### PR TITLE
Enable external DNS if a network has an IPv6 gateway

### DIFF
--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -388,7 +388,7 @@ func (ep *Endpoint) hasGatewayOrDefaultRoute() bool {
 	defer ep.mu.Unlock()
 
 	if ep.joinInfo != nil {
-		if len(ep.joinInfo.gw) > 0 {
+		if len(ep.joinInfo.gw) > 0 || len(ep.joinInfo.gw6) > 0 {
 			return true
 		}
 		for _, route := range ep.joinInfo.StaticRoutes {


### PR DESCRIPTION
**- What I did**

Make sure external DNS is enabled for an IPv6-only network with external access.

(No backport needed, this only affects the new IPv6-only networks.)

**- How I did it**

The function that checked whether a network has external access only looked for an IPv4 gateway, or IPv4/IPv6 static routes... it didn't understand the new IPv6-only networks.

**- How to verify it**

New integration test, fails without the fix.

**- Description for the changelog**
```markdown changelog

```
