### PR TITLE
client: remove uses of pkg/errors in tests

### DIFF
--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/distribution_inspect_test.go
+++ b/client/distribution_inspect_test.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/hijack_test.go
+++ b/client/hijack_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 
@@ -27,13 +26,13 @@ func TestTLSCloseWriter(t *testing.T) {
 			chErr = make(chan error, 1)
 			defer close(chErr)
 			if err := httputils.ParseForm(req); err != nil {
-				chErr <- errors.Wrap(err, "error parsing form")
+				chErr <- fmt.Errorf("error parsing form: %w", err)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 			r, rw, err := httputils.HijackConnection(w)
 			if err != nil {
-				chErr <- errors.Wrap(err, "error hijacking connection")
+				chErr <- fmt.Errorf("error hijacking connection: %w", err)
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -44,12 +43,12 @@ func TestTLSCloseWriter(t *testing.T) {
 			buf := make([]byte, 5)
 			_, err = r.Read(buf)
 			if err != nil {
-				chErr <- errors.Wrap(err, "error reading from client")
+				chErr <- fmt.Errorf("error reading from client: %w", err)
 				return
 			}
 			_, err = rw.Write(buf)
 			if err != nil {
-				chErr <- errors.Wrap(err, "error writing to client")
+				chErr <- fmt.Errorf("error writing to client: %w", err)
 				return
 			}
 		}),

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/client/volume_inspect_test.go
+++ b/client/volume_inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )


### PR DESCRIPTION
While there may be reasons to keep pkg/errors in production code, we don't need them for these tests.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

