### PR TITLE
client: remove serverResponse and use http.Response directly

### DIFF
--- a/client/build_cancel.go
+++ b/client/build_cancel.go
@@ -10,7 +10,7 @@ func (cli *Client) BuildCancel(ctx context.Context, id string) error {
 	query := url.Values{}
 	query.Set("id", id)
 
-	serverResp, err := cli.post(ctx, "/build/cancel", query, nil, nil)
-	ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/build/cancel", query, nil, nil)
+	ensureReaderClosed(resp)
 	return err
 }

--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -40,15 +40,15 @@ func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePru
 	}
 	query.Set("filters", f)
 
-	serverResp, err := cli.post(ctx, "/build/prune", query, nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/build/prune", query, nil, nil)
+	defer ensureReaderClosed(resp)
 
 	if err != nil {
 		return nil, err
 	}
 
 	report := types.BuildCachePruneReport{}
-	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
 		return nil, errors.Wrap(err, "error retrieving disk usage")
 	}
 

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -23,6 +23,6 @@ func (cli *Client) CheckpointList(ctx context.Context, container string, options
 		return checkpoints, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&checkpoints)
+	err = json.NewDecoder(resp.Body).Decode(&checkpoints)
 	return checkpoints, err
 }

--- a/client/config_create.go
+++ b/client/config_create.go
@@ -20,6 +20,6 @@ func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (t
 		return response, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -24,7 +24,7 @@ func (cli *Client) ConfigInspectWithRaw(ctx context.Context, id string) (swarm.C
 		return swarm.Config{}, nil, err
 	}
 
-	body, err := io.ReadAll(resp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return swarm.Config{}, nil, err
 	}

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -33,6 +33,6 @@ func (cli *Client) ConfigList(ctx context.Context, options types.ConfigListOptio
 	}
 
 	var configs []swarm.Config
-	err = json.NewDecoder(resp.body).Decode(&configs)
+	err = json.NewDecoder(resp.Body).Decode(&configs)
 	return configs, err
 }

--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -55,6 +55,6 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 		return response, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -24,12 +24,12 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
-	response, err := cli.head(ctx, "/containers/"+containerID+"/archive", query, nil)
-	defer ensureReaderClosed(response)
+	resp, err := cli.head(ctx, "/containers/"+containerID+"/archive", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return container.PathStat{}, err
 	}
-	return getContainerPathStatFromHeader(response.header)
+	return getContainerPathStatFromHeader(resp.Header)
 }
 
 // CopyToContainer copies content into the container filesystem.
@@ -71,7 +71,7 @@ func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath s
 	query := make(url.Values, 1)
 	query.Set("path", filepath.ToSlash(srcPath)) // Normalize the paths used in the API.
 
-	response, err := cli.get(ctx, "/containers/"+containerID+"/archive", query, nil)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/archive", query, nil)
 	if err != nil {
 		return nil, container.PathStat{}, err
 	}
@@ -82,11 +82,11 @@ func (cli *Client) CopyFromContainer(ctx context.Context, containerID, srcPath s
 	// copy it locally. Along with the stat info about the local destination,
 	// we have everything we need to handle the multiple possibilities there
 	// can be when copying a file/dir from one location to another file/dir.
-	stat, err := getContainerPathStatFromHeader(response.header)
+	stat, err := getContainerPathStatFromHeader(resp.Header)
 	if err != nil {
 		return nil, stat, fmt.Errorf("unable to get resource stat from response: %s", err)
 	}
-	return response.body, stat, err
+	return resp.Body, stat, err
 }
 
 func getContainerPathStatFromHeader(header http.Header) (container.PathStat, error) {

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -79,13 +79,13 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 		NetworkingConfig: networkingConfig,
 	}
 
-	serverResp, err := cli.post(ctx, "/containers/create", query, body, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/containers/create", query, body, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return response, err
 	}
 
-	err = json.NewDecoder(serverResp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }
 

--- a/client/container_diff.go
+++ b/client/container_diff.go
@@ -15,14 +15,14 @@ func (cli *Client) ContainerDiff(ctx context.Context, containerID string) ([]con
 		return nil, err
 	}
 
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/changes", url.Values{}, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/changes", url.Values{}, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var changes []container.FilesystemChange
-	err = json.NewDecoder(serverResp.body).Decode(&changes)
+	err = json.NewDecoder(resp.Body).Decode(&changes)
 	if err != nil {
 		return nil, err
 	}

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -40,7 +40,7 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, containerID string, 
 	}
 
 	var response container.ExecCreateResponse
-	err = json.NewDecoder(resp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }
 
@@ -75,7 +75,7 @@ func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (con
 		return response, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/container_export.go
+++ b/client/container_export.go
@@ -15,10 +15,10 @@ func (cli *Client) ContainerExport(ctx context.Context, containerID string) (io.
 		return nil, err
 	}
 
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/export", url.Values{}, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return serverResp.body, nil
+	return resp.Body, nil
 }

--- a/client/container_inspect.go
+++ b/client/container_inspect.go
@@ -17,14 +17,14 @@ func (cli *Client) ContainerInspect(ctx context.Context, containerID string) (co
 		return container.InspectResponse{}, err
 	}
 
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return container.InspectResponse{}, err
 	}
 
 	var response container.InspectResponse
-	err = json.NewDecoder(serverResp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }
 
@@ -39,13 +39,13 @@ func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID stri
 	if getSize {
 		query.Set("size", "1")
 	}
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/containers/"+containerID+"/json", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return container.InspectResponse{}, nil, err
 	}
 
-	body, err := io.ReadAll(serverResp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return container.InspectResponse{}, nil, err
 	}

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -51,6 +51,6 @@ func (cli *Client) ContainerList(ctx context.Context, options container.ListOpti
 	}
 
 	var containers []container.Summary
