### PR TITLE
Dockerfile: update buildx v0.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ ARG DOCKERCLI_VERSION=v27.5.0
 # cli version used for integration-cli tests
 ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
 ARG DOCKERCLI_INTEGRATION_VERSION=v17.06.2-ce
-ARG BUILDX_VERSION=0.20.0
+# BUILDX_VERSION is the version of buildx to install in the dev container.
+ARG BUILDX_VERSION=0.20.1
 ARG COMPOSE_VERSION=v2.32.4
 
 ARG SYSTEMD="false"


### PR DESCRIPTION
Update the buildx cli plugin used in the dev-container

full diff: https://github.com/docker/buildx/compare/v0.20.0...v0.20.1


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

