### PR TITLE
libnet/d/bridge: drop connections to lo mappings, and direct remote connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -542,6 +542,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             libprotobuf-c1 \
             libyajl2 \
             net-tools \
+            netcat-openbsd \
             patch \
             pigz \
             sudo \

--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -27,6 +27,22 @@ func WithIPv6() func(*network.CreateOptions) {
 	}
 }
 
+// WithIPv4Disabled makes sure IPv4 is disabled on the network.
+func WithIPv4Disabled() func(*network.CreateOptions) {
+	return func(n *network.CreateOptions) {
+		enable := false
+		n.EnableIPv4 = &enable
+	}
+}
+
+// WithIPv6Disabled makes sure IPv6 is disabled on the network.
+func WithIPv6Disabled() func(*network.CreateOptions) {
+	return func(n *network.CreateOptions) {
+		enable := false
+		n.EnableIPv6 = &enable
+	}
+}
+
 // WithInternal enables Internal flag on the create network request
 func WithInternal() func(*network.CreateOptions) {
 	return func(n *network.CreateOptions) {

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
@@ -1,0 +1,142 @@
+## Container on a user-defined network, with a port published on a loopback address
+
+Adding a network running a container with a port mapped on a loopback address, equivalent to:
+
+	docker network create \
+	  -o com.docker.network.bridge.name=bridge1 \
+	  --subnet 192.0.2.0/24 --gateway 192.0.2.1 bridge1
+	docker run --network bridge1 -p 127.0.0.1:8080:80 --name c1 busybox
+
+The filter and nat tables are identical to [nat mode][0]:
+
+<details>
+<summary>filter table</summary>
+
+    Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    
+    Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    6        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    
+    Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    
+    Chain DOCKER (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
+    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-ISOLATION-STAGE-1 (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER-ISOLATION-STAGE-2  0    --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-ISOLATION-STAGE-2  0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-ISOLATION-STAGE-2 (2 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DROP       0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DROP       0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-USER (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    
+
+    -P INPUT ACCEPT
+    -P FORWARD ACCEPT
+    -P OUTPUT ACCEPT
+    -N DOCKER
+    -N DOCKER-ISOLATION-STAGE-1
+    -N DOCKER-ISOLATION-STAGE-2
+    -N DOCKER-USER
+    -A FORWARD -j DOCKER-USER
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A FORWARD -i docker0 -j ACCEPT
+    -A FORWARD -i bridge1 -j ACCEPT
+    -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
+    -A DOCKER ! -i docker0 -o docker0 -j DROP
+    -A DOCKER ! -i bridge1 -o bridge1 -j DROP
+    -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
+    -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
+    -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
+    -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
+    -A DOCKER-USER -j RETURN
+    
+
+</details>
+
+<details>
+<summary>nat table</summary>
+
+    Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    
+    Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    
+    Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    
+    Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
+    2        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    
+    Chain DOCKER (2 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 RETURN     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 RETURN     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DNAT       6    --  !bridge1 *       0.0.0.0/0            127.0.0.1            tcp dpt:8080 to:192.0.2.2:80
+    
+
+    -P PREROUTING ACCEPT
+    -P INPUT ACCEPT
+    -P OUTPUT ACCEPT
+    -P POSTROUTING ACCEPT
+    -N DOCKER
+    -A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+    -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
+    -A POSTROUTING -s 192.0.2.0/24 ! -o bridge1 -j MASQUERADE
+    -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
+    -A DOCKER -i bridge1 -j RETURN
+    -A DOCKER -i docker0 -j RETURN
+    -A DOCKER -d 127.0.0.1/32 ! -i bridge1 -p tcp -m tcp --dport 8080 -j DNAT --to-destination 192.0.2.2:80
+    
+
+</details>
+
+    Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DROP       6    --  !lo    *       0.0.0.0/0            127.0.0.1            tcp dpt:8080
+    2        0     0 DROP       6    --  !bridge1 *       0.0.0.0/0            192.0.2.2            tcp dpt:80
+    
+    Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    
+
+<details>
+<summary>iptables commands</summary>
+
+    -P PREROUTING ACCEPT
+    -P OUTPUT ACCEPT
+    -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
+    -A PREROUTING -d 192.0.2.2/32 ! -i bridge1 -p tcp -m tcp --dport 80 -j DROP
+    
+
+</details>
+
+[filterPortMappedOnLoopback][1] adds an extra rule in the raw-PREROUTING chain to DROP remote traffic destined to the
+port mapped on the loopback address.
+
+[0]: usernet-portmap.md
+[1]: https://github.com/search?q=repo%3Amoby%2Fmoby%20filterPortMappedOnLoopback&type=code

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -92,7 +92,7 @@ Note that:
 [1]: https://github.com/moby/moby/blob/675c2ac2db93e38bb9c5a6615d4155a969535fd9/libnetwork/drivers/bridge/port_mapping_linux.go#L795
 [2]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L252
 
-And the corresponding nat table:
+The corresponding nat table:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -135,3 +135,27 @@ And the corresponding nat table:
     
 
 </details>
+
+And the raw table:
+
+    Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DROP       6    --  !bridge1 *       0.0.0.0/0            192.0.2.2            tcp dpt:80
+    
+    Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    
+
+<details>
+<summary>iptables commands</summary>
+
+    -P PREROUTING ACCEPT
+    -P OUTPUT ACCEPT
+    -A PREROUTING -d 192.0.2.2/32 ! -i bridge1 -p tcp -m tcp --dport 80 -j DROP
+    
+
+</details>
+
+[filterDirectAccess][3] adds a DROP rule to the raw-PREROUTING chain to block direct remote access to the mapped port.
+
+[3]: https://github.com/search?q=repo%3Amoby%2Fmoby%20filterDirectAccess&type=code

--- a/integration/network/bridge/iptablesdoc/index.md
+++ b/integration/network/bridge/iptablesdoc/index.md
@@ -40,6 +40,7 @@ Scenarios:
 
   - [New daemon](generated/new-daemon.md)
   - [Container on a user-defined network, with a published port](generated/usernet-portmap.md)
+  - [Container on a user-defined network, with a port published on a loopback address](generated/usernet-portmap-lo.md)
   - [Container on a user-defined network, with a published port, no userland proxy](generated/usernet-portmap-noproxy.md)
   - [Container on a user-defined network with inter-container communication disabled, with a published port](generated/usernet-portmap-noicc.md)
   - [Container on a user-defined --internal network](generated/usernet-internal.md)

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -174,6 +174,18 @@ var index = []section{
 			},
 		}},
 	},
+	{
+		name: "usernet-portmap-lo.md",
+		networks: []networkDesc{{
+			name: "bridge1",
+			containers: []ctrDesc{
+				{
+					name:         "c1",
+					portMappings: nat.PortMap{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
+				},
+			},
+		}},
+	},
 }
 
 // iptCmdType is used to look up iptCmds in the markdown (can't use an int

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -188,6 +188,8 @@ const (
 	iptCmdSFilterDocker4  iptCmdType = "SFilterDocker4"
 	iptCmdLNat4           iptCmdType = "LNat4"
 	iptCmdSNat4           iptCmdType = "SNat4"
+	iptCmdLRaw4           iptCmdType = "LRaw4"
+	iptCmdSRaw4           iptCmdType = "SRaw4"
 )
 
 var iptCmds = map[iptCmdType][]string{
@@ -198,6 +200,8 @@ var iptCmds = map[iptCmdType][]string{
 	iptCmdSFilterDocker4:  {"iptables", "-S", "DOCKER"},
 	iptCmdLNat4:           {"iptables", "-nvL", "--line-numbers", "-t", "nat"},
 	iptCmdSNat4:           {"iptables", "-S", "-t", "nat"},
+	iptCmdLRaw4:           {"iptables", "-nvL", "--line-numbers", "-t", "raw"},
+	iptCmdSRaw4:           {"iptables", "-S", "-t", "raw"},
 }
 
 func TestBridgeIptablesDoc(t *testing.T) {

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-lo.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-lo.md
@@ -1,0 +1,43 @@
+## Container on a user-defined network, with a port published on a loopback address
+
+Adding a network running a container with a port mapped on a loopback address, equivalent to:
+
+	docker network create \
+	  -o com.docker.network.bridge.name=bridge1 \
+	  --subnet 192.0.2.0/24 --gateway 192.0.2.1 bridge1
+	docker run --network bridge1 -p 127.0.0.1:8080:80 --name c1 busybox
+
+The filter and nat tables are identical to [nat mode][0]:
+
+<details>
+<summary>filter table</summary>
+
+    {{index . "LFilter4"}}
+
+    {{index . "SFilter4"}}
+
+</details>
+
+<details>
+<summary>nat table</summary>
+
+    {{index . "LNat4"}}
+
+    {{index . "SNat4"}}
+
+</details>
+
+    {{index . "LRaw4"}}
+
+<details>
+<summary>iptables commands</summary>
+
+    {{index . "SRaw4"}}
+
+</details>
+
+[filterPortMappedOnLoopback][1] adds an extra rule in the raw-PREROUTING chain to DROP remote traffic destined to the
+port mapped on the loopback address.
+
+[0]: usernet-portmap.md
+[1]: https://github.com/search?q=repo%3Amoby%2Fmoby%20filterPortMappedOnLoopback&type=code

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
@@ -37,7 +37,7 @@ Note that:
 [1]: https://github.com/moby/moby/blob/675c2ac2db93e38bb9c5a6615d4155a969535fd9/libnetwork/drivers/bridge/port_mapping_linux.go#L795
 [2]: https://github.com/robmry/moby/blob/52c89d467fc5326149e4bbb8903d23589b66ff0d/libnetwork/drivers/bridge/setup_ip_tables_linux.go#L252
 
-And the corresponding nat table:
+The corresponding nat table:
 
     {{index . "LNat4"}}
 
@@ -47,3 +47,18 @@ And the corresponding nat table:
     {{index . "SNat4"}}
 
 </details>
+
+And the raw table:
+
+    {{index . "LRaw4"}}
+
+<details>
+<summary>iptables commands</summary>
+
+    {{index . "SRaw4"}}
+
+</details>
+
+[filterDirectAccess][3] adds a DROP rule to the raw-PREROUTING chain to block direct remote access to the mapped port.
+
+[3]: https://github.com/search?q=repo%3Amoby%2Fmoby%20filterDirectAccess&type=code

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -3,7 +3,9 @@ package bridge
 import (
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/internal/nlwrap"
@@ -12,6 +14,7 @@ import (
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
@@ -464,27 +467,8 @@ func TestMirroredWSL2Workaround(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			defer netnsutils.SetupTestOSContext(t)()
-
-			if tc.loopback0 {
-				loopback0 := &netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: "loopback0",
-					},
-				}
-				err := netlink.LinkAdd(loopback0)
-				assert.NilError(t, err)
-			}
-
-			if tc.wslinfoPerm != 0 {
-				wslinfoPathOrig := wslinfoPath
-				defer func() {
-					wslinfoPath = wslinfoPathOrig
-				}()
-				tmpdir := t.TempDir()
-				wslinfoPath = filepath.Join(tmpdir, "wslinfo")
-				err := os.WriteFile(wslinfoPath, []byte("#!/bin/sh\necho dummy file\n"), tc.wslinfoPerm)
-				assert.NilError(t, err)
-			}
+			restoreWslinfoPath := simulateWSL2MirroredMode(t, tc.loopback0, tc.wslinfoPerm)
+			defer restoreWslinfoPath()
 
 			assert.NilError(t, setupHashNetIpset(ipsetExtBridges4, unix.AF_INET))
 
@@ -496,6 +480,97 @@ func TestMirroredWSL2Workaround(t *testing.T) {
 			err := setupIPChains(config, iptables.IPv4)
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(mirroredWSL2Rule().Exists(), tc.expLoopback0Rule))
+		})
+	}
+}
+
+// simulateWSL2MirroredMode simulates the WSL2 mirrored mode by creating a
+// loopback0 interface and optionally creating a wslinfo file with the given
+// permissions.
+// A clean up function is returned and will restore the original wslinfoPath
+// used within the 'bridge' package. The loopback0 interface isn't cleaned up.
+// Instead this function should be called from a disposable network namespace.
+func simulateWSL2MirroredMode(t *testing.T, loopback0 bool, wslinfoPerm os.FileMode) func() {
+	if loopback0 {
+		iface := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: "loopback0",
+			},
+		}
+		err := netlink.LinkAdd(iface)
+		assert.NilError(t, err)
+	}
+
+	wslinfoPathOrig := wslinfoPath
+	if wslinfoPerm != 0 {
+		tmpdir := t.TempDir()
+		p := filepath.Join(tmpdir, "wslinfo")
+		err := os.WriteFile(p, []byte("#!/bin/sh\necho dummy file\n"), wslinfoPerm)
+		assert.NilError(t, err)
+		wslinfoPath = p
+	}
+
+	return func() {
+		wslinfoPath = wslinfoPathOrig
+	}
+}
+
+func TestMirroredWSL2LoopbackFiltering(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		loopback0        bool
+		wslinfoPerm      os.FileMode // 0 for no-file
+		expLoopback0Rule bool
+	}{
+		{
+			desc: "No loopback0",
+		},
+		{
+			desc:             "WSL2 mirrored",
+			loopback0:        true,
+			wslinfoPerm:      0o777,
+			expLoopback0Rule: true,
+		},
+		{
+			desc:        "loopback0 but wslinfo not executable",
+			loopback0:   true,
+			wslinfoPerm: 0o666,
+		},
+		{
+			desc:      "loopback0 but no wslinfo",
+			loopback0: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			defer netnsutils.SetupTestOSContext(t)()
+			restoreWslinfoPath := simulateWSL2MirroredMode(t, tc.loopback0, tc.wslinfoPerm)
+			defer restoreWslinfoPath()
+
+			nw := bridgeNetwork{
+				driver: &driver{
+					config: configuration{EnableIPTables: true},
+				},
+			}
+			err := nw.filterPortMappedOnLoopback(portBinding{
+				PortBinding: types.PortBinding{
+					Proto:    types.TCP,
+					IP:       net.ParseIP("127.0.0.1"),
+					HostPort: 8000,
+				},
+				childHostIP: net.ParseIP("127.0.0.1"),
+			}, true)
+			assert.NilError(t, err)
+
+			out, err := exec.Command("iptables-save", "-t", "raw").CombinedOutput()
+			assert.NilError(t, err)
+
+			if tc.expLoopback0Rule {
+				assert.Check(t, is.Equal(strings.Count(string(out), "-A PREROUTING"), 2))
+				assert.Check(t, is.Contains(string(out), "-A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8000 -j ACCEPT"))
+			} else {
+				assert.Check(t, is.Equal(strings.Count(string(out), "-A PREROUTING"), 1))
+				assert.Check(t, !strings.Contains(string(out), "loopback0"), "There should be no rule in the raw-PREROUTING chain")
+			}
 		})
 	}
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -49,6 +49,8 @@ const (
 	Filter Table = "filter"
 	// Mangle table is used for mangling the packet.
 	Mangle Table = "mangle"
+	// Raw table is used for filtering packets before they are NATed.
+	Raw Table = "raw"
 )
 
 // IPVersion refers to IP version, v4 or v6


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/48721
- Related to https://github.com/moby/moby/pull/49310
- Close https://github.com/moby/moby/issues/45610

