### PR TITLE
[27.x backport]  Use the roundtripper during build

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -148,7 +148,7 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 	}
 	wo.Executor = exec
 
-	w, err := mobyworker.NewContainerdWorker(ctx, wo, opt.Callbacks)
+	w, err := mobyworker.NewContainerdWorker(ctx, wo, opt.Callbacks, rt)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/builder-next/worker/containerdworker.go
+++ b/builder/builder-next/worker/containerdworker.go
@@ -2,11 +2,14 @@ package worker
 
 import (
 	"context"
+	nethttp "net/http"
 
+	"github.com/containerd/log"
 	"github.com/docker/docker/builder/builder-next/exporter"
 	"github.com/moby/buildkit/client"
 	bkexporter "github.com/moby/buildkit/exporter"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/source/http"
 	"github.com/moby/buildkit/worker/base"
 )
 
@@ -17,11 +20,21 @@ type ContainerdWorker struct {
 }
 
 // NewContainerdWorker instantiates a local worker.
-func NewContainerdWorker(ctx context.Context, wo base.WorkerOpt, callbacks exporter.BuildkitCallbacks) (*ContainerdWorker, error) {
+func NewContainerdWorker(ctx context.Context, wo base.WorkerOpt, callbacks exporter.BuildkitCallbacks, rt nethttp.RoundTripper) (*ContainerdWorker, error) {
 	bw, err := base.NewWorker(ctx, wo)
 	if err != nil {
 		return nil, err
 	}
+	hs, err := http.NewSource(http.Opt{
+		CacheAccessor: bw.CacheManager(),
+		Transport:     rt,
+	})
+	if err == nil {
+		bw.SourceManager.Register(hs)
+	} else {
+		log.G(ctx).Warnf("Could not register builder http source: %s", err)
+	}
+
 	return &ContainerdWorker{Worker: bw, callbacks: callbacks}, nil
 }
 


### PR DESCRIPTION
Backport 

* https://github.com/moby/moby/pull/49178

---

**- What I did**
Added the roundtripper to the containerd worker source manager.

The roundtripper is responsible for giving back the build context when it comes from a tar directly. So we add it to the source manager of the containerd worker.

fixes #47717

**- How I did it**

**- How to verify it**

With the sample reproducer from https://github.com/moby/moby/issues/47717

You can also try this terraform:

```terraform
terraform {
  required_providers {
    docker = {
      source  = "kreuzwerker/docker"
      version = "~> 3.0.2"
    }
  }
}

provider "docker" {
  host = "unix:///tmp/docker.sock"
}

resource "docker_image" "my-image" {
  name = "my-image:latest"

  build {
    context = "${path.cwd}"
  }
}
```

Output of the apply:

```console
➜ terraform apply
docker_image.my-image: Refreshing state... [id=sha256:09fe4d17ab2ba82f9e3edb4355216f312a36d58ecf2510271bb225faee0b6329my-image:latest]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # docker_image.my-image will be created
  + resource "docker_image" "my-image" {
      + id          = (known after apply)
      + image_id    = (known after apply)
      + name        = "my-image:latest"
      + repo_digest = (known after apply)

      + build {
          + cache_from     = []
          + context        = "/home/rumpl/tftest"
          + dockerfile     = "Dockerfile"
          + extra_hosts    = []
          + remove         = true
          + security_opt   = []
          + tag            = []
            # (11 unchanged attributes hidden)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

docker_image.my-image: Creating...
docker_image.my-image: Creation complete after 3s [id=sha256:76c0301c79d56873b8aebf2442bd93e78f53fb9b95700448497ef68b20136fdcmy-image:latest]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
➜ docker -c local images
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
my-image     latest    76c0301c79d5   11 seconds ago   6.57MB
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Fix passing a build context via tarball to the `/build` endpoint.
```

**- A picture of a cute animal (not mandatory but encouraged)**

