### PR TITLE
[27.x backport] daemon: adjust tests for changes in go1.24 JSON errors

### DIFF
--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -159,7 +159,7 @@ func TestDaemonConfigurationFeatures(t *testing.T) {
 		{
 			name:        "invalid config value",
 			config:      `{"features": {"containerd-snapshotter": "not-a-boolean"}}`,
-			expectedErr: `json: cannot unmarshal string into Go struct field Config.features of type bool`,
+			expectedErr: `json: cannot unmarshal string into Go struct field`,
 		},
 	}
 
@@ -179,7 +179,7 @@ func TestDaemonConfigurationFeatures(t *testing.T) {
 			}
 			cc, err := MergeDaemonConfigurations(c, flags, configFile)
 			if tc.expectedErr != "" {
-				assert.Error(t, err, tc.expectedErr)
+				assert.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				assert.NilError(t, err)
 				assert.Check(t, is.DeepEqual(tc.expectedValue, cc.Features))


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49188


These tests failed because the error message changed in go1.24 through https://go.dev/cl/606956.

    === Failed
    === FAIL: daemon/config TestDaemonConfigurationFeatures/invalid_config_value (0.00s)
        config_linux_test.go:182: assertion failed: expected error "json: cannot unmarshal string into Go struct field Config.features of type bool", got "json: cannot unmarshal string into Go struct field Config.CommonConfig.features of type bool"

    === FAIL: daemon/config TestDaemonConfigurationFeatures (0.00s)

    === FAIL: daemon/config TestDaemonConfigurationHostGatewayIP/config_not_array (0.00s)
        config_linux_test.go:354: assertion failed: expected error "json: cannot unmarshal string into Go struct field Config.host-gateway-ips of type []netip.Addr", got "json: cannot unmarshal string into Go struct field Config.CommonConfig.DNSConfig.host-gateway-ips of type []netip.Addr"

Relax the tests a bit to accept errors produced by either go1.24 or older.


(cherry picked from commit 1c37a4454b852af48657276d022ccfd5f6031995)


**- A picture of a cute animal (not mandatory but encouraged)**

