### PR TITLE
vendor: github.com/miekg/dns v1.1.61

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -60,7 +60,7 @@ require (
 	github.com/hashicorp/serf v0.8.5
 	github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2
 	github.com/klauspost/compress v1.17.11
-	github.com/miekg/dns v1.1.57
+	github.com/miekg/dns v1.1.61
 	github.com/mistifyio/go-zfs/v3 v3.0.1
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/moby/buildkit v0.19.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -353,8 +353,8 @@ github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U
 github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
-github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
-github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
+github.com/miekg/dns v1.1.61 h1:nLxbwF3XxhwVSm8g9Dghm9MHPaUZuqhPiGL+675ZmEs=
+github.com/miekg/dns v1.1.61/go.mod h1:mnAarhS3nWaW+NVP2wTkYVIZyHNJ098SJZUki3eykwQ=
 github.com/mistifyio/go-zfs/v3 v3.0.1 h1:YaoXgBePoMA12+S1u/ddkv+QqxcfiZK4prI6HPnkFiU=
 github.com/mistifyio/go-zfs/v3 v3.0.1/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkOTUGbNrTja/k=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/vendor/github.com/miekg/dns/README.md
+++ b/vendor/github.com/miekg/dns/README.md
@@ -82,6 +82,9 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://dnscheck.tools/
 * https://github.com/egbakou/domainverifier
 * https://github.com/semihalev/sdns
+* https://github.com/wintbiit/NineDNS
+* https://linuxcontainers.org/incus/
+* https://ifconfig.es
 
 
 Send pull request if you want to be listed here.
@@ -125,6 +128,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 *all of them*
 
 * 103{4,5} - DNS standard
+* 1183 - ISDN, X25 and other deprecated records
 * 1348 - NSAP record (removed the record)
 * 1982 - Serial Arithmetic
 * 1876 - LOC record
@@ -184,6 +188,9 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 8777 - DNS Reverse IP Automatic Multicast Tunneling (AMT) Discovery
 * 8914 - Extended DNS Errors
 * 8976 - Message Digest for DNS Zones (ZONEMD RR)
+* 9460 - Service Binding and Parameter Specification via the DNS
+* 9461 - Service Binding Mapping for DNS Servers
+* 9462 - Discovery of Designated Resolvers
 
 ## Loosely Based Upon
 

--- a/vendor/github.com/miekg/dns/defaults.go
+++ b/vendor/github.com/miekg/dns/defaults.go
@@ -198,10 +198,12 @@ func IsDomainName(s string) (labels int, ok bool) {
 		off    int
 		begin  int
 		wasDot bool
+		escape bool
 	)
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
 		case '\\':
+			escape = !escape
 			if off+1 > lenmsg {
 				return labels, false
 			}
@@ -217,6 +219,7 @@ func IsDomainName(s string) (labels int, ok bool) {
 
 			wasDot = false
 		case '.':
+			escape = false
 			if i == 0 && len(s) > 1 {
 				// leading dots are not legal except for the root zone
 				return labels, false
@@ -243,10 +246,13 @@ func IsDomainName(s string) (labels int, ok bool) {
 			labels++
 			begin = i + 1
 		default:
+			escape = false
 			wasDot = false
 		}
 	}
-
+	if escape {
+		return labels, false
+	}
 	return labels, true
 }
 

--- a/vendor/github.com/miekg/dns/dnssec_keyscan.go
+++ b/vendor/github.com/miekg/dns/dnssec_keyscan.go
@@ -160,7 +160,7 @@ func parseKey(r io.Reader, file string) (map[string]string, error) {
 			k = l.token
 		case zValue:
 			if k == "" {
-				return nil, &ParseError{file, "no private key seen", l}
+				return nil, &ParseError{file: file, err: "no private key seen", lex: l}
 			}
 
 			m[strings.ToLower(k)] = l.token

--- a/vendor/github.com/miekg/dns/generate.go
+++ b/vendor/github.com/miekg/dns/generate.go
@@ -116,7 +116,7 @@ func (r *generateReader) parseError(msg string, end int) *ParseError {
 	l.token = r.s[r.si-1 : end]
 	l.column += r.si // l.column starts one zBLANK before r.s
 
-	return &ParseError{r.file, msg, l}
+	return &ParseError{file: r.file, err: msg, lex: l}
 }
 
 func (r *generateReader) Read(p []byte) (int, error) {

--- a/vendor/github.com/miekg/dns/msg.go
+++ b/vendor/github.com/miekg/dns/msg.go
@@ -714,7 +714,7 @@ func (h *MsgHdr) String() string {
 	return s
 }
 
-// Pack packs a Msg: it is converted to to wire format.
+// Pack packs a Msg: it is converted to wire format.
 // If the dns.Compress is true the message will be in compressed wire format.
 func (dns *Msg) Pack() (msg []byte, err error) {
 	return dns.PackBuffer(nil)

--- a/vendor/github.com/miekg/dns/privaterr.go
+++ b/vendor/github.com/miekg/dns/privaterr.go
@@ -84,7 +84,7 @@ Fetch:
 
 	err := r.Data.Parse(text)
 	if err != nil {
-		return &ParseError{"", err.Error(), l}
+		return &ParseError{wrappedErr: err, lex: l}
 	}
 
 	return nil

--- a/vendor/github.com/miekg/dns/scan.go
+++ b/vendor/github.com/miekg/dns/scan.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -64,19 +66,25 @@ const (
 // ParseError is a parsing error. It contains the parse error and the location in the io.Reader
 // where the error occurred.
 type ParseError struct {
-	file string
-	err  string
-	lex  lex
+	file       string
+	err        string
+	wrappedErr error
+	lex        lex
 }
 
 func (e *ParseError) Error() (s string) {
 	if e.file != "" {
 		s = e.file + ": "
 	}
+	if e.err == "" && e.wrappedErr != nil {
+		e.err = e.wrappedErr.Error()
+	}
 	s += "dns: " + e.err + ": " + strconv.QuoteToASCII(e.lex.token) + " at line: " +
 		strconv.Itoa(e.lex.line) + ":" + strconv.Itoa(e.lex.column)
 	return
 }
+
+func (e *ParseError) Unwrap() error { return e.wrappedErr }
 
 type lex struct {
 	token  string // text of the token
@@ -93,12 +101,13 @@ type ttlState struct {
 	isByDirective bool   // isByDirective indicates whether ttl was set by a $TTL directive
 }
 
-// NewRR reads the RR contained in the string s. Only the first RR is returned.
+// NewRR reads a string s and returns the first RR.
 // If s contains no records, NewRR will return nil with no error.
 //
-// The class defaults to IN and TTL defaults to 3600. The full zone file syntax
-// like $TTL, $ORIGIN, etc. is supported. All fields of the returned RR are
-// set, except RR.Header().Rdlength which is set to 0.
+// The class defaults to IN, TTL defaults to 3600, and
+// origin for resolving relative domain names defaults to the DNS root (.).
+// Full zone file syntax is supported, including directives like $TTL and $ORIGIN.
+// All fields of the returned RR are set from the read data, except RR.Header().Rdlength which is set to 0.
 func NewRR(s string) (RR, error) {
 	if len(s) > 0 && s[len(s)-1] != '\n' { // We need a closing newline
 		return ReadRR(strings.NewReader(s+"\n"), "")
@@ -168,8 +177,9 @@ type ZoneParser struct {
 	// sub is used to parse $INCLUDE files and $GENERATE directives.
 	// Next, by calling subNext, forwards the resulting RRs from this
 	// sub parser to the calling code.
-	sub    *ZoneParser
-	osFile *os.File
+	sub  *ZoneParser
+	r    io.Reader
+	fsys fs.FS
 
 	includeDepth uint8
 
@@ -188,7 +198,7 @@ func NewZoneParser(r io.Reader, origin, file string) *ZoneParser {
 	if origin != "" {
 		origin = Fqdn(origin)
 		if _, ok := IsDomainName(origin); !ok {
-			pe = &ParseError{file, "bad initial origin name", lex{}}
+			pe = &ParseError{file: file, err: "bad initial origin name"}
 		}
 	}
 
@@ -220,6 +230,24 @@ func (zp *ZoneParser) SetIncludeAllowed(v bool) {
 	zp.includeAllowed = v
 }
 
+// SetIncludeFS provides an [fs.FS] to use when looking for the target of
+// $INCLUDE directives.  ($INCLUDE must still be enabled separately by calling
+// [ZoneParser.SetIncludeAllowed].)  If fsys is nil, [os.Open] will be used.
+//
+// When fsys is an on-disk FS, the ability of $INCLUDE to reach files from
+// outside its root directory depends upon the FS implementation.  For
+// instance, [os.DirFS] will refuse to open paths like "../../etc/passwd",
+// however it will still follow links which may point anywhere on the system.
+//
+// FS paths are slash-separated on all systems, even Windows.  $INCLUDE paths
+// containing other characters such as backslash and colon may be accepted as
+// valid, but those characters will never be interpreted by an FS
+// implementation as path element separators.  See [fs.ValidPath] for more
+// details.
+func (zp *ZoneParser) SetIncludeFS(fsys fs.FS) {
+	zp.fsys = fsys
+}
+
 // Err returns the first non-EOF error that was encountered by the
 // ZoneParser.
 func (zp *ZoneParser) Err() error {
@@ -237,7 +265,7 @@ func (zp *ZoneParser) Err() error {
 }
 
 func (zp *ZoneParser) setParseError(err string, l lex) (RR, bool) {
-	zp.parseErr = &ParseError{zp.file, err, l}
+	zp.parseErr = &ParseError{file: zp.file, err: err, lex: l}
 	return nil, false
 }
 
@@ -260,9 +288,11 @@ func (zp *ZoneParser) subNext() (RR, bool) {
 		return rr, true
 	}
 
-	if zp.sub.osFile != nil {
-		zp.sub.osFile.Close()
-		zp.sub.osFile = nil
+	if zp.sub.r != nil {
+		if c, ok := zp.sub.r.(io.Closer); ok {
+			c.Close()
+		}
+		zp.sub.r = nil
 	}
 
 	if zp.sub.Err() != nil {
@@ -402,24 +432,44 @@ func (zp *ZoneParser) Next() (RR, bool) {
 
 			// Start with the new file
 			includePath := l.token
-			if !filepath.IsAbs(includePath) {
-				includePath = filepath.Join(filepath.Dir(zp.file), includePath)
-			}
-
-			r1, e1 := os.Open(includePath)
-			if e1 != nil {
-				var as string
-				if !filepath.IsAbs(l.token) {
-					as = fmt.Sprintf(" as `%s'", includePath)
+			var r1 io.Reader
+			var e1 error
+			if zp.fsys != nil {
+				// fs.FS always uses / as separator, even on Windows, so use
+				// path instead of filepath here:
+				if !path.IsAbs(includePath) {
+					includePath = path.Join(path.Dir(zp.file), includePath)
 				}
 
-				msg := fmt.Sprintf("failed to open `%s'%s: %v", l.token, as, e1)
-				return zp.setParseError(msg, l)
+				// os.DirFS, and probably others, expect all paths to be
+				// relative, so clean the path and remove leading / if
+				// present:
+				includePath = strings.TrimLeft(path.Clean(includePath), "/")
+
+				r1, e1 = zp.fsys.Open(includePath)
+			} else {
+				if !filepath.IsAbs(includePath) {
+					includePath = filepath.Join(filepath.Dir(zp.file), includePath)
+				}
+				r1, e1 = os.Open(includePath)
+			}
+			if e1 != nil {
+				var as string
+				if includePath != l.token {
+					as = fmt.Sprintf(" as `%s'", includePath)
+				}
+				zp.parseErr = &ParseError{
+					file:       zp.file,
+					wrappedErr: fmt.Errorf("failed to open `%s'%s: %w", l.token, as, e1),
+					lex:        l,
+				}
+				return nil, false
 			}
 
 			zp.sub = NewZoneParser(r1, neworigin, includePath)
-			zp.sub.defttl, zp.sub.includeDepth, zp.sub.osFile = zp.defttl, zp.includeDepth+1, r1
+			zp.sub.defttl, zp.sub.includeDepth, zp.sub.r = zp.defttl, zp.includeDepth+1, r1
 			zp.sub.SetIncludeAllowed(true)
+			zp.sub.SetIncludeFS(zp.fsys)
 			return zp.subNext()
 		case zExpectDirTTLBl:
 			if l.value != zBlank {
@@ -1233,7 +1283,7 @@ func stringToCm(token string) (e, m uint8, ok bool) {
 			cmeters *= 10
 		}
 	}
-	// This slighly ugly condition will allow omitting the 'meter' part, like .01 (meaning 0.01m = 1cm).
+	// This slightly ugly condition will allow omitting the 'meter' part, like .01 (meaning 0.01m = 1cm).
 	if !hasCM || mStr != "" {
 		meters, err = strconv.Atoi(mStr)
 		// RFC1876 states the max value is 90000000.00.  The latter two conditions enforce it.
@@ -1326,12 +1376,12 @@ func slurpRemainder(c *zlexer) *ParseError {
 	case zBlank:
 		l, _ = c.Next()
 		if l.value != zNewline && l.value != zEOF {
-			return &ParseError{"", "garbage after rdata", l}
+			return &ParseError{err: "garbage after rdata", lex: l}
 		}
 	case zNewline:
 	case zEOF:
 	default:
-		return &ParseError{"", "garbage after rdata", l}
+		return &ParseError{err: "garbage after rdata", lex: l}
 	}
 	return nil
 }
@@ -1340,16 +1390,16 @@ func slurpRemainder(c *zlexer) *ParseError {
 // Used for NID and L64 record.
 func stringToNodeID(l lex) (uint64, *ParseError) {
 	if len(l.token) < 19 {
-		return 0, &ParseError{l.token, "bad NID/L64 NodeID/Locator64", l}
+		return 0, &ParseError{file: l.token, err: "bad NID/L64 NodeID/Locator64", lex: l}
 	}
 	// There must be three colons at fixes positions, if not its a parse error
 	if l.token[4] != ':' && l.token[9] != ':' && l.token[14] != ':' {
-		return 0, &ParseError{l.token, "bad NID/L64 NodeID/Locator64", l}
+		return 0, &ParseError{file: l.token, err: "bad NID/L64 NodeID/Locator64", lex: l}
 	}
 	s := l.token[0:4] + l.token[5:9] + l.token[10:14] + l.token[15:19]
 	u, err := strconv.ParseUint(s, 16, 64)
 	if err != nil {
-		return 0, &ParseError{l.token, "bad NID/L64 NodeID/Locator64", l}
+		return 0, &ParseError{file: l.token, err: "bad NID/L64 NodeID/Locator64", lex: l}
 	}
 	return u, nil
 }

--- a/vendor/github.com/miekg/dns/scan_rr.go
+++ b/vendor/github.com/miekg/dns/scan_rr.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -15,14 +16,14 @@ func endingToString(c *zlexer, errstr string) (string, *ParseError) {
 	l, _ := c.Next() // zString
 	for l.value != zNewline && l.value != zEOF {
 		if l.err {
-			return s.String(), &ParseError{"", errstr, l}
+			return s.String(), &ParseError{err: errstr, lex: l}
 		}
 		switch l.value {
 		case zString:
 			s.WriteString(l.token)
 		case zBlank: // Ok
 		default:
-			return "", &ParseError{"", errstr, l}
+			return "", &ParseError{err: errstr, lex: l}
 		}
 		l, _ = c.Next()
 	}
@@ -36,7 +37,7 @@ func endingToTxtSlice(c *zlexer, errstr string) ([]string, *ParseError) {
 	// Get the remaining data until we see a zNewline
 	l, _ := c.Next()
 	if l.err {
-		return nil, &ParseError{"", errstr, l}
+		return nil, &ParseError{err: errstr, lex: l}
 	}
 
 	// Build the slice
@@ -45,34 +46,33 @@ func endingToTxtSlice(c *zlexer, errstr string) ([]string, *ParseError) {
 	empty := false
 	for l.value != zNewline && l.value != zEOF {
 		if l.err {
-			return nil, &ParseError{"", errstr, l}
+			return nil, &ParseError{err: errstr, lex: l}
 		}
 		switch l.value {
 		case zString:
 			empty = false
-			if len(l.token) > 255 {
-				// split up tokens that are larger than 255 into 255-chunks
-				sx := []string{}
-				p, i := 0, 255
-				for {
-					if i <= len(l.token) {
-						sx = append(sx, l.token[p:i])
-					} else {
-						sx = append(sx, l.token[p:])
-						break
-
-					}
-					p, i = p+255, i+255
+			// split up tokens that are larger than 255 into 255-chunks
+			sx := []string{}
+			p := 0
+			for {
+				i, ok := escapedStringOffset(l.token[p:], 255)
+				if !ok {
+					return nil, &ParseError{err: errstr, lex: l}
 				}
-				s = append(s, sx...)
-				break
-			}
+				if i != -1 && p+i != len(l.token) {
+					sx = append(sx, l.token[p:p+i])
+				} else {
+					sx = append(sx, l.token[p:])
+					break
 
-			s = append(s, l.token)
+				}
+				p += i
+			}
+			s = append(s, sx...)
 		case zBlank:
 			if quote {
 				// zBlank can only be seen in between txt parts.
-				return nil, &ParseError{"", errstr, l}
+				return nil, &ParseError{err: errstr, lex: l}
 			}
 		case zQuote:
 			if empty && quote {
@@ -81,13 +81,13 @@ func endingToTxtSlice(c *zlexer, errstr string) ([]string, *ParseError) {
 			quote = !quote
 			empty = true
 		default:
-			return nil, &ParseError{"", errstr, l}
+			return nil, &ParseError{err: errstr, lex: l}
 		}
 		l, _ = c.Next()
 	}
 
 	if quote {
-		return nil, &ParseError{"", errstr, l}
+		return nil, &ParseError{err: errstr, lex: l}
 	}
 
 	return s, nil
@@ -102,7 +102,7 @@ func (rr *A) parse(c *zlexer, o string) *ParseError {
 	// IPv4.
 	isIPv4 := !strings.Contains(l.token, ":")
 	if rr.A == nil || !isIPv4 || l.err {
-		return &ParseError{"", "bad A A", l}
+		return &ParseError{err: "bad A A", lex: l}
 	}
 	return slurpRemainder(c)
 }
@@ -114,7 +114,7 @@ func (rr *AAAA) parse(c *zlexer, o string) *ParseError {
 	// addresses cannot include ":".
 	isIPv6 := strings.Contains(l.token, ":")
 	if rr.AAAA == nil || !isIPv6 || l.err {
-		return &ParseError{"", "bad AAAA AAAA", l}
+		return &ParseError{err: "bad AAAA AAAA", lex: l}
 	}
 	return slurpRemainder(c)
 }
@@ -123,7 +123,7 @@ func (rr *NS) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad NS Ns", l}
+		return &ParseError{err: "bad NS Ns", lex: l}
 	}
 	rr.Ns = name
 	return slurpRemainder(c)
@@ -133,7 +133,7 @@ func (rr *PTR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad PTR Ptr", l}
+		return &ParseError{err: "bad PTR Ptr", lex: l}
 	}
 	rr.Ptr = name
 	return slurpRemainder(c)
@@ -143,7 +143,7 @@ func (rr *NSAPPTR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad NSAP-PTR Ptr", l}
+		return &ParseError{err: "bad NSAP-PTR Ptr", lex: l}
 	}
 	rr.Ptr = name
 	return slurpRemainder(c)
@@ -153,7 +153,7 @@ func (rr *RP) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	mbox, mboxOk := toAbsoluteName(l.token, o)
 	if l.err || !mboxOk {
-		return &ParseError{"", "bad RP Mbox", l}
+		return &ParseError{err: "bad RP Mbox", lex: l}
 	}
 	rr.Mbox = mbox
 
@@ -163,7 +163,7 @@ func (rr *RP) parse(c *zlexer, o string) *ParseError {
 
 	txt, txtOk := toAbsoluteName(l.token, o)
 	if l.err || !txtOk {
-		return &ParseError{"", "bad RP Txt", l}
+		return &ParseError{err: "bad RP Txt", lex: l}
 	}
 	rr.Txt = txt
 
@@ -174,7 +174,7 @@ func (rr *MR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad MR Mr", l}
+		return &ParseError{err: "bad MR Mr", lex: l}
 	}
 	rr.Mr = name
 	return slurpRemainder(c)
@@ -184,7 +184,7 @@ func (rr *MB) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad MB Mb", l}
+		return &ParseError{err: "bad MB Mb", lex: l}
 	}
 	rr.Mb = name
 	return slurpRemainder(c)
@@ -194,7 +194,7 @@ func (rr *MG) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad MG Mg", l}
+		return &ParseError{err: "bad MG Mg", lex: l}
 	}
 	rr.Mg = name
 	return slurpRemainder(c)
@@ -219,6 +219,29 @@ func (rr *HINFO) parse(c *zlexer, o string) *ParseError {
 
 	rr.Cpu = chunks[0]
 	rr.Os = strings.Join(chunks[1:], " ")
+	return nil
+}
+
+// according to RFC 1183 the parsing is identical to HINFO, so just use that code.
+func (rr *ISDN) parse(c *zlexer, o string) *ParseError {
+	chunks, e := endingToTxtSlice(c, "bad ISDN Fields")
+	if e != nil {
+		return e
+	}
+
+	if ln := len(chunks); ln == 0 {
+		return nil
+	} else if ln == 1 {
+		// Can we split it?
+		if out := strings.Fields(chunks[0]); len(out) > 1 {
+			chunks = out
+		} else {
+			chunks = append(chunks, "")
+		}
+	}
+
+	rr.Address = chunks[0]
+	rr.SubAddress = strings.Join(chunks[1:], " ")
 
 	return nil
 }
@@ -227,7 +250,7 @@ func (rr *MINFO) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	rmail, rmailOk := toAbsoluteName(l.token, o)
 	if l.err || !rmailOk {
-		return &ParseError{"", "bad MINFO Rmail", l}
+		return &ParseError{err: "bad MINFO Rmail", lex: l}
 	}
 	rr.Rmail = rmail
 
@@ -237,7 +260,7 @@ func (rr *MINFO) parse(c *zlexer, o string) *ParseError {
 
 	email, emailOk := toAbsoluteName(l.token, o)
 	if l.err || !emailOk {
-		return &ParseError{"", "bad MINFO Email", l}
+		return &ParseError{err: "bad MINFO Email", lex: l}
 	}
 	rr.Email = email
 
@@ -248,7 +271,7 @@ func (rr *MF) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad MF Mf", l}
+		return &ParseError{err: "bad MF Mf", lex: l}
 	}
 	rr.Mf = name
 	return slurpRemainder(c)
@@ -258,7 +281,7 @@ func (rr *MD) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad MD Md", l}
+		return &ParseError{err: "bad MD Md", lex: l}
 	}
 	rr.Md = name
 	return slurpRemainder(c)
@@ -268,7 +291,7 @@ func (rr *MX) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad MX Pref", l}
+		return &ParseError{err: "bad MX Pref", lex: l}
 	}
 	rr.Preference = uint16(i)
 
@@ -278,7 +301,7 @@ func (rr *MX) parse(c *zlexer, o string) *ParseError {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad MX Mx", l}
+		return &ParseError{err: "bad MX Mx", lex: l}
 	}
 	rr.Mx = name
 
@@ -289,7 +312,7 @@ func (rr *RT) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil {
-		return &ParseError{"", "bad RT Preference", l}
+		return &ParseError{err: "bad RT Preference", lex: l}
 	}
 	rr.Preference = uint16(i)
 
@@ -299,7 +322,7 @@ func (rr *RT) parse(c *zlexer, o string) *ParseError {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad RT Host", l}
+		return &ParseError{err: "bad RT Host", lex: l}
 	}
 	rr.Host = name
 
@@ -310,7 +333,7 @@ func (rr *AFSDB) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad AFSDB Subtype", l}
+		return &ParseError{err: "bad AFSDB Subtype", lex: l}
 	}
 	rr.Subtype = uint16(i)
 
@@ -320,7 +343,7 @@ func (rr *AFSDB) parse(c *zlexer, o string) *ParseError {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad AFSDB Hostname", l}
+		return &ParseError{err: "bad AFSDB Hostname", lex: l}
 	}
 	rr.Hostname = name
 	return slurpRemainder(c)
@@ -329,7 +352,7 @@ func (rr *AFSDB) parse(c *zlexer, o string) *ParseError {
 func (rr *X25) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	if l.err {
-		return &ParseError{"", "bad X25 PSDNAddress", l}
+		return &ParseError{err: "bad X25 PSDNAddress", lex: l}
 	}
 	rr.PSDNAddress = l.token
 	return slurpRemainder(c)
@@ -339,7 +362,7 @@ func (rr *KX) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad KX Pref", l}
+		return &ParseError{err: "bad KX Pref", lex: l}
 	}
 	rr.Preference = uint16(i)
 
@@ -349,7 +372,7 @@ func (rr *KX) parse(c *zlexer, o string) *ParseError {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad KX Exchanger", l}
+		return &ParseError{err: "bad KX Exchanger", lex: l}
 	}
 	rr.Exchanger = name
 	return slurpRemainder(c)
@@ -359,7 +382,7 @@ func (rr *CNAME) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad CNAME Target", l}
+		return &ParseError{err: "bad CNAME Target", lex: l}
 	}
 	rr.Target = name
 	return slurpRemainder(c)
@@ -369,7 +392,7 @@ func (rr *DNAME) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad DNAME Target", l}
+		return &ParseError{err: "bad DNAME Target", lex: l}
 	}
 	rr.Target = name
 	return slurpRemainder(c)
@@ -379,7 +402,7 @@ func (rr *SOA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	ns, nsOk := toAbsoluteName(l.token, o)
 	if l.err || !nsOk {
-		return &ParseError{"", "bad SOA Ns", l}
+		return &ParseError{err: "bad SOA Ns", lex: l}
 	}
 	rr.Ns = ns
 
@@ -389,7 +412,7 @@ func (rr *SOA) parse(c *zlexer, o string) *ParseError {
 
 	mbox, mboxOk := toAbsoluteName(l.token, o)
 	if l.err || !mboxOk {
-		return &ParseError{"", "bad SOA Mbox", l}
+		return &ParseError{err: "bad SOA Mbox", lex: l}
 	}
 	rr.Mbox = mbox
 
@@ -402,16 +425,16 @@ func (rr *SOA) parse(c *zlexer, o string) *ParseError {
 	for i := 0; i < 5; i++ {
 		l, _ = c.Next()
 		if l.err {
-			return &ParseError{"", "bad SOA zone parameter", l}
+			return &ParseError{err: "bad SOA zone parameter", lex: l}
 		}
 		if j, err := strconv.ParseUint(l.token, 10, 32); err != nil {
 			if i == 0 {
 				// Serial must be a number
-				return &ParseError{"", "bad SOA zone parameter", l}
+				return &ParseError{err: "bad SOA zone parameter", lex: l}
 			}
 			// We allow other fields to be unitful duration strings
 			if v, ok = stringToTTL(l.token); !ok {
-				return &ParseError{"", "bad SOA zone parameter", l}
+				return &ParseError{err: "bad SOA zone parameter", lex: l}
 
 			}
 		} else {
@@ -441,7 +464,7 @@ func (rr *SRV) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad SRV Priority", l}
+		return &ParseError{err: "bad SRV Priority", lex: l}
 	}
 	rr.Priority = uint16(i)
 
@@ -449,7 +472,7 @@ func (rr *SRV) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next() // zString
 	i, e1 := strconv.ParseUint(l.token, 10, 16)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad SRV Weight", l}
+		return &ParseError{err: "bad SRV Weight", lex: l}
 	}
 	rr.Weight = uint16(i)
 
@@ -457,7 +480,7 @@ func (rr *SRV) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next() // zString
 	i, e2 := strconv.ParseUint(l.token, 10, 16)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad SRV Port", l}
+		return &ParseError{err: "bad SRV Port", lex: l}
 	}
 	rr.Port = uint16(i)
 
@@ -467,7 +490,7 @@ func (rr *SRV) parse(c *zlexer, o string) *ParseError {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad SRV Target", l}
+		return &ParseError{err: "bad SRV Target", lex: l}
 	}
 	rr.Target = name
 	return slurpRemainder(c)
@@ -477,7 +500,7 @@ func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad NAPTR Order", l}
+		return &ParseError{err: "bad NAPTR Order", lex: l}
 	}
 	rr.Order = uint16(i)
 
@@ -485,7 +508,7 @@ func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next() // zString
 	i, e1 := strconv.ParseUint(l.token, 10, 16)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad NAPTR Preference", l}
+		return &ParseError{err: "bad NAPTR Preference", lex: l}
 	}
 	rr.Preference = uint16(i)
 
@@ -493,57 +516,57 @@ func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 	c.Next()        // zBlank
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
-		return &ParseError{"", "bad NAPTR Flags", l}
+		return &ParseError{err: "bad NAPTR Flags", lex: l}
 	}
 	l, _ = c.Next() // Either String or Quote
 	if l.value == zString {
 		rr.Flags = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
-			return &ParseError{"", "bad NAPTR Flags", l}
+			return &ParseError{err: "bad NAPTR Flags", lex: l}
 		}
 	} else if l.value == zQuote {
 		rr.Flags = ""
 	} else {
-		return &ParseError{"", "bad NAPTR Flags", l}
+		return &ParseError{err: "bad NAPTR Flags", lex: l}
 	}
 
 	// Service
 	c.Next()        // zBlank
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
-		return &ParseError{"", "bad NAPTR Service", l}
+		return &ParseError{err: "bad NAPTR Service", lex: l}
 	}
 	l, _ = c.Next() // Either String or Quote
 	if l.value == zString {
 		rr.Service = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
-			return &ParseError{"", "bad NAPTR Service", l}
+			return &ParseError{err: "bad NAPTR Service", lex: l}
 		}
 	} else if l.value == zQuote {
 		rr.Service = ""
 	} else {
-		return &ParseError{"", "bad NAPTR Service", l}
+		return &ParseError{err: "bad NAPTR Service", lex: l}
 	}
 
 	// Regexp
 	c.Next()        // zBlank
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
-		return &ParseError{"", "bad NAPTR Regexp", l}
+		return &ParseError{err: "bad NAPTR Regexp", lex: l}
 	}
 	l, _ = c.Next() // Either String or Quote
 	if l.value == zString {
 		rr.Regexp = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
-			return &ParseError{"", "bad NAPTR Regexp", l}
+			return &ParseError{err: "bad NAPTR Regexp", lex: l}
 		}
 	} else if l.value == zQuote {
 		rr.Regexp = ""
 	} else {
-		return &ParseError{"", "bad NAPTR Regexp", l}
+		return &ParseError{err: "bad NAPTR Regexp", lex: l}
 	}
 
 	// After quote no space??
@@ -553,7 +576,7 @@ func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad NAPTR Replacement", l}
+		return &ParseError{err: "bad NAPTR Replacement", lex: l}
 	}
 	rr.Replacement = name
 	return slurpRemainder(c)
@@ -563,7 +586,7 @@ func (rr *TALINK) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	previousName, previousNameOk := toAbsoluteName(l.token, o)
 	if l.err || !previousNameOk {
-		return &ParseError{"", "bad TALINK PreviousName", l}
+		return &ParseError{err: "bad TALINK PreviousName", lex: l}
 	}
 	rr.PreviousName = previousName
 
@@ -573,7 +596,7 @@ func (rr *TALINK) parse(c *zlexer, o string) *ParseError {
 
 	nextName, nextNameOk := toAbsoluteName(l.token, o)
 	if l.err || !nextNameOk {
-		return &ParseError{"", "bad TALINK NextName", l}
+		return &ParseError{err: "bad TALINK NextName", lex: l}
 	}
 	rr.NextName = nextName
 
@@ -591,7 +614,7 @@ func (rr *LOC) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err || i > 90 {
-		return &ParseError{"", "bad LOC Latitude", l}
+		return &ParseError{err: "bad LOC Latitude", lex: l}
 	}
 	rr.Latitude = 1000 * 60 * 60 * uint32(i)
 
@@ -602,7 +625,7 @@ func (rr *LOC) parse(c *zlexer, o string) *ParseError {
 		goto East
 	}
 	if i, err := strconv.ParseUint(l.token, 10, 32); err != nil || l.err || i > 59 {
-		return &ParseError{"", "bad LOC Latitude minutes", l}
+		return &ParseError{err: "bad LOC Latitude minutes", lex: l}
 	} else {
 		rr.Latitude += 1000 * 60 * uint32(i)
 	}
@@ -610,7 +633,7 @@ func (rr *LOC) parse(c *zlexer, o string) *ParseError {
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if i, err := strconv.ParseFloat(l.token, 64); err != nil || l.err || i < 0 || i >= 60 {
-		return &ParseError{"", "bad LOC Latitude seconds", l}
+		return &ParseError{err: "bad LOC Latitude seconds", lex: l}
 	} else {
 		rr.Latitude += uint32(1000 * i)
 	}
@@ -621,14 +644,14 @@ func (rr *LOC) parse(c *zlexer, o string) *ParseError {
 		goto East
 	}
 	// If still alive, flag an error
-	return &ParseError{"", "bad LOC Latitude North/South", l}
+	return &ParseError{err: "bad LOC Latitude North/South", lex: l}
 
 East:
 	// East
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if i, err := strconv.ParseUint(l.token, 10, 32); err != nil || l.err || i > 180 {
-		return &ParseError{"", "bad LOC Longitude", l}
+		return &ParseError{err: "bad LOC Longitude", lex: l}
 	} else {
 		rr.Longitude = 1000 * 60 * 60 * uint32(i)
 	}
@@ -639,14 +662,14 @@ East:
 		goto Altitude
 	}
 	if i, err := strconv.ParseUint(l.token, 10, 32); err != nil || l.err || i > 59 {
-		return &ParseError{"", "bad LOC Longitude minutes", l}
+		return &ParseError{err: "bad LOC Longitude minutes", lex: l}
 	} else {
 		rr.Longitude += 1000 * 60 * uint32(i)
 	}
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if i, err := strconv.ParseFloat(l.token, 64); err != nil || l.err || i < 0 || i >= 60 {
-		return &ParseError{"", "bad LOC Longitude seconds", l}
+		return &ParseError{err: "bad LOC Longitude seconds", lex: l}
 	} else {
 		rr.Longitude += uint32(1000 * i)
 	}
@@ -657,19 +680,19 @@ East:
 		goto Altitude
 	}
 	// If still alive, flag an error
-	return &ParseError{"", "bad LOC Longitude East/West", l}
+	return &ParseError{err: "bad LOC Longitude East/West", lex: l}
 
 Altitude:
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if l.token == "" || l.err {
-		return &ParseError{"", "bad LOC Altitude", l}
+		return &ParseError{err: "bad LOC Altitude", lex: l}
 	}
 	if l.token[len(l.token)-1] == 'M' || l.token[len(l.token)-1] == 'm' {
 		l.token = l.token[0 : len(l.token)-1]
 	}
 	if i, err := strconv.ParseFloat(l.token, 64); err != nil {
-		return &ParseError{"", "bad LOC Altitude", l}
+		return &ParseError{err: "bad LOC Altitude", lex: l}
 	} else {
 		rr.Altitude = uint32(i*100.0 + 10000000.0 + 0.5)
 	}
@@ -684,19 +707,19 @@ Altitude:
 			case 0: // Size
 				exp, m, ok := stringToCm(l.token)
 				if !ok {
-					return &ParseError{"", "bad LOC Size", l}
+					return &ParseError{err: "bad LOC Size", lex: l}
 				}
 				rr.Size = exp&0x0f | m<<4&0xf0
 			case 1: // HorizPre
 				exp, m, ok := stringToCm(l.token)
 				if !ok {
-					return &ParseError{"", "bad LOC HorizPre", l}
+					return &ParseError{err: "bad LOC HorizPre", lex: l}
 				}
 				rr.HorizPre = exp&0x0f | m<<4&0xf0
 			case 2: // VertPre
 				exp, m, ok := stringToCm(l.token)
 				if !ok {
-					return &ParseError{"", "bad LOC VertPre", l}
+					return &ParseError{err: "bad LOC VertPre", lex: l}
 				}
 				rr.VertPre = exp&0x0f | m<<4&0xf0
 			}
@@ -704,7 +727,7 @@ Altitude:
 		case zBlank:
 			// Ok
 		default:
-			return &ParseError{"", "bad LOC Size, HorizPre or VertPre", l}
+			return &ParseError{err: "bad LOC Size, HorizPre or VertPre", lex: l}
 		}
 		l, _ = c.Next()
 	}
@@ -716,14 +739,14 @@ func (rr *HIP) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad HIP PublicKeyAlgorithm", l}
+		return &ParseError{err: "bad HIP PublicKeyAlgorithm", lex: l}
 	}
 	rr.PublicKeyAlgorithm = uint8(i)
 
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	if l.token == "" || l.err {
-		return &ParseError{"", "bad HIP Hit", l}
+		return &ParseError{err: "bad HIP Hit", lex: l}
 	}
 	rr.Hit = l.token // This can not contain spaces, see RFC 5205 Section 6.
 	rr.HitLength = uint8(len(rr.Hit)) / 2
@@ -731,12 +754,12 @@ func (rr *HIP) parse(c *zlexer, o string) *ParseError {
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	if l.token == "" || l.err {
-		return &ParseError{"", "bad HIP PublicKey", l}
+		return &ParseError{err: "bad HIP PublicKey", lex: l}
 	}
 	rr.PublicKey = l.token // This cannot contain spaces
 	decodedPK, decodedPKerr := base64.StdEncoding.DecodeString(rr.PublicKey)
 	if decodedPKerr != nil {
-		return &ParseError{"", "bad HIP PublicKey", l}
+		return &ParseError{err: "bad HIP PublicKey", lex: l}
 	}
 	rr.PublicKeyLength = uint16(len(decodedPK))
 
@@ -748,13 +771,13 @@ func (rr *HIP) parse(c *zlexer, o string) *ParseError {
 		case zString:
 			name, nameOk := toAbsoluteName(l.token, o)
 			if l.err || !nameOk {
-				return &ParseError{"", "bad HIP RendezvousServers", l}
+				return &ParseError{err: "bad HIP RendezvousServers", lex: l}
 			}
 			xs = append(xs, name)
 		case zBlank:
 			// Ok
 		default:
-			return &ParseError{"", "bad HIP RendezvousServers", l}
+			return &ParseError{err: "bad HIP RendezvousServers", lex: l}
 		}
 		l, _ = c.Next()
 	}
@@ -768,7 +791,7 @@ func (rr *CERT) parse(c *zlexer, o string) *ParseError {
 	if v, ok := StringToCertType[l.token]; ok {
 		rr.Type = v
 	} else if i, err := strconv.ParseUint(l.token, 10, 16); err != nil {
-		return &ParseError{"", "bad CERT Type", l}
+		return &ParseError{err: "bad CERT Type", lex: l}
 	} else {
 		rr.Type = uint16(i)
 	}
@@ -776,7 +799,7 @@ func (rr *CERT) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next() // zString
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad CERT KeyTag", l}
+		return &ParseError{err: "bad CERT KeyTag", lex: l}
 	}
 	rr.KeyTag = uint16(i)
 	c.Next()        // zBlank
@@ -784,7 +807,7 @@ func (rr *CERT) parse(c *zlexer, o string) *ParseError {
 	if v, ok := StringToAlgorithm[l.token]; ok {
 		rr.Algorithm = v
 	} else if i, err := strconv.ParseUint(l.token, 10, 8); err != nil {
-		return &ParseError{"", "bad CERT Algorithm", l}
+		return &ParseError{err: "bad CERT Algorithm", lex: l}
 	} else {
 		rr.Algorithm = uint8(i)
 	}
@@ -810,7 +833,7 @@ func (rr *CSYNC) parse(c *zlexer, o string) *ParseError {
 	j, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil {
 		// Serial must be a number
-		return &ParseError{"", "bad CSYNC serial", l}
+		return &ParseError{err: "bad CSYNC serial", lex: l}
 	}
 	rr.Serial = uint32(j)
 
@@ -820,7 +843,7 @@ func (rr *CSYNC) parse(c *zlexer, o string) *ParseError {
 	j, e1 := strconv.ParseUint(l.token, 10, 16)
 	if e1 != nil {
 		// Serial must be a number
-		return &ParseError{"", "bad CSYNC flags", l}
+		return &ParseError{err: "bad CSYNC flags", lex: l}
 	}
 	rr.Flags = uint16(j)
 
@@ -838,12 +861,12 @@ func (rr *CSYNC) parse(c *zlexer, o string) *ParseError {
 			tokenUpper := strings.ToUpper(l.token)
 			if k, ok = StringToType[tokenUpper]; !ok {
 				if k, ok = typeToInt(l.token); !ok {
-					return &ParseError{"", "bad CSYNC TypeBitMap", l}
+					return &ParseError{err: "bad CSYNC TypeBitMap", lex: l}
 				}
 			}
 			rr.TypeBitMap = append(rr.TypeBitMap, k)
 		default:
-			return &ParseError{"", "bad CSYNC TypeBitMap", l}
+			return &ParseError{err: "bad CSYNC TypeBitMap", lex: l}
 		}
 		l, _ = c.Next()
 	}
@@ -854,7 +877,7 @@ func (rr *ZONEMD) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
-		return &ParseError{"", "bad ZONEMD Serial", l}
+		return &ParseError{err: "bad ZONEMD Serial", lex: l}
 	}
 	rr.Serial = uint32(i)
 
@@ -862,7 +885,7 @@ func (rr *ZONEMD) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad ZONEMD Scheme", l}
+		return &ParseError{err: "bad ZONEMD Scheme", lex: l}
 	}
 	rr.Scheme = uint8(i)
 
@@ -870,7 +893,7 @@ func (rr *ZONEMD) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return &ParseError{"", "bad ZONEMD Hash Algorithm", l}
+		return &ParseError{err: "bad ZONEMD Hash Algorithm", lex: l}
 	}
 	rr.Hash = uint8(i)
 
@@ -891,11 +914,11 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 		if strings.HasPrefix(tokenUpper, "TYPE") {
 			t, ok = typeToInt(l.token)
 			if !ok {
-				return &ParseError{"", "bad RRSIG Typecovered", l}
+				return &ParseError{err: "bad RRSIG Typecovered", lex: l}
 			}
 			rr.TypeCovered = t
 		} else {
-			return &ParseError{"", "bad RRSIG Typecovered", l}
+			return &ParseError{err: "bad RRSIG Typecovered", lex: l}
 		}
 	} else {
 		rr.TypeCovered = t
@@ -904,14 +927,14 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if l.err {
-		return &ParseError{"", "bad RRSIG Algorithm", l}
+		return &ParseError{err: "bad RRSIG Algorithm", lex: l}
 	}
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	rr.Algorithm = uint8(i) // if 0 we'll check the mnemonic in the if
 	if e != nil {
 		v, ok := StringToAlgorithm[l.token]
 		if !ok {
-			return &ParseError{"", "bad RRSIG Algorithm", l}
+			return &ParseError{err: "bad RRSIG Algorithm", lex: l}
 		}
 		rr.Algorithm = v
 	}
@@ -920,7 +943,7 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad RRSIG Labels", l}
+		return &ParseError{err: "bad RRSIG Labels", lex: l}
 	}
 	rr.Labels = uint8(i)
 
@@ -928,7 +951,7 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, e2 := strconv.ParseUint(l.token, 10, 32)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad RRSIG OrigTtl", l}
+		return &ParseError{err: "bad RRSIG OrigTtl", lex: l}
 	}
 	rr.OrigTtl = uint32(i)
 
@@ -939,7 +962,7 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 		if i, err := strconv.ParseUint(l.token, 10, 32); err == nil {
 			rr.Expiration = uint32(i)
 		} else {
-			return &ParseError{"", "bad RRSIG Expiration", l}
+			return &ParseError{err: "bad RRSIG Expiration", lex: l}
 		}
 	} else {
 		rr.Expiration = i
@@ -951,7 +974,7 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 		if i, err := strconv.ParseUint(l.token, 10, 32); err == nil {
 			rr.Inception = uint32(i)
 		} else {
-			return &ParseError{"", "bad RRSIG Inception", l}
+			return &ParseError{err: "bad RRSIG Inception", lex: l}
 		}
 	} else {
 		rr.Inception = i
@@ -961,7 +984,7 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, e3 := strconv.ParseUint(l.token, 10, 16)
 	if e3 != nil || l.err {
-		return &ParseError{"", "bad RRSIG KeyTag", l}
+		return &ParseError{err: "bad RRSIG KeyTag", lex: l}
 	}
 	rr.KeyTag = uint16(i)
 
@@ -970,7 +993,7 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 	rr.SignerName = l.token
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad RRSIG SignerName", l}
+		return &ParseError{err: "bad RRSIG SignerName", lex: l}
 	}
 	rr.SignerName = name
 
@@ -983,11 +1006,13 @@ func (rr *RRSIG) parse(c *zlexer, o string) *ParseError {
 	return nil
 }
 
+func (rr *NXT) parse(c *zlexer, o string) *ParseError { return rr.NSEC.parse(c, o) }
+
 func (rr *NSEC) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad NSEC NextDomain", l}
+		return &ParseError{err: "bad NSEC NextDomain", lex: l}
 	}
 	rr.NextDomain = name
 
