### PR TITLE
libcontainerd/local: remove unused code and arguments

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -567,13 +567,7 @@ func (daemon *Daemon) initLibcontainerd(ctx context.Context, cfg *config.Config)
 
 	switch rt {
 	case config.WindowsV1RuntimeName:
-		daemon.containerd, err = local.NewClient(
-			ctx,
-			daemon.containerdClient,
-			filepath.Join(cfg.ExecRoot, "containerd"),
-			cfg.ContainerdNamespace,
-			daemon,
-		)
+		daemon.containerd, err = local.NewClient(ctx, daemon)
 	case config.WindowsV2RuntimeName:
 		if cfg.ContainerdAddr == "" {
 			return fmt.Errorf("cannot use the specified runtime %q without containerd", rt)

--- a/libcontainerd/libcontainerd_windows.go
+++ b/libcontainerd/libcontainerd_windows.go
@@ -13,7 +13,7 @@ import (
 // NewClient creates a new libcontainerd client from a containerd client
 func NewClient(ctx context.Context, cli *containerd.Client, stateDir, ns string, b libcontainerdtypes.Backend) (libcontainerdtypes.Client, error) {
 	if !system.ContainerdRuntimeSupported() {
-		return local.NewClient(ctx, cli, stateDir, ns, b)
+		return local.NewClient(ctx, b)
 	}
 	return remote.NewClient(ctx, cli, stateDir, ns, b)
 }

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -359,31 +359,32 @@ func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions inter
 }
 
 func (c *client) extractResourcesFromSpec(spec *specs.Spec, configuration *hcsshim.ContainerConfig) {
-	if spec.Windows.Resources != nil {
-		if spec.Windows.Resources.CPU != nil {
-			if spec.Windows.Resources.CPU.Count != nil {
-				// This check is being done here rather than in adaptContainerSettings
-				// because we don't want to update the HostConfig in case this container
-				// is moved to a host with more CPUs than this one.
-				cpuCount := *spec.Windows.Resources.CPU.Count
-				hostCPUCount := uint64(runtime.NumCPU())
-				if cpuCount > hostCPUCount {
-					c.logger.Warnf("Changing requested CPUCount of %d to current number of processors, %d", cpuCount, hostCPUCount)
-					cpuCount = hostCPUCount
-				}
-				configuration.ProcessorCount = uint32(cpuCount)
+	if spec.Windows.Resources == nil {
+		return
+	}
+	if spec.Windows.Resources.CPU != nil {
+		if spec.Windows.Resources.CPU.Count != nil {
+			// This check is being done here rather than in adaptContainerSettings
+			// because we don't want to update the HostConfig in case this container
+			// is moved to a host with more CPUs than this one.
+			cpuCount := *spec.Windows.Resources.CPU.Count
+			hostCPUCount := uint64(runtime.NumCPU())
+			if cpuCount > hostCPUCount {
+				c.logger.Warnf("Changing requested CPUCount of %d to current number of processors, %d", cpuCount, hostCPUCount)
+				cpuCount = hostCPUCount
 			}
-			if spec.Windows.Resources.CPU.Shares != nil {
-				configuration.ProcessorWeight = uint64(*spec.Windows.Resources.CPU.Shares)
-			}
-			if spec.Windows.Resources.CPU.Maximum != nil {
-				configuration.ProcessorMaximum = int64(*spec.Windows.Resources.CPU.Maximum)
-			}
+			configuration.ProcessorCount = uint32(cpuCount)
 		}
-		if spec.Windows.Resources.Memory != nil {
-			if spec.Windows.Resources.Memory.Limit != nil {
-				configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit) / 1024 / 1024
-			}
+		if spec.Windows.Resources.CPU.Shares != nil {
+			configuration.ProcessorWeight = uint64(*spec.Windows.Resources.CPU.Shares)
+		}
+		if spec.Windows.Resources.CPU.Maximum != nil {
+			configuration.ProcessorMaximum = int64(*spec.Windows.Resources.CPU.Maximum)
+		}
+	}
+	if spec.Windows.Resources.Memory != nil {
+		if spec.Windows.Resources.Memory.Limit != nil {
+			configuration.MemoryMaximumInMB = int64(*spec.Windows.Resources.Memory.Limit) / 1024 / 1024
 		}
 	}
 }

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -150,11 +150,11 @@ func (c *client) Version(ctx context.Context) (containerd.Version, error) {
 //			"ImagePath": "C:\\\\control\\\\windowsfilter\\\\65bf96e5760a09edf1790cb229e2dfb2dbd0fcdc0bf7451bae099106bfbfea0c\\\\UtilityVM"
 //		},
 //	}
-func (c *client) NewContainer(_ context.Context, id string, spec *specs.Spec, shim string, runtimeOptions interface{}, opts ...containerd.NewContainerOpts) (libcontainerdtypes.Container, error) {
+func (c *client) NewContainer(_ context.Context, id string, spec *specs.Spec, _ string, _ interface{}, _ ...containerd.NewContainerOpts) (libcontainerdtypes.Container, error) {
 	if spec.Linux != nil {
 		return nil, errors.New("linux containers are not supported on this platform")
 	}
-	ctr, err := c.createWindows(id, spec, runtimeOptions)
+	ctr, err := c.createWindows(id, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (c *client) NewContainer(_ context.Context, id string, spec *specs.Spec, sh
 	return ctr, nil
 }
 
-func (c *client) createWindows(id string, spec *specs.Spec, runtimeOptions interface{}) (*container, error) {
+func (c *client) createWindows(id string, spec *specs.Spec) (*container, error) {
 	logger := c.logger.WithField("container", id)
 	configuration := &hcsshim.ContainerConfig{
 		SystemType:              "Container",

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -1023,13 +1023,13 @@ func (t *task) Status(ctx context.Context) (containerd.Status, error) {
 	return containerd.Status{Status: s}, nil
 }
 
-func (*task) UpdateResources(ctx context.Context, resources *libcontainerdtypes.Resources) error {
+func (*task) UpdateResources(context.Context, *libcontainerdtypes.Resources) error {
 	// Updating resource isn't supported on Windows
 	// but we should return nil for enabling updating container
 	return nil
 }
 
-func (*task) CreateCheckpoint(ctx context.Context, checkpointDir string, exit bool) error {
+func (*task) CreateCheckpoint(context.Context, string, bool) error {
 	return errors.New("Windows: Containers do not support checkpoints")
 }
 

--- a/libcontainerd/local/local_windows.go
+++ b/libcontainerd/local/local_windows.go
@@ -78,21 +78,17 @@ type container struct {
 const defaultOwner = "docker"
 
 type client struct {
-	stateDir string
-	backend  libcontainerdtypes.Backend
-	logger   *log.Entry
-	eventQ   queue.Queue
+	backend libcontainerdtypes.Backend
+	logger  *log.Entry
+	eventQ  queue.Queue
 }
 
 // NewClient creates a new local executor for windows
-func NewClient(ctx context.Context, cli *containerd.Client, stateDir, ns string, b libcontainerdtypes.Backend) (libcontainerdtypes.Client, error) {
-	c := &client{
-		stateDir: stateDir,
-		backend:  b,
-		logger:   log.G(ctx).WithField("module", "libcontainerd").WithField("namespace", ns),
-	}
-
-	return c, nil
+func NewClient(ctx context.Context, b libcontainerdtypes.Backend) (libcontainerdtypes.Client, error) {
+	return &client{
+		backend: b,
+		logger:  log.G(ctx).WithField("module", "libcontainerd"),
+	}, nil
 }
 
 func (c *client) Version(ctx context.Context) (containerd.Version, error) {


### PR DESCRIPTION
### libcontainerd/local: client.extractResourcesFromSpec: use early return

### libcontainerd/local: client.NewContainer: use early return

Also remove an intermediate var, and remove a "WithError" in favor of
adding the error field to the "WithFields".


### libcontainerd/local: client.createWindows: remove unused runtimeOptions

The "local" client does not use containerd, but implements the same interface,
many args are not used though, so remove these to make it more clear what's
actually in use.

### libcontainerd/local: NewClient: remove unused cli, stateDir, ns args

The "local" client does not use containerd, but implements the same interface,
many args are not used though, so remove these to make it more clear what's
actually in use.

### libcontainerd/local: remove arg-names for stubs



**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

