### PR TITLE
distribution: add pigz support with configurable env

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -464,7 +464,7 @@ func (pd *pushDescriptor) uploadUsingSession(
 
 	switch m := pd.layer.MediaType(); m {
 	case schema2.MediaTypeUncompressedLayer:
-		compressedReader, compressionDone := compress(reader)
+		compressedReader, compressionDone := compress(ctx, reader)
 		defer func(closer io.Closer) {
 			closer.Close()
 			<-compressionDone


### PR DESCRIPTION
Hi, there. Inspired by  #44008 , our team has been paying continuous attention and efforts for about two years on using pigz in docker. And now, we think, it's time to share our conclusion to community. 

Our team has been conducting experiments on enabling pigz for docker for over a year. Considering compliance issues, I'm unable to share precise original data. However, what can be confirmed is that our team has more 20k+ users, who have executed millions of image builds and k8s-based image deployments using pigz over the past year. Our conclusions and desensitized data are presented in the [How to verify it] section.

Based on our statistics, pigz will help a lot, and no loss will be made as it's closed by default. We are sincerely looking forward to the community's willingness to accept it.

**- What I did**
We found that the previous has stalled. There is no one to push them forward and there are code conflicts. 
So, we dicide to push it with a this PR.

**- How I did it**
Using pigz as a compression tool, and using MOBY_ENABLE_PIGZ to control which type of tools to compress.

**- How to verify it**
Based on the content of this PR, our team has compiled a private-version docker and rolled it out in a phased manner for our build system. During this period, our users have executed millions of image builds. Among them, about 40% to 50% have used the pigz algorithm, while the rest have used the gzip algorithm as a contrast. Additionally, the grouping is completely random.

- **Speed**
In the analysis of the experimental data, we have reached the following conclusions:
  - On average, the pigz **reduce 13+% timecost** for 'docker push' command.
  - In high-time-consuming tasks (that is, tasks whose time consumption ranks in the top 10%), the optimization effect of the pigz algorithm is even better, **with a reduce by 25+%**.

- **Correctness**
Our team use k8s as our deployment system. Over the past time, there have been more than one million pigz-image builds, which means millions of deployments. There is **no evidence to prove that there are any problems with pigz**. 
Two very simple indicators are as follows: 
  - As the proportion of pigz images increases, our deployment success rate has **never shown any remarkable fluctuations** . 
  - Among the thousands of user problem tickets we have received, **no issues caused by pigz** have been found.

- **Conclusion**
As the above discussion, we believe that it's reasonable to use the pigz algorithm in docker. And for those who worried about security question, the gizp is by default. Only when MOBY_ENABLE_PIGZ is true, the pigz algorithm is enabled.

**- Description for the changelog**
```markdown changelog
add pigz support with configurable env MOBY_ENABLE_PIGZ
```

**- A picture of a cute animal (not mandatory but encouraged)**



