### PR TITLE
pkg/ioutils: un-export ReadCloserWrapper

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -2,29 +2,28 @@ package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
 import (
 	"context"
-	"io"
-	"runtime/debug"
-	"sync/atomic"
-
 	// make sure crypto.SHA256, crypto.sha512 and crypto.SHA384 are registered
 	// TODO remove once https://github.com/opencontainers/go-digest/pull/64 is merged.
 	_ "crypto/sha256"
 	_ "crypto/sha512"
+	"io"
+	"runtime/debug"
+	"sync/atomic"
 
 	"github.com/containerd/log"
 )
 
-// ReadCloserWrapper wraps an io.Reader, and implements an io.ReadCloser
+// readCloserWrapper wraps an io.Reader, and implements an io.ReadCloser
 // It calls the given callback function when closed. It should be constructed
 // with NewReadCloserWrapper
-type ReadCloserWrapper struct {
+type readCloserWrapper struct {
 	io.Reader
 	closer func() error
 	closed atomic.Bool
 }
 
 // Close calls back the passed closer function
-func (r *ReadCloserWrapper) Close() error {
+func (r *readCloserWrapper) Close() error {
 	if !r.closed.CompareAndSwap(false, true) {
 		subsequentCloseWarn("ReadCloserWrapper")
 		return nil
@@ -32,9 +31,10 @@ func (r *ReadCloserWrapper) Close() error {
 	return r.closer()
 }
 
-// NewReadCloserWrapper returns a new io.ReadCloser.
+// NewReadCloserWrapper wraps an io.Reader, and implements an io.ReadCloser.
+// It calls the given callback function when closed.
 func NewReadCloserWrapper(r io.Reader, closer func() error) io.ReadCloser {
-	return &ReadCloserWrapper{
+	return &readCloserWrapper{
 		Reader: r,
 		closer: closer,
 	}


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/49073
- https://github.com/moby/moby/pull/35697
- https://github.com/moby/moby/issues/32989


This type was exported in fd35494a251a497c359f706f61f33e689e2af678 to be used in tests in pkg/archive. It's no longer used in pkg/archive since ba90fd8da0734dc109ce0147eba4fb1e877127a0, so we can un-export it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: remove pkg/ioutils.ReadCloserWrapper, as it was only used in tests.
```

**- A picture of a cute animal (not mandatory but encouraged)**

