### PR TITLE
API: add Platform (OS and Architecture) to /containers/json

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -113,6 +113,13 @@ func (c *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 		}
 	}
 
+	if versions.LessThan(version, "1.48") {
+		// ImageManifestDescriptor information was added in API 1.48
+		for _, c := range containers {
+			c.ImageManifestDescriptor = nil
+		}
+	}
+
 	return httputils.WriteJSON(w, http.StatusOK, containers)
 }
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5109,6 +5109,17 @@ definitions:
       ImageID:
         description: "The ID of the image that this container was created from"
         type: "string"
+      ImageManifestDescriptor:
+        $ref: "#/definitions/OCIDescriptor"
+        x-nullable: true
+        description: |
+          OCI descriptor of the platform-specific manifest of the image
+          the container was created from.
+
+          Note: Only available if the daemon provides a multi-platform
+          image store.
+
+          This field is not populated in the `GET /system/df` endpoint.
       Command:
         description: "Command to run when starting the container"
         type: "string"

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -121,19 +121,20 @@ type State struct {
 // Summary contains response of Engine API:
 // GET "/containers/json"
 type Summary struct {
-	ID         string `json:"Id"`
-	Names      []string
-	Image      string
-	ImageID    string
-	Command    string
-	Created    int64
-	Ports      []Port
-	SizeRw     int64 `json:",omitempty"`
-	SizeRootFs int64 `json:",omitempty"`
-	Labels     map[string]string
-	State      string
-	Status     string
-	HostConfig struct {
+	ID                      string `json:"Id"`
+	Names                   []string
+	Image                   string
+	ImageID                 string
+	ImageManifestDescriptor *ocispec.Descriptor `json:"ImageManifestDescriptor,omitempty"`
+	Command                 string
+	Created                 int64
+	Ports                   []Port
+	SizeRw                  int64 `json:",omitempty"`
+	SizeRootFs              int64 `json:",omitempty"`
+	Labels                  map[string]string
+	State                   string
+	Status                  string
+	HostConfig              struct {
 		NetworkMode string            `json:",omitempty"`
 		Annotations map[string]string `json:",omitempty"`
 	}
@@ -183,5 +184,5 @@ type InspectResponse struct {
 	Config          *Config
 	NetworkSettings *NetworkSettings
 	// ImageManifestDescriptor is the descriptor of a platform-specific manifest of the image used to create the container.
-	ImageManifestDescriptor *ocispec.Descriptor `json:",omitempty"`
+	ImageManifestDescriptor *ocispec.Descriptor `json:"ImageManifestDescriptor,omitempty"`
 }

--- a/container/view.go
+++ b/container/view.go
@@ -301,14 +301,15 @@ func (v *View) transform(ctr *Container) *Snapshot {
 	}
 	snapshot := &Snapshot{
 		Summary: container.Summary{
-			ID:      ctr.ID,
-			Names:   v.getNames(ctr.ID),
-			ImageID: ctr.ImageID.String(),
-			Ports:   []container.Port{},
-			Mounts:  ctr.GetMountPoints(),
-			State:   ctr.State.StateString(),
-			Status:  ctr.State.String(),
-			Created: ctr.Created.Unix(),
+			ID:                      ctr.ID,
+			Names:                   v.getNames(ctr.ID),
+			ImageID:                 ctr.ImageID.String(),
+			ImageManifestDescriptor: ctr.ImageManifest,
+			Ports:                   []container.Port{},
+			Mounts:                  ctr.GetMountPoints(),
+			State:                   ctr.State.StateString(),
+			Status:                  ctr.State.String(),
+			Created:                 ctr.Created.Unix(),
 		},
 		CreatedAt:    ctr.Created,
 		StartedAt:    ctr.StartedAt,
@@ -415,6 +416,10 @@ func (v *View) transform(ctr *Container) *Snapshot {
 		}
 	}
 	snapshot.NetworkSettings = &container.NetworkSettingsSummary{Networks: networks}
+
+	if ctr.ImageManifest != nil && ctr.ImageManifest.Platform == nil {
+		ctr.ImageManifest.Platform = &ctr.ImagePlatform
+	}
 
 	return snapshot
 }

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -26,6 +26,12 @@ func (daemon *Daemon) containerDiskUsage(ctx context.Context) ([]*container.Summ
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve container list: %v", err)
 		}
+
+		// Remove image manifest descriptor from the result as it should not be included.
+		// https://github.com/moby/moby/pull/49407#discussion_r1954396666
+		for _, c := range containers {
+			c.ImageManifestDescriptor = nil
+		}
 		return containers, nil
 	})
 	return res, err

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -89,6 +89,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   paths (`/v<API-version>/<endpoint>`).
 * `POST /build/prune` renames `keep-bytes` to `reserved-space` and now supports
   additional prune parameters `max-used-space` and `min-free-space`.
+* `GET /containers/json` now returns an `ImageManifestDescriptor` field
+  matching the same field in `/containers/{name}/json`.
+  This field is only populated if the daemon provides a multi-platform image
+  store.
 
 ## v1.47 API changes
 

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -107,6 +107,9 @@ func TestDiskUsage(t *testing.T) {
 				// previously used prev.Images[0].Size, which may differ from content data
 				assert.Check(t, is.Equal(du.Containers[0].SizeRootFs, du.LayersSize))
 
+				// ImageManifestDescriptor should NOT be populated.
+				assert.Check(t, is.Nil(du.Containers[0].ImageManifestDescriptor))
+
 				return du
 			},
 		},


### PR DESCRIPTION
Adds platform information to containers (for `docker ps`).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added the platform to the `container.Summary` struct so it could be returned in `/containers/json`.

**- How I did it**

Adapted this PR for the current master and upcoming api version: https://github.com/moby/moby/pull/42464

As mentioned in the original PR, there's still some follow up. I'm copying and pasting that message here.

- filter by architecture
- perhaps a way to indicate that a container/image is non-native (useful to provide that information, so that clients don't have to replicate the "variants" such as arm/v5 running on arm64 (which is not "matching", but no emulation should be needed in that case); similarly, Windows OS versions (?)
- check for consistency, e.g. docker inspect shows a Platform: linux, but does not contain Architecture.

The last one seems to be a potentially big issue with the name. The `Platform` is used instead of the name `OS`, but `Platform` in that API is the same as the OS.

**- How to verify it**

```
docker run -d --name foo nginx:alpine

curl --unix-socket /var/run/docker.sock http://localhost/containers/json | jq
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`GET /containers/json` now returns an `ImageManifestDescriptor` field matching the same field in `/containers/{name}/json`. This field is only populated if the daemon provides a multi-platform image store.
```

**- A picture of a cute animal (not mandatory but encouraged)**