@@ -1005,12 +1030,12 @@ func (rr *NSEC) parse(c *zlexer, o string) *ParseError {
 			tokenUpper := strings.ToUpper(l.token)
 			if k, ok = StringToType[tokenUpper]; !ok {
 				if k, ok = typeToInt(l.token); !ok {
-					return &ParseError{"", "bad NSEC TypeBitMap", l}
+					return &ParseError{err: "bad NSEC TypeBitMap", lex: l}
 				}
 			}
 			rr.TypeBitMap = append(rr.TypeBitMap, k)
 		default:
-			return &ParseError{"", "bad NSEC TypeBitMap", l}
+			return &ParseError{err: "bad NSEC TypeBitMap", lex: l}
 		}
 		l, _ = c.Next()
 	}
@@ -1021,27 +1046,27 @@ func (rr *NSEC3) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad NSEC3 Hash", l}
+		return &ParseError{err: "bad NSEC3 Hash", lex: l}
 	}
 	rr.Hash = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad NSEC3 Flags", l}
+		return &ParseError{err: "bad NSEC3 Flags", lex: l}
 	}
 	rr.Flags = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e2 := strconv.ParseUint(l.token, 10, 16)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad NSEC3 Iterations", l}
+		return &ParseError{err: "bad NSEC3 Iterations", lex: l}
 	}
 	rr.Iterations = uint16(i)
 	c.Next()
 	l, _ = c.Next()
 	if l.token == "" || l.err {
-		return &ParseError{"", "bad NSEC3 Salt", l}
+		return &ParseError{err: "bad NSEC3 Salt", lex: l}
 	}
 	if l.token != "-" {
 		rr.SaltLength = uint8(len(l.token)) / 2
@@ -1051,7 +1076,7 @@ func (rr *NSEC3) parse(c *zlexer, o string) *ParseError {
 	c.Next()
 	l, _ = c.Next()
 	if l.token == "" || l.err {
-		return &ParseError{"", "bad NSEC3 NextDomain", l}
+		return &ParseError{err: "bad NSEC3 NextDomain", lex: l}
 	}
 	rr.HashLength = 20 // Fix for NSEC3 (sha1 160 bits)
 	rr.NextDomain = l.token
@@ -1070,12 +1095,12 @@ func (rr *NSEC3) parse(c *zlexer, o string) *ParseError {
 			tokenUpper := strings.ToUpper(l.token)
 			if k, ok = StringToType[tokenUpper]; !ok {
 				if k, ok = typeToInt(l.token); !ok {
-					return &ParseError{"", "bad NSEC3 TypeBitMap", l}
+					return &ParseError{err: "bad NSEC3 TypeBitMap", lex: l}
 				}
 			}
 			rr.TypeBitMap = append(rr.TypeBitMap, k)
 		default:
-			return &ParseError{"", "bad NSEC3 TypeBitMap", l}
+			return &ParseError{err: "bad NSEC3 TypeBitMap", lex: l}
 		}
 		l, _ = c.Next()
 	}
@@ -1086,21 +1111,21 @@ func (rr *NSEC3PARAM) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad NSEC3PARAM Hash", l}
+		return &ParseError{err: "bad NSEC3PARAM Hash", lex: l}
 	}
 	rr.Hash = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad NSEC3PARAM Flags", l}
