### PR TITLE
update go:build tags to go1.23 to align with vendor.mod

### DIFF
--- a/api/server/router/container/inspect.go
+++ b/api/server/router/container/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package container // import "github.com/docker/docker/api/server/router/container"
 

--- a/api/server/router/grpc/grpc.go
+++ b/api/server/router/grpc/grpc.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package grpc // import "github.com/docker/docker/api/server/router/grpc"
 

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package system // import "github.com/docker/docker/api/server/router/system"
 

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package system // import "github.com/docker/docker/api/server/router/system"
 

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package registry // import "github.com/docker/docker/api/types/registry"
 

--- a/api/types/registry/registry_test.go
+++ b/api/types/registry/registry_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package registry
 

--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package containerimage
 

--- a/container/view.go
+++ b/container/view.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package container // import "github.com/docker/docker/container"
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package containerd
 

--- a/daemon/containerd/image_push_test.go
+++ b/daemon/containerd/image_push_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package containerd
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -1,5 +1,5 @@
 // TODO(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 // Package daemon exposes the functions that occur on the host server
 // that the Docker daemon is running.

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22 && (linux || freebsd)
+//go:build go1.23 && (linux || freebsd)
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package daemon // import "github.com/docker/docker/daemon"
 

--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package loggerutils // import "github.com/docker/docker/daemon/logger/loggerutils"
 

--- a/internal/gocompat/modulegenerator.go
+++ b/internal/gocompat/modulegenerator.go
@@ -171,9 +171,9 @@ import (
 // > For example, a module containing code that uses the Go 1.21 language version
 // > should have a go.mod file with a go line such as go 1.21 or go 1.21.3.
 // > If a specific source file should be compiled only when using a newer Go
-// > toolchain, adding //go:build go1.22 to that source file both ensures that
-// > only Go 1.22 and newer toolchains will compile the file and also changes
-// > the language version in that file to Go 1.22.
+// > toolchain, adding //go:build go1.23 to that source file both ensures that
+// > only Go 1.23 and newer toolchains will compile the file and also changes
+// > the language version in that file to Go 1.23.
 //
 // This file is a generated module that imports all packages provided in
 // the repository, which replicates an external consumer using our code

--- a/internal/maputil/maputil.go
+++ b/internal/maputil/maputil.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package maputil
 

--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -1,5 +1,5 @@
 // TODO(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package platform
 

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package sliceutil
 

--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package config
 

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package bridge
 

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22 && linux
+//go:build go1.23 && linux
 
 package overlay
 

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package libnetwork
 

--- a/libnetwork/endpoint_store.go
+++ b/libnetwork/endpoint_store.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package libnetwork
 

--- a/libnetwork/internal/l2disco/unsol_arp_linux.go
+++ b/libnetwork/internal/l2disco/unsol_arp_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package l2disco
 

--- a/libnetwork/internal/l2disco/unsol_na_linux.go
+++ b/libnetwork/internal/l2disco/unsol_na_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package l2disco
 

--- a/libnetwork/internal/nftables/nftables_linux.go
+++ b/libnetwork/internal/nftables/nftables_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 // Package nftables provides methods to create an nftables table and manage its maps, sets,
 // chains, and rules.
@@ -141,7 +141,7 @@ func Enabled() bool {
 	return nftPath != ""
 }
 
-//////////////////////////////
+// ////////////////////////////
 // Tables
 
 // table is the internal representation of an nftables table.
@@ -293,7 +293,7 @@ func (t TableRef) Apply(ctx context.Context) error {
 	return nil
 }
 
-//////////////////////////////
+// ////////////////////////////
 // Chains
 
 // RuleGroup is used to allocate rules within a chain to a group. These groups are
@@ -469,7 +469,7 @@ func (c ChainRef) DeleteRule(group RuleGroup, rule string, args ...interface{}) 
 	return nil
 }
 
-//////////////////////////////
+// ////////////////////////////
 // VMaps
 
 // vMap is the internal representation of an nftables verdict map.
@@ -555,7 +555,7 @@ func (v VMapRef) DeleteElement(key string) error {
 	return nil
 }
 
-//////////////////////////////
+// ////////////////////////////
 // Sets
 
 // set is the internal representation of an nftables set.
@@ -647,7 +647,7 @@ func (s SetRef) DeleteElement(element string) error {
 	return nil
 }
 
-//////////////////////////////
+// ////////////////////////////
 // Internal
 
 /* Can't make text/template range over this, not sure why ...

--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 // Package resolvconf is used to generate a container's /etc/resolv.conf file.
 //

--- a/libnetwork/internal/setmatrix/setmatrix.go
+++ b/libnetwork/internal/setmatrix/setmatrix.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package setmatrix
 

--- a/libnetwork/ipams/defaultipam/address_space.go
+++ b/libnetwork/ipams/defaultipam/address_space.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package defaultipam
 

--- a/libnetwork/ipamutils/utils.go
+++ b/libnetwork/ipamutils/utils.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 // Package ipamutils provides utility functions for ipam management
 package ipamutils

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22 && linux
+//go:build go1.23 && linux
 
 package iptables
 

--- a/libnetwork/netutils/utils_linux.go
+++ b/libnetwork/netutils/utils_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22 && linux
+//go:build go1.23 && linux
 
 package netutils
 

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package libnetwork
 

--- a/libnetwork/network_store.go
+++ b/libnetwork/network_store.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package libnetwork
 

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package networkdb
 

--- a/libnetwork/options/options.go
+++ b/libnetwork/options/options.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 // Package options provides a way to pass unstructured sets of options to a
 // component expecting a strongly-typed configuration structure.

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package osl
 

--- a/libnetwork/osl/route_linux.go
+++ b/libnetwork/osl/route_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22 && (linux || freebsd)
+//go:build go1.23 && (linux || freebsd)
 
 package osl
 

--- a/libnetwork/portallocator/portallocator.go
+++ b/libnetwork/portallocator/portallocator.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package portallocator
 

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package libnetwork
 

--- a/libnetwork/service.go
+++ b/libnetwork/service.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package libnetwork
 

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -1,5 +1,5 @@
 // TODO(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package oci // import "github.com/docker/docker/oci"
 

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package v2 // import "github.com/docker/docker/plugin/v2"
 

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package daemon // import "github.com/docker/docker/testutil/daemon"
 

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package testutil // import "github.com/docker/docker/testutil"
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49541


Go maintainers started to unconditionally update the minimum go version for golang.org/x/ dependencies to go1.23, which means that we'll no longer be able to support any version below that when updating those dependencies;

> all: upgrade go directive to at least 1.23.0 [generated]
>
> By now Go 1.24.0 has been released, and Go 1.22 is no longer supported
> per the Go Release Policy (https://go.dev/doc/devel/release#policy).
>
> For golang/go#69095.

This updates our minimum version to go1.23, as we won't be able to maintain compatibility with older versions because of the above.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

