### PR TITLE
testutil/environment: Execution.Clean: remove redundant condition

### DIFF
--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -30,7 +30,7 @@ func (e *Execution) Clean(ctx context.Context, t testing.TB) {
 	apiClient := e.APIClient()
 
 	platform := e.DaemonInfo.OSType
-	if (platform != "windows") || (platform == "windows" && e.DaemonInfo.Isolation == "hyperv") {
+	if platform != "windows" || e.DaemonInfo.Isolation == "hyperv" {
 		unpauseAllContainers(ctx, t, apiClient)
 	}
 	deleteAllContainers(ctx, t, apiClient, e.protectedElements.containers)


### PR DESCRIPTION
It's either "not windows" or "windows" (and something else), so the second condition doesn't have to check if it's windows.

**- A picture of a cute animal (not mandatory but encouraged)**