+		return &ParseError{err: "bad NSEC3PARAM Flags", lex: l}
 	}
 	rr.Flags = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e2 := strconv.ParseUint(l.token, 10, 16)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad NSEC3PARAM Iterations", l}
+		return &ParseError{err: "bad NSEC3PARAM Iterations", lex: l}
 	}
 	rr.Iterations = uint16(i)
 	c.Next()
@@ -1115,7 +1140,7 @@ func (rr *NSEC3PARAM) parse(c *zlexer, o string) *ParseError {
 func (rr *EUI48) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	if len(l.token) != 17 || l.err {
-		return &ParseError{"", "bad EUI48 Address", l}
+		return &ParseError{err: "bad EUI48 Address", lex: l}
 	}
 	addr := make([]byte, 12)
 	dash := 0
@@ -1124,7 +1149,7 @@ func (rr *EUI48) parse(c *zlexer, o string) *ParseError {
 		addr[i+1] = l.token[i+1+dash]
 		dash++
 		if l.token[i+1+dash] != '-' {
-			return &ParseError{"", "bad EUI48 Address", l}
+			return &ParseError{err: "bad EUI48 Address", lex: l}
 		}
 	}
 	addr[10] = l.token[15]
@@ -1132,7 +1157,7 @@ func (rr *EUI48) parse(c *zlexer, o string) *ParseError {
 
 	i, e := strconv.ParseUint(string(addr), 16, 48)
 	if e != nil {
-		return &ParseError{"", "bad EUI48 Address", l}
+		return &ParseError{err: "bad EUI48 Address", lex: l}
 	}
 	rr.Address = i
 	return slurpRemainder(c)
@@ -1141,7 +1166,7 @@ func (rr *EUI48) parse(c *zlexer, o string) *ParseError {
 func (rr *EUI64) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	if len(l.token) != 23 || l.err {
-		return &ParseError{"", "bad EUI64 Address", l}
+		return &ParseError{err: "bad EUI64 Address", lex: l}
 	}
 	addr := make([]byte, 16)
 	dash := 0
@@ -1150,7 +1175,7 @@ func (rr *EUI64) parse(c *zlexer, o string) *ParseError {
 		addr[i+1] = l.token[i+1+dash]
 		dash++
 		if l.token[i+1+dash] != '-' {
-			return &ParseError{"", "bad EUI64 Address", l}
+			return &ParseError{err: "bad EUI64 Address", lex: l}
 		}
 	}
 	addr[14] = l.token[21]
@@ -1158,7 +1183,7 @@ func (rr *EUI64) parse(c *zlexer, o string) *ParseError {
 
 	i, e := strconv.ParseUint(string(addr), 16, 64)
 	if e != nil {
-		return &ParseError{"", "bad EUI68 Address", l}
+		return &ParseError{err: "bad EUI68 Address", lex: l}
 	}
 	rr.Address = i
 	return slurpRemainder(c)
@@ -1168,14 +1193,14 @@ func (rr *SSHFP) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad SSHFP Algorithm", l}
+		return &ParseError{err: "bad SSHFP Algorithm", lex: l}
 	}
 	rr.Algorithm = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad SSHFP Type", l}
+		return &ParseError{err: "bad SSHFP Type", lex: l}
 	}
 	rr.Type = uint8(i)
 	c.Next() // zBlank
@@ -1191,21 +1216,21 @@ func (rr *DNSKEY) parseDNSKEY(c *zlexer, o, typ string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad " + typ + " Flags", l}
+		return &ParseError{err: "bad " + typ + " Flags", lex: l}
 	}
 	rr.Flags = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad " + typ + " Protocol", l}
+		return &ParseError{err: "bad " + typ + " Protocol", lex: l}
 	}
 	rr.Protocol = uint8(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e2 := strconv.ParseUint(l.token, 10, 8)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad " + typ + " Algorithm", l}
+		return &ParseError{err: "bad " + typ + " Algorithm", lex: l}
 	}
 	rr.Algorithm = uint8(i)
 	s, e3 := endingToString(c, "bad "+typ+" PublicKey")
@@ -1227,7 +1252,7 @@ func (rr *IPSECKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	num, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return &ParseError{"", "bad IPSECKEY value", l}
+		return &ParseError{err: "bad IPSECKEY value", lex: l}
 	}
 	rr.Precedence = uint8(num)
 	c.Next() // zBlank
@@ -1235,7 +1260,7 @@ func (rr *IPSECKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	num, err = strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return &ParseError{"", "bad IPSECKEY value", l}
+		return &ParseError{err: "bad IPSECKEY value", lex: l}
 	}
 	rr.GatewayType = uint8(num)
 	c.Next() // zBlank
@@ -1243,19 +1268,19 @@ func (rr *IPSECKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	num, err = strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return &ParseError{"", "bad IPSECKEY value", l}
+		return &ParseError{err: "bad IPSECKEY value", lex: l}
 	}
 	rr.Algorithm = uint8(num)
 	c.Next() // zBlank
 
 	l, _ = c.Next()
 	if l.err {
-		return &ParseError{"", "bad IPSECKEY gateway", l}
+		return &ParseError{err: "bad IPSECKEY gateway", lex: l}
 	}
 
 	rr.GatewayAddr, rr.GatewayHost, err = parseAddrHostUnion(l.token, o, rr.GatewayType)
 	if err != nil {
-		return &ParseError{"", "IPSECKEY " + err.Error(), l}
+		return &ParseError{wrappedErr: fmt.Errorf("IPSECKEY %w", err), lex: l}
 	}
 
 	c.Next() // zBlank
@@ -1272,14 +1297,14 @@ func (rr *AMTRELAY) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	num, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return &ParseError{"", "bad AMTRELAY value", l}
+		return &ParseError{err: "bad AMTRELAY value", lex: l}
 	}
 	rr.Precedence = uint8(num)
 	c.Next() // zBlank
 
 	l, _ = c.Next()
 	if l.err || !(l.token == "0" || l.token == "1") {
-		return &ParseError{"", "bad discovery value", l}
+		return &ParseError{err: "bad discovery value", lex: l}
 	}
 	if l.token == "1" {
 		rr.GatewayType = 0x80
@@ -1290,19 +1315,19 @@ func (rr *AMTRELAY) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	num, err = strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
-		return &ParseError{"", "bad AMTRELAY value", l}
+		return &ParseError{err: "bad AMTRELAY value", lex: l}
 	}
 	rr.GatewayType |= uint8(num)
 	c.Next() // zBlank
 
 	l, _ = c.Next()
 	if l.err {
-		return &ParseError{"", "bad AMTRELAY gateway", l}
+		return &ParseError{err: "bad AMTRELAY gateway", lex: l}
 	}
 
 	rr.GatewayAddr, rr.GatewayHost, err = parseAddrHostUnion(l.token, o, rr.GatewayType&0x7f)
 	if err != nil {
-		return &ParseError{"", "AMTRELAY " + err.Error(), l}
+		return &ParseError{wrappedErr: fmt.Errorf("AMTRELAY %w", err), lex: l}
 	}
 
 	return slurpRemainder(c)
