### PR TITLE
Debug flaky unsolicited Neighbour Advertisements

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -1536,6 +1536,9 @@ func TestAdvertiseAddresses(t *testing.T) {
 
 			icmps := stopICMP6Listen()
 			checkPkts("ICMP6", icmps, netip.MustParseAddr(ctr2Addr6), network.UnpackUnsolNA)
+			if t.Failed() {
+				d.TailLogsT(t, 100)
+			}
 		})
 	}
 }

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -350,6 +350,9 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix string,
 }
 
 func waitForIfUpped(ctx context.Context, ns netns.NsHandle, ifIndex int) (bool, error) {
+	ctx, span := otel.Tracer("").Start(context.WithoutCancel(ctx), "libnetwork.osl.waitforIfUpped")
+	defer span.End()
+
 	update := make(chan netlink.LinkUpdate, 100)
 	upped := make(chan struct{})
 	opts := netlink.LinkSubscribeOptions{
@@ -398,6 +401,7 @@ func waitForIfUpped(ctx context.Context, ns netns.NsHandle, ifIndex int) (bool, 
 	for {
 		select {
 		case <-timerC:
+			log.G(ctx).Warnf("timeout in waitForIfUpped")
 			return false, nil
 		case u, ok := <-update:
 			if !ok {


### PR DESCRIPTION
**- What I did**

Sending unsolicited ARPs/NAs (https://github.com/moby/moby/pull/48808) fails occasionally in CI in one of two ways ... either with error "write ip ::1->ff02::1: sendmsg: network is unreachable" on the NA send, causing the endpoint-join to fail, or NA and ARPs simply aren't sent but the join succeeds (spotted by `TestAdvertiseAddrs`).

I'm not sure why, and haven't been able to repro locally - so, try to get some more info from CI failures.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

