### PR TITLE
pkg/jsonmessage: stop printing deprecated progressDetail, errorDetail, remove DisplayJSONMessagesToStream and Stream interface

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2647,26 +2647,10 @@ definitions:
         type: "string"
       stream:
         type: "string"
-      error:
-        type: "string"
-        x-nullable: true
-        description: |-
-          errors encountered during the operation.
-
-
-          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
-      progress:
-        type: "string"
-        x-nullable: true
-        description: |-
-          Progress is a pre-formatted presentation of progressDetail.
-
-
-          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
       aux:
@@ -2764,52 +2748,20 @@ definitions:
     properties:
       id:
         type: "string"
-      error:
-        type: "string"
-        x-nullable: true
-        description: |-
-          errors encountered during the operation.
-
-
-          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
-      progress:
-        type: "string"
-        x-nullable: true
-        description: |-
-          Progress is a pre-formatted presentation of progressDetail.
-
-
-          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 
   PushImageInfo:
     type: "object"
     properties:
-      error:
-        type: "string"
-        x-nullable: true
-        description: |-
-          errors encountered during the operation.
-
-
-          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
-      progress:
-        type: "string"
-        x-nullable: true
-        description: |-
-          Progress is a pre-formatted presentation of progressDetail.
-
-
-          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 

--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -122,26 +122,15 @@ func (p *JSONProgress) width() int {
 // the created time, where it from, status, ID of the
 // message. It's used for docker events.
 type JSONMessage struct {
-	Stream   string        `json:"stream,omitempty"`
-	Status   string        `json:"status,omitempty"`
-	Progress *JSONProgress `json:"progressDetail,omitempty"`
-
-	// ProgressMessage is a pre-formatted presentation of [Progress].
-	//
-	// Deprecated: this field is deprecated since docker v0.7.1 / API v1.8. Use the information in [Progress] instead. This field will be omitted in a future release.
-	ProgressMessage string            `json:"progress,omitempty"`
-	ID              string            `json:"id,omitempty"`
-	From            string            `json:"from,omitempty"`
-	Time            int64             `json:"time,omitempty"`
-	TimeNano        int64             `json:"timeNano,omitempty"`
-	Error           *jsonstream.Error `json:"errorDetail,omitempty"`
-
-	// ErrorMessage contains errors encountered during the operation.
-	//
-	// Deprecated: this field is deprecated since docker v0.6.0 / API v1.4. Use [Error.Message] instead. This field will be omitted in a future release.
-	ErrorMessage string `json:"error,omitempty"` // deprecated
-	// Aux contains out-of-band data, such as digests for push signing and image id after building.
-	Aux *json.RawMessage `json:"aux,omitempty"`
+	Stream   string            `json:"stream,omitempty"`
+	Status   string            `json:"status,omitempty"`
+	Progress *JSONProgress     `json:"progressDetail,omitempty"`
+	ID       string            `json:"id,omitempty"`
+	From     string            `json:"from,omitempty"`
+	Time     int64             `json:"time,omitempty"`
+	TimeNano int64             `json:"timeNano,omitempty"`
+	Error    *jsonstream.Error `json:"errorDetail,omitempty"`
+	Aux      *json.RawMessage  `json:"aux,omitempty"` // Aux contains out-of-band data, such as digests for push signing and image id after building.
 }
 
 // We can probably use [aec.EmptyBuilder] for managing the output, but
@@ -201,8 +190,6 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	}
 	if jm.Progress != nil && isTerminal {
 		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)
