### PR TITLE
libnet, daemon: Recreate docker0 when unsetting default-address-pools

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -891,7 +891,7 @@ func configureNetworking(controller *libnetwork.Controller, conf *config.Config)
 
 	if !conf.DisableBridge {
 		// Initialize default driver "bridge"
-		if err := initBridgeDriver(controller, conf.BridgeConfig); err != nil {
+		if err := createDefaultBridgeNetwork(controller, conf.BridgeConfig); err != nil {
 			return err
 		}
 	} else {
@@ -980,7 +980,7 @@ type defBrOpts interface {
 	defGw() (gw net.IP, optName, auxAddrLabel string)
 }
 
-func initBridgeDriver(controller *libnetwork.Controller, cfg config.BridgeConfig) error {
+func createDefaultBridgeNetwork(controller *libnetwork.Controller, cfg config.BridgeConfig) error {
 	bridgeName, userManagedBridge := getDefaultBridgeName(cfg)
 	netOption := map[string]string{
 		bridge.BridgeName:         bridgeName,

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -855,7 +855,7 @@ func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes 
 
 	if len(activeSandboxes) > 0 {
 		log.G(context.TODO()).Info("there are running containers, updated network configuration will not take affect")
-	} else if err := configureNetworking(daemon.netController, cfg); err != nil {
+	} else if err := createDefaultNetworks(daemon.netController, cfg); err != nil {
 		return err
 	}
 
@@ -864,7 +864,13 @@ func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes 
 	return nil
 }
 
-func configureNetworking(controller *libnetwork.Controller, conf *config.Config) error {
+// createDefaultNetworks creates the default "none" and "host" networks if they
+// don't exist, and recreates the default bridge network.
+//
+// It's caller responsibility to make sure that it's safe to recreate the
+// default bridge network, ie. either live-restore is disabled or no containers
+// are currently running.
+func createDefaultNetworks(controller *libnetwork.Controller, conf *config.Config) error {
 	// Create predefined network "none"
 	if n, _ := controller.NetworkByName(network.NetworkNone); n == nil {
 		if _, err := controller.NewNetwork("null", network.NetworkNone, "", libnetwork.NetworkOptionPersist(true)); err != nil {

--- a/integration/container/attach_test.go
+++ b/integration/container/attach_test.go
@@ -73,7 +73,7 @@ func TestAttachDisconnectLeak(t *testing.T) {
 
 	// Use a new daemon to make sure stuff from other tests isn't affecting the
 	// goroutine count.
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	defer d.Cleanup(t)
 
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -40,7 +40,7 @@ func TestContainerStartOnDaemonRestart(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")
 	defer d.Stop(t)
 
@@ -94,7 +94,7 @@ func TestDaemonRestartIpcMode(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false", "--default-ipc-mode=private")
 	defer d.Stop(t)
 
@@ -192,7 +192,7 @@ func TestRestartDaemonWithRestartingContainer(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	defer d.Cleanup(t)
 
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")
@@ -238,7 +238,7 @@ func TestHardRestartWhenContainerIsRunning(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	defer d.Cleanup(t)
 
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -24,7 +24,7 @@ func TestContainerKillOnDaemonStart(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	defer d.Cleanup(t)
 
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")
@@ -64,7 +64,7 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	defer d.Cleanup(t)
 
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -80,7 +80,7 @@ func TestDaemonRestartKillContainers(t *testing.T) {
 
 					ctx := testutil.StartSpan(ctx, t)
 
-					d := daemon.New(t)
+					d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 					apiClient := d.NewClientT(t)
 
 					args := []string{"--iptables=false", "--ip6tables=false"}

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -274,6 +274,7 @@ func TestDaemonProxy(t *testing.T) {
 			"HTTPS_PROXY="+proxyServer.URL,
 			"NO_PROXY=example.com",
 			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
+			"DOCKER_KEEP_DEFAULT_BRIDGE=y",
 		))
 		c := d.NewClientT(t)
 
@@ -312,6 +313,7 @@ func TestDaemonProxy(t *testing.T) {
 			"NO_PROXY=ignore.invalid",
 			"no_proxy=ignore.invalid",
 			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
+			"DOCKER_KEEP_DEFAULT_BRIDGE=y",
 		))
 		d.Start(t, "--iptables=false", "--ip6tables=false", "--http-proxy", proxyServer.URL, "--https-proxy", proxyServer.URL, "--no-proxy", "example.com")
 		defer d.Stop(t)
@@ -363,6 +365,7 @@ func TestDaemonProxy(t *testing.T) {
 			"NO_PROXY=ignore.invalid",
 			"no_proxy=ignore.invalid",
 			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
+			"DOCKER_KEEP_DEFAULT_BRIDGE=y",
 		))
 		c := d.NewClientT(t)
 
@@ -434,6 +437,7 @@ func TestDaemonProxy(t *testing.T) {
 
 		d := daemon.New(t, daemon.WithEnvVars(
 			"OTEL_EXPORTER_OTLP_ENDPOINT=", // To avoid OTEL hitting the proxy.
+			"DOCKER_KEEP_DEFAULT_BRIDGE=y",
 		))
 		d.Start(t, "--iptables=false", "--ip6tables=false", "--http-proxy", proxyRawURL, "--https-proxy", proxyRawURL, "--no-proxy", "example.com")
 		defer d.Stop(t)
@@ -463,7 +467,7 @@ func testLiveRestoreAutoRemove(t *testing.T) {
 	ctx := testutil.StartSpan(baseContext, t)
 
 	run := func(t *testing.T) (*daemon.Daemon, func(), string) {
-		d := daemon.New(t)
+		d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 		d.StartWithBusybox(ctx, t, "--live-restore", "--iptables=false", "--ip6tables=false")
 		t.Cleanup(func() {
 			d.Stop(t)
@@ -526,7 +530,7 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 	t.Parallel()
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.StartWithBusybox(ctx, t, "--live-restore", "--iptables=false", "--ip6tables=false")
 	defer func() {
 		d.Stop(t)
@@ -679,7 +683,7 @@ func testLiveRestoreUserChainsSetup(t *testing.T) {
 	ctx := testutil.StartSpan(baseContext, t)
 
 	t.Run("user chains should be inserted", func(t *testing.T) {
-		d := daemon.New(t)
+		d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 		d.StartWithBusybox(ctx, t, "--live-restore")
 		t.Cleanup(func() {
 			d.Stop(t)

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -29,7 +29,7 @@ func TestImportExtremelyLargeImageWorks(t *testing.T) {
 	ctx := testutil.StartSpan(baseContext, t)
 
 	// Spin up a new daemon, so that we can run this test in parallel (it's a slow test)
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.Start(t, "--iptables=false", "--ip6tables=false")
 	defer d.Stop(t)
 

--- a/integration/plugin/logging/logging_linux_test.go
+++ b/integration/plugin/logging/logging_linux_test.go
@@ -23,7 +23,7 @@ func TestContinueAfterPluginCrash(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false", "--init")
 	defer d.Stop(t)
 

--- a/integration/plugin/logging/read_test.go
+++ b/integration/plugin/logging/read_test.go
@@ -26,7 +26,7 @@ func TestReadPluginNoRead(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false")
 	defer d.Stop(t)
 

--- a/integration/plugin/logging/validation_test.go
+++ b/integration/plugin/logging/validation_test.go
@@ -22,7 +22,7 @@ func TestDaemonStartWithLogOpt(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.Start(t, "--iptables=false", "--ip6tables=false")
 	defer d.Stop(t)
 

--- a/integration/plugin/volumes/mounts_test.go
+++ b/integration/plugin/volumes/mounts_test.go
@@ -22,7 +22,7 @@ func TestPluginWithDevMounts(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.Start(t, "--iptables=false", "--ip6tables=false")
 	defer d.Stop(t)
 

--- a/integration/system/cgroupdriver_systemd_test.go
+++ b/integration/system/cgroupdriver_systemd_test.go
@@ -34,7 +34,7 @@ func TestCgroupDriverSystemdMemoryLimit(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	c := d.NewClientT(t)
 
 	d.StartWithBusybox(ctx, t, "--exec-opt", "native.cgroupdriver=systemd", "--iptables=false", "--ip6tables=false")

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -116,7 +116,7 @@ func TestVolumesRemoveSwarmEnabled(t *testing.T) {
 	t.Parallel()
 
 	// Spin up a new daemon, so that we can run this test in parallel (it's a slow test)
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_KEEP_DEFAULT_BRIDGE=y"))
 	d.StartAndSwarmInit(ctx, t)
 	defer d.Stop(t)
 

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1041,12 +1041,8 @@ func (d *driver) deleteNetwork(nid string) error {
 
 	switch config.BridgeIfaceCreator {
 	case ifaceCreatedByLibnetwork, ifaceCreatorUnknown:
-		// We only delete the bridge if it was created by the bridge driver and
-		// it is not the default one (to keep the backward compatible behavior.)
-		if !config.DefaultBridge {
-			if err := d.nlh.LinkDel(n.bridge.Link); err != nil {
-				log.G(context.TODO()).Warnf("Failed to remove bridge interface %s on network %s delete: %v", config.BridgeName, nid, err)
-			}
+		if err := d.nlh.LinkDel(n.bridge.Link); err != nil {
+			log.G(context.TODO()).Warnf("Failed to remove bridge interface %s on network %s delete: %v", config.BridgeName, nid, err)
 		}
 	case ifaceCreatedByUser:
 		// Don't delete the bridge interface if it was not created by libnetwork.


### PR DESCRIPTION
Fixes:

- https://github.com/moby/moby/issues/49353

**- What I did**

Commit 268d418 added persistence to the bridge driver, and added logic to not delete the bridge interface if it's used by the default bridge network when the later is deleted (as part of the networking initialization steps).

Later on, commit 6bd15397b refined this logic to not delete the bridge interface if it's user-managed. But it didn't touch the original condition (ie. do not delete the bridge interface if it's used by the default network).

And then, commit 173b3c3 added support for the `default-address-pools` parameter. It also added some code to delete the bridge interface used by the default network, but in the daemon instead of leveraging the usual delete flow in the bridge driver. It also skips the deletion if no `default-address-pools` are defined.

This leads to a corner case where the bridge interface isn't recreated when `default-address-pools` is unset.

Tidy this up by letting the bridge driver delete the bridge interface even when it's used by the default network. There are two exceptions where the underlying interface shall not be deleted:

1. When the interface is user-managed. User is responsible for creating and deleting it.
2. When live-restore is enabled and there are containers running.

Note that the 2nd exception could be refined to only apply when there are active sandboxes attached to that network, but this is out of scope.

**- How to verify it**

**- Description for the changelog**

```markdown changelog
- Fix a bug that was preventing the default bridge interface to be recreated when unsetting `default-address-pools`, or when that parameter was never set.
```

