### PR TITLE
fix some errors for windows containers

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -856,3 +856,11 @@ func (i *rio) Wait() {
 
 	i.IO.Wait()
 }
+
+type conflictingUpdateOptions string
+
+func (e conflictingUpdateOptions) Error() string {
+	return string(e)
+}
+
+func (e conflictingUpdateOptions) Conflict() {}

--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -244,14 +244,6 @@ func (container *Container) UnmountSecrets() error {
 	return mount.RecursiveUnmount(p)
 }
 
-type conflictingUpdateOptions string
-
-func (e conflictingUpdateOptions) Error() string {
-	return string(e)
-}
-
-func (e conflictingUpdateOptions) Conflict() {}
-
 // UpdateContainer updates configuration of a container. Callers must hold a Lock on the Container.
 func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfig) error {
 	// update resources of container

--- a/container/container_windows.go
+++ b/container/container_windows.go
@@ -2,13 +2,14 @@ package container // import "github.com/docker/docker/container"
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/errdefs"
 )
 
 const (
@@ -165,12 +166,12 @@ func (container *Container) UpdateContainer(hostConfig *containertypes.HostConfi
 		resources.CPUPercent != 0 ||
 		resources.IOMaximumIOps != 0 ||
 		resources.IOMaximumBandwidth != 0 {
-		return fmt.Errorf("resource updating isn't supported on Windows")
+		return errdefs.InvalidParameter(errors.New("resource updating isn't supported on Windows"))
 	}
 	// update HostConfig of container
 	if hostConfig.RestartPolicy.Name != "" {
 		if container.HostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
-			return fmt.Errorf("Restart policy cannot be updated because AutoRemove is enabled for the container")
+			return conflictingUpdateOptions("Restart policy cannot be updated because AutoRemove is enabled for the container")
 		}
 		container.HostConfig.RestartPolicy = hostConfig.RestartPolicy
 	}

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	containertypes "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -55,4 +56,5 @@ func TestUpdateRestartWithAutoRemove(t *testing.T) {
 		},
 	})
 	assert.Check(t, is.ErrorContains(err, "Restart policy cannot be updated because AutoRemove is enabled for the container"))
+	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
 }

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -776,7 +776,7 @@ func (p *process) CloseStdin(context.Context) error {
 // Pause handles pause requests for containers
 func (t *task) Pause(_ context.Context) error {
 	if t.ctr.ociSpec.Windows.HyperV == nil {
-		return cerrdefs.ErrNotImplemented
+		return errdefs.NotImplemented(errors.WithStack(errors.New("not implemented for containers using process isolation")))
 	}
 
 	t.ctr.mu.Lock()


### PR DESCRIPTION
### container: fix some errors on Windows

While going through some logs from CI, I noticed this log-entry on Windows,
produced as part of a test;

    2025-02-25T03:23:17.6584227Z [Error] Handler for POST /v1.48/containers/b47b1e632188426d6d42a4be04f9a3cc1eca40cfed9536d277011052af0b04f5/update returned error: Cannot update container b47b1e632188426d6d42a4be04f9a3cc1eca40cfed9536d277011052af0b04f5: Restart policy cannot be updated because AutoRemove is enabled for the container

While updating is an error for the user, it's not an error in the daemon,
so we should return the correct error-type (and avoid logging it as an
error in daemon logs).


### libcontainerd: windows: return errdefs type for pausing

Noticed this log in CI on Windows,  which wasn't clear if it was an error
in Windows or in Docker;

    2025-02-25T03:21:35.9273942Z [Error] Handler for POST /v1.48/containers/1713bc845f9bde79aa0017c16613fbfc8810b3272b31dbb2535d3fb1a3550f9c/pause returned error: cannot pause container 1713bc845f9bde79aa0017c16613fbfc8810b3272b31dbb2535d3fb1a3550f9c: Unimplemented: not implemented

Looks like it's a feature that's not implemented when using process-isolation,
so updating the error-message to make it more identifiable as an error
produced by us.

I kept the type to be a "not implemented", which will be converted to a
501 HTTP status (so still logged as error); alternatively, we could make
this a "invalid parameter".


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

