### PR TITLE
daemon/cluster: some cleanups in initialisation

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -60,7 +60,6 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/util/tracing/detect"
-	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -931,11 +930,6 @@ func loadListeners(cfg *config.Config, tlsConfig *tls.Config) ([]net.Listener, [
 
 func createAndStartCluster(cli *daemonCLI, d *daemon.Daemon) (*cluster.Cluster, error) {
 	name, _ := os.Hostname()
-
-	// Use a buffered channel to pass changes from store watch API to daemon
-	// A buffer allows store watch API and daemon processing to not wait for each other
-	watchStream := make(chan *swarmapi.WatchMessage, 32)
-
 	c, err := cluster.New(cluster.Config{
 		Root:                   cli.Config.Root,
 		Name:                   name,
@@ -948,7 +942,6 @@ func createAndStartCluster(cli *daemonCLI, d *daemon.Daemon) (*cluster.Cluster, 
 		RaftHeartbeatTick:      cli.Config.SwarmRaftHeartbeatTick,
 		RaftElectionTick:       cli.Config.SwarmRaftElectionTick,
 		RuntimeRoot:            cli.getSwarmRunRoot(),
-		WatchStream:            watchStream,
 	})
 	if err != nil {
 		return nil, err

--- a/daemon/cluster/noderunner.go
+++ b/daemon/cluster/noderunner.go
@@ -131,7 +131,7 @@ func (n *nodeRunner) start(conf nodeStartConfig) error {
 			VXLANUDPPort:    conf.DataPathPort,
 		},
 		JoinAddr:  joinAddr,
-		StateDir:  n.cluster.root,
+		StateDir:  n.cluster.stateDir,
 		JoinToken: conf.joinToken,
 		Executor: container.NewExecutor(
 			n.cluster.config.Backend,
@@ -171,7 +171,7 @@ func (n *nodeRunner) start(conf nodeStartConfig) error {
 		conf.JoinInProgress = true
 	}
 	n.config = conf
-	savePersistentState(n.cluster.root, conf)
+	savePersistentState(n.cluster.stateDir, conf)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -262,7 +262,7 @@ func (n *nodeRunner) handleReadyEvent(ctx context.Context, node *swarmnode.Node,
 		n.err = nil
 		if n.config.JoinInProgress {
 			n.config.JoinInProgress = false
-			savePersistentState(n.cluster.root, n.config)
+			savePersistentState(n.cluster.stateDir, n.config)
 		}
 		n.mu.Unlock()
 		close(ready)

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -128,7 +128,7 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 		c.nr = nil
 		c.mu.Unlock()
 		if !req.ForceNewCluster { // if failure on first attempt don't keep state
-			if err := clearPersistentState(c.root); err != nil {
+			if err := clearPersistentState(c.stateDir); err != nil {
 				return "", err
 			}
 		}
@@ -207,7 +207,7 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 			c.mu.Lock()
 			c.nr = nil
 			c.mu.Unlock()
-			if err := clearPersistentState(c.root); err != nil {
+			if err := clearPersistentState(c.stateDir); err != nil {
 				return err
 			}
 		}
@@ -421,7 +421,7 @@ func (c *Cluster) Leave(ctx context.Context, force bool) error {
 	}
 
 	// todo: cleanup optional?
-	if err := clearPersistentState(c.root); err != nil {
+	if err := clearPersistentState(c.stateDir); err != nil {
 		return err
 	}
 	c.config.Backend.DaemonLeavesCluster()


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/pull/32421
- https://github.com/moby/moby/pull/36845

### daemon/cluster: remove Config.WatchStream and move to constructor

The WatchStream field was set as configuration option in cmd/dockerd,
but not configurable. Move creating the stream to the constructor,
and remove the configuration option. This field was introduced in
59d45c384a2de7bca73296ce1471646db14cb0c8, at which time the cmd/dockerd
code needed direct access to the stream, but a later refactor in
05346355dbd4300a21bfd64cda93ea6c5aef0cf0 introduced an accessor
(GetWatchStream) for this.

The cluster.Config struct is only used internally, it's unlikely
for any external project to use this, so skipping deprecation.

With this change, the cmd/dockerd package no longer has a direct
import of swarmkit.

### daemon/cluster: rename Cluster.root to Cluster.stateDir

This matches the name used by Swarm in swarmnode.Config. While updating,
also remove code from Cluster.Start that replicated the logic to construct
the path, in favor of using the `stateDir` field.


### daemon/cluster: create "state" and "runtime-dir" closer to where used

Don't create these paths until starting the cluster; they're not used
before this.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

