### PR TITLE
build: don't print warning when connection was terminated

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/httputils"
@@ -244,7 +245,8 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 			return err
 		}
 		_, err = output.Write(streamformatter.FormatError(err))
-		if err != nil {
+		// don't log broken pipe errors as this is the normal case when a client aborts.
+		if err != nil && !errors.Is(err, syscall.EPIPE) {
 			log.G(ctx).WithError(err).Warn("could not write error response")
 		}
 		return nil


### PR DESCRIPTION
A terminated connection is not an error on the daemon-side, and expected if the client disconnects. This patch detects if the error is because of a broken pipe, and skips the warning in that case.

Before this patch:

    WARN[2025-01-18T12:38:04.115298341Z] could not write error response: write unix /var/run/docker.sock->@: write: broken pipe

After this patch, no warning is logged. This patch also changes the log format to use structured logs.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

