### PR TITLE
golangci-lint: ignore "nested context" (fatcontext) in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -203,6 +203,13 @@ issues:
       linters:
         - staticcheck
 
+    # Ignore "nested context in function literal (fatcontext)" as we intentionally set up tracing on a base-context for tests.
+    # FIXME(thaJeztah): see if there's a more iodiomatic way to do this.
+    - text: 'nested context in function literal'
+      path: '((main|check)_(linux_|)test\.go)|testutil/helpers\.go'
+      linters:
+        - fatcontext
+
     - text: '^shadow: declaration of "(ctx|err|ok)" shadows declaration'
       linters:
         - govet


### PR DESCRIPTION
- fixes https://github.com/moby/moby/pull/49481#issuecomment-2664965364


Commit 15fbd67407613d63f9632bb9cfa19ad8c5121c3f updated golangci-lint, which came with an updated version of the "fatcontext" linter, causing linting to fail.

We use these to set up spans for our tests; suppress these through the golangci-lint config (instead of linline "//nolint" comments) so that we can revisit this approach and see if there's a more idiomatic way.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

