### PR TITLE
libnet: add support for custom interface names

### DIFF
--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	net "github.com/docker/docker/integration/internal/network"
 	n "github.com/docker/docker/integration/network"
+	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
@@ -681,4 +682,34 @@ func TestPointToPoint(t *testing.T) {
 			assert.Check(t, is.Contains(res.Stdout.String(), "1 packets transmitted, 1 packets received"))
 		})
 	}
+}
+
+func TestEndpointWithCustomIfname(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "rootless mode has different view of network")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	// master dummy interface 'di' notation represent 'docker ipvlan'
+	const master = "di-dummy0"
+	n.CreateMasterDummy(ctx, t, master)
+	defer n.DeleteInterface(ctx, t, master)
+
+	// create a network specifying the desired sub-interface name
+	const netName = "ipvlan-custom-ifname"
+	net.CreateNoError(ctx, t, apiClient, netName, net.WithIPvlan("di-dummy0.70", ""))
+
+	ctrID := container.Run(ctx, t, apiClient,
+		container.WithCmd("ip", "-o", "link", "show", "foobar"),
+		container.WithEndpointSettings(netName, &network.EndpointSettings{
+			DriverOpts: map[string]string{
+				netlabel.Ifname: "foobar",
+			},
+		}))
+	defer container.Remove(ctx, t, apiClient, ctrID, containertypes.RemoveOptions{Force: true})
+
+	out, err := container.Output(ctx, apiClient, ctrID)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(out.Stdout, ": foobar@if"), "expected ': foobar@if' in 'ip link show':\n%s", out.Stdout)
 }

--- a/integration/network/ipvlan/main_test.go
+++ b/integration/network/ipvlan/main_test.go
@@ -48,3 +48,10 @@ func TestMain(m *testing.M) {
 	shutdown(ctx)
 	os.Exit(code)
 }
+
+func setupTest(t *testing.T) context.Context {
+	ctx := testutil.StartSpan(baseContext, t)
+	environment.ProtectAll(ctx, t, testEnv)
+	t.Cleanup(func() { testEnv.Clean(ctx, t) })
+	return ctx
+}

