### PR TITLE
layerStore.registerWithDescriptor: improve logs for cleaning up cache

### DIFF
--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -307,12 +307,12 @@ func (ls *layerStore) registerWithDescriptor(ts io.Reader, parent ChainID, descr
 
 	defer func() {
 		if cErr != nil {
-			log.G(context.TODO()).Debugf("Cleaning up layer %s: %v", layer.cacheID, cErr)
+			log.G(context.TODO()).WithFields(log.Fields{"cache-id": layer.cacheID, "error": cErr}).Debug("Cleaning up cache layer after error")
 			if err := ls.driver.Remove(layer.cacheID); err != nil {
-				log.G(context.TODO()).Errorf("Error cleaning up cache layer %s: %v", layer.cacheID, err)
+				log.G(context.TODO()).WithFields(log.Fields{"cache-id": layer.cacheID, "error": err}).Error("Error cleaning up cache layer after error")
 			}
 			if err := tx.Cancel(); err != nil {
-				log.G(context.TODO()).Errorf("Error canceling metadata transaction %q: %s", tx.String(), err)
+				log.G(context.TODO()).WithFields(log.Fields{"cache-id": layer.cacheID, "error": err, "tx": tx.String()}).Error("Error canceling metadata transaction")
 			}
 		}
 	}()


### PR DESCRIPTION
The debug log was slightly confusing, as it seemed the cleaning up failed, but the log was intended to inform that cleaning up was started because of an error.

Before this patch:

    DEBU[2025-01-18T12:29:52.717452919Z] Cleaning up layer 472e3e532da3945040a6224ba36d2befcfe250aeb53536868d23e5f617e34226: exit status 1: unpigz: skipping: <stdin>: corrupted -- incomplete deflate data

With this patch:

    DEBU[2025-01-18T13:01:45.307983471Z] Cleaning up cache layer after error           cache-id=c4d9f38bdf6d8fcb69bd130b89d34d1511b42f3644fc49c91e253eda648bd37a error="exit status 1: unpigz: skipping: <stdin>: corrupted -- incomplete deflate data\n"

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

