### PR TITLE
registry: refactor to allow splitting out logic for CLI

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -363,12 +363,19 @@ func newRepositoryInfo(config *serviceConfig, name reference.Named) (*Repository
 	if err != nil {
 		return nil, err
 	}
-	official := !strings.ContainsRune(reference.FamiliarName(name), '/')
+	var officialRepo bool
+	if index.Official {
+		// RepositoryInfo.Official indicates whether the image repository
+		// is an official (docker library official images) repository.
+		//
+		// We only need to check this if the image-repository is on Docker Hub.
+		officialRepo = !strings.ContainsRune(reference.FamiliarName(name), '/')
+	}
 
 	return &RepositoryInfo{
 		Name:     reference.TrimNamed(name),
 		Index:    index,
-		Official: official,
+		Official: officialRepo,
 	}, nil
 }
 

--- a/registry/config.go
+++ b/registry/config.go
@@ -56,8 +56,38 @@ var (
 		Host:   DefaultRegistryHost,
 	}
 
-	emptyServiceConfig, _ = newServiceConfig(ServiceOptions{})
-	validHostPortRegex    = lazyregexp.New(`^` + reference.DomainRegexp.String() + `$`)
+	// ipv6Loopback is the CIDR for the IPv6 loopback address ("::1"); "::1/128"
+	ipv6Loopback = &net.IPNet{
+		IP:   net.IPv6loopback,
+		Mask: net.CIDRMask(128, 128),
+	}
+
+	// ipv4Loopback is the CIDR for IPv4 loopback addresses ("127.0.0.0/8")
+	ipv4Loopback = &net.IPNet{
+		IP:   net.IPv4(127, 0, 0, 0),
+		Mask: net.CIDRMask(8, 32),
+	}
+
+	// emptyServiceConfig is a default service-config for situations where
+	// no config-file is available (e.g. when used in the CLI). If won't
+	// have mirrors configured, but does have the default insecure registry
+	// CIDRs for loopback interfaces configured.
+	emptyServiceConfig = &serviceConfig{
+		IndexConfigs: map[string]*registry.IndexInfo{
+			IndexName: {
+				Name:     IndexName,
+				Mirrors:  make([]string, 0),
+				Secure:   true,
+				Official: true,
+			},
+		},
+		InsecureRegistryCIDRs: []*registry.NetIPNet{
+			(*registry.NetIPNet)(ipv6Loopback),
+			(*registry.NetIPNet)(ipv4Loopback),
+		},
+	}
+
+	validHostPortRegex = lazyregexp.New(`^` + reference.DomainRegexp.String() + `$`)
 
 	// certsDir is used to override defaultCertsDir.
 	certsDir string

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -270,15 +270,11 @@ func TestNewIndexInfo(t *testing.T) {
 	overrideLookupIP(t)
 	testIndexInfo := func(config *serviceConfig, expectedIndexInfos map[string]*registry.IndexInfo) {
 		for indexName, expectedIndexInfo := range expectedIndexInfos {
-			index, err := newIndexInfo(config, indexName)
-			if err != nil {
-				t.Fatal(err)
-			} else {
-				assert.Check(t, is.Equal(index.Name, expectedIndexInfo.Name), indexName+" name")
-				assert.Check(t, is.Equal(index.Official, expectedIndexInfo.Official), indexName+" is official")
-				assert.Check(t, is.Equal(index.Secure, expectedIndexInfo.Secure), indexName+" is secure")
-				assert.Check(t, is.Equal(len(index.Mirrors), len(expectedIndexInfo.Mirrors)), indexName+" mirrors")
-			}
+			index := newIndexInfo(config, indexName)
+			assert.Check(t, is.Equal(index.Name, expectedIndexInfo.Name), indexName+" name")
+			assert.Check(t, is.Equal(index.Official, expectedIndexInfo.Official), indexName+" is official")
+			assert.Check(t, is.Equal(index.Secure, expectedIndexInfo.Secure), indexName+" is secure")
+			assert.Check(t, is.Equal(len(index.Mirrors), len(expectedIndexInfo.Mirrors)), indexName+" mirrors")
 		}
 	}
 

--- a/registry/search.go
+++ b/registry/search.go
@@ -93,12 +93,8 @@ func (s *Service) searchUnfiltered(ctx context.Context, term string, limit int, 
 
 	// Search is a long-running operation, just lock s.config to avoid block others.
 	s.mu.RLock()
-	index, err := newIndexInfo(s.config, indexName)
+	index := newIndexInfo(s.config, indexName)
 	s.mu.RUnlock()
-
-	if err != nil {
-		return nil, err
-	}
 	if index.Official {
 		// If pull "library/foo", it's stored locally under "foo"
 		remoteName = strings.TrimPrefix(remoteName, "library/")
@@ -158,5 +154,5 @@ func splitReposSearchTerm(reposName string) (string, string) {
 // for that.
 func ParseSearchIndexInfo(reposName string) (*registry.IndexInfo, error) {
 	indexName, _ := splitReposSearchTerm(reposName)
-	return newIndexInfo(emptyServiceConfig, indexName)
+	return newIndexInfo(emptyServiceConfig, indexName), nil
 }

--- a/registry/service.go
+++ b/registry/service.go
@@ -97,7 +97,8 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 func (s *Service) ResolveRepository(name reference.Named) (*RepositoryInfo, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return newRepositoryInfo(s.config, name)
+	// TODO(thaJeztah): remove error return as it's no longer used.
+	return newRepositoryInfo(s.config, name), nil
 }
 
 // APIEndpoint represents a remote API endpoint


### PR DESCRIPTION
## registry: refactor to allow splitting out logic for CLI

The registry code contains various parts that were designed to be used
server-side, but ended up being used in the CLI and other clients. More
changes are coming, but doing so in smaller chunks to dismandle some of
the pieces.

follow-up to:

- https://github.com/moby/moby/pull/49050
- https://github.com/moby/moby/pull/48999


### registry: newRepositoryInfo only check for official images for Docker Hub

RepositoryInfo.Official indicates whether the image repository
is an official (docker library official images) repository.

We only need to check this if the image-repository is on Docker Hub.

This patch renames the variable to make it more transparent that this
boolean is for the repository, and not to be confused for IndexInfo.Official,
which indicates if the _registry_ is the "Official" (Docker Hub) registry.

### registry: create emptyServiceConfig without parsing

emptyServiceConfig is a default service-config for situations where
no config-file is available (e.g. when used in the CLI). If won't
have mirrors configured, but does have the default insecure registry
CIDRs for loopback interfaces configured.

Before this patch, this config was constructeed using the same code
that handled constructing the config with a config present, but this
involved parsing CIDR masks, and much more.

With this patch, the service config is constructed as a literal, making
it more transparent that it does not depend on any config or state.

### registry: split normalizing index name from validating

ValidateIndexName is used by the docker daemon CLI to validate options
passed through CLI flags and daemon.json. However, it also handled
normalizing the registry name ("index.docker.io" -> "docker.io").

This patch splits the normalization code to a separate function. It
is currently not exported, but could be considered in the future;
if we do so, we may want to look for a better place for that function
to not have it in the same package as the registry code.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

