### PR TITLE
[27.x backport] Dockerfile: update containerd to v1.7.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -196,7 +196,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.7.24
+ARG CONTAINERD_VERSION=v1.7.25
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -164,7 +164,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.22.10
 ARG GOTESTSUM_VERSION=v1.8.2
 ARG GOWINRES_VERSION=v0.3.1
-ARG CONTAINERD_VERSION=v1.7.24
+ARG CONTAINERD_VERSION=v1.7.25
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.7.24}"
+: "${CONTAINERD_VERSION:=v1.7.25}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49252


release notes: https://github.com/containerd/containerd/releases/tag/v1.7.25
full diff: https://github.com/containerd/containerd/compare/v1.7.24...v1.7.25


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Update containerd (static binaries only) to [v1.7.25](https://github.com/containerd/containerd/releases/tag/v1.7.25)
```

**- A picture of a cute animal (not mandatory but encouraged)**

