### PR TITLE
client: fix deprecation comment for ImageInspectWithRaw

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -115,8 +115,10 @@ type ImageAPIClient interface {
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string, opts image.HistoryOptions) ([]image.HistoryResponseItem, error)
 	ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)
-	// Deprecated: Use [Client.ImageInspect] instead.
-	// Raw response can be obtained by [ImageInspectWithRawResponse] option.
+
+	// ImageInspectWithRaw returns the image information and its raw representation.
+	//
+	// Deprecated: Use [Client.ImageInspect] instead. Raw response can be obtained using the [ImageInspectWithRawResponse] option.
 	ImageInspectWithRaw(ctx context.Context, image string) (image.InspectResponse, []byte, error)
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -97,8 +97,7 @@ func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts
 
 // ImageInspectWithRaw returns the image information and its raw representation.
 //
-// Deprecated: Use [Client.ImageInspect] instead.
-// Raw response can be obtained by [ImageInspectWithRawResponse] option.
+// Deprecated: Use [Client.ImageInspect] instead. Raw response can be obtained using the [ImageInspectWithRawResponse] option.
 func (cli *Client) ImageInspectWithRaw(ctx context.Context, imageID string) (image.InspectResponse, []byte, error) {
 	var buf bytes.Buffer
 	resp, err := cli.ImageInspect(ctx, imageID, ImageInspectWithRawResponse(&buf))


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48264

The comment was not formatted correctly as it was not the last line, resulting in some editors / linters not detecting the deprecation.

Updates 639a1214fa528153863e998ef2c9be7561beda0a

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

