### PR TITLE
pkg/archive: nosysFileInfo: implement tar.FileInfoNames to prevent lookups

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -472,11 +472,33 @@ func (compression *Compression) Extension() string {
 	return ""
 }
 
+// assert that we implement [tar.FileInfoNames].
+//
+// TODO(thaJeztah): disabled to allow compiling on < go1.23. un-comment once we drop support for older versions of go.
+// var _ tar.FileInfoNames = (*nosysFileInfo)(nil)
+
 // nosysFileInfo hides the system-dependent info of the wrapped FileInfo to
 // prevent tar.FileInfoHeader from introspecting it and potentially calling into
 // glibc.
+//
+// It implements [tar.FileInfoNames] to further prevent [tar.FileInfoHeader]
+// from performing any lookups on go1.23 and up. see https://go.dev/issue/50102
 type nosysFileInfo struct {
 	os.FileInfo
+}
+
+// Uname stubs out looking up username. It implements [tar.FileInfoNames]
+// to prevent [tar.FileInfoHeader] from loading libraries to perform
+// username lookups.
+func (fi nosysFileInfo) Uname() (string, error) {
+	return "", nil
+}
+
+// Gname stubs out looking up group-name. It implements [tar.FileInfoNames]
+// to prevent [tar.FileInfoHeader] from loading libraries to perform
+// username lookups.
+func (fi nosysFileInfo) Gname() (string, error) {
+	return "", nil
 }
 
 func (fi nosysFileInfo) Sys() interface{} {


### PR DESCRIPTION
relates to:

- https://github.com/golang/go/issues/50102
- https://github.com/moby/moby/pull/43185
- https://github.com/moby/moby/pull/39612



commit e9bbc41dd146d692e28660a392b068c9c112f2ad removed our fork of pkg/archive that was in place to mitigate CVE-2019-14271. As part of that change, a nosysFileInfo type was added to prevent tar.FileInfoHeader from looking up user- and group-names.

A proposal was pending in go https://go.dev/issue/50102 to define an interface for implementing custom lookup functions to be implemented, and disable go's builtin lookup. That proposal was accepted, and is now implemented in go1.23.

Thia patch makes the nosysFileInfo implement the tar.FileInfoNames interface to prevent tar.FileInfoHeader from performing its own lookups. While the mitigation implemented in e9bbc41dd146d692e28660a392b068c9c112f2ad should already prevent this from happening, implementing the interface does not cost us much and is complementary to the existing mitigation.

With this patch in place, we can consider removing the mitigation added in a316b10dab79d9298b02c7930958ed52e0ccf4e4, which was discussed to be ineffective, but left in place for the time being.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

