### PR TITLE
api/types: remove some redundant imports

### DIFF
--- a/api/types/container/hostconfig_test.go
+++ b/api/types/container/hostconfig_test.go
@@ -3,7 +3,6 @@ package container
 import (
 	"testing"
 
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -96,9 +95,19 @@ func TestValidateRestartPolicy(t *testing.T) {
 			if tc.expectedErr == "" {
 				assert.Check(t, err)
 			} else {
-				assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+				assert.Check(t, is.ErrorType(err, isInvalidParameter))
 				assert.Check(t, is.Error(err, tc.expectedErr))
 			}
 		})
 	}
+}
+
+// isInvalidParameter is a minimal implementation of [github.com/docker/docker/errdefs.IsInvalidParameter],
+// because this was the only import of that package in api/types, which is the
+// package imported by external users.
+func isInvalidParameter(err error) bool {
+	_, ok := err.(interface {
+		InvalidParameter()
+	})
+	return ok
 }

--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -3,10 +3,9 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // AuthHeader is the name of the header used to send encoded registry
@@ -98,7 +97,7 @@ func decodeAuthConfigFromReader(rdr io.Reader) (*AuthConfig, error) {
 }
 
 func invalid(err error) error {
-	return errInvalidParameter{errors.Wrap(err, "invalid X-Registry-Auth header")}
+	return errInvalidParameter{fmt.Errorf("invalid X-Registry-Auth header: %w", err)}
 }
 
 type errInvalidParameter struct{ error }


### PR DESCRIPTION
### api/types/registry: use stdlib errors package

It was the only use of github.com/pkg/errors inside api/types,
which is the package that's imported by external users.

### api/types/container: remove use of errdefs package in test

It was the only use of errdefs inside api/types, which is the package
that's imported by external users.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

