### PR TITLE
c8d/list&inspect: Better handle images without any platform blobs available locally

### DIFF
--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -31,9 +31,11 @@ type errPlatformNotFound struct {
 
 func (e *errPlatformNotFound) NotFound() {}
 func (e *errPlatformNotFound) Error() string {
-	msg := "image with reference " + e.imageRef + " was found but does not provide the specified platform"
+	msg := "image with reference " + e.imageRef + " was found but does not provide "
 	if e.wanted.OS != "" {
-		msg += " (" + platforms.FormatAll(e.wanted) + ")"
+		msg += "the specified platform (" + platforms.FormatAll(e.wanted) + ")"
+	} else {
+		msg += "any platform"
 	}
 	return msg
 }

--- a/daemon/containerd/image_inspect_test.go
+++ b/daemon/containerd/image_inspect_test.go
@@ -1,0 +1,64 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	c8dimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/log/logtest"
+	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/internal/testutils/specialimage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestImageInspect(t *testing.T) {
+	ctx := namespaces.WithNamespace(context.TODO(), "testing")
+
+	blobsDir := t.TempDir()
+
+	toContainerdImage := func(t *testing.T, imageFunc specialimage.SpecialImageFunc) c8dimages.Image {
+		idx, err := imageFunc(blobsDir)
+		assert.NilError(t, err)
+
+		return imagesFromIndex(idx)[0]
+	}
+
+	missingMultiPlatform := toContainerdImage(t, func(dir string) (*ocispec.Index, error) {
+		idx, _, err := specialimage.PartialMultiPlatform(dir, "missingmp:latest", specialimage.PartialOpts{
+			Stored: nil,
+			Missing: []ocispec.Platform{
+				{OS: "linux", Architecture: "arm64"},
+				{OS: "linux", Architecture: "amd64"},
+			},
+		})
+		return idx, err
+	})
+
+	cs := &blobsDirContentStore{blobs: filepath.Join(blobsDir, "blobs/sha256")}
+
+	t.Run("inspect image with manifests but missing platform blobs", func(t *testing.T) {
+		ctx := logtest.WithT(ctx, t)
+		service := fakeImageService(t, ctx, cs)
+
+		_, err := service.images.Create(ctx, missingMultiPlatform)
+		assert.NilError(t, err)
+
+		for _, manifests := range []bool{true, false} {
+			t.Run(fmt.Sprintf("manifests=%t", manifests), func(t *testing.T) {
+				inspect, err := service.ImageInspect(ctx, missingMultiPlatform.Name, backend.ImageInspectOpts{Manifests: manifests})
+				assert.NilError(t, err)
+
+				if manifests {
+					assert.Check(t, is.Len(inspect.Manifests, 2))
+				} else {
+					assert.Check(t, is.Len(inspect.Manifests, 0))
+				}
+			})
+		}
+	})
+}

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -406,6 +406,7 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 			RepoDigests: []string{target.Digest.String()},
 			RepoTags:    tagsByDigest[target.Digest],
 			Size:        summary.TotalSize,
+			Manifests:   summary.Manifests,
 			// -1 indicates that the value has not been set (avoids ambiguity
 			// between 0 (default) and "not set". We cannot use a pointer (nil)
 			// for this, as the JSON representation uses "omitempty", which would


### PR DESCRIPTION
## c8d/list: Fix empty Manifests for some images
    
Fix empty `Manifests` field for multi-platform images that have no platform blobs available locally.
    
## c8d/inspect: Fix image not found error for index-only image
    
Fix not being able to inspect images that are OCI-index only (like `tianon/empty`) or a real multi-platform image which has no platform blobs available locally.

Note: This was already working in 27.x but regressed in master.

**- How to verify it**
Tests

**- Human readable description for the release notes**

```markdown changelog
containerd image store: Fix `docker inspect` not being able to show multi-platform images with missing layers for all platforms
containerd image store: Fix `GET /images/json?manifests=1` not filling `Manifests` for index-only images
```

**- A picture of a cute animal (not mandatory but encouraged)**

