### PR TITLE
Fix network inspect IPv6 gateway address format

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -751,9 +751,13 @@ func buildIPAMResources(nw *libnetwork.Network) networktypes.IPAM {
 				if info.IPAMData.Pool == nil {
 					continue
 				}
+				var gw string
+				if info.IPAMData.Gateway != nil {
+					gw = info.IPAMData.Gateway.IP.String()
+				}
 				ipamConfig = append(ipamConfig, networktypes.IPAMConfig{
 					Subnet:  info.IPAMData.Pool.String(),
-					Gateway: info.IPAMData.Gateway.String(),
+					Gateway: gw,
 				})
 			}
 		}

--- a/integration/daemon/daemon_linux_test.go
+++ b/integration/daemon/daemon_linux_test.go
@@ -57,7 +57,7 @@ func TestDaemonDefaultBridgeIPAM_Docker0(t *testing.T) {
 			},
 			expIPAMConfig: []network.IPAMConfig{
 				{Subnet: "192.168.176.0/24", Gateway: "192.168.176.1"},
-				{Subnet: "fdd1:8161:2d2c::/64", Gateway: "fdd1:8161:2d2c::1/64"},
+				{Subnet: "fdd1:8161:2d2c::/64", Gateway: "fdd1:8161:2d2c::1"},
 			},
 		},
 		{

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -1542,3 +1542,21 @@ func TestAdvertiseAddresses(t *testing.T) {
 		})
 	}
 }
+
+// TestNetworkInspectGateway checks that gateways reported in inspect output are parseable as addresses.
+func TestNetworkInspectGateway(t *testing.T) {
+	ctx := setupTest(t)
+	c := testEnv.APIClient()
+
+	const netName = "test-inspgw"
+	nid, err := network.Create(ctx, c, netName, network.WithIPv6())
+	assert.NilError(t, err)
+	defer network.RemoveNoError(ctx, t, c, netName)
+
+	insp, err := c.NetworkInspect(ctx, nid, networktypes.InspectOptions{})
+	assert.NilError(t, err)
+	for _, ipamCfg := range insp.IPAM.Config {
+		_, err := netip.ParseAddr(ipamCfg.Gateway)
+		assert.Check(t, err)
+	}
+}


### PR DESCRIPTION
**- What I did**

Spotted in-passing ...

When an IPv6 network is first created with no specific IPAM config, network inspect adds a CIDR range to the gateway address. For example ...

```
# docker network create --ipv6 b46
# docker network inspect b46
       ...
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "172.19.0.0/16",
                    "Gateway": "172.19.0.1"
                },
                {
                    "Subnet": "fdcf:eadc:be2c::/64",
                    "Gateway": "fdcf:eadc:be2c::1/64"
                }
            ]
        },
        ...
```

After the daemon has been restarted, it's just a plain address - `"Gateway": "fdcf:eadc:be2c::1"`.

Before 27.0 (https://github.com/moby/moby/pull/47853), it wasn't possible to create an IPv6 network without supplying at-least a subnet (or including IPv6 ranges in `default-address-pools`). So, there was always IPAM config and, until a daemon restart, no gateway address was reported in inspect output.

Since that change, the IPv6 gateway address has been reported incorrectly (with a CIDR suffix) until a daemon restart.

When the daemon's restated, the IPAM "info" (running state) becomes "config" (it shouldn't!), and the "config" address is reported correctly.

**- How I did it**

Make the IPv6 code to report the gateway from IPAM "info" use net.IPNet.IP instead of the whole net.IPNet - like the IPv4 code.

**- How to verify it**

New test.

**- Human readable description for the release notes**
```markdown changelog
- Fix `docker network inspect` reporting an IPv6 gateway with CIDR suffix for a newly created network with no specific IPAM config, until a daemon restart.
```

**- A picture of a cute animal (not mandatory but encouraged)**

