### PR TITLE
c8d/list: Fix panic when listing images

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -413,7 +413,7 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 			SharedSize: -1,
 			Containers: -1,
 			Descriptor: &target,
-		}, nil, nil
+		}, summary, nil
 	}
 
 	image, err := i.singlePlatformImage(ctx, i.content, tagsByDigest[best.RealTarget.Digest], best)

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -104,7 +104,7 @@ func BenchmarkImageList(b *testing.B) {
 
 		b.Run(strconv.Itoa(count)+"-images", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := imgSvc.Images(ctx, imagetypes.ListOptions{All: true})
+				_, err := imgSvc.Images(ctx, imagetypes.ListOptions{All: true, SharedSize: true})
 				assert.NilError(b, err)
 			}
 		})
@@ -129,7 +129,7 @@ func TestImageListCheckTotalSize(t *testing.T) {
 	_, err = service.images.Create(ctx, imagesFromIndex(twoplatform)[0])
 	assert.NilError(t, err)
 
-	all, err := service.Images(ctx, imagetypes.ListOptions{Manifests: true})
+	all, err := service.Images(ctx, imagetypes.ListOptions{Manifests: true, SharedSize: true})
 	assert.NilError(t, err)
 
 	assert.Check(t, is.Len(all, 1))
@@ -204,7 +204,6 @@ func TestImageList(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		images []c8dimages.Image
-		opts   imagetypes.ListOptions
 
 		check func(*testing.T, []*imagetypes.Summary)
 	}{
@@ -334,8 +333,10 @@ func TestImageList(t *testing.T) {
 				assert.NilError(t, err)
 			}
 
-			opts := tc.opts
-			opts.Manifests = true
+			opts := imagetypes.ListOptions{
+				Manifests:  true,
+				SharedSize: true,
+			}
 			all, err := service.Images(ctx, opts)
 			assert.NilError(t, err)
 


### PR DESCRIPTION
First commits makes `TestImageList` run with `SharedSize` enabled.
This uncovers a panic when listing an image that is an "empty" index (we have an index locally, but no platform manifests).

```
=== RUN   TestImageList/three_images,_one_is_an_empty_index
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa34de4]

goroutine 124 [running]:
github.com/docker/docker/daemon/containerd.(*ImageService).Images.func2()
	/go/src/github.com/docker/docker/daemon/containerd/image_list.go:179 +0x1e4
github.com/docker/docker/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1()
	/go/src/github.com/docker/docker/vendor/golang.org/x/sync/errgroup/errgroup.go:78 +0x54
created by github.com/docker/docker/vendor/golang.org/x/sync/errgroup.(*Group).Go in goroutine 123
	/go/src/github.com/docker/docker/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x98
FAIL	github.com/docker/docker/daemon/containerd	0.023s
FAIL
```

Second commit fixes it.


**- How to verify it**
`TestImageList`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
Not in GA yet, so no changelog

**- A picture of a cute animal (not mandatory but encouraged)**