@@ -1338,21 +1363,21 @@ func (rr *RKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad RKEY Flags", l}
+		return &ParseError{err: "bad RKEY Flags", lex: l}
 	}
 	rr.Flags = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad RKEY Protocol", l}
+		return &ParseError{err: "bad RKEY Protocol", lex: l}
 	}
 	rr.Protocol = uint8(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	i, e2 := strconv.ParseUint(l.token, 10, 8)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad RKEY Algorithm", l}
+		return &ParseError{err: "bad RKEY Algorithm", lex: l}
 	}
 	rr.Algorithm = uint8(i)
 	s, e3 := endingToString(c, "bad RKEY PublicKey")
@@ -1385,21 +1410,21 @@ func (rr *GPOS) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	_, e := strconv.ParseFloat(l.token, 64)
 	if e != nil || l.err {
-		return &ParseError{"", "bad GPOS Longitude", l}
+		return &ParseError{err: "bad GPOS Longitude", lex: l}
 	}
 	rr.Longitude = l.token
 	c.Next() // zBlank
 	l, _ = c.Next()
 	_, e1 := strconv.ParseFloat(l.token, 64)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad GPOS Latitude", l}
+		return &ParseError{err: "bad GPOS Latitude", lex: l}
 	}
 	rr.Latitude = l.token
 	c.Next() // zBlank
 	l, _ = c.Next()
 	_, e2 := strconv.ParseFloat(l.token, 64)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad GPOS Altitude", l}
