### PR TITLE
vendor: gotest.tools/v3 v3.5.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,10 +151,6 @@ issues:
       path: "api/types/(volume|container)/"
       linters:
         - revive
-    # FIXME temporarily suppress these (see https://github.com/gotestyourself/gotest.tools/issues/272)
-    - text: "SA1019: (assert|cmp|is)\\.ErrorType is deprecated"
-      linters:
-        - staticcheck
 
     - text: "ineffectual assignment to ctx"
       source: "ctx[, ].*=.*\\(ctx[,)]"

--- a/vendor.mod
+++ b/vendor.mod
@@ -112,7 +112,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38
 	google.golang.org/grpc v1.68.1
 	google.golang.org/protobuf v1.35.2
-	gotest.tools/v3 v3.5.1
+	gotest.tools/v3 v3.5.2
 	resenje.org/singleflight v0.4.3
 	tags.cncf.io/container-device-interface v0.8.0
 )

--- a/vendor.sum
+++ b/vendor.sum
@@ -798,8 +798,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
-gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
+gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=

--- a/vendor/gotest.tools/v3/assert/assert.go
+++ b/vendor/gotest.tools/v3/assert/assert.go
@@ -284,8 +284,6 @@ func ErrorContains(t TestingT, err error, substring string, msgAndArgs ...interf
 // must be called from the goroutine running the test function, not from other
 // goroutines created during the test. Use [Check] with [cmp.ErrorType] from other
 // goroutines.
-//
-// Deprecated: Use [ErrorIs]
 func ErrorType(t TestingT, err error, expected interface{}, msgAndArgs ...interface{}) {
 	if ht, ok := t.(helperT); ok {
 		ht.Helper()

--- a/vendor/gotest.tools/v3/assert/cmp/compare.go
+++ b/vendor/gotest.tools/v3/assert/cmp/compare.go
@@ -248,7 +248,7 @@ type causer interface {
 }
 
 func formatErrorMessage(err error) string {
-	//nolint:errorlint // unwrapping is not appropriate here
+	//nolint:errorlint,nolintlint // unwrapping is not appropriate here
 	if _, ok := err.(causer); ok {
 		return fmt.Sprintf("%q\n%+v", err, err)
 	}
@@ -286,6 +286,7 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 }
 
 // ErrorType succeeds if err is not nil and is of the expected type.
+// New code should use [ErrorIs] instead.
 //
 // Expected can be one of:
 //
@@ -306,8 +307,6 @@ func isNil(obj interface{}, msgFunc func(reflect.Value) string) Comparison {
 //	reflect.Type
 //
 // Fails if err does not implement the [reflect.Type].
-//
-// Deprecated: Use [ErrorIs]
 func ErrorType(err error, expected interface{}) Comparison {
 	return func() Result {
 		switch expectedType := expected.(type) {

--- a/vendor/gotest.tools/v3/fs/report.go
+++ b/vendor/gotest.tools/v3/fs/report.go
@@ -50,8 +50,8 @@ func errProblem(reason string, err error) problem {
 	return problem(fmt.Sprintf("%s: %s", reason, err))
 }
 
-func existenceProblem(filename, reason string, args ...interface{}) problem {
-	return problem(filename + ": " + fmt.Sprintf(reason, args...))
+func existenceProblem(filename string, msgAndArgs ...interface{}) problem {
+	return problem(filename + ": " + format.Message(msgAndArgs...))
 }
 
 func eqResource(x, y resource) []problem {

--- a/vendor/gotest.tools/v3/internal/assert/assert.go
+++ b/vendor/gotest.tools/v3/internal/assert/assert.go
@@ -87,19 +87,18 @@ func logFailureFromBool(t LogT, msgAndArgs ...interface{}) {
 	args, err := source.CallExprArgs(stackIndex)
 	if err != nil {
 		t.Log(err.Error())
-		return
 	}
 
+	var msg string
 	const comparisonArgIndex = 1 // Assert(t, comparison)
 	if len(args) <= comparisonArgIndex {
-		t.Log(failureMessage + "but assert failed to find the expression to print")
-		return
-	}
-
-	msg, err := boolFailureMessage(args[comparisonArgIndex])
-	if err != nil {
-		t.Log(err.Error())
-		msg = "expression is false"
+		msg = "but assert failed to find the expression to print"
+	} else {
+		msg, err = boolFailureMessage(args[comparisonArgIndex])
+		if err != nil {
+			t.Log(err.Error())
+			msg = "expression is false"
+		}
 	}
 
 	t.Log(format.WithCustomMessage(failureMessage+msg, msgAndArgs...))

--- a/vendor/gotest.tools/v3/internal/difflib/difflib.go
+++ b/vendor/gotest.tools/v3/internal/difflib/difflib.go
@@ -1,4 +1,5 @@
-/*Package difflib is a partial port of Python difflib module.
+/*
+Package difflib is a partial port of Python difflib module.
 
 Original source: https://github.com/pmezard/go-difflib
 
@@ -6,14 +7,14 @@ This file is trimmed to only the parts used by this repository.
 */
 package difflib // import "gotest.tools/v3/internal/difflib"
 
-func min(a, b int) int {
+func minInt(a, b int) int {
 	if a < b {
 		return a
 	}
 	return b
 }
 
-func max(a, b int) int {
+func maxInt(a, b int) int {
 	if a > b {
 		return a
 	}
@@ -170,12 +171,15 @@ func (m *SequenceMatcher) isBJunk(s string) bool {
 // If IsJunk is not defined:
 //
 // Return (i,j,k) such that a[i:i+k] is equal to b[j:j+k], where
-//     alo <= i <= i+k <= ahi
-//     blo <= j <= j+k <= bhi
+//
+//	alo <= i <= i+k <= ahi
+//	blo <= j <= j+k <= bhi
+//
 // and for all (i',j',k') meeting those conditions,
-//     k >= k'
-//     i <= i'
-//     and if i == i', j <= j'
+//
+//	k >= k'
+//	i <= i'
+//	and if i == i', j <= j'
 //
 // In other words, of all maximal matching blocks, return one that
 // starts earliest in a, and of all those maximal matching blocks that
@@ -393,12 +397,12 @@ func (m *SequenceMatcher) GetGroupedOpCodes(n int) [][]OpCode {
 	if codes[0].Tag == 'e' {
 		c := codes[0]
 		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
-		codes[0] = OpCode{c.Tag, max(i1, i2-n), i2, max(j1, j2-n), j2}
+		codes[0] = OpCode{c.Tag, maxInt(i1, i2-n), i2, maxInt(j1, j2-n), j2}
 	}
 	if codes[len(codes)-1].Tag == 'e' {
 		c := codes[len(codes)-1]
 		i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
-		codes[len(codes)-1] = OpCode{c.Tag, i1, min(i2, i1+n), j1, min(j2, j1+n)}
+		codes[len(codes)-1] = OpCode{c.Tag, i1, minInt(i2, i1+n), j1, minInt(j2, j1+n)}
 	}
 	nn := n + n
 	groups := [][]OpCode{}
@@ -408,11 +412,11 @@ func (m *SequenceMatcher) GetGroupedOpCodes(n int) [][]OpCode {
 		// End the current group and start a new one whenever
 		// there is a large range with no changes.
 		if c.Tag == 'e' && i2-i1 > nn {
-			group = append(group, OpCode{c.Tag, i1, min(i2, i1+n),
-				j1, min(j2, j1+n)})
+			group = append(group, OpCode{c.Tag, i1, minInt(i2, i1+n),
+				j1, minInt(j2, j1+n)})
 			groups = append(groups, group)
 			group = []OpCode{}
-			i1, j1 = max(i1, i2-n), max(j1, j2-n)
+			i1, j1 = maxInt(i1, i2-n), maxInt(j1, j2-n)
 		}
 		group = append(group, OpCode{c.Tag, i1, i2, j1, j2})
 	}

--- a/vendor/gotest.tools/v3/internal/source/bazel.go
+++ b/vendor/gotest.tools/v3/internal/source/bazel.go
@@ -1,0 +1,51 @@
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// These Bazel env vars are documented here:
+// https://bazel.build/reference/test-encyclopedia
+
+// Signifies test executable is being driven by `bazel test`.
+//
+// Due to Bazel's compilation and sandboxing strategy,
+// some care is required to handle resolving the original *.go source file.
+var inBazelTest = os.Getenv("BAZEL_TEST") == "1"
+
+// The name of the target being tested (ex: //some_package:some_package_test)
+var bazelTestTarget = os.Getenv("TEST_TARGET")
+
+// Absolute path to the base of the runfiles tree
+var bazelTestSrcdir = os.Getenv("TEST_SRCDIR")
+
+// The local repository's workspace name (ex: __main__)
+var bazelTestWorkspace = os.Getenv("TEST_WORKSPACE")
+
+func bazelSourcePath(filename string) (string, error) {
+	// Use the env vars to resolve the test source files,
+	// which must be provided as test data in the respective go_test target.
+	filename = filepath.Join(bazelTestSrcdir, bazelTestWorkspace, filename)
+
+	_, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf(bazelMissingSourceMsg, filename, bazelTestTarget)
+	}
+	return filename, nil
+}
+
+var bazelMissingSourceMsg = `
+the test source file does not exist: %s
+It appears that you are running this test under Bazel (target: %s).
+Check that your test source files are added as test data in your go_test targets.
+
+Example:
+    go_test(
+        name = "your_package_test",
+        srcs = ["your_test.go"],
+        deps = ["@tools_gotest_v3//assert"],
+        data = glob(["*_test.go"])
+    )"
+`

--- a/vendor/gotest.tools/v3/internal/source/source.go
+++ b/vendor/gotest.tools/v3/internal/source/source.go
@@ -10,6 +10,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"runtime"
 )
 
@@ -35,6 +36,19 @@ func CallExprArgs(stackIndex int) ([]ast.Expr, error) {
 	}
 	debug("call stack position: %s:%d", filename, line)
 
+	// Normally, `go` will compile programs with absolute paths in
+	// the debug metadata. However, in the name of reproducibility,
+	// Bazel uses a compilation strategy that results in relative paths
+	// (otherwise, since Bazel uses a random tmp dir for compile and sandboxing,
+	// the resulting binaries would change across compiles/test runs).
+	if inBazelTest && !filepath.IsAbs(filename) {
+		var err error
+		filename, err = bazelSourcePath(filename)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	fileset := token.NewFileSet()
 	astFile, err := parser.ParseFile(fileset, filename, nil, parser.AllErrors)
 	if err != nil {
@@ -58,7 +72,7 @@ func getNodeAtLine(fileset *token.FileSet, astFile ast.Node, lineNum int) (ast.N
 			return node, err
 		}
 	}
-	return nil, nil
+	return nil, errors.New("failed to find expression")
 }
 
 func scanToLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {
@@ -78,11 +92,8 @@ func scanToLine(fileset *token.FileSet, node ast.Node, lineNum int) ast.Node {
 
 func getCallExprArgs(fileset *token.FileSet, astFile ast.Node, line int) ([]ast.Expr, error) {
 	node, err := getNodeAtLine(fileset, astFile, line)
-	switch {
-	case err != nil:
+	if err != nil {
 		return nil, err
-	case node == nil:
-		return nil, fmt.Errorf("failed to find an expression")
 	}
 
 	debug("found node: %s", debugFormatNode{node})
@@ -90,7 +101,7 @@ func getCallExprArgs(fileset *token.FileSet, astFile ast.Node, line int) ([]ast.
 	visitor := &callExprVisitor{}
 	ast.Walk(visitor, node)
 	if visitor.expr == nil {
-		return nil, errors.New("failed to find call expression")
+		return nil, errors.New("failed to find an expression")
 	}
 	debug("callExpr: %s", debugFormatNode{visitor.expr})
 	return visitor.expr.Args, nil

--- a/vendor/gotest.tools/v3/poll/poll.go
+++ b/vendor/gotest.tools/v3/poll/poll.go
@@ -9,6 +9,7 @@ import (
 
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/internal/assert"
+	"gotest.tools/v3/internal/format"
 )
 
 // TestingT is the subset of [testing.T] used by [WaitOn]
@@ -90,7 +91,7 @@ func (r result) Error() error {
 // polling. The message text will be used as the failure message if the timeout
 // is reached.
 func Continue(message string, args ...interface{}) Result {
-	return result{message: fmt.Sprintf(message, args...)}
+	return result{message: format.Message(append([]interface{}{message}, args...)...)}
 }
 
 // Success returns a [Result] where Done() returns true, which indicates to [WaitOn]
@@ -151,7 +152,7 @@ func Compare(compare cmp.Comparison) Result {
 	if assert.RunComparison(buf, assert.ArgsAtZeroIndex, compare) {
 		return Success()
 	}
-	return Continue(buf.String())
+	return Continue("%v", buf.String())
 }
 
 type logBuffer struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1604,7 +1604,7 @@ google.golang.org/protobuf/types/pluginpb
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# gotest.tools/v3 v3.5.1
+# gotest.tools/v3 v3.5.2
 ## explicit; go 1.17
 gotest.tools/v3/assert
 gotest.tools/v3/assert/cmp


### PR DESCRIPTION
- un-deprecates `assert.ErrorType`, `cmp.ErrorType`
- assert: ensure message is always displayed and fix under bazel
- poll: Continue(): use format.Message for formatting
- fix TestFromDirSymlink on Windows due to missing drive-letter
- fix various linting issues and minor bugs

full diff: https://github.com/gotestyourself/gotest.tools/compare/v3.5.1...v3.5.2

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

