### PR TITLE
client: deprecate ErrorConnectionFailed helper

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -2,11 +2,11 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 )
 
 // errConnectionFailed implements an error returned when connection failed.
@@ -29,10 +29,18 @@ func IsErrConnectionFailed(err error) bool {
 }
 
 // ErrorConnectionFailed returns an error with host in the error message when connection to docker daemon failed.
+//
+// Deprecated: this function was only used internally, and will be removed in the next release.
 func ErrorConnectionFailed(host string) error {
+	return connectionFailed(host)
+}
+
+// connectionFailed returns an error with host in the error message when connection
+// to docker daemon failed.
+func connectionFailed(host string) error {
 	var err error
 	if host == "" {
-		err = fmt.Errorf("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
+		err = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 	} else {
 		err = fmt.Errorf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", host)
 	}

--- a/client/request.go
+++ b/client/request.go
@@ -168,10 +168,10 @@ func (cli *Client) doRequest(req *http.Request) (serverResponse, error) {
 		if errors.As(err, &nErr) {
 			// FIXME(thaJeztah): any net.Error should be considered a connection error (but we should include the original error)?
 			if nErr.Timeout() {
-				return serverResp, ErrorConnectionFailed(cli.host)
+				return serverResp, connectionFailed(cli.host)
 			}
 			if strings.Contains(nErr.Error(), "connection refused") || strings.Contains(nErr.Error(), "dial unix") {
-				return serverResp, ErrorConnectionFailed(cli.host)
+				return serverResp, connectionFailed(cli.host)
 			}
 		}
 

--- a/client/request.go
+++ b/client/request.go
@@ -154,15 +154,18 @@ func (cli *Client) doRequest(req *http.Request) (serverResponse, error) {
 			return serverResp, err
 		}
 
-		if uErr, ok := err.(*url.Error); ok {
-			if nErr, ok := uErr.Err.(*net.OpError); ok {
+		var uErr *url.Error
+		if errors.As(err, &uErr) {
+			var nErr *net.OpError
+			if errors.As(uErr.Err, &nErr) {
 				if os.IsPermission(nErr.Err) {
 					return serverResp, errConnectionFailed{errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)}
 				}
 			}
 		}
 
-		if nErr, ok := err.(net.Error); ok {
+		var nErr net.Error
+		if errors.As(err, &nErr) {
 			// FIXME(thaJeztah): any net.Error should be considered a connection error (but we should include the original error)?
 			if nErr.Timeout() {
 				return serverResp, ErrorConnectionFailed(cli.host)


### PR DESCRIPTION
This function was only used internally, and will be removed in the next release.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Go SDK: client: deprecate ErrorConnectionFailed helper. This function was only used internally, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

