### PR TITLE
libnetwork: remove ErrNoSuchEndpoint, ErrInvalidID, ErrInvalidName

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -860,7 +860,7 @@ func (c *Controller) NetworkByName(name string) (*Network, error) {
 // If not found, the error [ErrNoSuchNetwork] is returned.
 func (c *Controller) NetworkByID(id string) (*Network, error) {
 	if id == "" {
-		return nil, ErrInvalidID(id)
+		return nil, types.InvalidParameterErrorf("invalid id: id is empty")
 	}
 	return c.getNetworkFromStore(id)
 }
@@ -974,7 +974,7 @@ func (c *Controller) NewSandbox(ctx context.Context, containerID string, options
 // [types.NotFoundError] if no Sandbox was found for the container.
 func (c *Controller) GetSandbox(containerID string) (*Sandbox, error) {
 	if containerID == "" {
-		return nil, ErrInvalidID("id is empty")
+		return nil, types.InvalidParameterErrorf("invalid id: id is empty")
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -998,7 +998,7 @@ func (c *Controller) GetSandbox(containerID string) (*Sandbox, error) {
 // If not found, a [types.NotFoundError] is returned.
 func (c *Controller) SandboxByID(id string) (*Sandbox, error) {
 	if id == "" {
-		return nil, ErrInvalidID(id)
+		return nil, types.InvalidParameterErrorf("invalid id: id is empty")
 	}
 	c.mu.Lock()
 	s, ok := c.sandboxes[id]

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -474,7 +474,7 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 	}
 
 	if strings.TrimSpace(name) == "" {
-		return nil, ErrInvalidName(name)
+		return nil, types.InvalidParameterErrorf("invalid name: name is empty")
 	}
 
 	// Make sure two concurrent calls to this method won't create conflicting
@@ -837,7 +837,7 @@ func (c *Controller) WalkNetworks(walker NetworkWalker) {
 // If not found, the error [ErrNoSuchNetwork] is returned.
 func (c *Controller) NetworkByName(name string) (*Network, error) {
 	if name == "" {
-		return nil, ErrInvalidName(name)
+		return nil, types.InvalidParameterErrorf("invalid name: name is empty")
 	}
 	var n *Network
 

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -14,17 +14,6 @@ func (nsn ErrNoSuchNetwork) Error() string {
 // NotFound denotes the type of this error
 func (nsn ErrNoSuchNetwork) NotFound() {}
 
-// ErrInvalidName is returned when a query-by-name or resource create method is
-// invoked with an empty name parameter
-type ErrInvalidName string
-
-func (in ErrInvalidName) Error() string {
-	return fmt.Sprintf("invalid name: %s", string(in))
-}
-
-// InvalidParameter denotes the type of this error
-func (in ErrInvalidName) InvalidParameter() {}
-
 // NetworkNameError is returned when a network with the same name already exists.
 type NetworkNameError string
 

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -14,16 +14,6 @@ func (nsn ErrNoSuchNetwork) Error() string {
 // NotFound denotes the type of this error
 func (nsn ErrNoSuchNetwork) NotFound() {}
 
-// ErrNoSuchEndpoint is returned when an endpoint query finds no result
-type ErrNoSuchEndpoint string
-
-func (nse ErrNoSuchEndpoint) Error() string {
-	return fmt.Sprintf("endpoint %s not found", string(nse))
-}
-
-// NotFound denotes the type of this error
-func (nse ErrNoSuchEndpoint) NotFound() {}
-
 // ErrInvalidID is returned when a query-by-id method is being invoked
 // with an empty id parameter
 type ErrInvalidID string

--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -14,17 +14,6 @@ func (nsn ErrNoSuchNetwork) Error() string {
 // NotFound denotes the type of this error
 func (nsn ErrNoSuchNetwork) NotFound() {}
 
-// ErrInvalidID is returned when a query-by-id method is being invoked
-// with an empty id parameter
-type ErrInvalidID string
-
-func (ii ErrInvalidID) Error() string {
-	return fmt.Sprintf("invalid id: %s", string(ii))
-}
-
-// InvalidParameter denotes the type of this error
-func (ii ErrInvalidID) InvalidParameter() {}
-
 // ErrInvalidName is returned when a query-by-name or resource create method is
 // invoked with an empty name parameter
 type ErrInvalidName string

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -10,11 +10,6 @@ import (
 )
 
 func TestErrorInterfaces(t *testing.T) {
-	badRequestErrorList := []error{ErrInvalidName("")}
-	for _, err := range badRequestErrorList {
-		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
-	}
-
 	maskableErrorList := []error{ManagerRedirectError("")}
 	for _, err := range maskableErrorList {
 		switch u := err.(type) {

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -24,7 +24,7 @@ func TestErrorInterfaces(t *testing.T) {
 		}
 	}
 
-	notFoundErrorList := []error{ErrNoSuchNetwork(""), ErrNoSuchEndpoint("")}
+	notFoundErrorList := []error{ErrNoSuchNetwork("")}
 	for _, err := range notFoundErrorList {
 		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	}

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestErrorInterfaces(t *testing.T) {
-	badRequestErrorList := []error{ErrInvalidID(""), ErrInvalidName("")}
+	badRequestErrorList := []error{ErrInvalidName("")}
 	for _, err := range badRequestErrorList {
 		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -552,7 +552,7 @@ func TestControllerQuery(t *testing.T) {
 
 	_, err = controller.NetworkByID("")
 	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
-	assert.Check(t, is.ErrorContains(err, "invalid id:"))
+	assert.Check(t, is.Error(err, "invalid id: id is empty"))
 
 	g, err := controller.NetworkByID("network1")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1310,7 +1310,7 @@ func (n *Network) WalkEndpoints(walker EndpointWalker) {
 }
 
 // EndpointByName returns the Endpoint which has the passed name. If not found,
-// the error ErrNoSuchEndpoint is returned.
+// an [errdefs.ErrNotFound] is returned.
 func (n *Network) EndpointByName(name string) (*Endpoint, error) {
 	if name == "" {
 		return nil, ErrInvalidName(name)
@@ -1328,7 +1328,7 @@ func (n *Network) EndpointByName(name string) (*Endpoint, error) {
 	n.WalkEndpoints(s)
 
 	if e == nil {
-		return nil, ErrNoSuchEndpoint(name)
+		return nil, errdefs.NotFound(fmt.Errorf("endpoint %s not found", name))
 	}
 
 	return e, nil

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1177,7 +1177,7 @@ func (n *Network) addEndpoint(ctx context.Context, ep *Endpoint) error {
 func (n *Network) CreateEndpoint(ctx context.Context, name string, options ...EndpointOption) (*Endpoint, error) {
 	var err error
 	if strings.TrimSpace(name) == "" {
-		return nil, ErrInvalidName(name)
+		return nil, types.InvalidParameterErrorf("invalid name: name is empty")
 	}
 
 	if n.ConfigOnly() {
@@ -1313,7 +1313,7 @@ func (n *Network) WalkEndpoints(walker EndpointWalker) {
 // an [errdefs.ErrNotFound] is returned.
 func (n *Network) EndpointByName(name string) (*Endpoint, error) {
 	if name == "" {
-		return nil, ErrInvalidName(name)
+		return nil, types.InvalidParameterErrorf("invalid name: name is empty")
 	}
 	var e *Endpoint
 


### PR DESCRIPTION
### libnetwork: remove ErrNoSuchEndpoint

It was only returned in 1 place, and not used any different than
a "notfound" error, so let's use a standard errdefs.ErrNotFound

### libnetwork: remove ErrInvalidID

It was only returned in a few places, and not used any different than
a "invalid parameter" error, so let's use a standard errdefs.ErrInvalidParameter

### libnetwork: remove ErrInvalidName

It was only returned in a few places, and not used any different than
a "invalid parameter" error, so let's use a standard errdefs.ErrInvalidParameter


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

