### PR TITLE
golangci-lint: enforce "is" alias for gotest.tools/v3/assert/cmp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,9 @@ linters-settings:
         alias: c8dimages
       - pkg: github.com/opencontainers/image-spec/specs-go/v1
         alias: ocispec
+      # Enforce that gotest.tools/v3/assert/cmp is always aliased as "is"
+      - pkg: gotest.tools/v3/assert/cmp
+        alias: is
 
   revive:
     rules:

--- a/daemon/logger/loggerutils/logfile_test.go
+++ b/daemon/logger/loggerutils/logfile_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/pkg/tailfile"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
 )
 
@@ -276,7 +276,7 @@ func waitForMsg(t *testing.T, lw *logger.LogWatcher, expected string, timeout ti
 		assert.NilError(t, err)
 	case msg, ok := <-lw.Msg:
 		assert.Assert(t, ok, "log producer gone before log message arrived")
-		assert.Check(t, cmp.Equal(string(msg.Line), expected))
+		assert.Check(t, is.Equal(string(msg.Line), expected))
 	case <-timer.C:
 		t.Fatal("timeout waiting for log message")
 	}

--- a/distribution/manifest_test.go
+++ b/distribution/manifest_test.go
@@ -23,7 +23,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 type mockManifestGetter struct {
@@ -210,12 +210,12 @@ func TestManifestStore(t *testing.T) {
 		m2, err := store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
-		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-		assert.Check(t, cmp.Equal(mg.gets, 1))
+		assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+		assert.Check(t, is.Equal(mg.gets, 1))
 
 		i, err := cs.Info(ctx, desc.Digest)
 		assert.NilError(t, err)
-		assert.Check(t, cmp.Equal(i.Digest, desc.Digest))
+		assert.Check(t, is.Equal(i.Digest, desc.Digest))
 
 		distKey, distSource := makeDistributionSourceLabel(ref)
 		assert.Check(t, hasDistributionSource(i.Labels[distKey], distSource))
@@ -224,8 +224,8 @@ func TestManifestStore(t *testing.T) {
 		m2, err = store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
-		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-		assert.Check(t, cmp.Equal(mg.gets, 1))
+		assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+		assert.Check(t, is.Equal(mg.gets, 1))
 
 		t.Run("digested", func(t *testing.T) {
 			ref, err := reference.WithDigest(ref, desc.Digest)
@@ -247,12 +247,12 @@ func TestManifestStore(t *testing.T) {
 		m2, err := store.Get(ctx, desc, ref)
 		checkIngest(t, cs, desc)
 		assert.NilError(t, err)
-		assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-		assert.Check(t, cmp.Equal(mg.gets, 0))
+		assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+		assert.Check(t, is.Equal(mg.gets, 0))
 
 		i, err := cs.Info(ctx, desc.Digest)
 		assert.NilError(t, err)
-		assert.Check(t, cmp.Equal(i.Digest, desc.Digest))
+		assert.Check(t, is.Equal(i.Digest, desc.Digest))
 	})
 
 	// This is for the case of pull by digest where we don't know the media type of the manifest until it's actually pulled.
@@ -267,8 +267,8 @@ func TestManifestStore(t *testing.T) {
 			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
-			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-			assert.Check(t, cmp.Equal(mg.gets, 1))
+			assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+			assert.Check(t, is.Equal(mg.gets, 1))
 		})
 
 		t.Run("with cache", func(t *testing.T) {
@@ -282,8 +282,8 @@ func TestManifestStore(t *testing.T) {
 				m2, err := store.Get(ctx, desc, ref)
 				checkIngest(t, cs, desc)
 				assert.NilError(t, err)
-				assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-				assert.Check(t, cmp.Equal(mg.gets, 0))
+				assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+				assert.Check(t, is.Equal(mg.gets, 0))
 			})
 
 			t.Run("cached manifest has no media type", func(t *testing.T) {
@@ -296,8 +296,8 @@ func TestManifestStore(t *testing.T) {
 				m2, err := store.Get(ctx, desc, ref)
 				checkIngest(t, cs, desc)
 				assert.NilError(t, err)
-				assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-				assert.Check(t, cmp.Equal(mg.gets, 0))
+				assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+				assert.Check(t, is.Equal(mg.gets, 0))
 			})
 		})
 	})
@@ -318,8 +318,8 @@ func TestManifestStore(t *testing.T) {
 			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
-			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-			assert.Check(t, cmp.Equal(mg.gets, 1))
+			assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+			assert.Check(t, is.Equal(mg.gets, 1))
 
 			_, err = cs.Info(ctx, desc.Digest)
 			// Nothing here since we couldn't persist
@@ -337,8 +337,8 @@ func TestManifestStore(t *testing.T) {
 			m2, err := store.Get(ctx, desc, ref)
 			checkIngest(t, cs, desc)
 			assert.NilError(t, err)
-			assert.Check(t, cmp.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
-			assert.Check(t, cmp.Equal(mg.gets, 1))
+			assert.Check(t, is.DeepEqual(m, m2, cmpopts.IgnoreUnexported(ocischema.DeserializedManifest{})))
+			assert.Check(t, is.Equal(mg.gets, 1))
 
 			_, err = cs.Info(ctx, desc.Digest)
 			// Nothing here since we couldn't persist

--- a/integration-cli/checker/checker.go
+++ b/integration-cli/checker/checker.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 // Compare defines the interface to compare values
@@ -29,14 +29,14 @@ func True() Compare {
 // Equals checks if the value is equal to the given value
 func Equals(y interface{}) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
-		return cmp.Equal(x, y)
+		return is.Equal(x, y)
 	}
 }
 
 // Contains checks if the value contains the given value
 func Contains(y interface{}) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
-		return cmp.Contains(x, y)
+		return is.Contains(x, y)
 	}
 }
 
@@ -47,7 +47,7 @@ func Not(c Compare) Compare {
 		switch r := r.(type) {
 		case bool:
 			return !r
-		case cmp.Comparison:
+		case is.Comparison:
 			return !r().Success()
 		default:
 			panic(fmt.Sprintf("unexpected type %T", r))
@@ -58,21 +58,21 @@ func Not(c Compare) Compare {
 // DeepEquals checks if two values are equal
 func DeepEquals(y interface{}) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
-		return cmp.DeepEqual(x, y)
+		return is.DeepEqual(x, y)
 	}
 }
 
 // HasLen checks if the value has the expected number of elements
 func HasLen(y int) Compare {
 	return func(x interface{}) assert.BoolOrComparison {
-		return cmp.Len(x, y)
+		return is.Len(x, y)
 	}
 }
 
 // IsNil checks if the value is nil
 func IsNil() Compare {
 	return func(x interface{}) assert.BoolOrComparison {
-		return cmp.Nil(x)
+		return is.Nil(x)
 	}
 }
 

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 	is "gotest.tools/v3/assert/cmp"
 )
 
@@ -127,7 +126,7 @@ func (s *DockerCLIHistorySuite) TestHistoryHumanOptionTrue(c *testing.T) {
 			endIndex = len(lines[i])
 		}
 		sizeString := lines[i][startIndex:endIndex]
-		assert.Assert(c, cmp.Regexp("^"+humanSizeRegexRaw+"$",
+		assert.Assert(c, is.Regexp("^"+humanSizeRegexRaw+"$",
 			strings.TrimSpace(sizeString)), fmt.Sprintf("The size '%s' was not in human format", sizeString))
 	}
 }

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/testutil"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
 )
