### PR TITLE
libnet/d/bridge: fix compilation on i386

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 	"strconv"
 	"syscall"
-	"unsafe"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/iptables"
@@ -675,14 +674,7 @@ func bindSCTP(cfg portBindingReq, port int) (_ portBinding, retErr error) {
 		syscall.SetsockoptInt(sd, syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, 1)
 	}
 
-	options := sctp.InitMsg{NumOstreams: sctp.SCTP_MAX_STREAM}
-	if _, _, errno := syscall.Syscall6(syscall.SYS_SETSOCKOPT,
-		uintptr(sd),
-		sctp.SOL_SCTP,
-		sctp.SCTP_INITMSG,
-		uintptr(unsafe.Pointer(&options)), // #nosec G103 -- Ignore "G103: Use of unsafe calls should be audited"
-		unsafe.Sizeof(options),
-		0); errno != 0 {
+	if errno := setSCTPInitMsg(sd, sctp.InitMsg{NumOstreams: sctp.SCTP_MAX_STREAM}); errno != 0 {
 		return portBinding{}, errno
 	}
 

--- a/libnetwork/drivers/bridge/port_mapping_linux_386.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_386.go
@@ -1,0 +1,21 @@
+package bridge
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/ishidawataru/sctp"
+)
+
+const sysSetsockopt = 14 // See https://elixir.bootlin.com/linux/v6.13.3/source/include/uapi/linux/net.h#L40
+
+func setSCTPInitMsg(sd int, options sctp.InitMsg) syscall.Errno {
+	_, _, errno := syscall.Syscall6(syscall.SYS_SOCKETCALL, // See `man 2 socketcall`
+		sysSetsockopt,
+		uintptr(sd),
+		sctp.SOL_SCTP,
+		sctp.SCTP_INITMSG,
+		uintptr(unsafe.Pointer(&options)), // #nosec G103 -- Ignore "G103: Use of unsafe calls should be audited"
+		unsafe.Sizeof(options))
+	return errno
+}

--- a/libnetwork/drivers/bridge/port_mapping_linux_others.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_others.go
@@ -1,0 +1,21 @@
+//go:build linux && !386
+
+package bridge
+
+import (
+	"syscall"
+	"unsafe"
+
+	"github.com/ishidawataru/sctp"
+)
+
+func setSCTPInitMsg(sd int, options sctp.InitMsg) syscall.Errno {
+	_, _, errno := syscall.Syscall6(syscall.SYS_SETSOCKOPT,
+		uintptr(sd),
+		sctp.SOL_SCTP,
+		sctp.SCTP_INITMSG,
+		uintptr(unsafe.Pointer(&options)), // #nosec G103 -- Ignore "G103: Use of unsafe calls should be audited"
+		unsafe.Sizeof(options),
+		0)
+	return errno
+}


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/issues/49523

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

On i386, Linux doesn't provide direct socket syscall but instead multiplexes them through the socketcall syscall (see `man 2 socketcall`).

**- How I did it**

This commit fixes compilation for i386 by wrapping the offending syscall in a new function that uses the socketcall syscall on i386, and the `setsockopt` syscall on other archs.

**- How to verify it**

`GOARCH=386 ./hack/make.sh binary`

**- Human readable description for the release notes**

```markdown changelog
Fix compilation on i386
```

