### PR TITLE
ci: update bake-action to v6

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -32,7 +32,6 @@ env:
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest
 
 jobs:
-
   unit-prepare:
     runs-on: ubuntu-20.04
     timeout-minutes: 10 # guardrails timeout for the whole job
@@ -98,7 +97,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -185,7 +184,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -239,7 +238,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -331,7 +330,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -521,7 +520,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -110,11 +110,6 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Download meta bake definition
         uses: actions/download-artifact@v4
         with:
@@ -140,11 +135,11 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl
-            /tmp/bake-meta.json
+            cwd:///tmp/bake-meta.json
           targets: bin-image
           set: |
             *.platform=${{ matrix.platform }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -38,9 +38,6 @@ jobs:
       - validate-dco
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -49,7 +46,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: binary
       -
@@ -146,8 +143,9 @@ jobs:
           docker info
       -
         name: Build test image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
+          source: .
           workdir: ./buildkit
           targets: integration-tests
           set: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,6 @@ jobs:
           - dynbinary
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -56,7 +51,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: ${{ matrix.target }}
       -
@@ -102,11 +97,6 @@ jobs:
         platform: ${{ fromJson(needs.prepare-cross.outputs.matrix) }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -120,7 +110,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: all
           set: |
@@ -144,11 +134,6 @@ jobs:
       contents: read
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -157,7 +142,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Run
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: govulncheck
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,6 @@ jobs:
             echo "SYSTEMD=true" >> $GITHUB_ENV
           fi
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -62,7 +59,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -135,7 +132,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -178,9 +175,6 @@ jobs:
         platform: ${{ fromJson(needs.smoke-prepare.outputs.matrix) }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -197,7 +191,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Test
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: binary-smoketest
           set: |


### PR DESCRIPTION
https://github.com/docker/bake-action/releases/tag/v6.0.0

similar to:
* https://github.com/moby/buildkit/pull/5634
* https://github.com/docker/buildx/pull/2894

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

