### PR TITLE
daemon/links: use gotest.tools, remove unneeded utility and duplicated test

### DIFF
--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/go-connections/nat"
+	"gotest.tools/v3/assert"
 )
 
 func TestLinkNaming(t *testing.T) {
@@ -40,20 +41,14 @@ func TestLinkNew(t *testing.T) {
 		"6379/tcp": struct{}{},
 	})
 
-	if link.Name != "/db/docker" {
-		t.Fail()
+	expected := &Link{
+		Name:     "/db/docker",
+		ParentIP: "172.0.17.3",
+		ChildIP:  "172.0.17.2",
+		Ports:    []nat.Port{"6379/tcp"},
 	}
-	if link.ParentIP != "172.0.17.3" {
-		t.Fail()
-	}
-	if link.ChildIP != "172.0.17.2" {
-		t.Fail()
-	}
-	for _, p := range link.Ports {
-		if p != "6379/tcp" {
-			t.Fail()
-		}
-	}
+
+	assert.DeepEqual(t, expected, link)
 }
 
 func TestLinkEnv(t *testing.T) {

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -1,10 +1,7 @@
 package links // import "github.com/docker/docker/daemon/links"
 
 import (
-	"fmt"
 	"sort"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/docker/go-connections/nat"
@@ -72,104 +69,33 @@ func TestLinkMultipleEnv(t *testing.T) {
 		"6381/tcp": struct{}{},
 	})
 
-	rawEnv := link.ToEnv()
-	env := make(map[string]string, len(rawEnv))
-	for _, e := range rawEnv {
-		parts := strings.Split(e, "=")
-		if len(parts) != 2 {
-			t.FailNow()
-		}
-		env[parts[0]] = parts[1]
-	}
-	if env["DOCKER_PORT"] != "tcp://172.0.17.2:6379" {
-		t.Fatalf("Expected 172.0.17.2:6379, got %s", env["DOCKER_PORT"])
-	}
-	if env["DOCKER_PORT_6379_TCP_START"] != "tcp://172.0.17.2:6379" {
-		t.Fatalf("Expected tcp://172.0.17.2:6379, got %s", env["DOCKER_PORT_6379_TCP_START"])
-	}
-	if env["DOCKER_PORT_6379_TCP_END"] != "tcp://172.0.17.2:6381" {
-		t.Fatalf("Expected tcp://172.0.17.2:6381, got %s", env["DOCKER_PORT_6379_TCP_END"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PROTO"] != "tcp" {
-		t.Fatalf("Expected tcp, got %s", env["DOCKER_PORT_6379_TCP_PROTO"])
-	}
-	if env["DOCKER_PORT_6379_TCP_ADDR"] != "172.0.17.2" {
-		t.Fatalf("Expected 172.0.17.2, got %s", env["DOCKER_PORT_6379_TCP_ADDR"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PORT_START"] != "6379" {
-		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT_START"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PORT_END"] != "6381" {
-		t.Fatalf("Expected 6381, got %s", env["DOCKER_PORT_6379_TCP_PORT_END"])
-	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
-	}
-	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
-		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])
-	}
-}
+	expectedEnv := []string{
+		"DOCKER_ENV_PASSWORD=gordon",
+		"DOCKER_NAME=/db/docker",
+		"DOCKER_PORT=tcp://172.0.17.2:6379",
+		"DOCKER_PORT_6379_TCP=tcp://172.0.17.2:6379",
+		"DOCKER_PORT_6379_TCP_ADDR=172.0.17.2",
+		"DOCKER_PORT_6379_TCP_ADDR=172.0.17.2", // FIXME(thaJeztah): duplicate?
+		"DOCKER_PORT_6379_TCP_END=tcp://172.0.17.2:6381",
+		"DOCKER_PORT_6379_TCP_PORT=6379",
+		"DOCKER_PORT_6379_TCP_PORT_END=6381",
+		"DOCKER_PORT_6379_TCP_PORT_START=6379",
+		"DOCKER_PORT_6379_TCP_PROTO=tcp",
+		"DOCKER_PORT_6379_TCP_PROTO=tcp", // FIXME(thaJeztah): duplicate?
+		"DOCKER_PORT_6379_TCP_START=tcp://172.0.17.2:6379",
 
-func TestLinkPortRangeEnv(t *testing.T) {
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, nat.PortSet{
-		"6379/tcp": struct{}{},
-		"6380/tcp": struct{}{},
-		"6381/tcp": struct{}{},
-	})
+		"DOCKER_PORT_6380_TCP=tcp://172.0.17.2:6380",
+		"DOCKER_PORT_6380_TCP_ADDR=172.0.17.2",
+		"DOCKER_PORT_6380_TCP_PORT=6380",
+		"DOCKER_PORT_6380_TCP_PROTO=tcp",
 
-	rawEnv := link.ToEnv()
-	env := make(map[string]string, len(rawEnv))
-	for _, e := range rawEnv {
-		parts := strings.Split(e, "=")
-		if len(parts) != 2 {
-			t.FailNow()
-		}
-		env[parts[0]] = parts[1]
+		"DOCKER_PORT_6381_TCP=tcp://172.0.17.2:6381",
+		"DOCKER_PORT_6381_TCP_ADDR=172.0.17.2",
+		"DOCKER_PORT_6381_TCP_PORT=6381",
+		"DOCKER_PORT_6381_TCP_PROTO=tcp",
 	}
 
-	if env["DOCKER_PORT"] != "tcp://172.0.17.2:6379" {
-		t.Fatalf("Expected 172.0.17.2:6379, got %s", env["DOCKER_PORT"])
-	}
-	if env["DOCKER_PORT_6379_TCP_START"] != "tcp://172.0.17.2:6379" {
-		t.Fatalf("Expected tcp://172.0.17.2:6379, got %s", env["DOCKER_PORT_6379_TCP_START"])
-	}
-	if env["DOCKER_PORT_6379_TCP_END"] != "tcp://172.0.17.2:6381" {
-		t.Fatalf("Expected tcp://172.0.17.2:6381, got %s", env["DOCKER_PORT_6379_TCP_END"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PROTO"] != "tcp" {
-		t.Fatalf("Expected tcp, got %s", env["DOCKER_PORT_6379_TCP_PROTO"])
-	}
-	if env["DOCKER_PORT_6379_TCP_ADDR"] != "172.0.17.2" {
-		t.Fatalf("Expected 172.0.17.2, got %s", env["DOCKER_PORT_6379_TCP_ADDR"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PORT_START"] != "6379" {
-		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT_START"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PORT_END"] != "6381" {
-		t.Fatalf("Expected 6381, got %s", env["DOCKER_PORT_6379_TCP_PORT_END"])
-	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
-	}
-	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
-		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])
-	}
-	for _, i := range []int{6379, 6380, 6381} {
-		tcpaddr := fmt.Sprintf("DOCKER_PORT_%d_TCP_ADDR", i)
-		tcpport := fmt.Sprintf("DOCKER_PORT_%d_TCP_PORT", i)
-		tcpproto := fmt.Sprintf("DOCKER_PORT_%d_TCP_PROTO", i)
-		tcp := fmt.Sprintf("DOCKER_PORT_%d_TCP", i)
-		if env[tcpaddr] != "172.0.17.2" {
-			t.Fatalf("Expected env %s  = 172.0.17.2, got %s", tcpaddr, env[tcpaddr])
-		}
-		if env[tcpport] != strconv.Itoa(i) {
-			t.Fatalf("Expected env %s  = %d, got %s", tcpport, i, env[tcpport])
-		}
-		if env[tcpproto] != "tcp" {
-			t.Fatalf("Expected env %s  = tcp, got %s", tcpproto, env[tcpproto])
-		}
-		if env[tcp] != fmt.Sprintf("tcp://172.0.17.2:%d", i) {
-			t.Fatalf("Expected env %s  = tcp://172.0.17.2:%d, got %s", tcp, i, env[tcp])
-		}
-	}
+	actual := link.ToEnv()
+	sort.Strings(actual) // order of env-vars is not relevant
+	assert.DeepEqual(t, expectedEnv, actual)
 }

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -50,36 +50,19 @@ func TestLinkEnv(t *testing.T) {
 		"6379/tcp": struct{}{},
 	})
 
-	rawEnv := link.ToEnv()
-	env := make(map[string]string, len(rawEnv))
-	for _, e := range rawEnv {
-		parts := strings.Split(e, "=")
-		if len(parts) != 2 {
-			t.FailNow()
-		}
-		env[parts[0]] = parts[1]
+	expectedEnv := []string{
+		"DOCKER_ENV_PASSWORD=gordon",
+		"DOCKER_NAME=/db/docker",
+		"DOCKER_PORT=tcp://172.0.17.2:6379",
+		"DOCKER_PORT_6379_TCP=tcp://172.0.17.2:6379",
+		"DOCKER_PORT_6379_TCP_ADDR=172.0.17.2",
+		"DOCKER_PORT_6379_TCP_PORT=6379",
+		"DOCKER_PORT_6379_TCP_PROTO=tcp",
 	}
-	if env["DOCKER_PORT"] != "tcp://172.0.17.2:6379" {
-		t.Fatalf("Expected 172.0.17.2:6379, got %s", env["DOCKER_PORT"])
-	}
-	if env["DOCKER_PORT_6379_TCP"] != "tcp://172.0.17.2:6379" {
-		t.Fatalf("Expected tcp://172.0.17.2:6379, got %s", env["DOCKER_PORT_6379_TCP"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PROTO"] != "tcp" {
-		t.Fatalf("Expected tcp, got %s", env["DOCKER_PORT_6379_TCP_PROTO"])
-	}
-	if env["DOCKER_PORT_6379_TCP_ADDR"] != "172.0.17.2" {
-		t.Fatalf("Expected 172.0.17.2, got %s", env["DOCKER_PORT_6379_TCP_ADDR"])
-	}
-	if env["DOCKER_PORT_6379_TCP_PORT"] != "6379" {
-		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT"])
-	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
-	}
-	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
-		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])
-	}
+
+	actual := link.ToEnv()
+	sort.Strings(actual) // order of env-vars is not relevant
+	assert.DeepEqual(t, expectedEnv, actual)
 }
 
 func TestLinkMultipleEnv(t *testing.T) {

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -2,6 +2,7 @@ package links // import "github.com/docker/docker/daemon/links"
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,25 +16,18 @@ func TestLinkNaming(t *testing.T) {
 		"6379/tcp": struct{}{},
 	})
 
