### PR TITLE
Assorted fixes,  improvements, and refactoring of  network diagnostic server

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -734,6 +734,9 @@ func Validate(config *Config) error {
 	if config.MaxDownloadAttempts < 0 {
 		return errors.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
 	}
+	if config.NetworkDiagnosticPort < 0 || config.NetworkDiagnosticPort > 65535 {
+		return errors.Errorf("invalid network-diagnostic-port (%d): value must be between 0 and 65535", config.NetworkDiagnosticPort)
+	}
 
 	if _, err := ParseGenericResources(config.NodeGenericResources); err != nil {
 		return err

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -319,6 +319,24 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			},
 		*/
 		{
+			name: "negative network-diagnostic-port",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					NetworkDiagnosticPort: -1,
+				},
+			},
+			expectedErr: "invalid network-diagnostic-port (-1): value must be between 0 and 65535",
+		},
+		{
+			name: "network-diagnostic-port out of range",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					NetworkDiagnosticPort: 65536,
+				},
+			},
+			expectedErr: "invalid network-diagnostic-port (65536): value must be between 0 and 65535",
+		},
+		{
 			name: "generic resource without =",
 			config: &Config{
 				CommonConfig: CommonConfig{

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -275,7 +275,6 @@ func (daemon *Daemon) reloadNetworkDiagnosticPort(txn *reloadTxn, newCfg *config
 			return nil
 		}
 		// Enable the network diagnostic if the flag is set with a valid port within the range
-		log.G(context.TODO()).WithFields(log.Fields{"port": conf.NetworkDiagnosticPort, "ip": "127.0.0.1"}).Warn("Starting network diagnostic server")
 		daemon.netController.StartDiagnostic(conf.NetworkDiagnosticPort)
 		return nil
 	})

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -266,8 +266,7 @@ func (daemon *Daemon) reloadLiveRestore(txn *reloadTxn, newCfg *configStore, con
 // reloadNetworkDiagnosticPort updates the network controller starting the diagnostic if the config is valid
 func (daemon *Daemon) reloadNetworkDiagnosticPort(txn *reloadTxn, newCfg *configStore, conf *config.Config, attributes map[string]string) error {
 	txn.OnCommit(func() error {
-		if conf == nil || daemon.netController == nil || !conf.IsValueSet("network-diagnostic-port") ||
-			conf.NetworkDiagnosticPort < 1 || conf.NetworkDiagnosticPort > 65535 {
+		if conf == nil || daemon.netController == nil || !conf.IsValueSet("network-diagnostic-port") || conf.NetworkDiagnosticPort == 0 {
 			// If there is no config make sure that the diagnostic is off
 			if daemon.netController != nil {
 				daemon.netController.StopDiagnostic()

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -332,7 +332,7 @@ func (c *Controller) agentInit(listenAddr, bindAddrOrInterface, advertiseAddr, d
 	}
 
 	// Register the diagnostic handlers
-	nDB.RegisterDiagnosticHandlers(c.DiagnosticServer)
+	nDB.RegisterDiagnosticHandlers(c.diagnosticServer)
 
 	var cancelList []func()
 	ch, cancel := nDB.Watch(libnetworkEPTable, "")

--- a/libnetwork/cmd/networkdb-test/dbserver/ndbServer.go
+++ b/libnetwork/cmd/networkdb-test/dbserver/ndbServer.go
@@ -62,7 +62,7 @@ func Server(args []string) {
 	nDB.RegisterDiagnosticHandlers(server)
 	server.HandleFunc("/myip", ipaddress)
 	dummyclient.RegisterDiagnosticHandlers(server, nDB)
-	server.EnableDiagnostic("", port)
+	server.Enable("", port)
 	// block here
 	select {}
 }

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1094,18 +1094,14 @@ func (c *Controller) Stop() {
 // StartDiagnostic starts the network diagnostic server listening on port.
 func (c *Controller) StartDiagnostic(port int) {
 	c.mu.Lock()
-	if !c.diagnosticServer.IsDiagnosticEnabled() {
-		c.diagnosticServer.EnableDiagnostic("127.0.0.1", port)
-	}
+	c.diagnosticServer.EnableDiagnostic("127.0.0.1", port)
 	c.mu.Unlock()
 }
 
 // StopDiagnostic stops the network diagnostic server.
 func (c *Controller) StopDiagnostic() {
 	c.mu.Lock()
-	if c.diagnosticServer.IsDiagnosticEnabled() {
-		c.diagnosticServer.DisableDiagnostic()
-	}
+	c.diagnosticServer.DisableDiagnostic()
 	c.mu.Unlock()
 }
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -97,7 +97,7 @@ type Controller struct {
 	agentInitDone    chan struct{}
 	agentStopDone    chan struct{}
 	keys             []*types.EncryptionKey
-	DiagnosticServer *diagnostic.Server
+	diagnosticServer *diagnostic.Server
 	mu               sync.Mutex
 
 	// FIXME(thaJeztah): defOsSbox is always nil on non-Linux: move these fields to Linux-only files.
@@ -122,7 +122,7 @@ func New(cfgOptions ...config.Option) (*Controller, error) {
 		serviceBindings:  make(map[serviceKey]*service),
 		agentInitDone:    make(chan struct{}),
 		networkLocker:    locker.New(),
-		DiagnosticServer: diagnostic.New(),
+		diagnosticServer: diagnostic.New(),
 	}
 
 	c.drvRegistry.Notify = c
@@ -1094,8 +1094,8 @@ func (c *Controller) Stop() {
 // StartDiagnostic starts the network diagnostic server listening on port.
 func (c *Controller) StartDiagnostic(port int) {
 	c.mu.Lock()
-	if !c.DiagnosticServer.IsDiagnosticEnabled() {
-		c.DiagnosticServer.EnableDiagnostic("127.0.0.1", port)
+	if !c.diagnosticServer.IsDiagnosticEnabled() {
+		c.diagnosticServer.EnableDiagnostic("127.0.0.1", port)
 	}
 	c.mu.Unlock()
 }
@@ -1103,8 +1103,8 @@ func (c *Controller) StartDiagnostic(port int) {
 // StopDiagnostic stops the network diagnostic server.
 func (c *Controller) StopDiagnostic() {
 	c.mu.Lock()
-	if c.DiagnosticServer.IsDiagnosticEnabled() {
-		c.DiagnosticServer.DisableDiagnostic()
+	if c.diagnosticServer.IsDiagnosticEnabled() {
+		c.diagnosticServer.DisableDiagnostic()
 	}
 	c.mu.Unlock()
 }
@@ -1113,5 +1113,5 @@ func (c *Controller) StopDiagnostic() {
 func (c *Controller) IsDiagnosticEnabled() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.DiagnosticServer.IsDiagnosticEnabled()
+	return c.diagnosticServer.IsDiagnosticEnabled()
 }

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1093,21 +1093,15 @@ func (c *Controller) Stop() {
 
 // StartDiagnostic starts the network diagnostic server listening on port.
 func (c *Controller) StartDiagnostic(port int) {
-	c.mu.Lock()
 	c.diagnosticServer.EnableDiagnostic("127.0.0.1", port)
-	c.mu.Unlock()
 }
 
 // StopDiagnostic stops the network diagnostic server.
 func (c *Controller) StopDiagnostic() {
-	c.mu.Lock()
 	c.diagnosticServer.DisableDiagnostic()
-	c.mu.Unlock()
 }
 
 // IsDiagnosticEnabled returns true if the diagnostic server is running.
 func (c *Controller) IsDiagnosticEnabled() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	return c.diagnosticServer.IsDiagnosticEnabled()
 }

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1093,15 +1093,15 @@ func (c *Controller) Stop() {
 
 // StartDiagnostic starts the network diagnostic server listening on port.
 func (c *Controller) StartDiagnostic(port int) {
-	c.diagnosticServer.EnableDiagnostic("127.0.0.1", port)
+	c.diagnosticServer.Enable("127.0.0.1", port)
 }
 
 // StopDiagnostic stops the network diagnostic server.
 func (c *Controller) StopDiagnostic() {
-	c.diagnosticServer.DisableDiagnostic()
+	c.diagnosticServer.Shutdown()
 }
 
 // IsDiagnosticEnabled returns true if the diagnostic server is running.
 func (c *Controller) IsDiagnosticEnabled() bool {
-	return c.diagnosticServer.IsDiagnosticEnabled()
+	return c.diagnosticServer.Enabled()
 }

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -77,6 +77,7 @@ func (s *Server) EnableDiagnostic(ip string, port int) {
 
 	s.port = port
 
+	// FIXME(thaJeztah): this check won't allow re-configuring the port on reload.
 	if s.enable {
 		log.G(context.TODO()).Info("The server is already up and running")
 		return
@@ -108,9 +109,10 @@ func (s *Server) DisableDiagnostic() {
 	if !s.enable {
 		return
 	}
-
-	s.srv.Shutdown(context.Background()) //nolint:errcheck
-	s.srv = nil
+	if s.srv != nil {
+		s.srv.Shutdown(context.Background()) //nolint:errcheck
+		s.srv = nil
+	}
 	s.enable = false
 	log.G(context.TODO()).Info("Disabling the diagnostic server")
 }

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -105,6 +105,9 @@ func (s *Server) EnableDiagnostic(ip string, port int) {
 func (s *Server) DisableDiagnostic() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if !s.enable {
+		return
+	}
 
 	s.srv.Shutdown(context.Background()) //nolint:errcheck
 	s.srv = nil

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -176,15 +176,16 @@ func stackTrace(w http.ResponseWriter, r *http.Request) {
 
 	// audit logs
 	logger := log.G(context.TODO()).WithFields(log.Fields{"component": "diagnostic", "remoteIP": r.RemoteAddr, "method": caller.Name(0), "url": r.URL.String()})
-	logger.Info("stack trace")
+	logger.Info("collecting stack trace")
 
+	// FIXME(thaJeztah): make path configurable, or use same location as used by daemon.setupDumpStackTrap
 	path, err := stack.DumpToFile("/tmp/")
 	if err != nil {
-		logger.WithError(err).Error("failed to write goroutines dump")
+		logger.WithError(err).Error("failed to write stack trace to file")
 		_, _ = HTTPReply(w, FailCommand(err), jsonOutput)
 	} else {
-		logger.Info("stack trace done")
-		_, _ = HTTPReply(w, CommandSucceed(&StringCmd{Info: "goroutine stacks written to " + path}), jsonOutput)
+		logger.WithField("file", path).Info("wrote stack trace to file")
+		_, _ = HTTPReply(w, CommandSucceed(&StringCmd{Info: "goroutine stacks written to " + path + "\n"}), jsonOutput)
 	}
 }
 

--- a/libnetwork/diagnostic/server.go
+++ b/libnetwork/diagnostic/server.go
@@ -70,8 +70,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
 }
 
-// EnableDiagnostic opens a TCP socket to debug the passed network DB
-func (s *Server) EnableDiagnostic(ip string, port int) {
+// Enable opens a TCP socket to debug the passed network DB
+func (s *Server) Enable(ip string, port int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -104,8 +104,8 @@ func (s *Server) EnableDiagnostic(ip string, port int) {
 	}(s)
 }
 
-// DisableDiagnostic stop the debug and closes the tcp socket
-func (s *Server) DisableDiagnostic() {
+// Shutdown stop the debug and closes the tcp socket
+func (s *Server) Shutdown() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.enable {
@@ -121,8 +121,8 @@ func (s *Server) DisableDiagnostic() {
 	log.G(context.TODO()).Info("Network diagnostic server shutdown complete")
 }
 
-// IsDiagnosticEnabled returns true when the debug is enabled
-func (s *Server) IsDiagnosticEnabled() bool {
+// Enabled returns true when the debug is enabled
+func (s *Server) Enabled() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.enable


### PR DESCRIPTION
Had  some of these locally; there's still things to address  after this because there's some actual bugs remaining (diagnostic server is only started  on daemon _reload_, never on _start_, and its config is never updated, other than enable/disable).

Pushing these first to get those out of the way already;

### libnetwork: un-export Controller.DiagnosticServer

It's only accessed internally, so doesn't have to be exported.

### libnetwork/diagnostic: print newline after stackdump log path

The response would not have a trailing newline, which made it difficult
to copy the path. While updating, also include the path of the stackdump
in the daemon log that's produced.

Before this:

    root@fa87ff1bcd00:/go/src/github.com/docker/docker# curl -s http://127.0.0.1:123/stackdump
    OK
    goroutine stacks written to /tmp/goroutine-stacks-2025-01-19T160337Z.logroot@fa87ff1bcd00:/go/src/github.com/docker/docker#

After this:

    root@fa87ff1bcd00:/go/src/github.com/docker/docker# curl -s http://127.0.0.1:123/stackdump
    OK
    goroutine stacks written to /tmp/goroutine-stacks-2025-01-19T160922Z.log
    root@fa87ff1bcd00:/go/src/github.com/docker/docker#

### libnetwork/diagnostic: make EnableDiagnostic, DisableDiagnostic idempotent

Handle situations where the server is already started or stopped internally,
instead of requiring the caller to do this.

### libnetwork: Controller: remove redundant mutex for diagnosticServer

diagnosticServer is only written to during controller.New, and the
diagnostic server itself already has a mutex on EnableDiagnostic,
DisableDiagnostic, and IsDiagnosticEnabled, which should prevent
issues trying to concurrently change its state.

### libnetwork/diagnostic: move, and improve logs for starting/stoping


###  libnetwork/diagnostic: rename methods

- `diagnosticServer.EnableDiagnostic` -> `diagnosticServer.Enable`
- `diagnosticServer.DisableDiagnostic` -> `diagnosticServer.Shutdown`
- `diagnosticServer.IsDiagnosticEnabled` -> `diagnosticServer.Enabled`

### daemon/config: validate network-diagnostic-port

with this patch:

    dockerd --network-diagnostic-port -1 --validate
    unable to configure the Docker daemon with file /etc/docker/daemon.json: merged configuration validation from file and command line flags failed: invalid network-diagnostic-port (-1): value must be between 0 and 65535






**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
dockerd: add validation of network-diagnostic-port daemon configuration option.
```

**- A picture of a cute animal (not mandatory but encouraged)**

