### PR TITLE
Mask Linux thermal interrupt info in /proc and /sys.

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -258,6 +258,7 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	testCases := []struct {
+		privileged  bool
 		maskedPaths []string
 		expected    []string
 	}{
@@ -273,6 +274,11 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 			maskedPaths: []string{"/proc/kcore", "/proc/keys"},
 			expected:    []string{"/proc/kcore", "/proc/keys"},
 		},
+		{
+			privileged:  true,
+			maskedPaths: nil,
+			expected:    nil,
+		},
 	}
 
 	checkInspect := func(t *testing.T, ctx context.Context, name string, expected []string) {
@@ -286,15 +292,20 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 		cfg, ok := inspectJSON["HostConfig"].(map[string]interface{})
 		assert.Check(t, is.Equal(true, ok), name)
 
-		maskedPaths, ok := cfg["MaskedPaths"].([]interface{})
-		assert.Check(t, is.Equal(true, ok), name)
+		if expected != nil {
+			maskedPaths, ok := cfg["MaskedPaths"].([]interface{})
+			assert.Check(t, is.Equal(true, ok), name)
 
-		mps := make([]string, 0, len(maskedPaths))
-		for _, mp := range maskedPaths {
-			mps = append(mps, mp.(string))
+			mps := make([]string, 0, len(maskedPaths))
+			for _, mp := range maskedPaths {
+				mps = append(mps, mp.(string))
+			}
+
+			assert.DeepEqual(t, expected, mps)
+		} else {
+			_, ok := cfg["MaskedPaths"].([]interface{})
+			assert.Check(t, is.Equal(false, ok), name)
 		}
-
-		assert.DeepEqual(t, expected, mps)
 	}
 
 	// TODO: This should be using subtests
@@ -305,7 +316,9 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 			Image: "busybox",
 			Cmd:   []string{"true"},
 		}
-		hc := container.HostConfig{}
+		hc := container.HostConfig{
+			Privileged: tc.privileged,
+		}
 		if tc.maskedPaths != nil {
 			hc.MaskedPaths = tc.maskedPaths
 		}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"runtime"
 	"sync"
 
 	"github.com/containerd/log"
@@ -28,4 +29,23 @@ func Architecture() string {
 		}
 	})
 	return arch
+}
+
+// PossibleCPU returns the set of possible CPUs on the host (which is equal or
+// larger to the number of CPUs currently online). The returned set may be a
+// single CPU number ({0}), or a continuous range of CPU numbers ({0,1,2,3}), or
+// a non-continuous range of CPU numbers ({0,1,2,3,12,13,14,15}).
+func PossibleCPU() []int {
+	if ncpu := possibleCPUs(); ncpu != nil {
+		return ncpu
+	}
+
+	// Fallback in case possibleCPUs() fails.
+	var cpus []int
+	ncpu := runtime.NumCPU()
+	for i := 0; i <= ncpu; i++ {
+		cpus = append(cpus, i)
+	}
+
+	return cpus
 }

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -1,0 +1,55 @@
+package platform
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// possibleCPUs returns the set of possible CPUs on the host (which is
+// equal or larger to the number of CPUs currently online). The returned
+// set may be a single number ({0}), or a continuous range ({0,1,2,3}), or
+// a non-continuous range ({0,1,2,3,12,13,14,15})
+//
+// Returns nil on errors. Assume CPUs are 0 -> runtime.NumCPU() in that case.
+var possibleCPUs = sync.OnceValue(func() []int {
+	data, err := os.ReadFile("/sys/devices/system/cpu/possible")
+	if err != nil {
+		return nil
+	}
+	content := strings.TrimSpace(string(data))
+	return parsePossibleCPUs(content)
+})
+
+func parsePossibleCPUs(content string) []int {
+	ranges := strings.Split(content, ",")
+
+	var cpus []int
+	for _, r := range ranges {
+		// Each entry is either a single number (e.g., "0") or a continuous range
+		// (e.g., "0-3").
+		if rStart, rEnd, ok := strings.Cut(r, "-"); !ok {
+			cpu, err := strconv.Atoi(rStart)
+			if err != nil {
+				return nil
+			}
+			cpus = append(cpus, cpu)
+		} else {
+			var start, end int
+			start, err := strconv.Atoi(rStart)
+			if err != nil {
+				return nil
+			}
+			end, err = strconv.Atoi(rEnd)
+			if err != nil {
+				return nil
+			}
+			for i := start; i <= end; i++ {
+				cpus = append(cpus, i)
+			}
+		}
+	}
+
+	return cpus
+}

--- a/internal/platform/platform_linux_test.go
+++ b/internal/platform/platform_linux_test.go
@@ -1,0 +1,54 @@
+package platform
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestParsePossibleCPUs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []int
+	}{
+		{
+			name:     "Continuous Range",
+			input:    "0-3",
+			expected: []int{0, 1, 2, 3},
+		},
+		{
+			name:     "Non-Continuous Range",
+			input:    "0-2,4,6-7",
+			expected: []int{0, 1, 2, 4, 6, 7},
+		},
+		{
+			name:     "Single CPU",
+			input:    "5",
+			expected: []int{5},
+		},
+		{
+			name:     "Empty Input",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "Invalid Range",
+			input:    "0-2,invalid",
+			expected: nil,
+		},
+		{
+			name:     "Malformed Range",
+			input:    "0-2-3",
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := parsePossibleCPUs(test.input)
+			assert.Assert(t, is.DeepEqual(result, test.expected), "Expected %v but got %v", test.expected, result)
+		})
+	}
+}

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -69,3 +69,8 @@ func NumProcs() uint32 {
 	_, _, _ = syscall.SyscallN(procGetSystemInfo.Addr(), uintptr(unsafe.Pointer(&sysinfo)))
 	return sysinfo.dwNumberOfProcessors
 }
+
+func possibleCPUs() []int {
+	// not implemented
+	return nil
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Mask Linux thermal interrupt info inside a container's `/proc` and `/sys`. 

Mitigates the use of thermal event interrupt information (available within the container via `/proc/interrupts` or `/sys/devices/system/cpu/<cpuX>/thermal_throttle/`) to perform thermal side channel attacks.

Big thanks to @zhangxin00 for reporting this issue.

**- How I did it**

Mask `/proc/interrupts` and `/sys/devices/system/cpu/<cpuX>/thermal_throttle` inside containers by default. Privileged containers or containers started with `--security-opt="systempaths=unconfined"` are not affected.

Integration test `TestCreateWithCustomMaskedPaths()` was updated with the new masked paths and improved to ensure the default masked paths don't apply to privileged containers.

**- How to verify it**

```
docker run -it --rm alpine sh -c "cat /proc/interrupts"
docker run -it --rm alpine sh -c "cat /sys/devices/system/cpu/cpu0/thermal_throttle"
```

Should each return an empty file.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Mask Linux thermal interrupt info in a container's `/proc` and `/sys` by default. Mitigates potential [Thermal Side-Channel Vulnerability Exploit](https://github.com/moby/moby/security/advisories/GHSA-6fw5-f8r9-fgfm).
```

**- A picture of a cute animal (not mandatory but encouraged)**

