### PR TITLE
IPAM: handle subnets bigger than "/64"

### DIFF
--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -141,10 +141,9 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 	c := testEnv.APIClient()
 
 	tests := []struct {
-		name       string
-		subnet     string
-		ipRange    string
-		expCtrFail bool
+		name    string
+		subnet  string
+		ipRange string
 	}{
 		{
 			name:    "ipRange before end of 64-bit subnet",
@@ -155,22 +154,11 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 			name:    "ipRange at end of 64-bit subnet",
 			subnet:  "fda9:8d04:086e::/64",
 			ipRange: "fda9:8d04:086e::ffff:ffff:ffff:fffe/127",
-			// FIXME(robmry) - there should be two addresses available for
-			//  allocation, just like the previous test. One for the gateway
-			//  and one for the container. But, because the Bitmap in the
-			//  allocator can't cope with a range that includes MaxUint64,
-			//  only one address is currently available - so the container
-			//  will not start.
-			expCtrFail: true,
 		},
 		{
 			name:    "ipRange at 64-bit boundary inside 56-bit subnet",
 			subnet:  "fda9:8d04:086e::/56",
 			ipRange: "fda9:8d04:086e:aa:ffff:ffff:ffff:fffe/127",
-			// FIXME(robmry) - same issue as above, but this time the ip-range
-			//  is in the middle of the subnet (on a 64-bit boundary) rather
-			//  than at the top end.
-			expCtrFail: true,
 		},
 	}
 
@@ -187,12 +175,7 @@ func TestIPRangeAt64BitLimit(t *testing.T) {
 			id := ctr.Create(ctx, t, c, ctr.WithNetworkMode(netName))
 			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
 			err := c.ContainerStart(ctx, id, containertypes.StartOptions{})
-			if tc.expCtrFail {
-				assert.Assert(t, err != nil)
-				t.Skipf("XFAIL Container startup failed with error: %v", err)
-			} else {
-				assert.NilError(t, err)
-			}
+			assert.NilError(t, err)
 		})
 	}
 }

--- a/libnetwork/bitmap/sequence_test.go
+++ b/libnetwork/bitmap/sequence_test.go
@@ -513,10 +513,19 @@ func TestPushReservation(t *testing.T) {
 	}
 
 	for n, i := range input {
-		mask := pushReservation(i.bytePos, i.bitPos, i.mask, false)
+		// The mask should only change if a bit is set/unset. Check whether a change is
+		// expected by comparing input and expected output before calling pushReservation,
+		// because the input (i.mask) is mutated.
+		expChanged := !i.mask.equal(i.newMask)
+
+		mask, changed := pushReservation(i.bytePos, i.bitPos, i.mask, false)
 		if !mask.equal(i.newMask) {
 			t.Fatalf("Error in (%d) pushReservation():\n%s + (%d,%d):\nExp: %s\nGot: %s,",
 				n, i.mask.toString(), i.bytePos, i.bitPos, i.newMask.toString(), mask.toString())
+		}
+		if expChanged != changed {
+			t.Errorf("Error in (%d) pushReservation():\n%s + (%d,%d):\nGot changed %v, expected %v",
+				n, i.mask.toString(), i.bytePos, i.bitPos, changed, expChanged)
 		}
 	}
 }

