### PR TITLE
daemon: Daemon.rmLink: don't fuzzy-match container when using ID

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -68,14 +68,13 @@ func (daemon *Daemon) rmLink(cfg *config.Config, container *container.Container,
 	}
 
 	parent = strings.TrimSuffix(parent, "/")
-	pe, err := daemon.containersReplica.Snapshot().GetID(parent)
+	parentID, err := daemon.containersReplica.Snapshot().GetID(parent)
 	if err != nil {
 		return fmt.Errorf("Cannot get parent %s for link name %s", parent, name)
 	}
 
 	daemon.releaseName(name)
-	parentContainer, _ := daemon.GetContainer(pe)
-	if parentContainer != nil {
+	if parentContainer := daemon.containers.Get(parentID); parentContainer != nil {
 		daemon.linkIndex.unlink(name, container, parentContainer)
 		if err := daemon.updateNetwork(cfg, parentContainer); err != nil {
 			log.G(context.TODO()).Debugf("Could not update network to remove link %s: %v", n, err)


### PR DESCRIPTION
rmLink already looked up the parent container's ID, so we should not use daemon.GetContainer to resolve the container, as that performs fuzzy matching (name, ID-prefix, or ID).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

