### PR TITLE
pkg/idtools: un-deprecate Windows consts for now

### DIFF
--- a/pkg/idtools/idtools_windows.go
+++ b/pkg/idtools/idtools_windows.go
@@ -5,15 +5,13 @@ import (
 )
 
 const (
-	// Deprecated: copy value locally
 	SeTakeOwnershipPrivilege = "SeTakeOwnershipPrivilege"
 )
 
+// TODO(thaJeztah): these magic consts need a source of reference, and should be defined in a canonical location
 const (
-	// Deprecated: copy value locally
 	ContainerAdministratorSidString = "S-1-5-93-2-1"
 
-	// Deprecated: copy value locally
 	ContainerUserSidString = "S-1-5-93-2-2"
 )
 


### PR DESCRIPTION
- https://github.com/moby/moby/pull/49087

These consts were deprecated in 9c368a93b690735bccfdb7c371371f6ec324d81e, but are used externally and lack a canonical location. These sids are "special", as they are available by default in Windows containers, but we need to;

- Reference official documentation / specification for that.
- Add names (not just the sid)
- Consider finding a canonical location for these consts, which could be as part of the OCI specs, or hcsshim (or otherwise).

Lacking a good place for these, let's un-deprecate them for the time being until we decided what's the best location for these.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

