### PR TITLE
Restore new iptables rules on firewalld reload

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -969,6 +969,12 @@ func (n *bridgeNetwork) reapplyPerPortIptables(needsReconfig func(portBinding) b
 			if err := n.setPerPortIptables(b, true); err != nil {
 				log.G(context.TODO()).Warnf("Failed to reconfigure NAT %s: %s", b, err)
 			}
+			if err := n.filterPortMappedOnLoopback(b, true); err != nil {
+				log.G(context.TODO()).Warnf("Failed to reconfigure NAT %s: %s", b, err)
+			}
+			if err := n.filterDirectAccess(b, true); err != nil {
+				log.G(context.TODO()).Warnf("Failed to reconfigure NAT %s: %s", b, err)
+			}
 		}
 	}
 }

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -242,11 +242,12 @@ func (n *bridgeNetwork) setupIPTables(ipVersion iptables.IPVersion, maskedAddr *
 				return fmt.Errorf("failed to add bridge %s (%s) to ipset: %w",
 					config.BridgeName, maskedAddr, err)
 			}
+			// Re-adding an IP address to an ipset on firewalld reload is expected, not an error.
 			log.G(context.TODO()).WithFields(log.Fields{
 				"ipset":  ipsetName,
 				"bridge": config.BridgeName,
 				"subnet": maskedAddr,
-			}).Warnf("Subnet was already in the ipset")
+			}).Debug("Subnet was already in the ipset")
 		}
 		n.registerIptCleanFunc(func() error {
 			return netlink.IpsetDel(ipsetName, ipsetEntry)


### PR DESCRIPTION
**- What I did**

- Make sure iptables rules are restored properly on a firewalld reload.
- Don't log a warning when re-adding an IP address to an ipset, because that's normal on a firewalld reload.

**- How I did it**

**- How to verify it**

On a host with firewalld running ...

```
docker network create b4
docker run --rm -ti --network b4 -p 8080:80 alpine

iptables-save # checked it showed the raw-PREROUTING rule for the port
systemctl reload firewalld
iptables-save # checked the raw-PREROUTING rule was still there
```

**- Human readable description for the release notes**
```markdown changelog

```
