### PR TITLE
libnet/portallocator: un-export errors that were not used as sentinel  errors

### DIFF
--- a/libnetwork/portallocator/portallocator_test.go
+++ b/libnetwork/portallocator/portallocator_test.go
@@ -1,6 +1,7 @@
 package portallocator
 
 import (
+	"errors"
 	"net"
 	"testing"
 
@@ -83,9 +84,8 @@ func TestReleaseUnreadledPort(t *testing.T) {
 
 	_, err = p.RequestPort(net.IPv4zero, "tcp", 5000)
 
-	switch err.(type) {
-	case ErrPortAlreadyAllocated:
-	default:
+	var expectedErrType alreadyAllocatedErr
+	if !errors.As(err, &expectedErrType) {
 		t.Fatalf("Expected port allocation error got %s", err)
 	}
 }
@@ -93,8 +93,8 @@ func TestReleaseUnreadledPort(t *testing.T) {
 func TestUnknowProtocol(t *testing.T) {
 	p := newInstance()
 
-	if _, err := p.RequestPort(net.IPv4zero, "tcpp", 0); err != ErrUnknownProtocol {
-		t.Fatalf("Expected error %s got %s", ErrUnknownProtocol, err)
+	if _, err := p.RequestPort(net.IPv4zero, "tcpp", 0); err != errUnknownProtocol {
+		t.Fatalf("Expected error %s got %s", errUnknownProtocol, err)
 	}
 }
 
@@ -112,8 +112,8 @@ func TestAllocateAllPorts(t *testing.T) {
 		}
 	}
 
-	if _, err := p.RequestPort(net.IPv4zero, "tcp", 0); err != ErrAllPortsAllocated {
-		t.Fatalf("Expected error %s got %s", ErrAllPortsAllocated, err)
+	if _, err := p.RequestPort(net.IPv4zero, "tcp", 0); err != errAllPortsAllocated {
+		t.Fatalf("Expected error %s got %s", errAllPortsAllocated, err)
 	}
 
 	_, err := p.RequestPort(net.IPv4zero, "udp", 0)
@@ -281,8 +281,8 @@ func TestPortAllocationWithCustomRange(t *testing.T) {
 		t.Fatal("Allocated the same port from a custom range")
 	}
 	// request 3rd port from the range of 2
-	if _, err := p.RequestPortInRange(net.IPv4zero, "tcp", start, end); err != ErrAllPortsAllocated {
-		t.Fatalf("Expected error %s got %s", ErrAllPortsAllocated, err)
+	if _, err := p.RequestPortInRange(net.IPv4zero, "tcp", start, end); err != errAllPortsAllocated {
+		t.Fatalf("Expected error %s got %s", errAllPortsAllocated, err)
 	}
 }
 


### PR DESCRIPTION
related;

- https://github.com/moby/moby/pull/6682
- https://github.com/moby/libnetwork/pull/34
- https://github.com/moby/moby/pull/13060


The `ErrPortAlreadyAllocated` error was introduced in ffd68badc0a3d70fbd063903702355a387621b10, and at the time used as sentinel error in the bridge driver. It was later integrated into libnetwork ([libnetwork@672ced7]), and brought back when libnetwork was integrated in v1.7.0; 272f8cd4bc537bd78e7bf02d5b06fac50afda8ff After libnetwork was integrated, the error was unused as sentinel error, except for locally inside the package as part of a test;

    git rev-parse --verify HEAD
    496bc46c8819a3c8af391ed57d11c43093df0fc1

    git grep '\.ErrPortAlreadyAllocated'

Which is still the case Today;

    git describe --tags --match="v[0-9]*" HEAD
    v28.0.0
    git rev-parse --verify HEAD
    af898abe44662d9554fb15ee4d4a7307f1b8e315
    git grep '\.ErrPortAlreadyAllocated'

Same for the `ErrAllPortsAllocated` (added in 739d1244807bc3522a0af4dc3490305d6f037601, https://github.com/moby/moby/pull/4949) and `ErrUnknownProtocol` (added in 303ed3c8300183bab09a36b58e0c1db89d12424a, https://github.com/moby/moby/pull/3790) errors, which were never used as sentinel errors, and still aren't;

    git grep '\.ErrAllPortsAllocated'
    git grep '\.ErrUnknownProtocol'
    vendor/github.com/moby/buildkit/client/llb/source.go:   if errors.Is(err, gitutil.ErrUnknownProtocol) {

This patch;

- un-exports these errors as they are not used as sentinel errors
- strips down the `ErrPortAlreadyAllocated`, removing the methods that were added, but never used.
- removes the `newErrPortAlreadyAllocated` constructor
- renames `ErrPortAlreadyAllocated` to `alreadyAllocatedErr` to follow go conventions.

[libnetwork@672ced7]: https://github.com/moby/libnetwork/commit/c0474b6438d4dc5a6a652a370323ceaa9251db96

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