--- a/integration/network/overlay/main_test.go
+++ b/integration/network/overlay/main_test.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package macvlan // import "github.com/docker/docker/integration/network/macvlan"
+package overlay // import "github.com/docker/docker/integration/network/overlay"
 
 import (
 	"context"
@@ -22,7 +22,7 @@ var (
 func TestMain(m *testing.M) {
 	shutdown := testutil.ConfigureTracing()
 
-	ctx, span := otel.Tracer("").Start(context.Background(), "integration/network/macvlan/TestMain")
+	ctx, span := otel.Tracer("").Start(context.Background(), "integration/network/overlay/TestMain")
 	baseContext = ctx
 
 	var err error

--- a/integration/network/overlay/main_windows_test.go
+++ b/integration/network/overlay/main_windows_test.go
@@ -1,0 +1,1 @@
+package overlay // import "github.com/docker/docker/integration/network/overlay"

--- a/integration/network/overlay/overlay_test.go
+++ b/integration/network/overlay/overlay_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package overlay // import "github.com/docker/docker/integration/network/overlay"
+
+import (
+	"strings"
+	"testing"
+
+	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/integration/internal/container"
+	net "github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
+)
+
+func TestEndpointWithCustomIfname(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support overlay networks")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartAndSwarmInit(ctx, t)
+	defer d.Stop(t)
+	defer d.SwarmLeave(ctx, t, true)
+
+	apiClient := d.NewClientT(t)
+
+	// create a network specifying the desired sub-interface name
+	const netName = "overlay-custom-ifname"
+	net.CreateNoError(ctx, t, apiClient, netName,
+		net.WithDriver("overlay"),
+		net.WithAttachable())
+
+	ctrID := container.Run(ctx, t, apiClient,
+		container.WithCmd("ip", "-o", "link", "show", "foobar"),
+		container.WithEndpointSettings(netName, &network.EndpointSettings{
+			DriverOpts: map[string]string{
+				netlabel.Ifname: "foobar",
+			},
+		}))
+	defer container.Remove(ctx, t, apiClient, ctrID, containertypes.RemoveOptions{Force: true})
+
+	out, err := container.Output(ctx, apiClient, ctrID)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(out.Stdout, ": foobar@if"), "expected ': foobar@if' in 'ip link show':\n%s", out.Stdout)
+}

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -532,3 +532,67 @@ func TestCustomIfnameCollidesWithExistingIface(t *testing.T) {
 	assert.ErrorContains(t, err, "error renaming interface")
 	assert.ErrorContains(t, err, "file exists")
 }
+
+func TestCustomIfnameWithMatchingDynamicPrefix(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "custom interface name is only supported by Linux netdrivers")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	defer d.Stop(t)
+	d.StartWithBusybox(ctx, t)
+
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
+
+	network.CreateNoError(ctx, t, apiClient, "testnet0",
+		network.WithDriver("bridge"),
+		network.WithIPAM("10.0.0.0/24", "10.0.0.1"))
+	defer network.RemoveNoError(ctx, t, apiClient, "testnet0")
+
+	network.CreateNoError(ctx, t, apiClient, "testnet1",
+		network.WithDriver("bridge"),
+		network.WithIPAM("10.0.1.0/24", "10.0.1.1"))
+	defer network.RemoveNoError(ctx, t, apiClient, "testnet1")
+
+	network.CreateNoError(ctx, t, apiClient, "testnet2",
+		network.WithDriver("bridge"),
+		network.WithIPAM("10.0.2.0/24", "10.0.2.1"))
+	defer network.RemoveNoError(ctx, t, apiClient, "testnet2")
+
+	ctrId := container.Run(ctx, t, apiClient,
+		container.WithCmd("top"),
+		container.WithEndpointSettings("testnet0", &networktypes.EndpointSettings{
+			DriverOpts: map[string]string{
+				netlabel.Ifname: "eth1",
+			},
+		}),
+		container.WithEndpointSettings("testnet1", &networktypes.EndpointSettings{}),
+	)
+	defer container.Remove(ctx, t, apiClient, ctrId, containertypes.RemoveOptions{Force: true})
+
+	checkIfaceAddr(t, ctx, apiClient, ctrId, "eth0", "inet 10.0.1.2/24")
+	checkIfaceAddr(t, ctx, apiClient, ctrId, "eth1", "inet 10.0.0.2/24")
+
+	err := apiClient.NetworkConnect(ctx, "testnet2", ctrId, nil)
+	assert.NilError(t, err)
+	checkIfaceAddr(t, ctx, apiClient, ctrId, "eth2", "inet 10.0.2.2/24")
+
+	// Disconnect from testnet1 (ie. eth0), and testnet2 (ie. eth2)
+	err = apiClient.NetworkDisconnect(ctx, "testnet1", ctrId, false)
+	assert.NilError(t, err)
+	err = apiClient.NetworkDisconnect(ctx, "testnet2", ctrId, false)
+	assert.NilError(t, err)
+
+	// Reconnect to testnet2 -- it should now provide eth0.
+	err = apiClient.NetworkConnect(ctx, "testnet2", ctrId, nil)
+	assert.NilError(t, err)
+	checkIfaceAddr(t, ctx, apiClient, ctrId, "eth0", "inet 10.0.2.2/24")
+}
+
+func checkIfaceAddr(t *testing.T, ctx context.Context, apiClient client.APIClient, ctrId string, iface string, expectedAddr string) {
+	res, err := container.Exec(ctx, apiClient, ctrId, []string{"ip", "-o", "addr", "show", iface})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(res.ExitCode, 0))
+	assert.Check(t, strings.Contains(res.Stdout(), expectedAddr), "expected '%s' in 'ip addr show %s':\n%s", expectedAddr, iface, res.Stdout())
+}

