### PR TITLE
Fix inconsistent letter case in error message

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -40,9 +40,9 @@ func ErrorConnectionFailed(host string) error {
 func connectionFailed(host string) error {
 	var err error
 	if host == "" {
-		err = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
+		err = errors.New("Cannot connect to the Docker daemon. Is the Docker daemon running on this host?")
 	} else {
-		err = fmt.Errorf("Cannot connect to the Docker daemon at %s. Is the docker daemon running?", host)
+		err = fmt.Errorf("Cannot connect to the Docker daemon at %s. Is the Docker daemon running?", host)
 	}
 	return errConnectionFailed{error: err}
 }


### PR DESCRIPTION
This fixes #49460 

This PR just fixes the inconsistent capitalization of the letter `D` in `Docker` in the CLI error messages.

> Cannot connect to the `Docker daemon` at unix:///var/run/docker.sock. Is the `docker daemon` running?

**- A picture of a cute animal (not mandatory but encouraged)**

```
 /\     /\
{  `---'  }
{  O   O  }
~~>  V  <~~
 \  \|/  /
  `-----'__
  /     \  `^\_
 {       }\ |\_\_   W
 |  \_/  |/ /  \_\_( )
  \__/  /(_E     \__/
    (  /
     MM
```