### PR TITLE
Implement GwAllocChecker for the remote network driver

### DIFF
--- a/libnetwork/docs/remote.md
+++ b/libnetwork/docs/remote.md
@@ -56,12 +56,37 @@ Other entries in the list value are allowed; `"NetworkDriver"` indicates that th
 After Handshake, the remote driver will receive another POST message to the URL `/NetworkDriver.GetCapabilities` with no payload. The driver's response should have the form:
 
 	{
-		"Scope":             "local"
-		"ConnectivityScope": "global"
+		"Scope":             "local",
+		"ConnectivityScope": "global",
+		"GwAllocChecker":    false
 	}
 
 Value of "Scope" should be either "local" or "global" which indicates whether the resource allocations for this driver's network can be done only locally to the node or globally across the cluster of nodes. Any other value will fail driver's registration and return an error to the caller.
 Similarly, value of "ConnectivityScope" should be either "local" or "global" which indicates whether the driver's network can provide connectivity only locally to this node or globally across the cluster of nodes. If the value is missing, libnetwork will set it to the value of "Scope". should be either "local" or "global" which indicates
+
+The field "GwAllocChecker" can be omitted but, if set to "true", the proxy will make a request to `/NetworkDriver.GwAllocCheck` before a request to `/NetworkDriver.CreateNetwork`.
+
+### Gateway Allocation Check
+
+If the proxy returned `"GwAllocChecker": true` in its capabilities response, the remote process shall receive a POST to the URL `/NetworkDriver.GwAllocCheck` of the form
+
+    {
+		"Options": {
+			...
+		}
+    }
+
+The value of `Options` is the same as the map that will be sent in the `/NetworkDriver.CreateNetwork` request.
+
+The response must have the form
+
+    {
+		"SkipIPv4": false,
+		"SkipIPv6": false
+    }
+
+* If `"SkipIPv4"` is `true` and no `Gateway` address is included in the IPv4 IPAM configuration, LibNetwork will not allocate an address for the network gateway.
+* Similarly `"SkipIPv6"` can be used to tell LibNetwork to skip allocation of an IPv6 network gateway address.
 
 ### Create network
 

--- a/libnetwork/drivers/remote/api/api.go
+++ b/libnetwork/drivers/remote/api/api.go
@@ -26,6 +26,10 @@ type GetCapabilityResponse struct {
 	Response
 	Scope             string
 	ConnectivityScope string
+
+	// GwAllocChecker is used by the driver to report that it will accept a
+	// [GwAllocCheckerRequest] at "GwAllocCheck".
+	GwAllocChecker bool
 }
 
 // AllocateNetworkRequest requests allocation of new network by manager
@@ -58,6 +62,27 @@ type FreeNetworkRequest struct {
 // FreeNetworkResponse is the response to a request for freeing a network.
 type FreeNetworkResponse struct {
 	Response
+}
+
+// GwAllocCheckerRequest is the body of a request sent to "GwAllocCheck", if the
+// driver reported capability "GwAllocChecker". This request is sent before the
+// [CreateNetworkRequest].
+type GwAllocCheckerRequest struct {
+	// Options has the same form as Options in [CreateNetworkRequest].
+	Options map[string]interface{}
+}
+
+// GwAllocCheckerResponse is the response to a [GwAllocCheckerRequest].
+type GwAllocCheckerResponse struct {
+	Response
+	// SkipIPv4, if true, tells Docker that when it creates a network with the
+	// Options in the [GwAllocCheckerRequest] it should not reserve an IPv4
+	// gateway address.
+	SkipIPv4 bool
+	// SkipIPv6, if true, tells Docker that when it creates a network with the
+	// Options in the [GwAllocCheckerRequest] it should not reserve an IPv6
+	// gateway address.
+	SkipIPv6 bool
 }
 
 // CreateNetworkRequest requests a new network.


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/49166
- somewhat optimistically, I've tagged this PR for 28.0 ... but it can slip into a 28.1 if needed!

Commit 38e76eb (Ask network drivers if they'll use a gateway address) added an optional driver interface "GwAllocChecker" to give the driver a chance to say whether, given network config options, it would use a gateway address if one was reserved for it in IPAM.

So, implement support for that in the remote network driver.

**- How I did it**

The remote driver itself implements the interface, but only tries to make an HTTP request to the driver plugin if the plugin has reported support for it in response to an initial capabilities request.

**- How to verify it**

New test.

**- Description for the changelog**
```markdown changelog
- If a custom network driver reports capability `GwAllocChecker` then, before a network is created, it will get
  a `GwAllocCheckerRequest` with the network's options. The custom driver may then reply that no gateway
  IP address should be allocated.
```
