### PR TITLE
imageService: Remove PerformWithBaseFS

### DIFF
--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/log"
@@ -10,15 +11,19 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 )
 
-func (i *ImageService) Changes(ctx context.Context, container *container.Container) ([]archive.Change, error) {
-	snapshotter := i.client.SnapshotService(container.Driver)
-	info, err := snapshotter.Stat(ctx, container.ID)
+func (i *ImageService) Changes(ctx context.Context, ctr *container.Container) ([]archive.Change, error) {
+	rwl := ctr.RWLayer
+	if rwl == nil {
+		return nil, fmt.Errorf("RWLayer is unexpectedly nil for container %s", ctr.ID)
+	}
+	snapshotter := i.client.SnapshotService(ctr.Driver)
+	info, err := snapshotter.Stat(ctx, ctr.ID)
 	if err != nil {
 		return nil, err
 	}
 
 	id := stringid.GenerateRandomID()
-	parentViewKey := container.ID + "-parent-view-" + id
+	parentViewKey := ctr.ID + "-parent-view-" + id
 	imageMounts, _ := snapshotter.View(ctx, parentViewKey, info.Parent)
 
 	defer func() {
@@ -27,13 +32,19 @@ func (i *ImageService) Changes(ctx context.Context, container *container.Contain
 		}
 	}()
 
+	containerRoot, err := rwl.Mount(ctr.GetMountLabel())
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := rwl.Unmount(); err != nil {
+			log.G(ctx).WithFields(log.Fields{"error": err, "container": ctr.ID}).Warn("Failed to unmount container RWLayer after export")
+		}
+	}()
 	var changes []archive.Change
-	err = i.PerformWithBaseFS(ctx, container, func(containerRoot string) error {
-		return mount.WithReadonlyTempMount(ctx, imageMounts, func(imageRoot string) error {
-			changes, err = archive.ChangesDirs(containerRoot, imageRoot)
-			return err
-		})
+	err = mount.WithReadonlyTempMount(ctx, imageMounts, func(imageRoot string) error {
+		changes, err = archive.ChangesDirs(containerRoot, imageRoot)
+		return err
 	})
-
 	return changes, err
 }

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -16,7 +16,6 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/errdefs"
 	dockerarchive "github.com/docker/docker/pkg/archive"
@@ -24,21 +23,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
-
-func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(root string) error) error {
-	snapshotter := i.client.SnapshotService(c.Driver)
-	mounts, err := snapshotter.Mounts(ctx, c.ID)
-	if err != nil {
-		return err
-	}
-	path, err := i.refCountMounter.Mount(mounts, c.ID)
-	if err != nil {
-		return err
-	}
-	defer i.refCountMounter.Unmount(path)
-
-	return fn(path)
-}
 
 // ExportImage exports a list of images to the given output stream. The
 // exported images are archived into a tar when written to the output

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
@@ -42,23 +43,42 @@ func (daemon *Daemon) ContainerExport(ctx context.Context, name string, out io.W
 	return nil
 }
 
-func (daemon *Daemon) containerExport(ctx context.Context, container *container.Container, out io.Writer) error {
-	err := daemon.imageService.PerformWithBaseFS(ctx, container, func(basefs string) error {
-		archv, err := chrootarchive.Tar(basefs, &archive.TarOptions{
-			Compression: archive.Uncompressed,
-			IDMap:       daemon.idMapping,
-		}, basefs)
-		if err != nil {
-			return err
-		}
+func (daemon *Daemon) containerExport(ctx context.Context, ctr *container.Container, out io.Writer) error {
+	rwl := ctr.RWLayer
+	if rwl == nil {
+		return fmt.Errorf("container %s has no rootfs", ctr.ID)
+	}
 
-		// Stream the entire contents of the container (basically a volatile snapshot)
-		_, err = io.Copy(out, archv)
+	if err := ctx.Err(); err != nil {
 		return err
-	})
+	}
+
+	basefs, err := rwl.Mount(ctr.GetMountLabel())
 	if err != nil {
 		return err
 	}
-	daemon.LogContainerEvent(container, events.ActionExport)
+	defer func() {
+		if err := rwl.Unmount(); err != nil {
+			log.G(ctx).WithFields(log.Fields{"error": err, "container": ctr.ID}).Warn("Failed to unmount container RWLayer after export")
+		}
+	}()
+
+	archv, err := chrootarchive.Tar(basefs, &archive.TarOptions{
+		Compression: archive.Uncompressed,
+		IDMap:       daemon.idMapping,
+	}, basefs)
+	if err != nil {
+		return err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Stream the entire contents of the container (basically a volatile snapshot)
+	if _, err := io.Copy(out, archv); err != nil {
+		return err
+	}
+
+	daemon.LogContainerEvent(ctr, events.ActionExport)
 	return nil
 }

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -31,7 +31,6 @@ type ImageService interface {
 	CreateImage(ctx context.Context, config []byte, parent string, contentStoreDigest digest.Digest) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]imagetype.DeleteResponse, error)
 	ExportImage(ctx context.Context, names []string, platform *ocispec.Platform, outStream io.Writer) error
-	PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(string) error) error
 	LoadImage(ctx context.Context, inTar io.ReadCloser, platform *ocispec.Platform, outStream io.Writer, quiet bool) error
 	Images(ctx context.Context, opts imagetype.ListOptions) ([]*imagetype.Summary, error)
 	LogImageEvent(ctx context.Context, imageID, refName string, action events.Action)

--- a/daemon/images/image_exporter.go
+++ b/daemon/images/image_exporter.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/containerd/log"
-	"github.com/docker/docker/container"
 	"github.com/docker/docker/image/tarexport"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -18,29 +16,6 @@ import (
 func (i *ImageService) ExportImage(ctx context.Context, names []string, platform *ocispec.Platform, outStream io.Writer) error {
 	imageExporter := tarexport.NewTarExporter(i.imageStore, i.layerStore, i.referenceStore, i, platform)
 	return imageExporter.Save(ctx, names, outStream)
-}
-
-func (i *ImageService) PerformWithBaseFS(ctx context.Context, c *container.Container, fn func(root string) error) error {
-	rwlayer, err := i.layerStore.GetRWLayer(c.ID)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		err := i.ReleaseLayer(rwlayer)
-		if err != nil {
-			log.G(ctx).WithError(err).WithField("container", c.ID).Warn("Failed to release layer")
-		}
-	}()
-
-	basefs, err := rwlayer.Mount(c.GetMountLabel())
-	if err != nil {
-		return err
-	}
-
-	defer rwlayer.Unmount()
-
-	return fn(basefs)
 }
 
 // LoadImage uploads a set of images into the repository. This is the


### PR DESCRIPTION
With `RWLayer` it's no longer necessary to define it for each image service as it became a wrapper for the RWLayer's Mount and Unmount.

