### PR TITLE
c8d/manifests: Fix Content size including missing content

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -256,15 +256,16 @@ func (i *ImageService) multiPlatformSummary(ctx context.Context, img c8dimages.I
 			summary.Manifests = append(summary.Manifests, mfstSummary)
 		}()
 
-		contentSize, err := img.Size(ctx)
-		if err != nil {
-			if !cerrdefs.IsNotFound(err) {
-				logger.WithError(err).Warn("failed to determine size")
-			}
-		} else {
+		var contentSize int64
+		if err := i.walkPresentChildren(ctx, target, func(ctx context.Context, desc ocispec.Descriptor) error {
+			contentSize += desc.Size
+			return nil
+		}); err == nil {
 			mfstSummary.Size.Content = contentSize
 			summary.TotalSize += contentSize
 			mfstSummary.Size.Total += contentSize
+		} else {
+			logger.WithError(err).Warn("failed to calculate content size")
 		}
 
 		isPseudo, err := img.IsPseudoImage(ctx)


### PR DESCRIPTION
- unit test needs: https://github.com/moby/moby/pull/49533

Content size should only include size of content that is present in the local store.

**- What I did**

**- How I did it**

**- How to verify it**
Tests

or

```
$ docker pull ubuntu
# Remove layer (but keep manifests and config)
$ ctr content rm sha256:5b17151e9710ed47471b3928b05325fa4832121a395b9647b7e50d3993e17ce0
```

### Before

<img width="565" alt="image" src="https://github.com/user-attachments/assets/30d8b8c2-c6d0-4004-afe5-b0fd6c3d3dcc" />


### After

<img width="565" alt="image" src="https://github.com/user-attachments/assets/478ec250-d876-4dda-84d5-54597724b370" />



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
containerd image store: Fix `GET /images/json and /images/<name>/json` `Size.Content` field including the size of content that's not available locally
```

**- A picture of a cute animal (not mandatory but encouraged)**