--- a/libnetwork/internal/addrset/addrset.go
+++ b/libnetwork/internal/addrset/addrset.go
@@ -1,0 +1,201 @@
+// Package addrset implements a set of IP addresses.
+package addrset
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+
+	"github.com/docker/docker/libnetwork/bitmap"
+	"github.com/docker/docker/libnetwork/internal/netiputil"
+	"github.com/docker/docker/libnetwork/ipbits"
+)
+
+var (
+	// ErrNotAvailable is returned when no more addresses are available to set
+	ErrNotAvailable = errors.New("address not available")
+	// ErrAllocated is returned when the specific address requested is already allocated
+	ErrAllocated = errors.New("address already allocated")
+)
+
+const (
+	// maxBitsPerBitmap is the max size for a single bitmap in the address set.
+	//
+	// [bitmap.Bitmap] is initialised with a uint64 num-bits. So, it can't contain
+	// enough bits for a 64-bit range (it's one bit short, the last address in the
+	// range can't be represented). If that's fixed, this max can be increased, but
+	// addrsPerBitmap() will need updating to deal with the overflow.
+	//
+	// A max of 63-bits means a 64-bit address range (the norm for IPv6) is
+	// represented by up-to two bitmaps.
+	maxBitsPerBitmap = 63
+	// minPrefixLen is the prefix length corresponding to maxBitsPerBitmap
+	minPrefixLen = (net.IPv6len * 8) - maxBitsPerBitmap
+)
+
+// AddrSet is a set of IP addresses.
+type AddrSet struct {
+	pool    netip.Prefix
+	bitmaps map[netip.Prefix]*bitmap.Bitmap
+}
+
+// New returns an AddrSet for the range of addresses in pool.
+func New(pool netip.Prefix) *AddrSet {
+	return &AddrSet{
+		pool:    pool.Masked(),
+		bitmaps: map[netip.Prefix]*bitmap.Bitmap{},
+	}
+}
+
+// Add adds address addr to the set. If addr is already in the set, it returns a
+// wrapped [ErrAllocated]. If addr is not in the set's address range, it returns
+// an error.
+func (as *AddrSet) Add(addr netip.Addr) error {
+	if !as.pool.Contains(addr) {
+		return fmt.Errorf("cannot add %s to '%s'", addr, as.pool)
+	}
+	bm, _, err := as.getBitmap(addr)
+	if err != nil {
+		return fmt.Errorf("finding bitmap for %s in '%s': %w", addr, as.pool, err)
+	}
+	bit := netiputil.HostID(addr, as.prefixLenPerBitmap())
+	if err := bm.Set(bit); err != nil {
+		return fmt.Errorf("setting bit %d for %s in pool '%s': %w", bit, addr, as.pool, mapErr(err))
+	}
+	return nil
+}
+
+// AddAny adds an arbitrary address to the set, and returns that address. Or, if
+// no addresses are available, it returns a wrapped [ErrNotAvailable].
+//
+// If the address set's pool contains fewer than 1<<maxBitsPerBitmap addresses,
+// AddAny will add any address from the entire set. If the pool is bigger than
+// that, AddAny will only consider the first 1<<maxBitsPerBitmap addresses. If
+// those are all allocated, it returns [ErrNotAvailable].
+//
+// When serial=true, the set is scanned starting from the address following
+// the address most recently set by [AddrSet.AddAny] (or [AddrSet.AddAnyInRange]
+// if the range is in the same 1<<maxBitsPerBitmap .
+func (as *AddrSet) AddAny(serial bool) (netip.Addr, error) {
+	// Only look at the first bitmap. It either contains the whole address range or
+	// the first 1<<maxBitsPerBitmap addresses, which is a lot. (So, no need to
+	// search other bitmaps, or work out if more bitmaps could be created).
+	bm, _, err := as.getBitmap(as.pool.Addr())
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("no bitmap to add-any to '%s': %w", as.pool.Addr(), err)
+	}
+	ordinal, err := bm.SetAny(serial)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("add-any to '%s': %w", as.pool.Addr(), mapErr(err))
+	}
+	return ipbits.Add(as.pool.Addr(), ordinal, 0), nil
+}
+
+// AddAnyInRange adds an arbitrary address from ipr to the set, and returns that
+// address. Or, if no addresses are available, it returns a wrapped [ErrNotAvailable].
+// If ipr is not fully contained within the set's range, it returns an error.
+//
+// When serial=true, the set is scanned starting from the address following
+// the address most recently set by [AddrSet.AddAny] or [AddrSet.AddAnyInRange].
+func (as *AddrSet) AddAnyInRange(ipr netip.Prefix, serial bool) (netip.Addr, error) {
+	if !as.pool.Contains(ipr.Addr()) || ipr.Bits() < as.pool.Bits() {
+		return netip.Addr{}, fmt.Errorf("add-any, range '%s' is not in subnet '%s'", ipr, as.pool)
+	}
+	iprMasked := ipr.Masked()
+	bm, bmKey, err := as.getBitmap(iprMasked.Addr())
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("no bitmap to add-any in '%s' range '%s': %w", as.pool, ipr, err)
+	}
+	var ordinal uint64
+	if ipr.Bits() <= bmKey.Bits() {
+		ordinal, err = bm.SetAny(serial)
+	} else {
+		start, end := netiputil.SubnetRange(bmKey, iprMasked)
+		ordinal, err = bm.SetAnyInRange(start, end, serial)
+	}
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("add-any in '%s' range '%s': %w", as.pool, ipr, mapErr(err))
+	}
+	return ipbits.Add(bmKey.Addr(), ordinal, 0), nil
+}
+
+// Remove removes addr from the set or, if addr is not in the set's address range it
+// returns an error. If addr is not in the set, it returns nil (removing an address
+// that's not in the set is not an error).
+func (as *AddrSet) Remove(addr netip.Addr) error {
+	if !as.pool.Contains(addr) {
+		return fmt.Errorf("%s cannot be removed from '%s'", addr, as.pool)
+	}
+	bm, bmKey, err := as.getBitmap(addr)
+	if err != nil {
+		return fmt.Errorf("remove '%s' from '%s': %w", addr, as.pool, err)
+	}
+	bit := netiputil.HostID(addr, as.prefixLenPerBitmap())
+	if err := bm.Unset(bit); err != nil {
+		return fmt.Errorf("unset bit %d for '%s' in '%s': %w", bit, addr, as.pool, err)
+	}
+	if bm.Bits()-bm.Unselected() == 0 {
+		delete(as.bitmaps, bmKey)
+	}
+	return nil
+}
+
+// String returns a description of the address set.
+func (as *AddrSet) String() string {
+	if len(as.bitmaps) == 0 {
+		return "empty address set"
+	}
+	if as.pool.Addr().BitLen()-as.pool.Bits() <= maxBitsPerBitmap {
+		return as.bitmaps[as.pool].String()
+	}
+	bmStrings := make([]string, 0, len(as.bitmaps))
+	for bmKey, bm := range as.bitmaps {
+		bmStrings = append(bmStrings, fmt.Sprintf("range %s %s", bmKey, bm))
+	}
+	return strings.Join(bmStrings, " ")
+}
+
+func (as *AddrSet) getBitmap(addr netip.Addr) (*bitmap.Bitmap, netip.Prefix, error) {
+	bits := as.pool.Addr().BitLen() - as.pool.Bits()
+	if bits > maxBitsPerBitmap {
+		bits = maxBitsPerBitmap
+	}
+	bmKey, err := addr.Prefix(as.pool.Addr().BitLen() - bits)
+	if err != nil {
+		return nil, netip.Prefix{}, err
+	}
+	bm, ok := as.bitmaps[bmKey]
+	if !ok {
+		bm = bitmap.New(as.addrsPerBitmap())
+		as.bitmaps[bmKey] = bm
+	}
+	return bm, bmKey, nil
+}
+
+func (as *AddrSet) addrsPerBitmap() uint64 {
+	bits := as.pool.Addr().BitLen() - as.pool.Bits()
+	if bits > maxBitsPerBitmap {
+		bits = maxBitsPerBitmap
+	}
+	return uint64(1) << bits
+}
+
+func (as *AddrSet) prefixLenPerBitmap() uint {
+	bits := as.pool.Bits()
+	if as.pool.Addr().Is6() && bits < minPrefixLen {
+		return minPrefixLen
+	}
+	return uint(bits)
+}
+
+func mapErr(err error) error {
+	if errors.Is(err, bitmap.ErrBitAllocated) {
+		return ErrAllocated
+	}
+	if errors.Is(err, bitmap.ErrNoBitAvailable) {
+		return ErrNotAvailable
+	}
+	return err
+}