@@ -427,7 +427,7 @@ func pollCheck(t *testing.T, f checkF, compare func(x interface{}) assert.BoolOr
 			if r {
 				return poll.Success()
 			}
-		case cmp.Comparison:
+		case is.Comparison:
 			if r().Success() {
 				return poll.Success()
 			}

--- a/integration/container/logs_test.go
+++ b/integration/container/logs_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/docker/integration/internal/termtest"
 	"github.com/docker/docker/pkg/stdcopy"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
@@ -164,8 +164,8 @@ func testLogs(t *testing.T, logDriver string) {
 				// which breaks the parsed output: https://github.com/moby/moby/issues/43710
 				if strings.Contains(testEnv.DaemonInfo.OperatingSystem, "Windows Server Version 1809") {
 					if tc.logOps.ShowStdout {
-						assert.Check(t, cmp.Contains(stdout.String(), "this is fine"))
-						assert.Check(t, cmp.Contains(stdout.String(), "accidents happen"))
+						assert.Check(t, is.Contains(stdout.String(), "this is fine"))
+						assert.Check(t, is.Contains(stdout.String(), "accidents happen"))
 					} else {
 						assert.DeepEqual(t, stdoutStr, "")
 					}

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
@@ -75,7 +74,7 @@ func TestSaveCheckTimes(t *testing.T) {
 
 	var ls []imageSaveManifestEntry
 	assert.NilError(t, json.Unmarshal(dt, &ls))
-	assert.Assert(t, cmp.Len(ls, 1))
+	assert.Assert(t, is.Len(ls, 1))
 
 	info, err := fs.Stat(tarfs, ls[0].Config)
 	assert.NilError(t, err)
@@ -300,7 +299,7 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 	} else {
 		sort.Strings(actual)
 		sort.Strings(expected)
-		assert.Assert(t, cmp.DeepEqual(actual, expected), "archive does not contains the right layers: got %v, expected %v", actual, expected)
+		assert.Assert(t, is.DeepEqual(actual, expected), "archive does not contains the right layers: got %v, expected %v", actual, expected)
 	}
 }
 

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/testutil"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 )
 
@@ -52,33 +52,33 @@ func LinkDoesntExist(ctx context.Context, t *testing.T, master string) {
 }
 
 // IsNetworkAvailable provides a comparison to check if a docker network is available
-func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
-	return func() cmp.Result {
+func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) is.Comparison {
+	return func() is.Result {
 		networks, err := c.NetworkList(ctx, network.ListOptions{})
 		if err != nil {
-			return cmp.ResultFromError(err)
+			return is.ResultFromError(err)
 		}
 		for _, network := range networks {
 			if network.Name == name {
-				return cmp.ResultSuccess
+				return is.ResultSuccess
 			}
 		}
-		return cmp.ResultFailure(fmt.Sprintf("could not find network %s", name))
+		return is.ResultFailure(fmt.Sprintf("could not find network %s", name))
 	}
 }
 
 // IsNetworkNotAvailable provides a comparison to check if a docker network is not available
-func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
-	return func() cmp.Result {
+func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) is.Comparison {
+	return func() is.Result {
 		networks, err := c.NetworkList(ctx, network.ListOptions{})
 		if err != nil {
-			return cmp.ResultFromError(err)
+			return is.ResultFromError(err)
 		}
 		for _, network := range networks {
 			if network.Name == name {
-				return cmp.ResultFailure(fmt.Sprintf("network %s is still present", name))
+				return is.ResultFailure(fmt.Sprintf("network %s is still present", name))
 			}
 		}
-		return cmp.ResultSuccess
+		return is.ResultSuccess
 	}
 }

--- a/volume/service/convert_test.go
+++ b/volume/service/convert_test.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/docker/docker/api/types/filters"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestFilterWithPrune(t *testing.T) {
 	f := filters.NewArgs()
 	assert.NilError(t, withPrune(f))
-	assert.Check(t, cmp.Len(f.Get("label"), 1))
+	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", AnonymousLabel))
 
 	f = filters.NewArgs(
@@ -20,7 +20,7 @@ func TestFilterWithPrune(t *testing.T) {
 	)
 	assert.NilError(t, withPrune(f))
 
-	assert.Check(t, cmp.Len(f.Get("label"), 3))
+	assert.Check(t, is.Len(f.Get("label"), 3))
 	assert.Check(t, f.Match("label", AnonymousLabel))
 	assert.Check(t, f.Match("label", "foo=bar"))
 	assert.Check(t, f.Match("label", "bar=baz"))
@@ -31,7 +31,7 @@ func TestFilterWithPrune(t *testing.T) {
 	)
 	assert.NilError(t, withPrune(f))
 
-	assert.Check(t, cmp.Len(f.Get("label"), 1))
+	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", "foo=bar"))
 
 	f = filters.NewArgs(
@@ -40,17 +40,17 @@ func TestFilterWithPrune(t *testing.T) {
 	)
 	assert.NilError(t, withPrune(f))
 
-	assert.Check(t, cmp.Len(f.Get("label"), 1))
+	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", "foo=bar"))
 
 	f = filters.NewArgs(filters.Arg("all", "0"))
 	assert.NilError(t, withPrune(f))
-	assert.Check(t, cmp.Len(f.Get("label"), 1))
+	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", AnonymousLabel))
 
 	f = filters.NewArgs(filters.Arg("all", "false"))
 	assert.NilError(t, withPrune(f))
-	assert.Check(t, cmp.Len(f.Get("label"), 1))
+	assert.Check(t, is.Len(f.Get("label"), 1))
 	assert.Check(t, f.Match("label", AnonymousLabel))
 
 	f = filters.NewArgs(filters.Arg("all", ""))


### PR DESCRIPTION
We already have been following this convention - add a linter rule that will help us follow that convention in future changes.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>