### PR TITLE
pkg/ioutils: remove deprecated NopWriter, NopWriteCloser

### DIFF
--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -5,19 +5,6 @@ import (
 	"sync/atomic"
 )
 
-type nopWriteCloser struct {
-	io.Writer
-}
-
-func (w *nopWriteCloser) Close() error { return nil }
-
-// NopWriteCloser returns a nopWriteCloser.
-//
-// Deprecated: This function is no longer used and will be removed in the next release.
-func NopWriteCloser(w io.Writer) io.WriteCloser {
-	return &nopWriteCloser{w}
-}
-
 type writeCloserWrapper struct {
 	io.Writer
 	closer func() error

--- a/pkg/ioutils/writers.go
+++ b/pkg/ioutils/writers.go
@@ -5,15 +5,6 @@ import (
 	"sync/atomic"
 )
 
-// NopWriter represents a type which write operation is nop.
-//
-// Deprecated: use [io.Discard] instead. This type will be removed in the next release.
-type NopWriter struct{}
-
-func (*NopWriter) Write(buf []byte) (int, error) {
-	return len(buf), nil
-}
-
 type nopWriteCloser struct {
 	io.Writer
 }

--- a/pkg/ioutils/writers_test.go
+++ b/pkg/ioutils/writers_test.go
@@ -19,11 +19,3 @@ func TestWriteCloserWrapperClose(t *testing.T) {
 		t.Fatalf("writeCloserWrapper should have call the anonymous function.")
 	}
 }
-
-func TestNopWriteCloser(t *testing.T) {
-	writer := bytes.NewBuffer([]byte{})
-	wrapper := NopWriteCloser(writer)
-	if err := wrapper.Close(); err != nil {
-		t.Fatal("NopWriteCloser always return nil on Close.")
-	}
-}

--- a/pkg/ioutils/writers_test.go
+++ b/pkg/ioutils/writers_test.go
@@ -27,14 +27,3 @@ func TestNopWriteCloser(t *testing.T) {
 		t.Fatal("NopWriteCloser always return nil on Close.")
 	}
 }
-
-func TestNopWriter(t *testing.T) {
-	nw := &NopWriter{}
-	l, err := nw.Write([]byte{'c'})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if l != 1 {
-		t.Fatalf("Expected 1 got %d", l)
-	}
-}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49254
- relates to https://github.com/moby/moby/issues/32989



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: pkg/ioutils: remove deprecated `NopWriter` in favour of `io.Discard`.
Go SDK: pkg/ioutils: remove deprecated `NopWriteCloser`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