-	err = json.NewDecoder(resp.body).Decode(&containers)
+	err = json.NewDecoder(resp.Body).Decode(&containers)
 	return containers, err
 }

--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -81,5 +81,5 @@ func (cli *Client) ContainerLogs(ctx context.Context, containerID string, option
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }

--- a/client/container_prune.go
+++ b/client/container_prune.go
@@ -20,14 +20,14 @@ func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Arg
 		return container.PruneReport{}, err
 	}
 
-	serverResp, err := cli.post(ctx, "/containers/prune", query, nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/containers/prune", query, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return container.PruneReport{}, err
 	}
 
 	var report container.PruneReport
-	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
 		return container.PruneReport{}, fmt.Errorf("Error retrieving disk usage: %v", err)
 	}
 

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -27,8 +27,8 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 	}
 
 	return container.StatsResponseReader{
-		Body:   resp.body,
-		OSType: getDockerOS(resp.header.Get("Server")),
+		Body:   resp.Body,
+		OSType: getDockerOS(resp.Header.Get("Server")),
 	}, nil
 }
 
@@ -50,7 +50,7 @@ func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string
 	}
 
 	return container.StatsResponseReader{
-		Body:   resp.body,
-		OSType: getDockerOS(resp.header.Get("Server")),
+		Body:   resp.Body,
+		OSType: getDockerOS(resp.Header.Get("Server")),
 	}, nil
 }

--- a/client/container_top.go
+++ b/client/container_top.go
@@ -28,6 +28,6 @@ func (cli *Client) ContainerTop(ctx context.Context, containerID string, argumen
 	}
 
 	var response container.TopResponse
-	err = json.NewDecoder(resp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/container_update.go
+++ b/client/container_update.go
@@ -14,13 +14,13 @@ func (cli *Client) ContainerUpdate(ctx context.Context, containerID string, upda
 		return container.UpdateResponse{}, err
 	}
 
-	serverResp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/update", nil, updateConfig, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return container.UpdateResponse{}, err
 	}
 
 	var response container.UpdateResponse
-	err = json.NewDecoder(serverResp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/container_wait.go
+++ b/client/container_wait.go
@@ -67,9 +67,8 @@ func (cli *Client) ContainerWait(ctx context.Context, containerID string, condit
 	go func() {
 		defer ensureReaderClosed(resp)
 
-		body := resp.body
 		responseText := bytes.NewBuffer(nil)
-		stream := io.TeeReader(body, responseText)
+		stream := io.TeeReader(resp.Body, responseText)
 
 		var res container.WaitResponse
 		if err := json.NewDecoder(stream).Decode(&res); err != nil {
@@ -111,7 +110,7 @@ func (cli *Client) legacyContainerWait(ctx context.Context, containerID string) 
 		defer ensureReaderClosed(resp)
 
 		var res container.WaitResponse
-		if err := json.NewDecoder(resp.body).Decode(&res); err != nil {
+		if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 			errC <- err
 			return
 		}

--- a/client/disk_usage.go
+++ b/client/disk_usage.go
@@ -19,14 +19,14 @@ func (cli *Client) DiskUsage(ctx context.Context, options types.DiskUsageOptions
 		}
 	}
 
-	serverResp, err := cli.get(ctx, "/system/df", query, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/system/df", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return types.DiskUsage{}, err
 	}
 
 	var du types.DiskUsage
-	if err := json.NewDecoder(serverResp.body).Decode(&du); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&du); err != nil {
 		return types.DiskUsage{}, fmt.Errorf("Error retrieving disk usage: %v", err)
 	}
 	return du, nil

--- a/client/distribution_inspect.go
+++ b/client/distribution_inspect.go
@@ -11,14 +11,12 @@ import (
 
 // DistributionInspect returns the image digest with the full manifest.
 func (cli *Client) DistributionInspect(ctx context.Context, imageRef, encodedRegistryAuth string) (registry.DistributionInspect, error) {
-	// Contact the registry to retrieve digest and platform information
-	var distributionInspect registry.DistributionInspect
 	if imageRef == "" {
-		return distributionInspect, objectNotFoundError{object: "distribution", id: imageRef}
+		return registry.DistributionInspect{}, objectNotFoundError{object: "distribution", id: imageRef}
 	}
 
 	if err := cli.NewVersionError(ctx, "1.30", "distribution inspect"); err != nil {
-		return distributionInspect, err
+		return registry.DistributionInspect{}, err
 	}
 
 	var headers http.Header
@@ -28,12 +26,14 @@ func (cli *Client) DistributionInspect(ctx context.Context, imageRef, encodedReg
 		}
 	}
 
+	// Contact the registry to retrieve digest and platform information
 	resp, err := cli.get(ctx, "/distribution/"+imageRef+"/json", url.Values{}, headers)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return distributionInspect, err
+		return registry.DistributionInspect{}, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&distributionInspect)
+	var distributionInspect registry.DistributionInspect
+	err = json.NewDecoder(resp.Body).Decode(&distributionInspect)
 	return distributionInspect, err
 }

--- a/client/events.go
+++ b/client/events.go
@@ -36,9 +36,9 @@ func (cli *Client) Events(ctx context.Context, options events.ListOptions) (<-ch
 			errs <- err
 			return
 		}
-		defer resp.body.Close()
+		defer resp.Body.Close()
 
-		decoder := json.NewDecoder(resp.body)
+		decoder := json.NewDecoder(resp.Body)
 
 		close(started)
 		for {

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -33,14 +33,14 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 	headers.Add("X-Registry-Config", base64.URLEncoding.EncodeToString(buf))
 	headers.Set("Content-Type", "application/x-tar")
 
-	serverResp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
+	resp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
 	if err != nil {
 		return types.ImageBuildResponse{}, err
 	}
 
 	return types.ImageBuildResponse{
-		Body:   serverResp.body,
-		OSType: getDockerOS(serverResp.header.Get("Server")),
+		Body:   resp.Body,
+		OSType: getDockerOS(resp.Header.Get("Server")),
 	}, nil
 }
 

--- a/client/image_create.go
+++ b/client/image_create.go
@@ -30,10 +30,10 @@ func (cli *Client) ImageCreate(ctx context.Context, parentReference string, opti
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }
 
-func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, registryAuth string) (*http.Response, error) {
 	return cli.post(ctx, "/images/create", query, nil, http.Header{
 		registry.AuthHeader: {registryAuth},
 	})

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -23,13 +23,13 @@ func (cli *Client) ImageHistory(ctx context.Context, imageID string, opts image.
 		query.Set("platform", p)
 	}
 
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/history", query, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/images/"+imageID+"/history", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err
 	}
 
 	var history []image.HistoryResponseItem
