### PR TITLE
Drop the use of ipset

### DIFF
--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
@@ -21,16 +21,26 @@ The filter table is:
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (1 references)
+    Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     2        0     0 ACCEPT     0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
+    Chain DOCKER-BRIDGE (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-CT (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
     5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
@@ -56,6 +66,8 @@ The filter table is:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-BRIDGE
+    -N DOCKER-CT
     -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
@@ -64,9 +76,13 @@ The filter table is:
     -A FORWARD -j DOCKER-FORWARD
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j ACCEPT
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-BRIDGE -o docker0 -j DOCKER
+    -A DOCKER-BRIDGE -o bridge1 -j DOCKER
+    -A DOCKER-CT -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-CT -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-CT
     -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -j DOCKER-BRIDGE
     -A DOCKER-FORWARD -i docker0 -j ACCEPT
     -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -21,17 +21,27 @@ The filter table is:
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (1 references)
+    Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
+    Chain DOCKER-BRIDGE (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-CT (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
     5        0     0 DROP       0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     6        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
@@ -58,6 +68,8 @@ The filter table is:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-BRIDGE
+    -N DOCKER-CT
     -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
@@ -67,9 +79,13 @@ The filter table is:
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-BRIDGE -o docker0 -j DOCKER
+    -A DOCKER-BRIDGE -o bridge1 -j DOCKER
+    -A DOCKER-CT -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-CT -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-CT
     -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -j DOCKER-BRIDGE
     -A DOCKER-FORWARD -i docker0 -j ACCEPT
     -A DOCKER-FORWARD -i bridge1 -o bridge1 -j DROP
     -A DOCKER-FORWARD -i bridge1 ! -o bridge1 -j ACCEPT
@@ -84,7 +100,7 @@ The filter table is:
 
 By comparison with [ICC=true][1]:
 
-  - Rules 6 and 7 replace the accept rule for outgoing packets.
+  - DOCKER-FORWARD rules 6 and 7 replace the accept rule for outgoing packets.
     - Rule 6, added by `setIcc`, drops any packet sent from the internal network to itself.
     - Rule 7, added by `setupIPTablesInternal` accepts any other outgoing packet.
 

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
@@ -24,17 +24,27 @@ The filter table is the same as with the userland proxy enabled.
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (1 references)
+    Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
+    Chain DOCKER-BRIDGE (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-CT (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
     5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
@@ -57,6 +67,8 @@ The filter table is the same as with the userland proxy enabled.
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-BRIDGE
+    -N DOCKER-CT
     -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
@@ -66,9 +78,13 @@ The filter table is the same as with the userland proxy enabled.
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-BRIDGE -o docker0 -j DOCKER
+    -A DOCKER-BRIDGE -o bridge1 -j DOCKER
+    -A DOCKER-CT -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-CT -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-CT
     -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -j DOCKER-BRIDGE
     -A DOCKER-FORWARD -i docker0 -j ACCEPT
     -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
@@ -21,18 +21,28 @@ The filter table is:
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (1 references)
+    Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 ACCEPT     1    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
     4        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
+    Chain DOCKER-BRIDGE (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-CT (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
     5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
@@ -60,6 +70,8 @@ The filter table is:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-BRIDGE
+    -N DOCKER-CT
     -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
@@ -70,9 +82,13 @@ The filter table is:
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER -o bridge1 -p icmp -j ACCEPT
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-BRIDGE -o docker0 -j DOCKER
+    -A DOCKER-BRIDGE -o bridge1 -j DOCKER
+    -A DOCKER-CT -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-CT -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-CT
     -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -j DOCKER-BRIDGE
     -A DOCKER-FORWARD -i docker0 -j ACCEPT
     -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
@@ -115,7 +131,7 @@ needed._
 The ICMP rule, as shown by `iptables -L`, looks alarming until you spot that it's
 for `prot 1`:
 
-    Chain DOCKER (1 references)
+    Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -20,17 +20,27 @@ The filter table is updated as follows:
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
-    Chain DOCKER (1 references)
+    Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
     2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
     3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
     
+    Chain DOCKER-BRIDGE (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    
+    Chain DOCKER-CT (1 references)
+    num   pkts bytes target     prot opt in     out     source               destination         
+    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst ctstate RELATED,ESTABLISHED
+    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     2        0     0 DOCKER-ISOLATION-STAGE-1  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            match-set docker-ext-bridges-v4 dst
+    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
     4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
     5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
     
@@ -56,6 +66,8 @@ The filter table is updated as follows:
     -P FORWARD ACCEPT
     -P OUTPUT ACCEPT
     -N DOCKER
+    -N DOCKER-BRIDGE
+    -N DOCKER-CT
     -N DOCKER-FORWARD
     -N DOCKER-ISOLATION-STAGE-1
     -N DOCKER-ISOLATION-STAGE-2
@@ -65,9 +77,13 @@ The filter table is updated as follows:
     -A DOCKER -d 192.0.2.2/32 ! -i bridge1 -o bridge1 -p tcp -m tcp --dport 80 -j ACCEPT
     -A DOCKER ! -i docker0 -o docker0 -j DROP
     -A DOCKER ! -i bridge1 -o bridge1 -j DROP
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-BRIDGE -o docker0 -j DOCKER
+    -A DOCKER-BRIDGE -o bridge1 -j DOCKER
+    -A DOCKER-CT -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-CT -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    -A DOCKER-FORWARD -j DOCKER-CT
     -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
-    -A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+    -A DOCKER-FORWARD -j DOCKER-BRIDGE
     -A DOCKER-FORWARD -i docker0 -j ACCEPT
     -A DOCKER-FORWARD -i bridge1 -j ACCEPT
     -A DOCKER-ISOLATION-STAGE-1 -i docker0 ! -o docker0 -j DOCKER-ISOLATION-STAGE-2
@@ -83,6 +99,7 @@ Note that:
 
  - In the DOCKER-FORWARD chain, rule 5 for outgoing traffic from the new network has been
    appended to the end of the chain.
+ - The DOCKER-CT and DOCKER-FORWARD chains each have a rule for the new network.
  - In the DOCKER-ISOLATION chains, rules equivalent to the docker0 rules have
    also been inserted for the new bridge.
  - In the DOCKER chain, there is an ACCEPT rule for TCP port 80 packets routed

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-noicc.md
@@ -21,7 +21,7 @@ The filter table is:
 
 By comparison with [ICC=true][1]:
 
-  - Rules 6 and 7 replace the accept rule for outgoing packets.
+  - DOCKER-FORWARD rules 6 and 7 replace the accept rule for outgoing packets.
     - Rule 6, added by `setIcc`, drops any packet sent from the internal network to itself.
     - Rule 7, added by `setupIPTablesInternal` accepts any other outgoing packet.
 

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap.md
@@ -22,6 +22,7 @@ Note that:
 
  - In the DOCKER-FORWARD chain, rule 5 for outgoing traffic from the new network has been
    appended to the end of the chain.
+ - The DOCKER-CT and DOCKER-FORWARD chains each have a rule for the new network.
  - In the DOCKER-ISOLATION chains, rules equivalent to the docker0 rules have
    also been inserted for the new bridge.
  - In the DOCKER chain, there is an ACCEPT rule for TCP port 80 packets routed

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/docker/docker/libnetwork/types"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
-	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
@@ -1265,9 +1264,6 @@ func TestCleanupIptableRules(t *testing.T) {
 		iptables.IPv4: {EnableIPTables: true},
 		iptables.IPv6: {EnableIP6Tables: true},
 	}
-
-	assert.NilError(t, setupHashNetIpset(ipsetExtBridges4, unix.AF_INET))
-	assert.NilError(t, setupHashNetIpset(ipsetExtBridges6, unix.AF_INET6))
 
 	for _, version := range ipVersions {
 		err := setupIPChains(configs[version], version)

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter4
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdafter6
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit4
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-false_dockerfwdinit6
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter4
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdafter6
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit4
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit4
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE

--- a/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit6
+++ b/libnetwork/testdata/TestUserChain_iptables-true_append-true_dockerfwdinit6
@@ -1,4 +1,4 @@
 -N DOCKER-FORWARD
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A DOCKER-FORWARD -j DOCKER-CT
 -A DOCKER-FORWARD -j DOCKER-ISOLATION-STAGE-1
--A DOCKER-FORWARD -m set --match-set docker-ext-bridges-v6 dst -j DOCKER
+-A DOCKER-FORWARD -j DOCKER-BRIDGE


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/49505
- fix https://github.com/moby/moby/issues/49508

Commit 0546d90 introduced the use of ipset to reduce the number of rules that need to be processed per-packet, and make the code a bit simpler.

But, docker's used on embedded kernels compiled without support for ipset, so the change is too disruptive.

**- How I did it**

Replace the two ipset rules with a new chain that writes out the rule's actions long-hand. So ..

This rule:
```
      -A FORWARD -m set --match-set docker-ext-bridges-v4 dst \
        -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
```
Is transformed into a per-bridge rule in new chain DOCKER-CT:
```
      -A DOCKER-FORWARD -j DOCKER-CT
      -A DOCKER-CT -o docker0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
      -A DOCKER-CT -o bridge1 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
```

And:
```
      -A FORWARD -m set --match-set docker-ext-bridges-v4 dst -j DOCKER
```
Is transformed into a per-bridge rule in new chain DOCKER-BRIDGE:
```
      -A DOCKER-FORWARD -j DOCKER-BRIDGE
      -A DOCKER-BRIDGE -o docker0 -j DOCKER
      -A DOCKER-BRIDGE -o bridge1 -j DOCKER
```

**- How to verify it**

The usual tests.

Ran 28.0.0 with some networks, stopped it and updated to this PR, checked that the ipset rules were removed.

**- Human readable description for the release notes**
```markdown changelog
- Remove dependency on kernel modules `ip_set`, `ip_set_hash_net` and `netfilter_xt_set`.
  - The dependency was introduced in release 28.0.0 but proved too disruptive. The iptables rules using these modules have been replaced.
```