### PR TITLE
Dockerfile: fix linting warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -454,8 +454,8 @@ FROM binary-dummy AS containerutil-linux
 FROM containerutil-build AS containerutil-windows-amd64
 FROM containerutil-windows-${TARGETARCH} AS containerutil-windows
 FROM containerutil-${TARGETOS} AS containerutil
-FROM docker/buildx-bin:${BUILDX_VERSION} as buildx
-FROM docker/compose-bin:${COMPOSE_VERSION} as compose
+FROM docker/buildx-bin:${BUILDX_VERSION} AS buildx
+FROM docker/compose-bin:${COMPOSE_VERSION} AS compose
 
 FROM base AS dev-systemd-false
 COPY --link --from=frozen-images /build/ /docker-frozen-images
@@ -650,7 +650,7 @@ COPY --link --from=build         /build  /
 # smoke tests
 # usage:
 # > docker buildx bake binary-smoketest
-FROM --platform=$TARGETPLATFORM base AS smoketest
+FROM base AS smoketest
 WORKDIR /usr/local/bin
 COPY --from=build /build .
 RUN <<EOT


### PR DESCRIPTION
    The 'as' keyword should match the case of the 'from' keyword
    FromAsCasing: 'as' and 'FROM' keywords' casing do not match
    More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/

    Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior
    RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in FROM is redundant as this is the default behavior
    More info: https://docs.docker.com/go/dockerfile/rule/redundant-target-platform/

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

