### PR TITLE
distribution: Pass `Traceparent` OTEL header

### DIFF
--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/auth"
-	"github.com/docker/distribution/registry/client/transport"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/registry"
@@ -95,7 +94,7 @@ func newRepository(
 	}
 
 	modifiers := registry.Headers(dockerversion.DockerUserAgent(ctx), metaHeaders)
-	authTransport := transport.NewTransport(base, modifiers...)
+	authTransport := newTransport(base, modifiers...)
 
 	challengeManager, err := registry.PingV2Registry(endpoint.URL, authTransport)
 	if err != nil {
@@ -126,7 +125,8 @@ func newRepository(
 		basicHandler := auth.NewBasicHandler(creds)
 		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
 	}
-	tr := transport.NewTransport(base, modifiers...)
+
+	tr := newTransport(base, modifiers...)
 
 	// FIXME(thaJeztah): should this just take the original repoInfo.Name instead of converting the remote name back to a named reference?
 	repoNameRef, err := reference.WithName(repoName)

--- a/distribution/transport.go
+++ b/distribution/transport.go
@@ -1,0 +1,18 @@
+package distribution
+
+import (
+	"net/http"
+
+	"github.com/docker/distribution/registry/client/transport"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// newTransport creates a new transport which will apply modifiers to
+// the request on a RoundTrip call.
+func newTransport(base http.RoundTripper, modifiers ...transport.RequestModifier) http.RoundTripper {
+	tr := transport.NewTransport(base, modifiers...)
+
+	// Wrap the transport with OpenTelemetry instrumentation
+	// This propagates the Traceparent header.
+	return otelhttp.NewTransport(tr)
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/go-connections/tlsconfig"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // HostCertsDir returns the config directory for a specific host.
@@ -115,7 +116,7 @@ func Headers(userAgent string, metaHeaders http.Header) []transport.RequestModif
 
 // newTransport returns a new HTTP transport. If tlsConfig is nil, it uses the
 // default TLS configuration.
-func newTransport(tlsConfig *tls.Config) *http.Transport {
+func newTransport(tlsConfig *tls.Config) http.RoundTripper {
 	if tlsConfig == nil {
 		tlsConfig = tlsconfig.ServerDefault()
 	}
@@ -125,12 +126,14 @@ func newTransport(tlsConfig *tls.Config) *http.Transport {
 		KeepAlive: 30 * time.Second,
 	}
 
-	return &http.Transport{
-		Proxy:               http.ProxyFromEnvironment,
-		DialContext:         direct.DialContext,
-		TLSHandshakeTimeout: 10 * time.Second,
-		TLSClientConfig:     tlsConfig,
-		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
-		DisableKeepAlives: true,
-	}
+	return otelhttp.NewTransport(
+		&http.Transport{
+			Proxy:               http.ProxyFromEnvironment,
+			DialContext:         direct.DialContext,
+			TLSHandshakeTimeout: 10 * time.Second,
+			TLSClientConfig:     tlsConfig,
+			// TODO(dmcgowan): Call close idle connections when complete and use keep alive
+			DisableKeepAlives: true,
+		},
+	)
 }


### PR DESCRIPTION
Wrap `http.RoundTripper` used by distribution code (push/pull) with the `otelhttp.Transport`.

**- How to verify it**
1. Configure OTEL exporter for the engine (`OTEL_EXPORTER_OTLP_ENDPOINT` env-var)
2. Setup a MITM proxy, eg: `mitmdump -p 5050 -m reverse:<actual registry mirror> --flow-detail 2`
3. Configure the MITM proxy as an insecure registry
4. `docker pull <proxy>/<something>`
5. Observe HTTP headers in proxy

Example:
```
10.10.10.241:63754: HEAD http://10.10.10.232:5001/v2/alpine/manifests/latest
    Host: 10.10.10.232:5001
    User-Agent: Go-http-client/1.1
    Accept: application/json
    Accept: application/vnd.docker.distribution.manifest.v2+json
    Accept: application/vnd.docker.distribution.manifest.list.v2+json
    Accept: application/vnd.oci.image.index.v1+json
    Accept: application/vnd.oci.image.manifest.v1+json
    Accept: application/vnd.docker.distribution.manifest.v1+prettyjws
    Traceparent: 00-811d186341b98b7dcce83b20c8cdc257-2814665a74a19a71-01
    Connection: close
 << 404 Not Found 0b
    Content-Type: application/json
    Docker-Distribution-Api-Version: registry/2.0
    X-Content-Type-Options: nosniff
    Date: Fri, 20 Dec 2024 13:42:21 GMT
    Content-Length: 100
    Connection: close
```

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

