### PR TITLE
client: Change `ImageHistory`, `ImageLoad` and `ImageSave` to use variadic functional options

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -126,7 +126,7 @@ type ImageAPIClient interface {
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) ([]image.HistoryResponseItem, error)
 	ImageLoad(ctx context.Context, input io.Reader, _ ...ImageLoadOption) (image.LoadResponse, error)
-	ImageSave(ctx context.Context, images []string, opts image.SaveOptions) (io.ReadCloser, error)
+	ImageSave(ctx context.Context, images []string, _ ...ImageSaveOption) (io.ReadCloser, error)
 
 	ImageAPIClientDeprecated
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -125,7 +125,7 @@ type ImageAPIClient interface {
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) ([]image.HistoryResponseItem, error)
-	ImageLoad(ctx context.Context, input io.Reader, opts image.LoadOptions) (image.LoadResponse, error)
+	ImageLoad(ctx context.Context, input io.Reader, _ ...ImageLoadOption) (image.LoadResponse, error)
 	ImageSave(ctx context.Context, images []string, opts image.SaveOptions) (io.ReadCloser, error)
 
 	ImageAPIClientDeprecated

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -113,23 +113,30 @@ type ImageAPIClient interface {
 	BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
 	BuildCancel(ctx context.Context, id string) error
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)
-	ImageHistory(ctx context.Context, image string, opts image.HistoryOptions) ([]image.HistoryResponseItem, error)
 	ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)
 
+	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
+	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
+	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
+	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
+	ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error)
+	ImageTag(ctx context.Context, image, ref string) error
+	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
+
+	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
+	ImageHistory(ctx context.Context, image string, opts image.HistoryOptions) ([]image.HistoryResponseItem, error)
+	ImageLoad(ctx context.Context, input io.Reader, opts image.LoadOptions) (image.LoadResponse, error)
+	ImageSave(ctx context.Context, images []string, opts image.SaveOptions) (io.ReadCloser, error)
+
+	ImageAPIClientDeprecated
+}
+
+// ImageAPIClientDeprecated defines deprecated methods of the ImageAPIClient.
+type ImageAPIClientDeprecated interface {
 	// ImageInspectWithRaw returns the image information and its raw representation.
 	//
 	// Deprecated: Use [Client.ImageInspect] instead. Raw response can be obtained using the [ImageInspectWithRawResponse] option.
 	ImageInspectWithRaw(ctx context.Context, image string) (image.InspectResponse, []byte, error)
-	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
-	ImageList(ctx context.Context, options image.ListOptions) ([]image.Summary, error)
-	ImageLoad(ctx context.Context, input io.Reader, opts image.LoadOptions) (image.LoadResponse, error)
-	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
-	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
-	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
-	ImageSave(ctx context.Context, images []string, opts image.SaveOptions) (io.ReadCloser, error)
-	ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error)
-	ImageTag(ctx context.Context, image, ref string) error
-	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
 }
 
 // NetworkAPIClient defines API client methods for the networks

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -124,7 +124,7 @@ type ImageAPIClient interface {
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
-	ImageHistory(ctx context.Context, image string, opts image.HistoryOptions) ([]image.HistoryResponseItem, error)
+	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) ([]image.HistoryResponseItem, error)
 	ImageLoad(ctx context.Context, input io.Reader, opts image.LoadOptions) (image.LoadResponse, error)
 	ImageSave(ctx context.Context, images []string, opts image.SaveOptions) (io.ReadCloser, error)
 

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -3,20 +3,55 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 
 	"github.com/docker/docker/api/types/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// ImageHistoryOption is a type representing functional options for the image history operation.
