### PR TITLE
use StatsResponse instead of Stats in tests

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -177,7 +177,7 @@ func (s *DockerAPISuite) TestGetContainerStats(c *testing.T) {
 	case sr := <-bc:
 		dec := json.NewDecoder(sr.stats.Body)
 		defer sr.stats.Body.Close()
-		var s *container.Stats
+		var s *container.StatsResponse
 		// decode only one object from the stream
 		assert.NilError(c, dec.Decode(&s))
 	}

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -34,7 +34,7 @@ func (s *DockerAPISuite) TestAPIStatsNoStreamGetCpu(c *testing.T) {
 	assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
 	assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
 
-	var v *container.Stats
+	var v *container.StatsResponse
 	err = json.NewDecoder(body).Decode(&v)
 	assert.NilError(c, err)
 	body.Close()
@@ -263,7 +263,7 @@ func (s *DockerAPISuite) TestAPIStatsNoStreamConnectedContainers(c *testing.T) {
 		if resp.Header.Get("Content-Type") != "application/json" {
 			ch <- fmt.Errorf("Invalid 'Content-Type' %v", resp.Header.Get("Content-Type"))
 		}
-		var v *container.Stats
+		var v *container.StatsResponse
 		if err := json.NewDecoder(body).Decode(&v); err != nil {
 			ch <- err
 		}

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -186,7 +186,7 @@ func (s *DockerCLIUpdateSuite) TestUpdateStats(c *testing.T) {
 		assert.NilError(c, err)
 		assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
 
-		var v *container.Stats
+		var v *container.StatsResponse
 		err = json.NewDecoder(body).Decode(&v)
 		assert.NilError(c, err)
 		body.Close()

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -28,7 +28,7 @@ func TestStats(t *testing.T) {
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
-	var v containertypes.Stats
+	var v containertypes.StatsResponse
 	err = json.NewDecoder(resp.Body).Decode(&v)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(int64(v.MemoryStats.Limit), info.MemTotal))
@@ -40,7 +40,7 @@ func TestStats(t *testing.T) {
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
-	v = containertypes.Stats{}
+	v = containertypes.StatsResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&v)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(int64(v.MemoryStats.Limit), info.MemTotal))


### PR DESCRIPTION
- relates to  https://github.com/moby/moby/pull/15786


The StatsResponse type  was a compatibility-wrapper introduced in d3379946ec96fb6163cb8c4517d7d5a067045801 to differentiate responses for  API < 1.21 and API >= 1.21. API versions lower than 1.24 are deprecated, and we should merge StatsResponse and Stats, but let's start with using the StatsResponse in our tests.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

