### PR TITLE
Fix deprecation of "error" and "progress" fields in streaming responses

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2754,12 +2754,24 @@ definitions:
         type: "string"
       error:
         type: "string"
+        x-nullable: true
+        description: |-
+          errors encountered during the operation.
+
+
+          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
       progress:
         type: "string"
+        x-nullable: true
+        description: |-
+          Progress is a pre-formatted presentation of progressDetail.
+
+
+          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
       aux:
@@ -2859,12 +2871,24 @@ definitions:
         type: "string"
       error:
         type: "string"
+        x-nullable: true
+        description: |-
+          errors encountered during the operation.
+
+
+          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
       errorDetail:
         $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
       progress:
         type: "string"
+        x-nullable: true
+        description: |-
+          Progress is a pre-formatted presentation of progressDetail.
+
+
+          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 
@@ -2873,10 +2897,24 @@ definitions:
     properties:
       error:
         type: "string"
+        x-nullable: true
+        description: |-
+          errors encountered during the operation.
+
+
+          > **Deprecated**: This field is deprecated since API v1.4, and will be omitted in a future API version. Use the information in errorDetail instead.
+      errorDetail:
+        $ref: "#/definitions/ErrorDetail"
       status:
         type: "string"
       progress:
         type: "string"
+        x-nullable: true
+        description: |-
+          Progress is a pre-formatted presentation of progressDetail.
+
+
+          > **Deprecated**: This field is deprecated since API v1.8, and will be omitted in a future API version. Use the information in progressDetail instead.
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,13 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.48](https://docs.docker.com/reference/api/engine/version/v1.48/) documentation
 
+* Deprecated: The "error" and "progress" fields in streaming responses for
+  endpoints that return a JSON progress response, such as `POST /images/create`,
+  `POST /images/{name}/push`, and `POST /build` are deprecated. These fields
+  were marked deprecated in API v1.4 (docker v0.6.0) and API v1.8 (docker v0.7.1)
+  respectively, but still returned. These fields will be left empty or will
+  be omitted in a future API version. Users should use the information in the
+  `errorDetail` and `progressDetail` fields instead.
 * Deprecated: The "allow-nondistributable-artifacts" daemon configuration is
   deprecated and enabled by default. The  `AllowNondistributableArtifactsCIDRs`
   and `AllowNondistributableArtifactsHostnames` fields in the `RegistryConfig`

--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -143,16 +143,24 @@ func (p *JSONProgress) width() int {
 // the created time, where it from, status, ID of the
 // message. It's used for docker events.
 type JSONMessage struct {
-	Stream          string        `json:"stream,omitempty"`
-	Status          string        `json:"status,omitempty"`
-	Progress        *JSONProgress `json:"progressDetail,omitempty"`
-	ProgressMessage string        `json:"progress,omitempty"` // deprecated
-	ID              string        `json:"id,omitempty"`
-	From            string        `json:"from,omitempty"`
-	Time            int64         `json:"time,omitempty"`
-	TimeNano        int64         `json:"timeNano,omitempty"`
-	Error           *JSONError    `json:"errorDetail,omitempty"`
-	ErrorMessage    string        `json:"error,omitempty"` // deprecated
+	Stream   string        `json:"stream,omitempty"`
+	Status   string        `json:"status,omitempty"`
+	Progress *JSONProgress `json:"progressDetail,omitempty"`
+
+	// ProgressMessage is a pre-formatted presentation of [Progress].
+	//
+	// Deprecated: this field is deprecated since docker v0.7.1 / API v1.8. Use the information in [Progress] instead. This field will be omitted in a future release.
+	ProgressMessage string     `json:"progress,omitempty"`
+	ID              string     `json:"id,omitempty"`
+	From            string     `json:"from,omitempty"`
+	Time            int64      `json:"time,omitempty"`
+	TimeNano        int64      `json:"timeNano,omitempty"`
+	Error           *JSONError `json:"errorDetail,omitempty"`
+
+	// ErrorMessage contains errors encountered during the operation.
+	//
+	// Deprecated: this field is deprecated since docker v0.6.0 / API v1.4. Use [Error.Message] instead. This field will be omitted in a future release.
+	ErrorMessage string `json:"error,omitempty"` // deprecated
 	// Aux contains out-of-band data, such as digests for push signing and image id after building.
 	Aux *json.RawMessage `json:"aux,omitempty"`
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49264
- relates to https://github.com/moby/moby/pull/2945
- relates to https://github.com/moby/moby/pull/1298

### pkg/jsonmessage: JSONMessage: fix deprecation of ProgressMessage, ErrorMessage

- ErrorMessage was deprecated in 3043c2641990d94298c6377b7ef14709263a4709
  which was part of docker v0.6.0 / API v1.4
- ProgressMessage was deprecated in 597e0e69b4c8521f39691d0a07d1f31b7116a337
  which was part of docker v0.7.1 / API v1.8

### api: deprecation of "error" and "progress" fields in streaming responses

- error (ErrorMessage) was deprecated in 3043c2641990d94298c6377b7ef14709263a4709
  which was part of docker v0.6.0 / API v1.4
- progress (ProgressMessage) was deprecated in 597e0e69b4c8521f39691d0a07d1f31b7116a337
  which was part of docker v0.7.1 / API v1.8



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: pkg/jsonmessage: JSONMessage: fix deprecation of ProgressMessage, ErrorMessage, which were deprecated in Docker v0.6.0 and v0.7.1 respectively.

API:

* Deprecated: The "error" and "progress" fields in streaming responses for
  endpoints that return a JSON progress response, such as `POST /images/create`,
  `POST /images/{name}/push`, and `POST /build` are deprecated. These fields
  were marked deprecated in API v1.4 (docker v0.6.0) and API v1.8 (docker v0.7.1)
  respectively, but still returned. These fields will be left empty or will
  be omitted in a future API version. Users should use the information in the
  `errorDetail` and `progressDetail` fields instead.
```

**- A picture of a cute animal (not mandatory but encouraged)**

