### PR TITLE
[27.x] Dockerfile: update RootlessKit to v2.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -356,7 +356,7 @@ FROM base AS rootlesskit-src
 WORKDIR /usr/src/rootlesskit
 RUN git init . && git remote add origin "https://github.com/rootless-containers/rootlesskit.git"
 # When updating, also update vendor.mod and hack/dockerfile/install/rootlesskit.installer accordingly.
-ARG ROOTLESSKIT_VERSION=v2.3.1
+ARG ROOTLESSKIT_VERSION=v2.3.2
 RUN git fetch -q --depth 1 origin "${ROOTLESSKIT_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS rootlesskit-build

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update vendor.mod and Dockerfile accordingly.
-: "${ROOTLESSKIT_VERSION:=v2.3.1}"
+: "${ROOTLESSKIT_VERSION:=v2.3.2}"
 
 install_rootlesskit() {
 	case "$1" in


### PR DESCRIPTION
Cherry-pick, except `vendor.mod`:
- https://github.com/moby/moby/pull/49303

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Update RootlessKit to v2.3.2 to support `passt` >= 2024_10_30.ee7d0b6
```