+		return &ParseError{err: "bad GPOS Altitude", lex: l}
 	}
 	rr.Altitude = l.token
 	return slurpRemainder(c)
@@ -1409,7 +1434,7 @@ func (rr *DS) parseDS(c *zlexer, o, typ string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad " + typ + " KeyTag", l}
+		return &ParseError{err: "bad " + typ + " KeyTag", lex: l}
 	}
 	rr.KeyTag = uint16(i)
 	c.Next() // zBlank
@@ -1418,7 +1443,7 @@ func (rr *DS) parseDS(c *zlexer, o, typ string) *ParseError {
 		tokenUpper := strings.ToUpper(l.token)
 		i, ok := StringToAlgorithm[tokenUpper]
 		if !ok || l.err {
-			return &ParseError{"", "bad " + typ + " Algorithm", l}
+			return &ParseError{err: "bad " + typ + " Algorithm", lex: l}
 		}
 		rr.Algorithm = i
 	} else {
@@ -1428,7 +1453,7 @@ func (rr *DS) parseDS(c *zlexer, o, typ string) *ParseError {
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad " + typ + " DigestType", l}
+		return &ParseError{err: "bad " + typ + " DigestType", lex: l}
 	}
 	rr.DigestType = uint8(i)
 	s, e2 := endingToString(c, "bad "+typ+" Digest")
@@ -1443,7 +1468,7 @@ func (rr *TA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad TA KeyTag", l}
+		return &ParseError{err: "bad TA KeyTag", lex: l}
 	}
 	rr.KeyTag = uint16(i)
 	c.Next() // zBlank
@@ -1452,7 +1477,7 @@ func (rr *TA) parse(c *zlexer, o string) *ParseError {
 		tokenUpper := strings.ToUpper(l.token)
 		i, ok := StringToAlgorithm[tokenUpper]
 		if !ok || l.err {
-			return &ParseError{"", "bad TA Algorithm", l}
+			return &ParseError{err: "bad TA Algorithm", lex: l}
 		}
 		rr.Algorithm = i
 	} else {
@@ -1462,7 +1487,7 @@ func (rr *TA) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad TA DigestType", l}
+		return &ParseError{err: "bad TA DigestType", lex: l}
 	}
 	rr.DigestType = uint8(i)
 	s, e2 := endingToString(c, "bad TA Digest")
@@ -1477,21 +1502,21 @@ func (rr *TLSA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad TLSA Usage", l}
+		return &ParseError{err: "bad TLSA Usage", lex: l}
 	}
 	rr.Usage = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad TLSA Selector", l}
+		return &ParseError{err: "bad TLSA Selector", lex: l}
 	}
 	rr.Selector = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e2 := strconv.ParseUint(l.token, 10, 8)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad TLSA MatchingType", l}
