### PR TITLE
vendor: github.com/Azure/go-ansiterm faa5f7b0171c, remove workaround for OSC string terminator parsing

### DIFF
--- a/integration/internal/termtest/stripansi.go
+++ b/integration/internal/termtest/stripansi.go
@@ -2,12 +2,9 @@ package termtest // import "github.com/docker/docker/integration/internal/termte
 
 import (
 	"errors"
-	"regexp"
 
 	"github.com/Azure/go-ansiterm"
 )
-
-var stripOSC = regexp.MustCompile(`\x1b\][^\x1b\a]*(\x1b\\|\a)`)
 
 // StripANSICommands attempts to strip ANSI console escape and control sequences
 // from s, returning a string containing only the final printed characters which
@@ -26,9 +23,6 @@ var stripOSC = regexp.MustCompile(`\x1b\][^\x1b\a]*(\x1b\\|\a)`)
 // Handlers for several ANSI control sequences are also unimplemented; attempts
 // to parse a string containing one will panic.
 func StripANSICommands(s string, opts ...ansiterm.Option) (string, error) {
-	// Work around https://github.com/Azure/go-ansiterm/issues/34
-	s = stripOSC.ReplaceAllLiteralString(s, "")
-
 	var h stringHandler
 	p := ansiterm.CreateParser("Ground", &h, opts...)
 	_, err := p.Parse([]byte(s))

--- a/vendor.mod
+++ b/vendor.mod
@@ -13,7 +13,7 @@ require (
 	code.cloudfoundry.org/clock v1.1.0
 	dario.cat/mergo v1.0.1
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
-	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c
 	github.com/Graylog2/go-gelf v0.0.0-20191017102106-1550ee647df0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/Microsoft/hcsshim v0.12.8

--- a/vendor.sum
+++ b/vendor.sum
@@ -17,8 +17,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 h1:59MxjQVfjXsBpLy+dbd2/ELV5ofnUkUZBvWSC85sheA=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0/go.mod h1:OahwfttHWG6eJ0clwcfBAHoDI6X/LV/15hx/wlMZSrU=
-github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
-github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
+github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Graylog2/go-gelf v0.0.0-20191017102106-1550ee647df0 h1:cOjLyhBhe91glgZZNbQUg9BJC57l6BiSKov0Ivv7k0U=

--- a/vendor/github.com/Azure/go-ansiterm/osc_string_state.go
+++ b/vendor/github.com/Azure/go-ansiterm/osc_string_state.go
@@ -11,21 +11,13 @@ func (oscState oscStringState) Handle(b byte) (s state, e error) {
 		return nextState, err
 	}
 
-	switch {
-	case isOscStringTerminator(b):
+	// There are several control characters and sequences which can
+	// terminate an OSC string. Most of them are handled by the baseState
+	// handler. The ANSI_BEL character is a special case which behaves as a
+	// terminator only for an OSC string.
+	if b == ANSI_BEL {
 		return oscState.parser.ground, nil
 	}
 
 	return oscState, nil
-}
-
-// See below for OSC string terminators for linux
-// http://man7.org/linux/man-pages/man4/console_codes.4.html
-func isOscStringTerminator(b byte) bool {
-
-	if b == ANSI_BEL || b == 0x5C {
-		return true
-	}
-
-	return false
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -28,7 +28,7 @@ github.com/AdaLogics/go-fuzz-headers
 # github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0
 ## explicit; go 1.18
 github.com/AdamKorcz/go-118-fuzz-build/testing
-# github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161
+# github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c
 ## explicit; go 1.16
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm


### PR DESCRIPTION
relates to:

- https://github.com/Azure/go-ansiterm/issues/34
- https://github.com/Azure/go-ansiterm/pull/35
- https://github.com/moby/moby/pull/43669
- https://github.com/moby/moby/issues/43710


### vendor: github.com/Azure/go-ansiterm faa5f7b0171c

- Fix OSC string terminator parsing

full diff: https://github.com/Azure/go-ansiterm/compare/306776ec8161b5dc8676039adbf598a39bce3de0...faa5f7b0171c46bb398a91b4a0c906324d3664cf


### daemon/logger/loggertest: remove workaround for OSC string terminator parsing

This workaround was added in 2ec3e14c0ff7f8552c1f9b09ffde743632fa1f8c
to work around a [bug in go-ansiterm][1], which was fixed in [o-ansiterm#35][1].

[1]: https://github.com/Azure/go-ansiterm/issues/34
[2]: https://github.com/Azure/go-ansiterm/pull/35




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

