### PR TITLE
daemon/c8d: Fix duplicate containerd/images import

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,8 @@ linters-settings:
       # own errdefs package (or vice-versa).
       - pkg: github.com/containerd/errdefs
         alias: cerrdefs
+      - pkg: github.com/containerd/containerd/images
+        alias: c8dimages
       - pkg: github.com/opencontainers/image-spec/specs-go/v1
         alias: ocispec
 

--- a/builder/builder-next/adapters/localinlinecache/inlinecache.go
+++ b/builder/builder-next/adapters/localinlinecache/inlinecache.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes/docker"
 	distreference "github.com/distribution/reference"
 	imagestore "github.com/docker/docker/image"
@@ -99,7 +99,7 @@ func (li *localImporter) importInlineCache(ctx context.Context, dt []byte, cc so
 		desc := ocispec.Descriptor{
 			Digest:      dgst,
 			Size:        -1,
-			MediaType:   images.MediaTypeDockerSchema2Layer,
+			MediaType:   c8dimages.MediaTypeDockerSchema2Layer,
 			Annotations: map[string]string{},
 		}
 		if createdAt := createdDates[i]; createdAt != "" {

--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/gc"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/rootfs"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -351,7 +351,7 @@ func (w *Worker) GetRemotes(ctx context.Context, ref cache.ImmutableRef, createI
 	descriptors := make([]ocispec.Descriptor, len(diffIDs))
 	for i, dgst := range diffIDs {
 		descriptors[i] = ocispec.Descriptor{
-			MediaType: images.MediaTypeDockerSchema2Layer,
+			MediaType: c8dimages.MediaTypeDockerSchema2Layer,
 			Digest:    digest.Digest(dgst),
 			Size:      -1,
 		}

--- a/daemon/containerd/handlers.go
+++ b/daemon/containerd/handlers.go
@@ -4,15 +4,15 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/content"
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// walkPresentChildren is a simple wrapper for containerdimages.Walk with presentChildrenHandler.
+// walkPresentChildren is a simple wrapper for c8dimages.Walk with presentChildrenHandler.
 // This is only a convenient helper to reduce boilerplate.
 func (i *ImageService) walkPresentChildren(ctx context.Context, target ocispec.Descriptor, f func(context.Context, ocispec.Descriptor) error) error {
-	return containerdimages.Walk(ctx, presentChildrenHandler(i.content, containerdimages.HandlerFunc(
+	return c8dimages.Walk(ctx, presentChildrenHandler(i.content, c8dimages.HandlerFunc(
 		func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			return nil, f(ctx, desc)
 		})), target)
@@ -20,7 +20,7 @@ func (i *ImageService) walkPresentChildren(ctx context.Context, target ocispec.D
 
 // presentChildrenHandler is a handler wrapper which traverses all children
 // descriptors that are present in the store and calls specified handler.
-func presentChildrenHandler(store content.Store, h containerdimages.HandlerFunc) containerdimages.HandlerFunc {
+func presentChildrenHandler(store content.Store, h c8dimages.HandlerFunc) c8dimages.HandlerFunc {
 	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		_, err := store.Info(ctx, desc.Digest)
 		if err != nil {
@@ -35,7 +35,7 @@ func presentChildrenHandler(store content.Store, h containerdimages.HandlerFunc)
 			return nil, err
 		}
 
-		c, err := containerdimages.Children(ctx, store, desc)
+		c, err := c8dimages.Children(ctx, store, desc)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -77,7 +77,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 // getBestPresentImageManifest returns a platform-specific image manifest that best matches the provided platform matcher.
 // Only locally available platform images are considered.
 // If no image manifest matches the platform, an error is returned.
-func (i *ImageService) getBestPresentImageManifest(ctx context.Context, img containerdimages.Image, pm platforms.MatchComparer) (*ImageManifest, error) {
+func (i *ImageService) getBestPresentImageManifest(ctx context.Context, img c8dimages.Image, pm platforms.MatchComparer) (*ImageManifest, error) {
 	var best *ImageManifest
 	var bestPlatform ocispec.Platform
 
@@ -123,24 +123,24 @@ func (i *ImageService) resolveDescriptor(ctx context.Context, refOrID string) (o
 }
 
 // ResolveImage looks up an image by reference or identifier in the image store.
-func (i *ImageService) ResolveImage(ctx context.Context, refOrID string) (containerdimages.Image, error) {
+func (i *ImageService) ResolveImage(ctx context.Context, refOrID string) (c8dimages.Image, error) {
 	return i.resolveImage(ctx, refOrID)
 }
 
-func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (containerdimages.Image, error) {
+func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (c8dimages.Image, error) {
 	parsed, err := reference.ParseAnyReference(refOrID)
 	if err != nil {
-		return containerdimages.Image{}, errdefs.InvalidParameter(err)
+		return c8dimages.Image{}, errdefs.InvalidParameter(err)
 	}
 
 	digested, ok := parsed.(reference.Digested)
 	if ok {
 		imgs, err := i.images.List(ctx, "target.digest=="+digested.Digest().String())
 		if err != nil {
-			return containerdimages.Image{}, errors.Wrap(err, "failed to lookup digest")
+			return c8dimages.Image{}, errors.Wrap(err, "failed to lookup digest")
 		}
 		if len(imgs) == 0 {
-			return containerdimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
+			return c8dimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
 		}
 
 		// If reference is both Named and Digested, make sure we don't match
@@ -158,7 +158,7 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (contai
 					return img, nil
 				}
 			}
-			return containerdimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
+			return c8dimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
 		}
 
 		return imgs[0], nil
@@ -171,7 +171,7 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (contai
 	} else {
 		// TODO(containerd): error translation can use common function
 		if !cerrdefs.IsNotFound(err) {
-			return containerdimages.Image{}, err
+			return c8dimages.Image{}, err
 		}
 	}
 
@@ -183,11 +183,11 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (contai
 		}
 		imgs, err := i.images.List(ctx, filters...)
 		if err != nil {
-			return containerdimages.Image{}, err
+			return c8dimages.Image{}, err
 		}
 
 		if len(imgs) == 0 {
-			return containerdimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
+			return c8dimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
 		}
 		if len(imgs) > 1 {
 			digests := map[digest.Digest]struct{}{}
@@ -199,24 +199,24 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (contai
 			}
 
 			if len(digests) > 1 {
-				return containerdimages.Image{}, errdefs.NotFound(errors.New("ambiguous reference"))
+				return c8dimages.Image{}, errdefs.NotFound(errors.New("ambiguous reference"))
 			}
 		}
 
 		return imgs[0], nil
 	}
 
-	return containerdimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
+	return c8dimages.Image{}, images.ErrImageDoesNotExist{Ref: parsed}
 }
 
 // getAllImagesWithRepository returns a slice of images which name is a reference
 // pointing to the same repository as the given reference.
-func (i *ImageService) getAllImagesWithRepository(ctx context.Context, ref reference.Named) ([]containerdimages.Image, error) {
+func (i *ImageService) getAllImagesWithRepository(ctx context.Context, ref reference.Named) ([]c8dimages.Image, error) {
 	nameFilter := "^" + regexp.QuoteMeta(ref.Name()) + ":" + reference.TagRegexp.String() + "$"
 	return i.images.List(ctx, "name~="+strconv.Quote(nameFilter))
 }
 
-func imageFamiliarName(img containerdimages.Image) string {
+func imageFamiliarName(img c8dimages.Image) string {
 	if isDanglingImage(img) {
 		return img.Target.Digest.String()
 	}
@@ -275,13 +275,13 @@ func convertError(err error) error {
 //
 //	An error looking up refOrID or no images found with matching name or target. Note that the first
 //	argument may be nil with a nil error if the second argument is non-empty.
-func (i *ImageService) resolveAllReferences(ctx context.Context, refOrID string) (*containerdimages.Image, []containerdimages.Image, error) {
+func (i *ImageService) resolveAllReferences(ctx context.Context, refOrID string) (*c8dimages.Image, []c8dimages.Image, error) {
 	parsed, err := reference.ParseAnyReference(refOrID)
 	if err != nil {
 		return nil, nil, errdefs.InvalidParameter(err)
 	}
 	var dgst digest.Digest
-	var img *containerdimages.Image
+	var img *c8dimages.Image
 
 	if idWithoutAlgo := checkTruncatedID(refOrID); idWithoutAlgo != "" { // Valid ID.
 		if d, ok := parsed.(reference.Digested); ok {

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/rootfs"
@@ -204,12 +204,12 @@ func newROLayerForImage(ctx context.Context, imgDesc *ocispec.Descriptor, i *Ima
 		platMatcher = platforms.Only(*platform)
 	}
 
-	confDesc, err := containerdimages.Config(ctx, i.content, *imgDesc, platMatcher)
+	confDesc, err := c8dimages.Config(ctx, i.content, *imgDesc, platMatcher)
 	if err != nil {
 		return nil, err
 	}
 
-	diffIDs, err := containerdimages.RootFS(ctx, i.content, confDesc)
+	diffIDs, err := c8dimages.RootFS(ctx, i.content, confDesc)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +448,7 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		if err != nil {
 			return nil, err
 		}
-		parentImageManifest, err := containerdimages.Manifest(ctx, i.content, parentDesc, platforms.Default())
+		parentImageManifest, err := c8dimages.Manifest(ctx, i.content, parentDesc, platforms.Default())
 		if err != nil {
 			return nil, err
 		}
@@ -476,7 +476,7 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 		}
 
 		layers = append(layers, ocispec.Descriptor{
-			MediaType: containerdimages.MediaTypeDockerSchema2LayerGzip,
+			MediaType: c8dimages.MediaTypeDockerSchema2LayerGzip,
 			Digest:    layerDigest,
 			Size:      info.Size,
 		})
@@ -505,7 +505,7 @@ func (i *ImageService) createImageOCI(ctx context.Context, imgToCreate imagespec
 		return "", err
 	}
 
-	img := containerdimages.Image{
+	img := c8dimages.Image{
 		Name:      danglingImageName(manifestDesc.Digest),
 		Target:    manifestDesc,
 		CreatedAt: time.Now(),

--- a/daemon/containerd/image_children.go
+++ b/daemon/containerd/image_children.go
@@ -3,7 +3,7 @@ package containerd
 import (
 	"context"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/opencontainers/go-digest"
@@ -33,13 +33,13 @@ func (i *ImageService) Children(ctx context.Context, id image.ID) ([]image.ID, e
 // parents returns a slice of image IDs that are parents of the `id` image
 //
 // Called from image_delete.go to prune dangling parents.
-func (i *ImageService) parents(ctx context.Context, id image.ID) ([]containerdimages.Image, error) {
+func (i *ImageService) parents(ctx context.Context, id image.ID) ([]c8dimages.Image, error) {
 	targetImage, err := i.resolveImage(ctx, id.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get child image")
 	}
 
-	var imgs []containerdimages.Image
+	var imgs []c8dimages.Image
 	for {
 		parent, ok := targetImage.Labels[imageLabelClassicBuilderParent]
 		if !ok || parent == "" {

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -422,7 +422,7 @@ func (idc *imageDeleteConflict) Error() string {
 	return fmt.Sprintf("conflict: unable to delete %s (%s) - %s", idc.reference, forceMsg, idc.message)
 }
 
-func (imageDeleteConflict) Conflict() {}
+func (*imageDeleteConflict) Conflict() {}
 
 // checkImageDeleteConflict returns a conflict representing
 // any issue preventing deletion of the given image ID, and

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
@@ -190,7 +190,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 // also deletes dangling parents if there is no conflict in doing so.
 // Parent images are removed quietly, and if there is any issue/conflict
 // it is logged but does not halt execution/an error is not returned.
-func (i *ImageService) deleteAll(ctx context.Context, imgID image.ID, all []containerdimages.Image, c conflictType, prune bool) (records []imagetypes.DeleteResponse, err error) {
+func (i *ImageService) deleteAll(ctx context.Context, imgID image.ID, all []c8dimages.Image, c conflictType, prune bool) (records []imagetypes.DeleteResponse, err error) {
 	// Workaround for: https://github.com/moby/buildkit/issues/3797
 	possiblyDeletedConfigs := map[digest.Digest]struct{}{}
 	if len(all) > 0 && i.content != nil {
@@ -202,7 +202,7 @@ func (i *ImageService) deleteAll(ctx context.Context, imgID image.ID, all []cont
 				handled[img.Target.Digest] = struct{}{}
 			}
 			err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, d ocispec.Descriptor) error {
-				if containerdimages.IsConfigType(d.MediaType) {
+				if c8dimages.IsConfigType(d.MediaType) {
 					possiblyDeletedConfigs[d.Digest] = struct{}{}
 				}
 				return nil
@@ -220,7 +220,7 @@ func (i *ImageService) deleteAll(ctx context.Context, imgID image.ID, all []cont
 		}
 	}()
 
-	var parents []containerdimages.Image
+	var parents []c8dimages.Image
 	if prune {
 		// TODO(dmcgowan): Consider using GC labels to walk for deletion
 		parents, err = i.parents(ctx, imgID)
@@ -278,11 +278,11 @@ func isImageIDPrefix(imageID, possiblePrefix string) bool {
 //
 // Note: All imgs should have the same target, only the image name will be considered
 // for determining whether images are the same.
-func (i *ImageService) getSameReferences(ctx context.Context, named reference.Named, imgs []containerdimages.Image) ([]containerdimages.Image, error) {
+func (i *ImageService) getSameReferences(ctx context.Context, named reference.Named, imgs []c8dimages.Image) ([]c8dimages.Image, error) {
 	var (
 		tag        string
-		sameRef    []containerdimages.Image
-		digestRefs = []containerdimages.Image{}
+		sameRef    []c8dimages.Image
+		digestRefs = []c8dimages.Image{}
 		allTags    bool
 	)
 	if named != nil {
@@ -351,7 +351,7 @@ const (
 // images and untagged references are appended to the given records. If any
 // error or conflict is encountered, it will be returned immediately without
 // deleting the image.
-func (i *ImageService) imageDeleteHelper(ctx context.Context, img containerdimages.Image, all []containerdimages.Image, records *[]imagetypes.DeleteResponse, extra conflictType) error {
+func (i *ImageService) imageDeleteHelper(ctx context.Context, img c8dimages.Image, all []c8dimages.Image, records *[]imagetypes.DeleteResponse, extra conflictType) error {
 	// First, determine if this image has any conflicts. Ignore soft conflicts
 	// if force is true.
 	c := conflictHard | extra
@@ -374,7 +374,7 @@ func (i *ImageService) imageDeleteHelper(ctx context.Context, img containerdimag
 			return err
 		}
 		if len(children) > 0 {
-			_, err = i.images.Create(ctx, containerdimages.Image{
+			_, err = i.images.Create(ctx, c8dimages.Image{
 				Name:      danglingImageName(img.Target.Digest),
 				Target:    img.Target,
 				CreatedAt: time.Now(),
@@ -387,7 +387,7 @@ func (i *ImageService) imageDeleteHelper(ctx context.Context, img containerdimag
 	}
 
 	// TODO: Add target option
-	err = i.images.Delete(ctx, img.Name, containerdimages.SynchronousDelete())
+	err = i.images.Delete(ctx, img.Name, c8dimages.SynchronousDelete())
 	if err != nil {
 		return err
 	}
@@ -429,7 +429,7 @@ func (*imageDeleteConflict) Conflict() {}
 // nil if there are none. It takes a bitmask representing a
 // filter for which conflict types the caller cares about,
 // and will only check for these conflict types.
-func (i *ImageService) checkImageDeleteConflict(ctx context.Context, imgID image.ID, all []containerdimages.Image, mask conflictType) error {
+func (i *ImageService) checkImageDeleteConflict(ctx context.Context, imgID image.ID, all []c8dimages.Image, mask conflictType) error {
 	if mask&conflictRunningContainer != 0 {
 		running := func(c *container.Container) bool {
 			return c.ImageID == imgID && c.IsRunning()

--- a/daemon/containerd/image_delete_test.go
+++ b/daemon/containerd/image_delete_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/log/logtest"
@@ -20,8 +20,8 @@ func TestImageDelete(t *testing.T) {
 
 	for _, tc := range []struct {
 		ref       string
-		starting  []images.Image
-		remaining []images.Image
+		starting  []c8dimages.Image
+		remaining []c8dimages.Image
 		err       error
 		// TODO: Records
 		// TODO: Containers
@@ -33,7 +33,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "justoneimage",
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/justoneimage:latest",
 					Target: desc(10),
@@ -42,7 +42,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "justoneref",
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/justoneref:latest",
 					Target: desc(10),
@@ -52,7 +52,7 @@ func TestImageDelete(t *testing.T) {
 					Target: desc(10),
 				},
 			},
-			remaining: []images.Image{
+			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/differentrepo:latest",
 					Target: desc(10),
@@ -61,7 +61,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "hasdigest",
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/hasdigest:latest",
 					Target: desc(10),
@@ -74,7 +74,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: digestFor(11).String(),
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/byid:latest",
 					Target: desc(11),
@@ -87,7 +87,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "bydigest@" + digestFor(12).String(),
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/bydigest:latest",
 					Target: desc(12),
@@ -100,7 +100,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "onerefoftwo",
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/onerefoftwo:latest",
 					Target: desc(12),
@@ -114,7 +114,7 @@ func TestImageDelete(t *testing.T) {
 					Target: desc(12),
 				},
 			},
-			remaining: []images.Image{
+			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/onerefoftwo:other",
 					Target: desc(12),
@@ -127,7 +127,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "otherreporemaining",
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/otherreporemaining:latest",
 					Target: desc(12),
@@ -141,7 +141,7 @@ func TestImageDelete(t *testing.T) {
 					Target: desc(12),
 				},
 			},
-			remaining: []images.Image{
+			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
 					Target: desc(12),
@@ -150,7 +150,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "repoanddigest@" + digestFor(15).String(),
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/repoanddigest:latest",
 					Target: desc(15),
@@ -164,7 +164,7 @@ func TestImageDelete(t *testing.T) {
 					Target: desc(15),
 				},
 			},
-			remaining: []images.Image{
+			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
 					Target: desc(15),
@@ -173,7 +173,7 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "repoanddigestothertags@" + digestFor(15).String(),
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/repoanddigestothertags:v1",
 					Target: desc(15),
@@ -195,7 +195,7 @@ func TestImageDelete(t *testing.T) {
 					Target: desc(15),
 				},
 			},
-			remaining: []images.Image{
+			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
 					Target: desc(15),
@@ -204,13 +204,13 @@ func TestImageDelete(t *testing.T) {
 		},
 		{
 			ref: "repoanddigestzerocase@" + digestFor(16).String(),
-			starting: []images.Image{
+			starting: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
 					Target: desc(16),
 				},
 			},
-			remaining: []images.Image{
+			remaining: []c8dimages.Image{
 				{
 					Name:   "docker.io/library/someotherrepo:latest",
 					Target: desc(16),

--- a/daemon/containerd/image_events.go
+++ b/daemon/containerd/image_events.go
@@ -3,7 +3,7 @@ package containerd
 import (
 	"context"
 
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
 )
@@ -29,7 +29,7 @@ func (i *ImageService) LogImageEvent(imageID, refName string, action events.Acti
 }
 
 // logImageEvent generates an event related to an image with only name attribute.
-func (i *ImageService) logImageEvent(img images.Image, refName string, action events.Action) {
+func (i *ImageService) logImageEvent(img c8dimages.Image, refName string, action events.Action) {
 	attributes := map[string]string{}
 	if refName != "" {
 		attributes["name"] = refName

--- a/daemon/containerd/image_history.go
+++ b/daemon/containerd/image_history.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
@@ -84,7 +84,7 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string, platform *
 		}}, history...)
 	}
 
-	findParents := func(img containerdimages.Image) []containerdimages.Image {
+	findParents := func(img c8dimages.Image) []c8dimages.Image {
 		imgs, err := i.getParentsByBuilderLabel(ctx, img)
 		if err != nil {
 			log.G(ctx).WithFields(log.Fields{
@@ -129,7 +129,7 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string, platform *
 	return history, nil
 }
 
-func getImageTags(ctx context.Context, imgs []containerdimages.Image) []string {
+func getImageTags(ctx context.Context, imgs []c8dimages.Image) []string {
 	var tags []string
 	for _, img := range imgs {
 		if isDanglingImage(img) {
@@ -154,7 +154,7 @@ func getImageTags(ctx context.Context, imgs []containerdimages.Image) []string {
 // getParentsByBuilderLabel finds images that were a base for the given image
 // by an image label set by the legacy builder.
 // NOTE: This only works for images built with legacy builder (not Buildkit).
-func (i *ImageService) getParentsByBuilderLabel(ctx context.Context, img containerdimages.Image) ([]containerdimages.Image, error) {
+func (i *ImageService) getParentsByBuilderLabel(ctx context.Context, img c8dimages.Image) ([]c8dimages.Image, error) {
 	parent, ok := img.Labels[imageLabelClassicBuilderParent]
 	if !ok || parent == "" {
 		return nil, nil

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -136,7 +136,7 @@ func (i *ImageService) ImportImage(ctx context.Context, ref reference.Named, pla
 	}
 
 	id := image.ID(manifestDesc.Digest.String())
-	img := images.Image{
+	img := c8dimages.Image{
 		Name:      refString,
 		Target:    manifestDesc,
 		CreatedAt: createdAt,
@@ -296,7 +296,7 @@ func writeBlobAndReturnDigest(ctx context.Context, cs content.Store, mt string, 
 }
 
 // unpackImage unpacks the platform-specific manifest of a image into the snapshotter.
-func (i *ImageService) unpackImage(ctx context.Context, snapshotter string, img images.Image, manifestDesc ocispec.Descriptor) error {
+func (i *ImageService) unpackImage(ctx context.Context, snapshotter string, img c8dimages.Image, manifestDesc ocispec.Descriptor) error {
 	c8dImg, err := i.NewImageManifest(ctx, img, manifestDesc)
 	if err != nil {
 		return err

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -139,9 +139,9 @@ func (i *ImageService) size(ctx context.Context, desc ocispec.Descriptor, platfo
 	var size atomic.Int64
 
 	cs := i.content
-	handler := containerdimages.LimitManifests(containerdimages.ChildrenHandler(cs), platform, 1)
+	handler := c8dimages.LimitManifests(c8dimages.ChildrenHandler(cs), platform, 1)
 
-	var wh containerdimages.HandlerFunc = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	var wh c8dimages.HandlerFunc = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		children, err := handler(ctx, desc)
 		if err != nil {
 			if !cerrdefs.IsNotFound(err) {
@@ -155,7 +155,7 @@ func (i *ImageService) size(ctx context.Context, desc ocispec.Descriptor, platfo
 	}
 
 	l := semaphore.NewWeighted(3)
-	if err := containerdimages.Dispatch(ctx, wh, l, desc); err != nil {
+	if err := c8dimages.Dispatch(ctx, wh, l, desc); err != nil {
 		return 0, err
 	}
 

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/log/logtest"
 	"github.com/containerd/platforms"
@@ -24,11 +24,11 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func imagesFromIndex(index ...*ocispec.Index) []images.Image {
-	var imgs []images.Image
+func imagesFromIndex(index ...*ocispec.Index) []c8dimages.Image {
+	var imgs []c8dimages.Image
 	for _, idx := range index {
 		for _, desc := range idx.Manifests {
-			imgs = append(imgs, images.Image{
+			imgs = append(imgs, c8dimages.Image{
 				Name:   desc.Annotations["io.containerd.image.name"],
 				Target: desc,
 			})
@@ -186,7 +186,7 @@ func TestImageList(t *testing.T) {
 
 	blobsDir := t.TempDir()
 
-	toContainerdImage := func(t *testing.T, imageFunc specialimage.SpecialImageFunc) images.Image {
+	toContainerdImage := func(t *testing.T, imageFunc specialimage.SpecialImageFunc) c8dimages.Image {
 		idx, err := imageFunc(blobsDir)
 		assert.NilError(t, err)
 
@@ -203,14 +203,14 @@ func TestImageList(t *testing.T) {
 
 	for _, tc := range []struct {
 		name   string
-		images []images.Image
+		images []c8dimages.Image
 		opts   imagetypes.ListOptions
 
 		check func(*testing.T, []*imagetypes.Summary)
 	}{
 		{
 			name:   "one multi-layer image",
-			images: []images.Image{multilayer},
+			images: []c8dimages.Image{multilayer},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 1))
 
@@ -227,7 +227,7 @@ func TestImageList(t *testing.T) {
 		},
 		{
 			name:   "one image with two platforms is still one entry",
-			images: []images.Image{twoplatform},
+			images: []c8dimages.Image{twoplatform},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 1))
 
@@ -253,7 +253,7 @@ func TestImageList(t *testing.T) {
 		},
 		{
 			name:   "two images are two entries",
-			images: []images.Image{multilayer, twoplatform},
+			images: []c8dimages.Image{multilayer, twoplatform},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 2))
 
@@ -282,14 +282,14 @@ func TestImageList(t *testing.T) {
 		},
 		{
 			name:   "three images, one is an empty index",
-			images: []images.Image{multilayer, emptyIndex, twoplatform},
+			images: []c8dimages.Image{multilayer, emptyIndex, twoplatform},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 3))
 			},
 		},
 		{
 			name:   "one good image, second has config as a target",
-			images: []images.Image{multilayer, configTarget},
+			images: []c8dimages.Image{multilayer, configTarget},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 2))
 
@@ -312,7 +312,7 @@ func TestImageList(t *testing.T) {
 		},
 		{
 			name:   "a non-container image manifest",
-			images: []images.Image{textplain},
+			images: []c8dimages.Image{textplain},
 			check: func(t *testing.T, all []*imagetypes.Summary) {
 				assert.Check(t, is.Len(all, 1))
 

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
 	containerdimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
@@ -164,7 +163,7 @@ func (im *ImageManifest) IsPseudoImage(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 	for _, l := range mfst.Layers {
-		if images.IsLayerType(l.MediaType) {
+		if containerdimages.IsLayerType(l.MediaType) {
 			return false, nil
 		}
 	}

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/errdefs"
@@ -22,7 +22,7 @@ var (
 
 // walkImageManifests calls the handler for each locally present manifest in
 // the image.
-func (i *ImageService) walkImageManifests(ctx context.Context, img containerdimages.Image, handler func(img *ImageManifest) error) error {
+func (i *ImageService) walkImageManifests(ctx context.Context, img c8dimages.Image, handler func(img *ImageManifest) error) error {
 	desc := img.Target
 
 	handleManifest := func(ctx context.Context, d ocispec.Descriptor) error {
@@ -36,11 +36,11 @@ func (i *ImageService) walkImageManifests(ctx context.Context, img containerdima
 		return handler(platformImg)
 	}
 
-	if containerdimages.IsManifestType(desc.MediaType) {
+	if c8dimages.IsManifestType(desc.MediaType) {
 		return handleManifest(ctx, desc)
 	}
 
-	if containerdimages.IsIndexType(desc.MediaType) {
+	if c8dimages.IsIndexType(desc.MediaType) {
 		return i.walkPresentChildren(ctx, desc, handleManifest)
 	}
 
@@ -50,7 +50,7 @@ func (i *ImageService) walkImageManifests(ctx context.Context, img containerdima
 // walkReachableImageManifests calls the handler for each manifest in the
 // multiplatform image that can be reached from the given image.
 // The image might not be present locally, but its descriptor is known.
-func (i *ImageService) walkReachableImageManifests(ctx context.Context, img containerdimages.Image, handler func(img *ImageManifest) error) error {
+func (i *ImageService) walkReachableImageManifests(ctx context.Context, img c8dimages.Image, handler func(img *ImageManifest) error) error {
 	desc := img.Target
 
 	handleManifest := func(ctx context.Context, d ocispec.Descriptor) error {
@@ -64,19 +64,19 @@ func (i *ImageService) walkReachableImageManifests(ctx context.Context, img cont
 		return handler(platformImg)
 	}
 
-	if containerdimages.IsManifestType(desc.MediaType) {
+	if c8dimages.IsManifestType(desc.MediaType) {
 		return handleManifest(ctx, desc)
 	}
 
-	if containerdimages.IsIndexType(desc.MediaType) {
-		return containerdimages.Walk(ctx, containerdimages.HandlerFunc(
+	if c8dimages.IsIndexType(desc.MediaType) {
+		return c8dimages.Walk(ctx, c8dimages.HandlerFunc(
 			func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 				err := handleManifest(ctx, desc)
 				if err != nil {
 					return nil, err
 				}
 
-				descs, err := containerdimages.Children(ctx, i.content, desc)
+				descs, err := c8dimages.Children(ctx, i.content, desc)
 				if err != nil {
 					if cerrdefs.IsNotFound(err) {
 						return nil, nil
@@ -102,8 +102,8 @@ type ImageManifest struct {
 	manifest *ocispec.Manifest
 }
 
-func (i *ImageService) NewImageManifest(ctx context.Context, img containerdimages.Image, manifestDesc ocispec.Descriptor) (*ImageManifest, error) {
-	if !containerdimages.IsManifestType(manifestDesc.MediaType) {
+func (i *ImageService) NewImageManifest(ctx context.Context, img c8dimages.Image, manifestDesc ocispec.Descriptor) (*ImageManifest, error) {
+	if !c8dimages.IsManifestType(manifestDesc.MediaType) {
 		return nil, errNotManifest
 	}
 
@@ -117,7 +117,7 @@ func (i *ImageService) NewImageManifest(ctx context.Context, img containerdimage
 	}, nil
 }
 
-func (im *ImageManifest) Metadata() containerdimages.Image {
+func (im *ImageManifest) Metadata() c8dimages.Image {
 	md := im.Image.Metadata()
 	md.Target = im.RealTarget
 	return md
@@ -163,7 +163,7 @@ func (im *ImageManifest) IsPseudoImage(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 	for _, l := range mfst.Layers {
-		if containerdimages.IsLayerType(l.MediaType) {
+		if c8dimages.IsLayerType(l.MediaType) {
 			return false, nil
 		}
 	}
@@ -188,7 +188,7 @@ func (im *ImageManifest) CheckContentAvailable(ctx context.Context) (bool, error
 	// The target is already a platform-specific manifest, so no need to match platform.
 	pm := platforms.All
 
-	available, _, _, missing, err := containerdimages.Check(ctx, im.ContentStore(), im.Target(), pm)
+	available, _, _, missing, err := c8dimages.Check(ctx, im.ContentStore(), im.Target(), pm)
 	if err != nil {
 		return false, err
 	}

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/tracing"
 	cerrdefs "github.com/containerd/errdefs"
@@ -106,7 +106,7 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 	// How many images make reference to a particular target digest.
 	digestRefCount := map[digest.Digest]int{}
 	// Images considered for pruning.
-	imagesToPrune := map[string]containerdimages.Image{}
+	imagesToPrune := map[string]c8dimages.Image{}
 	for _, img := range allImages {
 		digestRefCount[img.Target.Digest] += 1
 
@@ -154,7 +154,7 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 // and returns a map of used image digests.
 func filterImagesUsedByContainers(ctx context.Context,
 	allContainers []*container.Container,
-	imagesToPrune map[string]containerdimages.Image,
+	imagesToPrune map[string]c8dimages.Image,
 ) (usedDigests map[digest.Digest]struct{}) {
 	ctx, span := tracing.StartSpan(ctx, "filterImagesUsedByContainers")
 	span.SetAttributes(tracing.Attribute("count", len(allContainers)))
@@ -211,7 +211,7 @@ func filterImagesUsedByContainers(ctx context.Context,
 }
 
 // pruneAll deletes all images in the imagesToPrune map.
-func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]containerdimages.Image) (*image.PruneReport, error) {
+func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]c8dimages.Image) (*image.PruneReport, error) {
 	report := image.PruneReport{}
 
 	ctx, span := tracing.StartSpan(ctx, "ImageService.pruneAll")
@@ -235,7 +235,7 @@ func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]co
 
 		err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, desc ocispec.Descriptor) error {
 			blobs = append(blobs, desc)
-			if containerdimages.IsConfigType(desc.MediaType) {
+			if c8dimages.IsConfigType(desc.MediaType) {
 				possiblyDeletedConfigs[desc.Digest] = struct{}{}
 			}
 			return nil
@@ -247,7 +247,7 @@ func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]co
 			}
 			continue
 		}
-		err = i.images.Delete(ctx, img.Name, containerdimages.SynchronousDelete())
+		err = i.images.Delete(ctx, img.Name, c8dimages.SynchronousDelete())
 		if err != nil && !cerrdefs.IsNotFound(err) {
 			errs = multierror.Append(errs, err)
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -293,7 +293,7 @@ func (i *ImageService) unleaseSnapshotsFromDeletedConfigs(ctx context.Context, p
 	var errs error
 	for _, img := range all {
 		err := i.walkPresentChildren(ctx, img.Target, func(_ context.Context, desc ocispec.Descriptor) error {
-			if containerdimages.IsConfigType(desc.MediaType) {
+			if c8dimages.IsConfigType(desc.MediaType) {
 				delete(possiblyDeletedConfigs, desc.Digest)
 			}
 			return nil

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/pkg/snapshotters"
 	"github.com/containerd/containerd/remotes/docker"
 	cerrdefs "github.com/containerd/errdefs"
@@ -117,8 +117,8 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	}
 
 	jobs := newJobs()
-	h := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		if images.IsLayerType(desc.MediaType) {
+	h := c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if c8dimages.IsLayerType(desc.MediaType) {
 			jobs.Add(desc)
 		}
 		return nil, nil
@@ -153,8 +153,8 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	}()
 
 	var sentPullingFrom, sentSchema1Deprecation bool
-	ah := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		if desc.MediaType == images.MediaTypeDockerSchema1Manifest && !sentSchema1Deprecation {
+	ah := c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if desc.MediaType == c8dimages.MediaTypeDockerSchema1Manifest && !sentSchema1Deprecation {
 			err := distribution.DeprecatedSchema1ImageError(ref)
 			if os.Getenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE") == "" {
 				log.G(context.TODO()).Warn(err.Error())
@@ -163,11 +163,11 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 			progress.Message(out, "", err.Error())
 			sentSchema1Deprecation = true
 		}
-		if images.IsLayerType(desc.MediaType) {
+		if c8dimages.IsLayerType(desc.MediaType) {
 			id := stringid.TruncateID(desc.Digest.String())
 			progress.Update(out, id, "Pulling fs layer")
 		}
-		if images.IsManifestType(desc.MediaType) {
+		if c8dimages.IsManifestType(desc.MediaType) {
 			if !sentPullingFrom {
 				var tagOrDigest string
 				if tagged, ok := ref.(reference.Tagged); ok {
@@ -179,7 +179,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 				sentPullingFrom = true
 			}
 
-			available, _, _, missing, err := images.Check(ctx, i.content, desc, p)
+			available, _, _, missing, err := c8dimages.Check(ctx, i.content, desc, p)
 			if err != nil {
 				return nil, err
 			}

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
 	containerdimages "github.com/containerd/containerd/images"
 	containerdlabels "github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/remotes"
@@ -21,7 +20,7 @@ import (
 	"github.com/docker/docker/api/types/auxprogress"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/registry"
-	dimages "github.com/docker/docker/daemon/images"
+	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -45,7 +44,7 @@ func (i *ImageService) PushImage(ctx context.Context, sourceRef reference.Named,
 	start := time.Now()
 	defer func() {
 		if retErr == nil {
-			dimages.ImageActions.WithValues("push").UpdateSince(start)
+			images.ImageActions.WithValues("push").UpdateSince(start)
 		}
 	}()
 	out := streamformatter.NewJSONProgressOutput(outStream, false)
@@ -164,7 +163,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 		},
 	)
 
-	handlerWrapper := func(h images.Handler) images.Handler {
+	handlerWrapper := func(h containerdimages.Handler) containerdimages.Handler {
 		return containerdimages.Handlers(addLayerJobs, h)
 	}
 

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	containerdlabels "github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
@@ -149,12 +149,12 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 		return err
 	}
 
-	addLayerJobs := containerdimages.HandlerFunc(
+	addLayerJobs := c8dimages.HandlerFunc(
 		func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 			switch {
-			case containerdimages.IsIndexType(desc.MediaType),
-				containerdimages.IsManifestType(desc.MediaType),
-				containerdimages.IsConfigType(desc.MediaType):
+			case c8dimages.IsIndexType(desc.MediaType),
+				c8dimages.IsManifestType(desc.MediaType),
+				c8dimages.IsConfigType(desc.MediaType):
 			default:
 				jobsQueue.Add(desc)
 			}
@@ -163,15 +163,15 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 		},
 	)
 
-	handlerWrapper := func(h containerdimages.Handler) containerdimages.Handler {
-		return containerdimages.Handlers(addLayerJobs, h)
+	handlerWrapper := func(h c8dimages.Handler) c8dimages.Handler {
+		return c8dimages.Handlers(addLayerJobs, h)
 	}
 
 	err = remotes.PushContent(ctx, pusher, target, store, limiter, platforms.All, handlerWrapper)
 	if err != nil {
 		// If push failed because of a missing content, no specific platform was requested
 		// and the target is an index, select a platform-specific manifest to push instead.
-		if cerrdefs.IsNotFound(err) && containerdimages.IsIndexType(target.MediaType) && platform == nil {
+		if cerrdefs.IsNotFound(err) && c8dimages.IsIndexType(target.MediaType) && platform == nil {
 			var newTarget ocispec.Descriptor
 			newTarget, err = i.getPushDescriptor(ctx, img, nil)
 			if err != nil {
@@ -214,7 +214,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 	return nil
 }
 
-func (i *ImageService) getPushDescriptor(ctx context.Context, img containerdimages.Image, platform *ocispec.Platform) (ocispec.Descriptor, error) {
+func (i *ImageService) getPushDescriptor(ctx context.Context, img c8dimages.Image, platform *ocispec.Platform) (ocispec.Descriptor, error) {
 	pm := i.matchRequestedOrDefault(platforms.OnlyStrict, platform)
 
 	anyMissing := false
@@ -310,7 +310,7 @@ func appendDistributionSourceLabel(ctx context.Context, realStore content.Store,
 	}
 
 	handler := presentChildrenHandler(realStore, appendSource)
-	if err := containerdimages.Dispatch(ctx, handler, nil, target); err != nil {
+	if err := c8dimages.Dispatch(ctx, handler, nil, target); err != nil {
 		// Shouldn't happen, but even if it would fail, then make it only a warning
 		// because it doesn't affect the pushed data.
 		log.G(ctx).WithError(err).Warn("failed to append distribution source labels to pushed content")
@@ -354,10 +354,10 @@ func findMissingMountable(ctx context.Context, store content.Store, queue *jobs,
 			return nil, nil
 		}
 
-		return containerdimages.Children(ctx, store, desc)
+		return c8dimages.Children(ctx, store, desc)
 	}
 
-	err = containerdimages.Dispatch(ctx, containerdimages.HandlerFunc(handler), limiter, target)
+	err = c8dimages.Dispatch(ctx, c8dimages.HandlerFunc(handler), limiter, target)
 	if err != nil {
 		return nil, err
 	}
@@ -423,10 +423,10 @@ func (source distributionSource) GetReference(dgst digest.Digest) (reference.Nam
 // canBeMounted returns if the content with given media type can be cross-repo
 // mounted when pushing it to a remote reference ref.
 func canBeMounted(mediaType string, targetRef reference.Named, source distributionSource) bool {
-	if containerdimages.IsManifestType(mediaType) {
+	if c8dimages.IsManifestType(mediaType) {
 		return false
 	}
-	if containerdimages.IsIndexType(mediaType) {
+	if c8dimages.IsIndexType(mediaType) {
 		return false
 	}
 

--- a/daemon/containerd/image_push_test.go
+++ b/daemon/containerd/image_push_test.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"testing"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/errdefs"
@@ -25,7 +25,7 @@ type pushTestCase struct {
 	indexPlatforms     []ocispec.Platform // all platforms supported by the image
 	availablePlatforms []ocispec.Platform // platforms available locally
 	requestPlatform    *ocispec.Platform  // platform requested by the client (not the platform selected for push!)
-	check              func(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error)
+	check              func(t *testing.T, img c8dimages.Image, pushDescriptor ocispec.Descriptor, err error)
 	daemonPlatform     *ocispec.Platform
 }
 
@@ -228,7 +228,7 @@ func TestImagePushIndex(t *testing.T) {
 	}
 }
 
-func deletePlatform(ctx context.Context, imgSvc *ImageService, img containerdimages.Image, platform ocispec.Platform) error {
+func deletePlatform(ctx context.Context, imgSvc *ImageService, img c8dimages.Image, platform ocispec.Platform) error {
 	var blobs []ocispec.Descriptor
 	pm := platforms.OnlyStrict(platform)
 	err := imgSvc.walkImageManifests(ctx, img, func(im *ImageManifest) error {
@@ -261,15 +261,15 @@ func deletePlatform(ctx context.Context, imgSvc *ImageService, img containerdima
 }
 
 // wholeIndexSelected asserts that the push descriptor candidate is for the whole index.
-func wholeIndexSelected(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error) {
+func wholeIndexSelected(t *testing.T, img c8dimages.Image, pushDescriptor ocispec.Descriptor, err error) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(pushDescriptor.Digest, img.Target.Digest))
 }
 
 // singleManifestSelected asserts that the push descriptor candidate is for a single platform-specific manifest.
-func singleManifestSelected(platform ocispec.Platform) func(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error) {
+func singleManifestSelected(platform ocispec.Platform) func(t *testing.T, img c8dimages.Image, pushDescriptor ocispec.Descriptor, err error) {
 	pm := platforms.OnlyStrict(platform)
-	return func(t *testing.T, img containerdimages.Image, pushDescriptor ocispec.Descriptor, err error) {
+	return func(t *testing.T, img c8dimages.Image, pushDescriptor ocispec.Descriptor, err error) {
 		assert.NilError(t, err)
 		assert.Assert(t, is.Equal(pushDescriptor.MediaType, ocispec.MediaTypeImageManifest), "the push descriptor isn't for a manifest")
 		assert.Assert(t, pushDescriptor.Platform != nil, "the push descriptor doesn't have a platform")
@@ -278,11 +278,11 @@ func singleManifestSelected(platform ocispec.Platform) func(t *testing.T, img co
 }
 
 // candidateNotFound asserts that the no matching candidate was found.
-func candidateNotFound(t *testing.T, _ containerdimages.Image, desc ocispec.Descriptor, err error) {
+func candidateNotFound(t *testing.T, _ c8dimages.Image, desc ocispec.Descriptor, err error) {
 	assert.Check(t, errdefs.IsNotFound(err), "expected NotFound error, got %v, candidate: %v", err, desc.Platform)
 }
 
 // multipleCandidates asserts that multiple matching candidates were found and no decision could be made.
-func multipleCandidates(t *testing.T, _ containerdimages.Image, desc ocispec.Descriptor, err error) {
+func multipleCandidates(t *testing.T, _ c8dimages.Image, desc ocispec.Descriptor, err error) {
 	assert.Check(t, errdefs.IsConflict(err), "expected Conflict error, got %v, candidate: %v", err, desc.Platform)
 }

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd"
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/snapshots"
@@ -42,12 +42,12 @@ func (i *ImageService) PrepareSnapshot(ctx context.Context, id string, parentIma
 			}
 		}
 
-		desc, err := containerdimages.Config(ctx, cs, img.Target, matcher)
+		desc, err := c8dimages.Config(ctx, cs, img.Target, matcher)
 		if err != nil {
 			return err
 		}
 
-		diffIDs, err := containerdimages.RootFS(ctx, cs, desc)
+		diffIDs, err := c8dimages.RootFS(ctx, cs, desc)
 		if err != nil {
 			return err
 		}

--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
@@ -21,7 +21,7 @@ func (i *ImageService) TagImage(ctx context.Context, imageID image.ID, newTag re
 		return errors.Wrapf(err, "failed to resolve image id %q to a descriptor", imageID.String())
 	}
 
-	newImg := containerdimages.Image{
+	newImg := c8dimages.Image{
 		Name:   newTag.String(),
 		Target: targetImage.Target,
 		Labels: targetImage.Labels,
@@ -34,7 +34,7 @@ func (i *ImageService) TagImage(ctx context.Context, imageID image.ID, newTag re
 // If an image with the same name already exists, it will be replaced.
 // Overwritten image will be persisted as a dangling image if it's a last
 // reference to that image.
-func (i *ImageService) createOrReplaceImage(ctx context.Context, newImg containerdimages.Image) error {
+func (i *ImageService) createOrReplaceImage(ctx context.Context, newImg c8dimages.Image) error {
 	// Delete the source dangling image, as it's no longer dangling.
 	// Unless, the image to be created itself is dangling.
 	danglingName := danglingImageName(newImg.Target.Digest)

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/pkg/snapshotters"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
@@ -237,7 +237,7 @@ func (p *pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 }
 
 func (p *pullProgress) finished(ctx context.Context, out progress.Output, desc ocispec.Descriptor) {
-	if images.IsLayerType(desc.MediaType) {
+	if c8dimages.IsLayerType(desc.MediaType) {
 		p.layers = append(p.layers, desc)
 	}
 }
@@ -279,7 +279,7 @@ func (p *pushProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 				}
 				progress.Update(out, id, "Mounted from "+from)
 			} else if status.Exists {
-				if images.IsLayerType(j.MediaType) {
+				if c8dimages.IsLayerType(j.MediaType) {
 					progress.Update(out, id, "Layer already exists")
 				} else {
 					progress.Update(out, id, "Already exists")

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/plugin"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/snapshots"
@@ -29,7 +29,7 @@ import (
 // ImageService implements daemon.ImageService
 type ImageService struct {
 	client              *containerd.Client
-	images              images.Store
+	images              c8dimages.Store
 	content             content.Store
 	containers          container.Store
 	snapshotterServices map[string]snapshots.Snapshotter

--- a/daemon/containerd/soft_delete.go
+++ b/daemon/containerd/soft_delete.go
@@ -3,7 +3,7 @@ package containerd
 import (
 	"context"
 
-	containerdimages "github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/go-digest"
@@ -16,7 +16,7 @@ const imageNameDanglingPrefix = "moby-dangling@"
 // softImageDelete deletes the image, making sure that there are other images
 // that reference the content of the deleted image.
 // If no other image exists, a dangling one is created.
-func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages.Image, imgs []containerdimages.Image) error {
+func (i *ImageService) softImageDelete(ctx context.Context, img c8dimages.Image, imgs []c8dimages.Image) error {
 	// From this point explicitly ignore the passed context
 	// and don't allow to interrupt operation in the middle.
 
@@ -42,13 +42,13 @@ func (i *ImageService) softImageDelete(ctx context.Context, img containerdimages
 	return nil
 }
 
-func (i *ImageService) ensureDanglingImage(ctx context.Context, from containerdimages.Image) error {
+func (i *ImageService) ensureDanglingImage(ctx context.Context, from c8dimages.Image) error {
 	danglingImage := from
 
 	danglingImage.Labels = make(map[string]string)
 	for k, v := range from.Labels {
 		switch k {
-		case containerdimages.AnnotationImageName, ocispec.AnnotationRefName:
+		case c8dimages.AnnotationImageName, ocispec.AnnotationRefName:
 			// Don't copy name labels.
 		default:
 			danglingImage.Labels[k] = v
@@ -69,7 +69,7 @@ func danglingImageName(digest digest.Digest) string {
 	return imageNameDanglingPrefix + digest.String()
 }
 
-func isDanglingImage(image containerdimages.Image) bool {
+func isDanglingImage(image c8dimages.Image) bool {
 	// TODO: Also check for expired
 	return image.Name == danglingImageName(image.Target.Digest)
 }

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -7,7 +7,7 @@ import (
 	"io"
 
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/leases"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -115,7 +115,7 @@ func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.I
 
 		for _, md := range ml.Manifests {
 			switch md.MediaType {
-			case ocispec.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
+			case ocispec.MediaTypeImageManifest, c8dimages.MediaTypeDockerSchema2Manifest:
 			default:
 				continue
 			}

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/tracing"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -289,8 +289,8 @@ func (s *saveSession) save(ctx context.Context, outStream io.Writer) error {
 
 			taggedManifest := untaggedMfstDesc
 			taggedManifest.Annotations = map[string]string{
-				images.AnnotationImageName: ref.String(),
-				ocispec.AnnotationRefName:  ref.Tag(),
+				c8dimages.AnnotationImageName: ref.String(),
+				ocispec.AnnotationRefName:     ref.Tag(),
 			}
 			manifestDescriptors = append(manifestDescriptors, taggedManifest)
 		}

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/content/local"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
@@ -81,14 +81,14 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) oci
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
-		MediaType: images.MediaTypeDockerSchema2Manifest,
+		MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
 		Config: ocispec.Descriptor{
-			MediaType: images.MediaTypeDockerSchema2Config,
+			MediaType: c8dimages.MediaTypeDockerSchema2Config,
 			Digest:    configDigest,
 			Size:      int64(len(imgJSON)),
 		},
 		Layers: []ocispec.Descriptor{{
-			MediaType: images.MediaTypeDockerSchema2Layer,
+			MediaType: c8dimages.MediaTypeDockerSchema2Layer,
 			Digest:    layerDigest,
 			Size:      info.Size,
 		}},
@@ -108,7 +108,7 @@ func createTestImage(ctx context.Context, t testing.TB, store content.Store) oci
 	assert.Check(t, w.Close())
 
 	return ocispec.Descriptor{
-		MediaType: images.MediaTypeDockerSchema2Manifest,
+		MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
 		Digest:    manifestDigest,
 		Size:      int64(len(manifestJSON)),
 	}

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -342,7 +342,7 @@ func TestPluginBackCompatMediaTypes(t *testing.T) {
 	// that the default resolver code uses. "Older registries" here would be
 	// like the one currently included in the test suite.
 	headers := http.Header{}
-	headers.Add("Accept", images.MediaTypeDockerSchema2Manifest)
+	headers.Add("Accept", c8dimages.MediaTypeDockerSchema2Manifest)
 
 	resolver := docker.NewResolver(docker.ResolverOptions{
 		Headers: headers,
@@ -361,7 +361,7 @@ func TestPluginBackCompatMediaTypes(t *testing.T) {
 
 	var m ocispec.Manifest
 	assert.NilError(t, json.NewDecoder(rdr).Decode(&m))
-	assert.Check(t, is.Equal(m.MediaType, images.MediaTypeDockerSchema2Manifest))
+	assert.Check(t, is.Equal(m.MediaType, c8dimages.MediaTypeDockerSchema2Manifest))
 	assert.Check(t, is.Len(m.Layers, 1))
-	assert.Check(t, is.Equal(m.Layers[0].MediaType, images.MediaTypeDockerSchema2LayerGzip))
+	assert.Check(t, is.Equal(m.Layers[0].MediaType, c8dimages.MediaTypeDockerSchema2LayerGzip))
 }

--- a/libcontainerd/remote/client.go
+++ b/libcontainerd/remote/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
+	c8dimages "github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/protobuf"
 	v2runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	cerrdefs "github.com/containerd/errdefs"
@@ -162,7 +162,7 @@ func (c *container) NewTask(ctx context.Context, checkpointDir string, withStdin
 		// write checkpoint to the content store
 		tar := archive.Diff(ctx, "", checkpointDir)
 		var err error
-		checkpoint, err = c.client.writeContent(ctx, images.MediaTypeContainerd1Checkpoint, checkpointDir, tar)
+		checkpoint, err = c.client.writeContent(ctx, c8dimages.MediaTypeContainerd1Checkpoint, checkpointDir, tar)
 		// remove the checkpoint when we're done
 		defer func() {
 			if checkpoint != nil {
@@ -448,7 +448,7 @@ func (t *task) CreateCheckpoint(ctx context.Context, checkpointDir string, exit 
 
 	var cpDesc *ocispec.Descriptor
 	for _, m := range index.Manifests {
-		if m.MediaType == images.MediaTypeContainerd1Checkpoint {
+		if m.MediaType == c8dimages.MediaTypeContainerd1Checkpoint {
 			cpDesc = &m //nolint:gosec
 			break
 		}


### PR DESCRIPTION
### daemon/c8d: Fix duplicate containerd/images import

Remove duplicate imports under different aliases

### c8d/delete: Consistent method receiver

`imageDeleteConflict` is always returned via a reference, so adjust the
method receiver of `Conflict` to make it consistent with `Error`.

### daemon/c8d: Force c8dimages alias for containerd/images