+		return &ParseError{err: "bad TLSA MatchingType", lex: l}
 	}
 	rr.MatchingType = uint8(i)
 	// So this needs be e2 (i.e. different than e), because...??t
@@ -1507,21 +1532,21 @@ func (rr *SMIMEA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad SMIMEA Usage", l}
+		return &ParseError{err: "bad SMIMEA Usage", lex: l}
 	}
 	rr.Usage = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad SMIMEA Selector", l}
+		return &ParseError{err: "bad SMIMEA Selector", lex: l}
 	}
 	rr.Selector = uint8(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e2 := strconv.ParseUint(l.token, 10, 8)
 	if e2 != nil || l.err {
-		return &ParseError{"", "bad SMIMEA MatchingType", l}
+		return &ParseError{err: "bad SMIMEA MatchingType", lex: l}
 	}
 	rr.MatchingType = uint8(i)
 	// So this needs be e2 (i.e. different than e), because...??t
@@ -1536,14 +1561,14 @@ func (rr *SMIMEA) parse(c *zlexer, o string) *ParseError {
 func (rr *RFC3597) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	if l.token != "\\#" {
-		return &ParseError{"", "bad RFC3597 Rdata", l}
+		return &ParseError{err: "bad RFC3597 Rdata", lex: l}
 	}
 
 	c.Next() // zBlank
 	l, _ = c.Next()
 	rdlength, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad RFC3597 Rdata ", l}
+		return &ParseError{err: "bad RFC3597 Rdata ", lex: l}
 	}
 
 	s, e1 := endingToString(c, "bad RFC3597 Rdata")
@@ -1551,7 +1576,7 @@ func (rr *RFC3597) parse(c *zlexer, o string) *ParseError {
 		return e1
 	}
 	if int(rdlength)*2 != len(s) {
-		return &ParseError{"", "bad RFC3597 Rdata", l}
+		return &ParseError{err: "bad RFC3597 Rdata", lex: l}
 	}
 	rr.Rdata = s
 	return nil
@@ -1599,14 +1624,14 @@ func (rr *URI) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad URI Priority", l}
+		return &ParseError{err: "bad URI Priority", lex: l}
 	}
 	rr.Priority = uint16(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 16)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad URI Weight", l}
+		return &ParseError{err: "bad URI Weight", lex: l}
 	}
 	rr.Weight = uint16(i)
 
@@ -1616,7 +1641,7 @@ func (rr *URI) parse(c *zlexer, o string) *ParseError {
 		return e2
 	}
 	if len(s) != 1 {
-		return &ParseError{"", "bad URI Target", l}
+		return &ParseError{err: "bad URI Target", lex: l}
 	}
 	rr.Target = s[0]
 	return nil
@@ -1636,7 +1661,7 @@ func (rr *NID) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad NID Preference", l}
+		return &ParseError{err: "bad NID Preference", lex: l}
 	}
 	rr.Preference = uint16(i)
 	c.Next()        // zBlank
@@ -1653,14 +1678,14 @@ func (rr *L32) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad L32 Preference", l}
+		return &ParseError{err: "bad L32 Preference", lex: l}
 	}
 	rr.Preference = uint16(i)
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	rr.Locator32 = net.ParseIP(l.token)
 	if rr.Locator32 == nil || l.err {
-		return &ParseError{"", "bad L32 Locator", l}
+		return &ParseError{err: "bad L32 Locator", lex: l}
 	}
 	return slurpRemainder(c)
 }
@@ -1669,7 +1694,7 @@ func (rr *LP) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad LP Preference", l}
+		return &ParseError{err: "bad LP Preference", lex: l}
 	}
 	rr.Preference = uint16(i)
 
@@ -1678,7 +1703,7 @@ func (rr *LP) parse(c *zlexer, o string) *ParseError {
 	rr.Fqdn = l.token
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{"", "bad LP Fqdn", l}
+		return &ParseError{err: "bad LP Fqdn", lex: l}
 	}
 	rr.Fqdn = name
 	return slurpRemainder(c)
@@ -1688,7 +1713,7 @@ func (rr *L64) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad L64 Preference", l}
+		return &ParseError{err: "bad L64 Preference", lex: l}
 	}
 	rr.Preference = uint16(i)
 	c.Next()        // zBlank
@@ -1705,7 +1730,7 @@ func (rr *UID) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
-		return &ParseError{"", "bad UID Uid", l}
+		return &ParseError{err: "bad UID Uid", lex: l}
 	}
 	rr.Uid = uint32(i)
 	return slurpRemainder(c)
@@ -1715,7 +1740,7 @@ func (rr *GID) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
-		return &ParseError{"", "bad GID Gid", l}
+		return &ParseError{err: "bad GID Gid", lex: l}
 	}
 	rr.Gid = uint32(i)
 	return slurpRemainder(c)
@@ -1737,7 +1762,7 @@ func (rr *PX) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{"", "bad PX Preference", l}
+		return &ParseError{err: "bad PX Preference", lex: l}
 	}
 	rr.Preference = uint16(i)
 
