### PR TITLE
[27.x backport] libnetwork/drivers/windows: fix error-matching for hcsshim "not found"

### DIFF
--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -433,7 +433,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 
 	if n.created {
 		_, err = hcsshim.HNSNetworkRequest("DELETE", config.HnsID, "")
-		if err != nil && err.Error() != errNotFound {
+		if err != nil && !strings.EqualFold(err.Error(), errNotFound) {
 			return types.ForbiddenErrorf("%v", err)
 		}
 	}
@@ -782,7 +782,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	n.Unlock()
 
 	_, err = hcsshim.HNSEndpointRequest("DELETE", ep.profileID, "")
-	if err != nil && err.Error() != errNotFound {
+	if err != nil && !strings.EqualFold(err.Error(), errNotFound) {
 		return err
 	}
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49202

This code has some gnarly string-matching to detect "not found" errors returned by hcsshim.

Hcsshim at some point changed this error to lowercase; https://github.com/microsoft/hcsshim/commit/6d67a3085946ac311d0b6d382332ce9da487f405

It looks like we ran into that problem in integration tests, which was fixed in c530c9cbb0da177337a90a6651305daa9eb0c42b when updating hcsshim, however, it was only fixed in tests, and hiding the actual issue in our code.

It looks like hcsshim has some utilities to detect error-types, such as the IsElementNotFoundError function in hcn, which is the newer API that also wraps the "HNS" service;
https://github.com/microsoft/hcsshim/blob/d9a4231b9d7a03dffdabb6019318fc43eb6ba996/hcn/hcnerrors.go#L75-L77

But unfortunately, the hns API used by us, does not return typed errors, and returns HNS errors as a untyped formatted string.


(cherry picked from commit 5b31a5b3706a93d5917649928cec15c970198d8e)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

