### PR TITLE
Dockerfile: update docker CLI to v28.0.1, docker compose to v2.33.1 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
 ARG DOCKERCLI_INTEGRATION_VERSION=v17.06.2-ce
 # BUILDX_VERSION is the version of buildx to install in the dev container.
 ARG BUILDX_VERSION=0.20.1
-ARG COMPOSE_VERSION=v2.32.4
+ARG COMPOSE_VERSION=v2.33.1
 
 ARG SYSTEMD="false"
 ARG FIREWALLD="false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG XX_VERSION=1.6.1
 ARG VPNKIT_VERSION=0.5.0
 
 # DOCKERCLI_VERSION is the version of the CLI to install in the dev-container.
-ARG DOCKERCLI_VERSION=v28.0.0-rc.1
+ARG DOCKERCLI_VERSION=v28.0.1
 ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
 
 # cli version used for integration-cli tests


### PR DESCRIPTION
### Dockerfile: update docker CLI to v28.0.1

Update the Docker CLI used in the dev-container


### Dockerfile: update compose to v2.33.1

Update the compose cli plugin used in the dev-container

full diff: https://github.com/docker/compose/compare/v2.32.4...v2.33,1


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

