### PR TITLE
libnetwork/drivers/windows: remove ErrUnsupportedAddressType

### DIFF
--- a/libnetwork/drivers/windows/port_mapping.go
+++ b/libnetwork/drivers/windows/port_mapping.go
@@ -15,16 +15,7 @@ import (
 	"github.com/ishidawataru/sctp"
 )
 
-const (
-	maxAllocatePortAttempts = 10
-)
-
-// ErrUnsupportedAddressType is returned when the specified address type is not supported.
-type ErrUnsupportedAddressType string
-
-func (uat ErrUnsupportedAddressType) Error() string {
-	return fmt.Sprintf("unsupported address type: %s", string(uat))
-}
+const maxAllocatePortAttempts = 10
 
 // AllocatePorts allocates ports specified in bindings from the portMapper
 func AllocatePorts(portMapper *portmapper.PortMapper, bindings []types.PortBinding, containerIP net.IP) ([]types.PortBinding, error) {
@@ -98,7 +89,7 @@ func allocatePort(portMapper *portmapper.PortMapper, bnd *types.PortBinding, con
 		break
 	default:
 		// For completeness
-		return ErrUnsupportedAddressType(fmt.Sprintf("%T", netAddr))
+		return fmt.Errorf("unsupported address type: %T", netAddr)
 	}
 	// Windows does not support host port ranges.
 	bnd.HostPortEnd = bnd.HostPort


### PR DESCRIPTION
It was only used in a single place, and did not implement an errdef; the type itself was not used as sentinel error.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

