### PR TITLE
bin-image: embed contrib/init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -643,6 +643,11 @@ COPY --link --from=containerutil /build/ /
 COPY --link --from=vpnkit        /       /
 COPY --link --from=build         /build  /
 
+# usage:
+# > docker buildx bake bin-image
+FROM all AS bin-image
+COPY --link contrib/init /contrib/init
+
 # smoke tests
 # usage:
 # > docker buildx bake binary-smoketest

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -146,7 +146,8 @@ target "all-cross" {
 #
 
 target "bin-image" {
-  inherits = ["all", "docker-metadata-action"]
+  inherits = ["_common", "docker-metadata-action"]
+  target = "bin-image"
   output = ["type=docker"]
 }
 


### PR DESCRIPTION
relates to:
* https://github.com/docker/actions-toolkit/blob/9b3822d6989bfd623e68f875c2e682fb544f70c8/src/docker/install.ts#L144-L160
* https://github.com/docker/actions-toolkit/blob/9b3822d6989bfd623e68f875c2e682fb544f70c8/src/docker/assets.ts#L261-L264

**- What I did**

Embeds https://github.com/moby/moby/tree/master/contrib/init within the bin image so we can setup systemd units.

**- How to verify it**

```
docker buildx bake https://github.com/crazy-max/moby.git#bin-image-contrib-init bin-image
dive moby-bin:local
```

![image](https://github.com/user-attachments/assets/c5b7d3c1-a77c-42fb-9754-93b139dbcdd5)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

