### PR TITLE
improve validation of cpu-shares, and migrate TestRunInvalidCPUShares

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -137,10 +137,10 @@ func getPidsLimit(config containertypes.Resources) *specs.LinuxPids {
 func getCPUResources(config containertypes.Resources) (*specs.LinuxCPU, error) {
 	cpu := specs.LinuxCPU{}
 
-	if config.CPUShares < 0 {
-		return nil, fmt.Errorf("shares: invalid argument")
-	}
-	if config.CPUShares > 0 {
+	if config.CPUShares != 0 {
+		if config.CPUShares < 0 {
+			return nil, fmt.Errorf("invalid CPU shares (%d): value must be a positive integer", config.CPUShares)
+		}
 		shares := uint64(config.CPUShares)
 		cpu.Shares = &shares
 	}

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -724,24 +724,6 @@ func (s *DockerCLIRunSuite) TestRunInvalidCpusetMemsFlagValue(c *testing.T) {
 	assert.Assert(c, is.Contains(out, expected))
 }
 
-func (s *DockerCLIRunSuite) TestRunInvalidCPUShares(c *testing.T) {
-	testRequires(c, cpuShare, DaemonIsLinux)
-	out, _, err := dockerCmdWithError("run", "--cpu-shares", "1", "busybox", "echo", "test")
-	assert.ErrorContains(c, err, "", out)
-	expected := "minimum allowed cpu-shares is 2"
-	assert.Assert(c, is.Contains(out, expected))
-
-	out, _, err = dockerCmdWithError("run", "--cpu-shares", "-1", "busybox", "echo", "test")
-	assert.ErrorContains(c, err, "", out)
-	expected = "shares: invalid argument"
-	assert.Assert(c, is.Contains(out, expected))
-
-	out, _, err = dockerCmdWithError("run", "--cpu-shares", "99999999", "busybox", "echo", "test")
-	assert.ErrorContains(c, err, "", out)
-	expected = "maximum allowed cpu-shares is"
-	assert.Assert(c, is.Contains(out, expected))
-}
-
 func (s *DockerCLIRunSuite) TestRunWithDefaultShmSize(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -644,6 +644,11 @@ func TestCreateInvalidHostConfig(t *testing.T) {
 			hc:          container.HostConfig{Annotations: map[string]string{"": "a"}},
 			expectedErr: "Error response from daemon: invalid Annotations: the empty string is not permitted as an annotation key",
 		},
+		{
+			doc:         "invalid CPUShares",
+			hc:          container.HostConfig{Resources: container.Resources{CPUShares: -1}},
+			expectedErr: "Error response from daemon: invalid CPU shares (-1): value must be a positive integer",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -27,14 +27,12 @@ func TestValidateResources(t *testing.T) {
 			FailureMsg:               "Expected valid configuration",
 		},
 		{
-			ConfigCPURealtimePeriod:  5000,
-			ConfigCPURealtimeRuntime: 5000,
-			SysInfoCPURealtime:       false,
-			ErrorExpected:            true,
-			FailureMsg:               "Expected failure when cpu-rt-period is set but kernel doesn't support it",
+			ConfigCPURealtimePeriod: 5000,
+			SysInfoCPURealtime:      false,
+			ErrorExpected:           true,
+			FailureMsg:              "Expected failure when cpu-rt-period is set but kernel doesn't support it",
 		},
 		{
-			ConfigCPURealtimePeriod:  5000,
 			ConfigCPURealtimeRuntime: 5000,
 			SysInfoCPURealtime:       false,
 			ErrorExpected:            true,

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -7,56 +7,69 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/sysinfo"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestValidateResources(t *testing.T) {
 	type resourceTest struct {
-		ConfigCPURealtimePeriod  int64
-		ConfigCPURealtimeRuntime int64
-		SysInfoCPURealtime       bool
-		ErrorExpected            bool
-		FailureMsg               string
+		doc                string
+		resources          container.Resources
+		sysInfoCPURealtime bool
+		expectedError      string
 	}
 
 	tests := []resourceTest{
 		{
-			ConfigCPURealtimePeriod:  1000,
-			ConfigCPURealtimeRuntime: 1000,
-			SysInfoCPURealtime:       true,
-			ErrorExpected:            false,
-			FailureMsg:               "Expected valid configuration",
+			doc: "empty configuration",
 		},
 		{
-			ConfigCPURealtimePeriod: 5000,
-			SysInfoCPURealtime:      false,
-			ErrorExpected:           true,
-			FailureMsg:              "Expected failure when cpu-rt-period is set but kernel doesn't support it",
+			doc: "valid configuration",
+			resources: container.Resources{
+				CPURealtimePeriod:  1000,
+				CPURealtimeRuntime: 1000,
+			},
+			sysInfoCPURealtime: true,
 		},
 		{
-			ConfigCPURealtimeRuntime: 5000,
-			SysInfoCPURealtime:       false,
-			ErrorExpected:            true,
-			FailureMsg:               "Expected failure when cpu-rt-runtime is set but kernel doesn't support it",
+			doc: "cpu-rt-period not supported",
+			resources: container.Resources{
+				CPURealtimePeriod: 5000,
+			},
+			expectedError: "kernel does not support CPU real-time scheduler",
 		},
 		{
-			ConfigCPURealtimePeriod:  5000,
-			ConfigCPURealtimeRuntime: 10000,
-			SysInfoCPURealtime:       true,
-			ErrorExpected:            true,
-			FailureMsg:               "Expected failure when cpu-rt-runtime is greater than cpu-rt-period",
+			doc: "cpu-rt-runtime not supported",
+			resources: container.Resources{
+				CPURealtimeRuntime: 5000,
+			},
+			expectedError: "kernel does not support CPU real-time scheduler",
+		},
+		{
+			doc: "cpu-rt-runtime greater than cpu-rt-period",
+			resources: container.Resources{
+				CPURealtimePeriod:  5000,
+				CPURealtimeRuntime: 10000,
+			},
+			sysInfoCPURealtime: true,
+			expectedError:      "cpu real-time runtime cannot be higher than cpu real-time period",
 		},
 	}
 
-	for _, rt := range tests {
-		var hc container.HostConfig
-		hc.Resources.CPURealtimePeriod = rt.ConfigCPURealtimePeriod
-		hc.Resources.CPURealtimeRuntime = rt.ConfigCPURealtimeRuntime
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			var hc container.HostConfig
+			hc.Resources = tc.resources
 
-		var si sysinfo.SysInfo
-		si.CPURealtime = rt.SysInfoCPURealtime
+			var si sysinfo.SysInfo
+			si.CPURealtime = tc.sysInfoCPURealtime
 
-		if err := validateResources(&hc, &si); (err != nil) != rt.ErrorExpected {
-			t.Fatal(rt.FailureMsg, err)
-		}
+			err := validateResources(&hc, &si)
+			if tc.expectedError != "" {
+				assert.Check(t, is.Error(err, tc.expectedError))
+			} else {
+				assert.NilError(t, err)
+			}
+		})
 	}
 }

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -56,6 +56,16 @@ func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
 	if hc.Resources.CPURealtimePeriod != 0 && hc.Resources.CPURealtimeRuntime != 0 && hc.Resources.CPURealtimeRuntime > hc.Resources.CPURealtimePeriod {
 		return validationError("cpu real-time runtime cannot be higher than cpu real-time period")
 	}
+	if si.CPUShares {
+		// We're only producing an error if CPU-shares are supported to preserve
+		// existing behavior. The OCI runtime may still reject the config though.
+		// We should consider making this an error-condition when trying to set
+		// CPU-shares on a system that doesn't support it instead of silently
+		// ignoring.
+		if hc.Resources.CPUShares < 0 {
+			return validationError(fmt.Sprintf("invalid CPU shares (%d): value must be a positive integer", hc.Resources.CPUShares))
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
### runconfig: TestValidateResources: fix duplicate test-case

Make sure we're testing for the right condition.

### runconfig: TestValidateResources: use subtests

- rewrite to use subtests
- check for actual error returned

### improve validation of cpu-shares, and migrate TestRunInvalidCPUShares

This test was testing errors produced by runc; both the "maximum" and
"minimum" values originate from the OCI runtime;
https://github.com/opencontainers/runc/blob/d48d9cfefcdc13862ade35fd2df428cf9798bf22/libcontainer/cgroups/fs/cpu.go#L66-L83

    docker run --cpu-shares=1 alpine
    docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error setting cgroup config for procHooks process: the minimum allowed cpu-shares is 2: unknown.

Happy path for this setting is covered by TestRunWithCPUShares, and
various other tests, so we validate that the options take effect;
https://github.com/moby/moby/blob/f5af46d4d5db591da5ce330c9936baecd1df5d9c/integration-cli/docker_cli_run_unix_test.go#L494-L503

This patch:

- removes the test and migrates it to an integration test
- removes the checks for errors that might be produced by runc
- updates our validation for invalid (negative) values to happen
  when creating the contaienr; the existing check that happened when
  creating the OCI spec is preserved, so that configs of existing containers
  are still validated.
- updates validateResources to return the correct error-type
- updated unit-test to validate

With this patch:

    make TEST_FILTER='TestCreateInvalidHostConfig' TEST_SKIP_INTEGRATION_CLI=1 test-integration
    --- PASS: TestCreateInvalidHostConfig (0.00s)
        --- PASS: TestCreateInvalidHostConfig/invalid_IpcMode (0.00s)
        --- PASS: TestCreateInvalidHostConfig/invalid_CPUShares (0.00s)
        --- PASS: TestCreateInvalidHostConfig/invalid_PidMode (0.00s)
        --- PASS: TestCreateInvalidHostConfig/invalid_PidMode_without_container_ID (0.00s)
        --- PASS: TestCreateInvalidHostConfig/invalid_Annotations (0.00s)
        --- PASS: TestCreateInvalidHostConfig/invalid_UTSMode (0.00s)




**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

