### PR TITLE
integration/volume: remove some debug logs and minor fixes/cleanups

### DIFF
--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -181,7 +181,7 @@ func TestRunMountImage(t *testing.T) {
 			create, creatErr := apiClient.ContainerCreate(ctx, &cfg, &hostCfg, &network.NetworkingConfig{}, nil, ctrName)
 			id := create.ID
 			if id != "" {
-				defer apiClient.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
+				defer container.Remove(ctx, t, apiClient, id, containertypes.RemoveOptions{Force: true})
 			}
 
 			if tc.createErr != "" {

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -234,30 +234,25 @@ func TestRunMountImage(t *testing.T) {
 // |   |-- root                       (symlink to /)
 // |   |-- good                       (symlink to ../subdir)
 // |   |-- bad                        (symlink to root)
-func setupTestVolume(t *testing.T, client client.APIClient) string {
+func setupTestVolume(t *testing.T, apiClient client.APIClient) string {
 	t.Helper()
 	ctx := context.Background()
 
 	volumeName := t.Name() + "-volume"
 
-	err := client.VolumeRemove(ctx, volumeName, true)
+	err := apiClient.VolumeRemove(ctx, volumeName, true)
 	assert.NilError(t, err, "failed to clean volume")
 
-	_, err = client.VolumeCreate(ctx, volume.CreateOptions{
+	_, err = apiClient.VolumeCreate(ctx, volume.CreateOptions{
 		Name: volumeName,
 	})
 	assert.NilError(t, err, "failed to setup volume")
 
-	mount := mount.Mount{
-		Type:   mount.TypeVolume,
-		Source: volumeName,
-		Target: "/volume",
-	}
-
 	rootFs := "/"
+	target := "/volume"
 	if testEnv.DaemonInfo.OSType == "windows" {
-		mount.Target = `C:\volume`
 		rootFs = `C:`
+		target = `C:\volume`
 	}
 
 	initCmd := "echo foo > /volume/bar.txt && " +
@@ -271,7 +266,11 @@ func setupTestVolume(t *testing.T, client client.APIClient) string {
 		"mkdir /volume/hack/iwanttobehackedwithtoctou"
 
 	opts := []func(*container.TestContainerConfig){
-		container.WithMount(mount),
+		container.WithMount(mount.Mount{
+			Type:   mount.TypeVolume,
+			Source: volumeName,
+			Target: target,
+		}),
 		container.WithCmd("sh", "-c", initCmd+"; ls -lah /volume /volume/hack/"),
 	}
 	if testEnv.DaemonInfo.OSType == "windows" {
@@ -279,17 +278,14 @@ func setupTestVolume(t *testing.T, client client.APIClient) string {
 		opts = append(opts, container.WithIsolation(containertypes.IsolationProcess))
 	}
 
-	cid := container.Run(ctx, t, client, opts...)
-	defer client.ContainerRemove(ctx, cid, containertypes.RemoveOptions{Force: true})
-	output, err := container.Output(ctx, client, cid)
-
-	t.Logf("Setup stderr:\n%s", output.Stderr)
-	t.Logf("Setup stdout:\n%s", output.Stdout)
+	cid := container.Run(ctx, t, apiClient, opts...)
+	defer container.Remove(ctx, t, apiClient, cid, containertypes.RemoveOptions{Force: true})
+	output, err := container.Output(ctx, apiClient, cid)
 
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(output.Stderr, ""))
 
-	inspect, err := client.ContainerInspect(ctx, cid)
+	inspect, err := apiClient.ContainerInspect(ctx, cid)
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(inspect.State.ExitCode, 0))
 

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -104,8 +104,6 @@ func TestRunMountVolumeSubdir(t *testing.T) {
 
 			output, err := container.Output(ctx, apiClient, id)
 			assert.Check(t, err)
-			t.Logf("stdout:\n%s", output.Stdout)
-			t.Logf("stderr:\n%s", output.Stderr)
 
 			inspect, err := apiClient.ContainerInspect(ctx, id)
 			if assert.Check(t, err) {


### PR DESCRIPTION
### integration/volume: TestRunMountVolumeSubdir: remove some logs

Both stdout and stderr were already asserted further down, so any failure
would be printed.

### integration/volume: TestRunMountImage: use test-util for container cleanup

update the defer to use the container test-utils package to fix unhandled
error warnings.

### integration/volume: setupTestVolume: minor cleanups and fixes

- rename the "client" argument to "apiClient" to prevent shadowing the client import.
- remove intermediate "mount" var, which shadowed an import
- remove debug logs for stdOut/stdErr
- update the defer to use the container test-utils package to fix unhandled error warnings.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

