### PR TITLE
man: remove --allow-nondistributable-artifacts

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -125,20 +125,6 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
   **Note**: defining runtime arguments via the command line is not supported.
 
-**--allow-nondistributable-artifacts**=[]
-  Push nondistributable artifacts to the specified registries.
-
-  List can contain elements with CIDR notation to specify a whole subnet.
-
-  This option is useful when pushing images containing nondistributable
-  artifacts to a registry on an air-gapped network so hosts on that network can
-  pull the images without connecting to another server.
-
-  **Warning**: Nondistributable artifacts typically have restrictions on how
-  and where they can be distributed and shared. Only use this feature to push
-  artifacts to private registries and ensure that you are in compliance with
-  any terms that cover redistributing nondistributable artifacts.
-
 **--authorization-plugin**=""
   Set authorization plugins to load
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49065


commit 1932091e21b64abc52b42320393b0ac5f6921668 removed support for the --allow-nondistributable-artifacts, but forgot to remove this section.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