-	err = json.NewDecoder(serverResp.body).Decode(&history)
+	err = json.NewDecoder(resp.Body).Decode(&history)
 	return history, err
 }

--- a/client/image_import.go
+++ b/client/image_import.go
@@ -44,5 +44,5 @@ func (cli *Client) ImageImport(ctx context.Context, source image.ImportSource, r
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -75,8 +75,8 @@ func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts
 		query.Set("manifests", "1")
 	}
 
-	serverResp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return image.InspectResponse{}, err
 	}
@@ -86,7 +86,7 @@ func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts
 		buf = &bytes.Buffer{}
 	}
 
-	if _, err := io.Copy(buf, serverResp.body); err != nil {
+	if _, err := io.Copy(buf, resp.Body); err != nil {
 		return image.InspectResponse{}, err
 	}
 

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -56,12 +56,12 @@ func (cli *Client) ImageList(ctx context.Context, options image.ListOptions) ([]
 		query.Set("manifests", "1")
 	}
 
-	serverResp, err := cli.get(ctx, "/images/json", query, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/images/json", query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return images, err
 	}
 
-	err = json.NewDecoder(serverResp.body).Decode(&images)
+	err = json.NewDecoder(resp.Body).Decode(&images)
 	return images, err
 }

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -41,7 +41,7 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, opts image.Lo
 		return image.LoadResponse{}, err
 	}
 	return image.LoadResponse{
-		Body: resp.body,
-		JSON: resp.header.Get("Content-Type") == "application/json",
+		Body: resp.Body,
+		JSON: resp.Header.Get("Content-Type") == "application/json",
 	}, nil
 }

--- a/client/image_prune.go
+++ b/client/image_prune.go
@@ -20,14 +20,14 @@ func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (
 		return image.PruneReport{}, err
 	}
 
-	serverResp, err := cli.post(ctx, "/images/prune", query, nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/images/prune", query, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return image.PruneReport{}, err
 	}
 
 	var report image.PruneReport
-	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
 		return image.PruneReport{}, fmt.Errorf("Error retrieving disk usage: %v", err)
 	}
 

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -45,7 +45,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options image.P
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -63,10 +63,10 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options image.Pu
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }
 
-func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, registryAuth string) (*http.Response, error) {
 	return cli.post(ctx, "/images/"+imageID+"/push", query, nil, http.Header{
 		registry.AuthHeader: {registryAuth},
 	})

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -19,13 +19,13 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options imag
 		query.Set("noprune", "1")
 	}
 
-	var dels []image.DeleteResponse
 	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return dels, err
+		return nil, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&dels)
+	var dels []image.DeleteResponse
+	err = json.NewDecoder(resp.Body).Decode(&dels)
 	return dels, err
 }

--- a/client/image_save.go
+++ b/client/image_save.go
@@ -30,5 +30,5 @@ func (cli *Client) ImageSave(ctx context.Context, imageIDs []string, opts image.
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -43,11 +43,11 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options registr
 		return results, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&results)
+	err = json.NewDecoder(resp.Body).Decode(&results)
 	return results, err
 }
 
-func (cli *Client) tryImageSearch(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryImageSearch(ctx context.Context, query url.Values, registryAuth string) (*http.Response, error) {
 	return cli.get(ctx, "/images/search", query, http.Header{
 		registry.AuthHeader: {registryAuth},
 	})

--- a/client/info.go
+++ b/client/info.go
@@ -12,13 +12,13 @@ import (
 // Info returns information about the docker server.
 func (cli *Client) Info(ctx context.Context) (system.Info, error) {
 	var info system.Info
-	serverResp, err := cli.get(ctx, "/info", url.Values{}, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/info", url.Values{}, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return info, err
 	}
 
-	if err := json.NewDecoder(serverResp.body).Decode(&info); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
 		return info, fmt.Errorf("Error reading remote info: %v", err)
 	}
 

--- a/client/login.go
+++ b/client/login.go
@@ -19,6 +19,6 @@ func (cli *Client) RegistryLogin(ctx context.Context, auth registry.AuthConfig) 
 	}
 
 	var response registry.AuthenticateOKBody
-	err = json.NewDecoder(resp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/network_create.go
+++ b/client/network_create.go
@@ -10,15 +10,13 @@ import (
 
 // NetworkCreate creates a new network in the docker host.
 func (cli *Client) NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error) {
-	var response network.CreateResponse
-
 	// Make sure we negotiated (if the client is configured to do so),
 	// as code below contains API-version specific handling of options.
 	//
 	// Normally, version-negotiation (if enabled) would not happen until
 	// the API request is made.
 	if err := cli.checkVersion(ctx); err != nil {
-		return response, err
+		return network.CreateResponse{}, err
 	}
 
 	networkCreateRequest := network.CreateRequest{
@@ -30,12 +28,13 @@ func (cli *Client) NetworkCreate(ctx context.Context, name string, options netwo
 		networkCreateRequest.CheckDuplicate = &enabled //nolint:staticcheck // ignore SA1019: CheckDuplicate is deprecated since API v1.44.
 	}
 
-	serverResp, err := cli.post(ctx, "/networks/create", nil, networkCreateRequest, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/networks/create", nil, networkCreateRequest, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
-		return response, err
+		return network.CreateResponse{}, err
 	}
 
-	err = json.NewDecoder(serverResp.body).Decode(&response)
+	var response network.CreateResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -36,7 +36,7 @@ func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, 
 		return network.Inspect{}, nil, err
 	}
 
-	raw, err := io.ReadAll(resp.body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return network.Inspect{}, nil, err
 	}

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -27,6 +27,6 @@ func (cli *Client) NetworkList(ctx context.Context, options network.ListOptions)
 	if err != nil {
 		return networkResources, err
 	}
-	err = json.NewDecoder(resp.body).Decode(&networkResources)
+	err = json.NewDecoder(resp.Body).Decode(&networkResources)
 	return networkResources, err
 }

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -20,14 +20,14 @@ func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters filters.Args)
 		return network.PruneReport{}, err
 	}
 
-	serverResp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return network.PruneReport{}, err
 	}
 
 	var report network.PruneReport
