### PR TITLE
implement missing "Unwrapper" interface on errors that implemented "Causer" interface

### DIFF
--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -701,6 +701,10 @@ func (e *exitError) Cause() error {
 	return e.cause
 }
 
+func (e *exitError) Unwrap() error {
+	return e.cause
+}
+
 // checkHealth blocks until unhealthy container is detected or ctx exits
 func (r *controller) checkHealth(ctx context.Context) error {
 	eventq := r.adapter.events(ctx)

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -32,10 +32,14 @@ type fallbackError struct {
 
 // Error renders the FallbackError as a string.
 func (f fallbackError) Error() string {
-	return f.Cause().Error()
+	return f.err.Error()
 }
 
 func (f fallbackError) Cause() error {
+	return f.err
+}
+
+func (f fallbackError) Unwrap() error {
 	return f.err
 }
 
@@ -61,6 +65,10 @@ func (e notFoundError) Error() string {
 func (e notFoundError) NotFound() {}
 
 func (e notFoundError) Cause() error {
+	return e.cause
+}
+
+func (e notFoundError) Unwrap() error {
 	return e.cause
 }
 

--- a/volume/service/errors.go
+++ b/volume/service/errors.go
@@ -63,6 +63,11 @@ func (e *OpErr) Cause() error {
 	return e.Err
 }
 
+// Unwrap returns the error the caused this error
+func (e *OpErr) Unwrap() error {
+	return e.Err
+}
+
 // IsInUse returns a boolean indicating whether the error indicates that a
 // volume is in use
 func IsInUse(err error) bool {
@@ -84,10 +89,16 @@ type causal interface {
 	Cause() error
 }
 
+type wrapErr interface {
+	Unwrap() error
+}
+
 func isErr(err error, expected error) bool {
 	switch pe := err.(type) {
 	case nil:
 		return false
+	case wrapErr:
+		return isErr(pe.Unwrap(), expected)
 	case causal:
 		return isErr(pe.Cause(), expected)
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49378
- relates to https://github.com/containerd/errdefs/pull/22

### cluster/executor/container: exitError: implement go1.13 unwrapper

This error implemented the Causer interface, but did not implement
the go1.13 unwrapper, which could prevent errors from being matched.

### volumes/service: OpErr: implement go1.13 unwrapper

This error implemented the Causer interface, but did not implement
the go1.13 unwrapper, which could prevent errors from being matched.

### distribution: fallbackError, notFoundError implement go1.13 unwrapper

These errors implemented the Causer interface, but did not implement
the go1.13 unwrapper, which could prevent errors from being matched.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

