### PR TITLE
[25.0 backport] ci: update bake-action to v6

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -128,7 +128,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -178,7 +178,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -232,7 +232,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -374,7 +374,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -102,6 +102,11 @@ jobs:
         platform: ${{ fromJson(needs.prepare.outputs.platforms) }}
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -130,9 +135,10 @@ jobs:
         id: bake
         uses: docker/bake-action@v6
         with:
+          source: .
           files: |
             ./docker-bake.hcl
-            cwd:///tmp/bake-meta.json
+            /tmp/bake-meta.json
           targets: bin-image
           set: |
             *.platform=${{ matrix.platform }}

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -107,11 +107,6 @@ jobs:
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Download meta bake definition
         uses: actions/download-artifact@v4
         with:
@@ -133,11 +128,11 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl
-            /tmp/bake-meta.json
+            cwd:///tmp/bake-meta.json
           targets: bin-image
           set: |
             *.platform=${{ matrix.platform }}

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -37,14 +37,11 @@ jobs:
       - validate-dco
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: binary
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,11 @@ jobs:
           - dynbinary
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: ${{ matrix.target }}
       -
@@ -96,11 +91,6 @@ jobs:
         platform: ${{ fromJson(needs.prepare-cross.outputs.matrix) }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -110,7 +100,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: all
           set: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,11 @@ jobs:
             echo "SYSTEMD=true" >> $GITHUB_ENV
           fi
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -125,7 +122,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build dev image
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: dev
           set: |
@@ -168,9 +165,6 @@ jobs:
         platform: ${{ fromJson(needs.smoke-prepare.outputs.matrix) }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Prepare
         run: |
           platform=${{ matrix.platform }}
@@ -183,7 +177,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Test
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           targets: binary-smoketest
           set: |


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Backports CI fixes to 25.0 branch
1. https://github.com/moby/moby/pull/49233
2. https://github.com/moby/moby/pull/49289

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

