### PR TITLE
Add chain DOCKER-FORWARD

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/integration-cli/daemon"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/testutil"
@@ -718,7 +719,7 @@ func (s *DockerDaemonSuite) TestDaemonICCPing(c *testing.T) {
 	d.StartWithBusybox(testutil.GetContext(c), c, "--bridge", bridgeName, "--icc=false")
 	defer d.Restart(c)
 
-	result := icmd.RunCommand("sh", "-c", "iptables -vL FORWARD | grep DROP")
+	result := icmd.RunCommand("sh", "-c", "iptables -vL "+bridge.DockerForwardChain+" | grep DROP")
 	result.Assert(c, icmd.Success)
 
 	// strip whitespace and newlines to verify we only found a single DROP
@@ -769,7 +770,7 @@ func (s *DockerDaemonSuite) TestDaemonICCLinkExpose(c *testing.T) {
 	d.StartWithBusybox(testutil.GetContext(c), c, "--bridge", bridgeName, "--icc=false")
 	defer d.Restart(c)
 
-	result := icmd.RunCommand("sh", "-c", "iptables -vL FORWARD | grep DROP")
+	result := icmd.RunCommand("sh", "-c", "iptables -vL "+bridge.DockerForwardChain+" | grep DROP")
 	result.Assert(c, icmd.Success)
 
 	// strip whitespace and newlines to verify we only found a single DROP

--- a/integration/network/bridge/iptablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/generated/new-daemon.md
@@ -11,10 +11,7 @@ Table `filter`:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
-    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
-    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -22,6 +19,13 @@ Table `filter`:
     Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-FORWARD (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -43,15 +47,17 @@ Table `filter`:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-    -A FORWARD -i docker0 -j ACCEPT
+    -A FORWARD -j DOCKER-FORWARD
     -A DOCKER ! -i docker0 -o docker0 -j DROP
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -i docker0 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
     -A DOCKER-USER -j RETURN
@@ -76,18 +82,29 @@ The FORWARD chain rules are numbered in the output above, they are:
      Docker won't add rules to the DOCKER-USER chain, it's only for user-defined rules.
      It's (mostly) kept at the top of the by deleting it and re-creating after each
      new network is created, while traffic may be running for other networks.
-  2. Early ACCEPT for any RELATED,ESTABLISHED traffic to a docker bridge. This rule
+  2. Unconditional jump to DOCKER-FORWARD.
+     This is set up by libnetwork, in [setupUserChain][10].
+
+Once the daemon has initialised, it doesn't touch these rules. Users are free to
+append rules to the FORWARD chain, and they'll run after DOCKER's rules (or to
+the DOCKER-USER chain, for rules that run before DOCKER's).
+
+The DOCKER-FORWARD chain contains the first stage of Docker's filter rules. Initial
+rules are inserted at the top of the table, then not touched. Per-network rules
+are appended.
+
+  1. Early ACCEPT for any RELATED,ESTABLISHED traffic to a docker bridge. This rule
      matches against an `ipset` called `docker-ext-bridges-v4` (`v6` for IPv6). The
      set contains the CIDR address of each docker network, and it is updated as networks
      are created and deleted. This rule is created during driver initialisation, in
      `setupIPChains`.
-  3. Unconditional jump to DOCKER-ISOLATION-STAGE-1.
+  2. Unconditional jump to DOCKER-ISOLATION-STAGE-1.
      Also created during driver initialisation, in `setupIPChains`.
-  4. Jump to DOCKER, for any packet destined for any bridge network, identified by
+  3. Jump to DOCKER, for any packet destined for any bridge network, identified by
      matching against the `docker-ext-bridge-v[46]` set.
      Also created during driver initialisation, in `setupIPChains`.
      The DOCKER chain implements per-port/protocol filtering for each container.
-  5. ACCEPT any packet leaving a network, set up when the network is created, in
+  4. ACCEPT any packet leaving a network, set up when the network is created, in
      `setupIPTablesInternal`. Note that this accepts any packet leaving the
      network that's made it through the DOCKER and isolation chains, whether the
      destination is external or another network.

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
@@ -18,11 +18,7 @@ The filter and nat tables are identical to [nat mode][0]:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
-    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
-    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    6        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -32,6 +28,14 @@ The filter and nat tables are identical to [nat mode][0]:
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-FORWARD (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -52,18 +56,20 @@ The filter and nat tables are identical to [nat mode][0]:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-    -A FORWARD -i docker0 -j ACCEPT
-    -A FORWARD -i bridge1 -j ACCEPT
+    -A FORWARD -j DOCKER-FORWARD
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -i docker0 -j ACCEPT
+    -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
@@ -16,11 +16,7 @@ The filter table is:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
-    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
-    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    6        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -29,6 +25,14 @@ The filter table is:
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     2        0     0 ACCEPT     0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-FORWARD (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -52,17 +56,19 @@ The filter table is:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-    -A FORWARD -i docker0 -j ACCEPT
-    -A FORWARD -i bridge1 -j ACCEPT
+    -A FORWARD -j DOCKER-FORWARD
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j ACCEPT
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -i docker0 -j ACCEPT
+    -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -16,12 +16,7 @@ The filter table is:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
-    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
-    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    6        0     0 DROP       0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
-    7        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -31,6 +26,15 @@ The filter table is:
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-FORWARD (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    5        0     0 DROP       0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    6        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -54,19 +58,21 @@ The filter table is:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-    -A FORWARD -i docker0 -j ACCEPT
-    -A FORWARD -i bridge1 -o bridge1 -j DROP
-    -A FORWARD -i bridge1 ! -o bridge1 -j ACCEPT
+    -A FORWARD -j DOCKER-FORWARD
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -i docker0 -j ACCEPT
+    -A DOCKER-FORWARD -i bridge1 -o bridge1 -j DROP
+    -A DOCKER-FORWARD -i bridge1 ! -o bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
@@ -16,11 +16,7 @@ The filter table is:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
-    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
-    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    6        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -31,6 +27,14 @@ The filter table is:
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 ACCEPT     1    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
     4        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-FORWARD (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -56,19 +60,21 @@ The filter table is:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-    -A FORWARD -i docker0 -j ACCEPT
-    -A FORWARD -i bridge1 -j ACCEPT
+    -A FORWARD -j DOCKER-FORWARD
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER -o bridge1 -p icmp -j ACCEPT
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -i docker0 -j ACCEPT
+    -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -o bridge1 -j RETURN
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -15,11 +15,7 @@ The filter table is updated as follows:
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
-    3        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
-    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    6        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -29,6 +25,14 @@ The filter table is updated as follows:
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-FORWARD (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
     Chain DOCKER-ISOLATION-STAGE-1 (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -52,18 +56,20 @@ The filter table is updated as follows:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
     -N DOCKER-USER
     -A FORWARD -j DOCKER-USER
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-    -A FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-    -A FORWARD -i docker0 -j ACCEPT
-    -A FORWARD -i bridge1 -j ACCEPT
+    -A FORWARD -j DOCKER-FORWARD
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -i docker0 -j ACCEPT
+    -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 ! -o bridge1 -j DOCKER-ISOLATION-STAGE-2
     -A DOCKER-ISOLATION-STAGE-2 -o bridge1 -j DROP
@@ -75,7 +81,7 @@ The filter table is updated as follows:
 
 Note that:
 
- - In the FORWARD chain, rule 6 for outgoing traffic from the new network has been
+ - In the DOCKER-FORWARD chain, rule 5 for outgoing traffic from the new network has been
    appended to the end of the chain.
  - In the DOCKER-ISOLATION chains, rules equivalent to the docker0 rules have
    also been inserted for the new bridge.

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -193,27 +193,25 @@ var index = []section{
 type iptCmdType = string
 
 const (
-	iptCmdLFilter4        iptCmdType = "LFilter4"
-	iptCmdSFilter4        iptCmdType = "SFilter4"
-	iptCmdLFilterDocker4  iptCmdType = "LFilterDocker4"
-	iptCmdSFilterForward4 iptCmdType = "SFilterForward4"
-	iptCmdSFilterDocker4  iptCmdType = "SFilterDocker4"
-	iptCmdLNat4           iptCmdType = "LNat4"
-	iptCmdSNat4           iptCmdType = "SNat4"
-	iptCmdLRaw4           iptCmdType = "LRaw4"
-	iptCmdSRaw4           iptCmdType = "SRaw4"
+	iptCmdLFilter4       iptCmdType = "LFilter4"
+	iptCmdSFilter4       iptCmdType = "SFilter4"
+	iptCmdLFilterDocker4 iptCmdType = "LFilterDocker4"
+	iptCmdSFilterDocker4 iptCmdType = "SFilterDocker4"
+	iptCmdLNat4          iptCmdType = "LNat4"
+	iptCmdSNat4          iptCmdType = "SNat4"
+	iptCmdLRaw4          iptCmdType = "LRaw4"
+	iptCmdSRaw4          iptCmdType = "SRaw4"
 )
 
 var iptCmds = map[iptCmdType][]string{
-	iptCmdLFilter4:        {"iptables", "-nvL", "--line-numbers", "-t", "filter"},
-	iptCmdSFilter4:        {"iptables", "-S", "-t", "filter"},
-	iptCmdSFilterForward4: {"iptables", "-S", "FORWARD"},
-	iptCmdLFilterDocker4:  {"iptables", "-nvL", "DOCKER", "--line-numbers", "-t", "filter"},
-	iptCmdSFilterDocker4:  {"iptables", "-S", "DOCKER"},
-	iptCmdLNat4:           {"iptables", "-nvL", "--line-numbers", "-t", "nat"},
-	iptCmdSNat4:           {"iptables", "-S", "-t", "nat"},
-	iptCmdLRaw4:           {"iptables", "-nvL", "--line-numbers", "-t", "raw"},
-	iptCmdSRaw4:           {"iptables", "-S", "-t", "raw"},
+	iptCmdLFilter4:       {"iptables", "-nvL", "--line-numbers", "-t", "filter"},
+	iptCmdSFilter4:       {"iptables", "-S", "-t", "filter"},
+	iptCmdLFilterDocker4: {"iptables", "-nvL", "DOCKER", "--line-numbers", "-t", "filter"},
+	iptCmdSFilterDocker4: {"iptables", "-S", "DOCKER"},
+	iptCmdLNat4:          {"iptables", "-nvL", "--line-numbers", "-t", "nat"},
+	iptCmdSNat4:          {"iptables", "-S", "-t", "nat"},
+	iptCmdLRaw4:          {"iptables", "-nvL", "--line-numbers", "-t", "raw"},
+	iptCmdSRaw4:          {"iptables", "-S", "-t", "raw"},
 }
 
 func TestBridgeIptablesDoc(t *testing.T) {

--- a/integration/network/bridge/iptablesdoc/templates/swarm-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/swarm-portmap.md
@@ -20,7 +20,7 @@ Note that:
  - There's a bridge network called `docker_gwbridge` for swarm ingress.
    - Its rules follow the usual pattern for a network with inter-container communication disabled.
 - There's an additional chain `DOCKER-INGRESS`.
-  - The jump to `DOCKER-INGRESS` is in the `FORWARD` chain, after the jump to `DOCKER-USER`.
+  - The jump to `DOCKER-INGRESS` is in the `FORWARD` chain.
 
 And the corresponding nat table:
 

--- a/integration/network/bridge/iptablesdoc/templates/usernet-internal.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-internal.md
@@ -31,7 +31,7 @@ The filter table is updated as follows:
 
 By comparison with the [network with external access][1]:
 
-- In the FORWARD chain, there is no ACCEPT rule for outgoing packets (`-i bridgeINC`).
+- In the DOCKER-FORWARD chain, there is no ACCEPT rule for outgoing packets (`-i bridgeINC`).
 - There are no rules for this network in the DOCKER chain.
 - In DOCKER-ISOLATION-STAGE-1:
   - Rule 1 drops any packet routed to the network that does not have a source address in the network's subnet.
@@ -39,7 +39,7 @@ By comparison with the [network with external access][1]:
   - There is no jump to DOCKER-ISOLATION-STAGE-2.
 - DOCKER-ISOLATION-STAGE-2 is unused.
 
-The only difference between `bridgeICC` and `bridgeNoICC` is the rule in the FORWARD
+The only difference between `bridgeICC` and `bridgeNoICC` is the rule in the DOCKER-FORWARD
 chain. To enable ICC, the rule for packets looping through the bridge is ACCEPT. For
 no-ICC it's DROP.
 

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
@@ -20,7 +20,7 @@ The filter table is updated as follows:
 
 Note that:
 
- - In the FORWARD chain, rule 6 for outgoing traffic from the new network has been
+ - In the DOCKER-FORWARD chain, rule 5 for outgoing traffic from the new network has been
    appended to the end of the chain.
  - In the DOCKER-ISOLATION chains, rules equivalent to the docker0 rules have
    also been inserted for the new bridge.

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/docker/docker/libnetwork/drivers/bridge"
+
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/iptables"
@@ -62,6 +64,15 @@ func TestUserChain(t *testing.T) {
 				fmt.Sprintf("TestUserChain_iptables-%v_append-%v_fwdinit4", tc.iptables, tc.append))
 			golden.Assert(t, getRules(t, iptable6, fwdChainName),
 				fmt.Sprintf("TestUserChain_iptables-%v_append-%v_fwdinit6", tc.iptables, tc.append))
+			if tc.iptables {
+				golden.Assert(t, getRules(t, iptable4, bridge.DockerForwardChain),
+					fmt.Sprintf("TestUserChain_iptables-%v_append-%v_dockerfwdinit4", tc.iptables, tc.append))
+				golden.Assert(t, getRules(t, iptable6, bridge.DockerForwardChain),
+					fmt.Sprintf("TestUserChain_iptables-%v_append-%v_dockerfwdinit6", tc.iptables, tc.append))
+			} else {
+				assert.Check(t, !iptables.GetIptable(iptables.IPv4).ExistChain(bridge.DockerForwardChain, fwdChainName),
+					"Chain %s should not exist", bridge.DockerForwardChain)
+			}
 
 			if tc.append {
 				_, err := iptable4.Raw("-A", fwdChainName, "-j", "DROP")
@@ -75,6 +86,15 @@ func TestUserChain(t *testing.T) {
 				fmt.Sprintf("TestUserChain_iptables-%v_append-%v_fwdafter4", tc.iptables, tc.append))
 			golden.Assert(t, getRules(t, iptable6, fwdChainName),
 				fmt.Sprintf("TestUserChain_iptables-%v_append-%v_fwdafter6", tc.iptables, tc.append))
+			if tc.iptables {
+				golden.Assert(t, getRules(t, iptable4, bridge.DockerForwardChain),
+					fmt.Sprintf("TestUserChain_iptables-%v_append-%v_dockerfwdafter4", tc.iptables, tc.append))
+				golden.Assert(t, getRules(t, iptable6, bridge.DockerForwardChain),
+					fmt.Sprintf("TestUserChain_iptables-%v_append-%v_dockerfwdafter6", tc.iptables, tc.append))
+			} else {
+				assert.Check(t, !iptables.GetIptable(iptables.IPv4).ExistChain(bridge.DockerForwardChain, fwdChainName),
+					"Chain %s should not exist", bridge.DockerForwardChain)
+			}
 
 			if tc.iptables {
 				golden.Assert(t, getRules(t, iptable4, usrChainName),

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter4
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter6
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit4
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit6
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdafter4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdafter4
@@ -1,5 +1,3 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdafter6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdafter6
@@ -1,5 +1,3 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdinit4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdinit4
@@ -1,5 +1,3 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdinit6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_fwdinit6
@@ -1,5 +1,3 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter4
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter6
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit4
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit6
@@ -1,0 +1,4 @@
+-N DOCKER-FORWARD
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
+-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdafter4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdafter4
@@ -1,6 +1,4 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD
 -A FORWARD -j DROP

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdafter6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdafter6
@@ -1,6 +1,4 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD
 -A FORWARD -j DROP

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdinit4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdinit4
@@ -1,5 +1,3 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdinit6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_fwdinit6
@@ -1,5 +1,3 @@
 -P FORWARD ACCEPT
 -A FORWARD -j DOCKER-USER
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A FORWARD -j DOCKER-ISOLATION-STAGE-1
--A FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A FORWARD -j DOCKER-FORWARD


### PR DESCRIPTION
**- What I did**

In 28.0.0, Docker appended to the FORWARD chain - breaking other applications that had appended their own rules that needed to execute after Docker's rules.

- fix https://github.com/moby/moby/issues/49511
- fix https://github.com/docker/for-linux/issues/1521
- https://github.com/moby/moby/issues/49498
  - fixes the issues with Tailscale and Oracle Cloud
  - likely fixes issues with swag, but tbc.
- fix https://github.com/moby/moby/issues/49528

**- How I did it**

Move most of Docker's rules out of the filter-FORWARD chain into a new DOCKER-FORWARD chain, so that Docker can append to DOCKER-FORWARD without affecting the order of rules in the FORWARD chain.

After daemon startup inserts jumps to DOCKER-USER and DOCKER-FORWARD, the bridge driver will not touch the FORWARD chain again. DOCKER-INGRESS is still added to the FORWARD chain, if used, as it was in 27.x and earlier.

(Links to code in the generated iptables docs are all out of date ... I'll update them once this is merged and there's something to link to - haven't thought of a better way to deal with that, but I think the links are probably worth keeping.)

**- How to verify it**

Existing and updated tests.

New test `TestDropInForwardChain` - reliably fails without this change.

To check removal of rules from the FORWARD chain on upgrade from 27.5.1 ...
- flushed iptables/ip6tables
- started 27.5.1
- joined swarm, created some networks, started some containers ...
- stashed the output of iptables-save, ip6tables-save
- stopped dockerd, started docker built from this PR and restarted the containers
- stashed the iptables rules again
- stopped the dev-docker, flushed iptables/ip6tables, started everything back up
- stashed the iptables rules again, and compared them with the post-upgrade set
  - the only difference between the rules for upgrade/fresh start was due to creation order of networks (per-network rules in the DOCKER-FORWARD that can safely be swapped)

<details>
<summary>Upgrade test detail ...</summary>

### Networks and containers ...

```
docker network create --ipv6 b46
docker network create --internal --ipv6 internalnw
docker network create -o com.docker.network.bridge.enable_icc=false --ipv6 noicc

docker run --rm -d --network b46 -p 10000:1000 alpine sleep infinity
docker run --rm -d --network noicc -p 10001:1001 alpine sleep infinity
docker run --rm -d --network internalnw alpine sleep infinity
docker service create alpine sleep infinity
```

<details>
<summary>27.5.1 iptables</summary>

```
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:12:36 2025
*filter
:INPUT ACCEPT [0:0]
:FORWARD DROP [0:0]
:OUTPUT ACCEPT [0:0]
:DOCKER - [0:0]
:DOCKER-ISOLATION-STAGE-1 - [0:0]
:DOCKER-ISOLATION-STAGE-2 - [0:0]
:DOCKER-USER - [0:0]
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-ISOLATION-STAGE-1
-A FORWARD -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o docker0 -j DOCKER
-A FORWARD -i docker0 ! -o docker0 -j ACCEPT
-A FORWARD -i docker0 -o docker0 -j ACCEPT
-A FORWARD -i br-233f92e88674 -o br-233f92e88674 -j ACCEPT
-A FORWARD -o br-f2cfb6c855a7 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o br-f2cfb6c855a7 -j DOCKER
-A FORWARD -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j ACCEPT
-A FORWARD -o docker_gwbridge -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o docker_gwbridge -j DOCKER
-A FORWARD -i docker_gwbridge ! -o docker_gwbridge -j ACCEPT
-A FORWARD -o br-3cdb1cb92a36 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o br-3cdb1cb92a36 -j DOCKER
-A FORWARD -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j ACCEPT
-A FORWARD -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -j ACCEPT
-A FORWARD -i docker_gwbridge -o docker_gwbridge -j DROP
-A FORWARD -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER -d 172.18.0.2/32 ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j ACCEPT
-A DOCKER -d 172.20.0.2/32 ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j ACCEPT
-A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 ! -s 172.19.0.0/16 -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 ! -d 172.19.0.0/16 -i br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker_gwbridge ! -o docker_gwbridge -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -j RETURN
-A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o docker_gwbridge -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-3cdb1cb92a36 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -j RETURN
-A DOCKER-USER -j RETURN
COMMIT
# Completed on Fri Feb 21 15:12:36 2025
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:12:36 2025
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:DOCKER - [0:0]
-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
-A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
-A POSTROUTING -s 172.20.0.0/16 ! -o br-f2cfb6c855a7 -j MASQUERADE
-A POSTROUTING -s 172.21.0.0/16 ! -o docker_gwbridge -j MASQUERADE
-A POSTROUTING -s 172.18.0.0/16 ! -o br-3cdb1cb92a36 -j MASQUERADE
-A POSTROUTING -s 172.18.0.2/32 -d 172.18.0.2/32 -p tcp -m tcp --dport 1000 -j MASQUERADE
-A POSTROUTING -s 172.20.0.2/32 -d 172.20.0.2/32 -p tcp -m tcp --dport 1001 -j MASQUERADE
-A DOCKER -i docker0 -j RETURN
-A DOCKER -i br-f2cfb6c855a7 -j RETURN
-A DOCKER -i docker_gwbridge -j RETURN
-A DOCKER -i br-3cdb1cb92a36 -j RETURN
-A DOCKER ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 10000 -j DNAT --to-destination 172.18.0.2:1000
-A DOCKER ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 10001 -j DNAT --to-destination 172.20.0.2:1001
COMMIT
# Completed on Fri Feb 21 15:12:36 2025
```

</details>

<details>
<summary>27.5.1 - ip6tables</summary>

```
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:12:29 2025
*filter
:INPUT ACCEPT [0:0]
:FORWARD DROP [0:0]
:OUTPUT ACCEPT [0:0]
:DOCKER - [0:0]
:DOCKER-ISOLATION-STAGE-1 - [0:0]
:DOCKER-ISOLATION-STAGE-2 - [0:0]
:DOCKER-USER - [0:0]
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-ISOLATION-STAGE-1
-A FORWARD -i br-233f92e88674 -o br-233f92e88674 -j ACCEPT
-A FORWARD -o br-f2cfb6c855a7 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o br-f2cfb6c855a7 -j DOCKER
-A FORWARD -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j ACCEPT
-A FORWARD -o br-3cdb1cb92a36 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A FORWARD -o br-3cdb1cb92a36 -j DOCKER
-A FORWARD -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j ACCEPT
-A FORWARD -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -j ACCEPT
-A FORWARD -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER -d fd5b:823e:5b1a::2/128 ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j ACCEPT
-A DOCKER -d fd5b:823e:5b1a:2::2/128 ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j ACCEPT
-A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 ! -s fd5b:823e:5b1a:1::/64 ! -i br-233f92e88674 -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 ! -d fd5b:823e:5b1a:1::/64 -i br-233f92e88674 ! -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker_gwbridge ! -o docker_gwbridge -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -j RETURN
-A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o docker_gwbridge -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-3cdb1cb92a36 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -j RETURN
-A DOCKER-USER -j RETURN
COMMIT
# Completed on Fri Feb 21 15:12:29 2025
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:12:29 2025
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:DOCKER - [0:0]
-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-A OUTPUT ! -d ::1/128 -m addrtype --dst-type LOCAL -j DOCKER
-A POSTROUTING -s fd5b:823e:5b1a:2::/64 ! -o br-f2cfb6c855a7 -j MASQUERADE
-A POSTROUTING -s fd5b:823e:5b1a::/64 ! -o br-3cdb1cb92a36 -j MASQUERADE
-A POSTROUTING -s fd5b:823e:5b1a::2/128 -d fd5b:823e:5b1a::2/128 -p tcp -m tcp --dport 1000 -j MASQUERADE
-A POSTROUTING -s fd5b:823e:5b1a:2::2/128 -d fd5b:823e:5b1a:2::2/128 -p tcp -m tcp --dport 1001 -j MASQUERADE
-A DOCKER -i br-f2cfb6c855a7 -j RETURN
-A DOCKER -i br-3cdb1cb92a36 -j RETURN
-A DOCKER ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 10000 -j DNAT --to-destination [fd5b:823e:5b1a::2]:1000
-A DOCKER ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 10001 -j DNAT --to-destination [fd5b:823e:5b1a:2::2]:1001
COMMIT
# Completed on Fri Feb 21 15:12:29 2025
```

</details>


<details>
<summary>Dev build after upgrade from 27.5.1 - iptables</summary>

```
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:14:15 2025
*raw
:PREROUTING ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
-A PREROUTING -d 172.18.0.2/32 ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j DROP
-A PREROUTING -d 172.20.0.2/32 ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j DROP
COMMIT
# Completed on Fri Feb 21 15:14:15 2025
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:14:15 2025
*filter
:INPUT ACCEPT [0:0]
:FORWARD DROP [0:0]
:OUTPUT ACCEPT [0:0]
:DOCKER - [0:0]
:DOCKER-FORWARD - [0:0]
:DOCKER-ISOLATION-STAGE-1 - [0:0]
:DOCKER-ISOLATION-STAGE-2 - [0:0]
:DOCKER-USER - [0:0]
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-FORWARD
-A DOCKER -d 172.20.0.2/32 ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j ACCEPT
-A DOCKER -d 172.18.0.2/32 ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j ACCEPT
-A DOCKER ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -j DROP
-A DOCKER ! -i docker_gwbridge -o docker_gwbridge -j DROP
-A DOCKER ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER ! -i docker0 -o docker0 -j DROP
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-A DOCKER-FORWARD -i br-233f92e88674 -o br-233f92e88674 -j ACCEPT
-A DOCKER-FORWARD -i br-3cdb1cb92a36 -j ACCEPT
-A DOCKER-FORWARD -i docker_gwbridge -o docker_gwbridge -j DROP
-A DOCKER-FORWARD -i docker_gwbridge ! -o docker_gwbridge -j ACCEPT
-A DOCKER-FORWARD -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-FORWARD -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j ACCEPT
-A DOCKER-FORWARD -i docker0 -j ACCEPT
-A DOCKER-ISOLATION-STAGE-1 ! -s 172.19.0.0/16 -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 ! -d 172.19.0.0/16 -i br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker_gwbridge ! -o docker_gwbridge -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o docker_gwbridge -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-3cdb1cb92a36 -j DROP
-A DOCKER-USER -j RETURN
COMMIT
# Completed on Fri Feb 21 15:14:15 2025
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:14:15 2025
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:DOCKER - [0:0]
-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
-A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
-A POSTROUTING -s 172.20.0.0/16 ! -o br-f2cfb6c855a7 -j MASQUERADE
-A POSTROUTING -s 172.21.0.0/16 ! -o docker_gwbridge -j MASQUERADE
-A POSTROUTING -s 172.18.0.0/16 ! -o br-3cdb1cb92a36 -j MASQUERADE
-A DOCKER -i docker0 -j RETURN
-A DOCKER -i br-f2cfb6c855a7 -j RETURN
-A DOCKER -i docker_gwbridge -j RETURN
-A DOCKER -i br-3cdb1cb92a36 -j RETURN
-A DOCKER ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 10000 -j DNAT --to-destination 172.18.0.2:1000
-A DOCKER ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 10001 -j DNAT --to-destination 172.20.0.2:1001
COMMIT
# Completed on Fri Feb 21 15:14:15 2025
```

</details>

<details>
<summary>Dev build after upgrade from 27.5.1- ip6tables</summary>

```
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:14:25 2025
*raw
:PREROUTING ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
-A PREROUTING -d fd5b:823e:5b1a::2/128 ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j DROP
-A PREROUTING -d fd5b:823e:5b1a:2::2/128 ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j DROP
COMMIT
# Completed on Fri Feb 21 15:14:25 2025
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:14:25 2025
*filter
:INPUT ACCEPT [0:0]
:FORWARD DROP [0:0]
:OUTPUT ACCEPT [0:0]
:DOCKER - [0:0]
:DOCKER-FORWARD - [0:0]
:DOCKER-ISOLATION-STAGE-1 - [0:0]
:DOCKER-ISOLATION-STAGE-2 - [0:0]
:DOCKER-USER - [0:0]
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-FORWARD
-A DOCKER -d fd5b:823e:5b1a:2::2/128 ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j ACCEPT
-A DOCKER -d fd5b:823e:5b1a::2/128 ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j ACCEPT
-A DOCKER ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -j DROP
-A DOCKER ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
-A DOCKER-FORWARD -i br-233f92e88674 -o br-233f92e88674 -j ACCEPT
-A DOCKER-FORWARD -i br-3cdb1cb92a36 -j ACCEPT
-A DOCKER-FORWARD -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-FORWARD -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j ACCEPT
-A DOCKER-ISOLATION-STAGE-1 ! -s fd5b:823e:5b1a:1::/64 ! -i br-233f92e88674 -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 ! -d fd5b:823e:5b1a:1::/64 -i br-233f92e88674 ! -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker_gwbridge ! -o docker_gwbridge -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o docker_gwbridge -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-3cdb1cb92a36 -j DROP
-A DOCKER-USER -j RETURN
COMMIT
# Completed on Fri Feb 21 15:14:25 2025
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:14:25 2025
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:DOCKER - [0:0]
-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-A OUTPUT ! -d ::1/128 -m addrtype --dst-type LOCAL -j DOCKER
-A POSTROUTING -s fd5b:823e:5b1a:2::/64 ! -o br-f2cfb6c855a7 -j MASQUERADE
-A POSTROUTING -s fd5b:823e:5b1a::/64 ! -o br-3cdb1cb92a36 -j MASQUERADE
-A DOCKER -i br-f2cfb6c855a7 -j RETURN
-A DOCKER -i br-3cdb1cb92a36 -j RETURN
-A DOCKER ! -s fe80::/10 ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 10000 -j DNAT --to-destination [fd5b:823e:5b1a::2]:1000
-A DOCKER ! -s fe80::/10 ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 10001 -j DNAT --to-destination [fd5b:823e:5b1a:2::2]:1001
COMMIT
# Completed on Fri Feb 21 15:14:25 2025
```

</details>

<details>
<summary>Dev build started after iptables flush - iptables</summary>

```
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:18:20 2025
*raw
:PREROUTING ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
-A PREROUTING -d 172.18.0.2/32 ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j DROP
-A PREROUTING -d 172.20.0.2/32 ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j DROP
COMMIT
# Completed on Fri Feb 21 15:18:20 2025
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:18:20 2025
*filter
:INPUT ACCEPT [0:0]
:FORWARD DROP [0:0]
:OUTPUT ACCEPT [0:0]
:DOCKER - [0:0]
:DOCKER-FORWARD - [0:0]
:DOCKER-ISOLATION-STAGE-1 - [0:0]
:DOCKER-ISOLATION-STAGE-2 - [0:0]
:DOCKER-USER - [0:0]
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-FORWARD
-A DOCKER -d 172.20.0.2/32 ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j ACCEPT
-A DOCKER -d 172.18.0.2/32 ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j ACCEPT
-A DOCKER ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -j DROP
-A DOCKER ! -i docker_gwbridge -o docker_gwbridge -j DROP
-A DOCKER ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER ! -i docker0 -o docker0 -j DROP
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
-A DOCKER-FORWARD -i br-3cdb1cb92a36 -j ACCEPT
-A DOCKER-FORWARD -i docker_gwbridge -o docker_gwbridge -j DROP
-A DOCKER-FORWARD -i docker_gwbridge ! -o docker_gwbridge -j ACCEPT
-A DOCKER-FORWARD -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-FORWARD -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j ACCEPT
-A DOCKER-FORWARD -i br-233f92e88674 -o br-233f92e88674 -j ACCEPT
-A DOCKER-FORWARD -i docker0 -j ACCEPT
-A DOCKER-ISOLATION-STAGE-1 ! -s 172.19.0.0/16 -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 ! -d 172.19.0.0/16 -i br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker_gwbridge ! -o docker_gwbridge -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o docker_gwbridge -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-3cdb1cb92a36 -j DROP
-A DOCKER-USER -j RETURN
COMMIT
# Completed on Fri Feb 21 15:18:20 2025
# Generated by iptables-save v1.8.9 (nf_tables) on Fri Feb 21 15:18:20 2025
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:DOCKER - [0:0]
-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
-A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
-A POSTROUTING -s 172.20.0.0/16 ! -o br-f2cfb6c855a7 -j MASQUERADE
-A POSTROUTING -s 172.21.0.0/16 ! -o docker_gwbridge -j MASQUERADE
-A POSTROUTING -s 172.18.0.0/16 ! -o br-3cdb1cb92a36 -j MASQUERADE
-A DOCKER -i docker0 -j RETURN
-A DOCKER -i br-f2cfb6c855a7 -j RETURN
-A DOCKER -i docker_gwbridge -j RETURN
-A DOCKER -i br-3cdb1cb92a36 -j RETURN
-A DOCKER ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 10000 -j DNAT --to-destination 172.18.0.2:1000
-A DOCKER ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 10001 -j DNAT --to-destination 172.20.0.2:1001
COMMIT
# Completed on Fri Feb 21 15:18:20 2025
```

</details>

<details>
<summary>Dev build started after ip6tables flush - ip6tables</summary>

```
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:18:13 2025
*raw
:PREROUTING ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
-A PREROUTING -d fd5b:823e:5b1a::2/128 ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j DROP
-A PREROUTING -d fd5b:823e:5b1a:2::2/128 ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j DROP
COMMIT
# Completed on Fri Feb 21 15:18:13 2025
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:18:13 2025
*filter
:INPUT ACCEPT [0:0]
:FORWARD DROP [0:0]
:OUTPUT ACCEPT [0:0]
:DOCKER - [0:0]
:DOCKER-FORWARD - [0:0]
:DOCKER-ISOLATION-STAGE-1 - [0:0]
:DOCKER-ISOLATION-STAGE-2 - [0:0]
:DOCKER-USER - [0:0]
-A FORWARD -j DOCKER-USER
-A FORWARD -j DOCKER-FORWARD
-A DOCKER -d fd5b:823e:5b1a:2::2/128 ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -p tcp -m tcp --dport 1001 -j ACCEPT
-A DOCKER -d fd5b:823e:5b1a::2/128 ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -p tcp -m tcp --dport 1000 -j ACCEPT
-A DOCKER ! -i br-3cdb1cb92a36 -o br-3cdb1cb92a36 -j DROP
-A DOCKER ! -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
-A DOCKER-FORWARD -i br-3cdb1cb92a36 -j ACCEPT
-A DOCKER-FORWARD -i br-f2cfb6c855a7 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-FORWARD -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j ACCEPT
-A DOCKER-FORWARD -i br-233f92e88674 -o br-233f92e88674 -j ACCEPT
-A DOCKER-ISOLATION-STAGE-1 ! -s fd5b:823e:5b1a:1::/64 ! -i br-233f92e88674 -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 ! -d fd5b:823e:5b1a:1::/64 -i br-233f92e88674 ! -o br-233f92e88674 -j DROP
-A DOCKER-ISOLATION-STAGE-1 -i br-3cdb1cb92a36 ! -o br-3cdb1cb92a36 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker_gwbridge ! -o docker_gwbridge -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i br-f2cfb6c855a7 ! -o br-f2cfb6c855a7 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
-A DOCKER-ISOLATION-STAGE-2 -o docker0 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-f2cfb6c855a7 -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o docker_gwbridge -j DROP
-A DOCKER-ISOLATION-STAGE-2 -o br-3cdb1cb92a36 -j DROP
-A DOCKER-USER -j RETURN
COMMIT
# Completed on Fri Feb 21 15:18:13 2025
# Generated by ip6tables-save v1.8.9 (nf_tables) on Fri Feb 21 15:18:13 2025
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
:DOCKER - [0:0]
-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
-A OUTPUT ! -d ::1/128 -m addrtype --dst-type LOCAL -j DOCKER
-A POSTROUTING -s fd5b:823e:5b1a:2::/64 ! -o br-f2cfb6c855a7 -j MASQUERADE
-A POSTROUTING -s fd5b:823e:5b1a::/64 ! -o br-3cdb1cb92a36 -j MASQUERADE
-A DOCKER -i br-f2cfb6c855a7 -j RETURN
-A DOCKER -i br-3cdb1cb92a36 -j RETURN
-A DOCKER ! -s fe80::/10 ! -i br-3cdb1cb92a36 -p tcp -m tcp --dport 10000 -j DNAT --to-destination [fd5b:823e:5b1a::2]:1000
-A DOCKER ! -s fe80::/10 ! -i br-f2cfb6c855a7 -p tcp -m tcp --dport 10001 -j DNAT --to-destination [fd5b:823e:5b1a:2::2]:1001
COMMIT
```

</details>
</details>

**- Human readable description for the release notes**
```markdown changelog
Move most of Docker's iptables rules out of the filter-FORWARD chain, so that other applications are free to append rules that must follow Docker's rules.
```
