### PR TITLE
pkg/ioutils: deprecate NopWriter, NopWriteCloser

### DIFF
--- a/container/stream/streams.go
+++ b/container/stream/streams.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/log"
 	"github.com/docker/docker/container/stream/bytespipe"
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/pools"
 )
 
@@ -86,8 +85,14 @@ func (c *Config) NewInputPipes() {
 
 // NewNopInputPipe creates a new input pipe that will silently drop all messages in the input.
 func (c *Config) NewNopInputPipe() {
-	c.stdinPipe = ioutils.NopWriteCloser(io.Discard)
+	c.stdinPipe = &nopWriteCloser{io.Discard}
 }
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (w *nopWriteCloser) Close() error { return nil }
 
 // CloseStreams ensures that the configured streams are properly closed.
 func (c *Config) CloseStreams() error {

--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -21,6 +21,8 @@ type nopWriteCloser struct {
 func (w *nopWriteCloser) Close() error { return nil }
 
 // NopWriteCloser returns a nopWriteCloser.
+//
+// Deprecated: This function is no longer used and will be removed in the next release.
 func NopWriteCloser(w io.Writer) io.WriteCloser {
 	return &nopWriteCloser{w}
 }

--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -6,6 +6,8 @@ import (
 )
 
 // NopWriter represents a type which write operation is nop.
+//
+// Deprecated: use [io.Discard] instead. This type will be removed in the next release.
 type NopWriter struct{}
 
 func (*NopWriter) Write(buf []byte) (int, error) {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49245#issuecomment-2582587899
- relates to https://github.com/moby/moby/issues/32989



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: pkg/ioutils: deprecate `NopWriter` in favour of `io.Discard`. It will be removed in the next release.
Go SDK: pkg/ioutils: deprecate `NopWriteCloser`. It was only used internally, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

