### PR TITLE
golangci-lint: remove temporary exception for deprecated code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -156,12 +156,6 @@ issues:
       linters:
         - staticcheck
 
-    # FIXME temporarily suppress these until https://github.com/moby/moby/pull/49072 is merged, which removes their use.
-    - text: "SA1019: system\\.(FromStatT|Mkdev|Mknod|StatT)"
-      path: "pkg/archive/"
-      linters:
-        - staticcheck
-
     - text: "ineffectual assignment to ctx"
       source: "ctx[, ].*=.*\\(ctx[,)]"
       linters:


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/49098
- https://github.com/moby/moby/pull/49072


This was added in f0ce367e1ea5382652fafadc7f3e70ee450fd0f5, but are no longer used since b677cf93d3df1d67b723818fece30cb0085aff68, so we can now remove this.

**- A picture of a cute animal (not mandatory but encouraged)**

