### PR TITLE
Fix live restore for IPv6-only and multiple gateway endpoints

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -155,10 +155,11 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 	// generate many unnecessary warnings
 	c.reservePools()
 
-	// Cleanup resources
-	if err := c.sandboxCleanup(c.cfg.ActiveSandboxes); err != nil {
+	if err := c.sandboxRestore(c.cfg.ActiveSandboxes); err != nil {
 		log.G(context.TODO()).WithError(err).Error("error during sandbox cleanup")
 	}
+
+	// Cleanup resources
 	if err := c.cleanupLocalEndpoints(); err != nil {
 		log.G(context.TODO()).WithError(err).Warnf("error during endpoint cleanup")
 	}

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -283,15 +283,18 @@ func (sb *Sandbox) restoreOslSandbox() error {
 		}
 	}
 
-	gwep4, gwep6 := sb.getGatewayEndpoint()
-	if gwep4 != nil {
-		if err := sb.osSbox.Restore(interfaces, routes, gwep4.joinInfo.gw, gwep4.joinInfo.gw6); err != nil {
-			return err
-		}
+	if err := sb.osSbox.RestoreInterfaces(interfaces); err != nil {
+		return err
 	}
-	if gwep6 != nil {
-		if err := sb.osSbox.Restore(interfaces, routes, gwep6.joinInfo.gw, gwep6.joinInfo.gw6); err != nil {
-			return err
+	if len(routes) > 0 {
+		sb.osSbox.RestoreRoutes(routes)
+	}
+	if gwEp4, gwEp6 := sb.getGatewayEndpoint(); gwEp4 != nil || gwEp6 != nil {
+		if gwEp4 != nil {
+			sb.osSbox.RestoreGateway(true, gwEp4.joinInfo.gw, gwEp4.iface.srcName)
+		}
+		if gwEp6 != nil {
+			sb.osSbox.RestoreGateway(false, gwEp6.joinInfo.gw6, gwEp6.iface.srcName)
 		}
 	}
 

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -167,7 +167,8 @@ func (sb *Sandbox) storeDelete() error {
 	})
 }
 
-func (c *Controller) sandboxCleanup(activeSandboxes map[string]interface{}) error {
+// sandboxRestore restores Sandbox objects from the store, deleting them if they're not active.
+func (c *Controller) sandboxRestore(activeSandboxes map[string]interface{}) error {
 	sandboxStates, err := c.store.List(&sbState{c: c})
 	if err != nil {
 		if err == datastore.ErrKeyNotFound {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -184,6 +184,7 @@ func (c *Controller) sandboxRestore(activeSandboxes map[string]interface{}) erro
 			id:                 sbs.ID,
 			controller:         sbs.c,
 			containerID:        sbs.Cid,
+			epPriority:         sbs.EpPriority,
 			extDNS:             sbs.ExtDNS,
 			endpoints:          []*Endpoint{},
 			populatedEndpoints: map[string]struct{}{},

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -257,6 +257,10 @@ func (c *Controller) sandboxRestore(activeSandboxes map[string]interface{}) erro
 			continue
 		}
 
+		for _, ep := range sb.endpoints {
+			sb.populatedEndpoints[ep.id] = struct{}{}
+		}
+
 		// reconstruct osl sandbox field
 		if !sb.config.useDefaultSandBox {
 			if err := sb.restoreOslSandbox(); err != nil {


### PR DESCRIPTION
**- What I did**

On live-restore, the Sandbox tries to restore state in the osSbox by telling it about interface, routes, and gateways that would have been set up by the previous incarnation of the daemon.

Restoring gateways has been broken since commit 18327745c00 (Allow separate IPv4/IPv6 gateway endpoints) ... which didn't properly deal with searching for the "dstName" of an interface based on its IPv6 address.

**- How I did it**

Split the osSbox restore into three parts:
- Restore the interfaces, including finding the "dstName".
- Restore routes, unchanged, they're just a copy of the sandbox's StaticRoutes
- Restore gateway info ...
  - If the Sandbox's gateway endpoint has an IP address (v4 or v6, depending on which addr family/families it's acting as the gateway for), remember that.
  - Otherwise, the default route is bound to the interface, so remember that.

**- How to verify it**

Manually ...
- Enabled live restore.
- Started a container connected to a bridge network and an ipvlan-l3...
  - docker network create -d ipvlan -o parent=eth0 -o ipvlan_mode=l3 --ipv6 ipv 
  - docker network create --ipv6 b46
  - docker run --rm -d --network name=ipv,gw-priority=1 --network b46 --name c1 alpine sleep infinity
- Restarted the daemon.
  - connected and disconnected the ipvlan network, checked that the default route was updated properly.

Also, repeat test `TestMixL3IPVlanAndBridge` with a live-restore-enabled daemon restart before running the network connects/disconnects - and add an IPv6-only network. Without the fixes in this PR, gateways/default routes could not be removed when an Endpoint leaves the Sandbox, and the IPv6-only network couldn't become a gateway because the `dstName` of its interface hadn't been restored correctly.

**- Description for the changelog**
```markdown changelog

```