### PR TITLE
[27.x backport] fix non-constant format string (caught by go1.24)

### DIFF
--- a/distribution/pull_v2_windows.go
+++ b/distribution/pull_v2_windows.go
@@ -143,7 +143,7 @@ func checkImageCompatibility(imageOS, imageOSVersion string) error {
 			if imageOSBuild, err := strconv.Atoi(splitImageOSVersion[2]); err == nil {
 				if imageOSBuild > int(hostOSV.Build) {
 					errMsg := fmt.Sprintf("a Windows version %s.%s.%s-based image is incompatible with a %s host", splitImageOSVersion[0], splitImageOSVersion[1], splitImageOSVersion[2], hostOSV.ToString())
-					log.G(context.TODO()).Debugf(errMsg)
+					log.G(context.TODO()).Debug(errMsg)
 					return errors.New(errMsg)
 				}
 			}

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1374,7 +1374,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 func (d *driver) Leave(nid, eid string) error {
 	network, err := d.getNetwork(nid)
 	if err != nil {
-		return types.InternalMaskableErrorf("%s", err)
+		return types.InternalMaskableErrorf("%v", err)
 	}
 
 	endpoint, err := network.getEndpoint(eid)

--- a/libnetwork/drivers/windows/overlay/ov_network_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_network_windows.go
@@ -203,7 +203,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 
 	_, err := hcsshim.HNSNetworkRequest("DELETE", n.hnsID, "")
 	if err != nil {
-		return types.ForbiddenErrorf(err.Error())
+		return types.ForbiddenErrorf("%v", err)
 	}
 
 	d.deleteNetwork(nid)

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -424,7 +424,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 func (d *driver) DeleteNetwork(nid string) error {
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return types.InternalMaskableErrorf("%s", err)
+		return types.InternalMaskableErrorf("%v", err)
 	}
 
 	n.Lock()
@@ -434,7 +434,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	if n.created {
 		_, err = hcsshim.HNSNetworkRequest("DELETE", config.HnsID, "")
 		if err != nil && err.Error() != errNotFound {
-			return types.ForbiddenErrorf(err.Error())
+			return types.ForbiddenErrorf("%v", err)
 		}
 	}
 
@@ -765,7 +765,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 func (d *driver) DeleteEndpoint(nid, eid string) error {
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return types.InternalMaskableErrorf("%s", err)
+		return types.InternalMaskableErrorf("%v", err)
 	}
 
 	ep, err := n.getEndpoint(eid)
@@ -875,7 +875,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 func (d *driver) Leave(nid, eid string) error {
 	network, err := d.getNetwork(nid)
 	if err != nil {
-		return types.InternalMaskableErrorf("%s", err)
+		return types.InternalMaskableErrorf("%v", err)
 	}
 
 	// Ensure that the endpoint exists


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49201

---

Not exactly sure why our linters didn't spot this, as it did for Linux; https://github.com/moby/moby/pull/48359 - perhaps we're missing some `GOOS=windows` in our linter?

Ultimately we should also remove these libnetwork-specific errors, and just use errdefs probably.



### distribution: fix non-constant format string

caught by go1.24

    # github.com/docker/docker/distribution
    # github.com/docker/docker/distribution/pull_v2_windows.go:145:35: non-constant format string in call to (*github.com/docker/docker/vendor/github.com/sirupsen/logrus.Entry).Debugf
    FAIL    github.com/docker/docker/distribution [build failed]

### libnetwork/drivers/windows: fix non-constant format string

Also updated some existing ones to use `%v` instead of `%s` for consistency.

caught by go1.24

    # github.com/docker/docker/libnetwork/drivers/windows/overlay
    # github.com/docker/docker/libnetwork/drivers/windows/overlay/ov_network_windows.go:206:32: non-constant format string in call to github.com/docker/docker/libnetwork/types.ForbiddenErrorf
    FAIL    github.com/docker/docker/libnetwork/drivers/windows/overlay [build failed]

    # github.com/docker/docker/libnetwork/drivers/windows
    # github.com/docker/docker/libnetwork/drivers/windows/windows.go:449:33: non-constant format string in call to github.com/docker/docker/libnetwork/types.ForbiddenErrorf
    FAIL    github.com/docker/docker/libnetwork/drivers/windows [build failed]




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

