### PR TITLE
[27.x backport] Recover from default bridge init failure

### DIFF
--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -1,4 +1,4 @@
-package network
+package bridge
 
 import (
 	"context"
@@ -19,7 +19,6 @@ import (
 )
 
 func TestCreateWithMultiNetworks(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "requires API v1.44")
 
 	ctx := setupTest(t)
@@ -49,9 +48,6 @@ func TestCreateWithMultiNetworks(t *testing.T) {
 }
 
 func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
-	// On Windows, network creation fails with this error message: Error response from daemon: this request is not supported by the 'windows' ipam driver
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 
@@ -73,7 +69,6 @@ func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
 }
 
 func TestCreateWithIPv6WithoutEnableIPv6Flag(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows") // d.Start fails on Windows with `protocol not available`
 	ctx := setupTest(t)
 
 	d := daemon.New(t)
@@ -103,7 +98,6 @@ func TestCreateWithIPv6WithoutEnableIPv6Flag(t *testing.T) {
 // Check that it's possible to create IPv6 networks with a 64-bit ip-range,
 // in 64-bit and bigger subnets, with and without a gateway.
 func Test64BitIPRange(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "no bridge or IPv6 on Windows")
 	ctx := setupTest(t)
 	c := testEnv.APIClient()
 
@@ -139,7 +133,6 @@ func Test64BitIPRange(t *testing.T) {
 // Demonstrate a limitation of the IP address allocator, it can't
 // allocate the last address in range that ends on a 64-bit boundary.
 func TestIPRangeAt64BitLimit(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "no bridge or IPv6 on Windows")
 	ctx := setupTest(t)
 	c := testEnv.APIClient()
 

--- a/integration/network/bridge/main_test.go
+++ b/integration/network/bridge/main_test.go
@@ -1,0 +1,56 @@
+package bridge // import "github.com/docker/docker/integration/network/bridge"
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/testutil"
+	"github.com/docker/docker/testutil/environment"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+)
+
+var (
+	testEnv     *environment.Execution
+	baseContext context.Context
+)
+
+func TestMain(m *testing.M) {
+	shutdown := testutil.ConfigureTracing()
+	ctx, span := otel.Tracer("").Start(context.Background(), "integration/network/bridge.TestMain")
+	baseContext = ctx
+
+	var err error
+	testEnv, err = environment.New(ctx)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
+		shutdown(ctx)
+		panic(err)
+	}
+
+	err = environment.EnsureFrozenImagesLinux(ctx, testEnv)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.End()
+		shutdown(ctx)
+		panic(err)
+	}
+
+	testEnv.Print()
+	code := m.Run()
+	if code != 0 {
+		span.SetStatus(codes.Error, "m.Run() returned non-zero exit code")
+	}
+	span.End()
+	shutdown(ctx)
+	os.Exit(code)
+}
+
+func setupTest(t *testing.T) context.Context {
+	ctx := testutil.StartSpan(baseContext, t)
+	environment.ProtectAll(ctx, t, testEnv)
+	t.Cleanup(func() { testEnv.Clean(ctx, t) })
+	return ctx
+}

--- a/integration/network/bridge/netinit_linux_test.go
+++ b/integration/network/bridge/netinit_linux_test.go
@@ -1,0 +1,66 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
+	"github.com/docker/docker/testutil/daemon"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestNetworkInitError checks that, if the default bridge network can't be restored on startup,
+// it doesn't prevent the daemon from starting once the underlying problem is resolved.
+// Regression test for https://github.com/moby/moby/issues/49291
+func TestNetworkInitErrorDocker0(t *testing.T) {
+	d := daemon.New(t)
+	d.Start(t)
+	defer func() {
+		_ = d.StopWithError()
+	}()
+
+	const brName = "docker0"
+	d.SetEnvVar("DOCKER_TEST_BRIDGE_INIT_ERROR", brName)
+	err := d.RestartWithError()
+	assert.Assert(t, is.ErrorContains(err, "daemon exited during startup"))
+
+	d.SetEnvVar("DOCKER_TEST_BRIDGE_INIT_ERROR", "")
+	d.Start(t)
+}
+
+// TestNetworkInitErrorUserDefined is equivalent to TestNetworkInitErrorDocker0, for a
+// user-defined network. But, the daemon doesn't try to delete a user-defined network
+// and the daemon will still start if it can't be restored on startup. So, try to
+// delete the network when it's failed to initialise, and check that it can be
+// re-created when the initialisation problem has been resolved.
+func TestNetworkInitErrorUserDefined(t *testing.T) {
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.Start(t)
+	defer func() {
+		_ = d.StopWithError()
+	}()
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	const netName = "testnet"
+	const brName = "br-" + netName
+	network.CreateNoError(ctx, t, c, netName,
+		network.WithOption(bridge.BridgeName, brName),
+	)
+	defer network.RemoveNoError(ctx, t, c, netName)
+
+	d.SetEnvVar("DOCKER_TEST_BRIDGE_INIT_ERROR", brName)
+	d.Restart(t)
+
+	err := c.NetworkRemove(ctx, netName)
+	assert.NilError(t, err)
+
+	d.SetEnvVar("DOCKER_TEST_BRIDGE_INIT_ERROR", "")
+	d.Restart(t)
+	network.CreateNoError(ctx, t, c, netName,
+		network.WithOption(bridge.BridgeName, brName),
+	)
+}

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"strconv"
 	"sync"
 
