### PR TITLE
daemon: adjust tests for changes in go1.24 JSON errors

### DIFF
--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -161,7 +161,7 @@ func TestDaemonConfigurationFeatures(t *testing.T) {
 		{
 			name:        "invalid config value",
 			config:      `{"features": {"containerd-snapshotter": "not-a-boolean"}}`,
-			expectedErr: `json: cannot unmarshal string into Go struct field Config.features of type bool`,
+			expectedErr: `json: cannot unmarshal string into Go struct field`,
 		},
 	}
 
@@ -179,7 +179,7 @@ func TestDaemonConfigurationFeatures(t *testing.T) {
 			}
 			cc, err := MergeDaemonConfigurations(c, flags, configFile)
 			if tc.expectedErr != "" {
-				assert.Error(t, err, tc.expectedErr)
+				assert.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				assert.NilError(t, err)
 				assert.Check(t, is.DeepEqual(tc.expectedValue, cc.Features))
@@ -304,7 +304,7 @@ func TestDaemonConfigurationHostGatewayIP(t *testing.T) {
 		{
 			name:   "config not array",
 			config: `{"host-gateway-ips": "192.0.2.1"}`,
-			expErr: `json: cannot unmarshal string into Go struct field Config.host-gateway-ips of type []netip.Addr`,
+			expErr: `json: cannot unmarshal string into Go struct field`,
 		},
 		{
 			name:   "config old and new",
@@ -351,7 +351,7 @@ func TestDaemonConfigurationHostGatewayIP(t *testing.T) {
 			}
 			cc, err := MergeDaemonConfigurations(c, flags, configFile)
 			if tc.expErr != "" {
-				assert.Check(t, is.Error(err, tc.expErr))
+				assert.Check(t, is.ErrorContains(err, tc.expErr))
 				assert.Check(t, is.Nil(cc))
 			} else {
 				assert.NilError(t, err)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49174


These tests failed because the error message changed in go1.24 through https://go.dev/cl/606956.

    === Failed
    === FAIL: daemon/config TestDaemonConfigurationFeatures/invalid_config_value (0.00s)
        config_linux_test.go:182: assertion failed: expected error "json: cannot unmarshal string into Go struct field Config.features of type bool", got "json: cannot unmarshal string into Go struct field Config.CommonConfig.features of type bool"

    === FAIL: daemon/config TestDaemonConfigurationFeatures (0.00s)

    === FAIL: daemon/config TestDaemonConfigurationHostGatewayIP/config_not_array (0.00s)
        config_linux_test.go:354: assertion failed: expected error "json: cannot unmarshal string into Go struct field Config.host-gateway-ips of type []netip.Addr", got "json: cannot unmarshal string into Go struct field Config.CommonConfig.DNSConfig.host-gateway-ips of type []netip.Addr"

Relax the tests a bit to accept errors produced by either go1.24 or older.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

