### PR TITLE
libnetwork: remove Network.EndpointByID as it must not be used

### DIFF
--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -619,14 +619,6 @@ func TestNetworkQuery(t *testing.T) {
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	assert.Check(t, is.Error(err, "endpoint IamNotAnEndpoint not found"))
 	assert.Check(t, is.Nil(e), "EndpointByName() returned endpoint on error")
-
-	e, err = net1.EndpointByID(ep12.ID())
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(e.ID(), ep12.ID()), "EndpointByID() returned the wrong endpoint")
-
-	_, err = net1.EndpointByID("")
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
-	assert.Check(t, is.ErrorContains(err, "invalid id:"))
 }
 
 const containerID = "valid_c"

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1334,21 +1334,6 @@ func (n *Network) EndpointByName(name string) (*Endpoint, error) {
 	return e, nil
 }
 
-// EndpointByID should *never* be called as it's going to create a 2nd instance of an Endpoint. The first one lives in
-// the Sandbox the endpoint is attached to. Instead, the endpoint should be retrieved by calling [Sandbox.Endpoints()].
-func (n *Network) EndpointByID(id string) (*Endpoint, error) {
-	if id == "" {
-		return nil, ErrInvalidID(id)
-	}
-
-	ep, err := n.getEndpointFromStore(id)
-	if err != nil {
-		return nil, ErrNoSuchEndpoint(id)
-	}
-
-	return ep, nil
-}
-
 // updateSvcRecord adds or deletes local DNS records for a given Endpoint.
 func (n *Network) updateSvcRecord(ctx context.Context, ep *Endpoint, isAdd bool) {
 	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.updateSvcRecord", trace.WithAttributes(


### PR DESCRIPTION
-  follow-up to  https://github.com/moby/moby/pull/47195

> This is a quick-fix; instead of loading endpoints through Network.EndpointByID(), Sandbox.getEndpoint() was made public and is now used. I also added a comment on Network.EndpointByID() saying this method should never be used -- and actually it should be removed in a follow-up.

---

### libnetwork: remove Network.EndpointByID as it must not be used


commit 80c44b4b2e5028e003deac89fcaa4cbc2d172ee5 removed uses of this method and added a comment that it should never be used;

> EndpointByID should *never* be called as it's going to create a 2nd instance
> of an Endpoint. The first one lives in the Sandbox the endpoint is attached to.
> Instead, the endpoint should be retrieved by calling [Sandbox.Endpoints()].

Given that the only use of this method is in tests, we can remove if altogether.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

