### PR TITLE
Use bridge consts for "DefaultGatewayIPv[46]" aux-addr keys

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -942,7 +942,7 @@ func (o defBrOptsV4) bip() (bip, optName string) {
 }
 
 func (o defBrOptsV4) defGw() (gw net.IP, optName, auxAddrLabel string) {
-	return o.cfg.DefaultGatewayIPv4, "default-gateway", "DefaultGatewayIPv4"
+	return o.cfg.DefaultGatewayIPv4, "default-gateway", bridge.DefaultGatewayV4AuxKey
 }
 
 type defBrOptsV6 struct {
@@ -962,7 +962,7 @@ func (o defBrOptsV6) bip() (bip, optName string) {
 }
 
 func (o defBrOptsV6) defGw() (gw net.IP, optName, auxAddrLabel string) {
-	return o.cfg.DefaultGatewayIPv6, "default-gateway-v6", "DefaultGatewayIPv6"
+	return o.cfg.DefaultGatewayIPv6, "default-gateway-v6", bridge.DefaultGatewayV6AuxKey
 }
 
 type defBrOpts interface {


### PR DESCRIPTION
**- What I did**

Use `bridge.DefaultGatewayV4AuxKey` / `bridge.DefaultGatewayV6AuxKey` instead of the strings in the daemon code that sets up the default bridge (to make it more obvious where the keys are used).

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