+type ImageHistoryOption interface {
+	Apply(*imageHistoryOpts) error
+}
+type imageHistoryOptionFunc func(opt *imageHistoryOpts) error
+
+func (f imageHistoryOptionFunc) Apply(o *imageHistoryOpts) error {
+	return f(o)
+}
+
+// ImageHistoryWithPlatform sets the platform for the image history operation.
+func ImageHistoryWithPlatform(platform ocispec.Platform) ImageHistoryOption {
+	return imageHistoryOptionFunc(func(opt *imageHistoryOpts) error {
+		if opt.apiOptions.Platform != nil {
+			return fmt.Errorf("platform already set to %s", *opt.apiOptions.Platform)
+		}
+		opt.apiOptions.Platform = &platform
+		return nil
+	})
+}
+
+type imageHistoryOpts struct {
+	apiOptions image.HistoryOptions
+}
+
 // ImageHistory returns the changes in an image in history format.
-func (cli *Client) ImageHistory(ctx context.Context, imageID string, opts image.HistoryOptions) ([]image.HistoryResponseItem, error) {
+func (cli *Client) ImageHistory(ctx context.Context, imageID string, historyOpts ...ImageHistoryOption) ([]image.HistoryResponseItem, error) {
 	query := url.Values{}
-	if opts.Platform != nil {
+
+	var opts imageHistoryOpts
+	for _, o := range historyOpts {
+		if err := o.Apply(&opts); err != nil {
+			return nil, err
+		}
+	}
+
+	if opts.apiOptions.Platform != nil {
 		if err := cli.NewVersionError(ctx, "1.48", "platform"); err != nil {
 			return nil, err
 		}
 
-		p, err := encodePlatform(opts.Platform)
+		p, err := encodePlatform(opts.apiOptions.Platform)
 		if err != nil {
 			return nil, err
 		}

--- a/client/image_history.go
+++ b/client/image_history.go
@@ -10,16 +10,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// ImageHistoryOption is a type representing functional options for the image history operation.
-type ImageHistoryOption interface {
-	Apply(*imageHistoryOpts) error
-}
-type imageHistoryOptionFunc func(opt *imageHistoryOpts) error
-
-func (f imageHistoryOptionFunc) Apply(o *imageHistoryOpts) error {
-	return f(o)
-}
-
 // ImageHistoryWithPlatform sets the platform for the image history operation.
 func ImageHistoryWithPlatform(platform ocispec.Platform) ImageHistoryOption {
 	return imageHistoryOptionFunc(func(opt *imageHistoryOpts) error {
@@ -29,10 +19,6 @@ func ImageHistoryWithPlatform(platform ocispec.Platform) ImageHistoryOption {
 		opt.apiOptions.Platform = &platform
 		return nil
 	})
-}
-
-type imageHistoryOpts struct {
-	apiOptions image.HistoryOptions
 }
 
 // ImageHistory returns the changes in an image in history format.

--- a/client/image_history_opts.go
+++ b/client/image_history_opts.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"github.com/docker/docker/api/types/image"
+)
+
+// ImageHistoryOption is a type representing functional options for the image history operation.
+type ImageHistoryOption interface {
+	Apply(*imageHistoryOpts) error
+}
+type imageHistoryOptionFunc func(opt *imageHistoryOpts) error
+
+func (f imageHistoryOptionFunc) Apply(o *imageHistoryOpts) error {
+	return f(o)
+}
+
+type imageHistoryOpts struct {
+	apiOptions image.HistoryOptions
+}

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -18,7 +18,7 @@ func TestImageHistoryError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageHistory(context.Background(), "nothing", image.HistoryOptions{})
+	_, err := client.ImageHistory(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -49,13 +49,11 @@ func TestImageHistory(t *testing.T) {
 		},
 	}
 
-	imageHistories, err := client.ImageHistory(context.Background(), "image_id", image.HistoryOptions{
-		Platform: &ocispec.Platform{
-			Architecture: "arm64",
-			OS:           "linux",
-			Variant:      "v8",
-		},
-	})
+	imageHistories, err := client.ImageHistory(context.Background(), "image_id", ImageHistoryWithPlatform(ocispec.Platform{
+		Architecture: "arm64",
+		OS:           "linux",
+		Variant:      "v8",
+	}))
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(imageHistories, expected))
 }

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -11,49 +11,6 @@ import (
 	"github.com/docker/docker/api/types/image"
 )
 
-// ImageInspectOption is a type representing functional options for the image inspect operation.
-type ImageInspectOption interface {
-	Apply(*imageInspectOpts) error
-}
-type imageInspectOptionFunc func(opt *imageInspectOpts) error
-
-func (f imageInspectOptionFunc) Apply(o *imageInspectOpts) error {
-	return f(o)
-}
-
-// ImageInspectWithRawResponse instructs the client to additionally store the
-// raw inspect response in the provided buffer.
-func ImageInspectWithRawResponse(raw *bytes.Buffer) ImageInspectOption {
-	return imageInspectOptionFunc(func(opts *imageInspectOpts) error {
-		opts.raw = raw
-		return nil
-	})
-}
-
-// ImageInspectWithManifests sets manifests API option for the image inspect operation.
-// This option is only available for API version 1.48 and up.
-// With this option set, the image inspect operation response will have the
-// [image.InspectResponse.Manifests] field populated if the server is multi-platform capable.
-func ImageInspectWithManifests(manifests bool) ImageInspectOption {
-	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
-		clientOpts.apiOptions.Manifests = manifests
-		return nil
-	})
-}
-
-// ImageInspectWithAPIOpts sets the API options for the image inspect operation.
-func ImageInspectWithAPIOpts(opts image.InspectOptions) ImageInspectOption {
-	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
-		clientOpts.apiOptions = opts
-		return nil
-	})
-}
-
-type imageInspectOpts struct {
-	raw        *bytes.Buffer
-	apiOptions image.InspectOptions
-}
-
 // ImageInspect returns the image information.
 func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts ...ImageInspectOption) (image.InspectResponse, error) {
 	if imageID == "" {

--- a/client/image_inspect_opts.go
+++ b/client/image_inspect_opts.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"bytes"
+
+	"github.com/docker/docker/api/types/image"
+)
+
+// ImageInspectOption is a type representing functional options for the image inspect operation.
+type ImageInspectOption interface {
+	Apply(*imageInspectOpts) error
+}
+type imageInspectOptionFunc func(opt *imageInspectOpts) error
+
+func (f imageInspectOptionFunc) Apply(o *imageInspectOpts) error {
+	return f(o)
+}
+
+// ImageInspectWithRawResponse instructs the client to additionally store the
+// raw inspect response in the provided buffer.
+func ImageInspectWithRawResponse(raw *bytes.Buffer) ImageInspectOption {
+	return imageInspectOptionFunc(func(opts *imageInspectOpts) error {
+		opts.raw = raw
+		return nil
+	})
+}
+
+// ImageInspectWithManifests sets manifests API option for the image inspect operation.
+// This option is only available for API version 1.48 and up.
+// With this option set, the image inspect operation response will have the
+// [image.InspectResponse.Manifests] field populated if the server is multi-platform capable.
+func ImageInspectWithManifests(manifests bool) ImageInspectOption {
+	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
+		clientOpts.apiOptions.Manifests = manifests
+		return nil
+	})
+}
+
+// ImageInspectWithAPIOpts sets the API options for the image inspect operation.
+func ImageInspectWithAPIOpts(opts image.InspectOptions) ImageInspectOption {
+	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
+		clientOpts.apiOptions = opts
+		return nil
+	})
+}
+
+type imageInspectOpts struct {
+	raw        *bytes.Buffer
+	apiOptions image.InspectOptions
+}

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -2,12 +2,47 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+// ImageLoadOption is a type representing functional options for the image load operation.
+type ImageLoadOption interface {
+	Apply(*imageLoadOpts) error
+}
+type imageLoadOptionFunc func(opt *imageLoadOpts) error
+
+func (f imageLoadOptionFunc) Apply(o *imageLoadOpts) error {
+	return f(o)
+}
+
+type imageLoadOpts struct {
+	apiOptions image.LoadOptions
+}
+
+// ImageLoadWithQuiet sets the quiet option for the image load operation.
+func ImageLoadWithQuiet(quiet bool) ImageLoadOption {
+	return imageLoadOptionFunc(func(opt *imageLoadOpts) error {
+		opt.apiOptions.Quiet = quiet
+		return nil
+	})
+}
+
+// ImageLoadWithPlatforms sets the platforms to be loaded from the image.
+func ImageLoadWithPlatforms(platforms ...ocispec.Platform) ImageLoadOption {
+	return imageLoadOptionFunc(func(opt *imageLoadOpts) error {
+		if opt.apiOptions.Platforms != nil {
+			return fmt.Errorf("platforms already set to %v", opt.apiOptions.Platforms)
+		}
+		opt.apiOptions.Platforms = platforms
+		return nil
+	})
+}
 
 // ImageLoad loads an image in the docker host from the client host.
 // It's up to the caller to close the io.ReadCloser in the
