### PR TITLE
api/types: deprecate IDResponse

### DIFF
--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -9,7 +9,9 @@ import (
 	"github.com/docker/docker/api/types/storage"
 )
 
-// IDResponse Response to an API call that returns just an Id
+// IDResponse Response to an API call that returns just an Id.
+//
+// Deprecated: use either [container.CommitResponse] or [container.ExecCreateResponse]. It will be removed in the next release.
 type IDResponse = common.IDResponse
 
 // ContainerJSONBase contains response of Engine API GET "/containers/{name:.*}/json"


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49444

Deprecate `api/type.IDResponse` in favor of `container.CommitResponse` and `container.ExecCreateResponse`, which are currently an alias, but may become distinct types in a future release. This type  will be removed in the next release.

updates 0df3a0047af4d8d4fe7c0270be5859d39cf0fb11
updates 9a20edf7b60c4068c4be1c6575d94a699861d457

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK:  Deprecate `api/type.IDResponse` in favor of `container.CommitResponse` and `container.ExecCreateResponse`, which are currently an alias, but may become distinct types in a future release. This type  will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

