### PR TITLE
daemon/logger: assorted minor (linting) fixes and cleanups

### DIFF
--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -156,7 +156,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, fmt.Errorf("unable to connect or authenticate with Google Cloud Logging: %v", err)
 	}
 
-	extraAttributes, err := info.ExtraAttributes(nil)
+	extraAttrs, err := info.ExtraAttributes(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			ImageName: info.ContainerImageName,
 			ImageID:   info.ContainerImageID,
 			Created:   info.ContainerCreated,
-			Metadata:  extraAttributes,
+			Metadata:  extraAttrs,
 		},
 	}
 

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -81,7 +81,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 
-	attrs, err := info.ExtraAttributes(nil)
+	extraAttrs, err := info.ExtraAttributes(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -92,13 +92,13 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, err
 	}
 	if tag != "" {
-		attrs["tag"] = tag
+		extraAttrs["tag"] = tag
 	}
 
 	var extra json.RawMessage
-	if len(attrs) > 0 {
+	if len(extraAttrs) > 0 {
 		var err error
-		extra, err = json.Marshal(attrs)
+		extra, err = json.Marshal(extraAttrs)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/logger/loginfo.go
+++ b/daemon/logger/loginfo.go
@@ -29,8 +29,8 @@ type Info struct {
 // that support metadata to add more context to a log.
 func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string, error) {
 	extra := make(map[string]string)
-	labels, ok := info.Config["labels"]
-	if ok && len(labels) > 0 {
+
+	if labels, ok := info.Config["labels"]; ok && len(labels) > 0 {
 		for _, l := range strings.Split(labels, ",") {
 			if v, ok := info.ContainerLabels[l]; ok {
 				if keyMod != nil {
@@ -41,8 +41,7 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 		}
 	}
 
-	labelsRegex, ok := info.Config["labels-regex"]
-	if ok && len(labelsRegex) > 0 {
+	if labelsRegex, ok := info.Config["labels-regex"]; ok && len(labelsRegex) > 0 {
 		re, err := regexp.Compile(labelsRegex)
 		if err != nil {
 			return nil, err
@@ -64,8 +63,12 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 		}
 	}
 
-	env, ok := info.Config["env"]
-	if ok && len(env) > 0 {
+	// Code below is only to handle adding attributes based on env-vars.
+	if len(envMapping) == 0 {
+		return extra, nil
+	}
+
+	if env, ok := info.Config["env"]; ok && len(env) > 0 {
 		for _, l := range strings.Split(env, ",") {
 			if v, ok := envMapping[l]; ok {
 				if keyMod != nil {
@@ -76,8 +79,7 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 		}
 	}
 
-	envRegex, ok := info.Config["env-regex"]
-	if ok && len(envRegex) > 0 {
+	if envRegex, ok := info.Config["env-regex"]; ok && len(envRegex) > 0 {
 		re, err := regexp.Compile(envRegex)
 		if err != nil {
 			return nil, err

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -267,7 +267,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		streamChannelSize     = getAdvancedOptionInt(envVarStreamChannelSize, defaultStreamChannelSize)
 	)
 
-	logger := &splunkLogger{
+	splLogger := &splunkLogger{
 		client:                client,
 		transport:             transport,
 		url:                   splunkURL.String(),
@@ -292,7 +292,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 	if verifyConnection {
-		err = verifySplunkConnection(logger)
+		err = verifySplunkConnection(splLogger)
 		if err != nil {
 			return nil, err
 		}
@@ -321,14 +321,14 @@ func New(info logger.Info) (logger.Logger, error) {
 			Attrs: attrs,
 		}
 
-		loggerWrapper = &splunkLoggerInline{logger, nullEvent}
+		loggerWrapper = &splunkLoggerInline{splLogger, nullEvent}
 	case splunkFormatJSON:
 		nullEvent := &splunkMessageEvent{
 			Tag:   tag,
 			Attrs: attrs,
 		}
 
-		loggerWrapper = &splunkLoggerJSON{&splunkLoggerInline{logger, nullEvent}}
+		loggerWrapper = &splunkLoggerJSON{&splunkLoggerInline{splLogger, nullEvent}}
 	case splunkFormatRaw:
 		var prefix bytes.Buffer
 		if tag != "" {
@@ -342,7 +342,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			prefix.WriteString(" ")
 		}
 
-		loggerWrapper = &splunkLoggerRaw{logger, prefix.Bytes()}
+		loggerWrapper = &splunkLoggerRaw{splLogger, prefix.Bytes()}
 	default:
 		return nil, fmt.Errorf("Unexpected format %s", splunkFormat)
 	}

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -255,7 +255,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 
-	attrs, err := info.ExtraAttributes(nil)
+	extraAttrs, err := info.ExtraAttributes(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -318,14 +318,14 @@ func New(info logger.Info) (logger.Logger, error) {
 	case splunkFormatInline:
 		nullEvent := &splunkMessageEvent{
 			Tag:   tag,
-			Attrs: attrs,
+			Attrs: extraAttrs,
 		}
 
 		loggerWrapper = &splunkLoggerInline{splLogger, nullEvent}
 	case splunkFormatJSON:
 		nullEvent := &splunkMessageEvent{
 			Tag:   tag,
-			Attrs: attrs,
+			Attrs: extraAttrs,
 		}
 
 		loggerWrapper = &splunkLoggerJSON{&splunkLoggerInline{splLogger, nullEvent}}
@@ -335,7 +335,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			prefix.WriteString(tag)
 			prefix.WriteString(" ")
 		}
-		for key, value := range attrs {
+		for key, value := range extraAttrs {
 			prefix.WriteString(key)
 			prefix.WriteString("=")
 			prefix.WriteString(value)

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -414,10 +414,10 @@ func (l *splunkLogger) worker() {
 			if !open {
 				l.postMessages(messages, true)
 				l.lock.Lock()
-				defer l.lock.Unlock()
 				l.transport.CloseIdleConnections()
 				l.closed = true
 				l.closedCond.Signal()
+				l.lock.Unlock()
 				return
 			}
 			messages = append(messages, message)

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -529,8 +529,10 @@ func (l *splunkLogger) tryPostMessages(ctx context.Context, messages []*splunkMe
 		return err
 	}
 	defer func() {
-		pools.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
+		// Drain  and close the body to let the transport reuse the connection.
+		// see https://github.com/google/go-github/pull/317/files#r57536827
+		_, _ = pools.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {
 		rdr := io.LimitReader(resp.Body, maxResponseSize)
@@ -629,8 +631,10 @@ func verifySplunkConnection(l *splunkLogger) error {
 		return err
 	}
 	defer func() {
-		pools.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
+		// Drain  and close the body to let the transport reuse the connection.
+		// see https://github.com/google/go-github/pull/317/files#r57536827
+		_, _ = pools.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
 	}()
 
 	if resp.StatusCode != http.StatusOK {

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -289,18 +289,9 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 	}
 
-	var splunkFormat string
-	if splunkFormatParsed, ok := info.Config[splunkFormatKey]; ok {
-		switch splunkFormatParsed {
-		case splunkFormatInline:
-		case splunkFormatJSON:
-		case splunkFormatRaw:
-		default:
-			return nil, fmt.Errorf("Unknown format specified %s, supported formats are inline, json and raw", splunkFormat)
-		}
-		splunkFormat = splunkFormatParsed
-	} else {
-		splunkFormat = splunkFormatInline
+	splunkFormat := splunkFormatInline
+	if f, ok := info.Config[splunkFormatKey]; ok {
+		splunkFormat = f
 	}
 
 	var loggerWrapper splunkLoggerInterface
@@ -335,7 +326,7 @@ func New(info logger.Info) (logger.Logger, error) {
 
 		loggerWrapper = &splunkLoggerRaw{splLogger, prefix.Bytes()}
 	default:
-		return nil, fmt.Errorf("Unexpected format %s", splunkFormat)
+		return nil, fmt.Errorf("unknown format specified %s, supported formats are inline, json and raw", splunkFormat)
 	}
 
 	go loggerWrapper.worker()


### PR DESCRIPTION
### daemon/logger/splunk: rename var that shadowed import

### daemon/logger/splunk: don't defer in a loop

This is mostly to silences some linters, as we're returning immediately
after, so no looping would happen, but we don't need a defer here either
for the same reason, so let's just remove it.


### daemon/logger/splunk: suppress some unhandled errors

Also add a commend based on [`ensureReaderClosed`][1] to outline why we're
copying.

[1]: https://github.com/moby/moby/blob/5cc3f1dab8953c1e1f70332efecadd094de7ec0b/client/request.go#L313-L325


### daemon/logger/splunk: plunkLogger.postMessages(): improve logs

- No need to use `fmt.Errorf` to format the error message
- Use structured logs, and include the message that failed to be sent
  in a `message` field.
- When failing to marshal the message, log an error outlining what happened
  instead of logging the bare error.
- Move the `messagesLen` variable closer to where it's used, putting the
  context handling first as a reminder that we may want to pass a context
  through.

### daemon/logger/fluentd: fix minor (linting) issues

- Rename variables that collided with imports
- Make capturing interval.Milliseconds conditional as it would trip some
  linters for using a potential "zero" value.
- Use WithFields instead of chainging multiple "WithField" calls for logging.

### daemon/logger: use consistent name for "extra attributes"

### daemon/logger: Info.ExtraAttributes: make env-var handling conditional

- Move some variables inside the "if" branch to make it clear they're only
  used locally, and not outside of the branch.
- Skip handling "env" and "env-regex" options if there are no env-vars
  to handle.

### daemon/logger/splunk: remove some intermediate variables

Remove intermediate variables or move them closer to where they're used,
as this function has various early returns on errors.


### daemon/logger/splunk: New(): combine switches for format validation

The format was validated twice; first just to validate, then to construct
the correct format-wrapper, or error for an unknown format.

This patch combines both switches to a single one.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

