### PR TITLE
Dockerfile: update containerd binary to v1.7.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,7 +202,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.7.25
+ARG CONTAINERD_VERSION=v1.7.26
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -164,7 +164,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.23.7
 ARG GOTESTSUM_VERSION=v1.12.0
 ARG GOWINRES_VERSION=v0.3.1
-ARG CONTAINERD_VERSION=v1.7.25
+ARG CONTAINERD_VERSION=v1.7.26
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.7.25}"
+: "${CONTAINERD_VERSION:=v1.7.26}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
- full diff: https://github.com/containerd/containerd/compare/v1.7.25...v1.7.26
- release notes: https://github.com/containerd/containerd/releases/tag/v1.7.26

Welcome to the v1.7.26 release of containerd!

The twenty-sixth patch release for containerd 1.7 contains various fixes and updates.

Highlights

- Add support for syncfs after unpack
- Update runc binary to v1.2.55
- Fix race between serve and immediate shutdown on the server
- Reject oversized messages from the sender

Container Runtime Interface (CRI)

- Fix fatal concurrency error in port forwarding

Node Resource Interface (NRI)

- Fix initial sync race when registering NRI plugins
- Add API support for reading Pod IPs
- Fix plugin sync to use multiple messages if ttrpc max message limit is hit
- Update API to pass configured timeouts to plugins.
- Fix mount removal in adjustments
- Close plugin if initial synchronization fails
- Add support for adjusting OOM score
- Add API support for NRI-native CDI injection
- Add support for pids cgroup

Runtime

- Fix console TTY leak in runc shim


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update containerd (static binaries only) to [v1.7.26](https://github.com/containerd/containerd/releases/tag/v1.7.26)
```

**- A picture of a cute animal (not mandatory but encouraged)**

