### PR TITLE
distribution: fix / improve handling of "closed pipe" and context cancellation / timeouts

### DIFF
--- a/distribution/errors_test.go
+++ b/distribution/errors_test.go
@@ -1,6 +1,7 @@
 package distribution // import "github.com/docker/docker/distribution"
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"syscall"
@@ -25,10 +26,6 @@ var continueFromMirrorEndpoint = []error{
 	errcode.Error{},
 	// nested
 	errcode.Errors{errcode.Error{}},
-}
-
-var neverContinue = []error{
-	errors.New(strings.ToLower(syscall.ESRCH.Error())), // No such process
 }
 
 func TestContinueOnError_NonMirrorEndpoint(t *testing.T) {
@@ -57,6 +54,12 @@ func TestContinueOnError_MirrorEndpoint(t *testing.T) {
 }
 
 func TestContinueOnError_NeverContinue(t *testing.T) {
+	neverContinue := []error{
+		errors.New(strings.ToLower(syscall.ESRCH.Error())), // No such process
+		context.Canceled,
+		context.DeadlineExceeded,
+	}
+
 	for _, isMirrorEndpoint := range []bool{true, false} {
 		for _, err := range neverContinue {
 			if continueOnError(err, isMirrorEndpoint) {

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -8,6 +8,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/errdefs"
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
@@ -137,7 +138,12 @@ func pullEndpoints(ctx context.Context, registryService RegistryResolver, ref re
 				log.G(ctx).Infof("Attempting next endpoint for pull after error: %v", err)
 				continue
 			}
-			log.G(ctx).Errorf("Not continuing with pull after error: %v", err)
+			// FIXME(thaJeztah): cleanup error and context handling in this package, as it's really messy.
+			if errdefs.IsContext(err) {
+				log.G(ctx).WithError(err).Info("Not continuing with pull after error")
+			} else {
+				log.G(ctx).WithError(err).Error("Not continuing with pull after error")
+			}
 			return repoInfo, translatePullError(err, ref)
 		}
 

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/progress"
 )
 
@@ -74,7 +75,12 @@ func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) err
 				}
 			}
 
-			log.G(ctx).Errorf("Not continuing with push after error: %v", err)
+			// FIXME(thaJeztah): cleanup error and context handling in this package, as it's really messy.
+			if errdefs.IsContext(err) {
+				log.G(ctx).WithError(err).Info("Not continuing with push after error")
+			} else {
+				log.G(ctx).WithError(err).Error("Not continuing with push after error")
+			}
 			return err
 		}
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48696


### distribution/utils: WriteDistributionProgress simplify check for broken pipe

The isBrokenPipe utility was added in 3d86b0c79b16334ce5836c0315e4c310b84c2e17
to unwrap the error returned to detect if it was a broken pipe error.
`net.OpError` now implements Unwrap(), so we can simplify this check
using `errors.Is`.


### distribution: continueOnError: handle context cancellation / timeout

Before this change, it would fail to detect context errors, resulting in
pullEndpoints clobbering the context error and changing it into a fallback
error; https://github.com/moby/moby/blob/029933578be8070181d956a825e605c904f1865b/distribution/pull.go#L114-L119

While the context cancellation would still be handled, the error returned
would be wrapped, causing calling code to no longer being able to detect
it as context cancellation;
https://github.com/moby/moby/blob/029933578be8070181d956a825e605c904f1865b/distribution/pull.go#L125

Context cancellation are now logged as "info" in daemon-logs, as they
are not an error from the daemon's perspective;

Before:

    DEBU[2025-01-18T14:59:10.079259676Z] pulling blob "sha256:8bb55f0677778c3027fcc4253dc452bc9c22de989a696391e739fb1cdbbdb4c2"
    ERRO[2025-01-18T14:59:10.564076135Z] Not continuing with pull after error: context canceled

After:

    DEBU[2025-01-18T15:09:56.743045420Z] pulling blob "sha256:8bb55f0677778c3027fcc4253dc452bc9c22de989a696391e739fb1cdbbdb4c2"
    INFO[2025-01-18T15:09:57.390835628Z] Not continuing with pull after error          error="context canceled"

This package needs a big cleanup for context- and error-handling, as it's
very messy, so these changes are only a short-term workaround.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

