### PR TITLE
daemon: health: getShell: simplify logic (LCOW remnants)

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -455,11 +454,8 @@ func getShell(cntr *container.Container) []string {
 	if len(cntr.Config.Shell) != 0 {
 		return cntr.Config.Shell
 	}
-	if runtime.GOOS != "windows" {
-		return []string{"/bin/sh", "-c"}
+	if cntr.ImagePlatform.OS == "windows" {
+		return []string{"cmd", "/S", "/C"}
 	}
-	if cntr.ImagePlatform.OS != runtime.GOOS {
-		return []string{"/bin/sh", "-c"}
-	}
-	return []string{"cmd", "/S", "/C"}
+	return []string{"/bin/sh", "-c"}
 }


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/pull/28438
- https://github.com/moby/moby/pull/39389
- https://github.com/moby/moby/issues/39533


This function had some LCOW remnants, where the assumption was made the only on Windows, the image's OS could potentially not match the host's OS (see 3e6a13ccb8ec1395d46925bc4c075cb32cf395a6).

While we currently are not able to run a Windows image on Linux (or vice versa), this function doesn't have to take into account;

- If a shell is configured; use whatever is configured
- otherwise, use "cmd.exe" for Windows images, and "/bin/sh" otherwise (likely Linux, but the existing code did not account for other platforms).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

