### PR TITLE
remove pkg/broadcaster and make it internal to container/streams

### DIFF
--- a/container/stream/streams.go
+++ b/container/stream/streams.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/log"
-	"github.com/docker/docker/pkg/broadcaster"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/pools"
 )
@@ -25,8 +24,8 @@ import (
 // a kind of "broadcaster".
 type Config struct {
 	wg        sync.WaitGroup
-	stdout    *broadcaster.Unbuffered
-	stderr    *broadcaster.Unbuffered
+	stdout    *unbuffered
+	stderr    *unbuffered
 	stdin     io.ReadCloser
 	stdinPipe io.WriteCloser
 	dio       *cio.DirectIO
@@ -36,18 +35,18 @@ type Config struct {
 // the standard err and standard out to new unbuffered broadcasters.
 func NewConfig() *Config {
 	return &Config{
-		stderr: new(broadcaster.Unbuffered),
-		stdout: new(broadcaster.Unbuffered),
+		stderr: new(unbuffered),
+		stdout: new(unbuffered),
 	}
 }
 
 // Stdout returns the standard output in the configuration.
-func (c *Config) Stdout() *broadcaster.Unbuffered {
+func (c *Config) Stdout() io.Writer {
 	return c.stdout
 }
 
 // Stderr returns the standard error in the configuration.
-func (c *Config) Stderr() *broadcaster.Unbuffered {
+func (c *Config) Stderr() io.Writer {
 	return c.stderr
 }
 

--- a/container/stream/unbuffered.go
+++ b/container/stream/unbuffered.go
@@ -1,18 +1,18 @@
-package broadcaster // import "github.com/docker/docker/pkg/broadcaster"
+package stream
 
 import (
 	"io"
 	"sync"
 )
 
-// Unbuffered accumulates multiple io.WriteCloser by stream.
-type Unbuffered struct {
+// unbuffered accumulates multiple io.WriteCloser by stream.
+type unbuffered struct {
 	mu      sync.Mutex
 	writers []io.WriteCloser
 }
 
 // Add adds new io.WriteCloser.
-func (w *Unbuffered) Add(writer io.WriteCloser) {
+func (w *unbuffered) Add(writer io.WriteCloser) {
 	w.mu.Lock()
 	w.writers = append(w.writers, writer)
 	w.mu.Unlock()
@@ -20,7 +20,7 @@ func (w *Unbuffered) Add(writer io.WriteCloser) {
 
 // Write writes bytes to all writers. Failed writers will be evicted during
 // this call.
-func (w *Unbuffered) Write(p []byte) (n int, err error) {
+func (w *unbuffered) Write(p []byte) (n int, err error) {
 	w.mu.Lock()
 	var evict []int
 	for i, sw := range w.writers {
@@ -38,7 +38,7 @@ func (w *Unbuffered) Write(p []byte) (n int, err error) {
 
 // Clean closes and removes all writers. Last non-eol-terminated part of data
 // will be saved.
-func (w *Unbuffered) Clean() error {
+func (w *unbuffered) Clean() error {
 	w.mu.Lock()
 	for _, sw := range w.writers {
 		sw.Close()

--- a/container/stream/unbuffered_test.go
+++ b/container/stream/unbuffered_test.go
@@ -1,4 +1,4 @@
-package broadcaster // import "github.com/docker/docker/pkg/broadcaster"
+package stream
 
 import (
 	"bytes"
@@ -28,7 +28,7 @@ func (dw *dummyWriter) Close() error {
 }
 
 func TestUnbuffered(t *testing.T) {
-	writer := new(Unbuffered)
+	writer := new(unbuffered)
 
 	// Test 1: Both bufferA and bufferB should contain "foo"
 	bufferA := &dummyWriter{}
@@ -114,7 +114,7 @@ func (d devNullCloser) Write(buf []byte) (int, error) {
 
 // This test checks for races. It is only useful when run with the race detector.
 func TestRaceUnbuffered(t *testing.T) {
-	writer := new(Unbuffered)
+	writer := new(unbuffered)
 	c := make(chan bool)
 	go func() {
 		writer.Add(devNullCloser(0))
@@ -125,7 +125,7 @@ func TestRaceUnbuffered(t *testing.T) {
 }
 
 func BenchmarkUnbuffered(b *testing.B) {
-	writer := new(Unbuffered)
+	writer := new(unbuffered)
 	setUpWriter := func() {
 		for i := 0; i < 100; i++ {
 			writer.Add(devNullCloser(0))


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/32989

This package was only used internally in container/streams and had no external consumers.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go-SDK: remove pkg/broadcaster, as it was only used internally
```

**- A picture of a cute animal (not mandatory but encouraged)**

