### PR TITLE
golangci-lint: enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - importas
     - ineffassign
     - misspell      # Detects commonly misspelled English words in comments.
+    - nilnesserr    # Detects returning nil errors. It combines the features of nilness and nilerr,
     - revive        # Metalinter; drop-in replacement for golint.
     - staticcheck
     - typecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - dogsled       # Detects assignments with too many blank identifiers.
     - dupword       # Detects duplicate words.
     - durationcheck # Detect cases where two time.Duration values are being multiplied in possibly erroneous ways.
+    - errchkjson    # Detects unsupported types passed to json encoding functions and reports if checks for the returned error can be omitted.
     - exptostd      # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
     - fatcontext    # Detects nested contexts in loops and function literals.
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - misspell      # Detects commonly misspelled English words in comments.
     - nilnesserr    # Detects returning nil errors. It combines the features of nilness and nilerr,
     - nosprintfhostport # Detects misuse of Sprintf to construct a host with port in a URL.
+    - reassign      # Detects reassigning a top-level variable in another package.
     - revive        # Metalinter; drop-in replacement for golint.
     - spancheck     # Detects mistakes with OpenTelemetry/Census spans.
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - mirror        # Detects wrong mirror patterns of bytes/strings usage.
     - misspell      # Detects commonly misspelled English words in comments.
     - nilnesserr    # Detects returning nil errors. It combines the features of nilness and nilerr,
+    - nosprintfhostport # Detects misuse of Sprintf to construct a host with port in a URL.
     - revive        # Metalinter; drop-in replacement for golint.
     - spancheck     # Detects mistakes with OpenTelemetry/Census spans.
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - exhaustive    # Detects missing options in enum switch statements.
     - exptostd      # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
     - fatcontext    # Detects nested contexts in loops and function literals.
+    - gocheckcompilerdirectives # Detects invalid go compiler directive comments (//go:).
     - goimports
     - gosec         # Detects security problems.
     - gosimple

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - gosimple
     - govet
     - forbidigo
+    - iface         # Detects incorrect use of interfaces. Currently only used for "identical" interfaces in the same package.
     - importas
     - ineffassign
     - misspell      # Detects commonly misspelled English words in comments.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
     - depguard
     - dupword       # Detects duplicate words.
     - exptostd      # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
+    - fatcontext    # Detects nested contexts in loops and function literals.
     - goimports
     - gosec         # Detects security problems.
     - gosimple

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - misspell      # Detects commonly misspelled English words in comments.
     - nilnesserr    # Detects returning nil errors. It combines the features of nilness and nilerr,
     - revive        # Metalinter; drop-in replacement for golint.
+    - spancheck     # Detects mistakes with OpenTelemetry/Census spans.
     - staticcheck
     - typecheck
     - unconvert     # Detects unnecessary type conversions.
@@ -114,6 +115,13 @@ linters-settings:
       # FIXME make sure all packages have a description. Currently, there's many packages without.
       - name: package-comments
         disabled: true
+
+  spancheck:
+    # Default: ["end"]
+    checks:
+      - end             # check that `span.End()` is called
+      - record-error    # check that `span.RecordError(err)` is called when an error is returned
+      - set-status      # check that `span.SetStatus(codes.Error, msg)` is called when an error is returned
 
 issues:
   # The default exclusion rules are a bit too permissive, so copying the relevant ones below

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - typecheck
     - unconvert     # Detects unnecessary type conversions.
     - unused
+    - wastedassign  # Detects wasted assignment statements.
 
   disable:
     - errcheck
@@ -166,6 +167,11 @@ issues:
       path: "api/types/(volume|container)/"
       linters:
         - revive
+
+    # FIXME: ignoring unused assigns to ctx for now; too many hits in libnetwork/xxx functions that setup traces
+    - text: "assigned to ctx, but never used afterwards"
+      linters:
+        - wastedassign
 
     - text: "ineffectual assignment to ctx"
       source: "ctx[, ].*=.*\\(ctx[,)]"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - depguard
     - dogsled       # Detects assignments with too many blank identifiers.
     - dupword       # Detects duplicate words.
+    - durationcheck # Detect cases where two time.Duration values are being multiplied in possibly erroneous ways.
     - exptostd      # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
     - fatcontext    # Detects nested contexts in loops and function literals.
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
     - asasalint     # Detects "[]any" used as argument for variadic "func(...any)".
     - copyloopvar   # Detects places where loop variables are copied.
     - depguard
+    - dogsled       # Detects assignments with too many blank identifiers.
     - dupword       # Detects duplicate words.
     - exptostd      # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
     - fatcontext    # Detects nested contexts in loops and function literals.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - iface         # Detects incorrect use of interfaces. Currently only used for "identical" interfaces in the same package.
     - importas
     - ineffassign
+    - makezero      # Finds slice declarations with non-zero initial length.
     - misspell      # Detects commonly misspelled English words in comments.
     - nilnesserr    # Detects returning nil errors. It combines the features of nilness and nilerr,
     - revive        # Metalinter; drop-in replacement for golint.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
     - copyloopvar   # Detects places where loop variables are copied.
     - depguard
     - dupword       # Detects duplicate words.
