### PR TITLE
image/inspect: Add platform selection

### DIFF
--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -153,6 +153,7 @@ type GetImageOpts struct {
 // ImageInspectOpts holds parameters to inspect an image.
 type ImageInspectOpts struct {
 	Manifests bool
+	Platform  *ocispec.Platform
 }
 
 // CommitConfig is the configuration for creating an image as part of a build.

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -128,11 +128,12 @@ type InspectResponse struct {
 	// compatibility.
 	Descriptor *ocispec.Descriptor `json:"Descriptor,omitempty"`
 
-	// Manifests is a list of image manifests available in this image.  It
+	// Manifests is a list of image manifests available in this image. It
 	// provides a more detailed view of the platform-specific image manifests or
 	// other image-attached data like build attestations.
 	//
-	// Only available if the daemon provides a multi-platform image store.
+	// Only available if the daemon provides a multi-platform image store, the client
+	// requests manifests AND does not request a specific platform.
 	//
 	// WARNING: This is experimental and may change at any time without any backward
 	// compatibility.

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -106,6 +106,11 @@ type LoadOptions struct {
 type InspectOptions struct {
 	// Manifests returns the image manifests.
 	Manifests bool
+
+	// Platform selects the specific platform of a multi-platform image to inspect.
+	//
+	// This option is only available for API version 1.49 and up.
+	Platform *ocispec.Platform
 }
 
 // SaveOptions holds parameters to save images.

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -32,6 +32,17 @@ func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts
 		query.Set("manifests", "1")
 	}
 
+	if opts.apiOptions.Platform != nil {
+		if err := cli.NewVersionError(ctx, "1.49", "platform"); err != nil {
+			return image.InspectResponse{}, err
+		}
+		platform, err := encodePlatform(opts.apiOptions.Platform)
+		if err != nil {
+			return image.InspectResponse{}, err
+		}
+		query.Set("platform", platform)
+	}
+
 	resp, err := cli.get(ctx, "/images/"+imageID+"/json", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/client/image_inspect_opts.go
+++ b/client/image_inspect_opts.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/docker/docker/api/types/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImageInspectOption is a type representing functional options for the image inspect operation.
@@ -32,6 +33,17 @@ func ImageInspectWithRawResponse(raw *bytes.Buffer) ImageInspectOption {
 func ImageInspectWithManifests(manifests bool) ImageInspectOption {
 	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
 		clientOpts.apiOptions.Manifests = manifests
+		return nil
+	})
+}
+
+// ImageInspectWithPlatform sets platform API option for the image inspect operation.
+// This option is only available for API version 1.49 and up.
+// With this option set, the image inspect operation will return information for the
+// specified platform variant of the multi-platform image.
+func ImageInspectWithPlatform(platform *ocispec.Platform) ImageInspectOption {
+	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
+		clientOpts.apiOptions.Platform = platform
 		return nil
 	})
 }

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -78,4 +79,48 @@ func TestImageInspect(t *testing.T) {
 	if !reflect.DeepEqual(imageInspect.RepoTags, expectedTags) {
 		t.Fatalf("expected `%v`, got %v", expectedTags, imageInspect.RepoTags)
 	}
+}
+
+func TestImageInspectWithPlatform(t *testing.T) {
+	expectedURL := "/images/image_id/json"
+	requestedPlatform := &ocispec.Platform{
+		OS:           "linux",
+		Architecture: "arm64",
+	}
+
+	expectedPlatform, err := encodePlatform(requestedPlatform)
+	assert.NilError(t, err)
+
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+
+			// Check if platform parameter is passed correctly
+			platform := req.URL.Query().Get("platform")
+			if platform != expectedPlatform {
+				return nil, fmt.Errorf("Expected platform '%s', got '%s'", expectedPlatform, platform)
+			}
+
+			content, err := json.Marshal(image.InspectResponse{
+				ID:           "image_id",
+				Architecture: "arm64",
+				Os:           "linux",
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}),
+	}
+
+	imageInspect, err := client.ImageInspect(context.Background(), "image_id", ImageInspectWithPlatform(requestedPlatform))
+	assert.NilError(t, err)
+	assert.Equal(t, imageInspect.ID, "image_id")
+	assert.Equal(t, imageInspect.Architecture, "arm64")
+	assert.Equal(t, imageInspect.Os, "linux")
 }

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -23,8 +23,7 @@ import (
 )
 
 func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts backend.ImageInspectOpts) (*imagetypes.InspectResponse, error) {
-	// TODO: Pass in opts
-	var requestedPlatform *ocispec.Platform
+	requestedPlatform := opts.Platform
 
 	c8dImg, err := i.resolveImage(ctx, refOrID)
 	if err != nil {
@@ -60,7 +59,6 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 		return nil, err
 	}
 
-	//nolint:govet // TODO: requestedPlatform is always nil, but should be passed by the caller
 	if multi.Best == nil && requestedPlatform != nil {
 		return nil, &errPlatformNotFound{
 			imageRef: refOrID,
@@ -86,6 +84,10 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 	}
 
 	repoTags, repoDigests := collectRepoTagsAndDigests(ctx, tagged)
+
+	if requestedPlatform != nil {
+		target = multi.Best.Target()
+	}
 
 	resp := &imagetypes.InspectResponse{
 		ID:            target.Digest.String(),

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -12,8 +12,8 @@ import (
 	"github.com/docker/docker/layer"
 )
 
-func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, _ backend.ImageInspectOpts) (*imagetypes.InspectResponse, error) {
-	img, err := i.GetImage(ctx, refOrID, backend.GetImageOpts{})
+func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts backend.ImageInspectOpts) (*imagetypes.InspectResponse, error) {
+	img, err := i.GetImage(ctx, refOrID, backend.GetImageOpts{Platform: opts.Platform})
 	if err != nil {
 		return nil, err
 	}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.49](https://docs.docker.com/reference/api/engine/version/v1.49/) documentation
 
+* `GET /images/{name}/json` now supports a `platform` parameter (JSON
+  encoded OCI Platform type) allowing to specify a platform of the multi-platform
+  image to inspect.
+  This option is mutually exclusive with the `manifests` option.
+
 ## v1.48 API changes
 
 [Docker Engine API v1.48](https://docs.docker.com/reference/api/engine/version/v1.48/) documentation

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/internal/testutils/specialimage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -79,4 +80,124 @@ func TestImageInspectDescriptor(t *testing.T) {
 	assert.Assert(t, inspect.Descriptor != nil)
 	assert.Check(t, inspect.Descriptor.Digest.String() == inspect.ID)
 	assert.Check(t, inspect.Descriptor.Size > 0)
+}
+
+func TestImageInspectWithPlatform(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "The test image is a Linux image")
+	ctx := setupTest(t)
+
+	apiClient := testEnv.APIClient()
+
+	nativePlatform := ocispec.Platform{
+		OS:           testEnv.DaemonInfo.OSType,
+		Architecture: testEnv.DaemonInfo.Architecture,
+	}
+
+	// Create a platform that does not match the host platform
+	differentOS := "linux"
+	if nativePlatform.OS == "linux" {
+		differentOS = "windows"
+	}
+	differentPlatform := ocispec.Platform{
+		OS:           differentOS,
+		Architecture: "amd64",
+	}
+
+	imageID := specialimage.Load(ctx, t, apiClient, func(dir string) (*ocispec.Index, error) {
+		i, descs, err := specialimage.MultiPlatform(dir, "multiplatform:latest", []ocispec.Platform{nativePlatform, differentPlatform})
+		assert.NilError(t, err)
+
+		err = specialimage.LegacyManifest(dir, "multiplatform:latest", descs[0])
+		assert.NilError(t, err)
+
+		return i, err
+	})
+
+	for _, tc := range []struct {
+		name              string
+		requestedPlatform *ocispec.Platform
+		expectedPlatform  *ocispec.Platform
+		expectedError     string
+		withManifests     bool
+		snapshotterOnly   bool
+		graphdriverOnly   bool
+	}{
+		{
+			name:              "default",
+			requestedPlatform: nil,
+			expectedPlatform:  &nativePlatform,
+		},
+		{
+			name:              "snapshotter/with-manifests",
+			requestedPlatform: nil,
+			expectedPlatform:  &nativePlatform,
+			snapshotterOnly:   true,
+			withManifests:     true,
+		},
+		{
+			name:              "native",
+			requestedPlatform: &nativePlatform,
+			expectedPlatform:  &nativePlatform,
+		},
+		{
+			name:              "different",
+			requestedPlatform: &differentPlatform,
+			expectedPlatform:  &differentPlatform,
+			snapshotterOnly:   true,
+		},
+		{
+			name:              "different not supported on graphdriver",
+			requestedPlatform: &differentPlatform,
+			graphdriverOnly:   true,
+			//  image with reference multiplatform:latest was found but its platform (linux/aarch64) does not match the specified platform (windows/amd64)
+			expectedError: "image with reference multiplatform:latest was found but its platform",
+		},
+	} {
+		if tc.snapshotterOnly && !testEnv.UsingSnapshotter() {
+			continue
+		}
+		if tc.graphdriverOnly && testEnv.UsingSnapshotter() {
+			continue
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			var opts []client.ImageInspectOption
+			if tc.requestedPlatform != nil {
+				opts = append(opts, client.ImageInspectWithPlatform(tc.requestedPlatform))
+			}
+			if tc.withManifests {
+				opts = append(opts, client.ImageInspectWithManifests(true))
+			}
+			inspect, err := apiClient.ImageInspect(ctx, imageID, opts...)
+			if tc.expectedError != "" {
+				assert.Assert(t, is.ErrorContains(err, tc.expectedError))
+				return
+			}
+			assert.NilError(t, err)
+
+			assert.Check(t, is.Equal(inspect.Architecture, tc.expectedPlatform.Architecture))
+			assert.Check(t, is.Equal(inspect.Os, tc.expectedPlatform.OS))
+
+			if testEnv.UsingSnapshotter() {
+				assert.Assert(t, inspect.Descriptor != nil)
+				if tc.requestedPlatform != nil {
+					if assert.Check(t, inspect.Descriptor.Platform != nil) {
+						assert.Check(t, is.DeepEqual(*inspect.Descriptor.Platform, *tc.expectedPlatform))
+					}
+				}
+			} else {
+				assert.Check(t, inspect.Descriptor == nil)
+			}
+
+			if tc.withManifests {
+				t.Run("has manifests", func(t *testing.T) {
+					assert.Check(t, is.Len(inspect.Manifests, 2))
+				})
+			} else {
+				t.Run("has no manifests", func(t *testing.T) {
+					assert.Check(t, is.Nil(inspect.Manifests))
+				})
+			}
+		})
+	}
 }

--- a/internal/testutils/specialimage/multiplatform.go
+++ b/internal/testutils/specialimage/multiplatform.go
@@ -17,7 +17,7 @@ func MultiPlatform(dir string, imageRef string, imagePlatforms []ocispec.Platfor
 
 	for _, platform := range imagePlatforms {
 		ps := platforms.Format(platform)
-		manifestDesc, err := oneLayerPlatformManifest(dir, platform, FileInLayer{Path: "bash", Content: []byte("layer-" + ps)})
+		manifestDesc, _, err := oneLayerPlatformManifest(dir, platform, FileInLayer{Path: "bash", Content: []byte("layer-" + ps)})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/testutils/specialimage/partial.go
+++ b/internal/testutils/specialimage/partial.go
@@ -27,7 +27,7 @@ func PartialMultiPlatform(dir string, imageRef string, opts PartialOpts) (*ocisp
 
 	for _, platform := range opts.Stored {
 		ps := platforms.Format(platform)
-		manifestDesc, err := oneLayerPlatformManifest(dir, platform, FileInLayer{Path: "bash", Content: []byte("layer-" + ps)})
+		manifestDesc, _, err := oneLayerPlatformManifest(dir, platform, FileInLayer{Path: "bash", Content: []byte("layer-" + ps)})
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
- stacked on: https://github.com/moby/moby/pull/49718

`GET /image/{name}/json` now supports `platform` parameter allowing to
specify which platform variant of a multi-platform image to inspect.

For servers that do not use containerd image store integration, this
option will cause an error if the requested platform doesn't match the
image's actual platform

```markdown changelog
`GET /image/{name}/json` now supports a `platform` parameter allowing to specify which platform variant of a multi-platform image to inspect.
```