### PR TITLE
[27.x backport] Dockerfile: update runc binary to v1.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,7 +287,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.2.4
+ARG RUNC_VERSION=v1.2.5
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.2.4}"
+: "${RUNC_VERSION:=v1.2.5}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Backports https://github.com/moby/moby/pull/49464 to 27.x branch.

This is the fifth patch release in the 1.2.z series of runc. It primarily fixes an issue caused by an upstream systemd bug.

* There was a regression in systemd v230 which made the way we define device rule restrictions require a systemctl daemon-reload for our transient units. This caused issues for workloads using NVIDIA GPUs. Workaround the upstream regression by re-arranging how the unit properties are defined.
* Dependency github.com/cyphar/filepath-securejoin is updated to v0.4.1, to allow projects that vendor runc to bump it as well.
* CI: fixed criu-dev compilation.
* Dependency golang.org/x/net is updated to 0.33.0.

full diff: https://github.com/opencontainers/runc/compare/v1.2.4...v1.2.5
release notes: https://github.com/opencontainers/runc/releases/tag/v1.2.5


(cherry picked from commit 838ae09a2337e6561b40d13be6ddf43005a92a9e)

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Upgrade `runc` to [v1.2.5](https://github.com/opencontainers/runc/releases/tag/v1.2.5)
```

**- A picture of a cute animal (not mandatory but encouraged)**