+    - exptostd      # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
     - goimports
     - gosec         # Detects security problems.
     - gosimple

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - asasalint     # Detects "[]any" used as argument for variadic "func(...any)".
     - copyloopvar   # Detects places where loop variables are copied.
     - depguard
     - dupword       # Detects duplicate words.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - dupword       # Detects duplicate words.
     - durationcheck # Detect cases where two time.Duration values are being multiplied in possibly erroneous ways.
     - errchkjson    # Detects unsupported types passed to json encoding functions and reports if checks for the returned error can be omitted.
+    - exhaustive    # Detects missing options in enum switch statements.
     - exptostd      # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
     - fatcontext    # Detects nested contexts in loops and function literals.
     - goimports
@@ -68,6 +69,19 @@ linters-settings:
       - "true"    # some tests use this as expected output
       - "false"   # some tests use this as expected output
       - "root"    # for tests using "ls" output with files owned by "root:root"
+
+  exhaustive:
+    # Program elements to check for exhaustiveness.
+    # Default: [ switch ]
+    check:
+      - switch
+      # - map # TODO(thaJeztah): also enable for maps
+    # Presence of "default" case in switch statements satisfies exhaustiveness,
+    # even if all enum members are not listed.
+    # Default: false
+    #
+    # TODO(thaJeztah): consider not allowing this to catch new values being added (and falling through to "default")
+    default-signifies-exhaustive: true
 
   forbidigo:
     forbid:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - importas
     - ineffassign
     - makezero      # Finds slice declarations with non-zero initial length.
+    - mirror        # Detects wrong mirror patterns of bytes/strings usage.
     - misspell      # Detects commonly misspelled English words in comments.
     - nilnesserr    # Detects returning nil errors. It combines the features of nilness and nilerr,
     - revive        # Metalinter; drop-in replacement for golint.


### PR DESCRIPTION
- [x] depends on https://github.com/moby/moby/pull/49416
- [x] depends on https://github.com/moby/moby/pull/49417

-----

### golangci-lint: enable exptostd linter

New linter that detects functions from golang.org/x/exp/ that can be
replaced by std functions: https://github.com/ldez/exptostd

### golangci-lint: enable nilnesserr linter

New linter that detects returning nil errors. It combines the features
of nilness and nilerr: https://github.com/alingse/nilnesserr


### golangci-lint: enable iface linter (with default settings)

This linter has various other options for "correct" use of interfaces,
but those are too disruptive, so only enabling it with the default
settings, which detects duplicate interface definitions withing a
package.

### golangci-lint: enable makezero linter

Finds slice declarations with non-zero initial length;
https://github.com/ashanbrown/makezero

### golangci-lint: enable mirror linter

Detects wrong mirror patterns of bytes/strings usage; https://github.com/butuzov/mirror

### golangci-lint: enable spancheck linter

Detects mistakes with OpenTelemetry/Census spans;
https://github.com/jjti/go-spancheck

### golangci-lint: enable nosprintfhostport linter (again)

Looks like we had it enabled at some point, given that there's various
"nolint" comments; https://github.com/stbenjam/no-sprintf-host-port

### golangci-lint: enable fatcontext linter

Detects nested contexts in loops and function literals;
https://github.com/Crocmagnon/fatcontext


### golangci-lint: enable wastedassign linter

Detects wasted assignment statements; https://github.com/sanposhiho/wastedassign

For now, ignoring wasted asigns to `ctx` as there were too many hits in
libnetwork in functions that set up spans;

    libnetwork/drivers/bridge/bridge_linux.go:1319:2: assigned to ctx, but never used afterwards (wastedassign)
        ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.linkUp", trace.WithAttributes(
        ^
    libnetwork/drivers/bridge/bridge_linux.go:1448:2: assigned to ctx, but never used afterwards (wastedassign)
        ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.Join", trace.WithAttributes(
        ^

### golangci-lint: enable asasalint linter

Detects "[]any" used as argument for variadic "func(...any)";
https://github.com/alingse/asasalint

### golangci-lint: enable dogsled linter

Checks assignments with too many blank identifiers;
https://github.com/alexkohler/dogsled

### golangci-lint: enable durationcheck linter

detect cases where two time.Duration values are being multiplied in
possibly erroneous ways;
https://github.com/charithe/durationcheck

### golangci-lint: enable errchkjson linter

Detects unsupported types passed to json encoding functions and reports
if checks for the returned error can be omitted;
https://github.com/breml/errchkjson

### golangci-lint: enable exhaustive linter

Checks exhaustiveness of enum switch statements in Go source code;
https://github.com/nishanths/exhaustive

For now allowing "default" to satisfy this, but left TODOs in various
places to make switches actually exhaustive so that we can detect missing
cases when new options are added.


### golangci-lint: enable gocheckcompilerdirectives linter

Detects invalid go compiler directive comments (//go:);
https://github.com/leighmcculloch/gocheckcompilerdirectives

### golangci-lint: enable reassign linter

Detects reassigning a top-level variable in another package.
https://github.com/curioswitch/go-reassign





**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

