### PR TITLE
libnet/d/bridge: init driver.nlh in newDriver

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -170,6 +170,7 @@ const (
 func newDriver(store *datastore.Store) *driver {
 	return &driver{
 		store:    store,
+		nlh:      ns.NlHandle(),
 		networks: map[string]*bridgeNetwork{},
 	}
 }
@@ -814,13 +815,6 @@ func (d *driver) checkConflict(config *networkConfiguration) error {
 }
 
 func (d *driver) createNetwork(config *networkConfiguration) (err error) {
-	// Initialize handle when needed
-	d.Lock()
-	if d.nlh.Handle == nil {
-		d.nlh = ns.NlHandle()
-	}
-	d.Unlock()
-
 	// Create or retrieve the bridge L3 interface
 	bridgeIface, err := newInterface(d.nlh, config)
 	if err != nil {


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/48721#discussion_r1913478139

**- What I did**

This field was initialized by `driver.createNetwork` instead of being initialized by the `newDriver` constructor. That's currently the single place where it's initialized -- no tests override it, so it seems the 'current' netns is always used.

**- How to verify it**

Existing tests.

