### PR TITLE
pkg/system: deprecate MkdirAll and remove custom volume GUID handling

### DIFF
--- a/builder/dockerfile/copy.go
+++ b/builder/dockerfile/copy.go
@@ -502,11 +502,7 @@ func copyDirectory(archiver *archive.Archiver, source, dest string, identity *id
 
 func copyFile(archiver *archive.Archiver, source, dest string, identity *idtools.Identity) error {
 	if identity == nil {
-		// Use system.MkdirAll here, which is a custom version of os.MkdirAll
-		// modified for use on Windows to handle volume GUID paths. These paths
-		// are of the form \\?\Volume{<GUID>}\<path>. An example would be:
-		// \\?\Volume{dae8d3ac-b9a1-11e9-88eb-e8554b2ba1db}\bin\busybox.exe
-		if err := system.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -54,7 +54,6 @@ import (
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/rootless"
 	"github.com/docker/docker/pkg/sysinfo"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/plugin"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/go-connections/tlsconfig"
@@ -143,14 +142,14 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 		return err
 	}
 
-	if err := system.MkdirAll(cli.Config.ExecRoot, 0o700); err != nil {
+	if err := os.MkdirAll(cli.Config.ExecRoot, 0o700); err != nil {
 		return err
 	}
 
 	potentiallyUnderRuntimeDir := []string{cli.Config.ExecRoot}
 
 	if cli.Pidfile != "" {
-		if err = system.MkdirAll(filepath.Dir(cli.Pidfile), 0o755); err != nil {
+		if err = os.MkdirAll(filepath.Dir(cli.Pidfile), 0o755); err != nil {
 			return errors.Wrap(err, "failed to create pidfile directory")
 		}
 		if err = pidfile.Write(cli.Pidfile, os.Getpid()); err != nil {

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -9,7 +9,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/pkg/system"
 )
 
 const (
@@ -46,7 +45,7 @@ func (container *Container) CreateSecretSymlinks() error {
 		if err != nil {
 			return err
 		}
-		if err := system.MkdirAll(filepath.Dir(resolvedPath), 0); err != nil {
+		if err := os.MkdirAll(filepath.Dir(resolvedPath), 0); err != nil {
 			return err
 		}
 		if err := os.Symlink(filepath.Join(containerInternalSecretMountPath, r.SecretID), resolvedPath); err != nil {
@@ -96,7 +95,7 @@ func (container *Container) CreateConfigSymlinks() error {
 		if err != nil {
 			return err
 		}
-		if err := system.MkdirAll(filepath.Dir(resolvedPath), 0); err != nil {
+		if err := os.MkdirAll(filepath.Dir(resolvedPath), 0); err != nil {
 			return err
 		}
 		if err := os.Symlink(filepath.Join(containerInternalConfigsDirPath, configRef.ConfigID), resolvedPath); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -66,7 +66,6 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/sysinfo"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/plugin"
 	pluginexec "github.com/docker/docker/plugin/executor/containerd"
 	refstore "github.com/docker/docker/reference"
@@ -810,7 +809,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, fmt.Errorf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
 	}
 	if isWindows {
-		if err := system.MkdirAll(realTmp, 0); err != nil {
+		if err := os.MkdirAll(realTmp, 0); err != nil {
 			return nil, fmt.Errorf("Unable to create the TempDir (%s): %s", realTmp, err)
 		}
 		os.Setenv("TEMP", realTmp)

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -31,7 +31,6 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/longpath"
-	"github.com/docker/docker/pkg/system"
 	"github.com/docker/go-units"
 	"github.com/moby/sys/reexec"
 	"github.com/pkg/errors"
@@ -103,7 +102,7 @@ func InitFilter(home string, options []string, _ idtools.IdentityMapping) (graph
 
 	// Setting file-mode is a no-op on Windows, so passing "0" to make it more
 	// transparent that the filemode passed has no effect.
-	if err = system.MkdirAll(home, 0); err != nil {
+	if err = os.MkdirAll(home, 0); err != nil {
 		return nil, errors.Wrapf(err, "windowsfilter failed to create '%s'", home)
 	}
 

--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd/shimopts"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/system"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
 	"github.com/pkg/errors"
 )
@@ -94,7 +93,7 @@ func initRuntimesDir(cfg *config.Config) error {
 	if err := os.RemoveAll(runtimeDir); err != nil {
 		return err
 	}
-	return system.MkdirAll(runtimeDir, 0o700)
+	return os.MkdirAll(runtimeDir, 0o700)
 }
 
 func setupRuntimes(cfg *config.Config) (runtimes, error) {

--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/pkg/pidfile"
 	"github.com/docker/docker/pkg/process"
-	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/util/grpcerrors"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
@@ -93,7 +92,7 @@ func Start(ctx context.Context, rootDir, stateDir string, opts ...DaemonOpt) (Da
 		}
 	}
 
-	if err := system.MkdirAll(stateDir, 0o700); err != nil {
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return nil, err
 	}
 

--- a/pkg/idtools/idtools_windows.go
+++ b/pkg/idtools/idtools_windows.go
@@ -2,8 +2,6 @@ package idtools // import "github.com/docker/docker/pkg/idtools"
 
 import (
 	"os"
-
-	"github.com/docker/docker/pkg/system"
 )
 
 const (
@@ -15,10 +13,10 @@ const (
 	ContainerUserSidString          = "S-1-5-93-2-2"
 )
 
-// This is currently a wrapper around MkdirAll, however, since currently
+// This is currently a wrapper around [os.MkdirAll] since currently
 // permissions aren't set through this path, the identity isn't utilized.
 // Ownership is handled elsewhere, but in the future could be support here
 // too.
 func mkdirAs(path string, _ os.FileMode, _ Identity, _, _ bool) error {
-	return system.MkdirAll(path, 0)
+	return os.MkdirAll(path, 0)
 }

--- a/pkg/system/filesys.go
+++ b/pkg/system/filesys.go
@@ -17,3 +17,11 @@ import (
 func IsAbs(path string) bool {
 	return filepath.IsAbs(path) || strings.HasPrefix(path, string(os.PathSeparator))
 }
+
+// MkdirAll creates a directory named path along with any necessary parents,
+// with permission specified by attribute perm for all dir created.
+//
+// Deprecated: [os.MkdirAll] now natively supports Windows GUID volume paths, and should be used instead. This alias will be removed in the next release.
+func MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}

--- a/pkg/system/filesys_unix.go
+++ b/pkg/system/filesys_unix.go
@@ -5,12 +5,6 @@ package system // import "github.com/docker/docker/pkg/system"
 import "os"
 
 // MkdirAllWithACL is a wrapper for os.MkdirAll on unix systems.
-func MkdirAllWithACL(path string, perm os.FileMode, sddl string) error {
-	return os.MkdirAll(path, perm)
-}
-
-// MkdirAll creates a directory named path along with any necessary parents,
-// with permission specified by attribute perm for all dir created.
-func MkdirAll(path string, perm os.FileMode) error {
+func MkdirAllWithACL(path string, perm os.FileMode, _ string) error {
 	return os.MkdirAll(path, perm)
 }


### PR DESCRIPTION
relates to 

- https://github.com/moby/moby/issues/32989
- (introduced in) https://github.com/moby/moby/pull/12718
- (added ACL) https://github.com/moby/moby/pull/28274
- (improved volume-path matching) https://github.com/moby/moby/pull/44302
- upstream ticket: https://github.com/golang/go/issues/22230
- upstream ticket: https://github.com/golang/go/issues/39785

## pkg/system: deprecate MkdirAll and remove custom volume GUID handling

commit 86d1223a29907ffc6afba557b5138cfad7816bb4 introduced a custom version of `os.MkdirAll` for Windows to account for situations where the path to create would start with a Windows volume name (GUID path), for example, `"\\?\Volume{4c1b02c1-d990-11dc-99ae-806e6f6e6963}\`. At the time that patch was added we were using [go1.4.2], which did not have special handling for Windows in [MkdirAll], therefore would recognize such paths as regular paths, trying to create them, which would fail.

This code was later updated in 46ec4c1ae2700ed638072fd7fb326afc10eded20 to provide ACL (DACL) support on Windows.

Further updates were made in cfef1b11e571ad2469cfa9631180db398f106468 and 55ceb5047c304d3ac8ecd15801a4b0472832158e to allow for an early return when detecting a volume GUID path, and the code was re-aligned with the latest (go1.19.2) implementation in f058afc861c2f56bf9e97472e99df65c6493e694, which brought in the platform-specific [fixRootDirectory] handling introduced in go1.11. While that enhancement detected UNC volume-paths (`\\?c\`, `//?/c:`), it did not yet support volume GUID paths.

go1.22, through [golang.org/cl/86295] added support for this, and `os.MkdirAll` now natively detects volume GUID paths, making our own implementation for this redundant.

This patch:

- Deprecates pkg/system.MkdirAll in favor of os.MkdirAll, which now provides the same functionality on go1.22 and up.
- Renames the (non-exported) `mkdirall` function to `mkdirAllWithACL`, and synchronises `it` with the [implementation in go1.23.4], bringing in the changes from [golang.org/cl/86295] and [golang.org/cl/582499].
- Adds a fast path to `MkdirAllWithACL` if no ACL / SDDL is provided.

It's worth noting that we currently still support go1.22, and that the implementation changed in go1.23; those changes ([golang.org/cl/581517] and [golang.org/cl/566556]) were lateral moves, therefore should be identical to the implementation in go1.22, and we can safely use the implementation provided by [filepath.VolumeName] on either go1.22 or go1.23.

[go1.4.2]: https://github.com/moby/moby/blob/86d1223a29907ffc6afba557b5138cfad7816bb4/Dockerfile#L77
[MkdirAll]: https://github.com/golang/go/blob/go1.4.2/src/os/path.go#L19-L60
[fixRootDirectory]: https://github.com/golang/go/commit/b86e76681366447798c94abb959bb60875bcc856
[golang.org/cl/86295]: https://github.com/golang/go/commit/cd589c8a73415afbf94a8976f20cbed9d4061ba6
[golang.org/cl/582499]: https://github.com/golang/go/commit/5616ab602566b0daa87dfd250a76c61960c4b634
[golang.org/cl/581517]: https://github.com/golang/go/commit/ad22356ec660844ec43ccbe9a834845f1a6f7cf8
[golang.org/cl/566556]: https://github.com/golang/go/commit/ceef0633b3c5bbf5d17a12d6e663c136b30b3f36
[1]: https://github.com/golang/go/blob/go1.23.4/src/os/path.go#L12-L66
[filepath.VolumeName]: https://pkg.go.dev/path/filepath#VolumeName


## remove uses of deprecated system.MkdirAll

- pkg/idtools: remove uses of deprecated system.MkdirAll
- builder/dockerfile: remove uses of deprecated system.MkdirAll
- cmd/dockerd: remove uses of deprecated system.MkdirAll
- container: remove uses of deprecated system.MkdirAll
- libcontainerd: remove uses of deprecated system.MkdirAll
- daemon/graphdriver/windows: remove uses of deprecated system.MkdirAll
- daemon: remove uses of deprecated system.MkdirAll

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Go SDK: pkg/system: deprecate MkdirAll. This function provided custom handling
  for Windows GUID volume paths. Handling for such paths is now supported
  by go stdlib in go1.22 and higher, and this function is now an alias for
  os.MkdirAll, which should be used instead. This alias will be removed in
  the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

