### PR TITLE
image: Remove `GetImageManifest`

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -47,17 +47,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 
 	pm := i.matchRequestedOrDefault(platforms.OnlyStrict, options.Platform)
 
-	imgV1, err := i.getImageV1(ctx, img, pm)
-	if err != nil {
-		return nil, err
-	}
-
-	return imgV1, nil
-}
-
-// getImageV1 gets the containerd image as a docker v1 image struct.
-func (i *ImageService) getImageV1(ctx context.Context, img containerdimages.Image, platform platforms.MatchComparer) (*image.Image, error) {
-	im, err := i.getBestPresentImageManifest(ctx, img, platform)
+	im, err := i.getBestPresentImageManifest(ctx, img, pm)
 	if err != nil {
 		return nil, err
 	}
@@ -76,24 +66,12 @@ func (i *ImageService) getImageV1(ctx context.Context, img containerdimages.Imag
 		imgV1.Parent = image.ID(parent)
 	}
 
+	target := im.Target()
+	imgV1.Details = &image.Details{
+		ManifestDescriptor: &target,
+	}
+
 	return imgV1, nil
-}
-
-func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, options backend.GetImageOpts) (*ocispec.Descriptor, error) {
-	img, err := i.resolveImage(ctx, refOrID)
-	if err != nil {
-		return nil, err
-	}
-
-	pm := i.matchRequestedOrDefault(platforms.Only, options.Platform)
-
-	im, err := i.getBestPresentImageManifest(ctx, img, pm)
-	if err != nil {
-		return nil, err
-	}
-
-	desc := im.Target()
-	return &desc, nil
 }
 
 // getBestPresentImageManifest returns a platform-specific image manifest that best matches the provided platform matcher.

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -137,15 +137,8 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		if err != nil {
 			return nil, err
 		}
-		// when using the containerd store, we need to get the actual
-		// image manifest so we can store it and later deterministically
-		// resolve the specific image the container is running
-		if daemon.UsesSnapshotter() {
-			imgManifest, err = daemon.imageService.GetImageManifest(ctx, opts.params.Config.Image, backend.GetImageOpts{Platform: opts.params.Platform})
-			if err != nil {
-				log.G(ctx).WithError(err).Error("failed to find image manifest")
-				return nil, err
-			}
+		if img.Details != nil {
+			imgManifest = img.Details.ManifestDescriptor
 		}
 		platform = img.Platform()
 		imgID = img.ID()

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -48,7 +48,6 @@ type ImageService interface {
 	// Containerd related methods
 
 	PrepareSnapshot(ctx context.Context, id string, parentImage string, platform *ocispec.Platform, setupInit func(string) error) error
-	GetImageManifest(ctx context.Context, refOrID string, options backend.GetImageOpts) (*ocispec.Descriptor, error)
 
 	// Layers
 

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -162,10 +162,6 @@ func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.I
 	return false, nil
 }
 
-func (i *ImageService) GetImageManifest(ctx context.Context, refOrID string, options backend.GetImageOpts) (*ocispec.Descriptor, error) {
-	panic("not implemented")
-}
-
 // GetImage returns an image corresponding to the image referred to by refOrID.
 func (i *ImageService) GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (retImg *image.Image, retErr error) {
 	defer func() {

--- a/image/image.go
+++ b/image/image.go
@@ -121,6 +121,13 @@ type Details struct {
 	Metadata    map[string]string
 	Driver      string
 	LastUpdated time.Time
+
+	// ManifestDescriptor is the descriptor of the platform-specific manifest
+	// chosen by the [GetImage] call that returned this image.
+	// The exact descriptor depends on the [GetImageOpts.Platform] field
+	// passed to [GetImage] and the content availability.
+	// This is only set by the containerd image service.
+	ManifestDescriptor *ocispec.Descriptor
 }
 
 // RawJSON returns the immutable JSON associated with the image.

--- a/image/image.go
+++ b/image/image.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/layer"
@@ -116,12 +115,6 @@ type Image struct {
 
 // Details provides additional image data
 type Details struct {
-	References  []reference.Named
-	Size        int64
-	Metadata    map[string]string
-	Driver      string
-	LastUpdated time.Time
-
 	// ManifestDescriptor is the descriptor of the platform-specific manifest
 	// chosen by the [GetImage] call that returned this image.
 	// The exact descriptor depends on the [GetImageOpts.Platform] field


### PR DESCRIPTION
Its only usage was in container creation, which also called `GetImage` first.
This method is specific to the containerd image service and is largely the same as `GetImage`, except it returns a manifest descriptor. Instead, introduce add the descriptor as a new field in `Image.Details` and set it in the containerd image service implementation of `GetImage`.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/65e2f7ae-66dc-4007-a814-f365e8ed7ebc)
