### PR TITLE
deprecate pkg/parsers.ParseKeyValueOpt and move internal

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -39,7 +39,6 @@ import (
 	"github.com/docker/docker/daemon/internal/fstype"
 	"github.com/docker/docker/internal/containerfs"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/go-units"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/userns"
@@ -121,7 +120,7 @@ func parseOptions(opt []string) (btrfsOptions, bool, error) {
 	var options btrfsOptions
 	userDiskQuota := false
 	for _, option := range opt {
-		key, val, err := parsers.ParseKeyValueOpt(option)
+		key, val, err := graphdriver.ParseStorageOptKeyValue(option)
 		if err != nil {
 			return options, userDiskQuota, err
 		}

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -26,7 +26,6 @@ import (
 	"github.com/docker/docker/pkg/atomicwriter"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/quota"
 	"github.com/docker/go-units"
 	"github.com/moby/locker"
@@ -235,7 +234,7 @@ func isMounted(path string) bool {
 func parseOptions(options []string) (*overlayOptions, error) {
 	o := &overlayOptions{}
 	for _, option := range options {
-		key, val, err := parsers.ParseKeyValueOpt(option)
+		key, val, err := graphdriver.ParseStorageOptKeyValue(option)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/graphdriver/utils.go
+++ b/daemon/graphdriver/utils.go
@@ -1,0 +1,16 @@
+package graphdriver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseStorageOptKeyValue parses and validates the specified string as a key/value
+// pair (key=value).
+func ParseStorageOptKeyValue(opt string) (key string, value string, err error) {
+	k, v, ok := strings.Cut(opt, "=")
+	if !ok {
+		return "", "", fmt.Errorf("unable to parse storage-opt key/value: %s", opt)
+	}
+	return strings.TrimSpace(k), strings.TrimSpace(v), nil
+}

--- a/daemon/graphdriver/utils_test.go
+++ b/daemon/graphdriver/utils_test.go
@@ -1,0 +1,30 @@
+package graphdriver
+
+import "testing"
+
+func TestParseKeyValueOpt(t *testing.T) {
+	invalids := map[string]string{
+		"":    "unable to parse storage-opt key/value: ",
+		"key": "unable to parse storage-opt key/value: key",
+	}
+	for invalid, expectedError := range invalids {
+		if _, _, err := ParseStorageOptKeyValue(invalid); err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error %v for %v, got %v", expectedError, invalid, err)
+		}
+	}
+	valids := map[string][]string{
+		"key=value":               {"key", "value"},
+		" key = value ":           {"key", "value"},
+		"key=value1=value2":       {"key", "value1=value2"},
+		" key = value1 = value2 ": {"key", "value1 = value2"},
+	}
+	for valid, expectedKeyValue := range valids {
+		key, value, err := ParseStorageOptKeyValue(valid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if key != expectedKeyValue[0] || value != expectedKeyValue[1] {
+			t.Fatalf("Expected {%v: %v} got {%v: %v}", expectedKeyValue[0], expectedKeyValue[1], key, value)
+		}
+	}
+}

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/containerfs"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/quota"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -100,7 +99,7 @@ func (d *Driver) Cleanup() error {
 
 func (d *Driver) parseOptions(options []string) error {
 	for _, option := range options {
-		key, val, err := parsers.ParseKeyValueOpt(option)
+		key, val, err := graphdriver.ParseStorageOptKeyValue(option)
 		if err != nil {
 			return errdefs.InvalidParameter(err)
 		}

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/internal/mountref"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/parsers"
 	zfs "github.com/mistifyio/go-zfs/v3"
 	"github.com/moby/locker"
 	"github.com/moby/sys/mount"
@@ -136,7 +135,7 @@ func parseOptions(opt []string) (zfsOptions, error) {
 	var options zfsOptions
 	options.fsName = ""
 	for _, option := range opt {
-		key, val, err := parsers.ParseKeyValueOpt(option)
+		key, val, err := graphdriver.ParseStorageOptKeyValue(option)
 		if err != nil {
 			return options, err
 		}

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -11,6 +11,8 @@ import (
 
 // ParseKeyValueOpt parses and validates the specified string as a key/value
 // pair (key=value).
+//
+// Deprecated: use [strings.Cut] instead. This utility was only used internally, and will be removed in the next release.
 func ParseKeyValueOpt(opt string) (key string, value string, err error) {
 	k, v, ok := strings.Cut(opt, "=")
 	if !ok {

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -5,33 +5,6 @@ import (
 	"testing"
 )
 
-func TestParseKeyValueOpt(t *testing.T) {
-	invalids := map[string]string{
-		"":    "unable to parse key/value option: ",
-		"key": "unable to parse key/value option: key",
-	}
-	for invalid, expectedError := range invalids {
-		if _, _, err := ParseKeyValueOpt(invalid); err == nil || err.Error() != expectedError {
-			t.Fatalf("Expected error %v for %v, got %v", expectedError, invalid, err)
-		}
-	}
-	valids := map[string][]string{
-		"key=value":               {"key", "value"},
-		" key = value ":           {"key", "value"},
-		"key=value1=value2":       {"key", "value1=value2"},
-		" key = value1 = value2 ": {"key", "value1 = value2"},
-	}
-	for valid, expectedKeyValue := range valids {
-		key, value, err := ParseKeyValueOpt(valid)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if key != expectedKeyValue[0] || value != expectedKeyValue[1] {
-			t.Fatalf("Expected {%v: %v} got {%v: %v}", expectedKeyValue[0], expectedKeyValue[1], key, value)
-		}
-	}
-}
-
 func TestParseUintList(t *testing.T) {
 	valids := map[string]map[int]bool{
 		"":             {},


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/32989
- [x] depends on / stacked on https://github.com/moby/moby/pull/48979

### deprecate pkg/parsers.ParseKeyValueOpt and move internal

Move the utility to where it's used, and deprecate the implementation
in pkg/parsers.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: deprecate pkg/parsers.ParseKeyValueOpt
```


**- A picture of a cute animal (not mandatory but encouraged)**

