### PR TITLE
Add gateway mode "isolated"

### DIFF
--- a/libnetwork/drivers/bridge/interface_linux.go
+++ b/libnetwork/drivers/bridge/interface_linux.go
@@ -111,7 +111,7 @@ func (i *bridgeInterface) programIPv6Addresses(config *networkConfiguration) err
 		// Ignore the prefix length when comparing addresses, it's informational
 		// (RFC-5942 section 4), and removing/re-adding an address that's still valid
 		// would disrupt traffic on live-restore.
-		if ea != addrPrefix.Addr() {
+		if ea != addrPrefix.Addr() || config.GwModeIPv6.isolated() {
 			err := i.nlh.AddrDel(i.Link, &existingAddr) //#nosec G601 -- Memory aliasing is not an issue in practice as the &existingAddr pointer is not retained by the callee after the AddrDel() call returns.
 			if err != nil {
 				log.G(context.TODO()).WithFields(log.Fields{

--- a/libnetwork/drivers/bridge/setup_ipv4_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux.go
@@ -32,7 +32,7 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 	//             are decoupled, we should assign it only when it's really needed.
 	i.bridgeIPv4 = config.AddressIPv4
 
-	if !config.InhibitIPv4 {
+	if !config.InhibitIPv4 && !config.GwModeIPv4.isolated() {
 		addrv4List, err := i.addresses(netlink.FAMILY_V4)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve bridge interface addresses: %v", err)

--- a/libnetwork/drivers/bridge/setup_ipv6_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux.go
@@ -15,6 +15,19 @@ func setupBridgeIPv6(config *networkConfiguration, i *bridgeInterface) error {
 	if err != nil {
 		return fmt.Errorf("Cannot read IPv6 setup for bridge %v: %v", config.BridgeName, err)
 	}
+
+	// Disable IPv6 on the bridge if the network is "isolated", so that it
+	// doesn't get a kernel-assigned LL address (or any other IPv6 address).
+	if config.GwModeIPv6.isolated() {
+		if ipv6BridgeData[0] != '1' {
+			if err := os.WriteFile(procFile, []byte{'1', '\n'}, 0o644); err != nil {
+				return fmt.Errorf("unable to disable IPv6 addresses on bridge for gateway mode 'isolated': %v", err)
+			}
+		}
+		i.bridgeIPv6 = config.AddressIPv6
+		return nil
+	}
+
 	// Enable IPv6 on the bridge only if it isn't already enabled
 	if ipv6BridgeData[0] != '0' {
 		if err := os.WriteFile(procFile, []byte{'0', '\n'}, 0o644); err != nil {

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -12,6 +12,9 @@ import (
 // setupVerifyAndReconcileIPv4 checks what IPv4 addresses the given i interface has
 // and ensures that they match the passed network config.
 func setupVerifyAndReconcileIPv4(config *networkConfiguration, i *bridgeInterface) error {
+	if config.GwModeIPv4.isolated() {
+		return nil
+	}
 	// Fetch a slice of IPv4 addresses from the bridge.
 	addrsv4, err := i.addresses(netlink.FAMILY_V4)
 	if err != nil {


### PR DESCRIPTION
**- What I did**

Add value `isolated` for bridge  labels `com.docker.network.bridge.gateway_mode_ipv[46]`.

It prevents assignment of an address to the bridge, so the host has no address in the network - and can only be used when the network is also `--internal`.

For IPv4, mode `isolated` is equivalent to `--internal -o com.docker.network.bridge.inhibit_ipv4=true` - since commit 43f71fb, no gateway address is allocated in that case. Apart from `isolated` working for IPv6 too, the difference is in the intended use - `inhibit_ipv4` is described as a way to put the gateway address somewhere-else (see [Skip IP address configuration](https://docs.docker.com/engine/network/drivers/bridge/#skip-ip-address-configuration)) so, it's fine to use it without `--internal`, but it doesn't necessarily isolate the network. Whereas, mode `isolated` can only be used with `--internal` and fits alongside the other `gateway_mode_ipv[46]` options as a way to control connectivity of containers on the network.

**- How I did it**

Don't assign an address to the bridge in `isolated` mode.

For `gateway_mode_ipv6=isolated`, disable IPv6 on the bridge so that it doesn't get a link-local address.

**- How to verify it**

New integration tests.

**- Description for the changelog**
```markdown changelog
- An `internal` bridge network created with gateway mode `isolated` does not have an address on the docker host.
  - An address is normally assigned to the bridge device in an `internal` network, so processes on the docker host can access the network, and containers in the network can access host services listening on that bridge address (including services listening on "any" host address, `0.0.0.0` or `::`).
  - The `network create` options are `-o com.docker.network.bridge.gateway_mode_ipv4=isolated` and `-o com.docker.network.bridge.gateway_mode_ipv6=isolated`.
```
