### PR TITLE
remove redundant uses of api/types/strslice.StrSlice

### DIFF
--- a/builder/dockerfile/dispatchers.go
+++ b/builder/dockerfile/dispatchers.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/api"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -367,7 +366,7 @@ func dispatchRun(ctx context.Context, d dispatchRequest, c *instructions.RunComm
 		withCmd(cmdFromArgs),
 		withArgsEscaped(argsEscaped),
 		withEnv(append(stateRunConfig.Env, buildArgs...)),
-		withEntrypointOverride(saveCmd, strslice.StrSlice{""}),
+		withEntrypointOverride(saveCmd, []string{""}),
 		withoutHealthcheck())
 
 	cID, err := d.builder.create(ctx, runConfig)
@@ -412,7 +411,7 @@ func dispatchRun(ctx context.Context, d dispatchRequest, c *instructions.RunComm
 // remove any unreferenced built-in args from the environment variables.
 // These args are transparent so resulting image should be the same regardless
 // of the value.
-func prependEnvOnCmd(buildArgs *BuildArgs, buildArgVars []string, cmd strslice.StrSlice) strslice.StrSlice {
+func prependEnvOnCmd(buildArgs *BuildArgs, buildArgVars []string, cmd []string) []string {
 	tmpBuildEnv := make([]string, 0, len(buildArgVars))
 	for _, env := range buildArgVars {
 		key, _, _ := strings.Cut(env, "=")

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -62,7 +62,7 @@ func TestEnv2Variables(t *testing.T) {
 		"var1=val1",
 		"var2=val2",
 	}
-	assert.Check(t, is.DeepEqual(expected, sb.state.runConfig.Env))
+	assert.Check(t, is.DeepEqual(sb.state.runConfig.Env, expected))
 }
 
 func TestEnvValueWithExistingRunConfigEnv(t *testing.T) {
@@ -80,7 +80,7 @@ func TestEnvValueWithExistingRunConfigEnv(t *testing.T) {
 		"var1=val1",
 		"var2=fromenv",
 	}
-	assert.Check(t, is.DeepEqual(expected, sb.state.runConfig.Env))
+	assert.Check(t, is.DeepEqual(sb.state.runConfig.Env, expected))
 }
 
 func TestMaintainer(t *testing.T) {
@@ -90,7 +90,7 @@ func TestMaintainer(t *testing.T) {
 	cmd := &instructions.MaintainerCommand{Maintainer: maintainerEntry}
 	err := dispatch(context.TODO(), sb, cmd)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(maintainerEntry, sb.state.maintainer))
+	assert.Check(t, is.Equal(sb.state.maintainer, maintainerEntry))
 }
 
 func TestLabel(t *testing.T) {
@@ -126,17 +126,17 @@ func TestFromScratch(t *testing.T) {
 
 	assert.NilError(t, err)
 	assert.Check(t, sb.state.hasFromImage())
-	assert.Check(t, is.Equal("", sb.state.imageID))
+	assert.Check(t, is.Equal(sb.state.imageID, ""))
 	// TODO(thaJeztah): use github.com/moby/buildkit/util/system.DefaultPathEnv() once https://github.com/moby/buildkit/pull/3158 is resolved.
-	expected := "PATH=" + oci.DefaultPathEnv(runtime.GOOS)
-	assert.Check(t, is.DeepEqual([]string{expected}, sb.state.runConfig.Env))
+	expected := []string{"PATH=" + oci.DefaultPathEnv(runtime.GOOS)}
+	assert.Check(t, is.DeepEqual(sb.state.runConfig.Env, expected))
 }
 
 func TestFromWithArg(t *testing.T) {
 	tag, expected := ":sometag", "expectedthisid"
 
 	getImage := func(name string) (builder.Image, builder.ROLayer, error) {
-		assert.Check(t, is.Equal("alpine"+tag, name))
+		assert.Check(t, is.Equal(name, "alpine"+tag))
 		return &mockImage{id: "expectedthisid"}, nil, nil
 	}
 	b := newBuilderWithMockBackend(t)
@@ -158,8 +158,8 @@ func TestFromWithArg(t *testing.T) {
 	err = initializeStage(context.TODO(), sb, cmd)
 	assert.NilError(t, err)
 
-	assert.Check(t, is.Equal(expected, sb.state.imageID))
-	assert.Check(t, is.Equal(expected, sb.state.baseImage.ImageID()))
+	assert.Check(t, is.Equal(sb.state.imageID, expected))
+	assert.Check(t, is.Equal(sb.state.baseImage.ImageID(), expected))
 	assert.Check(t, is.Len(sb.state.buildArgs.GetAllAllowed(), 0))
 	assert.Check(t, is.Len(sb.state.buildArgs.GetAllMeta(), 1))
 }
@@ -184,7 +184,7 @@ func TestFromWithUndefinedArg(t *testing.T) {
 	tag, expected := "sometag", "expectedthisid"
 
 	getImage := func(name string) (builder.Image, builder.ROLayer, error) {
-		assert.Check(t, is.Equal("alpine", name))
+		assert.Check(t, is.Equal(name, "alpine"))
 		return &mockImage{id: "expectedthisid"}, nil, nil
 	}
 	b := newBuilderWithMockBackend(t)
@@ -198,7 +198,7 @@ func TestFromWithUndefinedArg(t *testing.T) {
 	}
 	err := initializeStage(context.TODO(), sb, cmd)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(expected, sb.state.imageID))
+	assert.Check(t, is.Equal(sb.state.imageID, expected))
 }
 
 func TestFromMultiStageWithNamedStage(t *testing.T) {
@@ -226,7 +226,7 @@ func TestOnbuild(t *testing.T) {
 	}
 	err := dispatch(context.TODO(), sb, cmd)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal("ADD . /app/src", sb.state.runConfig.OnBuild[0]))
+	assert.Check(t, is.Equal(sb.state.runConfig.OnBuild[0], "ADD . /app/src"))
 }
 
 func TestWorkdir(t *testing.T) {
@@ -243,7 +243,7 @@ func TestWorkdir(t *testing.T) {
 
 	err := dispatch(context.TODO(), sb, cmd)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(workingDir, sb.state.runConfig.WorkingDir))
+	assert.Check(t, is.Equal(sb.state.runConfig.WorkingDir, workingDir))
 }
 
 func TestCmd(t *testing.T) {
@@ -282,7 +282,7 @@ func TestHealthcheckNone(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Assert(t, sb.state.runConfig.Healthcheck != nil)
-	assert.Check(t, is.DeepEqual([]string{"NONE"}, sb.state.runConfig.Healthcheck.Test))
+	assert.Check(t, is.DeepEqual(sb.state.runConfig.Healthcheck.Test, []string{"NONE"}))
 }
 
 func TestHealthcheckCmd(t *testing.T) {
@@ -298,7 +298,7 @@ func TestHealthcheckCmd(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Assert(t, sb.state.runConfig.Healthcheck != nil)
-	assert.Check(t, is.DeepEqual(expectedTest, sb.state.runConfig.Healthcheck.Test))
+	assert.Check(t, is.DeepEqual(sb.state.runConfig.Healthcheck.Test, expectedTest))
 }
 
 func TestEntrypoint(t *testing.T) {
@@ -351,7 +351,7 @@ func TestUser(t *testing.T) {
 	}
 	err := dispatch(context.TODO(), sb, cmd)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal("test", sb.state.runConfig.User))
+	assert.Check(t, is.Equal(sb.state.runConfig.User, "test"))
 }
 
 func TestVolume(t *testing.T) {
@@ -378,14 +378,14 @@ func TestStopSignal(t *testing.T) {
 	b := newBuilderWithMockBackend(t)
 	sb := newDispatchRequest(b, '`', nil, NewBuildArgs(make(map[string]*string)), newStagesBuildResults())
 	sb.state.baseImage = &mockImage{}
-	signal := "SIGKILL"
+	const signal = "SIGKILL"
 
 	cmd := &instructions.StopSignalCommand{
 		Signal: signal,
 	}
 	err := dispatch(context.TODO(), sb, cmd)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(signal, sb.state.runConfig.StopSignal))
+	assert.Check(t, is.Equal(sb.state.runConfig.StopSignal, signal))
 }
 
 func TestArg(t *testing.T) {
@@ -399,7 +399,7 @@ func TestArg(t *testing.T) {
 	assert.NilError(t, err)
 
 	expected := map[string]string{argName: argVal}
-	assert.Check(t, is.DeepEqual(expected, sb.state.buildArgs.GetAllAllowed()))
+	assert.Check(t, is.DeepEqual(sb.state.buildArgs.GetAllAllowed(), expected))
 }
 
 func TestShell(t *testing.T) {
@@ -571,7 +571,7 @@ func TestRunIgnoresHealthcheck(t *testing.T) {
 
 	mockBackend.containerCreateFunc = func(config backend.ContainerCreateConfig) (container.CreateResponse, error) {
 		// Check the Healthcheck is disabled.
-		assert.Check(t, is.DeepEqual([]string{"NONE"}, config.Config.Healthcheck.Test))
+		assert.Check(t, is.DeepEqual(config.Config.Healthcheck.Test, []string{"NONE"}))
 		return container.CreateResponse{ID: "123456"}, nil
 	}
 
@@ -582,7 +582,7 @@ func TestRunIgnoresHealthcheck(t *testing.T) {
 	run.PrependShell = true
 
 	assert.NilError(t, dispatch(context.TODO(), sb, run))
-	assert.Check(t, is.DeepEqual(expectedTest, sb.state.runConfig.Healthcheck.Test))
+	assert.Check(t, is.DeepEqual(sb.state.runConfig.Healthcheck.Test, expectedTest))
 }
 
 func TestDispatchUnsupportedOptions(t *testing.T) {

--- a/image/cache/compare_test.go
+++ b/image/cache/compare_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -38,12 +37,12 @@ func TestCompare(t *testing.T) {
 	volumes3["/test3"] = struct{}{}
 	envs1 := []string{"ENV1=value1", "ENV2=value2"}
 	envs2 := []string{"ENV1=value1", "ENV3=value3"}
-	entrypoint1 := strslice.StrSlice{"/bin/sh", "-c"}
-	entrypoint2 := strslice.StrSlice{"/bin/sh", "-d"}
-	entrypoint3 := strslice.StrSlice{"/bin/sh", "-c", "echo"}
-	cmd1 := strslice.StrSlice{"/bin/sh", "-c"}
-	cmd2 := strslice.StrSlice{"/bin/sh", "-d"}
-	cmd3 := strslice.StrSlice{"/bin/sh", "-c", "echo"}
+	entrypoint1 := []string{"/bin/sh", "-c"}
+	entrypoint2 := []string{"/bin/sh", "-d"}
+	entrypoint3 := []string{"/bin/sh", "-c", "echo"}
+	cmd1 := []string{"/bin/sh", "-c"}
+	cmd2 := []string{"/bin/sh", "-d"}
+	cmd3 := []string{"/bin/sh", "-c", "echo"}
 	labels1 := map[string]string{"LABEL1": "value1", "LABEL2": "value2"}
 	labels2 := map[string]string{"LABEL1": "value1", "LABEL2": "value3"}
 	labels3 := map[string]string{"LABEL1": "value1", "LABEL2": "value2", "LABEL3": "value3"}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/go-connections/nat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -44,7 +43,7 @@ func WithImage(image string) func(*TestContainerConfig) {
 // WithCmd sets the commands of the container
 func WithCmd(cmds ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.Config.Cmd = strslice.StrSlice(cmds)
+		c.Config.Cmd = cmds
 	}
 }
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/strslice"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
@@ -448,8 +447,8 @@ func TestCreateServiceCapabilities(t *testing.T) {
 	// verify that the container has the capabilities option set
 	ctnr, err := client.ContainerInspect(ctx, tasks[0].Status.ContainerStatus.ContainerID)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, ctnr.HostConfig.CapAdd, strslice.StrSlice(capAdd))
-	assert.DeepEqual(t, ctnr.HostConfig.CapDrop, strslice.StrSlice(capDrop))
+	assert.DeepEqual(t, []string(ctnr.HostConfig.CapAdd), capAdd)
+	assert.DeepEqual(t, []string(ctnr.HostConfig.CapDrop), capDrop)
 
 	// verify that the task has the capabilities option set in the task object
 	assert.DeepEqual(t, tasks[0].Spec.ContainerSpec.CapabilityAdd, capAdd)

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/sysinfo"
 	"gotest.tools/v3/assert"
@@ -20,7 +19,7 @@ func TestDecodeContainerConfig(t *testing.T) {
 		doc        string
 		imgName    string
 		fixture    string
-		entrypoint strslice.StrSlice
+		entrypoint []string
 	}
 
 	// FIXME (thaJeztah): update fixtures for more current versions.
@@ -29,13 +28,13 @@ func TestDecodeContainerConfig(t *testing.T) {
 			doc:        "API 1.19 windows",
 			imgName:    "windows",
 			fixture:    "fixtures/windows/container_config_1_19.json",
-			entrypoint: strslice.StrSlice{"cmd"},
+			entrypoint: []string{"cmd"},
 		},
 		{
 			doc:        "API 1.19 unix",
 			imgName:    "ubuntu",
 			fixture:    "fixtures/unix/container_config_1_19.json",
-			entrypoint: strslice.StrSlice{"bash"},
+			entrypoint: []string{"bash"},
 		},
 	}
 
@@ -48,7 +47,7 @@ func TestDecodeContainerConfig(t *testing.T) {
 			assert.NilError(t, err)
 
 			assert.Check(t, is.Equal(c.Image, tc.imgName))
-			assert.Check(t, is.DeepEqual(c.Entrypoint, tc.entrypoint))
+			assert.Check(t, is.DeepEqual([]string(c.Entrypoint), tc.entrypoint))
 
 			var expected int64 = 1000
 			assert.Check(t, is.Equal(h.Memory, expected))


### PR DESCRIPTION
The only real purpose of strslice.StrSlice is to provide a custom json.Unmarshaler implementation for API responses. For all other purposes, it's a regular string-slice.

This patch removes uses of this type in cases where the custom json.Unmarshaler is irrelevant; in most cases this was in tests, where results were tested using "DeepEquals"; for those tests, the type-assertion did not add real value, so we can cast the values to a []string instead.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

