### PR TITLE
daemon: make daemon.getEntrypointAndArgs a regular function

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/container/stream"
 	"github.com/docker/docker/errdefs"
@@ -100,9 +99,6 @@ func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.E
 		return "", err
 	}
 
-	cmd := strslice.StrSlice(options.Cmd)
-	entrypoint, args := daemon.getEntrypointAndArgs(strslice.StrSlice{}, cmd)
-
 	keys := []byte{}
 	if options.DetachKeys != "" {
 		keys, err = term.ToBytes(options.DetachKeys)
@@ -117,8 +113,7 @@ func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.E
 	execConfig.OpenStdout = options.AttachStdout
 	execConfig.OpenStderr = options.AttachStderr
 	execConfig.DetachKeys = keys
-	execConfig.Entrypoint = entrypoint
-	execConfig.Args = args
+	execConfig.Entrypoint, execConfig.Args = options.Cmd[0], options.Cmd[1:]
 	execConfig.Tty = options.Tty
 	execConfig.ConsoleSize = options.ConsoleSize
 	execConfig.Privileged = options.Privileged

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/internal/metrics"
 )
@@ -69,18 +68,16 @@ type cmdProbe struct {
 // Returns the exit code and probe output (if any)
 func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container) (*containertypes.HealthcheckResult, error) {
 	startTime := time.Now()
-	cmdSlice := strslice.StrSlice(cntr.Config.Healthcheck.Test)[1:]
+	cmd := cntr.Config.Healthcheck.Test[1:]
 	if p.shell {
-		cmdSlice = append(getShell(cntr), cmdSlice...)
+		cmd = append(getShell(cntr), cmd...)
 	}
-	entrypoint, args := d.getEntrypointAndArgs(strslice.StrSlice{}, cmdSlice)
 	execConfig := container.NewExecConfig(cntr)
 	execConfig.OpenStdin = false
 	execConfig.OpenStdout = true
 	execConfig.OpenStderr = true
 	execConfig.DetachKeys = []byte{}
-	execConfig.Entrypoint = entrypoint
-	execConfig.Args = args
+	execConfig.Entrypoint, execConfig.Args = cmd[0], cmd[1:]
 	execConfig.Tty = false
 	execConfig.Privileged = false
 	execConfig.User = cntr.Config.User


### PR DESCRIPTION
It was not using the daemon, so can be a regular function. While at it, also changed the parameter type to accept a regular string-slice, as we don't need strslice.StrSlice's json.Unmarshaler implementation, and reversed the logic for the early return.

Finally, for uses where the entrypoint was always nil, this patch removes the use of this utility altogether.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