--- a/libnetwork/cnmallocator/manager.go
+++ b/libnetwork/cnmallocator/manager.go
@@ -55,7 +55,7 @@ func (d *manager) EndpointOperInfo(nid, eid string) (map[string]interface{}, err
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *manager) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *manager) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -51,7 +51,7 @@ type Driver interface {
 	EndpointOperInfo(nid, eid string) (map[string]interface{}, error)
 
 	// Join method is invoked when a Sandbox is attached to an endpoint.
-	Join(ctx context.Context, nid, eid string, sboxKey string, jinfo JoinInfo, options map[string]interface{}) error
+	Join(ctx context.Context, nid, eid string, sboxKey string, jinfo JoinInfo, epOpts, sbOpts map[string]interface{}) error
 
 	// Leave method is invoked when a Sandbox detaches from an endpoint.
 	Leave(nid, eid string) error
@@ -140,8 +140,10 @@ type InterfaceInfo interface {
 // InterfaceNameInfo provides a go interface for the drivers to assign names
 // to interfaces.
 type InterfaceNameInfo interface {
-	// SetNames method assigns the srcName and dstPrefix for the interface.
-	SetNames(srcName, dstPrefix string) error
+	// SetNames method assigns the srcName, dstPrefix, and dstName for the
+	// interface. If both dstName and dstPrefix are set, dstName takes
+	// precedence.
+	SetNames(srcName, dstPrefix, dstName string) error
 }
 
 // JoinInfo represents a set of resources that the driver has the ability to provide during

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1444,7 +1444,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, epOpts, sbOpts map[string]interface{}) error {
 	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.Join", trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid),
@@ -1465,7 +1465,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		return endpointNotFoundError(eid)
 	}
 
-	endpoint.containerConfig, err = parseContainerOptions(options)
+	endpoint.containerConfig, err = parseContainerOptions(sbOpts)
 	if err != nil {
 		return err
 	}
@@ -1475,7 +1475,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 	if network.config.ContainerIfacePrefix != "" {
 		containerVethPrefix = network.config.ContainerIfacePrefix
 	}
-	if err := iNames.SetNames(endpoint.srcName, containerVethPrefix); err != nil {
+	if err := iNames.SetNames(endpoint.srcName, containerVethPrefix, netlabel.GetIfname(epOpts)); err != nil {
 		return err
 	}
 

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -642,6 +642,7 @@ type testInterface struct {
 	addr               *net.IPNet
 	addrv6             *net.IPNet
 	srcName            string
+	dstPrefix          string
 	dstName            string
 	createdInContainer bool
 	netnsPath          string
@@ -727,8 +728,9 @@ func (i *testInterface) SetCreatedInContainer(cic bool) {
 	i.createdInContainer = cic
 }
 
-func (i *testInterface) SetNames(srcName string, dstName string) error {
+func (i *testInterface) SetNames(srcName, dstPrefix, dstName string) error {
 	i.srcName = srcName
+	i.dstPrefix = dstPrefix
 	i.dstName = dstName
 	return nil
 }
@@ -818,7 +820,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}
 
-	err = d.Join(context.Background(), "net1", "ep1", "sbox", te, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep1", "sbox", te, nil, sbOptions)
 	if err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
@@ -922,7 +924,7 @@ func TestLinkContainers(t *testing.T) {
 	sbOptions := make(map[string]interface{})
 	sbOptions[netlabel.ExposedPorts] = exposedPorts
 
-	err = d.Join(context.Background(), "net1", "ep1", "sbox", te1, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep1", "sbox", te1, nil, sbOptions)
 	if err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
@@ -953,7 +955,7 @@ func TestLinkContainers(t *testing.T) {
 		"ChildEndpoints": []string{"ep1"},
 	}
 
-	err = d.Join(context.Background(), "net1", "ep2", "", te2, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep2", "", te2, nil, sbOptions)
 	if err != nil {
 		t.Fatal("Failed to link ep1 and ep2")
 	}
@@ -1011,7 +1013,7 @@ func TestLinkContainers(t *testing.T) {
 		"ChildEndpoints": []string{"ep1", "ep4"},
 	}
 
-	err = d.Join(context.Background(), "net1", "ep2", "", te2, sbOptions)
+	err = d.Join(context.Background(), "net1", "ep2", "", te2, nil, sbOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1228,7 +1230,7 @@ func TestSetDefaultGw(t *testing.T) {
 		t.Fatalf("Failed to create endpoint: %v", err)
 	}
 
-	err = d.Join(context.Background(), "dummy", "ep", "sbox", te, nil)
+	err = d.Join(context.Background(), "dummy", "ep", "sbox", te, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to join endpoint: %v", err)
 	}

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -55,7 +55,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -43,8 +43,9 @@ func TestLinkCreate(t *testing.T) {
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te.Interface(), nil)
 	assert.NilError(t, err)
 
-	err = d.Join(context.Background(), "dummy", "ep", "sbox", te, nil)
+	err = d.Join(context.Background(), "dummy", "ep", "sbox", te, nil, nil)
 	assert.NilError(t, err)
+	assert.Assert(t, te.iface.dstPrefix != "", "got: %q, want: %q", te.iface.dstPrefix, "")
 
 	// Verify sbox endpoint interface inherited MTU value from bridge config
 	sboxLnk, err := nlwrap.LinkByName(te.iface.srcName)
@@ -58,8 +59,6 @@ func TestLinkCreate(t *testing.T) {
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te1.Interface(), nil)
 	assert.Check(t, is.ErrorType(err, errdefs.IsForbidden))
 	assert.Assert(t, is.Error(err, "Endpoint (ep) already exists (Only one endpoint allowed)"), "Failed to detect duplicate endpoint id on same network")
-
-	assert.Check(t, te.iface.dstName != "", "Invalid Dstname returned")
 
 	_, err = nlwrap.LinkByName(te.iface.srcName)
 	assert.Check(t, err, "Could not find source link %s", te.iface.srcName)

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -67,7 +67,7 @@ func TestPortMappingConfig(t *testing.T) {
 		t.Fatalf("Failed to create the endpoint: %s", err.Error())
 	}
 
-	if err = d.Join(context.Background(), "dummy", "ep1", "sbox", te, sbOptions); err != nil {
+	if err = d.Join(context.Background(), "dummy", "ep1", "sbox", te, nil, sbOptions); err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
@@ -153,7 +153,7 @@ func TestPortMappingV6Config(t *testing.T) {
 		t.Fatalf("Failed to create the endpoint: %s", err.Error())
 	}
 
-	if err = d.Join(context.Background(), "dummy", "ep1", "sbox", te, sbOptions); err != nil {
+	if err = d.Join(context.Background(), "dummy", "ep1", "sbox", te, nil, sbOptions); err != nil {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -68,7 +68,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/docker/docker/libnetwork/types"
@@ -29,7 +30,7 @@ const (
 )
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, epOpts, _ map[string]interface{}) error {
 	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.ipvlan.Join", trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid),
@@ -143,7 +144,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		jinfo.DisableGatewayService()
 	}
 	iNames := jinfo.InterfaceName()
-	err = iNames.SetNames(vethName, containerVethPrefix)
+	err = iNames.SetNames(vethName, containerVethPrefix, netlabel.GetIfname(epOpts))
 	if err != nil {
 		return err
 	}

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -55,7 +55,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/driverapi"
+	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/docker/docker/libnetwork/ns"
 	"go.opentelemetry.io/otel"
@@ -17,7 +18,7 @@ import (
 )
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, epOpts, _ map[string]interface{}) error {
 	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.macvlan.Join", trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid),
@@ -102,7 +103,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		jinfo.DisableGatewayService()
 	}
 	iNames := jinfo.InterfaceName()
-	err = iNames.SetNames(vethName, containerVethPrefix)
+	err = iNames.SetNames(vethName, containerVethPrefix, netlabel.GetIfname(epOpts))
 	if err != nil {
 		return err
 	}

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -55,7 +55,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	return nil, types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -68,7 +68,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return nil
 }
 

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -427,7 +427,7 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 	// create a bridge and vxlan device for this subnet and move it to the sandbox
 	sbox := n.sbox
 
-	if err := sbox.AddInterface(context.TODO(), brName, "br", osl.WithIPv4Address(s.gwIP), osl.WithIsBridge(true)); err != nil {
+	if err := sbox.AddInterface(context.TODO(), brName, "br", "", osl.WithIPv4Address(s.gwIP), osl.WithIsBridge(true)); err != nil {
 		return fmt.Errorf("bridge creation in sandbox failed for subnet %q: %v", s.subnetIP.String(), err)
 	}
 
@@ -439,7 +439,7 @@ func (n *network) setupSubnetSandbox(s *subnet, brName, vxlanName string) error 
 		return err
 	}
 
-	if err := sbox.AddInterface(context.TODO(), vxlanName, "vxlan", osl.WithMaster(brName)); err != nil {
+	if err := sbox.AddInterface(context.TODO(), vxlanName, "vxlan", "", osl.WithMaster(brName)); err != nil {
 		// If adding vxlan device to the overlay namespace fails, remove the bridge interface we
 		// already added to the namespace. This allows the caller to try the setup again.
 		for _, iface := range sbox.Interfaces() {

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -190,7 +190,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -273,7 +273,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) (retErr error) {
+func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, options map[string]interface{}) (retErr error) {
 	join := &api.JoinRequest{
 		NetworkID:  nid,
 		EndpointID: eid,
@@ -300,7 +300,7 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 
 	ifaceName := res.InterfaceName
 	if iface := jinfo.InterfaceName(); iface != nil && ifaceName != nil {
-		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix); err != nil {
+		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix, ""); err != nil {
 			return fmt.Errorf("failed to set interface name: %s", err)
 		}
 	}

--- a/libnetwork/drivers/windows/overlay/joinleave_windows.go
+++ b/libnetwork/drivers/windows/overlay/joinleave_windows.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, options map[string]interface{}) error {
 	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.windows_overlay.Join", trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid),

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -846,7 +846,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, options map[string]interface{}) error {
 	ctx, span := otel.Tracer("").Start(ctx, fmt.Sprintf("libnetwork.drivers.windows_%s.Join", d.name), trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid),

--- a/libnetwork/drivers/windows/windows_test.go
+++ b/libnetwork/drivers/windows/windows_test.go
@@ -134,7 +134,7 @@ func (test *testEndpoint) SetGatewayIPv6(ipv6 net.IP) error {
 	return nil
 }
 
-func (test *testEndpoint) SetNames(src string, dst string) error {
+func (test *testEndpoint) SetNames(_, _, _ string) error {
 	return nil
 }
 

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -536,7 +536,7 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 		return fmt.Errorf("failed to get driver during join: %v", err)
 	}
 
-	if err := d.Join(ctx, nid, epid, sb.Key(), ep, sb.Labels()); err != nil {
+	if err := d.Join(ctx, nid, epid, sb.Key(), ep, ep.generic, sb.Labels()); err != nil {
 		return err
 	}
 	defer func() {

--- a/libnetwork/endpoint_info.go
+++ b/libnetwork/endpoint_info.go
@@ -43,6 +43,7 @@ type EndpointInterface struct {
 	llAddrs            []*net.IPNet
 	srcName            string
 	dstPrefix          string
+	dstName            string // dstName is the name of the interface in the container namespace. It takes precedence over dstPrefix.
 	routes             []*net.IPNet
 	v4PoolID           string
 	v6PoolID           string
@@ -70,6 +71,7 @@ func (epi *EndpointInterface) MarshalJSON() ([]byte, error) {
 	}
 	epMap["srcName"] = epi.srcName
 	epMap["dstPrefix"] = epi.dstPrefix
+	epMap["dstName"] = epi.dstName
 	var routes []string
 	for _, route := range epi.routes {
 		routes = append(routes, route.String())
@@ -147,6 +149,7 @@ func (epi *EndpointInterface) CopyTo(dstEpi *EndpointInterface) error {
 	dstEpi.addrv6 = types.GetIPNetCopy(epi.addrv6)
 	dstEpi.srcName = epi.srcName
 	dstEpi.dstPrefix = epi.dstPrefix
+	dstEpi.dstName = epi.dstName
 	dstEpi.v4PoolID = epi.v4PoolID
 	dstEpi.v6PoolID = epi.v6PoolID
 	dstEpi.createdInContainer = epi.createdInContainer
@@ -269,10 +272,12 @@ func (epi *EndpointInterface) SrcName() string {
 	return epi.srcName
 }
 
-// SetNames method assigns the srcName and dstPrefix for the interface.
-func (epi *EndpointInterface) SetNames(srcName string, dstPrefix string) error {
+// SetNames method assigns the srcName, dstName, and dstPrefix for the
+// interface. If both dstName and dstPrefix are set, dstName takes precedence.
+func (epi *EndpointInterface) SetNames(srcName, dstPrefix, dstName string) error {
 	epi.srcName = srcName
 	epi.dstPrefix = dstPrefix
+	epi.dstName = dstName
 	return nil
 }
 

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -239,7 +239,7 @@ func compareEndpointInterface(a, b *EndpointInterface) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return a.srcName == b.srcName && a.dstPrefix == b.dstPrefix && a.v4PoolID == b.v4PoolID && a.v6PoolID == b.v6PoolID &&
+	return a.srcName == b.srcName && a.dstPrefix == b.dstPrefix && a.dstName == b.dstName && a.v4PoolID == b.v4PoolID && a.v6PoolID == b.v6PoolID &&
 		types.CompareIPNet(a.addr, b.addr) && types.CompareIPNet(a.addrv6, b.addrv6) && compareNwLists(a.llAddrs, b.llAddrs)
 }
 
@@ -807,7 +807,7 @@ func (b *badDriver) EndpointOperInfo(nid, eid string) (map[string]interface{}, e
 	return nil, nil
 }
 
-func (b *badDriver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+func (b *badDriver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
 	return fmt.Errorf("I will not allow any join")
 }
 

--- a/libnetwork/netlabel/labels.go
+++ b/libnetwork/netlabel/labels.go
@@ -30,6 +30,9 @@ const (
 	// where the interface name is represented by the string "IFNAME".
 	EndpointSysctls = Prefix + ".endpoint.sysctls"
 
+	// Ifname can be used to set the interface name used inside the container. It takes precedence over ContainerIfacePrefix.
+	Ifname = Prefix + ".endpoint.ifname"
+
 	// EnableIPv4 constant represents enabling IPV4 at network level
 	EnableIPv4 = Prefix + ".enable_ipv4"
 
@@ -70,3 +73,11 @@ const (
 	// is intended for internal use, it may be removed in a future release.
 	NoProxy6To4 = DriverPrivatePrefix + ".no_proxy_6to4"
 )
+
+// GetIfname returns the value associated to the Ifname netlabel from the
+// provided options. If there's no Ifname netlabel, or if the value isn't a
+// string, it returns an empty string.
+func GetIfname(opts map[string]interface{}) string {
+	ifname, _ := opts[Ifname].(string)
+	return ifname
+}

--- a/libnetwork/netlabel/labels_test.go
+++ b/libnetwork/netlabel/labels_test.go
@@ -1,0 +1,60 @@
+package netlabel
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetIfname(t *testing.T) {
+	testcases := []struct {
+		name      string
+		opts      map[string]interface{}
+		expIfname string
+	}{
+		{
+			name:      "nil opts",
+			opts:      nil,
+			expIfname: "",
+		},
+		{
+			name:      "no ifname",
+			opts:      map[string]interface{}{},
+			expIfname: "",
+		},
+		{
+			name: "ifname set",
+			opts: map[string]interface{}{
+				Ifname: "foobar",
+			},
+			expIfname: "foobar",
+		},
+		{
+			name: "ifname set to empty string",
+			opts: map[string]interface{}{
+				Ifname: "",
+			},
+			expIfname: "",
+		},
+		{
+			name: "ifname set to nil",
+			opts: map[string]interface{}{
+				Ifname: nil,
+			},
+			expIfname: "",
+		},
+		{
+			name: "ifname set to int",
+			opts: map[string]interface{}{
+				Ifname: 42,
+			},
+			expIfname: "",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expIfname, GetIfname(tc.opts))
+		})
+	}
+}

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -60,7 +60,7 @@ func newInterface(ns *Namespace, srcName, dstPrefix string, options ...IfaceOpti
 	i := &Interface{
 		stopCh:                make(chan struct{}),
 		srcName:               srcName,
-		dstName:               dstPrefix,
+		dstPrefix:             dstPrefix,
 		advertiseAddrNMsgs:    advertiseAddrNMsgsDefault,
 		advertiseAddrInterval: advertiseAddrIntervalDefault,
 		ns:                    ns,
@@ -90,6 +90,7 @@ func newInterface(ns *Namespace, srcName, dstPrefix string, options ...IfaceOpti
 type Interface struct {
 	stopCh      chan struct{} // stopCh is closed before the interface is deleted.
 	srcName     string
+	dstPrefix   string
 	dstName     string
 	master      string
 	dstMaster   string

--- a/libnetwork/osl/interface_linux_test.go
+++ b/libnetwork/osl/interface_linux_test.go
@@ -1,0 +1,95 @@
+package osl
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/docker/docker/internal/nlwrap"
+	"github.com/docker/docker/internal/sliceutil"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"gotest.tools/v3/assert"
+)
+
+func TestGenerateIfaceName(t *testing.T) {
+	testcases := []struct {
+		names []string
+		want  string
+	}{
+		{names: []string{"test0", "test1"}, want: "test2"},
+		{names: []string{"test0", "test2"}, want: "test1"},
+		{names: []string{"test2"}, want: "test0"},
+		{names: []string{"test-0", "test-1"}, want: "test0"},
+		{names: []string{}, want: "test0"},
+	}
+
+	for _, tc := range testcases {
+		ns := &Namespace{
+			iFaces: sliceutil.Map(tc.names, func(name string) *Interface {
+				return &Interface{dstName: name}
+			}),
+		}
+
+		got := ns.generateIfaceName("test")
+		assert.Equal(t, got, tc.want)
+	}
+}
+
+// TestAddInterfaceInParallel tests that interface name are correctly generated
+// even when many interfaces are added in parallel.
+func TestAddInterfaceInParallel(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	nsh, err := netns.NewNamed(t.Name())
+	assert.NilError(t, err)
+	defer netns.DeleteNamed(t.Name())
+	defer nsh.Close()
+
+	nlh, err := nlwrap.NewHandleAt(nsh)
+	assert.NilError(t, err)
+
+	ns := &Namespace{
+		path:     "/run/netns/" + t.Name(),
+		nlHandle: nlh,
+	}
+
+	// Create a few dummy interfaces with a dummy name. The call to
+	// AddInterface below will rename them into their final name (ie. ethX).
+	for i := range 10 {
+		nlh.LinkAdd(&netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: fmt.Sprintf("dummy%d", i),
+			},
+		})
+	}
+
+	wg := sync.WaitGroup{}
+	for i := range 10 {
+		src := fmt.Sprintf("dummy%d", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := ns.AddInterface(context.Background(), src, "eth", "", WithCreatedInContainer(true))
+			assert.NilError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	links, err := nlwrap.LinkList()
+	assert.NilError(t, err)
+	var eths []string
+	for _, link := range links {
+		if strings.HasPrefix(link.Attrs().Name, "eth") {
+			eths = append(eths, link.Attrs().Name)
+		}
+	}
+
+	sort.Strings(eths)
+	assert.DeepEqual(t, eths, []string{"eth0", "eth1", "eth2", "eth3", "eth4", "eth5", "eth6", "eth7", "eth8", "eth9"})
+}

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -402,7 +402,7 @@ func (n *Namespace) Destroy() error {
 func (n *Namespace) RestoreInterfaces(interfaces map[Iface][]IfaceOption) error {
 	// restore interfaces
 	for iface, opts := range interfaces {
-		i, err := newInterface(n, iface.SrcName, iface.DstPrefix, opts...)
+		i, err := newInterface(n, iface.SrcName, iface.DstPrefix, iface.DstName, opts...)
 		if err != nil {
 			return err
 		}

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -417,7 +417,7 @@ func (n *Namespace) RestoreInterfaces(interfaces map[Iface][]IfaceOption) error 
 			// restore from the namespace
 			for _, link := range links {
 				ifaceName := link.Attrs().Name
-				if i.dstName == "vxlan" && strings.HasPrefix(ifaceName, "vxlan") {
+				if i.dstPrefix == "vxlan" && strings.HasPrefix(ifaceName, "vxlan") {
 					i.dstName = ifaceName
 					break
 				}
@@ -451,7 +451,7 @@ func (n *Namespace) RestoreInterfaces(interfaces map[Iface][]IfaceOption) error 
 					}
 				}
 				// This is to find the interface name of the pair in overlay sandbox
-				if i.master != "" && i.dstName == "veth" && strings.HasPrefix(ifaceName, "veth") {
+				if i.master != "" && i.dstPrefix == "veth" && strings.HasPrefix(ifaceName, "veth") {
 					i.dstName = ifaceName
 				}
 			}

--- a/libnetwork/osl/namespace_linux.go
+++ b/libnetwork/osl/namespace_linux.go
@@ -225,7 +225,7 @@ func createNamespaceFile(path string) error {
 // or sets the gateway etc. It holds a list of Interfaces, routes etc., and more
 // can be added dynamically.
 type Namespace struct {
-	path                string
+	path                string // path is the absolute path to the network namespace. It is safe to access it concurrently.
 	iFaces              []*Interface
 	gw                  net.IP
 	gwv6                net.IP
@@ -234,10 +234,10 @@ type Namespace struct {
 	staticRoutes        []*types.StaticRoute
 	neighbors           []*neigh
 	nextIfIndex         map[string]int
-	isDefault           bool
+	isDefault           bool // isDefault is true when Namespace represents the host network namespace. It is safe to access it concurrently.
 	ipv6LoEnabledOnce   sync.Once
 	ipv6LoEnabledCached bool
-	nlHandle            nlwrap.Handle
+	nlHandle            nlwrap.Handle // nlHandle is the netlink handle for the network namespace. It is safe to access it concurrently.
 	mu                  sync.Mutex
 }
 

--- a/libnetwork/osl/sandbox.go
+++ b/libnetwork/osl/sandbox.go
@@ -12,7 +12,7 @@ const (
 )
 
 type Iface struct {
-	SrcName, DstPrefix string
+	SrcName, DstPrefix, DstName string
 }
 
 // IfaceOption is a function option type to set interface options.

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -511,7 +511,7 @@ func TestAddRemoveInterface(t *testing.T) {
 		t.Fatalf("Failed to add interfaces to sandbox: %v", err)
 	}
 
-	verifySandbox(t, s, []string{"1", "2", "3"})
+	verifySandbox(t, s, []string{"0", "1", "2"})
 
 	err = s.Destroy()
 	if err != nil {

--- a/libnetwork/osl/sandbox_linux_test.go
+++ b/libnetwork/osl/sandbox_linux_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	vethName1     = "wierdlongname1"
-	vethName2     = "wierdlongname2"
-	vethName3     = "wierdlongname3"
-	vethName4     = "wierdlongname4"
-	sboxIfaceName = "containername"
+	vethName1       = "wierdlongname1"
+	vethName2       = "wierdlongname2"
+	vethName3       = "wierdlongname3"
+	vethName4       = "wierdlongname4"
+	sboxIfacePrefix = "containername"
 )
 
 func generateRandomName(prefix string, size int) (string, error) {
@@ -85,16 +85,16 @@ func newInfo(t *testing.T, hnd nlwrap.Handle) (*Namespace, error) {
 	// This is needed for cleanup on DeleteEndpoint()
 	intf1 := &Interface{
 		srcName:     vethName2,
-		dstName:     sboxIfaceName,
+		dstPrefix:   sboxIfacePrefix,
 		address:     addr,
 		addressIPv6: addrv6,
 		routes:      []*net.IPNet{route},
 	}
 
 	intf2 := &Interface{
-		srcName: "testbridge",
-		dstName: sboxIfaceName,
-		bridge:  true,
+		srcName:   "testbridge",
+		dstPrefix: sboxIfacePrefix,
+		bridge:    true,
 	}
 
 	err = hnd.LinkAdd(&netlink.Veth{
@@ -106,9 +106,9 @@ func newInfo(t *testing.T, hnd nlwrap.Handle) (*Namespace, error) {
 	}
 
 	intf3 := &Interface{
-		srcName: vethName4,
-		dstName: sboxIfaceName,
-		master:  "testbridge",
+		srcName:   vethName4,
+		dstPrefix: sboxIfacePrefix,
+		master:    "testbridge",
 	}
 
 	return &Namespace{
@@ -132,10 +132,10 @@ func verifySandbox(t *testing.T, ns *Namespace, ifaceSuffixes []string) {
 	defer nh.Close()
 
 	for _, suffix := range ifaceSuffixes {
-		_, err = nh.LinkByName(sboxIfaceName + suffix)
+		_, err = nh.LinkByName(sboxIfacePrefix + suffix)
 		if err != nil {
 			t.Fatalf("Could not find the interface %s inside the sandbox: %v",
-				sboxIfaceName+suffix, err)
+				sboxIfacePrefix+suffix, err)
 		}
 	}
 }
@@ -381,7 +381,7 @@ func TestSandboxCreate(t *testing.T) {
 	}
 
 	for _, i := range tbox.Interfaces() {
-		err = s.AddInterface(context.Background(), i.SrcName(), i.DstName(),
+		err = s.AddInterface(context.Background(), i.SrcName(), i.dstPrefix, i.DstName(),
 			WithIsBridge(i.Bridge()),
 			WithIPv4Address(i.Address()),
 			WithIPv6Address(i.AddressIPv6()),
@@ -480,7 +480,7 @@ func TestAddRemoveInterface(t *testing.T) {
 	}
 
 	for _, i := range tbox.Interfaces() {
-		err = s.AddInterface(context.Background(), i.SrcName(), i.DstName(),
+		err = s.AddInterface(context.Background(), i.SrcName(), i.dstPrefix, i.DstName(),
 			WithIsBridge(i.Bridge()),
 			WithIPv4Address(i.Address()),
 			WithIPv6Address(i.AddressIPv6()),
@@ -501,7 +501,7 @@ func TestAddRemoveInterface(t *testing.T) {
 	verifySandbox(t, s, []string{"1", "2"})
 
 	i := tbox.Interfaces()[0]
-	err = s.AddInterface(context.Background(), i.SrcName(), i.DstName(),
+	err = s.AddInterface(context.Background(), i.SrcName(), i.dstPrefix, i.DstName(),
 		WithIsBridge(i.Bridge()),
 		WithIPv4Address(i.Address()),
 		WithIPv6Address(i.AddressIPv6()),

--- a/libnetwork/sandbox_linux.go
+++ b/libnetwork/sandbox_linux.go
@@ -286,7 +286,8 @@ func (sb *Sandbox) restoreOslSandbox() error {
 		if len(i.llAddrs) != 0 {
 			ifaceOptions = append(ifaceOptions, osl.WithLinkLocalAddresses(i.llAddrs))
 		}
-		interfaces[osl.Iface{SrcName: i.srcName, DstPrefix: i.dstPrefix}] = ifaceOptions
+		iface := osl.Iface{SrcName: i.srcName, DstPrefix: i.dstPrefix, DstName: i.dstName}
+		interfaces[iface] = ifaceOptions
 		if joinInfo != nil {
 			routes = append(routes, joinInfo.StaticRoutes...)
 		}
@@ -362,7 +363,7 @@ func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) e
 		}
 		ifaceOptions = append(ifaceOptions, osl.WithCreatedInContainer(i.createdInContainer))
 
-		if err := sb.osSbox.AddInterface(ctx, i.srcName, i.dstPrefix, ifaceOptions...); err != nil {
+		if err := sb.osSbox.AddInterface(ctx, i.srcName, i.dstPrefix, i.dstName, ifaceOptions...); err != nil {
 			return fmt.Errorf("failed to add interface %s to sandbox: %v", i.srcName, err)
 		}
 


### PR DESCRIPTION
Fixes:

- https://github.com/moby/moby/issues/25181

**- What I did**

To support this a new netlabel is added: `com.docker.network.endpoint.ifname`.

It gives the ability to specify the interface name to be set by netdrivers when the interface is added / moved into the container's network namespace.

All builtin netdrivers support it.

**- How I did it**

First commit refactor `libnetwork/osl` to add a new field `dstPrefix`. So far, its field `dstName` was used to store both the name prefix and the auto-generated interface name. When an interface was created, `dstName` would take the prefix and later on that field would be mutated to take the final name. Now, the `dstPrefix` is stored separately and the `dstName` is the final interface name (either auto-generated, or statically defined).

The second commit is the actual feature implementation.

The third commit refactors how iface names are generated. We now scan all the interfaces tied to a `Namespace` to find the first gap in numeric suffixes. This allows users to statically define ifnames that match generated names. For instance, a user can set `eth2` for a specific endpoint, and libnetwork will use [0, 1] and [3, ...] for dynamic ifname assignment.

**- How to verify it**

- All netdrivers have a new integration test.
- A new integration test makes sure custom ifnames are preserved on live restore.
- Mixing static and dynamic ifname assignments with the same prefix is also tested through a new integration test.

```
$ docker run --rm -it --network=name=bridge,driver-opt=com.docker.network.endpoint.ifname=foobar alpine ip link show | grep foobar
11: foobar@if20: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
```

**- Description for the changelog**

```markdown changelog
- Add a new netlabel `com.docker.network.endpoint.ifname` to customize the interface name used when connecting a container to a network. It's supported by all built-in network drivers on Linux.
  - When a container is created with multiple networks specified, there's no guarantee on the order networks will be connected to the container. So, if a custom interface name uses the same prefix as the auto-generated names (eg. `eth`), the container might fail to start.
  - The recommended practice is to use a different prefix (eg. `en0`), or a numerical suffix high enough to never collide (eg. `eth100`).
  - This label can be specified on `docker network connect` via the `--driver-opt` flag, eg. `docker network connect --driver-opt=com.docker.network.endpoint.ifname=foobar …`.
  - Or via the long-form `--network` flag on `docker run`, eg. `docker run --network=name=bridge,driver-opt=com.docker.network.endpoint.ifname=foobar …`
```
