### PR TITLE
github: Clarify release notes description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,11 +19,14 @@ Please provide the following information:
 
 **- How to verify it**
 
-**- Description for the changelog**
+**- Human readable description for the release notes**
 <!--
 Write a short (one line) summary that describes the changes in this
 pull request for inclusion in the changelog.
-It must be placed inside the below triple backticks section:
+It must be placed inside the below triple backticks section.
+
+NOTE: Only fill this section if changes introduced in this PR are user-facing.
+The PR must have a relevant impact/ label.
 -->
 ```markdown changelog
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -27,10 +27,10 @@ jobs:
         run: exit 0
 
   check-changelog:
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/')
     runs-on: ubuntu-20.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     env:
+      HAS_IMPACT_LABEL: ${{ contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') }}
       PR_BODY: |
         ${{ github.event.pull_request.body }}
     steps:
@@ -42,15 +42,23 @@ jobs:
           # Strip empty lines
           desc=$(echo "$block" |  awk NF)
 
-          if [ -z "$desc" ]; then
-            echo "::error::Changelog section is empty. Please provide a description for the changelog."
-            exit 1
-          fi
+          if [ "$HAS_IMPACT_LABEL" = "true" ]; then
+            if [ -z "$desc" ]; then
+              echo "::error::Changelog section is empty. Please provide a description for the changelog."
+              exit 1
+            fi
 
-          len=$(echo -n "$desc" | wc -c)
-          if [[ $len -le 6 ]]; then
-            echo "::error::Description looks too short: $desc"
-            exit 1
+            len=$(echo -n "$desc" | wc -c)
+            if [[ $len -le 6 ]]; then
+              echo "::error::Description looks too short: $desc"
+              exit 1
+            fi
+          else
+            if [ -n "$desc" ]; then
+              echo "::error::PR has a changelog description, but no changelog label"
+              echo "::error::Please add the relevant 'impact/' label to the PR or remove the changelog description"
+              exit 1
+            fi
           fi
 
           echo "This PR will be included in the release notes with the following note:"


### PR DESCRIPTION
Error out if the release notes section is filled for PRs without the `impact/` label.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

