### PR TITLE
registry: improve test-coverage, and some minor fixes

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -69,7 +69,7 @@ var (
 	}
 
 	// emptyServiceConfig is a default service-config for situations where
-	// no config-file is available (e.g. when used in the CLI). If won't
+	// no config-file is available (e.g. when used in the CLI). It won't
 	// have mirrors configured, but does have the default insecure registry
 	// CIDRs for loopback interfaces configured.
 	emptyServiceConfig = &serviceConfig{

--- a/registry/config.go
+++ b/registry/config.go
@@ -76,7 +76,7 @@ var (
 		IndexConfigs: map[string]*registry.IndexInfo{
 			IndexName: {
 				Name:     IndexName,
-				Mirrors:  make([]string, 0),
+				Mirrors:  []string{},
 				Secure:   true,
 				Official: true,
 			},
@@ -211,7 +211,7 @@ skip:
 			// Assume `host:port` if not CIDR.
 			indexConfigs[r] = &registry.IndexInfo{
 				Name:     r,
-				Mirrors:  make([]string, 0),
+				Mirrors:  []string{},
 				Secure:   false,
 				Official: false,
 			}
@@ -374,7 +374,7 @@ func newIndexInfo(config *serviceConfig, indexName string) *registry.IndexInfo {
 	// Construct a non-configured index info.
 	return &registry.IndexInfo{
 		Name:    indexName,
-		Mirrors: make([]string, 0),
+		Mirrors: []string{},
 		Secure:  config.isSecureIndex(indexName),
 	}
 }

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -117,7 +117,7 @@ func TestLoadInsecureRegistries(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		config := emptyServiceConfig
+		config := &serviceConfig{}
 		err := config.loadInsecureRegistries(testCase.registries)
 		if testCase.err == "" {
 			if err != nil {

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -68,13 +68,6 @@ func makePublicIndex() *registry.IndexInfo {
 	}
 }
 
-func makeServiceConfig(mirrors []string, insecureRegistries []string) (*serviceConfig, error) {
-	return newServiceConfig(ServiceOptions{
-		Mirrors:            mirrors,
-		InsecureRegistries: insecureRegistries,
-	})
-}
-
 func writeHeaders(w http.ResponseWriter) {
 	h := w.Header()
 	h.Add("Server", "docker-tests/mock")

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -120,6 +120,54 @@ func TestParseRepositoryInfo(t *testing.T) {
 			LocalName:     "127.0.0.1:8000/privatebase",
 			CanonicalName: "127.0.0.1:8000/privatebase",
 		},
+		"[::1]:8000/private/moonbase": {
+			Index: &registry.IndexInfo{
+				Name:     "[::1]:8000",
+				Mirrors:  []string{},
+				Official: false,
+				Secure:   false,
+			},
+			RemoteName:    "private/moonbase",
+			LocalName:     "[::1]:8000/private/moonbase",
+			CanonicalName: "[::1]:8000/private/moonbase",
+		},
+		"[::1]:8000/privatebase": {
+			Index: &registry.IndexInfo{
+				Name:     "[::1]:8000",
+				Mirrors:  []string{},
+				Official: false,
+				Secure:   false,
+			},
+			RemoteName:    "privatebase",
+			LocalName:     "[::1]:8000/privatebase",
+			CanonicalName: "[::1]:8000/privatebase",
+		},
+		// IPv6 only has a single loopback address, so ::2 is not a loopback,
+		// hence not marked "insecure".
+		"[::2]:8000/private/moonbase": {
+			Index: &registry.IndexInfo{
+				Name:     "[::2]:8000",
+				Mirrors:  []string{},
+				Official: false,
+				Secure:   true,
+			},
+			RemoteName:    "private/moonbase",
+			LocalName:     "[::2]:8000/private/moonbase",
+			CanonicalName: "[::2]:8000/private/moonbase",
+		},
+		// IPv6 only has a single loopback address, so ::2 is not a loopback,
+		// hence not marked "insecure".
+		"[::2]:8000/privatebase": {
+			Index: &registry.IndexInfo{
+				Name:     "[::2]:8000",
+				Mirrors:  []string{},
+				Official: false,
+				Secure:   true,
+			},
+			RemoteName:    "privatebase",
+			LocalName:     "[::2]:8000/privatebase",
+			CanonicalName: "[::2]:8000/privatebase",
+		},
 		"localhost:8000/private/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     "localhost:8000",

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -335,94 +335,90 @@ func TestNewIndexInfo(t *testing.T) {
 		for indexName, expected := range expectedIndexInfos {
 			t.Run(indexName, func(t *testing.T) {
 				actual := newIndexInfo(config, indexName)
-				assert.Check(t, is.Equal(actual.Name, expected.Name))
-				assert.Check(t, is.Equal(actual.Official, expected.Official))
-				assert.Check(t, is.Equal(actual.Secure, expected.Secure))
-				assert.Check(t, is.Equal(len(actual.Mirrors), len(expected.Mirrors)))
+				assert.Check(t, is.DeepEqual(actual, expected))
 			})
 		}
 	}
 
-	var noMirrors []string
 	expectedIndexInfos := map[string]*registry.IndexInfo{
 		IndexName: {
 			Name:     IndexName,
 			Official: true,
 			Secure:   true,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"index." + IndexName: {
 			Name:     IndexName,
 			Official: true,
 			Secure:   true,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"example.com": {
 			Name:     "example.com",
 			Official: false,
 			Secure:   true,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"127.0.0.1:5000": {
 			Name:     "127.0.0.1:5000",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 	}
 	t.Run("no mirrors", func(t *testing.T) {
 		testIndexInfo(t, emptyServiceConfig, expectedIndexInfos)
 	})
 
-	publicMirrors := []string{"http://mirror1.local", "http://mirror2.local"}
-
 	expectedIndexInfos = map[string]*registry.IndexInfo{
 		IndexName: {
 			Name:     IndexName,
 			Official: true,
 			Secure:   true,
-			Mirrors:  publicMirrors,
+			Mirrors:  []string{"http://mirror1.local/", "http://mirror2.local/"},
 		},
 		"index." + IndexName: {
 			Name:     IndexName,
 			Official: true,
 			Secure:   true,
-			Mirrors:  publicMirrors,
+			Mirrors:  []string{"http://mirror1.local/", "http://mirror2.local/"},
 		},
 		"example.com": {
 			Name:     "example.com",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"example.com:5000": {
 			Name:     "example.com:5000",
 			Official: false,
 			Secure:   true,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"127.0.0.1": {
 			Name:     "127.0.0.1",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"127.0.0.1:5000": {
 			Name:     "127.0.0.1:5000",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"other.com": {
 			Name:     "other.com",
 			Official: false,
 			Secure:   true,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 	}
 	t.Run("mirrors", func(t *testing.T) {
+		// Note that newServiceConfig calls ValidateMirror internally, which normalizes
+		// mirror-URLs to have a trailing slash.
 		config, err := newServiceConfig(ServiceOptions{
-			Mirrors:            publicMirrors,
+			Mirrors:            []string{"http://mirror1.local", "http://mirror2.local"},
 			InsecureRegistries: []string{"example.com"},
 		})
 		assert.NilError(t, err)
@@ -434,31 +430,31 @@ func TestNewIndexInfo(t *testing.T) {
 			Name:     "example.com",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"example.com:5000": {
 			Name:     "example.com:5000",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"127.0.0.1": {
 			Name:     "127.0.0.1",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"127.0.0.1:5000": {
 			Name:     "127.0.0.1:5000",
 			Official: false,
 			Secure:   false,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 		"other.com": {
 			Name:     "other.com",
 			Official: false,
 			Secure:   true,
-			Mirrors:  noMirrors,
+			Mirrors:  []string{},
 		},
 	}
 	t.Run("custom insecure", func(t *testing.T) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -407,6 +407,46 @@ func TestNewIndexInfo(t *testing.T) {
 			Secure:   false,
 			Mirrors:  []string{},
 		},
+		"127.255.255.255": {
+			Name:     "127.255.255.255",
+			Official: false,
+			Secure:   false,
+			Mirrors:  []string{},
+		},
+		"127.255.255.255:5000": {
+			Name:     "127.255.255.255:5000",
+			Official: false,
+			Secure:   false,
+			Mirrors:  []string{},
+		},
+		"::1": {
+			Name:     "::1",
+			Official: false,
+			Secure:   false,
+			Mirrors:  []string{},
+		},
+		"[::1]:5000": {
+			Name:     "[::1]:5000",
+			Official: false,
+			Secure:   false,
+			Mirrors:  []string{},
+		},
+		// IPv6 only has a single loopback address, so ::2 is not a loopback,
+		// hence not marked "insecure".
+		"::2": {
+			Name:     "::2",
+			Official: false,
+			Secure:   true,
+			Mirrors:  []string{},
+		},
+		// IPv6 only has a single loopback address, so ::2 is not a loopback,
+		// hence not marked "insecure".
+		"[::2]:5000": {
+			Name:     "[::2]:5000",
+			Official: false,
+			Secure:   true,
+			Mirrors:  []string{},
+		},
 		"other.com": {
 			Name:     "other.com",
 			Official: false,
@@ -448,6 +488,18 @@ func TestNewIndexInfo(t *testing.T) {
 			Name:     "127.0.0.1:5000",
 			Official: false,
 			Secure:   false,
+			Mirrors:  []string{},
+		},
+		"42.42.0.1:5000": {
+			Name:     "42.42.0.1:5000",
+			Official: false,
+			Secure:   false,
+			Mirrors:  []string{},
+		},
+		"42.43.0.1:5000": {
+			Name:     "42.43.0.1:5000",
+			Official: false,
+			Secure:   true,
 			Mirrors:  []string{},
 		},
 		"other.com": {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -42,7 +42,7 @@ func TestParseRepositoryInfo(t *testing.T) {
 		LocalName     string
 	}
 
-	expectedRepoInfos := map[string]staticRepositoryInfo{
+	tests := map[string]staticRepositoryInfo{
 		"fooo/bar": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
@@ -225,22 +225,20 @@ func TestParseRepositoryInfo(t *testing.T) {
 		},
 	}
 
-	for reposName, expectedRepoInfo := range expectedRepoInfos {
-		named, err := reference.ParseNormalizedNamed(reposName)
-		if err != nil {
-			t.Error(err)
-		}
+	for reposName, expected := range tests {
+		t.Run(reposName, func(t *testing.T) {
+			named, err := reference.ParseNormalizedNamed(reposName)
+			assert.NilError(t, err)
 
-		repoInfo, err := ParseRepositoryInfo(named)
-		if err != nil {
-			t.Error(err)
-		} else {
-			assert.Check(t, is.Equal(repoInfo.Index.Name, expectedRepoInfo.Index.Name), reposName)
-			assert.Check(t, is.Equal(reference.Path(repoInfo.Name), expectedRepoInfo.RemoteName), reposName)
-			assert.Check(t, is.Equal(reference.FamiliarName(repoInfo.Name), expectedRepoInfo.LocalName), reposName)
-			assert.Check(t, is.Equal(repoInfo.Name.Name(), expectedRepoInfo.CanonicalName), reposName)
-			assert.Check(t, is.Equal(repoInfo.Index.Official, expectedRepoInfo.Index.Official), reposName)
-		}
+			repoInfo, err := ParseRepositoryInfo(named)
+			assert.NilError(t, err)
+
+			assert.Check(t, is.Equal(repoInfo.Index.Name, expected.Index.Name))
+			assert.Check(t, is.Equal(reference.Path(repoInfo.Name), expected.RemoteName))
+			assert.Check(t, is.Equal(reference.FamiliarName(repoInfo.Name), expected.LocalName))
+			assert.Check(t, is.Equal(repoInfo.Name.Name(), expected.CanonicalName))
+			assert.Check(t, is.Equal(repoInfo.Index.Official, expected.Index.Official))
+		})
 	}
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -46,7 +46,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"fooo/bar": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "fooo/bar",
 			LocalName:     "fooo/bar",
@@ -55,7 +57,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"library/ubuntu": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "library/ubuntu",
 			LocalName:     "ubuntu",
@@ -64,7 +68,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"nonlibrary/ubuntu": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "nonlibrary/ubuntu",
 			LocalName:     "nonlibrary/ubuntu",
@@ -73,7 +79,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"ubuntu": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "library/ubuntu",
 			LocalName:     "ubuntu",
@@ -82,7 +90,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"other/library": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "other/library",
 			LocalName:     "other/library",
@@ -91,7 +101,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"127.0.0.1:8000/private/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     "127.0.0.1:8000",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   false,
 			},
 			RemoteName:    "private/moonbase",
 			LocalName:     "127.0.0.1:8000/private/moonbase",
@@ -100,7 +112,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"127.0.0.1:8000/privatebase": {
 			Index: &registry.IndexInfo{
 				Name:     "127.0.0.1:8000",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   false,
 			},
 			RemoteName:    "privatebase",
 			LocalName:     "127.0.0.1:8000/privatebase",
@@ -109,7 +123,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"localhost:8000/private/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     "localhost:8000",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   false,
 			},
 			RemoteName:    "private/moonbase",
 			LocalName:     "localhost:8000/private/moonbase",
@@ -118,7 +134,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"localhost:8000/privatebase": {
 			Index: &registry.IndexInfo{
 				Name:     "localhost:8000",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   false,
 			},
 			RemoteName:    "privatebase",
 			LocalName:     "localhost:8000/privatebase",
@@ -127,7 +145,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"example.com/private/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     "example.com",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   true,
 			},
 			RemoteName:    "private/moonbase",
 			LocalName:     "example.com/private/moonbase",
@@ -136,7 +156,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"example.com/privatebase": {
 			Index: &registry.IndexInfo{
 				Name:     "example.com",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   true,
 			},
 			RemoteName:    "privatebase",
 			LocalName:     "example.com/privatebase",
@@ -145,7 +167,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"example.com:8000/private/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     "example.com:8000",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   true,
 			},
 			RemoteName:    "private/moonbase",
 			LocalName:     "example.com:8000/private/moonbase",
@@ -154,7 +178,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"example.com:8000/privatebase": {
 			Index: &registry.IndexInfo{
 				Name:     "example.com:8000",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   true,
 			},
 			RemoteName:    "privatebase",
 			LocalName:     "example.com:8000/privatebase",
@@ -163,7 +189,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"localhost/private/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     "localhost",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   false,
 			},
 			RemoteName:    "private/moonbase",
 			LocalName:     "localhost/private/moonbase",
@@ -172,7 +200,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"localhost/privatebase": {
 			Index: &registry.IndexInfo{
 				Name:     "localhost",
+				Mirrors:  []string{},
 				Official: false,
+				Secure:   false,
 			},
 			RemoteName:    "privatebase",
 			LocalName:     "localhost/privatebase",
@@ -181,7 +211,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		IndexName + "/public/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "public/moonbase",
 			LocalName:     "public/moonbase",
@@ -190,7 +222,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"index." + IndexName + "/public/moonbase": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "public/moonbase",
 			LocalName:     "public/moonbase",
@@ -199,7 +233,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"ubuntu-12.04-base": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "library/ubuntu-12.04-base",
 			LocalName:     "ubuntu-12.04-base",
@@ -208,7 +244,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		IndexName + "/ubuntu-12.04-base": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "library/ubuntu-12.04-base",
 			LocalName:     "ubuntu-12.04-base",
@@ -217,7 +255,9 @@ func TestParseRepositoryInfo(t *testing.T) {
 		"index." + IndexName + "/ubuntu-12.04-base": {
 			Index: &registry.IndexInfo{
 				Name:     IndexName,
+				Mirrors:  []string{},
 				Official: true,
+				Secure:   true,
 			},
 			RemoteName:    "library/ubuntu-12.04-base",
 			LocalName:     "ubuntu-12.04-base",
@@ -233,11 +273,10 @@ func TestParseRepositoryInfo(t *testing.T) {
 			repoInfo, err := ParseRepositoryInfo(named)
 			assert.NilError(t, err)
 
-			assert.Check(t, is.Equal(repoInfo.Index.Name, expected.Index.Name))
+			assert.Check(t, is.DeepEqual(repoInfo.Index, expected.Index))
 			assert.Check(t, is.Equal(reference.Path(repoInfo.Name), expected.RemoteName))
 			assert.Check(t, is.Equal(reference.FamiliarName(repoInfo.Name), expected.LocalName))
 			assert.Check(t, is.Equal(repoInfo.Name.Name(), expected.CanonicalName))
-			assert.Check(t, is.Equal(repoInfo.Index.Official, expected.Index.Official))
 		})
 	}
 }


### PR DESCRIPTION
### registry: TestLoadInsecureRegistries: don't mutate emptyServiceConfig

This was not revealed in our tests, which only checked for the length
of the Mirror-slice, but when testing with DeepEquals, tests were failing
when all tests were run (but succeeded on individual tests). The problem
here is that some code can mutate the list of Mirrors and set it to `nil`
or an empty slice, resulting in other tests to fail.

### registry: remove makeServiceConfig test-utility

It was a very thin wrapper around newServiceConfig, and didn't save
any code needed; possibly even the reverse, as it was abstracting
what it did under the hood.

### registry: TestParseRepositoryInfo: use sub-tests

### registry: TestParseRepositoryInfo: assert all index-info fields

### registry: TestParseRepositoryInfo: add test-cases for IPv6 refs

### registry: TestNewIndexInfo: use sub-tests


### registry: TestNewIndexInfo: assert all fields

Using DeepEquals showed that the test was missing differences between
nil-mirrors and empty-slice, in addition to mirrors being normalized
(the test only checked for the length).

While we should consider if we need an explicit empty slice (or if a
nil value would be appropriate), at least we now have a test to verify
the behavior.

### registry: TestNewIndexInfo: add more test-cases

- Add test-cases for IPv6 refs
- Add test-cases for validating the insecure-registries passed in the test

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

