### PR TITLE
pkg/ioutils: remove or internalize deprecated types and functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -156,12 +156,6 @@ issues:
       linters:
         - staticcheck
 
-    # FIXME temporarily suppress these until they are moved internal to container/streams.
-    - text: "SA1019: ioutils\\.(ErrClosed|BytesPipe|NewBytesPipe)"
-      path: "container/stream/"
-      linters:
-        - staticcheck
-
     - text: "ineffectual assignment to ctx"
       source: "ctx[, ].*=.*\\(ctx[,)]"
       linters:

--- a/container/stream/bytespipe/buffer.go
+++ b/container/stream/bytespipe/buffer.go
@@ -1,4 +1,4 @@
-package ioutils // import "github.com/docker/docker/pkg/ioutils"
+package bytespipe
 
 import (
 	"errors"

--- a/container/stream/bytespipe/buffer_test.go
+++ b/container/stream/bytespipe/buffer_test.go
@@ -1,4 +1,4 @@
-package ioutils // import "github.com/docker/docker/pkg/ioutils"
+package bytespipe
 
 import (
 	"bytes"

--- a/container/stream/bytespipe/bytespipe.go
+++ b/container/stream/bytespipe/bytespipe.go
@@ -1,4 +1,4 @@
-package ioutils // import "github.com/docker/docker/pkg/ioutils"
+package bytespipe
 
 import (
 	"errors"
@@ -18,8 +18,6 @@ const blockThreshold = 1e6
 
 var (
 	// ErrClosed is returned when Write is called on a closed BytesPipe.
-	//
-	// Deprecated: this type is only used internally, and will be removed in the next release.
 	ErrClosed = errors.New("write to closed BytesPipe")
 
 	bufPools     = make(map[int]*sync.Pool)
@@ -30,8 +28,6 @@ var (
 // All written data may be read at most once. Also, BytesPipe allocates
 // and releases new byte slices to adjust to current needs, so the buffer
 // won't be overgrown after peak loads.
-//
-// Deprecated: this type is only used internally, and will be removed in the next release.
 type BytesPipe struct {
 	mu        sync.Mutex
 	wait      *sync.Cond
@@ -41,12 +37,10 @@ type BytesPipe struct {
 	readBlock bool  // check read BytesPipe is Wait() or not
 }
 
-// NewBytesPipe creates new BytesPipe, initialized by specified slice.
+// New creates new BytesPipe, initialized by specified slice.
 // If buf is nil, then it will be initialized with slice which cap is 64.
 // buf will be adjusted in a way that len(buf) == 0, cap(buf) == cap(buf).
-//
-// Deprecated: this function is only used internally, and will be removed in the next release.
-func NewBytesPipe() *BytesPipe {
+func New() *BytesPipe {
 	bp := &BytesPipe{}
 	bp.buf = append(bp.buf, getBuffer(minCap))
 	bp.wait = sync.NewCond(&bp.mu)

--- a/container/stream/bytespipe/bytespipe_test.go
+++ b/container/stream/bytespipe/bytespipe_test.go
@@ -1,4 +1,4 @@
-package ioutils // import "github.com/docker/docker/pkg/ioutils"
+package bytespipe
 
 import (
 	"crypto/sha256"
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBytesPipeRead(t *testing.T) {
-	buf := NewBytesPipe()
+	buf := New()
 	_, _ = buf.Write([]byte("12"))
 	_, _ = buf.Write([]byte("34"))
 	_, _ = buf.Write([]byte("56"))
@@ -49,7 +49,7 @@ func TestBytesPipeRead(t *testing.T) {
 }
 
 func TestBytesPipeWrite(t *testing.T) {
-	buf := NewBytesPipe()
+	buf := New()
 	_, _ = buf.Write([]byte("12"))
 	_, _ = buf.Write([]byte("34"))
 	_, _ = buf.Write([]byte("56"))
@@ -62,7 +62,7 @@ func TestBytesPipeWrite(t *testing.T) {
 
 // Regression test for #41941.
 func TestBytesPipeDeadlock(t *testing.T) {
-	bp := NewBytesPipe()
+	bp := New()
 	bp.buf = []*fixedBuffer{getBuffer(blockThreshold)}
 
 	rd := make(chan error)
@@ -145,7 +145,7 @@ func TestBytesPipeWriteRandomChunks(t *testing.T) {
 		expected := hex.EncodeToString(hash.Sum(nil))
 
 		// write/read through buffer
-		buf := NewBytesPipe()
+		buf := New()
 		hash.Reset()
 
 		done := make(chan struct{})
@@ -186,7 +186,7 @@ func BenchmarkBytesPipeWrite(b *testing.B) {
 	testData := []byte("pretty short line, because why not?")
 	for i := 0; i < b.N; i++ {
 		readBuf := make([]byte, 1024)
-		buf := NewBytesPipe()
+		buf := New()
 		go func() {
 			var err error
 			for err == nil {
@@ -205,7 +205,7 @@ func BenchmarkBytesPipeRead(b *testing.B) {
 	rd := make([]byte, 512)
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		buf := NewBytesPipe()
+		buf := New()
 		for j := 0; j < 500; j++ {
 			_, _ = buf.Write(make([]byte, 1024))
 		}

--- a/container/stream/streams.go
+++ b/container/stream/streams.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/log"
+	"github.com/docker/docker/container/stream/bytespipe"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/pools"
 )
@@ -64,7 +65,7 @@ func (c *Config) StdinPipe() io.WriteCloser {
 // It adds this new out pipe to the Stdout broadcaster.
 // This will block stdout if unconsumed.
 func (c *Config) StdoutPipe() io.ReadCloser {
-	bytesPipe := ioutils.NewBytesPipe()
+	bytesPipe := bytespipe.New()
 	c.stdout.Add(bytesPipe)
 	return bytesPipe
 }
@@ -73,7 +74,7 @@ func (c *Config) StdoutPipe() io.ReadCloser {
 // It adds this new err pipe to the Stderr broadcaster.
 // This will block stderr if unconsumed.
 func (c *Config) StderrPipe() io.ReadCloser {
-	bytesPipe := ioutils.NewBytesPipe()
+	bytesPipe := bytespipe.New()
 	c.stderr.Add(bytesPipe)
 	return bytesPipe
 }

--- a/pkg/ioutils/writeflusher.go
+++ b/pkg/ioutils/writeflusher.go
@@ -21,12 +21,10 @@ type flusher interface {
 	Flush()
 }
 
-var errWriteFlusherClosed = io.EOF
-
 func (wf *WriteFlusher) Write(b []byte) (n int, err error) {
 	select {
 	case <-wf.closed:
-		return 0, errWriteFlusherClosed
+		return 0, io.EOF
 	default:
 	}
 
@@ -73,7 +71,7 @@ func (wf *WriteFlusher) Close() error {
 
 	select {
 	case <-wf.closed:
-		return errWriteFlusherClosed
+		return io.EOF
 	default:
 		close(wf.closed)
 	}

--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -23,11 +23,6 @@ func NopWriteCloser(w io.Writer) io.WriteCloser {
 	return &nopWriteCloser{w}
 }
 
-// NopFlusher represents a type which flush operation is nop.
-//
-// Deprecated: NopFlusher is only used internally and will be removed in the next release.
-type NopFlusher = nopFlusher
-
 type writeCloserWrapper struct {
 	io.Writer
 	closer func() error

--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -49,29 +49,3 @@ func NewWriteCloserWrapper(r io.Writer, closer func() error) io.WriteCloser {
 		closer: closer,
 	}
 }
-
-// WriteCounter wraps a concrete io.Writer and hold a count of the number
-// of bytes written to the writer during a "session".
-// This can be convenient when write return is masked
-// (e.g., json.Encoder.Encode())
-//
-// Deprecated: this type is no longer used and will be removed in the next release.
-type WriteCounter struct {
-	Count  int64
-	Writer io.Writer
-}
-
-// NewWriteCounter returns a new WriteCounter.
-//
-// Deprecated: this function is no longer used and will be removed in the next release.
-func NewWriteCounter(w io.Writer) *WriteCounter {
-	return &WriteCounter{
-		Writer: w,
-	}
-}
-
-func (wc *WriteCounter) Write(p []byte) (count int, err error) {
-	count, err = wc.Writer.Write(p)
-	wc.Count += int64(count)
-	return
-}

--- a/pkg/ioutils/writers_test.go
+++ b/pkg/ioutils/writers_test.go
@@ -2,7 +2,6 @@ package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 )
 
@@ -37,28 +36,5 @@ func TestNopWriter(t *testing.T) {
 	}
 	if l != 1 {
 		t.Fatalf("Expected 1 got %d", l)
-	}
-}
-
-func TestWriteCounter(t *testing.T) {
-	dummy1 := "This is a dummy string."
-	dummy2 := "This is another dummy string."
-	totalLength := int64(len(dummy1) + len(dummy2))
-
-	reader1 := strings.NewReader(dummy1)
-	reader2 := strings.NewReader(dummy2)
-
-	var buffer bytes.Buffer
-	wc := NewWriteCounter(&buffer)
-
-	_, _ = reader1.WriteTo(wc)
-	_, _ = reader2.WriteTo(wc)
-
-	if wc.Count != totalLength {
-		t.Errorf("Wrong count: %d vs. %d", wc.Count, totalLength)
-	}
-
-	if buffer.String() != dummy1+dummy2 {
-		t.Error("Wrong message written")
 	}
 }


### PR DESCRIPTION
- [x] follow-up to https://github.com/moby/moby/pull/49244

---

### pkg/ioutils: move BytesPipe to container/streams/bytespipe

These types are only used internally in container/streams and have no
external consumers. move them to a subpackage of container/streams.

### pkg/ioutils: remove deprecated WriteCounter, NewWriteCounter

### pkg/ioutils: remove deprecated NopFlusher


### pkg/ioutils: remove errWriteFlusherClosed

It's an alias for io.EOF and not exported, so we don't need it.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: pkg/ioutils: remove deprecated `BytesPipe`, `NewBytesPipe`, `ErrClosed`.
Go SDK: pkg/ioutils: remove deprecated `WriteCounter`, `NewWriteCounter`.
Go SDK: pkg/ioutils: remove deprecated `NewReaderErrWrapper`.
Go SDK: pkg/ioutils: remove deprecated `NopFlusher`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

