### PR TITLE
[27.x backport] Restore labels when re-creating Windows networks

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -337,6 +337,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		})
 
 		drvOptions := make(map[string]string)
+		var labels map[string]string
 		nid := ""
 		if n != nil {
 			nid = n.ID()
@@ -351,6 +352,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 
 			// restore option if it existed before
 			drvOptions = n.DriverOptions()
+			labels = n.Labels()
 			n.Delete()
 		}
 		netOption := map[string]string{
@@ -388,6 +390,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 				netlabel.GenericData: netOption,
 			}),
 			libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil),
+			libnetwork.NetworkOptionLabels(labels),
 		)
 		if err != nil {
 			log.G(context.TODO()).Errorf("Error occurred when creating network %v", err)


### PR DESCRIPTION
**- What I did**

- backport https://github.com/moby/moby/pull/49196
- fix https://github.com/moby/moby/issues/49179

**- How I did it**

Save and restore network labels when re-creating Windows networks during daemon startup.

**- How to verify it**

As described in the issue ...

> docker network create --label test --driver nat test
> docker network inspect test. Check that the label test has been successfully added.
> Restart the Windows service for the docker engine ( or restart the computer to install OS updates)
> docker network inspect test. Check if the label test still exists.

**- Description for the changelog**
```markdown changelog
- Preserve network labels during daemon startup.
```