@@ -904,6 +905,13 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 	// Apply the prepared list of steps, and abort at the first error.
 	bridgeSetup.queueStep(setupDeviceUp)
+
+	if v := os.Getenv("DOCKER_TEST_BRIDGE_INIT_ERROR"); v == config.BridgeName {
+		bridgeSetup.queueStep(func(n *networkConfiguration, b *bridgeInterface) error {
+			return fmt.Errorf("DOCKER_TEST_BRIDGE_INIT_ERROR is %q", v)
+		})
+	}
+
 	return bridgeSetup.apply()
 }
 
@@ -923,6 +931,18 @@ func (d *driver) deleteNetwork(nid string) error {
 	d.Unlock()
 
 	if !ok {
+		// If the network was successfully created by an earlier incarnation of the daemon,
+		// but it failed to initialise this time, the network is still in the store (in
+		// case whatever caused the failure can be fixed for a future daemon restart). But,
+		// it's not in d.networks. To prevent the driver's state from getting out of step
+		// with its parent, make sure it's not in the store before reporting that it does
+		// not exist.
+		if err := d.storeDelete(&networkConfiguration{ID: nid}); err != nil && err != datastore.ErrKeyNotFound {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":   err,
+				"network": nid,
+			}).Warnf("Failed to delete network from bridge store")
+		}
 		return types.InternalMaskableErrorf("network %s does not exist", nid)
 	}
 

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -827,6 +828,17 @@ func (d *Daemon) ReloadConfig() error {
 		return errors.Errorf("[%s] daemon reload event timed out after 30 seconds", d.id)
 	}
 	return nil
+}
+
+// SetEnvVar updates the set of extra env variables for the daemon, to take
+// effect on the next start/restart.
+func (d *Daemon) SetEnvVar(name, val string) {
+	prefix := name + "="
+	if idx := slices.IndexFunc(d.extraEnv, func(ev string) bool { return strings.HasPrefix(ev, prefix) }); idx > 0 {
+		d.extraEnv[idx] = prefix + val
+		return
+	}
+	d.extraEnv = append(d.extraEnv, prefix+val)
 }
 
 // LoadBusybox image into the daemon


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49292
- fixes https://github.com/moby/moby/issues/49291
- :warning: also cherry-picks the first commit (24f53eba7f71dd60f0d56fc9450a53f080b05cdd) from  https://github.com/moby/moby/pull/48594, as tests were moved  in main; cherry-pick had no conflicts in files,  but the rename  was ambiguous;

```bash
git cherry-pick -s -S -x 22c02219de46b4565388491b18cbfcf61ce5ad3f
CONFLICT (directory rename split): Unclear where to rename integration/network/bridge to; it was renamed to multiple other directories, with no destination getting a majority of the files.
Auto-merging libnetwork/drivers/bridge/bridge_linux.go
Auto-merging testutil/daemon/daemon.go
error: could not apply 22c02219de... Bridge: on network delete, make sure it's deleted from store
```

----


If a bridge network can't be restored from the store on startup, then it's deleted, the daemon and bridge driver get out of step. If that happens to the default bridge, the daemon can't recover, it won't start again.

See the issue for more detailed description/analysis.

_The ipvlan/macvlan/overlay network drivers don't seem to be affected by an equivalent issue._

_This is a very long standing issue, but perhaps provoked by the checks on kernel module loading added in 27.x. (The version label on the PR is arbitrary, just something-old.)_

**- How I did it**

When deleting a network the bridge driver doesn't know about, make sure it's not still lurking in the data store.

**- How to verify it**

New tests.

**- Description for the changelog**
```markdown changelog
- Fixed an issue that could persistently prevent daemon startup after failure to initialize the default bridge.
```