--- a/libnetwork/internal/addrset/addrset_test.go
+++ b/libnetwork/internal/addrset/addrset_test.go
@@ -1,0 +1,214 @@
+package addrset
+
+import (
+	"net/netip"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestIPv4Pool(t *testing.T) {
+	var (
+		// It shouldn't matter that host bits are set in the pool Prefix.
+		subnet = netip.MustParsePrefix("10.20.30.40/16")
+		as     = New(subnet)
+		addr   netip.Addr
+		err    error
+	)
+
+	assert.Check(t, is.Len(as.bitmaps, 0))
+
+	// Add the first and last addresses in the range.
+	// Expect a single bitmap of 65536 bits, with two bits set.
+	err = as.Add(netip.MustParseAddr("10.20.0.0"))
+	assert.Assert(t, err)
+	err = as.Add(netip.MustParseAddr("10.20.255.255"))
+	assert.Assert(t, err)
+	assert.Check(t, is.Len(as.bitmaps, 1))
+	bm := as.bitmaps[subnet.Masked()]
+	assert.Check(t, is.Equal(bm.Bits(), uint64(65536)))
+	assert.Check(t, is.Equal(bm.Unselected(), uint64(65534)))
+
+	// Add an address that's already present. Expect an error.
+	err = as.Add(netip.MustParseAddr("10.20.255.255"))
+	assert.Check(t, is.ErrorIs(err, ErrAllocated))
+
+	// Remove an address that isn't in the set. Expect no error.
+	err = as.Remove(netip.MustParseAddr("10.20.30.40"))
+	assert.Check(t, err)
+
+	// Remove all addresses, expect to end up with no bitmap.
+	err = as.Remove(netip.MustParseAddr("10.20.0.0"))
+	assert.Check(t, err)
+	err = as.Remove(netip.MustParseAddr("10.20.255.255"))
+	assert.Check(t, err)
+	assert.Check(t, is.Len(as.bitmaps, 0))
+
+	// Remove an address that isn't in the set (now there's no bitmap). Expect no error.
+	err = as.Remove(netip.MustParseAddr("10.20.30.40"))
+	assert.Check(t, err)
+
+	// Add any two addresses to the set, with serial=true. Expect the first two addresses.
+	addr, err = as.AddAny(true)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(addr, netip.MustParseAddr("10.20.0.0")))
+	addr, err = as.AddAny(true)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(addr, netip.MustParseAddr("10.20.0.1")))
+
+	// Add any address in a range. It shouldn't matter that host bits are set in the
+	// range. Expect the first address in that range.
+	addr, err = as.AddAnyInRange(netip.MustParsePrefix("10.20.30.40/24"), true)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(addr, netip.MustParseAddr("10.20.30.0")))
+}
+
+func TestIPv6Pool(t *testing.T) {
+	var (
+		subnet = netip.MustParsePrefix("fddd::dddd/56")
+		as     = New(subnet)
+		addr   netip.Addr
+		err    error
+	)
+
+	assert.Check(t, is.Len(as.bitmaps, 0))
+
+	// Add the first and last addresses in the range.
+	// Expect two bitmaps of 1<<maxBitsPerBitmap bits, with one bit set in each.
+	err = as.Add(netip.MustParseAddr("fddd::"))
+	assert.Assert(t, err)
+	err = as.Add(netip.MustParseAddr("fddd::ff:ffff:ffff:ffff:ffff"))
+	assert.Assert(t, err)
+	assert.Check(t, is.Len(as.bitmaps, 2))
+	for _, bm := range as.bitmaps {
+		assert.Check(t, is.Equal(bm.Bits(), uint64(1)<<maxBitsPerBitmap))
+		assert.Check(t, is.Equal(bm.Unselected(), (uint64(1)<<maxBitsPerBitmap)-1))
+	}
+
+	// Add an address that's already present in the "upper" bitmap. Expect an error.
+	err = as.Add(netip.MustParseAddr("fddd::ff:ffff:ffff:ffff:ffff"))
+	assert.Check(t, is.ErrorIs(err, ErrAllocated))
+
+	// Remove an address that isn't in the set. Expect no error.
+	err = as.Remove(netip.MustParseAddr("fddd::f:0:0:0:0"))
+	assert.Check(t, err)
+
+	// Remove all addresses, expect to end up with no bitmap.
+	err = as.Remove(netip.MustParseAddr("fddd::"))
+	assert.Check(t, err)
+	err = as.Remove(netip.MustParseAddr("fddd::ff:ffff:ffff:ffff:ffff"))
+	assert.Check(t, err)
+	assert.Check(t, is.Len(as.bitmaps, 0))
+
+	// Remove an address that isn't in the set (now there's no bitmap). Expect no error.
+	err = as.Remove(netip.MustParseAddr("fddd::f:0:0:0:0"))
+	assert.Check(t, err)
+
+	// Add any two addresses to the set, with serial=true. Expect the first two addresses.
+	addr, err = as.AddAny(true)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(addr, netip.MustParseAddr("fddd::0")))
+	addr, err = as.AddAny(true)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(addr, netip.MustParseAddr("fddd::1")))
+
+	// Add any address in a range, somewhere in the middle of the pool. Expect the first address in that range.
+	addr, err = as.AddAnyInRange(netip.MustParsePrefix("fddd:0:0:f0::/60"), true)
+	assert.Check(t, err)
+	assert.Check(t, is.Equal(addr, netip.MustParseAddr("fddd:0:0:f0::")))
+}
+
+func Test64BitIPv6Range(t *testing.T) {
+	as := New(netip.MustParsePrefix("fd75:7f12:d221:7b32::/64"))
+	addr := netip.MustParseAddr("fd75:7f12:d221:7b32:94b0:97ff:fefe:52da")
+
+	err := as.Add(addr)
+	assert.Check(t, err)
+	err = as.Add(addr)
+	assert.Check(t, is.ErrorIs(err, ErrAllocated))
+	assert.Check(t, is.Error(err, "setting bit 1490858602410169050 for fd75:7f12:d221:7b32:94b0:97ff:fefe:52da in pool 'fd75:7f12:d221:7b32::/64': address already allocated"))
+	err = as.Remove(addr)
+	assert.Check(t, err)
+	err = as.Add(addr)
+	assert.Check(t, err)
+}
+
+func Test32BitIPv6Range(t *testing.T) {
+	as := New(netip.MustParsePrefix("fd75:7f12:d221:7b32::/96"))
+	addr := netip.MustParseAddr("fd75:7f12:d221:7b32::fefe:52da")
+
+	err := as.Add(addr)
+	assert.Check(t, err)
+	err = as.Add(addr)
+	assert.Check(t, is.ErrorIs(err, ErrAllocated))
+	assert.Check(t, is.Error(err, "setting bit 4278080218 for fd75:7f12:d221:7b32::fefe:52da in pool 'fd75:7f12:d221:7b32::/96': address already allocated"))
+	err = as.Remove(addr)
+	assert.Check(t, err)
+	err = as.Add(addr)
+	assert.Check(t, err)
+}
+
+func TestFullPool(t *testing.T) {
+	var (
+		subnet = netip.MustParsePrefix("10.20.30.0/24")
+		as     = New(subnet)
+		err    error
+	)
+
+	for range 256 {
+		_, err = as.AddAny(true)
+		assert.Check(t, err)
+	}
+	_, err = as.AddAny(true)
+	assert.Check(t, is.ErrorIs(err, ErrNotAvailable))
+	assert.Check(t, is.Error(err, "add-any to '10.20.30.0': address not available"))
+}
+
+func TestNotInPool(t *testing.T) {
+	var (
+		subnet = netip.MustParsePrefix("10.20.30.40/16")
+		as     = New(subnet)
+		addr   netip.Addr
+		err    error
+	)
+
+	// Address not in pool.
+	err = as.Add(netip.MustParseAddr("10.21.0.0"))
+	assert.Check(t, is.Error(err, "cannot add 10.21.0.0 to '10.20.0.0/16'"))
+
+	// Range bigger than pool.
+	addr, err = as.AddAnyInRange(netip.MustParsePrefix("10.20.0.0/15"), true)
+	assert.Check(t, is.Error(err, "add-any, range '10.20.0.0/15' is not in subnet '10.20.0.0/16'"))
+	assert.Check(t, is.Equal(addr, netip.Addr{}))
+
+	// Range outside pool.
+	addr, err = as.AddAnyInRange(netip.MustParsePrefix("10.21.0.0/24"), true)
+	assert.Check(t, is.Error(err, "add-any, range '10.21.0.0/24' is not in subnet '10.20.0.0/16'"))
+	assert.Check(t, is.Equal(addr, netip.Addr{}))
+}
+
+func TestInvalidPool(t *testing.T) {
+	var (
+		as   = New(netip.Prefix{})
+		addr netip.Addr
+		err  error
+	)
+
+	err = as.Add(netip.IPv6Loopback())
+	assert.Check(t, is.Error(err, "cannot add ::1 to 'invalid Prefix'"))
+
+	addr, err = as.AddAny(false)
+	assert.Check(t, is.Error(err, "no bitmap to add-any to 'invalid IP': negative Prefix bits"))
+	assert.Check(t, is.Equal(addr, netip.Addr{}))
+
+	addr, err = as.AddAnyInRange(netip.Prefix{}, false)
+	assert.Check(t, is.Error(err, "add-any, range 'invalid Prefix' is not in subnet 'invalid Prefix'"))
+	assert.Check(t, is.Equal(addr, netip.Addr{}))
+	addr, err = as.AddAnyInRange(netip.MustParsePrefix("10.20.30.0/24"), false)
+	assert.Check(t, is.Error(err, "add-any, range '10.20.30.0/24' is not in subnet 'invalid Prefix'"))
+	assert.Check(t, is.Equal(addr, netip.Addr{}))
+
+	err = as.Remove(netip.MustParseAddr("10.20.30.0"))
+	assert.Check(t, is.Error(err, "10.20.30.0 cannot be removed from 'invalid Prefix'"))
+}

