### PR TITLE
daemon: remove workaround for  go1.21 compiler bug

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -371,14 +371,11 @@ func getConfigOrEnv(config string, env ...string) string {
 	return getEnvAny(env...)
 }
 
-// promoteNil converts a nil slice to an empty slice.
+// promoteNil converts a nil slice to an empty slice of that type.
 // A non-nil slice is returned as is.
-//
-// TODO: make generic again once we are a go module,
-// go.dev/issue/64759 is fixed, or we drop support for Go 1.21.
-func promoteNil(s []string) []string {
+func promoteNil[S ~[]E, E any](s S) S {
 	if s == nil {
-		return []string{}
+		return S{}
 	}
 	return s
 }


### PR DESCRIPTION
- reverts https://github.com/moby/moby/pull/47020
- relates to https://github.com/golang/go/issues/64759
- relates to https://github.com/golang/go/issues/66064
- relates to https://github.com/golang/go/commit/efb7cc4275d20628d670493997c8952c49391f6e / https://github.com/golang/go/issues/66326


I checked this with https://github.com/moby/moby/pull/46941 (but requires https://github.com/moby/moby/pull/49186 to pass)

This reverts commit 6d2c4f87af873e5c23d8b2bd60f6cd682e615b5b.

https://go.dev/issue/64759 should be fixed in go1.21.9 through https://go.dev/cl/574736, so we can revert the workaround.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

