### PR TITLE
pkg/ioutils: deprecate unused types and functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -156,6 +156,12 @@ issues:
       linters:
         - staticcheck
 
+    # FIXME temporarily suppress these until they are moved internal to container/streams.
+    - text: "SA1019: ioutils\\.(ErrClosed|BytesPipe|NewBytesPipe)"
+      path: "container/stream/"
+      linters:
+        - staticcheck
+
     - text: "ineffectual assignment to ctx"
       source: "ctx[, ].*=.*\\(ctx[,)]"
       linters:

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -339,8 +339,12 @@ type flusher interface {
 	Flush()
 }
 
+type nopFlusher struct{}
+
+func (f *nopFlusher) Flush() {}
+
 func wrapOutputBufferedUntilRequestRead(rc io.ReadCloser, out io.Writer) (io.ReadCloser, io.Writer) {
-	var fl flusher = &ioutils.NopFlusher{}
+	var fl flusher = &nopFlusher{}
 	if f, ok := out.(flusher); ok {
 		fl = f
 	}

--- a/pkg/ioutils/bytespipe.go
+++ b/pkg/ioutils/bytespipe.go
@@ -18,6 +18,8 @@ const blockThreshold = 1e6
 
 var (
 	// ErrClosed is returned when Write is called on a closed BytesPipe.
+	//
+	// Deprecated: this type is only used internally, and will be removed in the next release.
 	ErrClosed = errors.New("write to closed BytesPipe")
 
 	bufPools     = make(map[int]*sync.Pool)
@@ -28,6 +30,8 @@ var (
 // All written data may be read at most once. Also, BytesPipe allocates
 // and releases new byte slices to adjust to current needs, so the buffer
 // won't be overgrown after peak loads.
+//
+// Deprecated: this type is only used internally, and will be removed in the next release.
 type BytesPipe struct {
 	mu        sync.Mutex
 	wait      *sync.Cond
@@ -40,6 +44,8 @@ type BytesPipe struct {
 // NewBytesPipe creates new BytesPipe, initialized by specified slice.
 // If buf is nil, then it will be initialized with slice which cap is 64.
 // buf will be adjusted in a way that len(buf) == 0, cap(buf) == cap(buf).
+//
+// Deprecated: this function is only used internally, and will be removed in the next release.
 func NewBytesPipe() *BytesPipe {
 	bp := &BytesPipe{}
 	bp.buf = append(bp.buf, getBuffer(minCap))

--- a/pkg/ioutils/writeflusher.go
+++ b/pkg/ioutils/writeflusher.go
@@ -80,13 +80,19 @@ func (wf *WriteFlusher) Close() error {
 	return nil
 }
 
+// nopFlusher represents a type which flush operation is nop.
+type nopFlusher struct{}
+
+// Flush is a nop operation.
+func (f *nopFlusher) Flush() {}
+
 // NewWriteFlusher returns a new WriteFlusher.
 func NewWriteFlusher(w io.Writer) *WriteFlusher {
 	var fl flusher
 	if f, ok := w.(flusher); ok {
 		fl = f
 	} else {
-		fl = &NopFlusher{}
+		fl = &nopFlusher{}
 	}
 	return &WriteFlusher{w: w, flusher: fl, closed: make(chan struct{}), flushed: make(chan struct{})}
 }

--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -24,10 +24,9 @@ func NopWriteCloser(w io.Writer) io.WriteCloser {
 }
 
 // NopFlusher represents a type which flush operation is nop.
-type NopFlusher struct{}
-
-// Flush is a nop operation.
-func (f *NopFlusher) Flush() {}
+//
+// Deprecated: NopFlusher is only used internally and will be removed in the next release.
+type NopFlusher = nopFlusher
 
 type writeCloserWrapper struct {
 	io.Writer

--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -55,12 +55,16 @@ func NewWriteCloserWrapper(r io.Writer, closer func() error) io.WriteCloser {
 // of bytes written to the writer during a "session".
 // This can be convenient when write return is masked
 // (e.g., json.Encoder.Encode())
+//
+// Deprecated: this type is no longer used and will be removed in the next release.
 type WriteCounter struct {
 	Count  int64
 	Writer io.Writer
 }
 
 // NewWriteCounter returns a new WriteCounter.
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func NewWriteCounter(w io.Writer) *WriteCounter {
 	return &WriteCounter{
 		Writer: w,


### PR DESCRIPTION
### pkg/ioutils: deprecate BytesPipe, NewBytesPipe, ErrClosed

These types are only used internally in container/streams and have no
external consumers. Deprecate them in preparation of moving them to
a subpackage of container/streams.

### pkg/ioutils: deprecate WriteCounter, NewWriteCounter

it was moved to pkg/ioutils in c30a55f14dbbe3971ba0ac716ba69a60868f4490,
and only had a single use at the time in [engine/Env.WriteTo]. That use
was removed in 531f4122bdcd4de289f613a5ef010f4c1989f098, which removed
the engine package.

[engine/Env.WriteTo]: https://github.com/moby/moby/blob/c30a55f14dbbe3971ba0ac716ba69a60868f4490/engine/env.go#L260-L264

### pkg/ioutils: deprecate NewReaderErrWrapper

It was introduced in bd130e72a06dc3e8de521ce365bf4933f36b2417 as part of
[docker#7542], but was never used.

[docker#7542]: https://github.com/docker/docker/pull/7542


### pkg/ioutils: deprecate NopFlusher

Apart from being used internally for NewWriteFlusher, it's only used
in a single location outside of this package. Copy the implementation
where it's used, and mark it deprecated.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: pkg/ioutils: deprecate `BytesPipe`, `NewBytesPipe`, `ErrClosed`. These types are only used internally and will be removed in the next release
Go SDK: pkg/ioutils: deprecate `WriteCounter`, `NewWriteCounter`. This type and utility were not used and will be removed in the next release
Go SDK: pkg/ioutils: deprecate `NewReaderErrWrapper`. This function was not used and will be removed in the next release.
Go SDK: pkg/ioutils: deprecate `NopFlusher`. This type was only used internally and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

