### PR TITLE
integration-cli: migrate TestCreateByImageID to integration suite

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -19,6 +19,7 @@ import (
 	ctr "github.com/docker/docker/integration/internal/container"
 	net "github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/oci"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/testutil"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -66,6 +67,75 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 			)
 			assert.Check(t, is.ErrorContains(err, tc.expectedError))
 			assert.Check(t, errdefs.IsNotFound(err))
+		})
+	}
+}
+
+func TestCreateByImageID(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	img, _, err := apiClient.ImageInspectWithRaw(ctx, "busybox")
+	assert.NilError(t, err)
+
+	imgIDWithAlgorithm := img.ID
+	imgID, _ := strings.CutPrefix(imgIDWithAlgorithm, "sha256:")
+	imgShortID := stringid.TruncateID(imgID)
+
+	testCases := []struct {
+		doc             string
+		image           string
+		expectedErrType func(error) bool
+		expectedErr     string
+	}{
+		{
+			doc:   "image ID with algorithm",
+			image: imgIDWithAlgorithm,
+		},
+		{
+			// test case for https://github.com/moby/moby/issues/20972
+			doc:   "image ID without algorithm",
+			image: imgID,
+		},
+		{
+			doc:   "image short-ID",
+			image: imgShortID,
+		},
+		{
+			doc:             "image with ID and algorithm as tag",
+			image:           "busybox:" + imgIDWithAlgorithm,
+			expectedErrType: errdefs.IsInvalidParameter,
+			expectedErr:     "Error response from daemon: invalid reference format",
+		},
+		{
+			doc:             "image with ID as tag",
+			image:           "busybox:" + imgID,
+			expectedErrType: errdefs.IsNotFound,
+			expectedErr:     "Error response from daemon: No such image: busybox:" + imgID,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.doc, func(t *testing.T) {
+			t.Parallel()
+			ctx := testutil.StartSpan(ctx, t)
+			resp, err := apiClient.ContainerCreate(ctx,
+				&container.Config{Image: tc.image},
+				&container.HostConfig{},
+				&network.NetworkingConfig{},
+				nil,
+				"",
+			)
+			if tc.expectedErr != "" {
+				assert.Check(t, is.DeepEqual(resp, container.CreateResponse{}))
+				assert.Check(t, is.Error(err, tc.expectedErr))
+				assert.Check(t, is.ErrorType(err, tc.expectedErrType))
+			} else {
+				assert.Check(t, resp.ID != "")
+				assert.NilError(t, err)
+			}
+			// cleanup the container if one was created.
+			_ = apiClient.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		})
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/32866


This test originally added in 4352da7803d182a6013a5238ce20a7c749db979a,
and was a bit involved as it involved building an image, and had some
dubious test-cases, such as  using `wrongimage:<ID of other image>` as
reference, and expecting that to produce a "not found" error. Possibly
this format was supported in the past, but currently it fails equally with
`correctimage:<ID of image>`.

This patch rewrites the test to an integration test, and removes the test
from integration-cli.  It also removes TestCreate64ByteHexID, as it was
duplicated by this test.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