-	rawEnv := link.ToEnv()
-	env := make(map[string]string, len(rawEnv))
-	for _, e := range rawEnv {
-		parts := strings.Split(e, "=")
-		if len(parts) != 2 {
-			t.FailNow()
-		}
-		env[parts[0]] = parts[1]
+	expectedEnv := []string{
+		"DOCKER_1_NAME=/db/docker-1",
+		"DOCKER_1_PORT=tcp://172.0.17.2:6379",
+		"DOCKER_1_PORT_6379_TCP=tcp://172.0.17.2:6379",
+		"DOCKER_1_PORT_6379_TCP_ADDR=172.0.17.2",
+		"DOCKER_1_PORT_6379_TCP_PORT=6379",
+		"DOCKER_1_PORT_6379_TCP_PROTO=tcp",
 	}
 
-	value, ok := env["DOCKER_1_PORT"]
-
-	if !ok {
-		t.Fatal("DOCKER_1_PORT not found in env")
-	}
-
-	if value != "tcp://172.0.17.2:6379" {
-		t.Fatalf("Expected 172.0.17.2:6379, got %s", env["DOCKER_1_PORT"])
-	}
+	actual := link.ToEnv()
+	sort.Strings(actual) // order of env-vars is not relevant
+	assert.DeepEqual(t, expectedEnv, actual)
 }
 
 func TestLinkNew(t *testing.T) {

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -9,17 +9,10 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-// Just to make life easier
-func newPortNoError(proto, port string) nat.Port {
-	p, _ := nat.NewPort(proto, port)
-	return p
-}
-
 func TestLinkNaming(t *testing.T) {
-	ports := make(nat.PortSet)
-	ports[newPortNoError("tcp", "6379")] = struct{}{}
-
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, ports)
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, nat.PortSet{
+		"6379/tcp": struct{}{},
+	})
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))
@@ -43,10 +36,9 @@ func TestLinkNaming(t *testing.T) {
 }
 
 func TestLinkNew(t *testing.T) {
-	ports := make(nat.PortSet)
-	ports[newPortNoError("tcp", "6379")] = struct{}{}
-
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, ports)
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, nat.PortSet{
+		"6379/tcp": struct{}{},
+	})
 
 	if link.Name != "/db/docker" {
 		t.Fail()
@@ -58,17 +50,16 @@ func TestLinkNew(t *testing.T) {
 		t.Fail()
 	}
 	for _, p := range link.Ports {
-		if p != newPortNoError("tcp", "6379") {
+		if p != "6379/tcp" {
 			t.Fail()
 		}
 	}
 }
 
 func TestLinkEnv(t *testing.T) {
-	ports := make(nat.PortSet)
-	ports[newPortNoError("tcp", "6379")] = struct{}{}
-
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, nat.PortSet{
+		"6379/tcp": struct{}{},
+	})
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))
@@ -103,12 +94,11 @@ func TestLinkEnv(t *testing.T) {
 }
 
 func TestLinkMultipleEnv(t *testing.T) {
-	ports := make(nat.PortSet)
-	ports[newPortNoError("tcp", "6379")] = struct{}{}
-	ports[newPortNoError("tcp", "6380")] = struct{}{}
-	ports[newPortNoError("tcp", "6381")] = struct{}{}
-
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, nat.PortSet{
+		"6379/tcp": struct{}{},
+		"6380/tcp": struct{}{},
+		"6381/tcp": struct{}{},
+	})
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))
@@ -149,12 +139,11 @@ func TestLinkMultipleEnv(t *testing.T) {
 }
 
 func TestLinkPortRangeEnv(t *testing.T) {
-	ports := make(nat.PortSet)
-	ports[newPortNoError("tcp", "6379")] = struct{}{}
-	ports[newPortNoError("tcp", "6380")] = struct{}{}
-	ports[newPortNoError("tcp", "6381")] = struct{}{}
-
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, nat.PortSet{
+		"6379/tcp": struct{}{},
+		"6380/tcp": struct{}{},
+		"6381/tcp": struct{}{},
+	})
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/14682
- https://github.com/moby/moby/pull/10061


