### PR TITLE
gha/validate-pr: Also run when PR has new commits

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -11,7 +11,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled]
+    types: [opened, edited, labeled, unlabeled, synchronize]
 
 jobs:
   check-area-label:


### PR DESCRIPTION
Otherwise, the workflow will won't be rerun even if it was failing before.
