### PR TITLE
Dockerfile: update runc binary to v1.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -288,7 +288,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.2.3
+ARG RUNC_VERSION=v1.2.4
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.2.3}"
+: "${RUNC_VERSION:=v1.2.4}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
This is the fourth patch release of the 1.2.z release branch of runc. It includes a fix for a regression introduced in 1.2.0 related to the default device list.

- Re-add tun/tap devices to built-in allowed devices lists.

 In runc 1.2.0 we removed these devices from the default allow-list
 (which were added seemingly by accident early in Docker's history) as
 a precaution in order to try to reduce the attack surface of device
 inodes available to most containers. At the time we thought
 that the vast majority of users using tun/tap would already be
 specifying what devices they need (such as by using --device with
 Docker/Podman) as opposed to doing the mknod manually, and thus
 there would've been no user-visible change.

 Unfortunately, it seems that this regressed a noticeable number of
 users (and not all higher-level tools provide easy ways to specify
 devices to allow) and so this change needed to be reverted. Users
 that do not need these devices are recommended to explicitly disable
 them by adding deny rules in their container configuration.

full diff: https://github.com/opencontainers/runc/compare/v1.2.3...v1.2.4
release notes: https://github.com/opencontainers/runc/releases/tag/v1.2.4

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Upgrade `runc` to [v1.2.4](https://github.com/opencontainers/runc/releases/tag/v1.2.4)
```

**- A picture of a cute animal (not mandatory but encouraged)**