### daemon/links: remove newPortNoError utility

This utility was added in 12b6083c8f82db7e5db4c683cfe20151731ea851 as a
replacement for nat.NewPort(), which before that patch would panic on
invalid values, but was changed to return an error.

Given that the utility ignores any error, and these values are fixed values
for the test, let's remove it to simplify constructing the tests.


### daemon/links: TestLinkNew: assert with gotest.tools


### daemon/links: TestLinkNaming: assert with gotest.tools

Simplify the test by testing the result, instead of manually checking
specific values. This makes sure we check the actual results, and don't
miss values, or ignore unexpected values.

### daemon/links: TestLinkEnv: assert with gotest.tools

Simplify the test by testing the result, instead of manually checking
specific values. This makes sure we check the actual results, and don't
miss values, or ignore unexpected values.

### daemon/links: TestLinkMultipleEnv: assert with gotest.tools, remove TestLinkPortRangeEnv

Simplify the test by testing the result, instead of manually checking
specific values. This makes sure we check the actual results, and don't
miss values, or ignore unexpected values.

TestLinkPortRangeEnv was added in 611a23aa7f443284fbbbb80716c46159e438bf52
to test for port-ranges to produce the expected env-vars, but used the
same input as TestLinkMultipleEnv. Now that we assert all env-vars produced,
it became a duplicate of TestLinkMultipleEnv, so we can remove that test.




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