-	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
 		return network.PruneReport{}, fmt.Errorf("Error retrieving network prune report: %v", err)
 	}
 

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -15,13 +15,13 @@ func (cli *Client) NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm
 	if err != nil {
 		return swarm.Node{}, nil, err
 	}
-	serverResp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Node{}, nil, err
 	}
 
-	body, err := io.ReadAll(serverResp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return swarm.Node{}, nil, err
 	}

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -30,6 +30,6 @@ func (cli *Client) NodeList(ctx context.Context, options types.NodeListOptions) 
 	}
 
 	var nodes []swarm.Node
-	err = json.NewDecoder(resp.body).Decode(&nodes)
+	err = json.NewDecoder(resp.Body).Decode(&nodes)
 	return nodes, err
 }

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -21,7 +21,7 @@ func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*type
 		return nil, nil, err
 	}
 
-	body, err := io.ReadAll(resp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/plugin_install.go
+++ b/client/plugin_install.go
@@ -35,13 +35,13 @@ func (cli *Client) PluginInstall(ctx context.Context, name string, options types
 		return nil, err
 	}
 
-	name = resp.header.Get("Docker-Plugin-Name")
+	name = resp.Header.Get("Docker-Plugin-Name")
 
 	pr, pw := io.Pipe()
 	go func() { // todo: the client should probably be designed more around the actual api
-		_, err := io.Copy(pw, resp.body)
+		_, err := io.Copy(pw, resp.Body)
 		if err != nil {
-			pw.CloseWithError(err)
+			_ = pw.CloseWithError(err)
 			return
 		}
 		defer func() {
@@ -52,29 +52,29 @@ func (cli *Client) PluginInstall(ctx context.Context, name string, options types
 		}()
 		if len(options.Args) > 0 {
 			if err := cli.PluginSet(ctx, name, options.Args); err != nil {
-				pw.CloseWithError(err)
+				_ = pw.CloseWithError(err)
 				return
 			}
 		}
 
 		if options.Disabled {
-			pw.Close()
+			_ = pw.Close()
 			return
 		}
 
 		enableErr := cli.PluginEnable(ctx, name, types.PluginEnableOptions{Timeout: 0})
-		pw.CloseWithError(enableErr)
+		_ = pw.CloseWithError(enableErr)
 	}()
 	return pr, nil
 }
 
-func (cli *Client) tryPluginPrivileges(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryPluginPrivileges(ctx context.Context, query url.Values, registryAuth string) (*http.Response, error) {
 	return cli.get(ctx, "/plugins/privileges", query, http.Header{
 		registry.AuthHeader: {registryAuth},
 	})
 }
 
-func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, privileges types.PluginPrivileges, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, privileges types.PluginPrivileges, registryAuth string) (*http.Response, error) {
 	return cli.post(ctx, "/plugins/pull", query, privileges, http.Header{
 		registry.AuthHeader: {registryAuth},
 	})
@@ -98,7 +98,7 @@ func (cli *Client) checkPluginPermissions(ctx context.Context, query url.Values,
 	}
 
 	var privileges types.PluginPrivileges
-	if err := json.NewDecoder(resp.body).Decode(&privileges); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&privileges); err != nil {
 		ensureReaderClosed(resp)
 		return nil, err
 	}

--- a/client/plugin_list.go
+++ b/client/plugin_list.go
@@ -28,6 +28,6 @@ func (cli *Client) PluginList(ctx context.Context, filter filters.Args) (types.P
 		return plugins, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&plugins)
+	err = json.NewDecoder(resp.Body).Decode(&plugins)
 	return plugins, err
 }

--- a/client/plugin_push.go
+++ b/client/plugin_push.go
@@ -20,5 +20,5 @@ func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth str
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }

--- a/client/plugin_upgrade.go
+++ b/client/plugin_upgrade.go
@@ -37,10 +37,10 @@ func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }
 
