### PR TITLE
[27.x backport] ci: update bake-action to v6, ci(bin-image): fix bake build

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -52,7 +52,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -138,7 +138,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -192,7 +192,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -250,7 +250,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -396,7 +396,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -110,11 +110,6 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Download meta bake definition
         uses: actions/download-artifact@v4
         with:
@@ -140,11 +135,11 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl
-            /tmp/bake-meta.json
+            cwd:///tmp/bake-meta.json
           targets: bin-image
           set: |
             *.platform=${{ matrix.platform }}

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -105,6 +105,11 @@ jobs:
         platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -137,9 +142,10 @@ jobs:
         id: bake
         uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             ./docker-bake.hcl
-            cwd:///tmp/bake-meta.json
+            /tmp/bake-meta.json
           targets: bin-image
           set: |
             *.platform=${{ matrix.platform }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -39,9 +39,6 @@ jobs:
       - validate-dco
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -50,7 +47,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: binary
       -
@@ -146,8 +143,9 @@ jobs:
           docker info
       -
         name: Build test image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
+          source: .
           workdir: ./buildkit
           targets: integration-tests
           set: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,6 @@ jobs:
           - dynbinary
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -57,7 +52,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: ${{ matrix.target }}
       -
@@ -103,11 +98,6 @@ jobs:
         platform: ${{ fromJson(needs.prepare-cross.outputs.matrix) }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -121,7 +111,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: all
           set: |
@@ -145,11 +135,6 @@ jobs:
       contents: read
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -158,7 +143,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Run
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: govulncheck
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,6 @@ jobs:
             echo "SYSTEMD=true" >> $GITHUB_ENV
           fi
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -63,7 +60,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -136,7 +133,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -179,9 +176,6 @@ jobs:
         platform: ${{ fromJson(needs.smoke-prepare.outputs.matrix) }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -198,7 +192,7 @@ jobs:
           buildkitd-flags: --debug
       -
         name: Test
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: binary-smoketest
           set: |


### PR DESCRIPTION
backport:

- https://github.com/moby/moby/pull/49233
- https://github.com/moby/moby/pull/49289




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