**- What I did**

This PR fixes two separate security issues that have a common cause -- lack of proper packet filtering before NATing.

**- How I did it**

1st and 2nd commit are just a small refactoring, and a new integration for the use-case broken by:

- https://github.com/moby/moby/pull/48721

**3rd commit: libnet/d/bridge: port mappings: drop direct-access when gw_mode=nat**

When a NAT-based port mapping is created, the daemon adds a DNAT rule in nat-DOCKER to replace the dest addr with the container IP. However, the daemon never sets up rules to filter packets destined directly to the container port. This allows a rogue neighbor (ie. a host that shares a L2 segment with the host) to send packets directly to the container on its container-side exposed port.

For instance, if container port 5000 is mapped to host port 6000, a neighbor could send packets directly to the container on its port 5000.

Since nat-DOCKER mangles the dest addr, and the nat table forbids DROP rules, this change adds a new rule in the raw-PREROUTING chain to filter ingress connections targeting the container's IP address.

This filtering is only done when gw_mode=nat. For the unprotected variant, no filtering is done.

**4th commit: libnet/d/bridge: drop remote connections to port mapped on lo**

Traditionnally when Linux receives remote packets with daddr set to a loopback address, it reject them as 'martians'. However, when a NAT rule is applied through iptables this doesn't happen. Our current DNAT rule used to map host ports to containers is applied unconditionnally, even for such 'martian' packets.

This means a neighbor host (ie. a host connected to the same L2 segment) can send packets to a port mapped on a loopback address. The purpose of publishing on a loopback address is to make ports inaccessible to remote hosts -- lack of proper filtering defeats that.

This commit adds an iptables rule to the raw-PREROUTING chain to drop packets with a loopback dest address and coming from any interface other than lo.

To accomodate WSL2 mirrored mode, another rule is inserted beforehand to specifically accept packets coming from the loopback0 interface.

**- How to verify it**

New integration tests.

**- Description for the changelog**

```markdown changelog
- Fix a security issue that was allowing remote hosts to connect directly to a container, on one of its published port.
- Fix a security issue that was allowing neighbor hosts to connect to ports mapped on a loopback address.
```