-func (cli *Client) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (*http.Response, error) {
 	return cli.post(ctx, "/plugins/"+name+"/upgrade", query, privileges, http.Header{
 		registry.AuthHeader: {registryAuth},
 	})

--- a/client/request.go
+++ b/client/request.go
@@ -19,47 +19,39 @@ import (
 	"github.com/pkg/errors"
 )
 
-// serverResponse is a wrapper for http API responses.
-type serverResponse struct {
-	body       io.ReadCloser
-	header     http.Header
-	statusCode int
-	reqURL     *url.URL
-}
-
 // head sends an http request to the docker API using the method HEAD.
-func (cli *Client) head(ctx context.Context, path string, query url.Values, headers http.Header) (serverResponse, error) {
+func (cli *Client) head(ctx context.Context, path string, query url.Values, headers http.Header) (*http.Response, error) {
 	return cli.sendRequest(ctx, http.MethodHead, path, query, nil, headers)
 }
 
 // get sends an http request to the docker API using the method GET with a specific Go context.
-func (cli *Client) get(ctx context.Context, path string, query url.Values, headers http.Header) (serverResponse, error) {
+func (cli *Client) get(ctx context.Context, path string, query url.Values, headers http.Header) (*http.Response, error) {
 	return cli.sendRequest(ctx, http.MethodGet, path, query, nil, headers)
 }
 
 // post sends an http request to the docker API using the method POST with a specific Go context.
-func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers http.Header) (serverResponse, error) {
+func (cli *Client) post(ctx context.Context, path string, query url.Values, obj interface{}, headers http.Header) (*http.Response, error) {
 	body, headers, err := encodeBody(obj, headers)
 	if err != nil {
-		return serverResponse{}, err
+		return nil, err
 	}
 	return cli.sendRequest(ctx, http.MethodPost, path, query, body, headers)
 }
 
-func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers http.Header) (serverResponse, error) {
+func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers http.Header) (*http.Response, error) {
 	return cli.sendRequest(ctx, http.MethodPost, path, query, body, headers)
 }
 
-func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers http.Header) (serverResponse, error) {
+func (cli *Client) put(ctx context.Context, path string, query url.Values, obj interface{}, headers http.Header) (*http.Response, error) {
 	body, headers, err := encodeBody(obj, headers)
 	if err != nil {
-		return serverResponse{}, err
+		return nil, err
 	}
 	return cli.putRaw(ctx, path, query, body, headers)
 }
 
 // putRaw sends an http request to the docker API using the method PUT.
-func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers http.Header) (serverResponse, error) {
+func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers http.Header) (*http.Response, error) {
 	// PUT requests are expected to always have a body (apparently)
 	// so explicitly pass an empty body to sendRequest to signal that
 	// it should set the Content-Type header if not already present.
@@ -70,7 +62,7 @@ func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, bo
 }
 
 // delete sends an http request to the docker API using the method DELETE.
-func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers http.Header) (serverResponse, error) {
+func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers http.Header) (*http.Response, error) {
 	return cli.sendRequest(ctx, http.MethodDelete, path, query, nil, headers)
 }
 
@@ -116,42 +108,40 @@ func (cli *Client) buildRequest(ctx context.Context, method, path string, body i
 	return req, nil
 }
 
-func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers http.Header) (serverResponse, error) {
+func (cli *Client) sendRequest(ctx context.Context, method, path string, query url.Values, body io.Reader, headers http.Header) (*http.Response, error) {
 	req, err := cli.buildRequest(ctx, method, cli.getAPIPath(ctx, path, query), body, headers)
 	if err != nil {
-		return serverResponse{}, err
+		return nil, err
 	}
 
 	resp, err := cli.doRequest(req)
 	switch {
 	case errors.Is(err, context.Canceled):
-		return serverResponse{}, errdefs.Cancelled(err)
+		return nil, errdefs.Cancelled(err)
 	case errors.Is(err, context.DeadlineExceeded):
-		return serverResponse{}, errdefs.Deadline(err)
+		return nil, errdefs.Deadline(err)
 	case err == nil:
-		err = cli.checkResponseErr(resp)
+		return resp, cli.checkResponseErr(resp)
+	default:
+		return resp, err
 	}
-	return resp, errdefs.FromStatusCode(err, resp.statusCode)
 }
 
-// FIXME(thaJeztah): Should this actually return a serverResp when a connection error occurred?
-func (cli *Client) doRequest(req *http.Request) (serverResponse, error) {
-	serverResp := serverResponse{statusCode: -1, reqURL: req.URL}
-
+func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	resp, err := cli.client.Do(req)
 	if err != nil {
 		if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
-			return serverResp, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
+			return nil, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
 		}
 
 		if cli.scheme == "https" && strings.Contains(err.Error(), "bad certificate") {
-			return serverResp, errConnectionFailed{errors.Wrap(err, "the server probably has client authentication (--tlsverify) enabled; check your TLS client certification settings")}
+			return nil, errConnectionFailed{errors.Wrap(err, "the server probably has client authentication (--tlsverify) enabled; check your TLS client certification settings")}
 		}
 
 		// Don't decorate context sentinel errors; users may be comparing to
 		// them directly.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return serverResp, err
+			return nil, err
 		}
 
 		var uErr *url.Error
@@ -159,7 +149,7 @@ func (cli *Client) doRequest(req *http.Request) (serverResponse, error) {
 			var nErr *net.OpError
 			if errors.As(uErr.Err, &nErr) {
 				if os.IsPermission(nErr.Err) {
-					return serverResp, errConnectionFailed{errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)}
+					return nil, errConnectionFailed{errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)}
 				}
 			}
 		}
@@ -168,10 +158,10 @@ func (cli *Client) doRequest(req *http.Request) (serverResponse, error) {
 		if errors.As(err, &nErr) {
 			// FIXME(thaJeztah): any net.Error should be considered a connection error (but we should include the original error)?
 			if nErr.Timeout() {
-				return serverResp, connectionFailed(cli.host)
+				return nil, connectionFailed(cli.host)
 			}
 			if strings.Contains(nErr.Error(), "connection refused") || strings.Contains(nErr.Error(), "dial unix") {
-				return serverResp, connectionFailed(cli.host)
+				return nil, connectionFailed(cli.host)
 			}
 		}
 
@@ -195,28 +185,37 @@ func (cli *Client) doRequest(req *http.Request) (serverResponse, error) {
 			}
 		}
 
-		return serverResp, errConnectionFailed{errors.Wrap(err, "error during connect")}
+		return nil, errConnectionFailed{errors.Wrap(err, "error during connect")}
 	}
 