--- a/libnetwork/ipams/defaultipam/address_space.go
+++ b/libnetwork/ipams/defaultipam/address_space.go
@@ -370,5 +370,5 @@ func (aSpace *addrSpace) releaseAddress(nw, sub netip.Prefix, address netip.Addr
 
 	defer log.G(context.TODO()).Debugf("Released address Address:%v Sequence:%s", address, p.addrs)
 
-	return p.addrs.Unset(netiputil.HostID(address, uint(nw.Bits())))
+	return p.addrs.Remove(address)
 }

--- a/libnetwork/ipams/defaultipam/allocator.go
+++ b/libnetwork/ipams/defaultipam/allocator.go
@@ -2,17 +2,16 @@ package defaultipam
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/netip"
 
 	"github.com/containerd/log"
-	"github.com/docker/docker/libnetwork/bitmap"
+	"github.com/docker/docker/libnetwork/internal/addrset"
 	"github.com/docker/docker/libnetwork/internal/netiputil"
 	"github.com/docker/docker/libnetwork/ipamapi"
 	"github.com/docker/docker/libnetwork/ipamutils"
-	"github.com/docker/docker/libnetwork/ipbits"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -211,28 +210,20 @@ func (a *Allocator) getAddrSpace(as string, v6 bool) (*addrSpace, error) {
 }
 
 func newPoolData(pool netip.Prefix) *PoolData {
-	ones, bits := pool.Bits(), pool.Addr().BitLen()
-	numAddresses := uint64(1 << uint(bits-ones))
-
-	// Allow /64 subnet
-	if pool.Addr().Is6() && numAddresses == 0 {
-		// FIXME(robmry) - see the comment in getAddress
-		numAddresses--
-	}
-
 	// Generate the new address masks.
-	h := bitmap.New(numAddresses)
+	h := addrset.New(pool)
 
 	// Pre-reserve the network address on IPv4 networks large
 	// enough to have one (i.e., anything bigger than a /31).
+	numAddresses := uint64(1) << uint(pool.Addr().BitLen()-pool.Bits())
 	if !(pool.Addr().Is4() && numAddresses <= 2) {
-		h.Set(0)
+		h.Add(pool.Addr())
 	}
 
 	// Pre-reserve the broadcast address on IPv4 networks large
 	// enough to have one (i.e., anything bigger than a /31).
 	if pool.Addr().Is4() && numAddresses > 2 {
-		h.Set(numAddresses - 1)
+		h.Add(netiputil.LastAddr(pool))
 	}
 
 	return &PoolData{addrs: h, children: map[netip.Prefix]struct{}{}}
@@ -289,50 +280,35 @@ func (a *Allocator) ReleaseAddress(poolID string, address net.IP) error {
 	return aSpace.releaseAddress(k.Subnet, k.ChildSubnet, addr.Unmap())
 }
 
-func getAddress(base netip.Prefix, bitmask *bitmap.Bitmap, prefAddress netip.Addr, ipr netip.Prefix, serial bool) (netip.Addr, error) {
+func getAddress(base netip.Prefix, addrSet *addrset.AddrSet, prefAddress netip.Addr, ipr netip.Prefix, serial bool) (netip.Addr, error) {
 	var (
-		ordinal uint64
-		err     error
+		addr netip.Addr
+		err  error
 	)
 
-	log.G(context.TODO()).Debugf("Request address PoolID:%v %s Serial:%v PrefAddress:%v ", base, bitmask, serial, prefAddress)
+	log.G(context.TODO()).Debugf("Request address PoolID:%v %s Serial:%v PrefAddress:%v ", base, addrSet, serial, prefAddress)
 
-	if bitmask.Unselected() == 0 {
-		return netip.Addr{}, ipamapi.ErrNoAvailableIPs
-	}
-	if (ipr == (netip.Prefix{}) || ipr == base) && prefAddress == (netip.Addr{}) {
-		ordinal, err = bitmask.SetAny(serial)
-	} else if prefAddress != (netip.Addr{}) {
-		ordinal = netiputil.HostID(prefAddress, uint(base.Bits()))
-		err = bitmask.Set(ordinal)
-	} else {
-		start, end := netiputil.SubnetRange(base, ipr)
-		if end == math.MaxUint64 {
-			// FIXME(robmry) ...
-			//  When newPoolData is asked for a range of 64-bits or more, it ends up with an
-			//  overflowed u64 - so, it just subtracts one to get a nearly-big-enough range
-			//  (for a 64-bit subnet). But, here, the range is exclusive of end. So, when
-			//  checking the range, SetAnyInRange fails if it's asked for any bit in the whole
-			//  of a 64-bit range. For now, just subtract one here. To see the problem,
-			//  remove this workaround, then try:
-			//    docker network create --ipv6 --subnet fddd::/56 --ip-range fddd::/64 b46
-			//  See Test64BitIPRange and TestIPRangeAt64BitLimit.
-			end -= 1
+	if prefAddress.IsValid() {
+		err = addrSet.Add(prefAddress)
+		if err == nil {
+			addr = prefAddress
 		}
-		ordinal, err = bitmask.SetAnyInRange(start, end, serial)
+	} else if ipr.IsValid() && ipr != base {
+		addr, err = addrSet.AddAnyInRange(ipr, serial)
+	} else {
+		addr, err = addrSet.AddAny(serial)
 	}
 
-	switch err {
-	case nil:
-		// Convert IP ordinal for this subnet into IP address
-		return ipbits.Add(base.Addr(), ordinal, 0), nil
-	case bitmap.ErrBitAllocated:
-		return netip.Addr{}, ipamapi.ErrIPAlreadyAllocated
-	case bitmap.ErrNoBitAvailable:
-		return netip.Addr{}, ipamapi.ErrNoAvailableIPs
-	default:
+	if err != nil {
+		if errors.Is(err, addrset.ErrAllocated) {
+			return netip.Addr{}, ipamapi.ErrIPAlreadyAllocated
+		}
+		if errors.Is(err, addrset.ErrNotAvailable) {
+			return netip.Addr{}, ipamapi.ErrNoAvailableIPs
+		}
 		return netip.Addr{}, err
 	}
+	return addr, nil
 }
 
 // IsBuiltIn returns true for builtin drivers

--- a/libnetwork/ipams/defaultipam/structures.go
+++ b/libnetwork/ipams/defaultipam/structures.go
@@ -5,7 +5,7 @@ import (
 	"net/netip"
 	"strings"
 
-	"github.com/docker/docker/libnetwork/bitmap"
+	"github.com/docker/docker/libnetwork/internal/addrset"
 	"github.com/docker/docker/libnetwork/types"
 )
 
@@ -17,7 +17,7 @@ type PoolID struct {
 
 // PoolData contains the configured pool data
 type PoolData struct {
-	addrs    *bitmap.Bitmap
+	addrs    *addrset.AddrSet
 	children map[netip.Prefix]struct{}
 
 	// Whether to implicitly release the pool once it no longer has any children.


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/21199
- fix https://github.com/moby/moby/issues/35195
- fix https://github.com/moby/moby/issues/45402
- fix https://github.com/moby/moby/issues/48527
- replaces the workaround added in https://github.com/moby/moby/pull/48322

The default IPAM allocator is unable to represent subnets larger than 64-bits (subnets with a smaller prefix), because it uses a Bitmap that's limited to 64-bits.

When it's used to represent a 64-bit subnet, the top address can't be allocated (because bitmap.Bitmap is initialised with the number of bits it needs to represent in a uint64, so it's one short).

The rest of the daemon doesn't know about these limitations, so strange things happen when a large IPv6 subnet is used. No errors are reported, addresses/subnets are just set up incorrectly.  The IPAM code calculates offsets into the bitmap itself, details it shouldn't need to understand and, because it's working on offsets into a range it doesn't always notice when it's asked to set a bit outside the range (see the notes about "offset" in https://github.com/moby/moby/pull/48319).

It's unusual to need a big subnet but, for example, it may be useful for modelling an ISP network, or an ISP's gateway may be in a "/56" subnet that's outside a 64-bit range used by hosts.

**- How I did it**

- Don't increment "unselected" in Bitmap when clearing a 0
  - Bug fix in the bitmap.Bitmap code
- Add addrset.AddrSet to track a set of IP addresses
  - A new internal package to track IP addresses.
  - It owns a `bitmap.Bitmap` for each range of up to 63-bits that has a bit set, within the subnet it's asked to represent.
- Use addrset.AddrSet instead of bitmap.Bitmap in IPAM

**- How to verify it**

New unit tests for `AddrSet`, plus existing tests (including the two "XFAIL" tests that now pass).

**- Description for the changelog**
```markdown changelog
- IPAM now handles subnets bigger than "/64".
```
