### PR TITLE
integration: minor cleanups  and linting fixes

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
-	ctr "github.com/docker/docker/integration/internal/container"
+	testContainer "github.com/docker/docker/integration/internal/container"
 	net "github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/testutil"
@@ -256,7 +256,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 		err = apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
 		assert.NilError(t, err)
 
-		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"))
+		poll.WaitOn(t, testContainer.IsInState(ctx, apiClient, c.ID, "exited"))
 
 		checkInspect(t, ctx, name, tc.expected)
 	}
@@ -334,7 +334,7 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 		err = apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
 		assert.NilError(t, err)
 
-		poll.WaitOn(t, ctr.IsInState(ctx, apiClient, c.ID, "exited"))
+		poll.WaitOn(t, testContainer.IsInState(ctx, apiClient, c.ID, "exited"))
 
 		checkInspect(t, ctx, name, tc.expected)
 	}
@@ -432,12 +432,12 @@ func TestCreateTmpfsOverrideAnonymousVolume(t *testing.T) {
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
-	id := ctr.Create(ctx, t, apiClient,
-		ctr.WithVolume("/foo"),
-		ctr.WithTmpfs("/foo"),
-		ctr.WithVolume("/bar"),
-		ctr.WithTmpfs("/bar:size=999"),
-		ctr.WithCmd("/bin/sh", "-c", "mount | grep '/foo' | grep tmpfs && mount | grep '/bar' | grep tmpfs"),
+	id := testContainer.Create(ctx, t, apiClient,
+		testContainer.WithVolume("/foo"),
+		testContainer.WithTmpfs("/foo"),
+		testContainer.WithVolume("/bar"),
+		testContainer.WithTmpfs("/bar:size=999"),
+		testContainer.WithCmd("/bin/sh", "-c", "mount | grep '/foo' | grep tmpfs && mount | grep '/bar' | grep tmpfs"),
 	)
 
 	defer func() {
@@ -638,10 +638,10 @@ func TestCreateWithCustomMACs(t *testing.T) {
 
 	attachCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
-	res := ctr.RunAttach(attachCtx, t, apiClient,
-		ctr.WithCmd("ip", "-o", "link", "show"),
-		ctr.WithNetworkMode("bridge"),
-		ctr.WithMacAddress("bridge", "02:32:1c:23:00:04"))
+	res := testContainer.RunAttach(attachCtx, t, apiClient,
+		testContainer.WithCmd("ip", "-o", "link", "show"),
+		testContainer.WithNetworkMode("bridge"),
+		testContainer.WithMacAddress("bridge", "02:32:1c:23:00:04"))
 
 	assert.Equal(t, res.ExitCode, 0)
 	assert.Equal(t, res.Stderr.String(), "")
@@ -682,7 +682,7 @@ func TestContainerdContainerImageInfo(t *testing.T) {
 
 	// Currently a containerd container is only created when the container is started.
 	// So start the container and then inspect the containerd container to verify the image info.
-	id := ctr.Run(ctx, t, apiClient, func(cfg *ctr.TestContainerConfig) {
+	id := testContainer.Run(ctx, t, apiClient, func(cfg *testContainer.TestContainerConfig) {
 		// busybox is the default (as of this writing) used by the test client, but lets be explicit here.
 		cfg.Config.Image = "busybox"
 	})

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -76,9 +76,9 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 func TestCreateLinkToNonExistingContainer(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "legacy links are not supported on windows")
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	_, err := c.ContainerCreate(ctx,
+	_, err := apiClient.ContainerCreate(ctx,
 		&container.Config{
 			Image: "busybox",
 		},
@@ -505,9 +505,9 @@ func TestCreateDifferentPlatform(t *testing.T) {
 
 func TestCreateVolumesFromNonExistingContainer(t *testing.T) {
 	ctx := setupTest(t)
-	cli := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	_, err := cli.ContainerCreate(
+	_, err := apiClient.ContainerCreate(
 		ctx,
 		&container.Config{Image: "busybox"},
 		&container.HostConfig{VolumesFrom: []string{"nosuchcontainer"}},
@@ -525,9 +525,9 @@ func TestCreatePlatformSpecificImageNoPlatform(t *testing.T) {
 
 	skip.If(t, testEnv.DaemonInfo.Architecture == "arm", "test only makes sense to run on non-arm systems")
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux", "test image is only available on linux")
-	cli := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	_, err := cli.ContainerCreate(
+	_, err := apiClient.ContainerCreate(
 		ctx,
 		&container.Config{Image: "arm32v7/hello-world"},
 		&container.HostConfig{},

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -65,7 +65,7 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 				"",
 			)
 			assert.Check(t, is.ErrorContains(err, tc.expectedError))
-			assert.Check(t, errdefs.IsNotFound(err))
+			assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 		})
 	}
 }
@@ -90,7 +90,7 @@ func TestCreateLinkToNonExistingContainer(t *testing.T) {
 		"",
 	)
 	assert.Check(t, is.ErrorContains(err, "could not get container for no-such-container"))
-	assert.Check(t, errdefs.IsInvalidParameter(err))
+	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 }
 
 func TestCreateWithInvalidEnv(t *testing.T) {
@@ -130,7 +130,7 @@ func TestCreateWithInvalidEnv(t *testing.T) {
 				"",
 			)
 			assert.Check(t, is.ErrorContains(err, tc.expectedError))
-			assert.Check(t, errdefs.IsInvalidParameter(err))
+			assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 		})
 	}
 }
@@ -177,7 +177,7 @@ func TestCreateTmpfsMountsTarget(t *testing.T) {
 			"",
 		)
 		assert.Check(t, is.ErrorContains(err, tc.expectedError))
-		assert.Check(t, errdefs.IsInvalidParameter(err))
+		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	}
 }
 
@@ -419,7 +419,7 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 
 			resp, err := apiClient.ContainerCreate(ctx, &cfg, &container.HostConfig{}, nil, nil, "")
 			assert.Check(t, is.Equal(len(resp.Warnings), 0))
-			assert.Check(t, errdefs.IsInvalidParameter(err))
+			assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 			assert.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
@@ -515,7 +515,7 @@ func TestCreateVolumesFromNonExistingContainer(t *testing.T) {
 		nil,
 		"",
 	)
-	assert.Check(t, errdefs.IsInvalidParameter(err))
+	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 }
 
 // Test that we can create a container from an image that is for a different platform even if a platform was not specified

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -688,11 +688,11 @@ func TestContainerdContainerImageInfo(t *testing.T) {
 	})
 	defer apiClient.ContainerRemove(ctx, id, container.RemoveOptions{Force: true})
 
-	client, err := containerd.New(info.Containerd.Address, containerd.WithDefaultNamespace(info.Containerd.Namespaces.Containers))
+	c8dClient, err := containerd.New(info.Containerd.Address, containerd.WithDefaultNamespace(info.Containerd.Namespaces.Containers))
 	assert.NilError(t, err)
-	defer client.Close()
+	defer c8dClient.Close()
 
-	ctr, err := client.ContainerService().Get(ctx, id)
+	ctr, err := c8dClient.ContainerService().Get(ctx, id)
 	assert.NilError(t, err)
 
 	if testEnv.UsingSnapshotter() {

--- a/integration/container/overlayfs_linux_test.go
+++ b/integration/container/overlayfs_linux_test.go
@@ -40,9 +40,9 @@ func TestNoOverlayfsWarningsAboutUndefinedBehaviors(t *testing.T) {
 			return err
 		}},
 		{name: "cp to container", operation: func(t *testing.T) error {
-			archive, err := archive.Generate("new-file", "hello-world")
+			archiveReader, err := archive.Generate("new-file", "hello-world")
 			assert.NilError(t, err, "failed to create a temporary archive")
-			return apiClient.CopyToContainer(ctx, cID, "/", archive, containertypes.CopyToContainerOptions{})
+			return apiClient.CopyToContainer(ctx, cID, "/", archiveReader, containertypes.CopyToContainerOptions{})
 		}},
 		{name: "cp from container", operation: func(*testing.T) error {
 			rc, _, err := apiClient.CopyFromContainer(ctx, cID, "/file")

--- a/integration/container/overlayfs_linux_test.go
+++ b/integration/container/overlayfs_linux_test.go
@@ -19,20 +19,20 @@ func TestNoOverlayfsWarningsAboutUndefinedBehaviors(t *testing.T) {
 	skip.If(t, testEnv.IsRootless(), "root is needed for reading kernel log")
 
 	ctx := setupTest(t)
-	client := testEnv.APIClient()
+	apiClient := testEnv.APIClient()
 
-	cID := container.Run(ctx, t, client, container.WithCmd("sh", "-c", `while true; do echo $RANDOM >>/file; sleep 0.1; done`))
+	cID := container.Run(ctx, t, apiClient, container.WithCmd("sh", "-c", `while true; do echo $RANDOM >>/file; sleep 0.1; done`))
 
 	tests := []struct {
 		name      string
 		operation func(t *testing.T) error
 	}{
 		{name: "diff", operation: func(*testing.T) error {
-			_, err := client.ContainerDiff(ctx, cID)
+			_, err := apiClient.ContainerDiff(ctx, cID)
 			return err
 		}},
 		{name: "export", operation: func(*testing.T) error {
-			rc, err := client.ContainerExport(ctx, cID)
+			rc, err := apiClient.ContainerExport(ctx, cID)
 			if err == nil {
 				defer rc.Close()
 				_, err = io.Copy(io.Discard, rc)
@@ -42,10 +42,10 @@ func TestNoOverlayfsWarningsAboutUndefinedBehaviors(t *testing.T) {
 		{name: "cp to container", operation: func(t *testing.T) error {
 			archive, err := archive.Generate("new-file", "hello-world")
 			assert.NilError(t, err, "failed to create a temporary archive")
-			return client.CopyToContainer(ctx, cID, "/", archive, containertypes.CopyToContainerOptions{})
+			return apiClient.CopyToContainer(ctx, cID, "/", archive, containertypes.CopyToContainerOptions{})
 		}},
 		{name: "cp from container", operation: func(*testing.T) error {
-			rc, _, err := client.CopyFromContainer(ctx, cID, "/file")
+			rc, _, err := apiClient.CopyFromContainer(ctx, cID, "/file")
 			if err == nil {
 				defer rc.Close()
 				_, err = io.Copy(io.Discard, rc)


### PR DESCRIPTION
- integration/container: use consistent alias for test-container pkg
- integration/container: use consistent name for api-client
- integration/container: rename vars that shadowed imports
- integration/container: use is.ErrorType for some tests
  It provides more details about the actual error-type obtained
  on failures.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

