### PR TITLE
pkg/fileutils: deprecate GetTotalUsedFds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,6 +151,10 @@ issues:
       path: "api/types/(volume|container)/"
       linters:
         - revive
+    # FIXME temporarily suppress these until we migrated these to internal.
+    - text: "SA1019: fileutils\\.GetTotalUsedFds"
+      linters:
+        - staticcheck
     # FIXME temporarily suppress these (see https://github.com/gotestyourself/gotest.tools/issues/272)
     - text: "SA1019: (assert|cmp|is)\\.ErrorType is deprecated"
       linters:

--- a/pkg/fileutils/fileutils_darwin.go
+++ b/pkg/fileutils/fileutils_darwin.go
@@ -14,6 +14,8 @@ import (
 // "-n", and "-P" options to omit looking up user-names, host-names, and port-
 // names. See [LSOF(8)].
 //
+// Deprecated: this function is only used internally, and will be removed in the next release.
+//
 // [LSOF(8)]: https://opensource.apple.com/source/lsof/lsof-49/lsof/lsof.man.auto.html
 func GetTotalUsedFds() int {
 	output, err := exec.Command("lsof", "-lnP", "-Ff", "-p", strconv.Itoa(os.Getpid())).CombinedOutput()

--- a/pkg/fileutils/fileutils_linux.go
+++ b/pkg/fileutils/fileutils_linux.go
@@ -13,6 +13,8 @@ import (
 
 // GetTotalUsedFds Returns the number of used File Descriptors by
 // reading it via /proc filesystem.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func GetTotalUsedFds(ctx context.Context) int {
 	ctx, span := tracing.StartSpan(ctx, "GetTotalUsedFds")
 	defer span.End()

--- a/pkg/fileutils/fileutils_windows.go
+++ b/pkg/fileutils/fileutils_windows.go
@@ -4,6 +4,8 @@ import "context"
 
 // GetTotalUsedFds Returns the number of used File Descriptors. Not supported
 // on Windows.
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func GetTotalUsedFds(ctx context.Context) int {
 	return -1
 }


### PR DESCRIPTION
This function is only used internally and has no external consumers. Mark it deprecated to be removed in the next release.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: pkg/fileutils: deprecate GetTotalUsedFds: this function is only used internally and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

