### PR TITLE
WIP: pkg/archive: move compression to a separate package

### DIFF
--- a/builder/dockerfile/evaluator_test.go
+++ b/builder/dockerfile/evaluator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/builder/remotecontext"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/sys/reexec"
 	"gotest.tools/v3/assert"
@@ -107,7 +108,7 @@ func TestDispatch(t *testing.T) {
 				createTestTempFile(t, contextDir, filename, content, 0o777)
 			}
 
-			tarStream, err := archive.Tar(contextDir, archive.Uncompressed)
+			tarStream, err := archive.Tar(contextDir, compression.None)
 			if err != nil {
 				t.Fatalf("Error when creating tar stream: %s", err)
 			}

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/go-connections/nat"
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
@@ -71,7 +72,7 @@ func readAndCheckDockerfile(t *testing.T, testName, contextDir, dockerfilePath, 
 	if runtime.GOOS != "windows" {
 		skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	}
-	tarStream, err := archive.Tar(contextDir, archive.Uncompressed)
+	tarStream, err := archive.Tar(contextDir, compression.None)
 	assert.NilError(t, err)
 
 	defer func() {

--- a/builder/remotecontext/archive.go
+++ b/builder/remotecontext/archive.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/builder"
-	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/longpath"
 	"github.com/docker/docker/pkg/system"
@@ -66,7 +66,7 @@ func FromArchive(tarStream io.Reader) (builder.Source, error) {
 		}
 	}()
 
-	decompressedStream, err := archive.DecompressStream(tarStream)
+	decompressedStream, err := compression.DecompressStream(tarStream)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/remotecontext/git.go
+++ b/builder/remotecontext/git.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext/git"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 )
 
 // MakeGitContext returns a Context from gitURL that is cloned in a temporary directory.
@@ -17,7 +18,7 @@ func MakeGitContext(gitURL string) (builder.Source, error) {
 		return nil, err
 	}
 
-	c, err := archive.Tar(root, archive.Uncompressed)
+	c, err := archive.Tar(root, compression.None)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/remotecontext/tarsum_test.go
+++ b/builder/remotecontext/tarsum_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/moby/sys/reexec"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/skip"
@@ -135,7 +136,7 @@ func TestRemoveDirectory(t *testing.T) {
 
 func makeTestArchiveContext(t *testing.T, dir string) builder.Source {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
-	tarStream, err := archive.Tar(dir, archive.Uncompressed)
+	tarStream, err := archive.Tar(dir, compression.None)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/ioutils"
 )
@@ -314,7 +315,7 @@ func (daemon *Daemon) containerCopy(container *container.Container, resource str
 		filter = []string{f}
 	}
 	archv, err := chrootarchive.Tar(basePath, &archive.TarOptions{
-		Compression:  archive.Uncompressed,
+		Compression:  compression.None,
 		IncludeFiles: filter,
 	}, container.BaseFS)
 	if err != nil {

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
-	dockerarchive "github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/streamformatter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -246,7 +246,7 @@ func (i *ImageService) leaseContent(ctx context.Context, store content.Store, de
 // complement of ExportImage.  The input stream is an uncompressed tar
 // ball containing images and metadata.
 func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, platform *ocispec.Platform, outStream io.Writer, quiet bool) error {
-	decompressed, err := dockerarchive.DecompressStream(inTar)
+	decompressed, err := compression.DecompressStream(inTar)
 	if err != nil {
 		return errors.Wrap(err, "failed to decompress input tar archive")
 	}

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/google/uuid"
 	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
@@ -168,17 +169,17 @@ func saveArchive(ctx context.Context, cs content.Store, layerReader io.Reader) (
 	bufRd := p.Get(layerReader)
 	defer p.Put(bufRd)
 
-	compression, err := detectCompression(bufRd)
+	comp, err := detectCompression(bufRd)
 	if err != nil {
 		return "", "", "", err
 	}
 
 	var uncompressedReader io.Reader = bufRd
-	switch compression {
-	case archive.Gzip, archive.Zstd:
+	switch comp {
+	case compression.Gzip, compression.Zstd:
 		// If the input is already a compressed layer, just save it as is.
 		mediaType := ocispec.MediaTypeImageLayerGzip
-		if compression == archive.Zstd {
+		if comp == compression.Zstd {
 			mediaType = ocispec.MediaTypeImageLayerZstd
 		}
 
@@ -188,7 +189,7 @@ func saveArchive(ctx context.Context, cs content.Store, layerReader io.Reader) (
 		}
 
 		return compressedDigest, uncompressedDigest, mediaType, nil
-	case archive.Bzip2, archive.Xz:
+	case compression.Bzip2, compression.Xz:
 		r, err := archive.DecompressStream(bufRd)
 		if err != nil {
 			return "", "", "", errdefs.InvalidParameter(err)
@@ -196,11 +197,10 @@ func saveArchive(ctx context.Context, cs content.Store, layerReader io.Reader) (
 		defer r.Close()
 		uncompressedReader = r
 		fallthrough
-	case archive.Uncompressed:
+	case compression.None:
 		mediaType := ocispec.MediaTypeImageLayerGzip
-		compression := archive.Gzip
 
-		compressedDigest, uncompressedDigest, err := compressAndWriteBlob(ctx, cs, compression, mediaType, uncompressedReader)
+		compressedDigest, uncompressedDigest, err := compressAndWriteBlob(ctx, cs, compression.Gzip, mediaType, uncompressedReader)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -249,12 +249,12 @@ func writeCompressedBlob(ctx context.Context, cs content.Store, mediaType string
 }
 
 // compressAndWriteBlob compresses the uncompressedReader and stores it in the content store.
-func compressAndWriteBlob(ctx context.Context, cs content.Store, compression archive.Compression, mediaType string, uncompressedLayerReader io.Reader) (digest.Digest, digest.Digest, error) {
+func compressAndWriteBlob(ctx context.Context, cs content.Store, comp compression.Compression, mediaType string, uncompressedLayerReader io.Reader) (digest.Digest, digest.Digest, error) {
 	pr, pw := io.Pipe()
 	defer pr.Close()
 	defer pw.Close()
 
-	compressor, err := archive.CompressStream(pw, compression)
+	compressor, err := archive.CompressStream(pw, comp)
 	if err != nil {
 		return "", "", errdefs.InvalidParameter(err)
 	}
@@ -312,7 +312,7 @@ func (i *ImageService) unpackImage(ctx context.Context, snapshotter string, img 
 }
 
 // detectCompression detects the reader compression type.
-func detectCompression(bufRd *bufio.Reader) (archive.Compression, error) {
+func detectCompression(bufRd *bufio.Reader) (compression.Compression, error) {
 	bs, err := bufRd.Peek(10)
 	if err != nil && err != io.EOF {
 		// Note: we'll ignore any io.EOF error because there are some odd
@@ -321,10 +321,10 @@ func detectCompression(bufRd *bufio.Reader) (archive.Compression, error) {
 		// cases we'll just treat it as a non-compressed stream and
 		// that means just create an empty layer.
 		// See Issue 18170
-		return archive.Uncompressed, errdefs.Unknown(err)
+		return compression.None, errdefs.Unknown(err)
 	}
 
-	return archive.DetectCompression(bs), nil
+	return compression.Detect(bs), nil
 }
 
 // fillUncompressedLabel sets the uncompressed digest label on the compressed blob metadata

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/builder/dockerfile"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
-	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/pools"
 	"github.com/google/uuid"
@@ -190,7 +189,7 @@ func saveArchive(ctx context.Context, cs content.Store, layerReader io.Reader) (
 
 		return compressedDigest, uncompressedDigest, mediaType, nil
 	case compression.Bzip2, compression.Xz:
-		r, err := archive.DecompressStream(bufRd)
+		r, err := compression.DecompressStream(bufRd)
 		if err != nil {
 			return "", "", "", errdefs.InvalidParameter(err)
 		}
@@ -228,7 +227,7 @@ func writeCompressedBlob(ctx context.Context, cs content.Store, mediaType string
 	digester := digest.Canonical.Digester()
 
 	// Decompress the piped blob.
-	decompressedStream, err := archive.DecompressStream(pr)
+	decompressedStream, err := compression.DecompressStream(pr)
 	if err == nil {
 		// Feed the digester with decompressed data.
 		_, err = io.Copy(digester.Hash(), decompressedStream)
@@ -254,7 +253,7 @@ func compressAndWriteBlob(ctx context.Context, cs content.Store, comp compressio
 	defer pr.Close()
 	defer pw.Close()
 
-	compressor, err := archive.CompressStream(pw, comp)
+	compressor, err := compression.CompressStream(pw, comp)
 	if err != nil {
 		return "", "", errdefs.InvalidParameter(err)
 	}

--- a/daemon/containerd/image_load_test.go
+++ b/daemon/containerd/image_load_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -35,7 +36,7 @@ func TestImageLoadMissing(t *testing.T) {
 	imgSvc.defaultPlatformOverride = platforms.Only(linuxAmd64)
 
 	tryLoad := func(ctx context.Context, t *testing.T, dir string, platform ocispec.Platform) error {
-		tarRc, err := archive.Tar(dir, archive.Uncompressed)
+		tarRc, err := archive.Tar(dir, compression.None)
 		assert.NilError(t, err)
 		defer tarRc.Close()
 

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/chrootarchive"
 )
 
@@ -45,7 +46,7 @@ func (daemon *Daemon) ContainerExport(ctx context.Context, name string, out io.W
 func (daemon *Daemon) containerExport(ctx context.Context, container *container.Container, out io.Writer) error {
 	err := daemon.imageService.PerformWithBaseFS(ctx, container, func(basefs string) error {
 		archv, err := chrootarchive.Tar(basefs, &archive.TarOptions{
-			Compression: archive.Uncompressed,
+			Compression: compression.None,
 			IDMap:       daemon.idMapping,
 		}, basefs)
 		if err != nil {

--- a/daemon/graphdriver/fsdiff.go
+++ b/daemon/graphdriver/fsdiff.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/ioutils"
@@ -64,7 +65,7 @@ func (gdw *NaiveDiffDriver) Diff(id, parent string) (arch io.ReadCloser, err err
 	}()
 
 	if parent == "" {
-		tarArchive, err := archive.Tar(layerFs, archive.Uncompressed)
+		tarArchive, err := archive.Tar(layerFs, compression.None)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -729,7 +729,6 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 	diffPath := d.getDiffPath(id)
 	logger.Debugf("Tar with options on %s", diffPath)
 	return archive.TarWithOptions(diffPath, &archive.TarOptions{
-		Compression:    archive.Uncompressed,
 		IDMap:          d.idMap,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
 	})

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -40,7 +40,7 @@ func (i *ImageService) ImportImage(ctx context.Context, newRef reference.Named, 
 		return "", errdefs.InvalidParameter(err)
 	}
 
-	inflatedLayerData, err := archive.DecompressStream(layerReader)
+	inflatedLayerData, err := compression.DecompressStream(layerReader)
 	if err != nil {
 		return "", err
 	}

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progress"
 )
@@ -338,7 +338,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 			reader := progress.NewProgressReader(ioutils.NewCancelReadCloser(d.transfer.context(), downloadReader), progressOutput, size, descriptor.ID(), "Extracting")
 			defer reader.Close()
 
-			inflatedLayerData, err := archive.DecompressStream(reader)
+			inflatedLayerData, err := compression.DecompressStream(reader)
 			if err != nil {
 				d.err = fmt.Errorf("could not get decompression stream: %v", err)
 				return

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -20,7 +20,7 @@ import (
 	v1 "github.com/docker/docker/image/v1"
 	"github.com/docker/docker/internal/ioutils"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -231,7 +231,7 @@ func (l *tarexporter) loadLayer(ctx context.Context, filename string, rootFS ima
 		r = rawTar
 	}
 
-	inflatedLayerData, err := archive.DecompressStream(ioutils.NewCtxReader(ctx, r))
+	inflatedLayerData, err := compression.DecompressStream(ioutils.NewCtxReader(ctx, r))
 	if err != nil {
 		return nil, err
 	}

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker/internal/ioutils"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/system"
 	"github.com/moby/sys/sequential"
 	"github.com/opencontainers/go-digest"
@@ -393,7 +394,7 @@ func (s *saveSession) writeTar(ctx context.Context, tempDir string, outStream io
 	ctx, span := tracing.StartSpan(ctx, "writeTar")
 	defer span.End()
 
-	fs, err := archive.Tar(tempDir, archive.Uncompressed)
+	fs, err := archive.Tar(tempDir, compression.None)
 	if err != nil {
 		span.SetStatus(err)
 		return err

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/docker/docker/testutil/fakegit"
@@ -2008,7 +2009,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddLocalAndRemoteFilesWithAndWithoutCache
 	}
 }
 
-func testContextTar(c *testing.T, compression archive.Compression) {
+func testContextTar(c *testing.T, comp compression.Compression) {
 	ctx := fakecontext.New(c, "",
 		fakecontext.WithDockerfile(`FROM busybox
 ADD foo /foo
@@ -2018,21 +2019,21 @@ CMD ["cat", "/foo"]`),
 		}),
 	)
 	defer ctx.Close()
-	context, err := archive.Tar(ctx.Dir, compression)
+	buildContext, err := archive.Tar(ctx.Dir, comp)
 	if err != nil {
 		c.Fatalf("failed to build context tar: %v", err)
 	}
 	const name = "contexttar"
 
-	cli.BuildCmd(c, name, build.WithStdinContext(context))
+	cli.BuildCmd(c, name, build.WithStdinContext(buildContext))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildContextTarGzip(c *testing.T) {
-	testContextTar(c, archive.Gzip)
+	testContextTar(c, compression.Gzip)
 }
 
 func (s *DockerCLIBuildSuite) TestBuildContextTarNoCompression(c *testing.T) {
-	testContextTar(c, archive.Uncompressed)
+	testContextTar(c, compression.None)
 }
 
 func (s *DockerCLIBuildSuite) TestBuildNoContext(c *testing.T) {

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/testutils"
 	"github.com/docker/docker/internal/testutils/specialimage"
-	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -363,7 +363,7 @@ RUN touch /opt/a/b/c && chown user:user /opt/a/b/c`
 
 func listTar(f io.Reader) ([]string, error) {
 	// If using the containerd snapshotter, the tar file may be compressed
-	dec, err := archive.DecompressStream(f)
+	dec, err := compression.DecompressStream(f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testutils/archive.go
+++ b/internal/testutils/archive.go
@@ -3,13 +3,13 @@ package testutils
 import (
 	"io"
 
-	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/opencontainers/go-digest"
 )
 
 // UncompressedTarDigest returns the canonical digest of the uncompressed tar stream.
 func UncompressedTarDigest(compressedTar io.Reader) (digest.Digest, error) {
-	rd, err := archive.DecompressStream(compressedTar)
+	rd, err := compression.DecompressStream(compressedTar)
 	if err != nil {
 		return "", err
 	}

--- a/internal/testutils/specialimage/multilayer.go
+++ b/internal/testutils/specialimage/multilayer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
@@ -137,7 +138,7 @@ func fileArchive(dir string, name string, content []byte) (io.ReadCloser, error)
 		return nil, err
 	}
 
-	return archive.Tar(tmp, archive.Uncompressed)
+	return archive.Tar(tmp, compression.None)
 }
 
 func writeLayerWithOneFile(dir string, filename string, content []byte) (ocispec.Descriptor, error) {

--- a/layer/layer_test.go
+++ b/layer/layer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/vfs"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/opencontainers/go-digest"
@@ -600,7 +601,7 @@ func tarFromFiles(files ...FileApplier) ([]byte, error) {
 		}
 	}
 
-	r, err := archive.Tar(td, archive.Uncompressed)
+	r, err := archive.Tar(td, compression.None)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -706,7 +706,7 @@ func NewTarballer(srcPath string, options *TarOptions) (*Tarballer, error) {
 
 	pipeReader, pipeWriter := io.Pipe()
 
-	compressWriter, err := CompressStream(pipeWriter, options.Compression)
+	compressWriter, err := compression.CompressStream(pipeWriter, options.Compression)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -11,9 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -128,24 +126,6 @@ func IsArchivePath(path string) bool {
 // Deprecated: use [compression.Detect].
 func DetectCompression(source []byte) compression.Compression {
 	return compression.Detect(source)
-}
-
-type readCloserWrapper struct {
-	io.Reader
-	closer func() error
-	closed atomic.Bool
-}
-
-func (r *readCloserWrapper) Close() error {
-	if !r.closed.CompareAndSwap(false, true) {
-		log.G(context.TODO()).Error("subsequent attempt to close readCloserWrapper")
-		if log.GetLevel() >= log.DebugLevel {
-			log.G(context.TODO()).Errorf("stack trace: %s", string(debug.Stack()))
-		}
-
-		return nil
-	}
-	return r.closer()
 }
 
 // DecompressStream decompresses the archive and returns a ReaderCloser with the decompressed archive.

--- a/pkg/archive/archive_linux_test.go
+++ b/pkg/archive/archive_linux_test.go
@@ -104,7 +104,6 @@ func TestOverlayTarUntar(t *testing.T) {
 	defer os.RemoveAll(dst)
 
 	options := &TarOptions{
-		Compression:    Uncompressed,
 		WhiteoutFormat: OverlayWhiteoutFormat,
 	}
 	reader, err := TarWithOptions(src, options)
@@ -170,14 +169,12 @@ func TestOverlayTarAUFSUntar(t *testing.T) {
 	defer os.RemoveAll(dst)
 
 	archive, err := TarWithOptions(src, &TarOptions{
-		Compression:    Uncompressed,
 		WhiteoutFormat: OverlayWhiteoutFormat,
 	})
 	assert.NilError(t, err)
 	defer archive.Close()
 
 	err = Untar(archive, dst, &TarOptions{
-		Compression:    Uncompressed,
 		WhiteoutFormat: AUFSWhiteoutFormat,
 	})
 	assert.NilError(t, err)

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -3,18 +3,15 @@ package archive
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/idtools"
@@ -89,148 +86,6 @@ func TestIsArchivePathTar(t *testing.T) {
 	}
 	if !IsArchivePath(tmp + "archive.gz") {
 		t.Fatalf("Did not recognise valid compressed tar path as archive")
-	}
-}
-
-func testDecompressStream(t *testing.T, ext, compressCommand string) io.Reader {
-	cmd := exec.Command("sh", "-c",
-		fmt.Sprintf("touch /tmp/archive && %s /tmp/archive", compressCommand))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to create an archive file for test : %s.", output)
-	}
-	filename := "archive." + ext
-	archive, err := os.Open(tmp + filename)
-	if err != nil {
-		t.Fatalf("Failed to open file %s: %v", filename, err)
-	}
-	defer archive.Close()
-
-	r, err := DecompressStream(archive)
-	if err != nil {
-		t.Fatalf("Failed to decompress %s: %v", filename, err)
-	}
-	if _, err = io.ReadAll(r); err != nil {
-		t.Fatalf("Failed to read the decompressed stream: %v ", err)
-	}
-	if err = r.Close(); err != nil {
-		t.Fatalf("Failed to close the decompressed stream: %v ", err)
-	}
-
-	return r
-}
-
-func TestDecompressStreamGzip(t *testing.T) {
-	testDecompressStream(t, "gz", "gzip -f")
-}
-
-func TestDecompressStreamBzip2(t *testing.T) {
-	testDecompressStream(t, "bz2", "bzip2 -f")
-}
-
-func TestDecompressStreamXz(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Xz not present in msys2")
-	}
-	testDecompressStream(t, "xz", "xz -f")
-}
-
-func TestDecompressStreamZstd(t *testing.T) {
-	if _, err := exec.LookPath("zstd"); err != nil {
-		t.Skip("zstd not installed")
-	}
-	testDecompressStream(t, "zst", "zstd -f")
-}
-
-func TestCompressStreamXzUnsupported(t *testing.T) {
-	dest, err := os.Create(tmp + "dest")
-	if err != nil {
-		t.Fatalf("Fail to create the destination file")
-	}
-	defer dest.Close()
-
-	_, err = CompressStream(dest, compression.Xz)
-	if err == nil {
-		t.Fatalf("Should fail as xz is unsupported for compression format.")
-	}
-}
-
-func TestCompressStreamBzip2Unsupported(t *testing.T) {
-	dest, err := os.Create(tmp + "dest")
-	if err != nil {
-		t.Fatalf("Fail to create the destination file")
-	}
-	defer dest.Close()
-
-	_, err = CompressStream(dest, compression.Bzip2)
-	if err == nil {
-		t.Fatalf("Should fail as bzip2 is unsupported for compression format.")
-	}
-}
-
-func TestCompressStreamInvalid(t *testing.T) {
-	dest, err := os.Create(tmp + "dest")
-	if err != nil {
-		t.Fatalf("Fail to create the destination file")
-	}
-	defer dest.Close()
-
-	_, err = CompressStream(dest, -1)
-	if err == nil {
-		t.Fatalf("Should fail as xz is unsupported for compression format.")
-	}
-}
-
-func TestCmdStreamLargeStderr(t *testing.T) {
-	cmd := exec.Command("sh", "-c", "dd if=/dev/zero bs=1k count=1000 of=/dev/stderr; echo hello")
-	out, err := cmdStream(cmd, nil)
-	if err != nil {
-		t.Fatalf("Failed to start command: %s", err)
-	}
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := io.Copy(io.Discard, out)
-		errCh <- err
-	}()
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("Command should not have failed (err=%.100s...)", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatalf("Command did not complete in 5 seconds; probable deadlock")
-	}
-}
-
-func TestCmdStreamBad(t *testing.T) {
-	// TODO Windows: Figure out why this is failing in CI but not locally
-	if runtime.GOOS == "windows" {
-		t.Skip("Failing on Windows CI machines")
-	}
-	badCmd := exec.Command("sh", "-c", "echo hello; echo >&2 error couldn\\'t reverse the phase pulser; exit 1")
-	out, err := cmdStream(badCmd, nil)
-	if err != nil {
-		t.Fatalf("Failed to start command: %s", err)
-	}
-	if output, err := io.ReadAll(out); err == nil {
-		t.Fatalf("Command should have failed")
-	} else if err.Error() != "exit status 1: error couldn't reverse the phase pulser\n" {
-		t.Fatalf("Wrong error value (%s)", err)
-	} else if s := string(output); s != "hello\n" {
-		t.Fatalf("Command output should be '%s', not '%s'", "hello\\n", output)
-	}
-}
-
-func TestCmdStreamGood(t *testing.T) {
-	cmd := exec.Command("sh", "-c", "echo hello; exit 0")
-	out, err := cmdStream(cmd, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if output, err := io.ReadAll(out); err != nil {
-		t.Fatalf("Command should not have failed (err=%s)", err)
-	} else if s := string(output); s != "hello\n" {
-		t.Fatalf("Command output should be '%s', not '%s'", "hello\\n", output)
 	}
 }
 
@@ -1356,39 +1211,6 @@ func readFileFromArchive(t *testing.T, archive io.ReadCloser, name string, expec
 	content, err := os.ReadFile(filepath.Join(destDir, name))
 	assert.Check(t, err)
 	return string(content)
-}
-
-func TestDisablePigz(t *testing.T) {
-	_, err := exec.LookPath("unpigz")
-	if err != nil {
-		t.Log("Test will not check full path when Pigz not installed")
-	}
-
-	t.Setenv("MOBY_DISABLE_PIGZ", "true")
-
-	r := testDecompressStream(t, "gz", "gzip -f")
-
-	// wrapped in closer to cancel contex and release buffer to pool
-	wrapper := r.(*readCloserWrapper)
-
-	assert.Equal(t, reflect.TypeOf(wrapper.Reader), reflect.TypeOf(&gzip.Reader{}))
-}
-
-func TestPigz(t *testing.T) {
-	r := testDecompressStream(t, "gz", "gzip -f")
-	// wrapper for buffered reader and context cancel
-	wrapper := r.(*readCloserWrapper)
-
-	_, err := exec.LookPath("unpigz")
-	if err == nil {
-		t.Log("Tested whether Pigz is used, as it installed")
-		// For the command wait wrapper
-		cmdWaitCloserWrapper := wrapper.Reader.(*readCloserWrapper)
-		assert.Equal(t, reflect.TypeOf(cmdWaitCloserWrapper.Reader), reflect.TypeOf(&io.PipeReader{}))
-	} else {
-		t.Log("Tested whether Pigz is not used, as it not installed")
-		assert.Equal(t, reflect.TypeOf(wrapper.Reader), reflect.TypeOf(&gzip.Reader{}))
-	}
 }
 
 func TestNosysFileInfo(t *testing.T) {

--- a/pkg/archive/compression/compression.go
+++ b/pkg/archive/compression/compression.go
@@ -1,5 +1,23 @@
 package compression
 
+import (
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime/debug"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/pkg/pools"
+	"github.com/klauspost/compress/zstd"
+)
+
 // Compression is the state represents if compressed or not.
 type Compression int
 
@@ -26,4 +44,179 @@ func (compression *Compression) Extension() string {
 		return "tar.zst"
 	}
 	return ""
+}
+
+type readCloserWrapper struct {
+	io.Reader
+	closer func() error
+	closed atomic.Bool
+}
+
+func (r *readCloserWrapper) Close() error {
+	if !r.closed.CompareAndSwap(false, true) {
+		log.G(context.TODO()).Error("subsequent attempt to close readCloserWrapper")
+		if log.GetLevel() >= log.DebugLevel {
+			log.G(context.TODO()).Errorf("stack trace: %s", string(debug.Stack()))
+		}
+
+		return nil
+	}
+	return r.closer()
+}
+
+// DecompressStream decompresses the archive and returns a ReaderCloser with the decompressed archive.
+func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
+	p := pools.BufioReader32KPool
+	buf := p.Get(archive)
+	bs, err := buf.Peek(10)
+	if err != nil && err != io.EOF {
+		// Note: we'll ignore any io.EOF error because there are some odd
+		// cases where the layer.tar file will be empty (zero bytes) and
+		// that results in an io.EOF from the Peek() call. So, in those
+		// cases we'll just treat it as a non-compressed stream and
+		// that means just create an empty layer.
+		// See Issue 18170
+		return nil, err
+	}
+
+	wrapReader := func(r io.Reader, cancel context.CancelFunc) io.ReadCloser {
+		return &readCloserWrapper{
+			Reader: r,
+			closer: func() error {
+				if cancel != nil {
+					cancel()
+				}
+				if readCloser, ok := r.(io.ReadCloser); ok {
+					readCloser.Close()
+				}
+				p.Put(buf)
+				return nil
+			},
+		}
+	}
+
+	compressionType := Detect(bs)
+	switch compressionType {
+	case None:
+		return wrapReader(buf, nil), nil
+	case Gzip:
+		ctx, cancel := context.WithCancel(context.Background())
+
+		gzReader, err := gzipDecompress(ctx, buf)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		return wrapReader(gzReader, cancel), nil
+	case Bzip2:
+		bz2Reader := bzip2.NewReader(buf)
+		return wrapReader(bz2Reader, nil), nil
+	case Xz:
+		ctx, cancel := context.WithCancel(context.Background())
+
+		xzReader, err := xzDecompress(ctx, buf)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+		return wrapReader(xzReader, cancel), nil
+	case Zstd:
+		zstdReader, err := zstd.NewReader(buf)
+		if err != nil {
+			return nil, err
+		}
+		return wrapReader(zstdReader, nil), nil
+	default:
+		return nil, fmt.Errorf("unsupported compression format %s", (&compressionType).Extension())
+	}
+}
+
+// CompressStream compresses the dest with specified compression algorithm.
+func CompressStream(dest io.Writer, comp Compression) (io.WriteCloser, error) {
+	p := pools.BufioWriter32KPool
+	buf := p.Get(dest)
+	switch comp {
+	case None:
+		writeBufWrapper := p.NewWriteCloserWrapper(buf, buf)
+		return writeBufWrapper, nil
+	case Gzip:
+		gzWriter := gzip.NewWriter(dest)
+		writeBufWrapper := p.NewWriteCloserWrapper(buf, gzWriter)
+		return writeBufWrapper, nil
+	case Bzip2, Xz:
+		// archive/bzip2 does not support writing, and there is no xz support at all
+		// However, this is not a problem as docker only currently generates gzipped tars
+		return nil, fmt.Errorf("unsupported compression format %s", (&comp).Extension())
+	default:
+		return nil, fmt.Errorf("unsupported compression format %s", (&comp).Extension())
+	}
+}
+
+func xzDecompress(ctx context.Context, archive io.Reader) (io.ReadCloser, error) {
+	args := []string{"xz", "-d", "-c", "-q"}
+
+	return cmdStream(exec.CommandContext(ctx, args[0], args[1:]...), archive)
+}
+
+func gzipDecompress(ctx context.Context, buf io.Reader) (io.ReadCloser, error) {
+	if noPigzEnv := os.Getenv("MOBY_DISABLE_PIGZ"); noPigzEnv != "" {
+		noPigz, err := strconv.ParseBool(noPigzEnv)
+		if err != nil {
+			log.G(ctx).WithError(err).Warn("invalid value in MOBY_DISABLE_PIGZ env var")
+		}
+		if noPigz {
+			log.G(ctx).Debugf("Use of pigz is disabled due to MOBY_DISABLE_PIGZ=%s", noPigzEnv)
+			return gzip.NewReader(buf)
+		}
+	}
+
+	unpigzPath, err := exec.LookPath("unpigz")
+	if err != nil {
+		log.G(ctx).Debugf("unpigz binary not found, falling back to go gzip library")
+		return gzip.NewReader(buf)
+	}
+
+	log.G(ctx).Debugf("Using %s to decompress", unpigzPath)
+
+	return cmdStream(exec.CommandContext(ctx, unpigzPath, "-d", "-c"), buf)
+}
+
+// cmdStream executes a command, and returns its stdout as a stream.
+// If the command fails to run or doesn't complete successfully, an error
+// will be returned, including anything written on stderr.
+func cmdStream(cmd *exec.Cmd, input io.Reader) (io.ReadCloser, error) {
+	cmd.Stdin = input
+	pipeR, pipeW := io.Pipe()
+	cmd.Stdout = pipeW
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+
+	// Run the command and return the pipe
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	// Ensure the command has exited before we clean anything up
+	done := make(chan struct{})
+
+	// Copy stdout to the returned pipe
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			pipeW.CloseWithError(fmt.Errorf("%s: %s", err, errBuf.String()))
+		} else {
+			pipeW.Close()
+		}
+		close(done)
+	}()
+
+	return &readCloserWrapper{
+		Reader: pipeR,
+		closer: func() error {
+			// Close pipeR, and then wait for the command to complete before returning. We have to close pipeR first, as
+			// cmd.Wait waits for any non-file stdout/stderr/stdin to close.
+			err := pipeR.Close()
+			<-done
+			return err
+		},
+	}, nil
 }

--- a/pkg/archive/compression/compression.go
+++ b/pkg/archive/compression/compression.go
@@ -1,0 +1,29 @@
+package compression
+
+// Compression is the state represents if compressed or not.
+type Compression int
+
+const (
+	None  Compression = 0 // None represents the uncompressed.
+	Bzip2 Compression = 1 // Bzip2 is bzip2 compression algorithm.
+	Gzip  Compression = 2 // Gzip is gzip compression algorithm.
+	Xz    Compression = 3 // Xz is xz compression algorithm.
+	Zstd  Compression = 4 // Zstd is zstd compression algorithm.
+)
+
+// Extension returns the extension of a file that uses the specified compression algorithm.
+func (compression *Compression) Extension() string {
+	switch *compression {
+	case None:
+		return "tar"
+	case Bzip2:
+		return "tar.bz2"
+	case Gzip:
+		return "tar.gz"
+	case Xz:
+		return "tar.xz"
+	case Zstd:
+		return "tar.zst"
+	}
+	return ""
+}

--- a/pkg/archive/compression/compression_detect.go
+++ b/pkg/archive/compression/compression_detect.go
@@ -1,0 +1,65 @@
+package compression
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+const (
+	zstdMagicSkippableStart = 0x184D2A50
+	zstdMagicSkippableMask  = 0xFFFFFFF0
+)
+
+var (
+	bzip2Magic = []byte{0x42, 0x5A, 0x68}
+	gzipMagic  = []byte{0x1F, 0x8B, 0x08}
+	xzMagic    = []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00}
+	zstdMagic  = []byte{0x28, 0xb5, 0x2f, 0xfd}
+)
+
+type matcher = func([]byte) bool
+
+// Detect detects the compression algorithm of the source.
+func Detect(source []byte) Compression {
+	compressionMap := map[Compression]matcher{
+		Bzip2: magicNumberMatcher(bzip2Magic),
+		Gzip:  magicNumberMatcher(gzipMagic),
+		Xz:    magicNumberMatcher(xzMagic),
+		Zstd:  zstdMatcher(),
+	}
+	for _, compression := range []Compression{Bzip2, Gzip, Xz, Zstd} {
+		fn := compressionMap[compression]
+		if fn(source) {
+			return compression
+		}
+	}
+	return None
+}
+
+func magicNumberMatcher(m []byte) matcher {
+	return func(source []byte) bool {
+		return bytes.HasPrefix(source, m)
+	}
+}
+
+// zstdMatcher detects zstd compression algorithm.
+// Zstandard compressed data is made of one or more frames.
+// There are two frame formats defined by Zstandard: Zstandard frames and Skippable frames.
+// See https://datatracker.ietf.org/doc/html/rfc8878#section-3 for more details.
+func zstdMatcher() matcher {
+	return func(source []byte) bool {
+		if bytes.HasPrefix(source, zstdMagic) {
+			// Zstandard frame
+			return true
+		}
+		// skippable frame
+		if len(source) < 8 {
+			return false
+		}
+		// magic number from 0x184D2A50 to 0x184D2A5F.
+		if binary.LittleEndian.Uint32(source[:4])&zstdMagicSkippableMask == zstdMagicSkippableStart {
+			return true
+		}
+		return false
+	}
+}

--- a/pkg/archive/compression/compression_fuzz_test.go
+++ b/pkg/archive/compression/compression_fuzz_test.go
@@ -1,0 +1,13 @@
+package compression
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzDecompressStream(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r := bytes.NewReader(data)
+		_, _ = DecompressStream(r)
+	})
+}

--- a/pkg/archive/compression/compression_test.go
+++ b/pkg/archive/compression/compression_test.go
@@ -1,0 +1,79 @@
+package compression
+
+import "testing"
+
+func TestExtensionInvalid(t *testing.T) {
+	compression := Compression(-1)
+	output := compression.Extension()
+	if output != "" {
+		t.Fatalf("The extension of an invalid compression should be an empty string.")
+	}
+}
+
+func TestExtensionUncompressed(t *testing.T) {
+	compression := None
+	output := compression.Extension()
+	if output != "tar" {
+		t.Fatalf("The extension of an uncompressed archive should be 'tar'.")
+	}
+}
+
+func TestExtensionBzip2(t *testing.T) {
+	compression := Bzip2
+	output := compression.Extension()
+	if output != "tar.bz2" {
+		t.Fatalf("The extension of a bzip2 archive should be 'tar.bz2'")
+	}
+}
+
+func TestExtensionGzip(t *testing.T) {
+	compression := Gzip
+	output := compression.Extension()
+	if output != "tar.gz" {
+		t.Fatalf("The extension of a gzip archive should be 'tar.gz'")
+	}
+}
+
+func TestExtensionXz(t *testing.T) {
+	compression := Xz
+	output := compression.Extension()
+	if output != "tar.xz" {
+		t.Fatalf("The extension of a xz archive should be 'tar.xz'")
+	}
+}
+
+func TestExtensionZstd(t *testing.T) {
+	compression := Zstd
+	output := compression.Extension()
+	if output != "tar.zst" {
+		t.Fatalf("The extension of a zstd archive should be 'tar.zst'")
+	}
+}
+
+func TestDetectCompressionZstd(t *testing.T) {
+	// test zstd compression without skippable frames.
+	compressedData := []byte{
+		0x28, 0xb5, 0x2f, 0xfd, // magic number of Zstandard frame: 0xFD2FB528
+		0x04, 0x00, 0x31, 0x00, 0x00, // frame header
+		0x64, 0x6f, 0x63, 0x6b, 0x65, 0x72, // data block "docker"
+		0x16, 0x0e, 0x21, 0xc3, // content checksum
+	}
+	compression := Detect(compressedData)
+	if compression != Zstd {
+		t.Fatal("Unexpected compression")
+	}
+	// test zstd compression with skippable frames.
+	hex := []byte{
+		0x50, 0x2a, 0x4d, 0x18, // magic number of skippable frame: 0x184D2A50 to 0x184D2A5F
+		0x04, 0x00, 0x00, 0x00, // frame size
+		0x5d, 0x00, 0x00, 0x00, // user data
+		0x28, 0xb5, 0x2f, 0xfd, // magic number of Zstandard frame: 0xFD2FB528
+		0x04, 0x00, 0x31, 0x00, 0x00, // frame header
+		0x64, 0x6f, 0x63, 0x6b, 0x65, 0x72, // data block "docker"
+		0x16, 0x0e, 0x21, 0xc3, // content checksum
+	}
+	compression = Detect(hex)
+	if compression != Zstd {
+		t.Fatal("Unexpected compression")
+	}
+}

--- a/pkg/archive/compression/compression_test.go
+++ b/pkg/archive/compression/compression_test.go
@@ -1,6 +1,25 @@
 package compression
 
-import "testing"
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+)
+
+var tmp string
+
+func init() {
+	tmp = "/tmp/"
+	if runtime.GOOS == "windows" {
+		tmp = os.Getenv("TEMP") + `\`
+	}
+}
 
 func TestExtensionInvalid(t *testing.T) {
 	compression := Compression(-1)
@@ -75,5 +94,192 @@ func TestDetectCompressionZstd(t *testing.T) {
 	compression = Detect(hex)
 	if compression != Zstd {
 		t.Fatal("Unexpected compression")
+	}
+}
+
+func testDecompressStream(t *testing.T, ext, compressCommand string) io.Reader {
+	cmd := exec.Command("sh", "-c",
+		fmt.Sprintf("touch /tmp/archive && %s /tmp/archive", compressCommand))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Failed to create an archive file for test : %s.", output)
+	}
+	filename := "archive." + ext
+	archive, err := os.Open(tmp + filename)
+	if err != nil {
+		t.Fatalf("Failed to open file %s: %v", filename, err)
+	}
+	defer archive.Close()
+
+	r, err := DecompressStream(archive)
+	if err != nil {
+		t.Fatalf("Failed to decompress %s: %v", filename, err)
+	}
+	if _, err = io.ReadAll(r); err != nil {
+		t.Fatalf("Failed to read the decompressed stream: %v ", err)
+	}
+	if err = r.Close(); err != nil {
+		t.Fatalf("Failed to close the decompressed stream: %v ", err)
+	}
+
+	return r
+}
+
+func TestDecompressStreamGzip(t *testing.T) {
+	testDecompressStream(t, "gz", "gzip -f")
+}
+
+func TestDecompressStreamBzip2(t *testing.T) {
+	testDecompressStream(t, "bz2", "bzip2 -f")
+}
+
+func TestDecompressStreamXz(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Xz not present in msys2")
+	}
+	testDecompressStream(t, "xz", "xz -f")
+}
+
+func TestDecompressStreamZstd(t *testing.T) {
+	if _, err := exec.LookPath("zstd"); err != nil {
+		t.Skip("zstd not installed")
+	}
+	testDecompressStream(t, "zst", "zstd -f")
+}
+
+func TestCompressStreamXzUnsupported(t *testing.T) {
+	dest, err := os.Create(tmp + "dest")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	defer dest.Close()
+
+	_, err = CompressStream(dest, Xz)
+	if err == nil {
+		t.Fatalf("Should fail as xz is unsupported for compression format.")
+	}
+}
+
+func TestCompressStreamBzip2Unsupported(t *testing.T) {
+	dest, err := os.Create(tmp + "dest")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	defer dest.Close()
+
+	_, err = CompressStream(dest, Bzip2)
+	if err == nil {
+		t.Fatalf("Should fail as bzip2 is unsupported for compression format.")
+	}
+}
+
+func TestCompressStreamInvalid(t *testing.T) {
+	dest, err := os.Create(tmp + "dest")
+	if err != nil {
+		t.Fatalf("Fail to create the destination file")
+	}
+	defer dest.Close()
+
+	_, err = CompressStream(dest, -1)
+	if err == nil {
+		t.Fatalf("Should fail as xz is unsupported for compression format.")
+	}
+}
+
+func TestCmdStreamLargeStderr(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "dd if=/dev/zero bs=1k count=1000 of=/dev/stderr; echo hello")
+	out, err := cmdStream(cmd, nil)
+	if err != nil {
+		t.Fatalf("Failed to start command: %s", err)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, out)
+		errCh <- err
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Command should not have failed (err=%.100s...)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Command did not complete in 5 seconds; probable deadlock")
+	}
+}
+
+func TestCmdStreamBad(t *testing.T) {
+	// TODO Windows: Figure out why this is failing in CI but not locally
+	if runtime.GOOS == "windows" {
+		t.Skip("Failing on Windows CI machines")
+	}
+	badCmd := exec.Command("sh", "-c", "echo hello; echo >&2 error couldn\\'t reverse the phase pulser; exit 1")
+	out, err := cmdStream(badCmd, nil)
+	if err != nil {
+		t.Fatalf("Failed to start command: %s", err)
+	}
+	if output, err := io.ReadAll(out); err == nil {
+		t.Fatalf("Command should have failed")
+	} else if err.Error() != "exit status 1: error couldn't reverse the phase pulser\n" {
+		t.Fatalf("Wrong error value (%s)", err)
+	} else if s := string(output); s != "hello\n" {
+		t.Fatalf("Command output should be '%s', not '%s'", "hello\\n", output)
+	}
+}
+
+func TestCmdStreamGood(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo hello; exit 0")
+	out, err := cmdStream(cmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output, err := io.ReadAll(out); err != nil {
+		t.Fatalf("Command should not have failed (err=%s)", err)
+	} else if s := string(output); s != "hello\n" {
+		t.Fatalf("Command output should be '%s', not '%s'", "hello\\n", output)
+	}
+}
+
+func TestDisablePigz(t *testing.T) {
+	_, err := exec.LookPath("unpigz")
+	if err != nil {
+		t.Log("Test will not check full path when Pigz not installed")
+	}
+
+	t.Setenv("MOBY_DISABLE_PIGZ", "true")
+
+	r := testDecompressStream(t, "gz", "gzip -f")
+
+	// wrapped in closer to cancel contex and release buffer to pool
+	wrapper := r.(*readCloserWrapper)
+
+	expected := reflect.TypeOf(&gzip.Reader{})
+	actual := reflect.TypeOf(wrapper.Reader)
+	if actual != expected {
+		t.Fatalf("Expected: %v, Actual: %v", expected, actual)
+	}
+}
+
+func TestPigz(t *testing.T) {
+	r := testDecompressStream(t, "gz", "gzip -f")
+	// wrapper for buffered reader and context cancel
+	wrapper := r.(*readCloserWrapper)
+
+	_, err := exec.LookPath("unpigz")
+	if err == nil {
+		t.Log("Tested whether Pigz is used, as it installed")
+		// For the command wait wrapper
+		cmdWaitCloserWrapper := wrapper.Reader.(*readCloserWrapper)
+		expected := reflect.TypeOf(&io.PipeReader{})
+		actual := reflect.TypeOf(cmdWaitCloserWrapper.Reader)
+		if actual != expected {
+			t.Fatalf("Expected: %v, Actual: %v", expected, actual)
+		}
+	} else {
+		t.Log("Tested whether Pigz is not used, as it not installed")
+		expected := reflect.TypeOf(&gzip.Reader{})
+		actual := reflect.TypeOf(wrapper.Reader)
+		if actual != expected {
+			t.Fatalf("Expected: %v, Actual: %v", expected, actual)
+		}
 	}
 }

--- a/pkg/archive/copy.go
+++ b/pkg/archive/copy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/pkg/archive/compression"
 )
 
 // Errors used or returned by this file.
@@ -116,7 +117,7 @@ func TarResourceRebase(sourcePath, rebaseName string) (content io.ReadCloser, er
 func TarResourceRebaseOpts(sourceBase string, rebaseName string) *TarOptions {
 	filter := []string{sourceBase}
 	return &TarOptions{
-		Compression:      Uncompressed,
+		Compression:      compression.None,
 		IncludeFiles:     filter,
 		IncludeSourceDir: true,
 		RebaseNames: map[string]string{

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/pools"
 )
 
@@ -225,7 +226,7 @@ func ApplyUncompressedLayer(dest string, layer io.Reader, options *TarOptions) (
 
 // IsEmpty checks if the tar archive is empty (doesn't contain any entries).
 func IsEmpty(rd io.Reader) (bool, error) {
-	decompRd, err := DecompressStream(rd)
+	decompRd, err := compression.DecompressStream(rd)
 	if err != nil {
 		return true, fmt.Errorf("failed to decompress archive: %v", err)
 	}
@@ -251,7 +252,7 @@ func applyLayerHandler(dest string, layer io.Reader, options *TarOptions, decomp
 	defer restore()
 
 	if decompress {
-		decompLayer, err := DecompressStream(layer)
+		decompLayer, err := compression.DecompressStream(layer)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/archive/diff_test.go
+++ b/pkg/archive/diff_test.go
@@ -310,6 +310,15 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 	}
 }
 
+type readCloserWrapper struct {
+	io.Reader
+	closer func() error
+}
+
+func (r *readCloserWrapper) Close() error {
+	return r.closer()
+}
+
 func makeTestLayer(paths []string) (rc io.ReadCloser, err error) {
 	tmpDir, err := os.MkdirTemp("", "graphdriver-test-mklayer")
 	if err != nil {

--- a/pkg/archive/diff_test.go
+++ b/pkg/archive/diff_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/docker/docker/pkg/archive/compression"
 )
 
 func TestApplyLayerInvalidFilenames(t *testing.T) {
@@ -331,7 +333,7 @@ func makeTestLayer(paths []string) (rc io.ReadCloser, err error) {
 			}
 		}
 	}
-	archive, err := Tar(tmpDir, Uncompressed)
+	archive, err := Tar(tmpDir, compression.None)
 	if err != nil {
 		return
 	}

--- a/pkg/archive/fuzz_test.go
+++ b/pkg/archive/fuzz_test.go
@@ -7,13 +7,6 @@ import (
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 )
 
-func FuzzDecompressStream(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
-		r := bytes.NewReader(data)
-		_, _ = DecompressStream(r)
-	})
-}
-
 func FuzzUntar(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		ff := fuzz.NewConsumer(data)

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/idtools"
 )
 
@@ -76,7 +77,7 @@ func untarHandler(tarArchive io.Reader, dest string, options *archive.TarOptions
 
 	r := io.NopCloser(tarArchive)
 	if decompress {
-		decompressedArchive, err := archive.DecompressStream(tarArchive)
+		decompressedArchive, err := compression.DecompressStream(tarArchive)
 		if err != nil {
 			return err
 		}

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/pkg/idtools"
 	"gotest.tools/v3/skip"
 )
@@ -48,7 +49,7 @@ func TestChrootTarUntar(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(src, "lolo"), []byte("hello lolo"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	stream, err := archive.Tar(src, archive.Uncompressed)
+	stream, err := archive.Tar(src, compression.None)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +74,7 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(src, "toto"), []byte("hello toto"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	stream, err := archive.Tar(src, archive.Uncompressed)
+	stream, err := archive.Tar(src, compression.None)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +277,7 @@ func TestChrootUntarPath(t *testing.T) {
 	}
 
 	// Untar a tar file
-	stream, err := archive.Tar(src, archive.Uncompressed)
+	stream, err := archive.Tar(src, compression.None)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +354,7 @@ func TestChrootApplyDotDotFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(src, "..gitme"), []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	stream, err := archive.Tar(src, archive.Uncompressed)
+	stream, err := archive.Tar(src, compression.None)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/moby/sys/userns"
 )
 
@@ -15,7 +16,7 @@ import (
 // contents of the layer.
 func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions, decompress bool) (size int64, err error) {
 	if decompress {
-		decompressed, err := archive.DecompressStream(layer)
+		decompressed, err := compression.DecompressStream(layer)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 )
 
 // applyLayerHandler parses a diff in the standard layer format from `layer`, and
@@ -13,7 +14,7 @@ import (
 // contents of the layer.
 func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions, decompress bool) (size int64, err error) {
 	if decompress {
-		decompressed, err := archive.DecompressStream(layer)
+		decompressed, err := compression.DecompressStream(layer)
 		if err != nil {
 			return 0, err
 		}

--- a/testutil/fixtures/plugin/plugin.go
+++ b/testutil/fixtures/plugin/plugin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/archive/compression"
 	"github.com/docker/docker/plugin"
 	registrypkg "github.com/docker/docker/registry"
 	"github.com/pkg/errors"
@@ -205,7 +206,7 @@ func makePluginBundle(inPath string, opts ...CreateOpt) (io.ReadCloser, error) {
 	if err := archive.NewDefaultArchiver().CopyFileWithTar(cfg.binPath, filepath.Join(inPath, "rootfs", p.Entrypoint[0])); err != nil {
 		return nil, errors.Wrap(err, "error copying plugin binary to rootfs path")
 	}
-	tar, err := archive.Tar(inPath, archive.Uncompressed)
+	tar, err := archive.Tar(inPath, compression.None)
 	return tar, errors.Wrap(err, "error making plugin archive")
 }
 


### PR DESCRIPTION
This is _really_ (really!) WIP; something I was considering if this would make sense to do; fun fact; when I started doing this, I noticed that containerd's fork of `pkg/archive` did exactly the same, so doing this would align our implementation more with containerd's approach; https://github.com/containerd/containerd/tree/v2.0.1/pkg/archive/compression

containerd has some minor differences in the `Compression` type;

- `Compression.Extension()` only returns file extension for the _compression_ (e.g. `.gzip`) instead of also including `.tar`;  https://github.com/containerd/containerd/blob/v2.0.1/pkg/archive/compression/compression.go#L256-L266
- Containerd preserves the compression in the `readCloserWrapper`, and povides a `GetCompression()` accessor for this https://github.com/containerd/containerd/blob/v2.0.1/pkg/archive/compression/compression.go#L88-L90
- containerd 2.0 also supports Intel's `igzip` (in addition to `pigz`); https://github.com/containerd/containerd/pull/9200


In reverse, Moby;

- Supports additional  compression types (e.g. `Xz`, `Bzip2`), which are not supported in containers)
- Has an atomic `closed` field for `readCloserWrapper ` https://github.com/moby/moby/blob/a72026acbbdfcf90f0ba203abd4e0943e3d546e7/pkg/archive/archive.go#L221-L233


I'm not sure if we actually need that one though, as it was added to work around an OTEL issue, and not sure if we actually hit that codepath in this code; https://github.com/moby/moby/commit/585d74bad162e0946d17808e316d10e60cb9ac59 (https://github.com/moby/moby/pull/46419)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

