### PR TITLE
container: ensure image manifest is deep copied from the container into the snapshot

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -301,15 +301,14 @@ func (v *View) transform(ctr *Container) *Snapshot {
 	}
 	snapshot := &Snapshot{
 		Summary: container.Summary{
-			ID:                      ctr.ID,
-			Names:                   v.getNames(ctr.ID),
-			ImageID:                 ctr.ImageID.String(),
-			ImageManifestDescriptor: ctr.ImageManifest,
-			Ports:                   []container.Port{},
-			Mounts:                  ctr.GetMountPoints(),
-			State:                   ctr.State.StateString(),
-			Status:                  ctr.State.String(),
-			Created:                 ctr.Created.Unix(),
+			ID:      ctr.ID,
+			Names:   v.getNames(ctr.ID),
+			ImageID: ctr.ImageID.String(),
+			Ports:   []container.Port{},
+			Mounts:  ctr.GetMountPoints(),
+			State:   ctr.State.StateString(),
+			Status:  ctr.State.String(),
+			Created: ctr.Created.Unix(),
 		},
 		CreatedAt:    ctr.Created,
 		StartedAt:    ctr.StartedAt,
@@ -417,8 +416,12 @@ func (v *View) transform(ctr *Container) *Snapshot {
 	}
 	snapshot.NetworkSettings = &container.NetworkSettingsSummary{Networks: networks}
 
-	if ctr.ImageManifest != nil && ctr.ImageManifest.Platform == nil {
-		ctr.ImageManifest.Platform = &ctr.ImagePlatform
+	if ctr.ImageManifest != nil {
+		imageManifest := *ctr.ImageManifest
+		if imageManifest.Platform == nil {
+			imageManifest.Platform = &ctr.ImagePlatform
+		}
+		snapshot.Summary.ImageManifestDescriptor = &imageManifest
 	}
 
 	return snapshot


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Performed a deep copy of the container data into the snapshot.

**- How I did it**

Copied the data from the pointer into a new temporary variable and then took the pointer to it.

https://github.com/moby/moby/pull/49407#discussion_r1955880308

**- How to verify it**

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

