### PR TITLE
api/types/container: merge Stats and StatsResponse

### DIFF
--- a/api/types/container/stats.go
+++ b/api/types/container/stats.go
@@ -148,7 +148,15 @@ type PidsStats struct {
 }
 
 // Stats is Ultimate struct aggregating all types of stats of one container
-type Stats struct {
+//
+// Deprecated: use [StatsResponse] instead. This type will be removed in the next release.
+type Stats = StatsResponse
+
+// StatsResponse aggregates all types of stats of one container.
+type StatsResponse struct {
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+
 	// Common stats
 	Read    time.Time `json:"read"`
 	PreRead time.Time `json:"preread"`
@@ -162,20 +170,8 @@ type Stats struct {
 	StorageStats StorageStats `json:"storage_stats,omitempty"`
 
 	// Shared stats
-	CPUStats    CPUStats    `json:"cpu_stats,omitempty"`
-	PreCPUStats CPUStats    `json:"precpu_stats,omitempty"` // "Pre"="Previous"
-	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
-}
-
-// StatsResponse is newly used Networks.
-//
-// TODO(thaJeztah): unify with [Stats]. This wrapper was to account for pre-api v1.21 changes, see https://github.com/moby/moby/commit/d3379946ec96fb6163cb8c4517d7d5a067045801
-type StatsResponse struct {
-	Stats
-
-	Name string `json:"name,omitempty"`
-	ID   string `json:"id,omitempty"`
-
-	// Networks request version >=1.21
-	Networks map[string]NetworkStats `json:"networks,omitempty"`
+	CPUStats    CPUStats                `json:"cpu_stats,omitempty"`
+	PreCPUStats CPUStats                `json:"precpu_stats,omitempty"` // "Pre"="Previous"
+	MemoryStats MemoryStats             `json:"memory_stats,omitempty"`
+	Networks    map[string]NetworkStats `json:"networks,omitempty"`
 }

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -44,8 +44,9 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 		}
 		return nil, err
 	}
-	s := &containertypes.StatsResponse{}
-	s.Read = cs.Read
+	s := &containertypes.StatsResponse{
+		Read: cs.Read,
+	}
 	stats := cs.Metrics
 	switch t := stats.(type) {
 	case *statsV1.Metrics:

--- a/daemon/stats_windows.go
+++ b/daemon/stats_windows.go
@@ -27,9 +27,10 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 	}
 
 	// Start with an empty structure
-	s := &containertypes.StatsResponse{}
-	s.Stats.Read = stats.Read
-	s.Stats.NumProcs = platform.NumProcs()
+	s := &containertypes.StatsResponse{
+		Read:     stats.Read,
+		NumProcs: platform.NumProcs(),
+	}
 
 	if stats.HCSStats != nil {
 		hcss := stats.HCSStats


### PR DESCRIPTION
The StatsResponse type  was a compatibility-wrapper introduced in d3379946ec96fb6163cb8c4517d7d5a067045801 to differentiate responses for  API < 1.21 and API >= 1.21. API versions lower than 1.24 are deprecated, and we can merge these types again.

The Stats type was not used directly, but deprecating it, and making it an alias for StatsResponse, which provides a superset of its fields.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Go SDK: api/types/container: merge Stats and StatsResponse
```

**- A picture of a cute animal (not mandatory but encouraged)**