-	} else if jm.ProgressMessage != "" { // deprecated
-		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.ProgressMessage, endl)
 	} else if jm.Stream != "" {
 		_, _ = fmt.Fprintf(out, "%s%s", jm.Stream, endl)
 	} else {
@@ -253,7 +240,7 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 		if jm.Progress != nil {
 			jm.Progress.terminalFd = terminalFd
 		}
-		if jm.ID != "" && (jm.Progress != nil || jm.ProgressMessage != "") {
+		if jm.ID != "" && jm.Progress != nil {
 			line, ok := ids[jm.ID]
 			if !ok {
 				// NOTE: This approach of using len(id) to

--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -288,9 +288,3 @@ type Stream interface {
 	FD() uintptr
 	IsTerminal() bool
 }
-
-// DisplayJSONMessagesToStream prints json messages to the output Stream. It is
-// used by the Docker CLI to print JSONMessage streams.
-func DisplayJSONMessagesToStream(in io.Reader, stream Stream, auxCallback func(JSONMessage)) error {
-	return DisplayJSONMessagesStream(in, stream, stream.FD(), stream.IsTerminal(), auxCallback)
-}

--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -277,14 +277,3 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 	}
 	return nil
 }
-
-// Stream is an io.Writer for output with utilities to get the output's file
-// descriptor and to detect whether it's a terminal.
-//
-// it is subset of the streams.Out type in
-// https://pkg.go.dev/github.com/docker/cli@v20.10.17+incompatible/cli/streams#Out
-type Stream interface {
-	io.Writer
-	FD() uintptr
-	IsTerminal() bool
-}

--- a/client/pkg/jsonmessage/jsonmessage_test.go
+++ b/client/pkg/jsonmessage/jsonmessage_test.go
@@ -162,14 +162,6 @@ func TestJSONMessageDisplay(t *testing.T) {
 			"stream",
 			"stream",
 		},
-		// With progress message
-		{
-			Status:          "status",
-			ProgressMessage: "progressMessage",
-		}: {
-			"status progressMessage",
-			"status progressMessage",
-		},
 		// With progress, stream empty
 		{
 			Status:   "status",
@@ -247,11 +239,6 @@ func TestDisplayJSONMessagesStream(t *testing.T) {
 		`{ "id": "ID","status": "status" }`: {
 			"ID: status\n",
 			"ID: status\n",
-		},
-		// With progress
-		`{ "id": "ID", "status": "status", "progress": "ProgressMessage" }`: {
-			"ID: status ProgressMessage",
-			fmt.Sprintf("\n%c[%dAID: status ProgressMessage%c[%dB", 27, 1, 27, 1),
 		},
 		// With progressDetail
 		`{ "id": "ID", "status": "status", "progressDetail": { "Current": 1} }`: {

--- a/vendor/github.com/moby/moby/api/swagger.yaml
+++ b/vendor/github.com/moby/moby/api/swagger.yaml
@@ -2647,26 +2647,10 @@ definitions:
         type: "string"
       stream:
         type: "string"
-      error:
-        type: "string"
-        x-nullable: true
-        description: |-
-          errors encountered during the operation.
-
-
-          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
-      progress:
-        type: "string"
-        x-nullable: true
-        description: |-
-          Progress is a pre-formatted presentation of progressDetail.
-
-
-          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
       aux:
@@ -2764,52 +2748,20 @@ definitions:
     properties:
       id:
         type: "string"
-      error:
-        type: "string"
-        x-nullable: true
-        description: |-
-          errors encountered during the operation.
-
-
-          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
-      progress:
-        type: "string"
-        x-nullable: true
-        description: |-
-          Progress is a pre-formatted presentation of progressDetail.
-
-
-          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 
   PushImageInfo:
     type: "object"
     properties:
-      error:
-        type: "string"
-        x-nullable: true
-        description: |-
-          errors encountered during the operation.
-
-
-          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
-      progress:
-        type: "string"
-        x-nullable: true
-        description: |-
-          Progress is a pre-formatted presentation of progressDetail.
-
-
-          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -122,26 +122,15 @@ func (p *JSONProgress) width() int {
 // the created time, where it from, status, ID of the
 // message. It's used for docker events.
 type JSONMessage struct {
-	Stream   string        `json:"stream,omitempty"`
-	Status   string        `json:"status,omitempty"`
-	Progress *JSONProgress `json:"progressDetail,omitempty"`
-
-	// ProgressMessage is a pre-formatted presentation of [Progress].
-	//
-	// Deprecated: this field is deprecated since docker v0.7.1 / API v1.8. Use the information in [Progress] instead. This field will be omitted in a future release.
-	ProgressMessage string            `json:"progress,omitempty"`
-	ID              string            `json:"id,omitempty"`
-	From            string            `json:"from,omitempty"`
-	Time            int64             `json:"time,omitempty"`
-	TimeNano        int64             `json:"timeNano,omitempty"`
-	Error           *jsonstream.Error `json:"errorDetail,omitempty"`
-
-	// ErrorMessage contains errors encountered during the operation.
-	//
-	// Deprecated: this field is deprecated since docker v0.6.0 / API v1.4. Use [Error.Message] instead. This field will be omitted in a future release.
-	ErrorMessage string `json:"error,omitempty"` // deprecated
-	// Aux contains out-of-band data, such as digests for push signing and image id after building.
-	Aux *json.RawMessage `json:"aux,omitempty"`
+	Stream   string            `json:"stream,omitempty"`
+	Status   string            `json:"status,omitempty"`
+	Progress *JSONProgress     `json:"progressDetail,omitempty"`
+	ID       string            `json:"id,omitempty"`
+	From     string            `json:"from,omitempty"`
+	Time     int64             `json:"time,omitempty"`
+	TimeNano int64             `json:"timeNano,omitempty"`
+	Error    *jsonstream.Error `json:"errorDetail,omitempty"`
+	Aux      *json.RawMessage  `json:"aux,omitempty"` // Aux contains out-of-band data, such as digests for push signing and image id after building.
 }
 
 // We can probably use [aec.EmptyBuilder] for managing the output, but
@@ -201,8 +190,6 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	}
 	if jm.Progress != nil && isTerminal {
 		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)
-	} else if jm.ProgressMessage != "" { // deprecated
-		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.ProgressMessage, endl)
 	} else if jm.Stream != "" {
 		_, _ = fmt.Fprintf(out, "%s%s", jm.Stream, endl)
 	} else {
@@ -253,7 +240,7 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 		if jm.Progress != nil {
 			jm.Progress.terminalFd = terminalFd
 		}
-		if jm.ID != "" && (jm.Progress != nil || jm.ProgressMessage != "") {
+		if jm.ID != "" && jm.Progress != nil {
 			line, ok := ids[jm.ID]
 			if !ok {
 				// NOTE: This approach of using len(id) to

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -288,9 +288,3 @@ type Stream interface {
 	FD() uintptr
 	IsTerminal() bool
 }
-
-// DisplayJSONMessagesToStream prints json messages to the output Stream. It is
-// used by the Docker CLI to print JSONMessage streams.
-func DisplayJSONMessagesToStream(in io.Reader, stream Stream, auxCallback func(JSONMessage)) error {
-	return DisplayJSONMessagesStream(in, stream, stream.FD(), stream.IsTerminal(), auxCallback)
-}

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -277,14 +277,3 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 	}
 	return nil
 }
-
-// Stream is an io.Writer for output with utilities to get the output's file
-// descriptor and to detect whether it's a terminal.
-//
-// it is subset of the streams.Out type in
-// https://pkg.go.dev/github.com/docker/cli@v20.10.17+incompatible/cli/streams#Out
-type Stream interface {
-	io.Writer
-	FD() uintptr
-	IsTerminal() bool
-}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/2945
- relates to https://github.com/moby/moby/pull/1298

---

depends on these fixes to be released in docker-py;

- https://github.com/docker/docker-py/pull/3203
- https://github.com/docker/docker-py/pull/3336
- https://github.com/docker/docker-py/pull/3290
- https://github.com/docker/docker-py/pull/3267
- https://github.com/docker/docker-py/pull/3307

---

### pkg/jsonmessage: stop printing deprecated progressDetail, errorDetail

The API still returns it for backward-compatibility (but probably
shouldn't), but we should no longer print it. This removes the
use of these fields for printing, but keeps them for streamformatter
to use.

- ErrorMessage was deprecated in 3043c2641990d94298c6377b7ef14709263a4709
- ProgressMessage was deprecated in 597e0e69b4c8521f39691d0a07d1f31b7116a337

### client/pkg/jsonmessage: remove DisplayJSONMessagesToStream

It was an adaptor around DisplayJSONMessagesStream for CLI-specific
primitives that was used in the CLI, but can be implemented by users
of this package.

### client/pkg/jsonmessage: remove Stream interface

It was an interface to match CLI-specific primitives and is no
longer used.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
`client/pkg/jsonmessage`: remove deprecated `ProgressMessage`, `ErrorMessage`, `DisplayJSONMessagesToStream` and `Stream` interface
```

**- A picture of a cute animal (not mandatory but encouraged)**