@@ -1746,7 +1771,7 @@ func (rr *PX) parse(c *zlexer, o string) *ParseError {
 	rr.Map822 = l.token
 	map822, map822Ok := toAbsoluteName(l.token, o)
 	if l.err || !map822Ok {
-		return &ParseError{"", "bad PX Map822", l}
+		return &ParseError{err: "bad PX Map822", lex: l}
 	}
 	rr.Map822 = map822
 
@@ -1755,7 +1780,7 @@ func (rr *PX) parse(c *zlexer, o string) *ParseError {
 	rr.Mapx400 = l.token
 	mapx400, mapx400Ok := toAbsoluteName(l.token, o)
 	if l.err || !mapx400Ok {
-		return &ParseError{"", "bad PX Mapx400", l}
+		return &ParseError{err: "bad PX Mapx400", lex: l}
 	}
 	rr.Mapx400 = mapx400
 	return slurpRemainder(c)
@@ -1765,14 +1790,14 @@ func (rr *CAA) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad CAA Flag", l}
+		return &ParseError{err: "bad CAA Flag", lex: l}
 	}
 	rr.Flag = uint8(i)
 
 	c.Next()        // zBlank
 	l, _ = c.Next() // zString
 	if l.value != zString {
-		return &ParseError{"", "bad CAA Tag", l}
+		return &ParseError{err: "bad CAA Tag", lex: l}
 	}
 	rr.Tag = l.token
 
@@ -1782,7 +1807,7 @@ func (rr *CAA) parse(c *zlexer, o string) *ParseError {
 		return e1
 	}
 	if len(s) != 1 {
-		return &ParseError{"", "bad CAA Value", l}
+		return &ParseError{err: "bad CAA Value", lex: l}
 	}
 	rr.Value = s[0]
 	return nil
@@ -1793,7 +1818,7 @@ func (rr *TKEY) parse(c *zlexer, o string) *ParseError {
 
 	// Algorithm
 	if l.value != zString {
-		return &ParseError{"", "bad TKEY algorithm", l}
+		return &ParseError{err: "bad TKEY algorithm", lex: l}
 	}
 	rr.Algorithm = l.token
 	c.Next() // zBlank
@@ -1802,13 +1827,13 @@ func (rr *TKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
-		return &ParseError{"", "bad TKEY key length", l}
+		return &ParseError{err: "bad TKEY key length", lex: l}
 	}
 	rr.KeySize = uint16(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if l.value != zString {
-		return &ParseError{"", "bad TKEY key", l}
+		return &ParseError{err: "bad TKEY key", lex: l}
 	}
 	rr.Key = l.token
 	c.Next() // zBlank
@@ -1817,13 +1842,13 @@ func (rr *TKEY) parse(c *zlexer, o string) *ParseError {
 	l, _ = c.Next()
 	i, e1 := strconv.ParseUint(l.token, 10, 8)
 	if e1 != nil || l.err {
-		return &ParseError{"", "bad TKEY otherdata length", l}
+		return &ParseError{err: "bad TKEY otherdata length", lex: l}
 	}
 	rr.OtherLen = uint16(i)
 	c.Next() // zBlank
 	l, _ = c.Next()
 	if l.value != zString {
-		return &ParseError{"", "bad TKEY otherday", l}
+		return &ParseError{err: "bad TKEY otherday", lex: l}
 	}
 	rr.OtherData = l.token
 	return nil
@@ -1841,14 +1866,14 @@ func (rr *APL) parse(c *zlexer, o string) *ParseError {
 			continue
 		}
 		if l.value != zString {
-			return &ParseError{"", "unexpected APL field", l}
+			return &ParseError{err: "unexpected APL field", lex: l}
 		}
 
 		// Expected format: [!]afi:address/prefix
 
 		colon := strings.IndexByte(l.token, ':')
 		if colon == -1 {
-			return &ParseError{"", "missing colon in APL field", l}
+			return &ParseError{err: "missing colon in APL field", lex: l}
 		}
 
 		family, cidr := l.token[:colon], l.token[colon+1:]
@@ -1861,7 +1886,7 @@ func (rr *APL) parse(c *zlexer, o string) *ParseError {
 
 		afi, e := strconv.ParseUint(family, 10, 16)
 		if e != nil {
-			return &ParseError{"", "failed to parse APL family: " + e.Error(), l}
+			return &ParseError{wrappedErr: fmt.Errorf("failed to parse APL family: %w", e), lex: l}
 		}
 		var addrLen int
 		switch afi {
@@ -1870,19 +1895,19 @@ func (rr *APL) parse(c *zlexer, o string) *ParseError {
 		case 2:
 			addrLen = net.IPv6len
 		default:
-			return &ParseError{"", "unrecognized APL family", l}
+			return &ParseError{err: "unrecognized APL family", lex: l}
 		}
 
 		ip, subnet, e1 := net.ParseCIDR(cidr)
 		if e1 != nil {
-			return &ParseError{"", "failed to parse APL address: " + e1.Error(), l}
+			return &ParseError{wrappedErr: fmt.Errorf("failed to parse APL address: %w", e1), lex: l}
 		}
 		if !ip.Equal(subnet.IP) {
-			return &ParseError{"", "extra bits in APL address", l}
+			return &ParseError{err: "extra bits in APL address", lex: l}
 		}
 
 		if len(subnet.IP) != addrLen {
-			return &ParseError{"", "address mismatch with the APL family", l}
+			return &ParseError{err: "address mismatch with the APL family", lex: l}
 		}
 
 		prefixes = append(prefixes, APLPrefix{
@@ -1893,4 +1918,40 @@ func (rr *APL) parse(c *zlexer, o string) *ParseError {
 
 	rr.Prefixes = prefixes
 	return nil
+}
+
+// escapedStringOffset finds the offset within a string (which may contain escape
+// sequences) that corresponds to a certain byte offset. If the input offset is
+// out of bounds, -1 is returned (which is *not* considered an error).
+func escapedStringOffset(s string, desiredByteOffset int) (int, bool) {
+	if desiredByteOffset == 0 {
+		return 0, true
+	}
+
+	currentByteOffset, i := 0, 0
+
+	for i < len(s) {
+		currentByteOffset += 1
+
+		// Skip escape sequences
+		if s[i] != '\\' {
+			// Single plain byte, not an escape sequence.
+			i++
+		} else if isDDD(s[i+1:]) {
+			// Skip backslash and DDD.
+			i += 4
+		} else if len(s[i+1:]) < 1 {
+			// No character following the backslash; that's an error.
+			return 0, false
+		} else {
+			// Skip backslash and following byte.
+			i += 2
+		}
+
+		if currentByteOffset >= desiredByteOffset {
+			return i, true
+		}
+	}
+
+	return -1, true
 }

--- a/vendor/github.com/miekg/dns/svcb.go
+++ b/vendor/github.com/miekg/dns/svcb.go
@@ -14,7 +14,7 @@ import (
 // SVCBKey is the type of the keys used in the SVCB RR.
 type SVCBKey uint16
 
-// Keys defined in draft-ietf-dnsop-svcb-https-08 Section 14.3.2.
+// Keys defined in rfc9460
 const (
 	SVCB_MANDATORY SVCBKey = iota
 	SVCB_ALPN
@@ -23,7 +23,8 @@ const (
 	SVCB_IPV4HINT
 	SVCB_ECHCONFIG
 	SVCB_IPV6HINT
-	SVCB_DOHPATH // draft-ietf-add-svcb-dns-02 Section 9
+	SVCB_DOHPATH // rfc9461 Section 5
+	SVCB_OHTTP   // rfc9540 Section 8
 
 	svcb_RESERVED SVCBKey = 65535
 )
@@ -37,6 +38,7 @@ var svcbKeyToStringMap = map[SVCBKey]string{
 	SVCB_ECHCONFIG:       "ech",
 	SVCB_IPV6HINT:        "ipv6hint",
 	SVCB_DOHPATH:         "dohpath",
+	SVCB_OHTTP:           "ohttp",
 }
 
 var svcbStringToKeyMap = reverseSVCBKeyMap(svcbKeyToStringMap)
@@ -85,7 +87,7 @@ func (rr *SVCB) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
-		return &ParseError{l.token, "bad SVCB priority", l}
+		return &ParseError{file: l.token, err: "bad SVCB priority", lex: l}
 	}
 	rr.Priority = uint16(i)
 
@@ -95,7 +97,7 @@ func (rr *SVCB) parse(c *zlexer, o string) *ParseError {
 
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
-		return &ParseError{l.token, "bad SVCB Target", l}
+		return &ParseError{file: l.token, err: "bad SVCB Target", lex: l}
 	}
 	rr.Target = name
 
@@ -111,7 +113,7 @@ func (rr *SVCB) parse(c *zlexer, o string) *ParseError {
 			if !canHaveNextKey {
 				// The key we can now read was probably meant to be
 				// a part of the last value.
-				return &ParseError{l.token, "bad SVCB value quotation", l}
+				return &ParseError{file: l.token, err: "bad SVCB value quotation", lex: l}
 			}
 
 			// In key=value pairs, value does not have to be quoted unless value
@@ -124,7 +126,7 @@ func (rr *SVCB) parse(c *zlexer, o string) *ParseError {
 				// Key with no value and no equality sign
 				key = l.token
 			} else if idx == 0 {
-				return &ParseError{l.token, "bad SVCB key", l}
+				return &ParseError{file: l.token, err: "bad SVCB key", lex: l}
 			} else {
 				key, value = l.token[:idx], l.token[idx+1:]
 
@@ -144,30 +146,30 @@ func (rr *SVCB) parse(c *zlexer, o string) *ParseError {
 							value = l.token
 							l, _ = c.Next()
 							if l.value != zQuote {
-								return &ParseError{l.token, "SVCB unterminated value", l}
+								return &ParseError{file: l.token, err: "SVCB unterminated value", lex: l}
 							}
 						case zQuote:
 							// There's nothing in double quotes.
 						default:
-							return &ParseError{l.token, "bad SVCB value", l}
+							return &ParseError{file: l.token, err: "bad SVCB value", lex: l}
 						}
 					}
 				}
 			}
 			kv := makeSVCBKeyValue(svcbStringToKey(key))
 			if kv == nil {
-				return &ParseError{l.token, "bad SVCB key", l}
+				return &ParseError{file: l.token, err: "bad SVCB key", lex: l}
 			}
 			if err := kv.parse(value); err != nil {
-				return &ParseError{l.token, err.Error(), l}
+				return &ParseError{file: l.token, wrappedErr: err, lex: l}
 			}
 			xs = append(xs, kv)
 		case zQuote:
-			return &ParseError{l.token, "SVCB key can't contain double quotes", l}
+			return &ParseError{file: l.token, err: "SVCB key can't contain double quotes", lex: l}
 		case zBlank:
 			canHaveNextKey = true
 		default:
-			return &ParseError{l.token, "bad SVCB values", l}
+			return &ParseError{file: l.token, err: "bad SVCB values", lex: l}
 		}
 		l, _ = c.Next()
 	}
@@ -201,6 +203,8 @@ func makeSVCBKeyValue(key SVCBKey) SVCBKeyValue {
 		return new(SVCBIPv6Hint)
 	case SVCB_DOHPATH:
 		return new(SVCBDoHPath)
+	case SVCB_OHTTP:
+		return new(SVCBOhttp)
 	case svcb_RESERVED:
 		return nil
 	default:
@@ -771,8 +775,8 @@ func (s *SVCBIPv6Hint) copy() SVCBKeyValue {
 // SVCBDoHPath pair is used to indicate the URI template that the
 // clients may use to construct a DNS over HTTPS URI.
 //
-// See RFC xxxx (https://datatracker.ietf.org/doc/html/draft-ietf-add-svcb-dns-02)
-// and RFC yyyy (https://datatracker.ietf.org/doc/html/draft-ietf-add-ddr-06).
+// See RFC 9461 (https://datatracker.ietf.org/doc/html/rfc9461)
+// and RFC 9462 (https://datatracker.ietf.org/doc/html/rfc9462).
 //
 // A basic example of using the dohpath option together with the alpn
 // option to indicate support for DNS over HTTPS on a certain path:
@@ -814,6 +818,44 @@ func (s *SVCBDoHPath) copy() SVCBKeyValue {
 	return &SVCBDoHPath{
 		Template: s.Template,
 	}
+}
+
+// The "ohttp" SvcParamKey is used to indicate that a service described in a SVCB RR
+// can be accessed as a target using an associated gateway.
+// Both the presentation and wire-format values for the "ohttp" parameter MUST be empty.
+//
+// See RFC 9460 (https://datatracker.ietf.org/doc/html/rfc9460/)
+// and RFC 9230 (https://datatracker.ietf.org/doc/html/rfc9230/)
+//
+// A basic example of using the dohpath option together with the alpn
+// option to indicate support for DNS over HTTPS on a certain path:
+//
+//	s := new(dns.SVCB)
+//	s.Hdr = dns.RR_Header{Name: ".", Rrtype: dns.TypeSVCB, Class: dns.ClassINET}
+//	e := new(dns.SVCBAlpn)
+//	e.Alpn = []string{"h2", "h3"}
+//	p := new(dns.SVCBOhttp)
+//	s.Value = append(s.Value, e, p)
+type SVCBOhttp struct{}
+
+func (*SVCBOhttp) Key() SVCBKey          { return SVCB_OHTTP }
+func (*SVCBOhttp) copy() SVCBKeyValue    { return &SVCBOhttp{} }
+func (*SVCBOhttp) pack() ([]byte, error) { return []byte{}, nil }
+func (*SVCBOhttp) String() string        { return "" }
+func (*SVCBOhttp) len() int              { return 0 }
+
+func (*SVCBOhttp) unpack(b []byte) error {
+	if len(b) != 0 {
+		return errors.New("dns: svcbotthp: svcbotthp must have no value")
+	}
+	return nil
+}
+
+func (*SVCBOhttp) parse(b string) error {
+	if b != "" {
+		return errors.New("dns: svcbotthp: svcbotthp must have no value")
+	}
+	return nil
 }
 
 // SVCBLocal pair is intended for experimental/private use. The key is recommended

--- a/vendor/github.com/miekg/dns/types.go
+++ b/vendor/github.com/miekg/dns/types.go
@@ -135,8 +135,8 @@ const (
 	RcodeNXRrset        = 8  // NXRRSet   - RR Set that should exist does not [DNS Update]
 	RcodeNotAuth        = 9  // NotAuth   - Server Not Authoritative for zone [DNS Update]
 	RcodeNotZone        = 10 // NotZone   - Name not contained in zone        [DNS Update/TSIG]
-	RcodeBadSig         = 16 // BADSIG    - TSIG Signature Failure            [TSIG]
-	RcodeBadVers        = 16 // BADVERS   - Bad OPT Version                   [EDNS0]
+	RcodeBadSig         = 16 // BADSIG    - TSIG Signature Failure            [TSIG]  https://www.rfc-editor.org/rfc/rfc6895.html#section-2.3
+	RcodeBadVers        = 16 // BADVERS   - Bad OPT Version                   [EDNS0] https://www.rfc-editor.org/rfc/rfc6895.html#section-2.3
 	RcodeBadKey         = 17 // BADKEY    - Key not recognized                [TSIG]
 	RcodeBadTime        = 18 // BADTIME   - Signature out of time window      [TSIG]
 	RcodeBadMode        = 19 // BADMODE   - Bad TKEY Mode                     [TKEY]
@@ -400,6 +400,17 @@ type X25 struct {
 
 func (rr *X25) String() string {
 	return rr.Hdr.String() + rr.PSDNAddress
+}
+
+// ISDN RR. See RFC 1183, Section 3.2.
+type ISDN struct {
+	Hdr        RR_Header
+	Address    string
+	SubAddress string
+}
+
+func (rr *ISDN) String() string {
+	return rr.Hdr.String() + sprintTxt([]string{rr.Address, rr.SubAddress})
 }
 
 // RT RR. See RFC 1183, Section 3.3.
@@ -786,7 +797,7 @@ func (rr *GPOS) String() string {
 	return rr.Hdr.String() + rr.Longitude + " " + rr.Latitude + " " + rr.Altitude
 }
 
-// LOC RR. See RFC RFC 1876.
+// LOC RR. See RFC 1876.
 type LOC struct {
 	Hdr       RR_Header
 	Version   uint8
@@ -898,6 +909,11 @@ func (rr *RRSIG) String() string {
 	return s
 }
 
+// NXT RR. See RFC 2535.
+type NXT struct {
+	NSEC
+}
+
 // NSEC RR. See RFC 4034 and RFC 3755.
 type NSEC struct {
 	Hdr        RR_Header
@@ -982,7 +998,7 @@ func (rr *TALINK) String() string {
 		sprintName(rr.PreviousName) + " " + sprintName(rr.NextName)
 }
 
-// SSHFP RR. See RFC RFC 4255.
+// SSHFP RR. See RFC 4255.
 type SSHFP struct {
 	Hdr         RR_Header
 	Algorithm   uint8
@@ -996,7 +1012,7 @@ func (rr *SSHFP) String() string {
 		" " + strings.ToUpper(rr.FingerPrint)
 }
 
-// KEY RR. See RFC RFC 2535.
+// KEY RR. See RFC 2535.
 type KEY struct {
 	DNSKEY
 }
@@ -1306,7 +1322,7 @@ type NINFO struct {
 
 func (rr *NINFO) String() string { return rr.Hdr.String() + sprintTxt(rr.ZSData) }
 
-// NID RR. See RFC RFC 6742.
+// NID RR. See RFC 6742.
 type NID struct {
 	Hdr        RR_Header
 	Preference uint16

--- a/vendor/github.com/miekg/dns/version.go
+++ b/vendor/github.com/miekg/dns/version.go
@@ -3,7 +3,7 @@ package dns
 import "fmt"
 
 // Version is current version of this library.
-var Version = v{1, 1, 57}
+var Version = v{1, 1, 58}
 
 // v holds the version of this library.
 type v struct {

--- a/vendor/github.com/miekg/dns/zduplicate.go
+++ b/vendor/github.com/miekg/dns/zduplicate.go
@@ -481,6 +481,21 @@ func (r1 *IPSECKEY) isDuplicate(_r2 RR) bool {
 	return true
 }
 
+func (r1 *ISDN) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*ISDN)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if r1.Address != r2.Address {
+		return false
+	}
+	if r1.SubAddress != r2.SubAddress {
+		return false
+	}
+	return true
+}
+
 func (r1 *KEY) isDuplicate(_r2 RR) bool {
 	r2, ok := _r2.(*KEY)
 	if !ok {
@@ -867,6 +882,26 @@ func (r1 *NULL) isDuplicate(_r2 RR) bool {
 	_ = r2
 	if r1.Data != r2.Data {
 		return false
+	}
+	return true
+}
+
+func (r1 *NXT) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NXT)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if !isDuplicateName(r1.NextDomain, r2.NextDomain) {
+		return false
+	}
+	if len(r1.TypeBitMap) != len(r2.TypeBitMap) {
+		return false
+	}
+	for i := 0; i < len(r1.TypeBitMap); i++ {
+		if r1.TypeBitMap[i] != r2.TypeBitMap[i] {
+			return false
+		}
 	}
 	return true
 }

--- a/vendor/github.com/miekg/dns/zmsg.go
+++ b/vendor/github.com/miekg/dns/zmsg.go
@@ -372,6 +372,18 @@ func (rr *IPSECKEY) pack(msg []byte, off int, compression compressionMap, compre
 	return off, nil
 }
 
+func (rr *ISDN) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packString(rr.Address, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packString(rr.SubAddress, msg, off)
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
 func (rr *KEY) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packUint16(rr.Flags, msg, off)
 	if err != nil {
@@ -688,6 +700,18 @@ func (rr *NSEC3PARAM) pack(msg []byte, off int, compression compressionMap, comp
 
 func (rr *NULL) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringAny(rr.Data, msg, off)
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
+func (rr *NXT) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(rr.NextDomain, msg, off, compression, false)
+	if err != nil {
+		return off, err
+	}
+	off, err = packDataNsec(rr.TypeBitMap, msg, off)
 	if err != nil {
 		return off, err
 	}
@@ -1746,6 +1770,24 @@ func (rr *IPSECKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	return off, nil
 }
 
+func (rr *ISDN) unpack(msg []byte, off int) (off1 int, err error) {
+	rdStart := off
+	_ = rdStart
+
+	rr.Address, off, err = unpackString(msg, off)
+	if err != nil {
+		return off, err
+	}
+	if off == len(msg) {
+		return off, nil
+	}
+	rr.SubAddress, off, err = unpackString(msg, off)
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
 func (rr *KEY) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
@@ -2218,6 +2260,24 @@ func (rr *NULL) unpack(msg []byte, off int) (off1 int, err error) {
 	_ = rdStart
 
 	rr.Data, off, err = unpackStringAny(msg, off, rdStart+int(rr.Hdr.Rdlength))
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
+func (rr *NXT) unpack(msg []byte, off int) (off1 int, err error) {
+	rdStart := off
+	_ = rdStart
+
+	rr.NextDomain, off, err = UnpackDomainName(msg, off)
+	if err != nil {
+		return off, err
+	}
+	if off == len(msg) {
+		return off, nil
+	}
+	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
 		return off, err
 	}

--- a/vendor/github.com/miekg/dns/ztypes.go
+++ b/vendor/github.com/miekg/dns/ztypes.go
@@ -36,6 +36,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeHIP:        func() RR { return new(HIP) },
 	TypeHTTPS:      func() RR { return new(HTTPS) },
 	TypeIPSECKEY:   func() RR { return new(IPSECKEY) },
+	TypeISDN:       func() RR { return new(ISDN) },
 	TypeKEY:        func() RR { return new(KEY) },
 	TypeKX:         func() RR { return new(KX) },
 	TypeL32:        func() RR { return new(L32) },
@@ -59,6 +60,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeNSEC3:      func() RR { return new(NSEC3) },
 	TypeNSEC3PARAM: func() RR { return new(NSEC3PARAM) },
 	TypeNULL:       func() RR { return new(NULL) },
+	TypeNXT:        func() RR { return new(NXT) },
 	TypeOPENPGPKEY: func() RR { return new(OPENPGPKEY) },
 	TypeOPT:        func() RR { return new(OPT) },
 	TypePTR:        func() RR { return new(PTR) },
@@ -204,6 +206,7 @@ func (rr *HINFO) Header() *RR_Header      { return &rr.Hdr }
 func (rr *HIP) Header() *RR_Header        { return &rr.Hdr }
 func (rr *HTTPS) Header() *RR_Header      { return &rr.Hdr }
 func (rr *IPSECKEY) Header() *RR_Header   { return &rr.Hdr }
+func (rr *ISDN) Header() *RR_Header       { return &rr.Hdr }
 func (rr *KEY) Header() *RR_Header        { return &rr.Hdr }
 func (rr *KX) Header() *RR_Header         { return &rr.Hdr }
 func (rr *L32) Header() *RR_Header        { return &rr.Hdr }
@@ -227,6 +230,7 @@ func (rr *NSEC) Header() *RR_Header       { return &rr.Hdr }
 func (rr *NSEC3) Header() *RR_Header      { return &rr.Hdr }
 func (rr *NSEC3PARAM) Header() *RR_Header { return &rr.Hdr }
 func (rr *NULL) Header() *RR_Header       { return &rr.Hdr }
+func (rr *NXT) Header() *RR_Header        { return &rr.Hdr }
 func (rr *OPENPGPKEY) Header() *RR_Header { return &rr.Hdr }
 func (rr *OPT) Header() *RR_Header        { return &rr.Hdr }
 func (rr *PTR) Header() *RR_Header        { return &rr.Hdr }
@@ -434,6 +438,13 @@ func (rr *IPSECKEY) len(off int, compression map[string]struct{}) int {
 		l += len(rr.GatewayHost) + 1
 	}
 	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
+	return l
+}
+
+func (rr *ISDN) len(off int, compression map[string]struct{}) int {
+	l := rr.Hdr.len(off, compression)
+	l += len(rr.Address) + 1
+	l += len(rr.SubAddress) + 1
 	return l
 }
 
@@ -966,6 +977,10 @@ func (rr *IPSECKEY) copy() RR {
 	}
 }
 
+func (rr *ISDN) copy() RR {
+	return &ISDN{rr.Hdr, rr.Address, rr.SubAddress}
+}
+
 func (rr *KEY) copy() RR {
 	return &KEY{*rr.DNSKEY.copy().(*DNSKEY)}
 }
@@ -1090,6 +1105,10 @@ func (rr *NSEC3PARAM) copy() RR {
 
 func (rr *NULL) copy() RR {
 	return &NULL{rr.Hdr, rr.Data}
+}
+
+func (rr *NXT) copy() RR {
+	return &NXT{*rr.NSEC.copy().(*NSEC)}
 }
 
 func (rr *OPENPGPKEY) copy() RR {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -702,7 +702,7 @@ github.com/klauspost/compress/internal/cpuinfo
 github.com/klauspost/compress/internal/snapref
 github.com/klauspost/compress/zstd
 github.com/klauspost/compress/zstd/internal/xxhash
-# github.com/miekg/dns v1.1.57
+# github.com/miekg/dns v1.1.61
 ## explicit; go 1.19
 github.com/miekg/dns
 # github.com/mistifyio/go-zfs/v3 v3.0.1


### PR DESCRIPTION
not the latest-latest version, but v1.1.58 is used elsewhere, and I saw some fixes in v1.1.59 and v1.1.60, and v1.1.61 was docs-only changes.

- Allow use of fs.FS for $INCLUDE and wrap errors
- Add NXT record
- Add ISDN record
- Fix counting of escape sequences when splitting TXT string
- IsDomainName: check for escape as last character
- Add a hook to catch invalid messages
- Fix possible out-of-bounds read in endingToTxtSlice

full diff: https://github.com/miekg/dns/compare/v1.1.57...v1.1.61


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

