### PR TITLE
docs/api: allow for an empty string for Isolation (api v1.25-v1.47)

### DIFF
--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -697,6 +697,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   Config:
     description: "Configuration for a container that is portable between hosts"

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -697,6 +697,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   Config:
     description: "Configuration for a container that is portable between hosts"

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -724,6 +724,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   Config:
     description: "Configuration for a container that is portable between hosts"

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -730,6 +730,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   Config:
     description: "Configuration for a container that is portable between hosts"

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -736,6 +736,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   Config:
     description: "Configuration for a container that is portable between hosts"

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -738,6 +738,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -738,6 +738,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -800,6 +800,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |
@@ -3793,6 +3794,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -804,6 +804,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |
@@ -3797,6 +3798,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -814,6 +814,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |
@@ -3825,6 +3826,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -815,6 +815,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |
@@ -2723,6 +2724,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
       Resources:
         description: "Resource requirements which apply to each individual container created as part of the service."
         type: "object"
@@ -3828,6 +3830,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -815,6 +815,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |
@@ -2736,6 +2737,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
       Resources:
         description: "Resource requirements which apply to each individual container created as part of the service."
         type: "object"
@@ -3841,6 +3843,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -819,6 +819,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
 
   ContainerConfig:
     description: |
@@ -2739,6 +2740,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
       Resources:
         description: "Resource requirements which apply to each individual container created as part of the service."
         type: "object"
@@ -3861,6 +3863,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -820,6 +820,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: "The list of paths to be masked inside the container (this overrides the default set of paths)"
@@ -2773,6 +2774,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: "Run an init inside the container that forwards signals and reaps processes. This field is omitted if empty, and the default (as configured on the daemon) is used."
             type: "boolean"
@@ -3915,6 +3917,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -1055,6 +1055,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -3780,6 +3781,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5174,6 +5176,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -1115,6 +1115,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -3883,6 +3884,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5310,6 +5312,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -1146,6 +1146,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4010,6 +4011,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5545,6 +5547,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -1149,6 +1149,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4029,6 +4030,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5545,6 +5547,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -1156,6 +1156,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4060,6 +4061,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5577,6 +5579,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -1172,6 +1172,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4128,6 +4129,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5692,6 +5694,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -1180,6 +1180,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4114,6 +4115,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5678,6 +5680,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -1195,6 +1195,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4167,6 +4168,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5737,6 +5739,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -1195,6 +1195,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           MaskedPaths:
             type: "array"
             description: |
@@ -4185,6 +4186,7 @@ definitions:
               - "default"
               - "process"
               - "hyperv"
+              - ""
           Init:
             description: |
               Run an init inside the container that forwards signals and reaps
@@ -5759,6 +5761,7 @@ definitions:
           - "default"
           - "hyperv"
           - "process"
+          - ""
       InitBinary:
         description: |
           Name and, optional, path of the `docker-init` binary.


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48616
- relates to https://github.com/moby/moby/issues/47452

Backport the changes from 26049febb22fdba9a67e520cc55d07a02927e256 to all versions used in the documentation.

**- A picture of a cute animal (not mandatory but encouraged)**

