### PR TITLE
c8d: Expose containerd content store via HTTP API

### DIFF
--- a/api/server/router/image/content_store.go
+++ b/api/server/router/image/content_store.go
@@ -1,0 +1,495 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/leases"
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/docker/docker/api/server/httputils"
+	"github.com/docker/docker/api/server/router"
+	"github.com/docker/docker/errdefs"
+	"github.com/google/uuid"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type contentStoreRouter struct {
+	routes  []router.Route
+	backend *contentBackend
+}
+
+type contentBackend struct {
+	sessions map[string]*session
+	super    content.Store
+	lm       leases.Manager
+	mut      sync.Mutex
+}
+
+func (cb *contentBackend) NewSession(ctx context.Context) (*session, error) {
+	cb.mut.Lock()
+	defer cb.mut.Unlock()
+
+	lease, err := cb.lm.Create(ctx, leases.WithRandomID())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lease for session: %w", err)
+	}
+
+	sessionCtx, cancelCtx := context.WithCancel(context.Background())
+	id := uuid.New().String()
+
+	sessionCtx = leases.WithLease(sessionCtx, lease.ID)
+	sess := &session{
+		Id:        id,
+		Super:     cb.super,
+		Ctx:       sessionCtx,
+		CancelCtx: cancelCtx,
+		writers:   make(map[string]content.Writer),
+		lease:     lease,
+	}
+
+	cb.sessions[id] = sess
+	return sess, nil
+}
+
+func (cb *contentBackend) GetSession(_ context.Context, id string) (*session, error) {
+	cb.mut.Lock()
+	defer cb.mut.Unlock()
+
+	sess, ok := cb.sessions[id]
+	if !ok {
+		return nil, errdefs.NotFound(fmt.Errorf("session %s not found", id))
+	}
+
+	return sess, nil
+}
+
+func (cb *contentBackend) NewWriter(ctx context.Context, sess *session, opts ...content.WriterOpt) (content.Writer, string, error) {
+	var o content.WriterOpts
+	for _, opt := range opts {
+		_ = opt(&o)
+	}
+
+	cb.mut.Lock()
+	defer cb.mut.Unlock()
+
+	id := uuid.New().String()
+	wr, err := sess.Super.Writer(sess.Ctx, opts...)
+	if err != nil {
+		return nil, "", err
+	}
+
+	sess.writers[id] = wr
+	return wr, id, nil
+}
+
+func (cb *contentBackend) CloseWriter(ctx context.Context, wr content.Writer) {
+	cb.mut.Lock()
+	defer cb.mut.Unlock()
+
+	for _, sess := range cb.sessions {
+		for id, w := range sess.writers {
+			if w == wr {
+				delete(sess.writers, id)
+				return
+			}
+		}
+	}
+}
+
+func (cb *contentBackend) CloseSession(ctx context.Context, sess *session) error {
+	cb.mut.Lock()
+	defer cb.mut.Unlock()
+
+	sess.CancelCtx()
+
+	if _, ok := cb.sessions[sess.Id]; !ok {
+		return errdefs.NotFound(fmt.Errorf("session %s not found", sess.Id))
+	}
+
+	for _, wr := range sess.writers {
+		_ = wr.Close()
+	}
+	sess.writers = nil
+
+	if err := cb.lm.Delete(ctx, sess.lease, leases.SynchronousDelete); err != nil {
+		return fmt.Errorf("failed to delete session lease: %w", err)
+	}
+
+	delete(cb.sessions, sess.Id)
+	return nil
+}
+
+type session struct {
+	Id        string
+	Super     content.Store
+	Ctx       context.Context
+	CancelCtx context.CancelFunc
+	lease     leases.Lease
+
+	writers map[string]content.Writer
+}
+
+// NewContentRouter initializes a new image router
+func NewContentRouter(store content.Store, lm leases.Manager) router.Router {
+	ir := &contentStoreRouter{
+		backend: &contentBackend{
+			sessions: make(map[string]*session),
+			super:    store,
+			lm:       lm,
+		},
+	}
+	ir.initRoutes()
+	return ir
+}
+
+// Routes returns the available routes to the image controller
+func (cr *contentStoreRouter) Routes() []router.Route {
+	return cr.routes
+}
+
+// initRoutes initializes the routes in the image router
+func (cr *contentStoreRouter) initRoutes() {
+	cr.routes = []router.Route{
+		// POST
+		router.NewPostRoute("/contentstore", cr.postContentStoreOpen),
+		// DELETE
+		router.NewPostRoute("/contentstore", cr.sessionMiddleware(cr.deleteContentStoreClose)),
+
+		router.NewPostRoute("/contentstore/writer", cr.sessionMiddleware(cr.postWriterOpen)),
+		router.NewPostRoute("/contentstore/writer/write", cr.writerMiddleware(cr.postWriterWrite)),
+		router.NewPostRoute("/contentstore/writer/commit", cr.writerMiddleware(cr.postWriterCommit)),
+		router.NewGetRoute("/contentstore/writer/digest", cr.writerMiddleware(cr.getWriterDigest)),
+		router.NewGetRoute("/contentstore/writer/status", cr.writerMiddleware(cr.getWriterStatus)),
+		router.NewDeleteRoute("/contentstore/writer", cr.writerMiddleware(cr.deleteWriterClose)),
+		router.NewPostRoute("/contentstore/writer/truncate", cr.writerMiddleware(cr.postWriterTruncate)),
+
+		// PUT
+		router.NewPutRoute("/contentstore/write", cr.sessionMiddleware(cr.putContentStoreWrite)),
+
+		// GET
+		router.NewGetRoute("/contentstore/info", cr.sessionMiddleware(cr.getContentStoreInfo)),
+		router.NewGetRoute("/contentstore/size", cr.sessionMiddleware(cr.getContentStoreSize)),
+		router.NewGetRoute("/contentstore/read", cr.sessionMiddleware(cr.getContentStoreRead)),
+	}
+}
+
+type sessionKey struct{}
+type writerKey struct{}
+
+func getSession(ctx context.Context) *session {
+	return ctx.Value(sessionKey{}).(*session)
+}
+
+func getWriter(ctx context.Context) content.Writer {
+	return ctx.Value(writerKey{}).(content.Writer)
+}
+
+func (cr *contentStoreRouter) sessionMiddleware(next httputils.APIFunc) httputils.APIFunc {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		if err := r.ParseForm(); err != nil {
+			return err
+		}
+
+		sessId := r.Form.Get("session")
+		if sessId == "" {
+			return errdefs.InvalidParameter(errors.New("session is required"))
+		}
+
+		sess, err := cr.backend.GetSession(ctx, sessId)
+		if err != nil {
+			return err
+		}
+
+		ctx = context.WithValue(ctx, sessionKey{}, sess)
+		return next(ctx, w, r, vars)
+	}
+}
+
+func (cr *contentStoreRouter) writerMiddleware(next httputils.APIFunc) httputils.APIFunc {
+	return cr.sessionMiddleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+		if err := r.ParseForm(); err != nil {
+			return err
+		}
+
+		sess := getSession(ctx)
+		wrId := r.Form.Get("writer")
+		if wrId == "" {
+			return errdefs.InvalidParameter(errors.New("writer is required"))
+		}
+
+		wr, ok := sess.writers[wrId]
+		if !ok {
+			return errdefs.NotFound(fmt.Errorf("writer %s not found", wrId))
+		}
+
+		ctx = context.WithValue(ctx, writerKey{}, wr)
+		return next(ctx, w, r, vars)
+	})
+}
+
+func (cr *contentStoreRouter) postWriterOpen(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	opts, err := cr.writerOpts(r)
+	if err != nil {
+		return err
+	}
+
+	sess := getSession(ctx)
+	_, id, err := cr.backend.NewWriter(ctx, sess, opts...)
+	if err != nil {
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, map[string]string{"writer": id})
+}
+
+func (cr *contentStoreRouter) deleteWriterClose(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	wr := getWriter(ctx)
+	if wr == nil {
+		return errdefs.InvalidParameter(errors.New("writer is required"))
+	}
+
+	if err := wr.Close(); err != nil {
+		return err
+	}
+
+	cr.backend.CloseWriter(ctx, wr)
+
+	return nil
+}
+
+func (cr *contentStoreRouter) getWriterDigest(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	wr := getWriter(ctx)
+	if wr == nil {
+		return errdefs.InvalidParameter(errors.New("writer is required"))
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, map[string]string{"digest": wr.Digest().String()})
+}
+
+func (cr *contentStoreRouter) postWriterTruncate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	wr := getWriter(ctx)
+	if wr == nil {
+		return errdefs.InvalidParameter(errors.New("writer is required"))
+	}
+
+	size, err := strconv.ParseInt(r.Form.Get("size"), 10, 64)
+	if err != nil {
+		return errdefs.InvalidParameter(fmt.Errorf("invalid size: %v", err))
+	}
+
+	if err := wr.Truncate(size); err != nil {
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, struct{}{})
+}
+
+func (cr *contentStoreRouter) postWriterCommit(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	wr := getWriter(ctx)
+	if wr == nil {
+		return errdefs.InvalidParameter(errors.New("writer is required"))
+	}
+
+	var size int64
+	if s := r.Form.Get("size"); s != "" {
+		s, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return errdefs.InvalidParameter(fmt.Errorf("invalid size: %v", err))
+		}
+		size = s
+	}
+
+	var expected digest.Digest
+	if e := r.Form.Get("expected"); e != "" {
+		d, err := digest.Parse(e)
+		if err != nil {
+			return errdefs.InvalidParameter(fmt.Errorf("invalid expected digest: %v", err))
+		}
+		expected = d
+	}
+
+	if err := wr.Commit(ctx, size, expected); err != nil {
+		if ctx.Err() != nil {
+			return errdefs.Cancelled(err)
+		}
+		if cerrdefs.IsAlreadyExists(err) {
+			return errdefs.Conflict(err)
+		}
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, struct{}{})
+}
+
+func (cr *contentStoreRouter) getWriterStatus(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	wr := getWriter(ctx)
+	if wr == nil {
+		return errdefs.InvalidParameter(errors.New("writer is required"))
+	}
+
+	status, err := wr.Status()
+	if err != nil {
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, status)
+}
+
+func (cr *contentStoreRouter) postWriterWrite(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	wr := getWriter(ctx)
+	if wr == nil {
+		return errdefs.InvalidParameter(errors.New("writer is required"))
+	}
+
+	n, err := content.CopyReader(wr, r.Body)
+	if err != nil {
+		return err
+	}
+
+	if ctx.Err() != nil {
+		return errdefs.Cancelled(err)
+	}
+	return httputils.WriteJSON(w, http.StatusOK, map[string]int64{"n": n})
+}
+
+func (cr *contentStoreRouter) postContentStoreOpen(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	sess, err := cr.backend.NewSession(ctx)
+	if err != nil {
+		return err
+	}
+
+	// TODO handle leases
+	return httputils.WriteJSON(w, http.StatusOK, map[string]string{"session": sess.Id})
+}
+
+func (cr *contentStoreRouter) deleteContentStoreClose(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	sess := getSession(ctx)
+	cr.backend.CloseSession(ctx, sess)
+	return nil
+}
+
+func (cr *contentStoreRouter) putContentStoreWrite(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	sess := getSession(ctx)
+
+	opts, err := cr.writerOpts(r)
+	if err != nil {
+		return err
+	}
+
+	ctx = leases.WithLease(ctx, sess.lease.ID)
+	wr, _, err := cr.backend.NewWriter(ctx, sess, opts...)
+	if err != nil {
+		return err
+	}
+	defer wr.Close()
+
+	if _, err := content.CopyReader(wr, r.Body); err != nil {
+		return err
+	}
+
+	if err := wr.Commit(ctx, r.ContentLength, ""); err != nil {
+		if cerrdefs.IsAlreadyExists(err) {
+			return errdefs.Conflict(err)
+		}
+		return err
+	}
+
+	dgst := wr.Digest()
+	return httputils.WriteJSON(w, http.StatusOK, map[string]string{"digest": dgst.String()})
+}
+
+func (cr *contentStoreRouter) writerOpts(r *http.Request) ([]content.WriterOpt, error) {
+	var opts []content.WriterOpt
+	if r := r.Form.Get("ref"); r != "" {
+		opts = append(opts, content.WithRef(r))
+	} else {
+		return nil, errdefs.InvalidParameter(errors.New("ref is required"))
+	}
+
+	if d := r.Form.Get("descriptor"); d != "" {
+		var desc ocispec.Descriptor
+		if err := json.Unmarshal([]byte(d), &desc); err != nil {
+			return nil, err
+		}
+		opts = append(opts, content.WithDescriptor(desc))
+	}
+
+	return opts, nil
+}
+
+func (cr *contentStoreRouter) getContentStoreRead(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	ociDesc, err := cr.readDescriptor(r)
+	if err != nil {
+		return err
+	}
+
+	sess := getSession(ctx)
+	rds, err := content.BlobReadSeeker(ctx, sess.Super, ociDesc)
+	if err != nil {
+		return err
+	}
+	defer rds.Close()
+
+	http.ServeContent(w, r, string(ociDesc.Digest), time.Now(), rds)
+	return nil
+}
+
+func (cr *contentStoreRouter) readDescriptor(r *http.Request) (ocispec.Descriptor, error) {
+	desc := r.Form.Get("descriptor")
+	if desc == "" {
+		return ocispec.Descriptor{}, errdefs.InvalidParameter(errors.New("descriptor must be provided"))
+	}
+
+	ociDesc := ocispec.Descriptor{}
+	if err := json.Unmarshal([]byte(desc), &ociDesc); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return ociDesc, nil
+}
+
+func (cr *contentStoreRouter) getContentStoreSize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	ociDesc, err := cr.readDescriptor(r)
+	if err != nil {
+		return err
+	}
+
+	sess := getSession(ctx)
+	ra, err := sess.Super.ReaderAt(ctx, ociDesc)
+	if err != nil {
+		return err
+	}
+
+	size := ra.Size()
+	_ = ra.Close()
+
+	return httputils.WriteJSON(w, http.StatusOK, map[string]int64{"size": size})
+}
+
+func (cr *contentStoreRouter) getContentStoreInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	dgst := r.Form.Get("digest")
+
+	if dgst == "" {
+		return errdefs.InvalidParameter(errors.New("digest is required"))
+	}
+
+	d, err := digest.Parse(dgst)
+	if err != nil {
+		return errdefs.InvalidParameter(fmt.Errorf("invalid digest: %v", err))
+	}
+
+	sess := getSession(ctx)
+	info, err := sess.Super.Info(ctx, d)
+	if err != nil {
+		return err
+	}
+
+	return httputils.WriteJSON(w, http.StatusOK, info)
+}

