### PR TITLE
Ask network drivers if they'll use a gateway address

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -562,8 +562,14 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 
 	// Make sure we have a driver available for this network type
 	// before we allocate anything.
-	if _, err := nw.driver(true); err != nil {
+	if d, err := nw.driver(true); err != nil {
 		return nil, err
+	} else if gac, ok := d.(driverapi.GwAllocChecker); ok {
+		// Give the driver a chance to say it doesn't need a gateway IP address.
+		nw.skipGwAllocIPv4, nw.skipGwAllocIPv6, err = gac.GetSkipGwAlloc(nw.generic)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// From this point on, we need the network specific configuration,

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -3,6 +3,8 @@ package driverapi
 import (
 	"context"
 	"net"
+
+	"github.com/docker/docker/libnetwork/options"
 )
 
 // NetworkPluginEndpointType represents the Endpoint Type used by Plugin system
@@ -83,6 +85,13 @@ type Driver interface {
 
 	// IsBuiltIn returns true if it is a built-in driver
 	IsBuiltIn() bool
+}
+
+// GwAllocChecker is an optional interface for a network driver.
+type GwAllocChecker interface {
+	// GetSkipGwAlloc returns true if the opts describe a network
+	// that does not need a gateway IPv4/IPv6 address, else false.
+	GetSkipGwAlloc(opts options.Generic) (skipIPv4, skipIPv6 bool, err error)
 }
 
 // NetworkInfo provides a go interface for drivers to provide network

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -745,6 +745,19 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 	return "", nil
 }
 
+func (d *driver) GetSkipGwAlloc(opts options.Generic) (ipv4, ipv6 bool, _ error) {
+	// The network doesn't exist yet, so use a dummy id that's long enough to be
+	// truncated to a short-id (12 characters) and used in the bridge device name.
+	cfg, err := parseNetworkOptions("dummyNetworkId", opts)
+	if err != nil {
+		return false, false, err
+	}
+	// cfg.InhibitIPv4 means no gateway address will be assigned to the bridge, if
+	// the network is also cfg.Internal, there will not be a default route to use
+	// the gateway address either.
+	return cfg.InhibitIPv4 && cfg.Internal, false, nil
+}
+
 // CreateNetwork creates a new network using the bridge driver.
 func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	// Sanity checks

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -206,6 +206,8 @@ type Network struct {
 	configFrom       string
 	loadBalancerIP   net.IP
 	loadBalancerMode string
+	skipGwAllocIPv4  bool
+	skipGwAllocIPv6  bool
 	platformNetwork  //nolint:nolintlint,unused // only populated on windows
 	mu               sync.Mutex
 }
@@ -466,6 +468,8 @@ func (n *Network) CopyTo(o datastore.KVObject) error {
 	dstN.configFrom = n.configFrom
 	dstN.loadBalancerIP = n.loadBalancerIP
 	dstN.loadBalancerMode = n.loadBalancerMode
+	dstN.skipGwAllocIPv4 = n.skipGwAllocIPv4
+	dstN.skipGwAllocIPv6 = n.skipGwAllocIPv6
 
 	// copy labels
 	if dstN.labels == nil {
@@ -584,6 +588,8 @@ func (n *Network) MarshalJSON() ([]byte, error) {
 	netMap["configFrom"] = n.configFrom
 	netMap["loadBalancerIP"] = n.loadBalancerIP
 	netMap["loadBalancerMode"] = n.loadBalancerMode
+	netMap["skipGwAllocIPv4"] = n.skipGwAllocIPv4
+	netMap["skipGwAllocIPv6"] = n.skipGwAllocIPv6
 	return json.Marshal(netMap)
 }
 
@@ -706,6 +712,12 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 	n.loadBalancerMode = loadBalancerModeDefault
 	if v, ok := netMap["loadBalancerMode"]; ok {
 		n.loadBalancerMode = v.(string)
+	}
+	if v, ok := netMap["skipGwAllocIPv4"]; ok {
+		n.skipGwAllocIPv4 = v.(bool)
+	}
+	if v, ok := netMap["skipGwAllocIPv6"]; ok {
+		n.skipGwAllocIPv6 = v.(bool)
 	}
 	return nil
 }
@@ -1515,18 +1527,21 @@ func (n *Network) ipamAllocate() (retErr error) {
 
 func (n *Network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 	var (
-		cfgList  *[]*IpamConf
-		infoList *[]*IpamInfo
-		err      error
+		cfgList     *[]*IpamConf
+		infoList    *[]*IpamInfo
+		skipGwAlloc bool
+		err         error
 	)
 
 	switch ipVer {
 	case 4:
 		cfgList = &n.ipamV4Config
 		infoList = &n.ipamV4Info
+		skipGwAlloc = n.skipGwAllocIPv4
 	case 6:
 		cfgList = &n.ipamV6Config
 		infoList = &n.ipamV6Info
+		skipGwAlloc = n.skipGwAllocIPv6
 	default:
 		return types.InternalErrorf("incorrect ip version passed to ipam allocate: %d", ipVer)
 	}
@@ -1587,8 +1602,9 @@ func (n *Network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 			}
 		}
 
-		// If there's still no gateway, reserve cfg.Gateway or let the IPAM driver select an address.
-		if d.Gateway == nil {
+		// If there's still no gateway, reserve cfg.Gateway if the user specified it. Else,
+		// if the driver wants a gateway, let the IPAM driver select an address.
+		if d.Gateway == nil && (cfg.Gateway != "" || !skipGwAlloc) {
 			gatewayOpts := map[string]string{
 				ipamapi.RequestAddressType: netlabel.Gateway,
 			}
@@ -1654,6 +1670,9 @@ func (n *Network) ipamReleaseVersion(ipVer int, ipam ipamapi.Ipam) {
 
 	for _, d := range *infoList {
 		if d.Gateway != nil {
+			// FIXME(robmry) - if an IPAM driver returned a gateway in Meta[netlabel.Gateway], and
+			// no user config overrode that address, it wasn't explicitly allocated so it shouldn't
+			// be released here?
 			if err := ipam.ReleaseAddress(d.PoolID, d.Gateway.IP); err != nil {
 				log.G(context.TODO()).Warnf("Failed to release gateway ip address %s on delete of network %s (%s): %v", d.Gateway.IP, n.Name(), n.ID(), err)
 			}


### PR DESCRIPTION
**- What I did**

There's not currently any way to set up a "/31" bridge network running two containers - https://github.com/moby/moby/pull/42626 made sure the network and broadcast addresses weren't reserved in this case, but one of the two available addresses is still always reserved for the bridge itself (the network's gateway).

Option `com.docker.network.bridge.inhibit_ipv4` tells the bridge driver not to assign an address to the bridge. But, the address is still reserved (the intention is to allow the user to assign the address to something-else that's hooked up to the bridge). However, if the network is also `--internal`, that gateway address won't be used. So, reserving it in IPAM is wrong.

This change handles that very-specific case, making it possible to create a "/31" bridge network connecting two containers. There's no `inhibit_ipv6` option at the moment, so this only works for IPv4. But, for example ...

`docker network create --internal -o com.docker.network.bridge.inhibit_ipv4=true --subnet 192.168.0.0/31 mynet`

The ipvlan and macvlan drivers both also have cases where they won't use a gateway address ... with no parent interface, they're equivalent to a `--internal` bridge (and so, probably not that useful), and an L3 ipvlan can't resolve a next-hop gateway so it uses connected routes. So, this PR includes those cases.

On its own, this is probably not that useful! The cases where it can kick in are quite niche.

But, if it looks like a reasonable direction ...
- The remote network driver can be given an equivalent way to say it doesn't want a gateway address.
  - That should help with https://github.com/moby/moby/issues/49166
- This could be used by "isolated" networks ("internal" networks with no gateway, and therefore no direct network access from the docker host). https://github.com/moby/moby/pull/49262

**- How I did it**

The gateway address is currently allocated by libnetwork before creating a network. So, the driver doesn't get involved until it's too late. To fix that ...

Added `driverapi.GwAllocChecker` and, if implemented by a network driver, pass config for a network to it (before allocating a gateway or creating a network) ... and don't allocate the gateway address if not needed.

(An alternative would be just to have a "no gateway" netlabel for libnetwork itself. But, I think it'd be hard to explain when to use it, and it'd be a easy to break things - we'd have to make sure all the drivers cope without a gateway address, or raise an error rather than crashing, in all configurations. For built-in drivers that'd probably amount to raising an error in cases where, in this version, the new `GetSkipGwAlloc` returns false ... so, it'd only cover the same cases, but it wouldn't be automatic. For remote drivers, not supplying a gateway could just be crashy.)

**- How to verify it**

New and existing tests.

**- Description for the changelog**
```markdown changelog
- Unless explicitly configured, an IP address is no longer reserved for a gateway in cases where it is not required:
  - `internal` bridge network with option `com.docker.network.bridge.inhibit_ipv4`.
  - ipvlan or macvlan with no parent interface.
  - L3 ipvlan modes.
```