-	if resp != nil {
-		serverResp.statusCode = resp.StatusCode
-		serverResp.body = resp.Body
-		serverResp.header = resp.Header
-	}
-	return serverResp, nil
+	return resp, nil
 }
 
-func (cli *Client) checkResponseErr(serverResp serverResponse) error {
-	if serverResp.statusCode >= 200 && serverResp.statusCode < 400 {
+func (cli *Client) checkResponseErr(serverResp *http.Response) (retErr error) {
+	if serverResp == nil {
 		return nil
 	}
+	if serverResp.StatusCode >= 200 && serverResp.StatusCode < 400 {
+		return nil
+	}
+	defer func() {
+		retErr = errdefs.FromStatusCode(retErr, serverResp.StatusCode)
+	}()
 
 	var body []byte
 	var err error
-	if serverResp.body != nil {
+	var reqURL string
+	if serverResp.Request != nil {
+		reqURL = serverResp.Request.URL.String()
+	}
+	statusMsg := serverResp.Status
+	if statusMsg == "" {
+		statusMsg = http.StatusText(serverResp.StatusCode)
+	}
+	if serverResp.Body != nil {
 		bodyMax := 1 * 1024 * 1024 // 1 MiB
 		bodyR := &io.LimitedReader{
-			R: serverResp.body,
+			R: serverResp.Body,
 			N: int64(bodyMax),
 		}
 		body, err = io.ReadAll(bodyR)
@@ -224,15 +223,21 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 			return err
 		}
 		if bodyR.N == 0 {
-			return fmt.Errorf("request returned %s with a message (> %d bytes) for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), bodyMax, serverResp.reqURL)
+			if reqURL != "" {
+				return fmt.Errorf("request returned %s with a message (> %d bytes) for API route and version %s, check if the server supports the requested API version", statusMsg, bodyMax, reqURL)
+			}
+			return fmt.Errorf("request returned %s with a message (> %d bytes); check if the server supports the requested API version", statusMsg, bodyMax)
 		}
 	}
 	if len(body) == 0 {
-		return fmt.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), serverResp.reqURL)
+		if reqURL != "" {
+			return fmt.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", statusMsg, reqURL)
+		}
+		return fmt.Errorf("request returned %s; check if the server supports the requested API version", statusMsg)
 	}
 
 	var daemonErr error
-	if serverResp.header.Get("Content-Type") == "application/json" && (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) {
+	if serverResp.Header.Get("Content-Type") == "application/json" && (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) {
 		var errorResponse types.ErrorResponse
 		if err := json.Unmarshal(body, &errorResponse); err != nil {
 			return errors.Wrap(err, "Error reading JSON")
@@ -255,8 +260,8 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 			//
 			// TODO(thaJeztah): consider adding a log.Debug to allow clients to debug the actual response when enabling debug logging.
 			daemonErr = fmt.Errorf(`API returned a %d (%s) but provided no error-message`,
-				serverResp.statusCode,
-				http.StatusText(serverResp.statusCode),
+				serverResp.StatusCode,
+				http.StatusText(serverResp.StatusCode),
 			)
 		} else {
 			daemonErr = errors.New(strings.TrimSpace(errorResponse.Message))
@@ -305,10 +310,16 @@ func encodeData(data interface{}) (*bytes.Buffer, error) {
 	return params, nil
 }
 
-func ensureReaderClosed(response serverResponse) {
-	if response.body != nil {
+func ensureReaderClosed(response *http.Response) {
+	if response != nil && response.Body != nil {
 		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
-		_, _ = io.CopyN(io.Discard, response.body, 512)
-		_ = response.body.Close()
+		// see https://github.com/google/go-github/pull/317/files#r57536827
+		//
+		// TODO(thaJeztah): see if this optimization is still needed, or already implemented in stdlib,
+		//   and check if context-cancellation should handle this as well. If still needed, consider
+		//   wrapping response.Body, or returning a "closer()" from [Client.sendRequest] and related
+		//   methods.
+		_, _ = io.CopyN(io.Discard, response.Body, 512)
+		_ = response.Body.Close()
 	}
 }

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -237,6 +237,7 @@ func TestInfiniteError(t *testing.T) {
 	}
 
 	_, err := client.Ping(context.Background())
+	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 	assert.Check(t, is.ErrorContains(err, "request returned Internal Server Error"))
 }
 

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -10,16 +10,16 @@ import (
 
 // SecretCreate creates a new secret.
 func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error) {
-	var response types.SecretCreateResponse
 	if err := cli.NewVersionError(ctx, "1.25", "secret create"); err != nil {
-		return response, err
+		return types.SecretCreateResponse{}, err
 	}
 	resp, err := cli.post(ctx, "/secrets/create", nil, secret, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return response, err
+		return types.SecretCreateResponse{}, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&response)
+	var response types.SecretCreateResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -24,7 +24,7 @@ func (cli *Client) SecretInspectWithRaw(ctx context.Context, id string) (swarm.S
 		return swarm.Secret{}, nil, err
 	}
 
-	body, err := io.ReadAll(resp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return swarm.Secret{}, nil, err
 	}

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -33,6 +33,6 @@ func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptio
 	}
 
 	var secrets []swarm.Secret
-	err = json.NewDecoder(resp.body).Decode(&secrets)
+	err = json.NewDecoder(resp.Body).Decode(&secrets)
 	return secrets, err
 }

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -73,7 +73,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		return response, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if resolveWarning != "" {
 		response.Warnings = append(response.Warnings, resolveWarning)
 	}

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -21,13 +21,13 @@ func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, 
 
 	query := url.Values{}
 	query.Set("insertDefaults", fmt.Sprintf("%v", opts.InsertDefaults))
-	serverResp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Service{}, nil, err
 	}
 
-	body, err := io.ReadAll(serverResp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return swarm.Service{}, nil, err
 	}

--- a/client/service_list.go
+++ b/client/service_list.go
@@ -34,6 +34,6 @@ func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOpt
 	}
 
 	var services []swarm.Service
-	err = json.NewDecoder(resp.body).Decode(&services)
+	err = json.NewDecoder(resp.Body).Decode(&services)
 	return services, err
 }

--- a/client/service_logs.go
+++ b/client/service_logs.go
@@ -53,5 +53,5 @@ func (cli *Client) ServiceLogs(ctx context.Context, serviceID string, options co
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -80,8 +80,8 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		return swarm.ServiceUpdateResponse{}, err
 	}
 
-	response := swarm.ServiceUpdateResponse{}
-	err = json.NewDecoder(resp.body).Decode(&response)
+	var response swarm.ServiceUpdateResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if resolveWarning != "" {
 		response.Warnings = append(response.Warnings, resolveWarning)
 	}

--- a/client/swarm_get_unlock_key.go
+++ b/client/swarm_get_unlock_key.go
@@ -9,13 +9,13 @@ import (
 
 // SwarmGetUnlockKey retrieves the swarm's unlock key.
 func (cli *Client) SwarmGetUnlockKey(ctx context.Context) (types.SwarmUnlockKeyResponse, error) {
-	serverResp, err := cli.get(ctx, "/swarm/unlockkey", nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/swarm/unlockkey", nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return types.SwarmUnlockKeyResponse{}, err
 	}
 
 	var response types.SwarmUnlockKeyResponse
-	err = json.NewDecoder(serverResp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/swarm_init.go
+++ b/client/swarm_init.go
@@ -9,13 +9,13 @@ import (
 
 // SwarmInit initializes the swarm.
 func (cli *Client) SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error) {
-	serverResp, err := cli.post(ctx, "/swarm/init", nil, req, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/swarm/init", nil, req, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return "", err
 	}
 
 	var response string
-	err = json.NewDecoder(serverResp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/swarm_inspect.go
+++ b/client/swarm_inspect.go
@@ -9,13 +9,13 @@ import (
 
 // SwarmInspect inspects the swarm.
 func (cli *Client) SwarmInspect(ctx context.Context) (swarm.Swarm, error) {
-	serverResp, err := cli.get(ctx, "/swarm", nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/swarm", nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Swarm{}, err
 	}
 
 	var response swarm.Swarm
-	err = json.NewDecoder(serverResp.body).Decode(&response)
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/swarm_unlock.go
+++ b/client/swarm_unlock.go
@@ -8,7 +8,7 @@ import (
 
 // SwarmUnlock unlocks locked swarm.
 func (cli *Client) SwarmUnlock(ctx context.Context, req swarm.UnlockRequest) error {
-	serverResp, err := cli.post(ctx, "/swarm/unlock", nil, req, nil)
-	ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/swarm/unlock", nil, req, nil)
+	ensureReaderClosed(resp)
 	return err
 }

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -16,13 +16,13 @@ func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm
 		return swarm.Task{}, nil, err
 	}
 
-	serverResp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return swarm.Task{}, nil, err
 	}
 
-	body, err := io.ReadAll(serverResp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return swarm.Task{}, nil, err
 	}

--- a/client/task_list.go
+++ b/client/task_list.go
@@ -30,6 +30,6 @@ func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) 
 	}
 
 	var tasks []swarm.Task
-	err = json.NewDecoder(resp.body).Decode(&tasks)
+	err = json.NewDecoder(resp.Body).Decode(&tasks)
 	return tasks, err
 }

--- a/client/task_logs.go
+++ b/client/task_logs.go
@@ -47,5 +47,5 @@ func (cli *Client) TaskLogs(ctx context.Context, taskID string, options containe
 	if err != nil {
 		return nil, err
 	}
-	return resp.body, nil
+	return resp.Body, nil
 }

--- a/client/version.go
+++ b/client/version.go
@@ -16,6 +16,6 @@ func (cli *Client) ServerVersion(ctx context.Context) (types.Version, error) {
 	}
 
 	var server types.Version
-	err = json.NewDecoder(resp.body).Decode(&server)
+	err = json.NewDecoder(resp.Body).Decode(&server)
 	return server, err
 }

--- a/client/volume_create.go
+++ b/client/volume_create.go
@@ -9,12 +9,13 @@ import (
 
 // VolumeCreate creates a volume in the docker host.
 func (cli *Client) VolumeCreate(ctx context.Context, options volume.CreateOptions) (volume.Volume, error) {
-	var vol volume.Volume
 	resp, err := cli.post(ctx, "/volumes/create", nil, options, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return vol, err
+		return volume.Volume{}, err
 	}
-	err = json.NewDecoder(resp.body).Decode(&vol)
+
+	var vol volume.Volume
+	err = json.NewDecoder(resp.Body).Decode(&vol)
 	return vol, err
 }

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -22,17 +22,18 @@ func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (v
 		return volume.Volume{}, nil, err
 	}
 
-	var vol volume.Volume
 	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return vol, nil, err
+		return volume.Volume{}, nil, err
 	}
 
-	body, err := io.ReadAll(resp.body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return vol, nil, err
+		return volume.Volume{}, nil, err
 	}
+
+	var vol volume.Volume
 	rdr := bytes.NewReader(body)
 	err = json.NewDecoder(rdr).Decode(&vol)
 	return vol, body, err

--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -11,23 +11,23 @@ import (
 
 // VolumeList returns the volumes configured in the docker host.
 func (cli *Client) VolumeList(ctx context.Context, options volume.ListOptions) (volume.ListResponse, error) {
-	var volumes volume.ListResponse
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
-			return volumes, err
+			return volume.ListResponse{}, err
 		}
 		query.Set("filters", filterJSON)
 	}
 	resp, err := cli.get(ctx, "/volumes", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return volumes, err
+		return volume.ListResponse{}, err
 	}
 
-	err = json.NewDecoder(resp.body).Decode(&volumes)
+	var volumes volume.ListResponse
+	err = json.NewDecoder(resp.Body).Decode(&volumes)
 	return volumes, err
 }

--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -20,14 +20,14 @@ func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) 
 		return volume.PruneReport{}, err
 	}
 
-	serverResp, err := cli.post(ctx, "/volumes/prune", query, nil, nil)
-	defer ensureReaderClosed(serverResp)
+	resp, err := cli.post(ctx, "/volumes/prune", query, nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
 		return volume.PruneReport{}, err
 	}
 
 	var report volume.PruneReport
-	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
 		return volume.PruneReport{}, fmt.Errorf("Error retrieving volume prune report: %v", err)
 	}
 


