### PR TITLE
Increase integration test timeout from 5m to 10m

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -14,7 +14,7 @@ source "${MAKEDIR}/.go-autogen"
 
 # Set defaults
 : "${TEST_REPEAT:=1}"
-: "${TIMEOUT:=5m}"
+: "${TIMEOUT:=10m}"
 : "${TESTFLAGS:=}"
 : "${TESTDEBUG:=}"
 : "${TESTCOVERAGE:=}"


### PR DESCRIPTION
**- What I did**

Networking tests have been creeping towards the limit for a while, but they're reliably failing in a upcoming PR.

This shouldn't need a backport - the new and relatively-slow tests are related to changes in 28.0 for IPv6 and iptables.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

