### PR TITLE
integration/internal/container: IsInState: touch up error-logs

### DIFF
--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -43,7 +43,11 @@ func IsInState(ctx context.Context, apiClient client.APIClient, containerID stri
 				return poll.Success()
 			}
 		}
-		return poll.Continue("waiting for container to be one of (%s), currently %s", strings.Join(state, ", "), inspect.State.Status)
+		if len(state) == 1 {
+			return poll.Continue("waiting for container State.Status to be '%s', currently '%s'", state[0], inspect.State.Status)
+		} else {
+			return poll.Continue("waiting for container State.Status to be one of (%s), currently '%s'", strings.Join(state, ", "), inspect.State.Status)
+		}
 	}
 }
 


### PR DESCRIPTION
Before this patch:

    remove_test.go:62: timeout hit after 10s: waiting for container to be one of (exited), currently running

After this patch:

    remove_test.go:62: waiting for container State.Status to be 'exited', currently 'running'


**- A picture of a cute animal (not mandatory but encouraged)**

