### PR TITLE
pkg/ioutils: remove unused NewReaderErrWrapper

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -40,27 +40,6 @@ func NewReadCloserWrapper(r io.Reader, closer func() error) io.ReadCloser {
 	}
 }
 
-type readerErrWrapper struct {
-	reader io.Reader
-	closer func()
-}
-
-func (r *readerErrWrapper) Read(p []byte) (int, error) {
-	n, err := r.reader.Read(p)
-	if err != nil {
-		r.closer()
-	}
-	return n, err
-}
-
-// NewReaderErrWrapper returns a new io.Reader.
-func NewReaderErrWrapper(r io.Reader, closer func()) io.Reader {
-	return &readerErrWrapper{
-		reader: r,
-		closer: closer,
-	}
-}
-
 // cancelReadCloser wraps an io.ReadCloser with a context for cancelling read
 // operations.
 type cancelReadCloser struct {

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"testing/iotest"
 	"time"
 )
 
@@ -28,35 +27,6 @@ func TestReadCloserWrapperClose(t *testing.T) {
 	if !errors.Is(err, testErr) {
 		// readCloserWrapper should have called the anonymous func and thus, fail
 		t.Errorf("expected %v, got: %v", testErr, err)
-	}
-}
-
-func TestReaderErrWrapperReadOnError(t *testing.T) {
-	called := false
-	expectedErr := errors.New("error reader always fail")
-	wrapper := NewReaderErrWrapper(iotest.ErrReader(expectedErr), func() {
-		called = true
-	})
-	_, err := wrapper.Read([]byte{})
-	if !errors.Is(err, expectedErr) {
-		t.Errorf("expected %v, got: %v", expectedErr, err)
-	}
-	if !called {
-		t.Fatalf("readErrWrapper should have called the anonymous function on failure")
-	}
-}
-
-func TestReaderErrWrapperRead(t *testing.T) {
-	const text = "hello world"
-	wrapper := NewReaderErrWrapper(strings.NewReader(text), func() {
-		t.Fatalf("readErrWrapper should not have called the anonymous function")
-	})
-	num, err := wrapper.Read(make([]byte, len(text)+10))
-	if err != nil {
-		t.Error(err)
-	}
-	if expected := len(text); num != expected {
-		t.Errorf("readerErrWrapper should have read %d byte, but read %d", expected, num)
 	}
 }
 


### PR DESCRIPTION
It was added in Docker [v1.3.0] through bd130e72a06dc3e8de521ce365bf4933f36b2417, but never used, and its behavior never documented. There are no publicly visible external consumers  of this function, so let's remove it.

[v1.3.0]: https://github.com/moby/moby/releases/tag/v1.3.0

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: pkg/ioutils: remove NewReaderErrWrapper as it was never used.
```

**- A picture of a cute animal (not mandatory but encouraged)**

