### PR TITLE
daemon: isOnlineFSOperationPermitted: cleanup confusing syntax

### DIFF
--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -347,17 +347,13 @@ func checkIfPathIsInAVolume(container *container.Container, absPath string) (boo
 // cannot have their file-system interrogated from the host as the filter is
 // loaded inside the utility VM, not the host.
 // IMPORTANT: The container lock MUST be held when calling this function.
-func (daemon *Daemon) isOnlineFSOperationPermitted(container *container.Container) error {
-	if !container.Running {
+func (daemon *Daemon) isOnlineFSOperationPermitted(ctr *container.Container) error {
+	if !ctr.Running {
 		return nil
 	}
 
 	// Determine isolation. If not specified in the hostconfig, use daemon default.
-	actualIsolation := container.HostConfig.Isolation
-	if containertypes.Isolation.IsDefault(containertypes.Isolation(actualIsolation)) {
-		actualIsolation = daemon.defaultIsolation
-	}
-	if containertypes.Isolation.IsHyperV(actualIsolation) {
+	if ctr.HostConfig.Isolation.IsHyperV() || ctr.HostConfig.Isolation.IsDefault() && daemon.defaultIsolation.IsHyperV() {
 		return errors.New("filesystem operations against a running Hyper-V container are not supported")
 	}
 	return nil


### PR DESCRIPTION
This function was using a confusing syntax because `Isolation.IsDefault()` and `Isolation.IsHyperV()` don't accept an argument. It's valid (see below), but just confusing, so let's use a more common approach.

https://go.dev/play/p/as6ILVpqbV5

```go
package main

import "fmt"

type NameSayer string

func (f NameSayer) SayMyName() {
	fmt.Println(f)
}

func main() {
	var foo NameSayer = "my name is"
	foo.SayMyName()

	NameSayer("my name is..").SayMyName()

	// Thought SayMyName() would take no arguments? Think again!
	NameSayer.SayMyName("slim shady!")
}
```

While at it, also renamed the `container` argument as it was shadowing the `container` import.

**- A picture of a cute animal (not mandatory but encouraged)**

