### PR TITLE
Revert "contrib/check-config: add ipset related flags"

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -210,9 +210,7 @@ check_flags \
 	NETFILTER_XT_MATCH_CONNTRACK \
 	NETFILTER_XT_MATCH_IPVS \
 	NETFILTER_XT_MARK \
-	NETFILTER_XT_SET \
 	IP_NF_NAT NF_NAT \
-	IP_SET IP_SET_HASH_NET \
 	POSIX_MQUEUE
 # (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
 


### PR DESCRIPTION
**- What I did**

- revert https://github.com/moby/moby/pull/49510
- related to https://github.com/moby/moby/pull/49530

We decided not to use ipset, so the kernel ip_set module (and friends) are not required.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

