### PR TITLE
Fix --config-from creation of swarm networks

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -310,7 +310,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.Crea
 		}
 	}
 
-	enableIPv4 := create.ConfigFrom == nil
+	enableIPv4 := true
 	if create.EnableIPv4 != nil {
 		enableIPv4 = *create.EnableIPv4
 	} else if v, ok := networkOptions[netlabel.EnableIPv4]; ok {

--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -50,10 +50,31 @@ func WithInternal() func(*network.CreateOptions) {
 	}
 }
 
+// WithConfigOnly sets the ConfigOnly flag in the create network request
+func WithConfigOnly(co bool) func(*network.CreateOptions) {
+	return func(n *network.CreateOptions) {
+		n.ConfigOnly = co
+	}
+}
+
+// WithConfigFrom sets the ConfigOnly flag in the create network request
+func WithConfigFrom(name string) func(*network.CreateOptions) {
+	return func(n *network.CreateOptions) {
+		n.ConfigFrom = &network.ConfigReference{Network: name}
+	}
+}
+
 // WithAttachable sets Attachable flag on the create network request
 func WithAttachable() func(*network.CreateOptions) {
 	return func(n *network.CreateOptions) {
 		n.Attachable = true
+	}
+}
+
+// WithScope sets the network scope.
+func WithScope(s string) func(*network.CreateOptions) {
+	return func(n *network.CreateOptions) {
+		n.Scope = s
 	}
 }
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -543,6 +543,26 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		return nil, types.ForbiddenErrorf("Ingress network can only be global scope network")
 	}
 
+	// From this point on, we need the network specific configuration,
+	// which may come from a configuration-only network
+	if nw.configFrom != "" {
+		configNetwork, err := c.getConfigNetwork(nw.configFrom)
+		if err != nil {
+			return nil, types.NotFoundErrorf("configuration network %q does not exist", nw.configFrom)
+		}
+		if err := configNetwork.applyConfigurationTo(nw); err != nil {
+			return nil, types.InternalErrorf("Failed to apply configuration: %v", err)
+		}
+		nw.generic[netlabel.Internal] = nw.internal
+		defer func() {
+			if retErr == nil && !skipCfgEpCount {
+				if err := configNetwork.getEpCnt().IncEndpointCnt(); err != nil {
+					log.G(context.TODO()).Warnf("Failed to update reference count for configuration network %q on creation of network %q: %v", configNetwork.Name(), nw.name, err)
+				}
+			}
+		}()
+	}
+
 	// At this point the network scope is still unknown if not set by user
 	if (caps.DataScope == scope.Global || nw.scope == scope.Swarm) &&
 		c.isSwarmNode() && !nw.dynamic {
@@ -570,26 +590,6 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	// From this point on, we need the network specific configuration,
-	// which may come from a configuration-only network
-	if nw.configFrom != "" {
-		configNetwork, err := c.getConfigNetwork(nw.configFrom)
-		if err != nil {
-			return nil, types.NotFoundErrorf("configuration network %q does not exist", nw.configFrom)
-		}
-		if err := configNetwork.applyConfigurationTo(nw); err != nil {
-			return nil, types.InternalErrorf("Failed to apply configuration: %v", err)
-		}
-		nw.generic[netlabel.Internal] = nw.internal
-		defer func() {
-			if retErr == nil && !skipCfgEpCount {
-				if err := configNetwork.getEpCnt().IncEndpointCnt(); err != nil {
-					log.G(context.TODO()).Warnf("Failed to update reference count for configuration network %q on creation of network %q: %v", configNetwork.Name(), nw.name, err)
-				}
-			}
-		}()
 	}
 
 	if err := nw.ipamAllocate(); err != nil {

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -499,6 +499,7 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		networkType:      networkType,
 		generic:          map[string]interface{}{netlabel.GenericData: make(map[string]string)},
 		ipamType:         defaultIpam,
+		enableIPv4:       true,
 		id:               id,
 		created:          time.Now(),
 		ctrlr:            c,
@@ -553,7 +554,6 @@ func (c *Controller) NewNetwork(networkType, name string, id string, options ...
 		if err := configNetwork.applyConfigurationTo(nw); err != nil {
 			return nil, types.InternalErrorf("Failed to apply configuration: %v", err)
 		}
-		nw.generic[netlabel.Internal] = nw.internal
 		defer func() {
 			if retErr == nil && !skipCfgEpCount {
 				if err := configNetwork.getEpCnt().IncEndpointCnt(); err != nil {

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -286,7 +286,7 @@ func TestNetworkConfig(t *testing.T) {
 
 	// Verify a network cannot be created with both config-from and network specific configurations
 	for i, opt := range []libnetwork.NetworkOption{
-		libnetwork.NetworkOptionEnableIPv4(true),
+		libnetwork.NetworkOptionEnableIPv4(false),
 		libnetwork.NetworkOptionEnableIPv6(true),
 		libnetwork.NetworkOptionIpam("my-ipam", "", nil, nil, nil),
 		libnetwork.NetworkOptionIpam("", "", ipamV4ConfList, nil, nil),


### PR DESCRIPTION
**- What I did**

- fix https://github.com/docker/cli/issues/5857

**- How I did it**

#### Fix swarm net validation for config-from networks

For swarm networks, Controller.NewNetwork is called to validate network config ... nothing gets created, but `ManagerRedirectError` is returned if the config is ok - then swarm does its own thing.

So, for a `--config-from` network, merge config before checking whether it'll have IPv4 enabled.

#### Fix swarm network creation from a config-only network

Creating a swarm network from a config-only network failed because the new EnableIPv4 wasn't validated/propagated correctly.

So:
- Always initialise EnableIPv4 to true, including for a config only network, and on load from the store.
- Treat enableIPv4=true as the no-overridden state when checking params for a config-from network.
- Propagate settings from the config 'Network' objects attributes to its generic options, because the network driver only sees generic options.
  - This was happening already for Network.internal, after the config-only network options were processed. Move that to
    'applyConfigurationTo'.
  - Add enableIPv4/enableIpv6 - enableIPv6 will normaly be present anyway. But, for a network created pre-28.x and restored from the store, there was no entry for 'netlabel.EnableIpv4'.


**- How to verify it**

New test `TestSwarmScopedNetFromConfig` creates a swarm network from a `--config-only` network (fails without the first commit), and starts a service using it (fails without the second commit).

Also, created a config-from network using 27.5.1, upgraded to 28.0.0 to check it didn't work, upgraded to a dev build based on this PR and it started normally.

**- Human readable description for the release notes**
```markdown changelog
Fix creation of a swarm-scoped network from a `--config-only` network.
```
