### PR TITLE
daemon: ignore some errors when setting env-vars

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -813,10 +813,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		if err := system.MkdirAll(realTmp, 0); err != nil {
 			return nil, fmt.Errorf("Unable to create the TempDir (%s): %s", realTmp, err)
 		}
-		os.Setenv("TEMP", realTmp)
-		os.Setenv("TMP", realTmp)
+		_ = os.Setenv("TEMP", realTmp)
+		_ = os.Setenv("TMP", realTmp)
 	} else {
-		os.Setenv("TMPDIR", realTmp)
+		_ = os.Setenv("TMPDIR", realTmp)
 	}
 
 	if err := initRuntimesDir(config); err != nil {


### PR DESCRIPTION
These are unlikely to ever fail, and were not handled, so explicitly ignoring any error.

**- A picture of a cute animal (not mandatory but encouraged)**

