### PR TITLE
Jump to DOCKER-INGRESS from DOCKER-FORWARD

### DIFF
--- a/integration/network/bridge/iptablesdoc/templates/swarm-portmap.md
+++ b/integration/network/bridge/iptablesdoc/templates/swarm-portmap.md
@@ -20,7 +20,7 @@ Note that:
  - There's a bridge network called `docker_gwbridge` for swarm ingress.
    - Its rules follow the usual pattern for a network with inter-container communication disabled.
 - There's an additional chain `DOCKER-INGRESS`.
-  - The jump to `DOCKER-INGRESS` is in the `FORWARD` chain.
+  - The jump to `DOCKER-INGRESS` is first in the `DOCKER-FORWARD` chain.
 
 And the corresponding nat table:
 

--- a/libnetwork/service_linux.go
+++ b/libnetwork/service_linux.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/ns"
 	"github.com/ishidawataru/sctp"
@@ -359,13 +360,21 @@ func programIngress(gwIP net.IP, ingressPorts []*PortConfig, isDelete bool) erro
 			}
 		}
 
-		if !iptable.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
-			if err := iptable.RawCombinedOutput("-I", "FORWARD", "-j", ingressChain); err != nil {
-				return fmt.Errorf("failed to add jump rule to %s in filter table forward chain: %v", ingressChain, err)
+		// The DOCKER-FORWARD chain is created by the bridge driver on startup. It's a stable place to
+		// put the jump to DOCKER-INGRESS (nothing else will ever be inserted before it, and the jump
+		// will precede the bridge driver's other rules).
+		if !iptable.Exists(iptables.Filter, bridge.DockerForwardChain, "-j", ingressChain) {
+			if err := iptable.RawCombinedOutput("-I", bridge.DockerForwardChain, "-j", ingressChain); err != nil {
+				return fmt.Errorf("failed to add jump rule to %s in filter table %s chain: %v",
+					ingressChain, bridge.DockerForwardChain, err)
 			}
-			// The jump to DOCKER-USER needs to be before the jump to DOCKER-INGRESS.
-			if err := setupUserChain(iptables.IPv4); err != nil {
-				log.G(context.TODO()).Warnf("Failed to restore "+userChain+" after creating "+ingressChain+": %v", err)
+		}
+		// Remove the jump from FORWARD to DOCKER-INGRESS, if it was created there by a version of
+		// the daemon older than 28.0.1.
+		// FIXME(robmry) - should only do this once, on startup.
+		if iptable.Exists(iptables.Filter, "FORWARD", "-j", ingressChain) {
+			if err := iptable.RawCombinedOutput("-D", "FORWARD", "-j", ingressChain); err != nil {
+				log.G(context.TODO()).WithError(err).Debug("Failed to delete jump from FORWARD to " + ingressChain)
 			}
 		}
 


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49498#issuecomment-2671479350
- fix https://github.com/moby/moby/issues/49536

In 28.0.0, the iptables jump to `DOCKER-INGRESS` could get out of place, fixed that.

Introduced in commit 0ef2b24 - the intention was that jumps to `DOCKER-USER`, `DOCKER-ISOLATION-STAGE-1` and `DOCKER-INGRESS` no longer needed to be deleted and re-created at the top of the `FORWARD` chain each time a new network was added. That works for the other chains, because on daemon restart they're re-created. However, the jump to `DOCKER-INGRESS` is not re-created (shuffled back to the top of the table) if the `DOCKER-INGRESS` chain already existed. So, it ended up in the wrong place in the `FORWARD` chain. It worked in 27.x, because `arrangeIngressFilterRule` was called when the ingress network was re-created on startup.

**- How I did it**

A jump to DOCKER-INGRESS chain is only created when Swarm needs it. That's always after jumps to DOCKER-USER and DOCKER-FORWARD have been inserted at the top of the FORWARD chain. The DOCKER-INGRESS rule needs to be between those two other jumps.

Placing the jump to DOCKER-INGRESS at the top of the DOCKER-FORWARD chain puts it in the right place, without needing to shuffle any other rules around when it's added.

**- How to verify it**

With 27.5.1, created a swarm service with a published port (`docker service create -p 8080:80 nginx`), checked that the jump to `DOCKER-INGRESS` followed the jump to `DOCKER-USER` in the `FORWARD` chain. Stopped the daemon and started one built with this change - waited until the swarm service restarted, checked that the jump to `DOCKER-INGRESS` had been removed from the `FORWARD` chain and added to the top of `DOCKER-FORWARD`.

I'll follow up with a regression test, but that doesn't need to block 28.0.1.

**- Human readable description for the release notes**
```markdown changelog
Fix an issue with Swarm ingress, caused by incorrect ordering of iptables rules.
```