### PR TITLE
daemon/cluster/executor: simplify handling of Network Attachments

### DIFF
--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -207,12 +207,8 @@ func (c *containerAdapter) waitNodeAttachments(ctx context.Context) error {
 }
 
 func (c *containerAdapter) createNetworks(ctx context.Context) error {
-	for name := range c.container.networksAttachments {
-		ncr, err := c.container.networkCreateRequest(name)
-		if err != nil {
-			return err
-		}
-
+	for name, nw := range c.container.networksAttachments {
+		ncr := networkCreateRequest(name, nw.Network)
 		if err := c.backend.CreateManagedNetwork(ncr); err != nil { // todo name missing
 			if _, ok := err.(libnetwork.NetworkNameError); ok {
 				continue

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -180,13 +180,13 @@ func (c *containerAdapter) waitNodeAttachments(ctx context.Context) error {
 		// set a flag ready to true. if we try to get a network IP that doesn't
 		// exist yet, we will set this flag to "false"
 		ready := true
-		for _, attachment := range c.container.networksAttachments {
+		for _, nw := range c.container.networks {
 			// we only need node attachments (IP address) for overlay networks
 			// TODO(dperny): unsure if this will work with other network
 			// drivers, but i also don't think other network drivers use the
 			// node attachment IP address.
-			if attachment.Network.DriverState.Name == "overlay" {
-				if _, exists := attachmentStore.GetIPForNetwork(attachment.Network.ID); !exists {
+			if nw.DriverState.Name == "overlay" {
+				if _, exists := attachmentStore.GetIPForNetwork(nw.ID); !exists {
 					ready = false
 				}
 			}
@@ -207,8 +207,8 @@ func (c *containerAdapter) waitNodeAttachments(ctx context.Context) error {
 }
 
 func (c *containerAdapter) createNetworks(ctx context.Context) error {
-	for name, nw := range c.container.networksAttachments {
-		ncr := networkCreateRequest(name, nw.Network)
+	for name, nw := range c.container.networks {
+		ncr := networkCreateRequest(name, nw)
 		if err := c.backend.CreateManagedNetwork(ncr); err != nil { // todo name missing
 			if _, ok := err.(libnetwork.NetworkNameError); ok {
 				continue
@@ -231,8 +231,8 @@ func (c *containerAdapter) removeNetworks(ctx context.Context) error {
 		errNoSuchNetwork     libnetwork.ErrNoSuchNetwork
 	)
 
-	for name, v := range c.container.networksAttachments {
-		if err := c.backend.DeleteManagedNetwork(v.Network.ID); err != nil {
+	for name, nw := range c.container.networks {
+		if err := c.backend.DeleteManagedNetwork(nw.ID); err != nil {
 			switch {
 			case errors.As(err, &activeEndpointsError):
 				continue

--- a/daemon/cluster/executor/container/adapter_test.go
+++ b/daemon/cluster/executor/container/adapter_test.go
@@ -34,35 +34,29 @@ func TestWaitNodeAttachment(t *testing.T) {
 	// actually; only the networkAttachments are needed.
 	container := &containerConfig{
 		task: nil,
-		networksAttachments: map[string]*api.NetworkAttachment{
+		networks: map[string]*api.Network{
 			// network1 is already present in the attachment store.
 			"network1": {
-				Network: &api.Network{
-					ID: "network1",
-					DriverState: &api.Driver{
-						Name: "overlay",
-					},
+				ID: "network1",
+				DriverState: &api.Driver{
+					Name: "overlay",
 				},
 			},
 			// network2 is not yet present in the attachment store, and we
 			// should block while waiting for it.
 			"network2": {
-				Network: &api.Network{
-					ID: "network2",
-					DriverState: &api.Driver{
-						Name: "overlay",
-					},
+				ID: "network2",
+				DriverState: &api.Driver{
+					Name: "overlay",
 				},
 			},
 			// localnetwork is not and will never be in the attachment store,
 			// but we should not block on it, because it is not an overlay
 			// network
 			"localnetwork": {
-				Network: &api.Network{
-					ID: "localnetwork",
-					DriverState: &api.Driver{
-						Name: "bridge",
-					},
+				ID: "localnetwork",
+				DriverState: &api.Driver{
+					Name: "bridge",
 				},
 			},
 		},

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -625,36 +625,37 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 	if !ok {
 		return clustertypes.NetworkCreateRequest{}, errors.New("container: unknown network referenced")
 	}
+	nw := na.Network
 
 	ipv4Enabled := true
-	ipv6Enabled := na.Network.Spec.Ipv6Enabled
+	ipv6Enabled := nw.Spec.Ipv6Enabled
 	options := network.CreateOptions{
-		// ID:     na.Network.ID,
-		Labels:     na.Network.Spec.Annotations.Labels,
-		Internal:   na.Network.Spec.Internal,
-		Attachable: na.Network.Spec.Attachable,
-		Ingress:    convert.IsIngressNetwork(na.Network),
+		// ID:     nw.ID,
+		Labels:     nw.Spec.Annotations.Labels,
+		Internal:   nw.Spec.Internal,
+		Attachable: nw.Spec.Attachable,
+		Ingress:    convert.IsIngressNetwork(nw),
 		EnableIPv4: &ipv4Enabled,
 		EnableIPv6: &ipv6Enabled,
 		Scope:      scope.Swarm,
 	}
 
-	if na.Network.Spec.GetNetwork() != "" {
+	if nw.Spec.GetNetwork() != "" {
 		options.ConfigFrom = &network.ConfigReference{
-			Network: na.Network.Spec.GetNetwork(),
+			Network: nw.Spec.GetNetwork(),
 		}
 	}
 
-	if na.Network.DriverState != nil {
-		options.Driver = na.Network.DriverState.Name
-		options.Options = na.Network.DriverState.Options
+	if nw.DriverState != nil {
+		options.Driver = nw.DriverState.Name
+		options.Options = nw.DriverState.Options
 	}
-	if na.Network.IPAM != nil {
+	if nw.IPAM != nil {
 		options.IPAM = &network.IPAM{
-			Driver:  na.Network.IPAM.Driver.Name,
-			Options: na.Network.IPAM.Driver.Options,
+			Driver:  nw.IPAM.Driver.Name,
+			Options: nw.IPAM.Driver.Options,
 		}
-		for _, ic := range na.Network.IPAM.Configs {
+		for _, ic := range nw.IPAM.Configs {
 			options.IPAM.Config = append(options.IPAM.Config, network.IPAMConfig{
 				Subnet:  ic.Subnet,
 				IPRange: ic.Range,
@@ -664,7 +665,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 	}
 
 	return clustertypes.NetworkCreateRequest{
-		ID: na.Network.ID,
+		ID: nw.ID,
 		CreateRequest: network.CreateRequest{
 			Name:          name,
 			CreateOptions: options,

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -3,7 +3,6 @@ package container // import "github.com/docker/docker/daemon/cluster/executor/co
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -620,13 +619,7 @@ func (c *containerConfig) serviceConfig() *clustertypes.ServiceConfig {
 	return svcCfg
 }
 
-func (c *containerConfig) networkCreateRequest(name string) (clustertypes.NetworkCreateRequest, error) {
-	na, ok := c.networksAttachments[name]
-	if !ok {
-		return clustertypes.NetworkCreateRequest{}, errors.New("container: unknown network referenced")
-	}
-	nw := na.Network
-
+func networkCreateRequest(name string, nw *api.Network) clustertypes.NetworkCreateRequest {
 	ipv4Enabled := true
 	ipv6Enabled := nw.Spec.Ipv6Enabled
 	options := network.CreateOptions{
@@ -670,7 +663,7 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 			Name:          name,
 			CreateOptions: options,
 		},
-	}, nil
+	}
 }
 
 func (c *containerConfig) applyPrivileges(hc *containertypes.HostConfig) {

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -655,12 +655,11 @@ func (c *containerConfig) networkCreateRequest(name string) (clustertypes.Networ
 			Options: na.Network.IPAM.Driver.Options,
 		}
 		for _, ic := range na.Network.IPAM.Configs {
-			c := network.IPAMConfig{
+			options.IPAM.Config = append(options.IPAM.Config, network.IPAMConfig{
 				Subnet:  ic.Subnet,
 				IPRange: ic.Range,
 				Gateway: ic.Gateway,
-			}
-			options.IPAM.Config = append(options.IPAM.Config, c)
+			})
 		}
 	}
 


### PR DESCRIPTION
### daemon/cluster/executor: networkCreateRequest don't shadow config

c is used as name for the containerConfig receiver; remove the intermediate
variable so that we don't shadow it. There's no bug here, because a new
variable is created; just to prevent confusion and to make linters happier.

### daemon/cluster/executor: networkCreateRequest: slight DRY cleanup

All of this function only referenced the Network field in the attachment;
use an intermediate variable to make the code less repetitive.

### daemon/cluster/executor: networkCreateRequest: not a method

This method was called in a loop, iterating over the container config's
network-attachments. It was defined as a method, but only to lookup
the same attachment we just iterated over existed, and to obtain a copy.
As there were no goroutines involved, dereferencing should not be an issue
and with Go 1.22+, dereferencing loop vars is no longer needed at all,
so we can change this method to a regular constructor; also removing the
redundant error-return in the process.

### daemon/cluster/executor: containerConfig: store Network instead of envelope

The Network field is the only field used from the NetworkAttachment within
this code. Remove the NetworkAttachment envelope, and store the Network
field directly instead.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

