### PR TITLE
daemon: remove Daemon.children(), Daemon.parents() wrappers

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -36,7 +36,7 @@ func (daemon *Daemon) setupLinkedContainers(ctr *container.Container) ([]string,
 	}
 
 	var env []string
-	for linkAlias, child := range daemon.children(ctr) {
+	for linkAlias, child := range daemon.linkIndex.children(ctr) {
 		if !child.IsRunning() {
 			return nil, fmt.Errorf("Cannot link to a non running container: %s AS %s", child.Name, linkAlias)
 		}
@@ -74,10 +74,10 @@ func (daemon *Daemon) addLegacyLinks(
 		return nil
 	}
 
-	children := daemon.children(ctr)
+	children := daemon.linkIndex.children(ctr)
 	var parents map[string]*container.Container
 	if !cfg.DisableBridge && ctr.HostConfig.NetworkMode.IsPrivate() {
-		parents = daemon.parents(ctr)
+		parents = daemon.linkIndex.parents(ctr)
 	}
 	if len(children) == 0 && len(parents) == 0 {
 		return nil

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -570,7 +570,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 
 			// ignore errors here as this is a best effort to wait for children to be
 			//   running before we try to start the container
-			children := daemon.children(c)
+			children := daemon.linkIndex.children(c)
 			timeout := time.NewTimer(5 * time.Second)
 			defer timeout.Stop()
 
@@ -690,16 +690,6 @@ func (daemon *Daemon) restartSwarmContainers(ctx context.Context, cfg *configSto
 		}
 	}
 	group.Wait()
-}
-
-func (daemon *Daemon) children(c *container.Container) map[string]*container.Container {
-	return daemon.linkIndex.children(c)
-}
-
-// parents returns the names of the parent containers of the container
-// with the given name.
-func (daemon *Daemon) parents(c *container.Container) map[string]*container.Container {
-	return daemon.linkIndex.parents(c)
 }
 
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -568,17 +568,18 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 
 			logger.Debug("starting container")
 
-			// ignore errors here as this is a best effort to wait for children to be
-			//   running before we try to start the container
-			children := daemon.linkIndex.children(c)
-			timeout := time.NewTimer(5 * time.Second)
-			defer timeout.Stop()
+			// ignore errors here as this is a best effort to wait for children
+			// (legacy links) to be running before we try to start the container
+			if children := daemon.linkIndex.children(c); len(children) > 0 {
+				timeout := time.NewTimer(5 * time.Second)
+				defer timeout.Stop()
 
-			for _, child := range children {
-				if notifier, exists := restartContainers[child]; exists {
-					select {
-					case <-notifier:
-					case <-timeout.C:
+				for _, child := range children {
+					if notifier, exists := restartContainers[child]; exists {
+						select {
+						case <-notifier:
+						case <-timeout.C:
+						}
 					}
 				}
 			}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -99,7 +99,8 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, container *contai
 	// make a copy to play with
 	hostConfig := *container.HostConfig
 
-	children := daemon.children(container)
+	// Add information for legacy links
+	children := daemon.linkIndex.children(container)
 	hostConfig.Links = nil // do not expose the internal structure
 	for linkAlias, child := range children {
 		hostConfig.Links = append(hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))


### PR DESCRIPTION
### daemon: remove Daemon.children(), Daemon.parents() wrappers

Remove the wrappers to make it more explicit that these are related to
the legacy links feature.

### daemon: Daemon.restore: make legacy-link code conditional

Make it more clear that this loop is for legacy-links, and the timer is
only needed for that purpose.




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

