### PR TITLE
update minimum go version to go1.23

### DIFF
--- a/hack/with-go-mod.sh
+++ b/hack/with-go-mod.sh
@@ -25,7 +25,7 @@ else
 	tee "${ROOTDIR}/go.mod" >&2 <<- EOF
 		module github.com/docker/docker
 
-		go 1.22.0
+		go 1.23.0
 	EOF
 	trap 'rm -f "${ROOTDIR}/go.mod"' EXIT
 fi

--- a/vendor.mod
+++ b/vendor.mod
@@ -5,7 +5,7 @@
 
 module github.com/docker/docker
 
-go 1.22.0
+go 1.23.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.5.2


### PR DESCRIPTION
Go maintainers started to unconditionally update the minimum go version for golang.org/x/ dependencies to go1.23, which means that we'll no longer be able to support any version below that when updating those dependencies;

> all: upgrade go directive to at least 1.23.0 [generated]
>
> By now Go 1.24.0 has been released, and Go 1.22 is no longer supported
> per the Go Release Policy (https://go.dev/doc/devel/release#policy).
>
> For golang/go#69095.

This updates our minimum version to go1.23, as we won't be able to maintain compatibility with older versions because of the above.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: Update minimum required Go version to go1.23
```

**- A picture of a cute animal (not mandatory but encouraged)**