@@ -16,18 +51,25 @@ import (
 // Platform is an optional parameter that specifies the platform to load from
 // the provided multi-platform image. This is only has effect if the input image
 // is a multi-platform image.
-func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, opts image.LoadOptions) (image.LoadResponse, error) {
+func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...ImageLoadOption) (image.LoadResponse, error) {
+	var opts imageLoadOpts
+	for _, opt := range loadOpts {
+		if err := opt.Apply(&opts); err != nil {
+			return image.LoadResponse{}, err
+		}
+	}
+
 	query := url.Values{}
 	query.Set("quiet", "0")
-	if opts.Quiet {
+	if opts.apiOptions.Quiet {
 		query.Set("quiet", "1")
 	}
-	if len(opts.Platforms) > 0 {
+	if len(opts.apiOptions.Platforms) > 0 {
 		if err := cli.NewVersionError(ctx, "1.48", "platform"); err != nil {
 			return image.LoadResponse{}, err
 		}
 
-		p, err := encodePlatforms(opts.Platforms...)
+		p, err := encodePlatforms(opts.apiOptions.Platforms...)
 		if err != nil {
 			return image.LoadResponse{}, err
 		}

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -2,47 +2,12 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/docker/docker/api/types/image"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
-
-// ImageLoadOption is a type representing functional options for the image load operation.
-type ImageLoadOption interface {
-	Apply(*imageLoadOpts) error
-}
-type imageLoadOptionFunc func(opt *imageLoadOpts) error
-
-func (f imageLoadOptionFunc) Apply(o *imageLoadOpts) error {
-	return f(o)
-}
-
-type imageLoadOpts struct {
-	apiOptions image.LoadOptions
-}
-
-// ImageLoadWithQuiet sets the quiet option for the image load operation.
-func ImageLoadWithQuiet(quiet bool) ImageLoadOption {
-	return imageLoadOptionFunc(func(opt *imageLoadOpts) error {
-		opt.apiOptions.Quiet = quiet
-		return nil
-	})
-}
-
-// ImageLoadWithPlatforms sets the platforms to be loaded from the image.
-func ImageLoadWithPlatforms(platforms ...ocispec.Platform) ImageLoadOption {
-	return imageLoadOptionFunc(func(opt *imageLoadOpts) error {
-		if opt.apiOptions.Platforms != nil {
-			return fmt.Errorf("platforms already set to %v", opt.apiOptions.Platforms)
-		}
-		opt.apiOptions.Platforms = platforms
-		return nil
-	})
-}
 
 // ImageLoad loads an image in the docker host from the client host.
 // It's up to the caller to close the io.ReadCloser in the

--- a/client/image_load_opts.go
+++ b/client/image_load_opts.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ImageLoadOption is a type representing functional options for the image load operation.
+type ImageLoadOption interface {
+	Apply(*imageLoadOpts) error
+}
+type imageLoadOptionFunc func(opt *imageLoadOpts) error
+
+func (f imageLoadOptionFunc) Apply(o *imageLoadOpts) error {
+	return f(o)
+}
+
+type imageLoadOpts struct {
+	apiOptions image.LoadOptions
+}
+
+// ImageLoadWithQuiet sets the quiet option for the image load operation.
+func ImageLoadWithQuiet(quiet bool) ImageLoadOption {
+	return imageLoadOptionFunc(func(opt *imageLoadOpts) error {
+		opt.apiOptions.Quiet = quiet
+		return nil
+	})
+}
+
+// ImageLoadWithPlatforms sets the platforms to be loaded from the image.
+func ImageLoadWithPlatforms(platforms ...ocispec.Platform) ImageLoadOption {
+	return imageLoadOptionFunc(func(opt *imageLoadOpts) error {
+		if opt.apiOptions.Platforms != nil {
+			return fmt.Errorf("platforms already set to %v", opt.apiOptions.Platforms)
+		}
+		opt.apiOptions.Platforms = platforms
+		return nil
+	})
+}

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -20,7 +19,7 @@ func TestImageLoadError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ImageLoad(context.Background(), nil, image.LoadOptions{Quiet: true})
+	_, err := client.ImageLoad(context.Background(), nil, ImageLoadWithQuiet(true))
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -97,10 +96,10 @@ func TestImageLoad(t *testing.T) {
 			}
 
 			input := bytes.NewReader([]byte(expectedInput))
-			imageLoadResponse, err := client.ImageLoad(context.Background(), input, image.LoadOptions{
-				Quiet:     tc.quiet,
-				Platforms: tc.platforms,
-			})
+			imageLoadResponse, err := client.ImageLoad(context.Background(), input,
+				ImageLoadWithQuiet(tc.quiet),
+				ImageLoadWithPlatforms(tc.platforms...),
+			)
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(imageLoadResponse.JSON, tc.expectedResponseJSON))
 

--- a/client/image_save.go
+++ b/client/image_save.go
@@ -2,24 +2,58 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/url"
 
 	"github.com/docker/docker/api/types/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+type ImageSaveOption interface {
+	Apply(*imageSaveOpts) error
+}
+type imageSaveOptionFunc func(opt *imageSaveOpts) error
+
+func (f imageSaveOptionFunc) Apply(o *imageSaveOpts) error {
+	return f(o)
+}
+
+func ImageSaveWithPlatforms(platforms ...ocispec.Platform) ImageSaveOption {
+	return imageSaveOptionFunc(func(opt *imageSaveOpts) error {
+		if opt.apiOptions.Platforms != nil {
+			return fmt.Errorf("platforms already set to %v", opt.apiOptions.Platforms)
+		}
+		opt.apiOptions.Platforms = platforms
+		return nil
+	})
+}
+
+type imageSaveOpts struct {
+	apiOptions image.SaveOptions
+}
+
 // ImageSave retrieves one or more images from the docker host as an io.ReadCloser.
-// It's up to the caller to store the images and close the stream.
-func (cli *Client) ImageSave(ctx context.Context, imageIDs []string, opts image.SaveOptions) (io.ReadCloser, error) {
+//
+// Platforms is an optional parameter that specifies the platforms to save from the image.
+// This is only has effect if the input image is a multi-platform image.
+func (cli *Client) ImageSave(ctx context.Context, imageIDs []string, saveOpts ...ImageSaveOption) (io.ReadCloser, error) {
+	var opts imageSaveOpts
+	for _, opt := range saveOpts {
+		if err := opt.Apply(&opts); err != nil {
+			return nil, err
+		}
+	}
+
 	query := url.Values{
 		"names": imageIDs,
 	}
 
-	if len(opts.Platforms) > 0 {
+	if len(opts.apiOptions.Platforms) > 0 {
 		if err := cli.NewVersionError(ctx, "1.48", "platform"); err != nil {
 			return nil, err
 		}
-		p, err := encodePlatforms(opts.Platforms...)
+		p, err := encodePlatforms(opts.apiOptions.Platforms...)
 		if err != nil {
 			return nil, err
 		}

--- a/client/image_save.go
+++ b/client/image_save.go
@@ -2,36 +2,9 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/url"
-
-	"github.com/docker/docker/api/types/image"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
-
-type ImageSaveOption interface {
-	Apply(*imageSaveOpts) error
-}
-type imageSaveOptionFunc func(opt *imageSaveOpts) error
-
-func (f imageSaveOptionFunc) Apply(o *imageSaveOpts) error {
-	return f(o)
-}
-
-func ImageSaveWithPlatforms(platforms ...ocispec.Platform) ImageSaveOption {
-	return imageSaveOptionFunc(func(opt *imageSaveOpts) error {
-		if opt.apiOptions.Platforms != nil {
-			return fmt.Errorf("platforms already set to %v", opt.apiOptions.Platforms)
-		}
-		opt.apiOptions.Platforms = platforms
-		return nil
-	})
-}
-
-type imageSaveOpts struct {
-	apiOptions image.SaveOptions
-}
 
 // ImageSave retrieves one or more images from the docker host as an io.ReadCloser.
 //

--- a/client/image_save_opts.go
+++ b/client/image_save_opts.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type ImageSaveOption interface {
+	Apply(*imageSaveOpts) error
+}
+
+type imageSaveOptionFunc func(opt *imageSaveOpts) error
+
+func (f imageSaveOptionFunc) Apply(o *imageSaveOpts) error {
+	return f(o)
+}
+
+// ImageSaveWithPlatforms sets the platforms to be saved from the image.
+func ImageSaveWithPlatforms(platforms ...ocispec.Platform) ImageSaveOption {
+	return imageSaveOptionFunc(func(opt *imageSaveOpts) error {
+		if opt.apiOptions.Platforms != nil {
+			return fmt.Errorf("platforms already set to %v", opt.apiOptions.Platforms)
+		}
+		opt.apiOptions.Platforms = platforms
+		return nil
+	})
+}
+
+type imageSaveOpts struct {
+	apiOptions image.SaveOptions
+}

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -73,7 +73,7 @@ func (s *DockerAPISuite) TestAPIImagesHistory(c *testing.T) {
 	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, name)
 
-	historydata, err := apiClient.ImageHistory(testutil.GetContext(c), id, image.HistoryOptions{})
+	historydata, err := apiClient.ImageHistory(testutil.GetContext(c), id)
 	assert.NilError(c, err)
 
 	assert.Assert(c, len(historydata) != 0)

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
 	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -109,9 +108,9 @@ func TestBuildSquashParent(t *testing.T) {
 		container.WithCmd("/bin/sh", "-c", `[ "$(echo $HELLO)" = "world" ]`),
 	)
 
-	origHistory, err := client.ImageHistory(ctx, origID, image.HistoryOptions{})
+	origHistory, err := client.ImageHistory(ctx, origID)
 	assert.NilError(t, err)
-	testHistory, err := client.ImageHistory(ctx, name, image.HistoryOptions{})
+	testHistory, err := client.ImageHistory(ctx, name)
 	assert.NilError(t, err)
 
 	inspect, err = client.ImageInspect(ctx, name)

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -108,7 +108,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	defer tarFile.Close()
 
 	tarReader := bufio.NewReader(tarFile)
-	loadResp, err := clientNoUserRemap.ImageLoad(ctx, tarReader, image.LoadOptions{})
+	loadResp, err := clientNoUserRemap.ImageLoad(ctx, tarReader)
 	assert.NilError(t, err, "failed to load image tar file")
 	defer loadResp.Body.Close()
 	buf = bytes.NewBuffer(nil)

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -78,7 +77,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, buf, 0, false, nil)
 	assert.NilError(t, err)
 
-	reader, err := clientUserRemap.ImageSave(ctx, []string{imageTag}, image.SaveOptions{})
+	reader, err := clientUserRemap.ImageSave(ctx, []string{imageTag})
 	assert.NilError(t, err, "failed to download capabilities image")
 	defer reader.Close()
 

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -439,13 +439,13 @@ func imageSave(ctx context.Context, client client.APIClient, path, imgRef string
 	return err
 }
 
-func imageLoad(ctx context.Context, client client.APIClient, path string) error {
+func imageLoad(ctx context.Context, apiClient client.APIClient, path string) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
-	response, err := client.ImageLoad(ctx, file, image.LoadOptions{Quiet: true})
+	response, err := apiClient.ImageLoad(ctx, file, client.ImageLoadWithQuiet(true))
 	if err != nil {
 		return err
 	}

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -424,8 +424,8 @@ func TestAuthzPluginEnsureContainerCopyToFrom(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func imageSave(ctx context.Context, client client.APIClient, path, imgRef string) error {
-	responseReader, err := client.ImageSave(ctx, []string{imgRef}, image.SaveOptions{})
+func imageSave(ctx context.Context, apiClient client.APIClient, path, imgRef string) error {
+	responseReader, err := apiClient.ImageSave(ctx, []string{imgRef})
 	if err != nil {
 		return err
 	}

--- a/internal/testutils/specialimage/load.go
+++ b/internal/testutils/specialimage/load.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -30,7 +29,7 @@ func Load(ctx context.Context, t *testing.T, apiClient client.APIClient, imageFu
 
 	defer rc.Close()
 
-	resp, err := apiClient.ImageLoad(ctx, rc, image.LoadOptions{Quiet: true})
+	resp, err := apiClient.ImageLoad(ctx, rc, client.ImageLoadWithQuiet(true))
 	assert.NilError(t, err, "Failed to load dangling image")
 
 	defer resp.Body.Close()

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/container"
@@ -868,7 +867,7 @@ func (d *Daemon) LoadImage(ctx context.Context, t testing.TB, img string) {
 	assert.NilError(t, err, "[%s] failed to create client", d.id)
 	defer clientHost.Close()
 
-	reader, err := clientHost.ImageSave(ctx, []string{img}, image.SaveOptions{})
+	reader, err := clientHost.ImageSave(ctx, []string{img})
 	assert.NilError(t, err, "[%s] failed to download %s", d.id, img)
 	defer reader.Close()
 

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -875,7 +875,7 @@ func (d *Daemon) LoadImage(ctx context.Context, t testing.TB, img string) {
 	c := d.NewClientT(t)
 	defer c.Close()
 
-	resp, err := c.ImageLoad(ctx, reader, image.LoadOptions{Quiet: true})
+	resp, err := c.ImageLoad(ctx, reader, client.ImageLoadWithQuiet(true))
 	assert.NilError(t, err, "[%s] failed to load %s", d.id, img)
 	defer resp.Body.Close()
 }

--- a/testutil/fixtures/load/frozen.go
+++ b/testutil/fixtures/load/frozen.go
@@ -92,7 +92,7 @@ func imageExists(ctx context.Context, client client.APIClient, name string) bool
 	return err == nil
 }
 
-func loadFrozenImages(ctx context.Context, client client.APIClient) error {
+func loadFrozenImages(ctx context.Context, apiClient client.APIClient) error {
 	ctx, span := otel.Tracer("").Start(ctx, "load frozen images")
 	defer span.End()
 
@@ -111,7 +111,7 @@ func loadFrozenImages(ctx context.Context, client client.APIClient) error {
 	tarCmd.Start()
 	defer tarCmd.Wait()
 
-	resp, err := client.ImageLoad(ctx, out, image.LoadOptions{Quiet: true})
+	resp, err := apiClient.ImageLoad(ctx, out, client.ImageLoadWithQuiet(true))
 	if err != nil {
 		return errors.Wrap(err, "failed to load frozen images")
 	}


### PR DESCRIPTION
- closes https://github.com/moby/moby/pull/49403

To allow us being more flexible when adding new functionality to the client and reduce potential breaking changes to the interface in future, change the signatures of `ImageLoad`, `ImageHistory` and `ImageSave` to use variadic functional options, to mirror the same approach as `ImageInspect`.

Note: We _could_ change all client functions to follow this approach, but currently this PR only does it for functions which already had a signature change in the `master`, but weren't released yet.

**- How to verify it**
CI

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: `ImageHistory`, `ImageLoad` and `ImageSave` now use variadic functional options
```

**- A picture of a cute animal (not mandatory but encouraged)**

