### PR TITLE
pkg/ioutils: remove OnEOFReader and move it internal

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -61,35 +61,6 @@ func NewReaderErrWrapper(r io.Reader, closer func()) io.Reader {
 	}
 }
 
-// OnEOFReader wraps an io.ReadCloser and a function
-// the function will run at the end of file or close the file.
-type OnEOFReader struct {
-	Rc io.ReadCloser
-	Fn func()
-}
-
-func (r *OnEOFReader) Read(p []byte) (n int, err error) {
-	n, err = r.Rc.Read(p)
-	if err == io.EOF {
-		r.runFunc()
-	}
-	return
-}
-
-// Close closes the file and run the function.
-func (r *OnEOFReader) Close() error {
-	err := r.Rc.Close()
-	r.runFunc()
-	return err
-}
-
-func (r *OnEOFReader) runFunc() {
-	if fn := r.Fn; fn != nil {
-		fn()
-		r.Fn = nil
-	}
-}
-
 // cancelReadCloser wraps an io.ReadCloser with a context for cancelling read
 // operations.
 type cancelReadCloser struct {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/13375
- relates to https://github.com/moby/moby/issues/32989

This type was originally in pkg/transport, but got moved to pkg/ioutils in 276c640be4b4335e3b8d684cb3562a56d3337b39.

This type is only used in a single location, and has no external consumers, so we can move it where it's used and un-export it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go-SDK: pkg/ioutils: remove OnEOFReader, which was  only used  internally
```

**- A picture of a cute animal (not mandatory but encouraged)**

