### PR TITLE
libnetwork/drivers/bridge: remove, or internalize errors

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -235,7 +235,7 @@ func ValidateFixedCIDRV6(val string) error {
 // Whatever can be assessed a priori before attempting any programming.
 func (c *networkConfiguration) Validate() error {
 	if c.Mtu < 0 {
-		return ErrInvalidMtu(c.Mtu)
+		return errdefs.InvalidParameter(fmt.Errorf("invalid MTU number: %d", c.Mtu))
 	}
 
 	if c.EnableIPv4 {

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -499,7 +499,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 	case nil:
 		// No GenericData option set. Use defaults.
 	default:
-		return &ErrInvalidDriverConfig{}
+		return errdefs.InvalidParameter(fmt.Errorf("invalid configuration type (%T) passed", opt))
 	}
 
 	if config.EnableIPTables {

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -447,7 +447,7 @@ func (n *bridgeNetwork) getPortDriverClient() portDriverClient {
 
 func (n *bridgeNetwork) getEndpoint(eid string) (*bridgeEndpoint, error) {
 	if eid == "" {
-		return nil, InvalidEndpointIDError(eid)
+		return nil, invalidEndpointIDError(eid)
 	}
 
 	n.Lock()
@@ -1116,7 +1116,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	n.Lock()
 	if n.id != nid {
 		n.Unlock()
-		return InvalidNetworkIDError(nid)
+		return invalidNetworkIDError(nid)
 	}
 	n.Unlock()
 
@@ -1329,7 +1329,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	n.Lock()
 	if n.id != nid {
 		n.Unlock()
-		return InvalidNetworkIDError(nid)
+		return invalidNetworkIDError(nid)
 	}
 	n.Unlock()
 
@@ -1339,7 +1339,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 		return err
 	}
 	if ep == nil {
-		return EndpointNotFoundError(eid)
+		return endpointNotFoundError(eid)
 	}
 
 	// Remove it
@@ -1390,7 +1390,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 	n.Lock()
 	if n.id != nid {
 		n.Unlock()
-		return nil, InvalidNetworkIDError(nid)
+		return nil, invalidNetworkIDError(nid)
 	}
 	n.Unlock()
 
@@ -1449,7 +1449,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 	}
 
 	if endpoint == nil {
-		return EndpointNotFoundError(eid)
+		return endpointNotFoundError(eid)
 	}
 
 	endpoint.containerConfig, err = parseContainerOptions(options)
@@ -1491,7 +1491,7 @@ func (d *driver) Leave(nid, eid string) error {
 	}
 
 	if endpoint == nil {
-		return EndpointNotFoundError(eid)
+		return endpointNotFoundError(eid)
 	}
 
 	if !network.config.EnableICC {
@@ -1520,7 +1520,7 @@ func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid strin
 	}
 
 	if endpoint == nil {
-		return EndpointNotFoundError(eid)
+		return endpointNotFoundError(eid)
 	}
 
 	endpoint.extConnConfig, err = parseConnectivityOptions(options)
@@ -1580,7 +1580,7 @@ func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
 	}
 
 	if endpoint == nil {
-		return EndpointNotFoundError(eid)
+		return endpointNotFoundError(eid)
 	}
 
 	err = network.releasePorts(endpoint)
@@ -1638,7 +1638,7 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 				return err
 			}
 			if parentEndpoint == nil {
-				return InvalidEndpointIDError(p)
+				return invalidEndpointIDError(p)
 			}
 
 			l, err := newLink(parentEndpoint.addr.IP, endpoint.addr.IP, ec.ExposedPorts, network.config.BridgeName)
@@ -1662,7 +1662,7 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 			return err
 		}
 		if childEndpoint == nil {
-			return InvalidEndpointIDError(c)
+			return invalidEndpointIDError(c)
 		}
 		if childEndpoint.extConnConfig == nil || childEndpoint.extConnConfig.ExposedPorts == nil {
 			continue

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -246,7 +246,7 @@ func (c *networkConfiguration) Validate() error {
 		// If default gw is specified, it must be part of bridge subnet
 		if c.DefaultGatewayIPv4 != nil {
 			if !c.AddressIPv4.Contains(c.DefaultGatewayIPv4) {
-				return &ErrInvalidGateway{}
+				return errInvalidGateway
 			}
 		}
 	}
@@ -266,7 +266,7 @@ func (c *networkConfiguration) Validate() error {
 		}
 		// If a default gw is specified, it must belong to AddressIPv6's subnet
 		if c.DefaultGatewayIPv6 != nil && !c.AddressIPv6.Contains(c.DefaultGatewayIPv6) {
-			return &ErrInvalidGateway{}
+			return errInvalidGateway
 		}
 	}
 

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -12,35 +12,35 @@ import (
 // errInvalidGateway is returned when the user provided default gateway (v4/v6) is not valid.
 var errInvalidGateway = errdefs.InvalidParameter(errors.New("default gateway ip must be part of the network"))
 
-// InvalidNetworkIDError is returned when the passed
+// invalidNetworkIDError is returned when the passed
 // network id for an existing network is not a known id.
-type InvalidNetworkIDError string
+type invalidNetworkIDError string
 
-func (inie InvalidNetworkIDError) Error() string {
-	return fmt.Sprintf("invalid network id %s", string(inie))
+func (e invalidNetworkIDError) Error() string {
+	return fmt.Sprintf("invalid network id %s", string(e))
 }
 
 // NotFound denotes the type of this error
-func (inie InvalidNetworkIDError) NotFound() {}
+func (e invalidNetworkIDError) NotFound() {}
 
-// InvalidEndpointIDError is returned when the passed
+// invalidEndpointIDError is returned when the passed
 // endpoint id is not valid.
-type InvalidEndpointIDError string
+type invalidEndpointIDError string
 
-func (ieie InvalidEndpointIDError) Error() string {
-	return fmt.Sprintf("invalid endpoint id: %s", string(ieie))
+func (e invalidEndpointIDError) Error() string {
+	return fmt.Sprintf("invalid endpoint id: %s", string(e))
 }
 
 // InvalidParameter denotes the type of this error
-func (ieie InvalidEndpointIDError) InvalidParameter() {}
+func (e invalidEndpointIDError) InvalidParameter() {}
 
-// EndpointNotFoundError is returned when the no endpoint
+// endpointNotFoundError is returned when the no endpoint
 // with the passed endpoint id is found.
-type EndpointNotFoundError string
+type endpointNotFoundError string
 
-func (enfe EndpointNotFoundError) Error() string {
-	return fmt.Sprintf("endpoint not found: %s", string(enfe))
+func (e endpointNotFoundError) Error() string {
+	return fmt.Sprintf("endpoint not found: %s", string(e))
 }
 
 // NotFound denotes the type of this error
-func (enfe EndpointNotFoundError) NotFound() {}
+func (e endpointNotFoundError) NotFound() {}

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -3,18 +3,14 @@
 package bridge
 
 import (
+	"errors"
 	"fmt"
+
+	"github.com/docker/docker/errdefs"
 )
 
-// ErrInvalidGateway is returned when the user provided default gateway (v4/v6) is not valid.
-type ErrInvalidGateway struct{}
-
-func (eig *ErrInvalidGateway) Error() string {
-	return "default gateway ip must be part of the network"
-}
-
-// InvalidParameter denotes the type of this error
-func (eig *ErrInvalidGateway) InvalidParameter() {}
+// errInvalidGateway is returned when the user provided default gateway (v4/v6) is not valid.
+var errInvalidGateway = errdefs.InvalidParameter(errors.New("default gateway ip must be part of the network"))
 
 // InvalidNetworkIDError is returned when the passed
 // network id for an existing network is not a known id.

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -17,13 +17,6 @@ func (ece *ErrConfigExists) Error() string {
 // Forbidden denotes the type of this error
 func (ece *ErrConfigExists) Forbidden() {}
 
-// ErrInvalidDriverConfig error is returned when Bridge Driver is passed an invalid config
-type ErrInvalidDriverConfig struct{}
-
-func (eidc *ErrInvalidDriverConfig) Error() string {
-	return "Invalid configuration passed to Bridge Driver"
-}
-
 // ErrInvalidNetworkConfig error is returned when a network is created on a driver without valid config.
 type ErrInvalidNetworkConfig struct{}
 

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -7,13 +7,6 @@ import (
 	"net"
 )
 
-// ErrNoIPAddr error is returned when bridge has no IPv4 address configured.
-type ErrNoIPAddr struct{}
-
-func (enip *ErrNoIPAddr) Error() string {
-	return "bridge has no IPv4 address configured"
-}
-
 // ErrInvalidGateway is returned when the user provided default gateway (v4/v6) is not valid.
 type ErrInvalidGateway struct{}
 

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -4,7 +4,6 @@ package bridge
 
 import (
 	"fmt"
-	"net"
 )
 
 // ErrInvalidGateway is returned when the user provided default gateway (v4/v6) is not valid.
@@ -70,13 +69,3 @@ func (ndbee NonDefaultBridgeExistError) Error() string {
 
 // Forbidden denotes the type of this error
 func (ndbee NonDefaultBridgeExistError) Forbidden() {}
-
-// IPv4AddrNoMatchError is returned when the bridge's IPv4 address does not match configured.
-type IPv4AddrNoMatchError struct {
-	IP    net.IP
-	CfgIP net.IP
-}
-
-func (ipv4 *IPv4AddrNoMatchError) Error() string {
-	return fmt.Sprintf("bridge IPv4 (%s) does not match requested configuration %s", ipv4.IP, ipv4.CfgIP)
-}

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -44,14 +44,3 @@ func (enfe EndpointNotFoundError) Error() string {
 
 // NotFound denotes the type of this error
 func (enfe EndpointNotFoundError) NotFound() {}
-
-// NonDefaultBridgeExistError is returned when a non-default
-// bridge config is passed but it does not already exist.
-type NonDefaultBridgeExistError string
-
-func (ndbee NonDefaultBridgeExistError) Error() string {
-	return fmt.Sprintf("bridge device with non default name %s must be created manually", string(ndbee))
-}
-
-// Forbidden denotes the type of this error
-func (ndbee NonDefaultBridgeExistError) Forbidden() {}

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -14,9 +14,6 @@ func (enip *ErrNoIPAddr) Error() string {
 	return "bridge has no IPv4 address configured"
 }
 
-// InternalError denotes the type of this error
-func (enip *ErrNoIPAddr) InternalError() {}
-
 // ErrInvalidGateway is returned when the user provided default gateway (v4/v6) is not valid.
 type ErrInvalidGateway struct{}
 
@@ -90,9 +87,6 @@ type IPv4AddrAddError struct {
 func (ipv4 *IPv4AddrAddError) Error() string {
 	return fmt.Sprintf("failed to add IPv4 address %s to bridge: %v", ipv4.IP, ipv4.Err)
 }
-
-// InternalError denotes the type of this error
-func (ipv4 *IPv4AddrAddError) InternalError() {}
 
 // IPv4AddrNoMatchError is returned when the bridge's IPv4 address does not match configured.
 type IPv4AddrNoMatchError struct {

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -16,16 +16,6 @@ func (eig *ErrInvalidGateway) Error() string {
 // InvalidParameter denotes the type of this error
 func (eig *ErrInvalidGateway) InvalidParameter() {}
 
-// ErrInvalidMtu is returned when the user provided MTU is not valid.
-type ErrInvalidMtu int
-
-func (eim ErrInvalidMtu) Error() string {
-	return fmt.Sprintf("invalid MTU number: %d", int(eim))
-}
-
-// InvalidParameter denotes the type of this error
-func (eim ErrInvalidMtu) InvalidParameter() {}
-
 // InvalidNetworkIDError is returned when the passed
 // network id for an existing network is not a known id.
 type InvalidNetworkIDError string

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -71,16 +71,6 @@ func (ndbee NonDefaultBridgeExistError) Error() string {
 // Forbidden denotes the type of this error
 func (ndbee NonDefaultBridgeExistError) Forbidden() {}
 
-// IPv4AddrAddError is returned when IPv4 address could not be added to the bridge.
-type IPv4AddrAddError struct {
-	IP  *net.IPNet
-	Err error
-}
-
-func (ipv4 *IPv4AddrAddError) Error() string {
-	return fmt.Sprintf("failed to add IPv4 address %s to bridge: %v", ipv4.IP, ipv4.Err)
-}
-
 // IPv4AddrNoMatchError is returned when the bridge's IPv4 address does not match configured.
 type IPv4AddrNoMatchError struct {
 	IP    net.IP

--- a/libnetwork/drivers/bridge/errors.go
+++ b/libnetwork/drivers/bridge/errors.go
@@ -7,56 +7,6 @@ import (
 	"net"
 )
 
-// ErrConfigExists error is returned when driver already has a config applied.
-type ErrConfigExists struct{}
-
-func (ece *ErrConfigExists) Error() string {
-	return "configuration already exists, bridge configuration can be applied only once"
-}
-
-// Forbidden denotes the type of this error
-func (ece *ErrConfigExists) Forbidden() {}
-
-// ErrInvalidNetworkConfig error is returned when a network is created on a driver without valid config.
-type ErrInvalidNetworkConfig struct{}
-
-func (einc *ErrInvalidNetworkConfig) Error() string {
-	return "trying to create a network on a driver without valid config"
-}
-
-// Forbidden denotes the type of this error
-func (einc *ErrInvalidNetworkConfig) Forbidden() {}
-
-// ErrInvalidEndpointConfig error is returned when an endpoint create is attempted with an invalid endpoint configuration.
-type ErrInvalidEndpointConfig struct{}
-
-func (eiec *ErrInvalidEndpointConfig) Error() string {
-	return "trying to create an endpoint with an invalid endpoint configuration"
-}
-
-// InvalidParameter denotes the type of this error
-func (eiec *ErrInvalidEndpointConfig) InvalidParameter() {}
-
-// ErrNetworkExists error is returned when a network already exists and another network is created.
-type ErrNetworkExists struct{}
-
-func (ene *ErrNetworkExists) Error() string {
-	return "network already exists, bridge can only have one network"
-}
-
-// Forbidden denotes the type of this error
-func (ene *ErrNetworkExists) Forbidden() {}
-
-// ErrIfaceName error is returned when a new name could not be generated.
-type ErrIfaceName struct{}
-
-func (ein *ErrIfaceName) Error() string {
-	return "failed to find name for new interface"
-}
-
-// InternalError denotes the type of this error
-func (ein *ErrIfaceName) InternalError() {}
-
 // ErrNoIPAddr error is returned when bridge has no IPv4 address configured.
 type ErrNoIPAddr struct{}
 
@@ -86,16 +36,6 @@ func (eim ErrInvalidMtu) Error() string {
 
 // InvalidParameter denotes the type of this error
 func (eim ErrInvalidMtu) InvalidParameter() {}
-
-// ErrUnsupportedAddressType is returned when the specified address type is not supported.
-type ErrUnsupportedAddressType string
-
-func (uat ErrUnsupportedAddressType) Error() string {
-	return fmt.Sprintf("unsupported address type: %s", string(uat))
-}
-
-// InvalidParameter denotes the type of this error
-func (uat ErrUnsupportedAddressType) InvalidParameter() {}
 
 // InvalidNetworkIDError is returned when the passed
 // network id for an existing network is not a known id.
@@ -141,17 +81,6 @@ func (ndbee NonDefaultBridgeExistError) Error() string {
 // Forbidden denotes the type of this error
 func (ndbee NonDefaultBridgeExistError) Forbidden() {}
 
-// NonDefaultBridgeNeedsIPError is returned when a non-default
-// bridge config is passed but it has no ip configured
-type NonDefaultBridgeNeedsIPError string
-
-func (ndbee NonDefaultBridgeNeedsIPError) Error() string {
-	return fmt.Sprintf("bridge device with non default name %s must have a valid IP address", string(ndbee))
-}
-
-// Forbidden denotes the type of this error
-func (ndbee NonDefaultBridgeNeedsIPError) Forbidden() {}
-
 // IPv4AddrAddError is returned when IPv4 address could not be added to the bridge.
 type IPv4AddrAddError struct {
 	IP  *net.IPNet
@@ -173,11 +102,4 @@ type IPv4AddrNoMatchError struct {
 
 func (ipv4 *IPv4AddrNoMatchError) Error() string {
 	return fmt.Sprintf("bridge IPv4 (%s) does not match requested configuration %s", ipv4.IP, ipv4.CfgIP)
-}
-
-// IPv6AddrNoMatchError is returned when the bridge's IPv6 address does not match configured.
-type IPv6AddrNoMatchError net.IPNet
-
-func (ipv6 *IPv6AddrNoMatchError) Error() string {
-	return fmt.Sprintf("bridge IPv6 addresses do not match the expected bridge configuration %s", (*net.IPNet)(ipv6).String())
 }

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -4,20 +4,21 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/nlwrap"
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/internal/testutils/storeutils"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/netlabel"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestLinkCreate(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 	d := newDriver(storeutils.NewTempStore(t))
-
-	if err := d.configure(nil); err != nil {
-		t.Fatalf("Failed to setup driver config: %v", err)
-	}
+	err := d.configure(nil)
+	assert.NilError(t, err)
 
 	mtu := 1490
 	option := map[string]interface{}{
@@ -31,80 +32,50 @@ func TestLinkCreate(t *testing.T) {
 
 	ipdList := getIPv4Data(t)
 	ipd6List := getIPv6Data(t)
-	err := d.CreateNetwork("dummy", option, nil, ipdList, ipd6List)
-	if err != nil {
-		t.Fatalf("Failed to create bridge: %v", err)
-	}
+	err = d.CreateNetwork("dummy", option, nil, ipdList, ipd6List)
+	assert.NilError(t, err, "Failed to create bridge")
+
 	te := newTestEndpoint46(ipdList[0].Pool, ipd6List[0].Pool, 10)
 	err = d.CreateEndpoint(context.Background(), "dummy", "", te.Interface(), nil)
-	if err != nil {
-		if _, ok := err.(InvalidEndpointIDError); !ok {
-			t.Fatalf("Failed with a wrong error :%s", err.Error())
-		}
-	} else {
-		t.Fatal("Failed to detect invalid config")
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.Error(err, "invalid endpoint id: "))
 
 	// Good endpoint creation
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te.Interface(), nil)
-	if err != nil {
-		t.Fatalf("Failed to create a link: %s", err.Error())
-	}
+	assert.NilError(t, err)
 
 	err = d.Join(context.Background(), "dummy", "ep", "sbox", te, nil)
-	if err != nil {
-		t.Fatalf("Failed to create a link: %s", err.Error())
-	}
+	assert.NilError(t, err)
 
 	// Verify sbox endpoint interface inherited MTU value from bridge config
 	sboxLnk, err := nlwrap.LinkByName(te.iface.srcName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if mtu != sboxLnk.Attrs().MTU {
-		t.Fatal("Sandbox endpoint interface did not inherit bridge interface MTU config")
-	}
+	assert.NilError(t, err)
+	assert.Assert(t, is.Equal(sboxLnk.Attrs().MTU, mtu), "Sandbox endpoint interface did not inherit bridge interface MTU config")
+
 	// TODO: if we could get peer name from (sboxLnk.(*netlink.Veth)).PeerName
 	// then we could check the MTU on hostLnk as well.
 
 	te1 := newTestEndpoint(ipdList[0].Pool, 11)
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te1.Interface(), nil)
-	if err == nil {
-		t.Fatal("Failed to detect duplicate endpoint id on same network")
-	}
+	assert.Check(t, is.ErrorType(err, errdefs.IsForbidden))
+	assert.Assert(t, is.Error(err, "Endpoint (ep) already exists (Only one endpoint allowed)"), "Failed to detect duplicate endpoint id on same network")
 
-	if te.iface.dstName == "" {
-		t.Fatal("Invalid Dstname returned")
-	}
+	assert.Check(t, te.iface.dstName != "", "Invalid Dstname returned")
 
 	_, err = nlwrap.LinkByName(te.iface.srcName)
-	if err != nil {
-		t.Fatalf("Could not find source link %s: %v", te.iface.srcName, err)
-	}
+	assert.Check(t, err, "Could not find source link %s", te.iface.srcName)
 
 	n, ok := d.networks["dummy"]
-	if !ok {
-		t.Fatalf("Cannot find network %s inside driver", "dummy")
-	}
+	assert.Check(t, ok, "Failed to find dummy network inside driveer")
+
 	ip := te.iface.addr.IP
-	if !n.bridge.bridgeIPv4.Contains(ip) {
-		t.Fatalf("IP %s is not a valid ip in the subnet %s", ip.String(), n.bridge.bridgeIPv4.String())
-	}
+	assert.Check(t, n.bridge.bridgeIPv4.Contains(ip), "IP %s should be a valid ip in the subnet %s", ip.String(), n.bridge.bridgeIPv4.String())
 
 	ip6 := te.iface.addrv6.IP
-	if !n.bridge.bridgeIPv6.Contains(ip6) {
-		t.Fatalf("IP %s is not a valid ip in the subnet %s", ip6.String(), n.bridge.bridgeIPv6.String())
-	}
+	assert.Check(t, n.bridge.bridgeIPv6.Contains(ip6), "IP %s should be a valid ip in the subnet %s", ip6.String(), n.bridge.bridgeIPv6.String())
 
-	if !te.gw.Equal(n.bridge.bridgeIPv4.IP) {
-		t.Fatalf("Invalid default gateway. Expected %s. Got %s", n.bridge.bridgeIPv4.IP.String(),
-			te.gw.String())
-	}
-
-	if !te.gw6.Equal(n.bridge.bridgeIPv6.IP) {
-		t.Fatalf("Invalid default gateway for IPv6. Expected %s. Got %s", n.bridge.bridgeIPv6.IP.String(),
-			te.gw6.String())
-	}
+	assert.Check(t, te.gw.Equal(n.bridge.bridgeIPv4.IP), "Invalid default gateway. Expected %s. Got %s", n.bridge.bridgeIPv4.IP.String(), te.gw.String())
+	assert.Check(t, te.gw6.Equal(n.bridge.bridgeIPv6.IP), "Invalid default gateway for IPv6. Expected %s. Got %s", n.bridge.bridgeIPv6.IP.String(), te.gw6.String())
 }
 
 func TestLinkCreateTwo(t *testing.T) {

--- a/libnetwork/drivers/bridge/setup_device_linux.go
+++ b/libnetwork/drivers/bridge/setup_device_linux.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/netutils"
 	"github.com/vishvananda/netlink"
 )
@@ -14,7 +15,8 @@ import (
 // SetupDevice create a new bridge interface/
 func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 	if config.BridgeName != DefaultBridgeName && config.DefaultBridge {
-		return NonDefaultBridgeExistError(config.BridgeName)
+		// TODO(thaJeztah): should this be an [errdefs.ErrInvalidParameter], not an [errdefs.ErrForbidden]?
+		return errdefs.Forbidden(fmt.Errorf("bridge device with non default name %s must be created manually", config.BridgeName))
 	}
 
 	// Set the bridgeInterface netlink.Bridge.

--- a/libnetwork/drivers/bridge/setup_ipv4_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux.go
@@ -48,7 +48,7 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 			}
 			log.G(context.TODO()).Debugf("Assigning address to bridge interface %s: %s", config.BridgeName, config.AddressIPv4)
 			if err := i.nlh.AddrAdd(i.Link, &netlink.Addr{IPNet: config.AddressIPv4}); err != nil {
-				return &IPv4AddrAddError{IP: config.AddressIPv4, Err: err}
+				return fmt.Errorf("failed to add IPv4 address %s to bridge: %v", config.AddressIPv4, err)
 			}
 		}
 	}

--- a/libnetwork/drivers/bridge/setup_ipv4_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv4_linux.go
@@ -63,7 +63,7 @@ func setupBridgeIPv4(config *networkConfiguration, i *bridgeInterface) error {
 
 func setupGatewayIPv4(config *networkConfiguration, i *bridgeInterface) error {
 	if !i.bridgeIPv4.Contains(config.DefaultGatewayIPv4) {
-		return &ErrInvalidGateway{}
+		return errInvalidGateway
 	}
 	if config.Internal {
 		return types.InvalidParameterErrorf("no gateway can be set on an internal bridge network")

--- a/libnetwork/drivers/bridge/setup_ipv6_linux.go
+++ b/libnetwork/drivers/bridge/setup_ipv6_linux.go
@@ -32,7 +32,7 @@ func setupBridgeIPv6(config *networkConfiguration, i *bridgeInterface) error {
 
 func setupGatewayIPv6(config *networkConfiguration, i *bridgeInterface) error {
 	if !config.AddressIPv6.Contains(config.DefaultGatewayIPv6) {
-		return &ErrInvalidGateway{}
+		return errInvalidGateway
 	}
 
 	// Store requested default gateway

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -21,7 +22,7 @@ func setupVerifyAndReconcileIPv4(config *networkConfiguration, i *bridgeInterfac
 
 	// Verify that the bridge has an IPv4 address.
 	if addrv4.IPNet == nil {
-		return &ErrNoIPAddr{}
+		return errors.New("bridge has no IPv4 address configured")
 	}
 
 	// Verify that the bridge IPv4 address matches the requested configuration.

--- a/libnetwork/drivers/bridge/setup_verify_linux.go
+++ b/libnetwork/drivers/bridge/setup_verify_linux.go
@@ -27,7 +27,7 @@ func setupVerifyAndReconcileIPv4(config *networkConfiguration, i *bridgeInterfac
 
 	// Verify that the bridge IPv4 address matches the requested configuration.
 	if config.AddressIPv4 != nil && !addrv4.IP.Equal(config.AddressIPv4.IP) {
-		return &IPv4AddrNoMatchError{IP: addrv4.IP, CfgIP: config.AddressIPv4.IP}
+		return fmt.Errorf("bridge IPv4 (%s) does not match requested configuration %s", addrv4.IP, config.AddressIPv4.IP)
 	}
 
 	return nil


### PR DESCRIPTION
### libnetwork/drivers/bridge: remove ErrInvalidDriverConfig

It's a generic error, doesn't implement an errdefs type, is poorly formatted,
and not used as sentinel error anywhere. Let's remove it, and update the error
produced to be slightly more informative (include the invalid type). Worth
noting that there's no need to include the name of the driver in the error,
because the only uses of the error (in `registerNetworkDrivers`) already
decorates it; https://github.com/moby/moby/blob/5fd7ed2937a2308681e9e8c4b049231a84b3ca88/libnetwork/drivers_linux.go#L34-L36

### libnetwork/drivers/bridge: remove unused errors

This removes the following errors, which were not used anywhere;

- ErrConfigExists
- ErrInvalidNetworkConfig
- ErrInvalidEndpointConfig
- ErrNetworkExists
- ErrIfaceName
- ErrUnsupportedAddressType
- NonDefaultBridgeNeedsIPError
- IPv6AddrNoMatchError


### libnetwork/drivers/bridge: remove "InternalError()" method from errors

The `InternalError()` method was added in [moby/libnetwork@50964c9] to
classify the error. However, the same commit defined interfaces for error
types (in the types package). The [InternalError] interface defined did
not match, as it defines a `Internal()` method instead of `InternalError()`.

In short; these errors were never matching any interface, and the actual
error implementations themselves were also never used as a sentinel error,
so we can safely remove these methods.

[moby/libnetwork@50964c9]: https://github.com/moby/libnetwork/commit/50964c994831c3a960d306ff130ff42983e2fe4a
[InternalError]: https://github.com/moby/libnetwork/blob/50964c994831c3a960d306ff130ff42983e2fe4a/types/types.go#L233-L237


TODO!!!! THIS IS THE ONE WITH THE WEIRD WAY OF SETTING OPTIONS;

```
func (d *driver) createNetwork(config *networkConfiguration) (err error) {
```

### libnetwork/drivers/bridge: remove ErrNoIPAddr

It's a generic error, doesn't implement an errdefs type, and not used as
sentinel error anywhere.

### libnetwork/drivers/bridge: remove IPv4AddrAddError

It's a generic error, doesn't implement an errdefs type, and not used as
sentinel error anywhere.

### libnetwork/drivers/bridge: remove IPv4AddrNoMatchError

It's a generic error, doesn't implement an errdefs type, and not used as
sentinel error anywhere.

### libnetwork/drivers/bridge: remove ErrInvalidMtu

It's a generic errdefs.ErrInvalidParameter, and the type itself is not
used as sentinel error anywhere.

### libnetwork/drivers/bridge: remove NonDefaultBridgeExistError

It was only used in a single place, and a generic errdefs.ErrInvalid; the
type itself was not used as sentinel error other than for a unit test.

### libnetwork/drivers/bridge: internalize ErrInvalidGateway

It's a generic errdefs.ErrInvalidParameter, and the type itself is not
used as sentinel error anywhere.

### libnetwork/drivers/bridge: TestLinkCreate: use gotest.tools
### libnetwork/drivers/bridge: TestLinkCreateTwo: use gotest.tools
### libnetwork/drivers/bridge: TestLinkCreateNoEnableIPv6: use gotest.tools
### libnetwork/drivers/bridge: TestLinkDelete: use gotest.tools

### libnetwork/drivers/bridge: un-export errors

These errors implement errdefs interfaces, and are only used internally
for convenience. Un-export their implemetations because the types themselves
are not used as sentinel errors.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

