### PR TITLE
plugin enable: validate timeout parameter and set default in daemon

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -11679,9 +11679,12 @@ paths:
           type: "string"
         - name: "timeout"
           in: "query"
-          description: "Set the HTTP client timeout (in seconds)"
+          description: |
+            Set the HTTP client timeout (in seconds)
+
           type: "integer"
-          default: 0
+          minimum: 1
+          default: 30
       tags: ["Plugin"]
   /plugins/{name}/disable:
     post:

--- a/client/plugin_enable.go
+++ b/client/plugin_enable.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/errdefs"
+	"github.com/pkg/errors"
 )
 
 // PluginEnable enables a plugin
@@ -15,8 +17,12 @@ func (cli *Client) PluginEnable(ctx context.Context, name string, options types.
 		return err
 	}
 	query := url.Values{}
-	query.Set("timeout", strconv.Itoa(options.Timeout))
-
+	if v := options.Timeout; v != 0 {
+		if v < 0 {
+			return errdefs.InvalidParameter(errors.New("invalid timeout: value must be positive"))
+		}
+		query.Set("timeout", strconv.Itoa(v))
+	}
 	resp, err := cli.post(ctx, "/plugins/"+name+"/enable", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -77,6 +77,9 @@ func (pm *Manager) Disable(refOrID string, config *backend.PluginDisableConfig) 
 
 // Enable activates a plugin, which implies that they are ready to be used by containers.
 func (pm *Manager) Enable(refOrID string, config *backend.PluginEnableConfig) error {
+	if config.Timeout < 0 {
+		return errdefs.InvalidParameter(errors.New("invalid timeout: value must be positive"))
+	}
 	p, err := pm.config.Store.GetV2Plugin(refOrID)
 	if err != nil {
 		return err

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -92,6 +92,13 @@ type controller struct {
 	timeoutInSecs int
 }
 
+// defaultTimeoutInSecs is the default timeout to use if no value is
+// set for [controller.timeoutInSecs].
+//
+// This default matches the default that the CLI defined:
+// https://github.com/docker/cli/blob/dff0dc8afa0c7e6f99c6f0d24f749af76366a5f0/cli/command/plugin/enable.go#L33
+const defaultTimeoutInSecs = 30
+
 // NewManager returns a new plugin manager.
 func NewManager(config ManagerConfig) (*Manager, error) {
 	manager := &Manager{

--- a/plugin/manager_linux.go
+++ b/plugin/manager_linux.go
@@ -73,7 +73,12 @@ func (pm *Manager) enable(p *v2.Plugin, c *controller, force bool) error {
 
 func (pm *Manager) pluginPostStart(p *v2.Plugin, c *controller) error {
 	sockAddr := filepath.Join(pm.config.ExecRoot, p.GetID(), p.GetSocket())
-	p.SetTimeout(time.Duration(c.timeoutInSecs) * time.Second)
+
+	to := defaultTimeoutInSecs
+	if c.timeoutInSecs > 0 {
+		to = c.timeoutInSecs
+	}
+	p.SetTimeout(time.Duration(to) * time.Second)
 	addr := &net.UnixAddr{Net: "unix", Name: sockAddr}
 	p.SetAddr(addr)
 


### PR DESCRIPTION
### plugin enable: validate timeout parameter

plugin enable: validate timeout parameter, and set default on daemon

Add validation for negative timeouts; currently this is validated in the
CLI; https://github.com/docker/cli/blob/dff0dc8afa0c7e6f99c6f0d24f749af76366a5f0/cli/command/plugin/enable.go#L37-L48

```go
func runEnable(ctx context.Context, dockerCli command.Cli, opts *enableOpts) error {
	name := opts.name
	if opts.timeout < 0 {
		return errors.Errorf("negative timeout %d is invalid", opts.timeout)
	}

	if err := dockerCli.Client().PluginEnable(ctx, name, types.PluginEnableOptions{Timeout: opts.timeout}); err != nil {
		return err
	}
	fmt.Fprintln(dockerCli.Out(), name)
	return nil
}
```

Previously, the argument was a required argument, which did not match
the API specification and depended on the CLI setting the default to
30 seconds;
https://github.com/docker/cli/blob/dff0dc8afa0c7e6f99c6f0d24f749af76366a5f0/cli/command/plugin/enable.go#L33

This patch;

- checks whether a timeout is set; if not set, we use the default
- if a value is set, it must be a positive number (1 second at least)

Validation is added both in the API (to allow early exit), and in
the controller, to prevent invalid values being set through other
ways.plugin enable: validate timeout parameter, and set default on daemon


### client: Client.PluginEnable: validate timeout

Add validation for negative timeouts; currently this is validated in the
CLI; https://github.com/docker/cli/blob/dff0dc8afa0c7e6f99c6f0d24f749af76366a5f0/cli/command/plugin/enable.go#L37-L48

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
API: `POST  /plugins/{name}/enable`: add validation for timeout parameter to not be negative
```

**- A picture of a cute animal (not mandatory but encouraged)**

