### PR TITLE
pkg/chrootarchive: use stdlib errors, remove "// import" comments

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -1,4 +1,4 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"fmt"

--- a/pkg/chrootarchive/archive_linux.go
+++ b/pkg/chrootarchive/archive_linux.go
@@ -1,4 +1,4 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"fmt"

--- a/pkg/chrootarchive/archive_linux.go
+++ b/pkg/chrootarchive/archive_linux.go
@@ -1,10 +1,10 @@
 package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/pkg/archive"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -20,11 +20,11 @@ func doUnpack(decompressedArchive io.Reader, relDest, root string, options *arch
 func doPack(relSrc, root string, options *archive.TarOptions) (io.ReadCloser, error) {
 	tb, err := archive.NewTarballer(relSrc, options)
 	if err != nil {
-		return nil, errors.Wrap(err, "error processing tar file")
+		return nil, fmt.Errorf("error processing tar file: %w", err)
 	}
 	err = goInChroot(root, tb.Do)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not chroot")
+		return nil, fmt.Errorf("could not chroot: %w", err)
 	}
 	return tb.Reader(), nil
 }

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -1,4 +1,4 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"bytes"

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -3,6 +3,7 @@
 package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
 
 import (
+	"errors"
 	"io"
 	"net"
 	"os/user"
@@ -10,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/archive"
-	"github.com/pkg/errors"
 )
 
 func init() {

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"errors"

--- a/pkg/chrootarchive/archive_unix_nolinux.go
+++ b/pkg/chrootarchive/archive_unix_nolinux.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/moby/sys/reexec"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -76,15 +75,15 @@ func doUnpack(decompressedArchive io.Reader, relDest, root string, options *arch
 	}
 
 	if err = cmd.Start(); err != nil {
-		return errors.Wrap(err, "re-exec error")
+		return fmt.Errorf("re-exec error: %w", err)
 	}
 
 	if err = json.NewEncoder(optionsW).Encode(options); err != nil {
-		return errors.Wrap(err, "tar options encoding failed")
+		return fmt.Errorf("tar options encoding failed: %w", err)
 	}
 
 	if err = cmd.Wait(); err != nil {
-		return errors.Wrap(err, stderr.String())
+		return fmt.Errorf("%s: %w", stderr.String(), err)
 	}
 
 	return nil
@@ -112,21 +111,21 @@ func doPack(relSrc, root string, options *archive.TarOptions) (io.ReadCloser, er
 	r, w := io.Pipe()
 
 	if err = cmd.Start(); err != nil {
-		return nil, errors.Wrap(err, "re-exec error")
+		return nil, fmt.Errorf("re-exec error: %w", err)
 	}
 
 	go func() {
 		_, _ = io.Copy(w, stdout)
 		// Cleanup once stdout pipe is closed.
 		if err = cmd.Wait(); err != nil {
-			r.CloseWithError(errors.Wrap(err, stderr.String()))
+			r.CloseWithError(fmt.Errorf("%s: %w", stderr.String(), err))
 		} else {
 			r.Close()
 		}
 	}()
 
 	if err = json.NewEncoder(optionsW).Encode(options); err != nil {
-		return nil, errors.Wrap(err, "tar options encoding failed")
+		return nil, fmt.Errorf("tar options encoding failed: %w", err)
 	}
 
 	return r, nil
@@ -151,19 +150,19 @@ func doUnpackLayer(root string, layer io.Reader, options *archive.TarOptions) (i
 	}
 
 	if err = cmd.Start(); err != nil {
-		return 0, errors.Wrap(err, "re-exec error")
+		return 0, fmt.Errorf("re-exec error: %w", err)
 	}
 
 	if err = json.NewEncoder(optionsW).Encode(options); err != nil {
-		return 0, errors.Wrap(err, "tar options encoding failed")
+		return 0, fmt.Errorf("tar options encoding failed: %w", err)
 	}
 
 	if err = cmd.Wait(); err != nil {
-		return 0, errors.Wrap(err, buffer.String())
+		return 0, fmt.Errorf("%s: %w", buffer.String(), err)
 	}
 
 	if err = json.NewDecoder(buffer).Decode(&result); err != nil {
-		return 0, errors.Wrap(err, "json decoding error")
+		return 0, fmt.Errorf("json decoding error: %w", err)
 	}
 
 	return result, nil

--- a/pkg/chrootarchive/archive_unix_nolinux.go
+++ b/pkg/chrootarchive/archive_unix_nolinux.go
@@ -1,6 +1,6 @@
 //go:build unix && !linux
 
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"bytes"

--- a/pkg/chrootarchive/archive_unix_nolinux_test.go
+++ b/pkg/chrootarchive/archive_unix_nolinux_test.go
@@ -1,6 +1,6 @@
 //go:build unix && !linux
 
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"testing"

--- a/pkg/chrootarchive/archive_windows.go
+++ b/pkg/chrootarchive/archive_windows.go
@@ -1,4 +1,4 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"io"

--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -1,4 +1,4 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"github.com/docker/docker/internal/mounttree"

--- a/pkg/chrootarchive/diff.go
+++ b/pkg/chrootarchive/diff.go
@@ -1,4 +1,4 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"io"

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"io"

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -1,4 +1,4 @@
-package chrootarchive // import "github.com/docker/docker/pkg/chrootarchive"
+package chrootarchive
 
 import (
 	"fmt"


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/issues/32989
- https://github.com/moby/moby/issues/21700
- https://github.com/moby/moby/issues/49069


### pkg/chrootarchive: use stdlib errors

Remove use of github.com/pkg/errors for this package, in preparation
of it being moved to a separate module.


### pkg/chrootarchive: remove "// import" comments

These comments were added to prevent users from accidentally
importing using the wrong module name, but they don't have
an effect when working in go modules mode.

Remove the comments in preparation of moving this package
to a separate module.


**- A picture of a cute animal (not mandatory but encouraged)**

