### PR TITLE
Only set up an L3-ipvlan's default route when it's the gateway endpoint

### DIFF
--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -192,12 +192,23 @@ func selectGatewayEndpoint(endpoints []*Endpoint) (ep4, ep6 *Endpoint) {
 		gw4 := len(ep.Gateway()) != 0
 		gw6 := len(ep.GatewayIPv6()) != 0
 		if gw4 && gw6 {
+			// The first dual-stack endpoint is the gateway, no need to search further.
+			//
+			// FIXME(robmry) - this means a dual-stack gateway is preferred over single-stack
+			// gateways with higher gateway-priorities. A dual-stack network should probably
+			// be preferred over two single-stack networks, if they all have equal priorities.
+			// It'd probably also be better to use a dual-stack endpoint as the gateway for
+			// a single address family, if there's a higher-priority single-stack gateway for
+			// the other address family. (But, priority is currently a Sandbox property, not
+			// an Endpoint property. So, this function doesn't have access to priorities.)
 			return ep, ep
 		}
 		if gw4 && ep4 == nil {
+			// Found the best IPv4-only gateway, keep searching for an IPv6 or dual-stack gateway.
 			ep4 = ep
 		}
 		if gw6 && ep6 == nil {
+			// Found the best IPv6-only gateway, keep searching for an IPv4 or dual-stack gateway.
 			ep6 = ep
 		}
 	}

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -189,8 +189,7 @@ func selectGatewayEndpoint(endpoints []*Endpoint) (ep4, ep6 *Endpoint) {
 		if ep.getNetwork().Type() == "null" || ep.getNetwork().Type() == "host" {
 			continue
 		}
-		gw4 := len(ep.Gateway()) != 0
-		gw6 := len(ep.GatewayIPv6()) != 0
+		gw4, gw6 := ep.hasGatewayOrDefaultRoute()
 		if gw4 && gw6 {
 			// The first dual-stack endpoint is the gateway, no need to search further.
 			//

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -514,12 +514,16 @@ func setInterfaceRoutes(ctx context.Context, nlh nlwrap.Handle, iface netlink.Li
 	defer span.End()
 
 	for _, route := range i.Routes() {
-		err := nlh.RouteAdd(&netlink.Route{
+		if route.IP.IsUnspecified() {
+			// Don't set up a default route now, it'll be set later if this interface is
+			// selected as the default gateway.
+			continue
+		}
+		if err := nlh.RouteAdd(&netlink.Route{
 			Scope:     netlink.SCOPE_LINK,
 			LinkIndex: iface.Attrs().Index,
 			Dst:       route,
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -229,6 +229,8 @@ type Namespace struct {
 	iFaces              []*Interface
 	gw                  net.IP
 	gwv6                net.IP
+	defRoute4SrcName    string
+	defRoute6SrcName    string
 	staticRoutes        []*types.StaticRoute
 	neighbors           []*neigh
 	nextIfIndex         map[string]int
@@ -247,6 +249,17 @@ func (n *Namespace) Interfaces() []*Interface {
 	ifaces := make([]*Interface, len(n.iFaces))
 	copy(ifaces, n.iFaces)
 	return ifaces
+}
+
+func (n *Namespace) ifaceBySrcName(srcName string) *Interface {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for _, iface := range n.iFaces {
+		if iface.srcName == srcName {
+			return iface
+		}
+	}
+	return nil
 }
 
 func (n *Namespace) loopbackUp() error {

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -603,7 +603,7 @@ func (sb *Sandbox) clearNetworkResources(origEp *Endpoint) error {
 
 	if (gwepAfter4 != nil && gwepBefore4 != gwepAfter4) || (gwepAfter6 != nil && gwepBefore6 != gwepAfter6) {
 		if err := sb.updateGateway(gwepAfter4, gwepAfter6); err != nil {
-			return err
+			return fmt.Errorf("updating gateway endpoint: %w", err)
 		}
 	}
 

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -509,7 +509,7 @@ func (sb *Sandbox) hasExternalAccess() bool {
 		if nw.Internal() || nw.Type() == "null" || nw.Type() == "host" {
 			continue
 		}
-		if ep.hasGatewayOrDefaultRoute() {
+		if v4, v6 := ep.hasGatewayOrDefaultRoute(); v4 || v6 {
 			return true
 		}
 	}
@@ -648,34 +648,35 @@ func (sb *Sandbox) joinLeaveEnd() {
 	}
 }
 
+// Less defines an ordering over endpoints, with better candidates for the default
+// gateway sorted first.
+//
 // <=> Returns true if a < b, false if a > b and advances to next level if a == b
 // epi.prio <=> epj.prio           # 2 < 1
 // epi.gw <=> epj.gw               # non-gw < gw
 // epi.internal <=> epj.internal   # non-internal < internal
-// epi.joininfo <=> epj.joininfo   # ipv6 < ipv4
+// epi.hasGw <=> epj.hasGw         # (gw4 and gw6) < (gw4 or gw6) < (no gw)
 // epi.name <=> epj.name           # bar < foo
 func (epi *Endpoint) Less(epj *Endpoint) bool {
-	var prioi, prioj int
-
 	sbi, _ := epi.getSandbox()
 	sbj, _ := epj.getSandbox()
 
 	// Prio defaults to 0
+	var prioi, prioj int
 	if sbi != nil {
 		prioi = sbi.epPriority[epi.ID()]
 	}
 	if sbj != nil {
 		prioj = sbj.epPriority[epj.ID()]
 	}
-
 	if prioi != prioj {
 		return prioi > prioj
 	}
 
-	gwi := epi.endpointInGWNetwork()
-	gwj := epj.endpointInGWNetwork()
-	if gwi != gwj {
-		return gwj
+	gwNeti := epi.endpointInGWNetwork()
+	gwNetj := epj.endpointInGWNetwork()
+	if gwNeti != gwNetj {
+		return gwNetj
 	}
 
 	inti := epi.getNetwork().Internal()
@@ -684,28 +685,20 @@ func (epi *Endpoint) Less(epj *Endpoint) bool {
 		return intj
 	}
 
-	jii := 0
-	if epi.joinInfo != nil {
-		if epi.joinInfo.gw != nil {
-			jii = jii + 1
+	gwCount := func(ep *Endpoint) int {
+		gw4, gw6 := ep.hasGatewayOrDefaultRoute()
+		if gw4 && gw6 {
+			return 2
 		}
-		if epi.joinInfo.gw6 != nil {
-			jii = jii + 2
+		if gw4 || gw6 {
+			return 1
 		}
+		return 0
 	}
-
-	jij := 0
-	if epj.joinInfo != nil {
-		if epj.joinInfo.gw != nil {
-			jij = jij + 1
-		}
-		if epj.joinInfo.gw6 != nil {
-			jij = jij + 2
-		}
-	}
-
-	if jii != jij {
-		return jii > jij
+	gwCounti := gwCount(epi)
+	gwCountj := gwCount(epj)
+	if gwCounti != gwCountj {
+		return gwCounti > gwCountj
 	}
 
 	return epi.network.Name() < epj.network.Name()


### PR DESCRIPTION
**- What I did**

- fixes https://github.com/moby/moby/issues/48576

It wasn't possible to connect a container to a layer-3 ipvlan network as well as a bridge networks ... because they both had their own ideas about how to set up a default route.

See https://github.com/moby/moby/issues/48576#issuecomment-2418979480 for the analysis.

**- How I did it**

- Made libnetwork understand that an Interface route with destination 0.0.0.0/:: is equivalent to a default gateway.
  - `getGatewayEndpoint` includes `routes` as well as gateways in its search.
  - Include those routes in the ordering over Endpoints that's used to select a gateway.
- Only set up connected default routes when the ipvlan network is selected as the container's gateway.
  - Don't apply those routes when joining the endpoint to a sandbox.
  - Add/remove the routes when configuring the gateway endpoint.

**- How to verify it**

New integration test.

**- Description for the changelog**
```markdown changelog
- fixed an issue that meant a container could not be attached to an L3 ipvlan at the same time as other network types
```
