### PR TITLE
daemon: handleContainerExit: ignore networking errors

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -37,6 +37,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+const errSetupNetworking = "failed to set up container networking"
+
 func ipAddresses(ips []net.IP) []string {
 	var addrs []string
 	for _, ip := range ips {

--- a/daemon/start_linux.go
+++ b/daemon/start_linux.go
@@ -34,5 +34,8 @@ func (daemon *Daemon) initializeCreatedTask(
 			return errdefs.System(err)
 		}
 	}
-	return daemon.allocateNetwork(ctx, cfg, ctr)
+	if err := daemon.allocateNetwork(ctx, cfg, ctr); err != nil {
+		return fmt.Errorf("%s: %w", errSetupNetworking, err)
+	}
+	return nil
 }


### PR DESCRIPTION

- fixes https://github.com/moby/moby/issues/49501

Related to:

- https://github.com/moby/moby/pull/47406

**- What I did**

Prior to commit fe856b94b5149718b1a7f369220608846fea32bc, containers' network sandbox and interfaces were created before the containerd task. Now, it's created after.

If this step fails, the containerd task is forcefully deleted, and an event is sent to the c8d event monitor, which triggers `handleContainerExit`. Then this method tries to restart the faulty container.

This leads to containers with a published port already in use to be stuck in a tight restart loop (if they're started with `--restart=always`) until the port is available. This is needlessly spamming the daemon logs.

Prior to that commit, a published port already in use wouldn't trigger the restart process.

**- How I did it**

This commit adds a check to `handleContainerExit` to ignore exit events if the latest container error is related to networking setup.

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
Fix a bug that was causing containers with `--restart=always` and a published port already in use to be restarting in a tight loop.
```

**- A picture of a cute animal (not mandatory but encouraged)**

