### PR TITLE
Create bridge veth in container netns

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -912,6 +912,10 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 		}
 	}
 
+	if path, ok := sb.NetnsPath(); ok {
+		createOptions = append(createOptions, libnetwork.WithNetnsPath(path))
+	}
+
 	return createOptions, nil
 }
 

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -127,6 +127,14 @@ type InterfaceInfo interface {
 
 	// AddressIPv6 returns the IPv6 address.
 	AddressIPv6() *net.IPNet
+
+	// NetnsPath returns the path of the network namespace, if there is one. Else "".
+	NetnsPath() string
+
+	// SetCreatedInContainer can be called by the driver to indicate that it's
+	// created the network interface in the container's network namespace (so,
+	// it doesn't need to be moved there).
+	SetCreatedInContainer(bool)
 }
 
 // InterfaceNameInfo provides a go interface for the drivers to assign names

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -183,6 +183,10 @@ func (test *testEndpoint) SetGatewayIPv6(ipv6 net.IP) error {
 	return nil
 }
 
+func (test *testEndpoint) NetnsPath() string { return "" }
+
+func (test *testEndpoint) SetCreatedInContainer(bool) {}
+
 func (test *testEndpoint) SetNames(src string, dst string) error {
 	if test.src != src {
 		test.t.Fatalf(`Wrong SrcName; expected "%s", got "%s"`, test.src, src)
@@ -570,6 +574,10 @@ func (r *rollbackEndpoint) SetMacAddress(mac net.HardwareAddr) error {
 func (r *rollbackEndpoint) SetIPAddress(ip *net.IPNet) error {
 	return errors.New("invalid ip")
 }
+
+func (r *rollbackEndpoint) NetnsPath() string { return "" }
+
+func (r *rollbackEndpoint) SetCreatedInContainer(bool) {}
 
 func TestRollback(t *testing.T) {
 	plugin := "test-net-driver-rollback"

--- a/libnetwork/drivers/windows/windows_test.go
+++ b/libnetwork/drivers/windows/windows_test.go
@@ -145,3 +145,10 @@ func (test *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, 
 func (test *testEndpoint) DisableGatewayService() {
 	test.disableGatewayService = true
 }
+
+func (test *testEndpoint) NetnsPath() string {
+	return ""
+}
+
+func (test *testEndpoint) SetCreatedInContainer(bool) {
+}

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1254,6 +1254,12 @@ func JoinOptionPriority(prio int) EndpointOption {
 	}
 }
 
+func WithNetnsPath(path string) EndpointOption {
+	return func(ep *Endpoint) {
+		ep.iface.netnsPath = path
+	}
+}
+
 func (ep *Endpoint) assignAddress(ipam ipamapi.Ipam, assignIPv4, assignIPv6 bool) error {
 	n := ep.getNetwork()
 	if n.hasSpecialDriver() {

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -205,19 +205,15 @@ func (n *Namespace) findDst(srcName string, isBridge bool) string {
 	return ""
 }
 
-func moveLink(ctx context.Context, nlhHost nlwrap.Handle, iface netlink.Link, i *Interface, path string) (netns.NsHandle, error) {
+func moveLink(ctx context.Context, nlhHost nlwrap.Handle, iface netlink.Link, i *Interface, nsh netns.NsHandle) error {
 	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.osl.moveLink", trace.WithAttributes(
 		attribute.String("ifaceName", i.DstName())))
 	defer span.End()
 
-	newNs, err := netns.GetFromPath(path)
-	if err != nil {
-		return netns.None(), fmt.Errorf("failed get network namespace %q: %v", path, err)
+	if err := nlhHost.LinkSetNsFd(iface, int(nsh)); err != nil {
+		return fmt.Errorf("failed to set namespace on link %q: %v", i.srcName, err)
 	}
-	if err := nlhHost.LinkSetNsFd(iface, int(newNs)); err != nil {
-		return netns.None(), fmt.Errorf("failed to set namespace on link %q: %v", i.srcName, err)
-	}
-	return newNs, nil
+	return nil
 }
 
 // AddInterface adds an existing Interface to the sandbox. The operation will rename
@@ -251,6 +247,13 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 	n.mu.Unlock()
 
 	newNs := netns.None()
+	if !isDefault {
+		newNs, err = netns.GetFromPath(path)
+		if err != nil {
+			return fmt.Errorf("failed get network namespace %q: %v", path, err)
+		}
+		defer newNs.Close()
+	}
 
 	// If it is a bridge interface we have to create the bridge inside
 	// the namespace so don't try to lookup the interface using srcName
@@ -273,12 +276,9 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 		// namespace only if the namespace is not a default
 		// type
 		if !isDefault {
-			var err error
-			newNs, err = moveLink(ctx, nlhHost, iface, i, path)
-			if err != nil {
+			if err := moveLink(ctx, nlhHost, iface, i, newNs); err != nil {
 				return err
 			}
-			defer newNs.Close()
 		}
 	}
 

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -106,6 +106,7 @@ type Interface struct {
 	// advertiseAddrInterval is the interval between unsolicited ARP/NA messages sent to
 	// advertise the interface's addresses.
 	advertiseAddrInterval time.Duration
+	createdInContainer    bool
 	ns                    *Namespace
 }
 
@@ -265,7 +266,7 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 		}); err != nil {
 			return fmt.Errorf("failed to create bridge %q: %v", i.srcName, err)
 		}
-	} else {
+	} else if !i.createdInContainer {
 		// Find the network interface identified by the SrcName attribute.
 		iface, err := nlhHost.LinkByName(i.srcName)
 		if err != nil {

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -350,6 +350,9 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 }
 
 func waitForIfUpped(ctx context.Context, ns netns.NsHandle, ifIndex int) (bool, error) {
+	ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "libnetwork.osl.waitforIfUpped")
+	defer span.End()
+
 	update := make(chan netlink.LinkUpdate, 100)
 	upped := make(chan struct{})
 	opts := netlink.LinkSubscribeOptions{
@@ -398,6 +401,7 @@ func waitForIfUpped(ctx context.Context, ns netns.NsHandle, ifIndex int) (bool, 
 	for {
 		select {
 		case <-timerC:
+			log.G(ctx).Warnf("timeout in waitForIfUpped")
 			return false, nil
 		case u, ok := <-update:
 			if !ok {

--- a/libnetwork/osl/options_linux.go
+++ b/libnetwork/osl/options_linux.go
@@ -119,3 +119,13 @@ func WithAdvertiseAddrInterval(interval time.Duration) IfaceOption {
 		return nil
 	}
 }
+
+// WithCreatedInContainer can be used to say the network driver created the
+// interface in the container's network namespace (and, therefore, it doesn't
+// need to be moved into that namespace.)
+func WithCreatedInContainer(cic bool) IfaceOption {
+	return func(i *Interface) error {
+		i.createdInContainer = cic
+		return nil
+	}
+}

--- a/libnetwork/sandbox_windows.go
+++ b/libnetwork/sandbox_windows.go
@@ -28,6 +28,11 @@ func (sb *Sandbox) restoreOslSandbox() error {
 	return nil
 }
 
+// NetnsPath is not implemented on Windows (Sandbox.osSbox is always nil)
+func (sb *Sandbox) NetnsPath() (path string, ok bool) {
+	return "", false
+}
+
 func (sb *Sandbox) populateNetworkResources(context.Context, *Endpoint) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)
 	return nil


### PR DESCRIPTION
**- What I did**

Since commit https://github.com/moby/moby/commit/933fcc981418bd6994abd76701a2833789e143f5 (Re-remove the SetKey OCI prestart hook), the network namespace will be set up before endpoints are created in most cases (apart from build containers).

So, when possible, create the veth with one end in that netns to save moving it in later.

On my Mac M2 host, that reduces container startup time by about 20ms for each bridge network it's connected to.

**- How I did it**

Added methods for a driver to ask for the network namespace, and to announce that it's created the interface in the container's netns ... if anything goes wrong, fall back to the old behaviour, creating the veth in the host's namespace.

Tell the `osl` code when it doesn't need to move the interface into the namespace.

No change to the `srcName` property, the name the interface would have been created with in the host namespace. When created in the container's namespace, the interface has that same name (it has to be renamed, as it was before).

**- How to verify it**

New and existing tests.

Before - `moveLink` in this run took 26ms of the total 94ms ...

<img width="1670" alt="before" src="https://github.com/user-attachments/assets/c69faa90-5e57-4f6e-b656-26911e6e5ca8" />

After - `moveLink` isn't called, reducing the total time to 68ms ...

<img width="1674" alt="after" src="https://github.com/user-attachments/assets/efd2a9e9-3a51-44db-92fc-a191d8e10008" />

**- Description for the changelog**
```markdown changelog
Faster connection to bridge networks, in most cases.
```