### PR DESCRIPTION
Relates to;

- https://github.com/moby/moby/pull/432
- https://github.com/moby/moby/pull/3541
- https://github.com/moby/moby/pull/10050
- https://github.com/moby/moby/pull/13860
- https://github.com/moby/moby/pull/13740
- https://github.com/moby/moby/pull/33827
- https://github.com/docker/engine-api/pull/229


## client: remove serverResponse and use http.Response directly

Looking in history to learn why this struct existed, shows that this type was mostly the result of tech-debt accumulating over time;

- originally ([moby@1aa7f13]) most of the request handling was internal; the [`call()` function][1] would make a request, read the `response.Body`, and return it as a `[]byte` (or an error if one happened).
- some features needed the statuscode, so [moby@a4bcf7e] added an extra output variable to return the `response.StatusCode`.
- some new features required streaming, so [moby@fdd8d4b] changed the function to return the `response.Body` as a `io.ReadCloser`, instead of a `[]byte`.
- some features needed access to the content-type header, so a new `clientRequest` method was introduced in [moby@6b2eeaf] to read the `Content-Type` header from `response.Headers` and return it as a string.
- of course, `Content-Type` may not be the only header needed, so [moby@0cdc3b7] changed the signature to return `response.Headers` as a whole as a `http.Header`
- things became a bit unwieldy now, with the function having four (4) output variables, so [moby@126529c] chose to refactor this code, introducing a `serverResponse` struct to wrap them all, not realizing that all these values were effectively deconstructed from the `url.Response`, so now re-assembling them into our own "URL response", only preserving a subset of the information available.
- now that we had a custom struct, it was possible to add more information to it without changing the signature. When there was a need to know the URL of the request that initiated the response, [moby@27ef09a] introduced a `reqURL` field to hold the `request.URL` which notably also is available in `response.Request.URL`.

