### PR TITLE
client: custom trace options

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -227,8 +228,13 @@ func WithAPIVersionNegotiation() Opt {
 // WithTraceProvider sets the trace provider for the client.
 // If this is not set then the global trace provider will be used.
 func WithTraceProvider(provider trace.TracerProvider) Opt {
+	return WithTraceOptions(otelhttp.WithTracerProvider(provider))
+}
+
+// WithTraceOptions sets tracing span options for the client.
+func WithTraceOptions(opts ...otelhttp.Option) Opt {
 	return func(c *Client) error {
-		c.tp = provider
+		c.traceOpts = append(c.traceOpts, opts...)
 		return nil
 	}
 }


### PR DESCRIPTION
I was surprised to see docker HTTP spans appearing in my newly instrumented app. These are useful but a little noisy in my traces.
I'd like to add some extra attributes to visually identify Docker spans in Grafana, something like
```golang
otelhttp.WithSpanOptions(trace.WithAttributes(semconv.PeerService("docker")))
```
Rather than forcing this on everyone, a new `client.With*` option accepting `[]otelhttp.Option` would be ideal.

**- What I did**

Introduced a `client.WithTraceOptions` func for supplying custom options to `otelhttp.NewTransport`. This extends the current `WithTraceProvider` option to include any `otelhttp` option.

**- How to verify it**

Create a client with extra span attributes and validate in your APM tool of choice.
```golang
cli, err := client.NewClientWithOpts(
	client.WithTraceOptions(
		otelhttp.WithSpanOptions(
			trace.WithAttributes(
				semconv.PeerService("docker"),
			),
		),
	),
)
```

**Bonus:** A side effect of this is the ability to override the span name formatter, since custom options are applied after the defaults.
```golang
cli, err := client.NewClientWithOpts(
	client.WithTraceOptions(
		otelhttp.WithSpanNameFormatter(
			func(operation string, r *http.Request) string {
				return "DOCKER: " + operation
			},
		),
	),
)
```

**- Human readable description for the release notes**
```markdown changelog
client: Add `WithTraceOptions` allowing to specify custom OTEL trace options.
```
