### PR TITLE
api: Remove unused imageStore and layerStore

### DIFF
--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -2,8 +2,6 @@ package image // import "github.com/docker/docker/api/server/router/image"
 
 import (
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/image"
-	"github.com/docker/docker/layer"
 	"github.com/docker/docker/reference"
 )
 
@@ -12,19 +10,15 @@ type imageRouter struct {
 	backend          Backend
 	searcher         Searcher
 	referenceBackend reference.Store
-	imageStore       image.Store
-	layerStore       layer.Store
 	routes           []router.Route
 }
 
 // NewRouter initializes a new image router
-func NewRouter(backend Backend, searcher Searcher, referenceBackend reference.Store, imageStore image.Store, layerStore layer.Store) router.Router {
+func NewRouter(backend Backend, searcher Searcher, referenceBackend reference.Store) router.Router {
 	ir := &imageRouter{
 		backend:          backend,
 		searcher:         searcher,
 		referenceBackend: referenceBackend,
-		imageStore:       imageStore,
-		layerStore:       layerStore,
 	}
 	ir.initRoutes()
 	return ir

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -696,8 +696,6 @@ func buildRouters(opts routerOptions) []router.Router {
 			opts.daemon.ImageService(),
 			opts.daemon.RegistryService(),
 			opts.daemon.ReferenceStore,
-			opts.daemon.ImageService().DistributionServices().ImageStore,
-			opts.daemon.ImageService().DistributionServices().LayerStore,
 		),
 		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.buildkit, opts.daemon.Features),
 		volume.NewRouter(opts.daemon.VolumesService(), opts.cluster),


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44622

Commit 8fb71ce20894c0c7fbd9ee6058bf2c0e82d6a77c moved access to these to the image service directly, so they are no longer used in the router.


**- How to verify it**
CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