In short;

- The original implementation tried to (pre-maturely) abstract the underlying response to provide a simplified interface.
- While initially not needed, abstracting caused relevant information from the response (and request) to be unavailable to callers.
- As a result, we ended up in a situation where we are deconstructing the original `url.Response`, only to re-assemble it into our own, custom struct (`serverResponsee`) with only a subset of the information preserved.

This patch removes the `serverResponse` struct, instead returning the `url.Response` as-is, so that all information is preserved, allowing callers to use the information they need.

There is one follow-up change to consider; commit [moby@589df17] introduced a `ensureReaderClosed` utility. Before that commit, the response body would be closed in a more idiomatic way through a [`defer serverResp.body.Close()`][2]. A later change in [docker/engine-api@5dd6452] added an optimization to that utility, draining the response to allow connections to be reused. While skipping that utility (and not draining the response) would not be a critical issue, it may be easy to overlook that utility, and to close the response body in the "idiomatic" way, resulting in a possible performance regression.

We need to check if that optimization is still relevant or if later changes in Go itself already take care of this; we should also look if context cancellation is handled correctly for these. If it's still relevant, we could

- Wrap the the `url.Response` in a custom struct ("drainCloser") to provide a `Close()` function handling the draining and closing; this would re- introduce a custom type to be returned, so perhaps not what we want.
- Wrap the `url.Response.Body` in the response returned (so, calling) `response.Body.Close()` would call the wrapped closer.
- Change the signature of `Client.sendRequest()` (and related) to return a `close()` func to handle this; doing so would more strongly encourage callers to close the response body.

[1]: https://github.com/moby/moby/blob/1aa7f1392de665a6c8f751f53e1f7bb7bb6bf4f3/commands.go#L1008-L1027
[2]: https://github.com/moby/moby/blob/589df17a1a1dc649a4c3095cea6dd05e0c2a3bb5/api/client/ps.go#L84-L89
[moby@1aa7f13]: https://github.com/moby/moby/commit/1aa7f1392de665a6c8f751f53e1f7bb7bb6bf4f3
[moby@a4bcf7e]: https://github.com/moby/moby/commit/a4bcf7e1ac19dbf4c2e4f65af4addc1bfc47d567
[moby@fdd8d4b]: https://github.com/moby/moby/commit/fdd8d4b7d9dbc32a76a708d0d51c201cf9c977f0
[moby@6b2eeaf]: https://github.com/moby/moby/commit/6b2eeaf8965bac07022752c411b1f8a0f35f9571
[moby@0cdc3b7]: https://github.com/moby/moby/commit/0cdc3b7539b618778becf233157604698b4e8281
[moby@126529c]: https://github.com/moby/moby/commit/126529c6d0a20675de8f50939c57f23259d3e763
[moby@27ef09a]: https://github.com/moby/moby/commit/27ef09a46ffeb8ba42548de937b68351009f30ea
[moby@589df17]: https://github.com/moby/moby/commit/589df17a1a1dc649a4c3095cea6dd05e0c2a3bb5
[docker/engine-api@5dd6452]: https://github.com/docker/engine-api/commit/5dd6452d4dbe3e772728545e9531e3a27dd1e7a9


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

