### PR TITLE
WIP: daemon/c8d: Image layer

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -69,9 +69,9 @@ type Container struct {
 	// State also provides a [sync.Mutex] which is used as lock for both
 	// the Container and State.
 	*State          `json:"State"`
-	Root            string  `json:"-"` // Path to the "home" of the container, including metadata.
-	BaseFS          string  `json:"-"` // Path to the graphdriver mountpoint
-	RWLayer         RWLayer `json:"-"`
+	Root            string `json:"-"` // Path to the "home" of the container, including metadata.
+	BaseFS          string `json:"-"` // Path to the graphdriver mountpoint
+	RWLayer         Layer  `json:"-"`
 	ID              string
 	Created         time.Time
 	Managed         bool

--- a/container/layer.go
+++ b/container/layer.go
@@ -2,13 +2,15 @@ package container
 
 import "context"
 
-// RWLayer represents a writable layer for a container.
-type RWLayer interface {
-	// Mount mounts the RWLayer and returns the filesystem path
+// Layer represents a layer useable by container.
+type Layer interface {
+	Writable() bool
+
+	// Mount mounts the Layer and returns the filesystem path
 	// to the writable layer.
 	Mount(ctx context.Context, mountLabel string) (string, error)
 
-	// Unmount unmounts the RWLayer. This should be called
+	// Unmount unmounts the Layer. This should be called
 	// for every mount. If there are multiple mount calls
 	// this operation will only decrement the internal mount counter.
 	Unmount(ctx context.Context) error

--- a/container/rwlayer.go
+++ b/container/rwlayer.go
@@ -1,15 +1,17 @@
 package container
 
+import "context"
+
 // RWLayer represents a writable layer for a container.
 type RWLayer interface {
 	// Mount mounts the RWLayer and returns the filesystem path
 	// to the writable layer.
-	Mount(mountLabel string) (string, error)
+	Mount(ctx context.Context, mountLabel string) (string, error)
 
 	// Unmount unmounts the RWLayer. This should be called
 	// for every mount. If there are multiple mount calls
 	// this operation will only decrement the internal mount counter.
-	Unmount() error
+	Unmount(ctx context.Context) error
 
 	// Metadata returns the low level metadata for the mutable layer
 	Metadata() (map[string]string, error)

--- a/daemon/containerd/image_changes.go
+++ b/daemon/containerd/image_changes.go
@@ -32,12 +32,12 @@ func (i *ImageService) Changes(ctx context.Context, ctr *container.Container) ([
 		}
 	}()
 
-	containerRoot, err := rwl.Mount(ctr.GetMountLabel())
+	containerRoot, err := rwl.Mount(ctx, ctr.GetMountLabel())
 	if err != nil {
 		return nil, err
 	}
 	defer func() {
-		if err := rwl.Unmount(); err != nil {
+		if err := rwl.Unmount(context.WithoutCancel(ctx)); err != nil {
 			log.G(ctx).WithFields(log.Fields{"error": err, "container": ctr.ID}).Warn("Failed to unmount container RWLayer after export")
 		}
 	}()

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -102,9 +102,7 @@ func (l *rwLayer) mounts(ctx context.Context) ([]mount.Mount, error) {
 	return l.snapshotter.Mounts(ctx, l.id)
 }
 
-func (l *rwLayer) Mount(mountLabel string) (string, error) {
-	ctx := context.TODO()
-
+func (l *rwLayer) Mount(ctx context.Context, mountLabel string) (string, error) {
 	// TODO: Investigate how we can handle mountLabel
 	_ = mountLabel
 	mounts, err := l.mounts(ctx)
@@ -165,9 +163,7 @@ func (i *ImageService) GetLayerByID(cid string) (container.RWLayer, error) {
 
 }
 
-func (l *rwLayer) Unmount() error {
-	ctx := context.TODO()
-
+func (l *rwLayer) Unmount(ctx context.Context) error {
 	if l.root == "" {
 		target, err := l.refCountMounter.Mounted(l.id)
 		if err != nil {

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -11,44 +11,26 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/daemon/snapshotter"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
 // CreateLayer creates a new layer for a container.
 // TODO(vvoland): Decouple from container
-func (i *ImageService) CreateLayer(ctr *container.Container, initFunc layer.MountInit) (container.RWLayer, error) {
+func (i *ImageService) CreateLayer(ctr *container.Container, initFunc layer.MountInit) (container.Layer, error) {
 	ctx := context.TODO()
 
 	var parentSnapshot string
 	if ctr.ImageManifest != nil {
-		img := c8dimages.Image{
-			Target: *ctr.ImageManifest,
-		}
-		platformImg, err := i.NewImageManifest(ctx, img, img.Target)
+		s, err := i.getImageSnapshot(ctx, *ctr.ImageManifest)
 		if err != nil {
 			return nil, err
 		}
-		unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)
-		if err != nil {
-			return nil, err
-		}
-
-		if !unpacked {
-			if err := platformImg.Unpack(ctx, i.snapshotter); err != nil {
-				return nil, err
-			}
-		}
-
-		diffIDs, err := platformImg.RootFS(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		parentSnapshot = identity.ChainID(diffIDs).String()
+		parentSnapshot = s
 	}
 
 	id := ctr.ID
@@ -80,7 +62,7 @@ func (i *ImageService) CreateLayer(ctr *container.Container, initFunc layer.Moun
 		return nil, err
 	}
 
-	return &rwLayer{
+	return &snapshotLayer{
 		id:              id,
 		snapshotterName: i.StorageDriver(),
 		snapshotter:     sn,
@@ -89,40 +71,94 @@ func (i *ImageService) CreateLayer(ctr *container.Container, initFunc layer.Moun
 	}, nil
 }
 
-type rwLayer struct {
-	id              string
-	snapshotter     snapshots.Snapshotter
-	snapshotterName string
-	refCountMounter snapshotter.Mounter
-	root            string
-	lease           leases.Lease
+func (i *ImageService) GetImageLayer(ctx context.Context, img *image.Image) (container.Layer, error) {
+	if img.Details.ManifestDescriptor == nil {
+		return nil, fmt.Errorf("no manifest descriptor found for image %s", img.ID)
+	}
+
+	snapshotID, err := i.getImageSnapshot(ctx, *img.Details.ManifestDescriptor)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotterName := i.snapshotter
+	leaseId := "imagelayer-" + snapshotID
+	lm := i.client.LeasesService()
+
+	lease, err := getLeaseByID(ctx, lm, leaseId)
+	if err != nil {
+		if !errdefs.IsNotFound(err) {
+			return nil, err
+		}
+
+		lease, err = lm.Create(ctx, leases.WithID(leaseId))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := lm.AddResource(ctx, lease, leases.Resource{
+		Type: "snapshots/" + snapshotterName,
+		ID:   snapshotID,
+	}); err != nil {
+		if err := lm.Delete(ctx, lease, leases.SynchronousDelete); err != nil {
+			log.G(ctx).WithError(err).Warn("failed to cleanup lease")
+		}
+		return nil, err
+	}
+
+	return &snapshotLayer{
+		id:              snapshotID,
+		readonly:        true,
+		snapshotterName: i.StorageDriver(),
+		snapshotter:     i.client.SnapshotService(i.StorageDriver()),
+		refCountMounter: i.refCountMounter,
+		lease:           lease,
+	}, nil
 }
 
-func (l *rwLayer) mounts(ctx context.Context) ([]mount.Mount, error) {
-	return l.snapshotter.Mounts(ctx, l.id)
+func (i *ImageService) ReleaseImageLayer(ctx context.Context, l container.Layer) error {
+	c8dLayer, ok := l.(*snapshotLayer)
+	if !ok {
+		return fmt.Errorf("invalid layer type %T", l)
+	}
+
+	ls := i.client.LeasesService()
+	if err := ls.Delete(ctx, c8dLayer.lease, leases.SynchronousDelete); err != nil {
+		if !cerrdefs.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }
 
-func (l *rwLayer) Mount(ctx context.Context, mountLabel string) (string, error) {
-	// TODO: Investigate how we can handle mountLabel
-	_ = mountLabel
-	mounts, err := l.mounts(ctx)
+func (i *ImageService) getImageSnapshot(ctx context.Context, desc ocispec.Descriptor) (string, error) {
+	platformImg, err := i.NewImageManifest(ctx, c8dimages.Image{Target: desc}, desc)
+	if err != nil {
+		return "", err
+	}
+	unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)
 	if err != nil {
 		return "", err
 	}
 
-	var root string
-	if root, err = l.refCountMounter.Mount(mounts, l.id); err != nil {
-		return "", fmt.Errorf("failed to mount %s: %w", root, err)
+	if !unpacked {
+		if err := platformImg.Unpack(ctx, i.snapshotter); err != nil {
+			return "", err
+		}
 	}
-	l.root = root
 
-	log.G(ctx).WithFields(log.Fields{"container": l.id, "root": root, "snapshotter": l.snapshotterName}).Debug("container mounted via snapshotter")
-	return root, nil
+	diffIDs, err := platformImg.RootFS(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return identity.ChainID(diffIDs).String(), nil
 }
 
 // GetLayerByID returns a layer by ID
 // called from daemon.go Daemon.restore().
-func (i *ImageService) GetLayerByID(cid string) (container.RWLayer, error) {
+func (i *ImageService) GetLayerByID(cid string) (container.Layer, error) {
 	ctx := context.TODO()
 
 	sn := i.client.SnapshotService(i.StorageDriver())
@@ -133,7 +169,7 @@ func (i *ImageService) GetLayerByID(cid string) (container.RWLayer, error) {
 		return nil, errdefs.NotFound(fmt.Errorf("RW layer for container %s not found", cid))
 	}
 
-	lease, err := i.getLeaseByID(ctx, cid)
+	lease, err := getLeaseByID(ctx, i.client.LeasesService(), cid)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +179,7 @@ func (i *ImageService) GetLayerByID(cid string) (container.RWLayer, error) {
 		log.G(ctx).WithField("container", cid).Warn("failed to determine if container is already mounted")
 	}
 
-	return &rwLayer{
+	return &snapshotLayer{
 		id:              cid,
 		snapshotterName: i.StorageDriver(),
 		snapshotter:     sn,
@@ -154,34 +190,10 @@ func (i *ImageService) GetLayerByID(cid string) (container.RWLayer, error) {
 
 }
 
-func (l *rwLayer) Unmount(ctx context.Context) error {
-	if l.root == "" {
-		target, err := l.refCountMounter.Mounted(l.id)
-		if err != nil {
-			log.G(ctx).WithField("id", l.id).Warn("failed to determine if container is already mounted")
-		}
-		if target == "" {
-			return errors.New("layer not mounted")
-		}
-		l.root = target
-	}
-
-	if err := l.refCountMounter.Unmount(l.root); err != nil {
-		log.G(ctx).WithField("container", l.id).WithError(err).Error("error unmounting container")
-		return fmt.Errorf("failed to unmount %s: %w", l.root, err)
-	}
-
-	return nil
-}
-
-func (l rwLayer) Metadata() (map[string]string, error) {
-	return nil, nil
-}
-
 // ReleaseLayer releases a layer allowing it to be removed
 // called from delete.go Daemon.cleanupContainer(), and Daemon.containerExport()
-func (i *ImageService) ReleaseLayer(rwlayer container.RWLayer) error {
-	c8dLayer, ok := rwlayer.(*rwLayer)
+func (i *ImageService) ReleaseLayer(rwlayer container.Layer) error {
+	c8dLayer, ok := rwlayer.(*snapshotLayer)
 	if !ok {
 		return fmt.Errorf("invalid layer type %T", rwlayer)
 	}
@@ -257,9 +269,8 @@ func calculateSnapshotTotalUsage(ctx context.Context, snapshotter snapshots.Snap
 	return total, nil
 }
 
-func (i *ImageService) getLeaseByID(ctx context.Context, id string) (leases.Lease, error) {
-	ls := i.client.LeasesService()
-	lss, err := ls.List(ctx, "id=="+id)
+func getLeaseByID(ctx context.Context, lm leases.Manager, id string) (leases.Lease, error) {
+	lss, err := lm.List(ctx, "id=="+id)
 	if err != nil {
 		return leases.Lease{}, nil
 	}

--- a/daemon/containerd/layer.go
+++ b/daemon/containerd/layer.go
@@ -1,0 +1,85 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/containerd/containerd/leases"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
+	"github.com/containerd/log"
+	"github.com/docker/docker/daemon/snapshotter"
+)
+
+type snapshotLayer struct {
+	readonly        bool
+	id              string
+	snapshotter     snapshots.Snapshotter
+	snapshotterName string
+	refCountMounter snapshotter.Mounter
+	root            string
+	lease           leases.Lease
+	mut             sync.Mutex
+}
+
+func (l *snapshotLayer) mounts(ctx context.Context) ([]mount.Mount, error) {
+	return l.snapshotter.Mounts(ctx, l.id)
+}
+
+func (l *snapshotLayer) Writable() bool {
+	return !l.readonly
+}
+
+func (l *snapshotLayer) Mount(ctx context.Context, mountLabel string) (string, error) {
+	l.mut.Lock()
+	defer l.mut.Unlock()
+
+	// TODO: Investigate how we can handle mountLabel
+	_ = mountLabel
+	mounts, err := l.mounts(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if l.readonly {
+		mounts = readonlyMounts(mounts)
+	}
+
+	var root string
+	if root, err = l.refCountMounter.Mount(mounts, l.id); err != nil {
+		return "", fmt.Errorf("failed to mount %s: %w", root, err)
+	}
+	l.root = root
+
+	log.G(ctx).WithFields(log.Fields{"container": l.id, "root": root, "snapshotter": l.snapshotterName}).Debug("container mounted via snapshotter")
+	return root, nil
+}
+
+func (l *snapshotLayer) Unmount(ctx context.Context) error {
+	l.mut.Lock()
+	defer l.mut.Unlock()
+
+	if l.root == "" {
+		target, err := l.refCountMounter.Mounted(l.id)
+		if err != nil {
+			log.G(ctx).WithField("id", l.id).Warn("failed to determine if container is already mounted")
+		}
+		if target == "" {
+			return errors.New("layer not mounted")
+		}
+		l.root = target
+	}
+
+	if err := l.refCountMounter.Unmount(l.root); err != nil {
+		log.G(ctx).WithField("container", l.id).WithError(err).Error("error unmounting container")
+		return fmt.Errorf("failed to unmount %s: %w", l.root, err)
+	}
+
+	return nil
+}
+
+func (l *snapshotLayer) Metadata() (map[string]string, error) {
+	return nil, nil
+}

--- a/daemon/containerd/mount_c8d.go
+++ b/daemon/containerd/mount_c8d.go
@@ -1,0 +1,68 @@
+/*
+	Copyright The containerd Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+// Source: https://github.com/containerd/containerd/blob/ccb4c7429e99e101ec0720841605194ef66a879f/core/mount/mount.go#L109-L150
+// TODO: Export in containerd or move to a more appropriate package
+
+package containerd
+
+import (
+	"strings"
+
+	"github.com/containerd/containerd/mount"
+)
+
+// readonlyMounts modifies the received mount options
+// to make them readonly
+func readonlyMounts(mounts []mount.Mount) []mount.Mount {
+	for i, m := range mounts {
+		if m.Type == "overlay" {
+			mounts[i].Options = readonlyOverlay(m.Options)
+			continue
+		}
+		opts := make([]string, 0, len(m.Options))
+		for _, opt := range m.Options {
+			if opt != "rw" && opt != "ro" { // skip `ro` too so we don't append it twice
+				opts = append(opts, opt)
+			}
+		}
+		opts = append(opts, "ro")
+		mounts[i].Options = opts
+	}
+	return mounts
+}
+
+// readonlyOverlay takes mount options for overlay mounts and makes them readonly by
+// removing workdir and upperdir (and appending the upperdir layer to lowerdir) - see:
+// https://www.kernel.org/doc/html/latest/filesystems/overlayfs.html#multiple-lower-layers
+func readonlyOverlay(opt []string) []string {
+	out := make([]string, 0, len(opt))
+	upper := ""
+	for _, o := range opt {
+		if strings.HasPrefix(o, "upperdir=") {
+			upper = strings.TrimPrefix(o, "upperdir=")
+		} else if !strings.HasPrefix(o, "workdir=") {
+			out = append(out, o)
+		}
+	}
+	if upper != "" {
+		for i, o := range out {
+			if strings.HasPrefix(o, "lowerdir=") {
+				out[i] = "lowerdir=" + upper + ":" + strings.TrimPrefix(o, "lowerdir=")
+			}
+		}
+	}
+	return out
+}

--- a/daemon/containerd/service_unix.go
+++ b/daemon/containerd/service_unix.go
@@ -10,6 +10,6 @@ import (
 )
 
 // GetLayerFolders returns the layer folders from an image RootFS.
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer container.RWLayer, containerID string) ([]string, error) {
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer container.Layer, containerID string) ([]string, error) {
 	return nil, errdefs.NotImplemented(errors.New("not implemented"))
 }

--- a/daemon/containerd/service_windows.go
+++ b/daemon/containerd/service_windows.go
@@ -10,12 +10,12 @@ import (
 )
 
 // GetLayerFolders returns the layer folders from an image RootFS.
-func (i *ImageService) GetLayerFolders(img *image.Image, layer container.RWLayer, containerID string) ([]string, error) {
+func (i *ImageService) GetLayerFolders(img *image.Image, layer container.Layer, containerID string) ([]string, error) {
 	if layer == nil {
 		return nil, errors.New("RWLayer is unexpectedly nil")
 	}
 
-	c8dLayer, ok := layer.(*rwLayer)
+	c8dLayer, ok := layer.(*snapshotLayer)
 	if !ok {
 		return nil, fmt.Errorf("unexpected layer type: %T", layer)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1347,7 +1347,7 @@ func (daemon *Daemon) Mount(container *container.Container) error {
 	if container.RWLayer == nil {
 		return errors.New("RWLayer of container " + container.ID + " is unexpectedly nil")
 	}
-	dir, err := container.RWLayer.Mount(container.GetMountLabel())
+	dir, err := container.RWLayer.Mount(ctx, container.GetMountLabel())
 	if err != nil {
 		return err
 	}
@@ -1374,7 +1374,7 @@ func (daemon *Daemon) Unmount(container *container.Container) error {
 	if container.RWLayer == nil {
 		return errors.New("RWLayer of container " + container.ID + " is unexpectedly nil")
 	}
-	if err := container.RWLayer.Unmount(); err != nil {
+	if err := container.RWLayer.Unmount(context.WithoutCancel(ctx)); err != nil {
 		log.G(ctx).WithField("container", container.ID).WithError(err).Error("error unmounting container")
 		return err
 	}

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -53,12 +53,12 @@ func (daemon *Daemon) containerExport(ctx context.Context, ctr *container.Contai
 		return err
 	}
 
-	basefs, err := rwl.Mount(ctr.GetMountLabel())
+	basefs, err := rwl.Mount(ctx, ctr.GetMountLabel())
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if err := rwl.Unmount(); err != nil {
+		if err := rwl.Unmount(context.WithoutCancel(ctx)); err != nil {
 			log.G(ctx).WithFields(log.Fields{"error": err, "container": ctr.ID}).Warn("Failed to unmount container RWLayer after export")
 		}
 	}()

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -20,6 +20,11 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+type ImageLayerService interface {
+	GetImageLayer(ctx context.Context, img *image.Image) (container.Layer, error)
+	ReleaseImageLayer(ctx context.Context, l container.Layer) error
+}
+
 // ImageService is a temporary interface to assist in the migration to the
 // containerd image-store. This interface should not be considered stable,
 // and may change over time.
@@ -46,22 +51,22 @@ type ImageService interface {
 
 	// Layers
 
-	GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error)
-	CreateLayer(container *container.Container, initFunc layer.MountInit) (container.RWLayer, error)
-	GetLayerByID(cid string) (container.RWLayer, error)
+	CreateLayer(container *container.Container, initFunc layer.MountInit) (container.Layer, error)
+	GetLayerByID(cid string) (container.Layer, error)
 	LayerStoreStatus() [][2]string
 	GetLayerMountID(cid string) (string, error)
-	ReleaseLayer(rwlayer container.RWLayer) error
+	ReleaseLayer(rwlayer container.Layer) error
 	LayerDiskUsage(ctx context.Context) (int64, error)
 	GetContainerLayerSize(ctx context.Context, containerID string) (int64, int64, error)
 	Changes(ctx context.Context, container *container.Container) ([]archive.Change, error)
 
 	// Windows specific
 
-	GetLayerFolders(img *image.Image, rwLayer container.RWLayer, containerID string) ([]string, error)
+	GetLayerFolders(img *image.Image, rwLayer container.Layer, containerID string) ([]string, error)
 
 	// Build
 
+	GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error)
 	MakeImageCache(ctx context.Context, cacheFrom []string) (builder.ImageCache, error)
 	CommitBuildStep(ctx context.Context, c backend.CommitConfig) (image.ID, error)
 

--- a/daemon/images/image_unix.go
+++ b/daemon/images/image_unix.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GetLayerFolders returns the layer folders from an image RootFS
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer container.RWLayer, containerID string) ([]string, error) {
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer container.Layer, containerID string) ([]string, error) {
 	// Windows specific
 	panic("not implemented")
 }

--- a/daemon/images/image_windows.go
+++ b/daemon/images/image_windows.go
@@ -16,7 +16,7 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 }
 
 // GetLayerFolders returns the layer folders from an image RootFS
-func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer container.RWLayer, containerID string) ([]string, error) {
+func (i *ImageService) GetLayerFolders(img *image.Image, rwLayer container.Layer, containerID string) ([]string, error) {
 	folders := []string{}
 	rd := len(img.RootFS.DiffIDs)
 	for index := 1; index <= rd; index++ {

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -134,13 +134,33 @@ func (i *ImageService) CreateLayer(container *container.Container, initFunc laye
 		StorageOpt: container.HostConfig.StorageOpt,
 	}
 
-	return i.layerStore.CreateRWLayer(container.ID, layerID, rwLayerOpts)
+	rl, err := i.layerStore.CreateRWLayer(container.ID, layerID, rwLayerOpts)
+	if err != nil {
+		return nil, err
+	}
+	return rwLayerCtx{rl}, nil
 }
 
 // GetLayerByID returns a layer by ID
 // called from daemon.go Daemon.restore().
 func (i *ImageService) GetLayerByID(cid string) (container.RWLayer, error) {
-	return i.layerStore.GetRWLayer(cid)
+	rl, err := i.layerStore.GetRWLayer(cid)
+	if err != nil {
+		return nil, err
+	}
+	return rwLayerCtx{rl}, nil
+}
+
+type rwLayerCtx struct {
+	layer.RWLayer
+}
+
+func (r rwLayerCtx) Mount(_ context.Context, mountLabel string) (string, error) {
+	return r.RWLayer.Mount(mountLabel)
+}
+
+func (r rwLayerCtx) Unmount(_ context.Context) error {
+	return r.RWLayer.Unmount()
 }
 
 // LayerStoreStatus returns the status for each layer store


### PR DESCRIPTION
- stacked on: https://github.com/moby/moby/pull/49265

Implement image-based readonly layers.

Target use case: https://github.com/moby/moby/pull/48798


This needs some further work (probably in follow-up):
- [ ] Combine with the code `image_builder.go` that does a very similar thing for the classic builder
- [ ] Move top `layer` package to a graphdriver store internals and reshape it into a simpler interface used between the daemon and image service 