--- a/client/content_store.go
+++ b/client/content_store.go
@@ -1,0 +1,302 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type ContentStoreSession struct {
+	sessionId string
+	cli       *Client
+}
+
+func (c ContentStoreSession) Close() error {
+	query := url.Values{}
+	query.Set("session", c.sessionId)
+	resp, err := c.cli.delete(context.Background(), "/contentstore", query, nil)
+	defer ensureReaderClosed(resp)
+
+	return err
+}
+
+func (c ContentStoreSession) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	query := url.Values{}
+	query.Set("session", c.sessionId)
+	query.Set("digest", dgst.String())
+	resp, err := c.cli.post(ctx, "/contentstore/info", query, nil, nil)
+	if err != nil {
+		return content.Info{}, err
+	}
+	defer ensureReaderClosed(resp)
+
+	var info content.Info
+	if err := json.NewDecoder(resp.body).Decode(&info); err != nil {
+		return content.Info{}, err
+	}
+	return info, nil
+}
+
+type readerAt struct {
+	descJson string
+	size     int64
+	sess     *ContentStoreSession
+}
+
+func (r *readerAt) Close() error {
+	return nil
+}
+
+func (r *readerAt) Size() int64 {
+	return r.size
+}
+
+func (r *readerAt) getSize() (int64, error) {
+	query := url.Values{}
+	query.Set("session", r.sess.sessionId)
+	query.Set("descriptor", r.descJson)
+
+	resp, err := r.sess.cli.get(context.Background(), "/contentstore/size", query, nil)
+	if err != nil {
+		return -1, err
+	}
+	defer ensureReaderClosed(resp)
+
+	var out struct {
+		Size int64 `json:"size"`
+	}
+	if err := json.NewDecoder(resp.body).Decode(&out); err != nil {
+		return -1, err
+	}
+	return out.Size, nil
+}
+
+func (r *readerAt) ReadAt(p []byte, off int64) (n int, err error) {
+	query := url.Values{}
+	query.Set("session", r.sess.sessionId)
+	query.Set("descriptor", r.descJson)
+
+	headers := http.Header{}
+	end := off + int64(len(p))
+	if end > r.size {
+		end = r.size
+	}
+	headers.Set("Range", fmt.Sprintf("bytes=%d-%d", off, end))
+
+	resp, err := r.sess.cli.get(context.Background(), "/contentstore/read", query, headers)
+	if err != nil {
+		return -1, err
+	}
+	defer ensureReaderClosed(resp)
+
+	return io.ReadFull(resp.body, p)
+}
+
+var _ content.ReaderAt = &readerAt{}
+
+func (c ContentStoreSession) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	descJson, err := json.Marshal(desc)
+	if err != nil {
+		return nil, nil
+	}
+
+	ra := &readerAt{
+		descJson: string(descJson),
+		sess:     &c,
+	}
+	size, err := ra.getSize()
+	if err != nil {
+		return nil, err
+	}
+	ra.size = size
+	return ra, nil
+}
+
+func (c ContentStoreSession) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	query := url.Values{}
+	query.Set("session", c.sessionId)
+
+	var writerOpts content.WriterOpts
+	for _, opt := range opts {
+		if err := opt(&writerOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	if writerOpts.Ref != "" {
+		query.Set("ref", writerOpts.Ref)
+	}
+
+	if writerOpts.Desc.Digest != "" {
+		descJson, err := json.Marshal(writerOpts.Desc)
+		if err != nil {
+			return nil, err
+		}
+		query.Set("descriptor", string(descJson))
+	}
+
+	resp, err := c.cli.post(ctx, "/contentstore/writer", query, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer ensureReaderClosed(resp)
+
+	var response struct {
+		Writer string `json:"writer"`
+	}
+
+	if err := json.NewDecoder(resp.body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	return &writer{
+		session: &c,
+		writer:  response.Writer,
+		h:       crypto.SHA256.New(),
+	}, nil
+}
+
+type writer struct {
+	session *ContentStoreSession
+	writer  string
+	h       hash.Hash
+}
+
+func (w *writer) Write(p []byte) (n int, err error) {
+	ctx := context.Background()
+
+	query := url.Values{}
+	query.Set("session", w.session.sessionId)
+	query.Set("writer", w.writer)
+
+	rd := io.TeeReader(bytes.NewReader(p), w.h)
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/octet-stream")
+	headers.Set("Content-Length", strconv.Itoa(len(p)))
+
+	resp, err := w.session.cli.sendRequest(ctx, http.MethodPost, "/contentstore/writer/write", query, rd, headers)
+	if err != nil {
+		return -1, err
+	}
+	defer ensureReaderClosed(resp)
+
+	var out struct {
+		N int `json:"n"`
+	}
+
+	if err := json.NewDecoder(resp.body).Decode(&out); err != nil {
+		return -1, err
+	}
+
+	return out.N, nil
+}
+
+func (w *writer) Close() error {
+	ctx := context.Background()
+
+	query := url.Values{}
+	query.Set("session", w.session.sessionId)
+	query.Set("writer", w.writer)
+
+	resp, err := w.session.cli.delete(ctx, "/contentstore/writer", query, nil)
+	defer ensureReaderClosed(resp)
+
+	return err
+}
+
+func (w *writer) Digest() digest.Digest {
+	return digest.NewDigest("sha256", w.h)
+}
+
+func (w *writer) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	query := url.Values{}
+	query.Set("session", w.session.sessionId)
+	query.Set("writer", w.writer)
+	query.Set("size", strconv.FormatInt(size, 10))
+	query.Set("expected", expected.String())
+
+	resp, err := w.session.cli.post(ctx, "/contentstore/writer/commit", query, nil, nil)
+	if err != nil {
+		return err
+	}
+	defer ensureReaderClosed(resp)
+
+	_, err = io.Copy(io.Discard, resp.body)
+	return err
+}
+
+func (w *writer) Status() (content.Status, error) {
+	query := url.Values{}
+	query.Set("session", w.session.sessionId)
+	query.Set("writer", w.writer)
+
+	resp, err := w.session.cli.get(context.Background(), "/contentstore/writer/status", query, nil)
+	if err != nil {
+		return content.Status{}, err
+	}
+	defer ensureReaderClosed(resp)
+
+	var status content.Status
+	if err := json.NewDecoder(resp.body).Decode(&status); err != nil {
+		return content.Status{}, err
+	}
+	return status, nil
+}
+
+func (w *writer) Truncate(size int64) error {
+	query := url.Values{}
+	query.Set("session", w.session.sessionId)
+	query.Set("writer", w.writer)
+	query.Set("size", strconv.FormatInt(size, 10))
+
+	resp, err := w.session.cli.post(context.Background(), "/contentstore/writer/truncate", query, nil, nil)
+	if err != nil {
+		return err
+	}
+	defer ensureReaderClosed(resp)
+
+	_, err = io.Copy(io.Discard, resp.body)
+	return err
+
+}
+
+var _ content.Provider = &ContentStoreSession{}
+var _ content.InfoProvider = &ContentStoreSession{}
+var _ content.Ingester = &ContentStoreSession{}
+
+type ContentStoreSessionOpt func(*ContentStoreSession)
+
+func (cli *Client) ContentStore(ctx context.Context, opts ...ContentStoreSessionOpt) (ContentStoreSession, error) {
+	cs := ContentStoreSession{
+		cli: cli,
+	}
+
+	resp, err := cli.post(ctx, "/contentstore", nil, nil, nil)
+	if err != nil {
+		return cs, err
+	}
+	defer ensureReaderClosed(resp)
+
+	var response struct {
+		Session string `json:"session"`
+	}
+
+	if err := json.NewDecoder(resp.body).Decode(&response); err != nil {
+		return cs, err
+	}
+	cs.sessionId = response.Session
+
+	return cs, err
+}

--- a/client/interface.go
+++ b/client/interface.go
@@ -33,6 +33,7 @@ type CommonAPIClient interface {
 	SecretAPIClient
 	SystemAPIClient
 	VolumeAPIClient
+	ContentStore(ctx context.Context, opts ...ContentStoreSessionOpt) (ContentStoreSession, error)
 	ClientVersion() string
 	DaemonHost() string
 	HTTPClient() *http.Client

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -43,6 +43,7 @@ import (
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/cluster"
 	"github.com/docker/docker/daemon/config"
+	"github.com/docker/docker/daemon/containerd"
 	"github.com/docker/docker/daemon/listeners"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/internal/otelutil"
@@ -719,6 +720,11 @@ func buildRouters(opts routerOptions) []router.Router {
 				}
 			}
 		}
+	}
+
+	imageSvc := opts.daemon.ImageService()
+	if c8dstore, ok := imageSvc.(*containerd.ImageService); ok {
+		routers = append(routers, image.NewContentRouter(c8dstore.ContentStore(), c8dstore.LeasesService()))
 	}
 
 	return routers

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -8,6 +8,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	c8dimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/plugins"
@@ -42,6 +43,10 @@ type ImageService struct {
 
 	// defaultPlatformOverride is used in tests to override the host platform.
 	defaultPlatformOverride platforms.MatchComparer
+}
+
+func (i *ImageService) LeasesService() leases.Manager {
+	return i.client.LeasesService()
 }
 
 type registryResolver interface {
@@ -79,6 +84,10 @@ func NewService(config ImageServiceConfig) *ImageService {
 		refCountMounter: config.RefCountMounter,
 		idMapping:       config.IDMapping,
 	}
+}
+
+func (i *ImageService) ContentStore() content.Store {
+	return i.content
 }
 
 func (i *ImageService) snapshotterService(snapshotter string) snapshots.Snapshotter {

--- a/integration/image/content_test.go
+++ b/integration/image/content_test.go
@@ -1,0 +1,115 @@
+package image
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/testutil/daemon"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+func TestContentStoreReadSimple(t *testing.T) {
+	skip.If(t, !testEnv.UsingSnapshotter())
+	ctx := setupTest(t)
+
+	client := testEnv.APIClient()
+
+	inspect, _, err := client.ImageInspectWithRaw(ctx, "busybox")
+	assert.NilError(t, err)
+
+	session, err := client.ContentStore(ctx)
+	assert.NilError(t, err)
+
+	defer session.Close()
+
+	// This implements the regular containerd interfaces
+	var provider content.InfoReaderProvider = session
+
+	assert.Assert(t, inspect.Descriptor != nil)
+
+	b, err := content.ReadBlob(ctx, provider, *inspect.Descriptor)
+	assert.NilError(t, err)
+
+	var index ocispec.Index
+	assert.NilError(t, json.Unmarshal(b, &index))
+
+	assert.Check(t, is.Equal(index.MediaType, "application/vnd.docker.distribution.manifest.v2+json"))
+
+	t.Run("not existing", func(t *testing.T) {
+		desc := ocispec.Descriptor{
+			Digest: digest.FromString("this shouldnt exist at all"),
+			Size:   100,
+		}
+
+		rd, err := provider.ReaderAt(ctx, desc)
+		if err == nil {
+			rd.Close()
+		}
+		assert.ErrorType(t, err, errdefs.IsNotFound)
+	})
+}
+
+func TestContentStoreWrite(t *testing.T) {
+	skip.If(t, !testEnv.UsingSnapshotter())
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.Start(t)
+	defer d.Stop(t)
+
+	session, err := d.NewClientT(t).ContentStore(ctx)
+	assert.NilError(t, err)
+	defer session.Close()
+
+	var ingester content.Ingester = session
+
+	wr, err := ingester.Writer(ctx, content.WithRef("test"))
+	assert.NilError(t, err)
+
+	_, err = io.Copy(wr, strings.NewReader("hello"))
+	assert.NilError(t, err)
+
+	err = wr.Commit(ctx, 5, "")
+	assert.NilError(t, err)
+
+	desc := ocispec.Descriptor{
+		Digest: wr.Digest(),
+		Size:   5,
+	}
+
+	t.Run("read back", func(t *testing.T) {
+		var provider content.Provider = session
+
+		b, err := content.ReadBlob(ctx, provider, desc)
+		assert.NilError(t, err)
+
+		assert.Check(t, is.Equal(string(b), "hello"))
+	})
+
+	t.Run("read back after close", func(t *testing.T) {
+		// The written content should be gone after the session is closed
+		// because it wasn't referenced by anything that would keep it from
+		// being GC'd.
+		session.Close()
+		d.Restart(t)
+
+		newSession, err := d.NewClientT(t).ContentStore(ctx)
+		assert.NilError(t, err)
+
+		defer newSession.Close()
+
+		_, err = content.ReadBlob(ctx, newSession, desc)
+		assert.ErrorContains(t, err, "not found")
+	})
+
+}


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/44369

# DRAFT / RFC

**Note: This is a draft/strawman PR for exposing the content store API over our HTTP API.**

This PR implements a HTTP API that exposes the containerd's content store.
This API is designed to provide a transparent client-side implementation of the containerd content management interfaces.
HTTP was chosen over gRPC to avoid requiring clients to deal with gRPC and dependencies.

## Example

Also see tests: https://github.com/moby/moby/blob/a71f2fcd650ecbff9e046b664eedf69848c76bb2/integration/image/content_test.go

```go
inspect, _, err := client.ImageInspectWithRaw(ctx, "busybox")
must(err)

session, err := client.ContentStore(ctx)
must(err)

defer session.Close()

// This implements the regular containerd interfaces
var provider content.InfoReaderProvider = session

b, err := content.ReadBlob(ctx, provider, *inspect.Descriptor)
must(err)

var index ocispec.Index
fmt.Println(index)
```

## Client
The client provides a `ContentStore` method that returns a `ContentStoreSession` which implements the following containerd interfaces:

- `content.Provider` - For reading content
  - `ReaderAt(ctx, desc)` - Returns a reader for accessing content identified by the descriptor
  
- `content.InfoProvider` - For getting content metadata
  - `Info(ctx, digest)` - Returns metadata about content identified by digest

- `content.Ingester` - For writing content
  - `Writer(ctx, opts...)` - Returns a writer for ingesting content with the given options

The session must be closed when no longer needed using the `Close()` method.

## API Endpoints

### Session Management
- `POST /contentstore` - Create a new session
  - Returns: `{"session": "<session-id>"}`
- `DELETE /contentstore?session=<id>` - Close a session

### Content Writing
- `POST /contentstore/writer?session=<id>&ref=<ref>&descriptor=<json-descriptor>` - Create a new content writer
  - Mirrors: `content.Ingester.Writer()`
  - Returns: `{"writer": "<writer-id>"}`
- `POST /contentstore/writer/write?session=<id>&writer=<id>` - Write data to a writer
  - Mirrors: `content.Writer.Write()`
  - Body: Raw content bytes
  - Returns: `{"n": <bytes-written>}`
- `POST /contentstore/writer/commit?session=<id>&writer=<id>&size=<size>&expected=<digest>` - Commit written content
  - Mirrors: `content.Writer.Commit()`
- `DELETE /contentstore/writer?session=<id>&writer=<id>` - Close a writer
  - Mirrors: `content.Writer.Close()`
- `POST /contentstore/writer/truncate?session=<id>&writer=<id>&size=<size>` - Truncate a writer
  - Mirrors: `content.Writer.Truncate()`
- `GET /contentstore/writer/digest?session=<id>&writer=<id>` - Get current digest of written content
  - Mirrors: `content.Writer.Digest()`
  - Returns: `{"digest": "<digest>"}`
- `GET /contentstore/writer/status?session=<id>&writer=<id>` - Get writer status
  - Mirrors: `content.Writer.Status()`

### Content Reading
- `GET /contentstore/read?session=<id>&descriptor=<json-descriptor>` - Read content (supports the `Range` http reader)
  - Mirrors: `content.Provider.ReaderAt()`
  - Returns: Raw content bytes
- `GET /contentstore/info?session=<id>&digest=<digest>` - Get content metadata
  - Mirrors: `content.InfoProvider.Info()`
  - Returns: Content info object
- `GET /contentstore/size?session=<id>&descriptor=<json-descriptor>` - Get content size using ReaderAt
  - Returns: `{"size": <size>}`

### Single-Request Write Helper

This endpoint provides a simplified call to mirror the `content.WriteBlob` on the client side, allowing content to be written in a single HTTP request.

- `PUT /contentstore/write?session=<id>&ref=<ref>&descriptor=<json-descriptor>` - Write content in a single request
  - Body: Raw content bytes
  - Returns: `{"digest": "<digest>"}`

## Usage Flow

1. Create a session with `POST /contentstore`
2. Use the session ID for subsequent operations
3. For multi-part writes:
   - Create a writer with `POST /contentstore/writer`
   - Write data in chunks with `POST /contentstore/writer/write`
   - Commit with `POST /contentstore/writer/commit`
   - Close writer with `DELETE /contentstore/writer`
4. For single-part writes:
   - Use `PUT /contentstore/write` with complete content
5. Read content using `GET /contentstore/read`
6. Close session with `DELETE /contentstore`

All operations require a valid session ID. Writers are tracked per session and must be explicitly closed. Sessions manage underlying containerd leases to ensure content persistence.


## TODO
- Support for easier image creation
- Proper lease/expiration management
- Cleanup stale sessions
- Swagger API docs and document in API history


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd image store: Expose containerd image store over the HTTP API
```

**- A picture of a cute animal (not mandatory but encouraged)**

![duduskipudlo](https://github.com/user-attachments/assets/635dc88a-38f1-4cab-be87-7340972d0665)
