### PR TITLE
[27.x backport] Fix unit tests for an nftables host

### DIFF
--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -30,11 +30,6 @@ func TestUserChain(t *testing.T) {
 		userChain []string
 	}{
 		{
-			iptables: false,
-			insert:   false,
-			fwdChain: []string{"-P FORWARD ACCEPT"},
-		},
-		{
 			iptables:  true,
 			insert:    false,
 			fwdChain:  []string{"-P FORWARD ACCEPT", "-A FORWARD -j DOCKER-USER"},
@@ -45,6 +40,11 @@ func TestUserChain(t *testing.T) {
 			insert:    true,
 			fwdChain:  []string{"-P FORWARD ACCEPT", "-A FORWARD -j DOCKER-USER", "-A FORWARD -j DROP"},
 			userChain: []string{"-N DOCKER-USER", "-A DOCKER-USER -j RETURN"},
+		},
+		{
+			iptables: false,
+			insert:   false,
+			fwdChain: []string{"-P FORWARD ACCEPT"},
 		},
 	}
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49248
  - the test has changed, so not a straight cherry-pick, but the principle is the same

**- What I did**

On a freshly rebooted Linux host that's configured to use nftables with the iptables front-end, `make test-unit` fails "TestUserChains" on the first run - it's ok in subsequent runs.

The unit tests run in moby's dev container.

The first test in TestUserChain runs with ip6tables disabled, so the bridge driver doesn't try to load the ip6_tables module. Then, because the module isn't loaded (it wasn't needed by the daemon running on the nftables host when it started), the test fails because it can't check what's in the ip6tables filter chain.

The next test in TestUserChain does the same thing, but with ip6tables enabled. So the module gets loaded by the bridge driver, and everything works normally after that.

The dev container used to try to load the module on startup, but that was removed in commit 2af19b6b ("Don't try to modprobe ip6_tables in the moby dev container"), as part of a change to give the daemon a way to load modules itself.

**- How I did it**

Rather that put back the dev container's code to load ip6_tables on startup (which would mean the daemon's module-loading code not getting to run on nftables/firewalld hosts) ...

Run the tests in TestUserChains in a different order, with iptables enabled in the first test will make it happen to work. At least for now.

It's not ideal, but we'll be switching to nftables soon, so the issue will go away.

**- How to verify it**

`make test-unit` works on a freshly rebooted `nftables`-based host (tested on an Ubuntu 24.04 VM).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

