### PR TITLE
pkg/parsers: deprecate ParseUintListMaximum, ParseUintList

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -34,6 +34,8 @@ func ParseKeyValueOpt(opt string) (key string, value string, err error) {
 //	03,1-3      <- this is gonna get parsed as [1,2,3]
 //	3,2,1
 //	0-2,3,1
+//
+// Deprecated: ParseUintListMaximum was only used internally and will be removed in the next release.
 func ParseUintListMaximum(val string, maximum int) (map[int]bool, error) {
 	return parseUintList(val, maximum)
 }
@@ -52,6 +54,8 @@ func ParseUintListMaximum(val string, maximum int) (map[int]bool, error) {
 //	03,1-3      <- this is gonna get parsed as [1,2,3]
 //	3,2,1
 //	0-2,3,1
+//
+// Deprecated: ParseUintList was only used internally and will be removed in the next release.
 func ParseUintList(val string) (map[int]bool, error) {
 	return parseUintList(val, 0)
 }

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -45,7 +45,7 @@ func TestParseUintList(t *testing.T) {
 		"0-2,3,1":      {0: true, 1: true, 2: true, 3: true},
 	}
 	for k, v := range valids {
-		out, err := ParseUintList(k)
+		out, err := parseUintList(k, 0)
 		if err != nil {
 			t.Fatalf("Expected not to fail, got %v", err)
 		}
@@ -63,7 +63,7 @@ func TestParseUintList(t *testing.T) {
 		"-1,0",
 	}
 	for _, v := range invalids {
-		if out, err := ParseUintList(v); err == nil {
+		if out, err := parseUintList(v, 0); err == nil {
 			t.Fatalf("Expected failure with %s but got %v", v, out)
 		}
 	}
@@ -71,13 +71,13 @@ func TestParseUintList(t *testing.T) {
 
 func TestParseUintListMaximumLimits(t *testing.T) {
 	v := "10,1000"
-	if _, err := ParseUintListMaximum(v, 0); err != nil {
+	if _, err := parseUintList(v, 0); err != nil {
 		t.Fatalf("Expected not to fail, got %v", err)
 	}
-	if _, err := ParseUintListMaximum(v, 1000); err != nil {
+	if _, err := parseUintList(v, 1000); err != nil {
 		t.Fatalf("Expected not to fail, got %v", err)
 	}
-	if out, err := ParseUintListMaximum(v, 100); err == nil {
+	if out, err := parseUintList(v, 100); err == nil {
 		t.Fatalf("Expected failure with %s but got %v", v, out)
 	}
 }


### PR DESCRIPTION
depends on:

- [x] https://github.com/moby/moby/pull/49193
- [x] https://github.com/moby/moby/pull/49221
- relates to https://github.com/moby/moby/issues/32989


These utilities have been moved internal to pkg/sysinfo in
2282279180c610938778f514a201883ef23f751a, and are no longer
used.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: pkg/parsers: deprecate ParseUintListMaximum, ParseUintList. These utilities were only used internally and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

