### PR TITLE
pkg/sysinfo: parse cpuset.cpus/mems once and memoize

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
-	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/testutil"
 	"github.com/moby/sys/mount"
@@ -694,12 +693,10 @@ func (s *DockerCLIRunSuite) TestRunSwapLessThanMemoryLimit(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunInvalidCpusetCpusFlagValue(c *testing.T) {
 	testRequires(c, cgroupCpuset, testEnv.IsLocalDaemon)
 
-	sysInfo := sysinfo.New()
-	cpus, err := parsers.ParseUintList(sysInfo.Cpus)
-	assert.NilError(c, err)
+	cpus := sysinfo.New().CPUSets
 	var invalid int
 	for i := 0; i <= len(cpus)+1; i++ {
-		if !cpus[i] {
+		if _, ok := cpus[i]; !ok {
 			invalid = i
 			break
 		}
@@ -713,12 +710,10 @@ func (s *DockerCLIRunSuite) TestRunInvalidCpusetCpusFlagValue(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunInvalidCpusetMemsFlagValue(c *testing.T) {
 	testRequires(c, cgroupCpuset)
 
-	sysInfo := sysinfo.New()
-	mems, err := parsers.ParseUintList(sysInfo.Mems)
-	assert.NilError(c, err)
+	mems := sysinfo.New().MemSets
 	var invalid int
 	for i := 0; i <= len(mems)+1; i++ {
-		if !mems[i] {
+		if _, ok := mems[i]; !ok {
 			invalid = i
 			break
 		}

--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -125,11 +125,25 @@ func applyCPUSetCgroupInfoV2(info *SysInfo) {
 	}
 	info.Cpus = strings.TrimSpace(string(cpus))
 
+	cpuSets, err := parseUintList(info.Cpus, 0)
+	if err != nil {
+		info.Warnings = append(info.Warnings, "Unable to parse cpuset cpus: "+err.Error())
+		return
+	}
+	info.CPUSets = cpuSets
+
 	mems, err := os.ReadFile(path.Join("/sys/fs/cgroup", info.cg2GroupPath, "cpuset.mems.effective"))
 	if err != nil {
 		return
 	}
 	info.Mems = strings.TrimSpace(string(mems))
+
+	memSets, err := parseUintList(info.Cpus, 0)
+	if err != nil {
+		info.Warnings = append(info.Warnings, "Unable to parse cpuset mems: "+err.Error())
+		return
+	}
+	info.MemSets = memSets
 }
 
 func applyPIDSCgroupInfoV2(info *SysInfo) {

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -124,9 +124,17 @@ type cgroupCpusetInfo struct {
 	// or "cpuset.cpus" (cgroups v1).
 	Cpus string
 
+	// CPUSets holds the list of available cpusets parsed from "cpuset.cpus.effective" (cgroups v2)
+	// or "cpuset.cpus" (cgroups v1).
+	CPUSets map[int]struct{}
+
 	// Available Cpuset's memory nodes as read from "cpuset.mems.effective" (cgroups v2)
 	// or "cpuset.mems" (cgroups v1).
 	Mems string
+
+	// MemSets holds the list of available cpusets parsed from "cpuset.mems.effective" (cgroups v2)
+	// or "cpuset.mems" (cgroups v1).
+	MemSets map[int]struct{}
 }
 
 type cgroupPids struct {
@@ -138,12 +146,12 @@ type cgroupPids struct {
 // in cgroup's cpuset.cpus set, `false` otherwise.
 // If error is not nil a parsing error occurred.
 func (c cgroupCpusetInfo) IsCpusetCpusAvailable(requested string) (bool, error) {
-	return isCpusetListAvailable(requested, c.Cpus)
+	return isCpusetListAvailable(requested, c.CPUSets)
 }
 
 // IsCpusetMemsAvailable returns `true` if the provided string set is contained
 // in cgroup's cpuset.mems set, `false` otherwise.
 // If error is not nil a parsing error occurred.
 func (c cgroupCpusetInfo) IsCpusetMemsAvailable(requested string) (bool, error) {
-	return isCpusetListAvailable(requested, c.Mems)
+	return isCpusetListAvailable(requested, c.MemSets)
 }

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -83,12 +83,16 @@ func TestIsCpusetListAvailable(t *testing.T) {
 		{"01,3", "0-4", true, false},
 		{"", "0-7", true, false},
 		{"1--42", "0-7", false, true},
-		{"1-42", "00-1,8,,9", false, true},
+		{"1-42", "00-1,8,9", false, true},
 		{"1,41-42", "43,45", false, false},
 		{"0-3", "", false, false},
 	}
 	for _, c := range cases {
-		r, err := isCpusetListAvailable(c.provided, c.available)
+		available, err := parseUintList(c.available, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r, err := isCpusetListAvailable(c.provided, available)
 		if (c.err && err == nil) && r != c.res {
 			t.Fatalf("Expected pair: %v, %v for %s, %s. Got %v, %v instead", c.res, c.err, c.provided, c.available, (c.err && err == nil), r)
 		}
@@ -96,16 +100,17 @@ func TestIsCpusetListAvailable(t *testing.T) {
 }
 
 func TestParseUintList(t *testing.T) {
-	valids := map[string]map[int]bool{
+	yes := struct{}{}
+	valids := map[string]map[int]struct{}{
 		"":             {},
-		"7":            {7: true},
-		"1-6":          {1: true, 2: true, 3: true, 4: true, 5: true, 6: true},
-		"0-7":          {0: true, 1: true, 2: true, 3: true, 4: true, 5: true, 6: true, 7: true},
-		"0,3-4,7,8-10": {0: true, 3: true, 4: true, 7: true, 8: true, 9: true, 10: true},
-		"0-0,0,1-4":    {0: true, 1: true, 2: true, 3: true, 4: true},
-		"03,1-3":       {1: true, 2: true, 3: true},
-		"3,2,1":        {1: true, 2: true, 3: true},
-		"0-2,3,1":      {0: true, 1: true, 2: true, 3: true},
+		"7":            {7: yes},
+		"1-6":          {1: yes, 2: yes, 3: yes, 4: yes, 5: yes, 6: yes},
+		"0-7":          {0: yes, 1: yes, 2: yes, 3: yes, 4: yes, 5: yes, 6: yes, 7: yes},
+		"0,3-4,7,8-10": {0: yes, 3: yes, 4: yes, 7: yes, 8: yes, 9: yes, 10: yes},
+		"0-0,0,1-4":    {0: yes, 1: yes, 2: yes, 3: yes, 4: yes},
+		"03,1-3":       {1: yes, 2: yes, 3: yes},
+		"3,2,1":        {1: yes, 2: yes, 3: yes},
+		"0-2,3,1":      {0: yes, 1: yes, 2: yes, 3: yes},
 	}
 	for k, v := range valids {
 		out, err := parseUintList(k, 0)

--- a/pkg/sysinfo/sysinfo_other.go
+++ b/pkg/sysinfo/sysinfo_other.go
@@ -7,6 +7,6 @@ func New(options ...Opt) *SysInfo {
 	return &SysInfo{}
 }
 
-func isCpusetListAvailable(string, string) (bool, error) {
+func isCpusetListAvailable(string, map[int]struct{}) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49193
- relates to https://github.com/moby/moby/issues/32989


Preserve the result instead of parsing these for each container that specifies cpuset options,

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

