### PR TITLE
pkg/stringid: use UUIDv7 (or ULID) for IDs

### DIFF
--- a/pkg/stringid/stringid.go
+++ b/pkg/stringid/stringid.go
@@ -2,14 +2,16 @@
 package stringid // import "github.com/docker/docker/pkg/stringid"
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
 	shortLen = 12
 	fullLen  = 64
+	padding  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // Padding added to the UUID to make it produce the same length as the old ID format.
 )
 
 // TruncateID returns a shorthand version of a string identifier for convenience.
@@ -31,33 +33,33 @@ func TruncateID(id string) string {
 // of numbers only, so that the truncated ID can be used as hostname for
 // containers.
 func GenerateRandomID() string {
-	b := make([]byte, 32)
-	for {
-		if _, err := rand.Read(b); err != nil {
-			panic(err) // This shouldn't happen
-		}
-		id := hex.EncodeToString(b)
-
-		// make sure that the truncated ID does not consist of only numeric
-		// characters, as it's used as default hostname for containers.
-		//
-		// See:
-		// - https://github.com/moby/moby/issues/3869
-		// - https://bugzilla.redhat.com/show_bug.cgi?id=1059122
-		if allNum(id[:shortLen]) {
-			// all numbers; try again
-			continue
-		}
-		return id
-	}
+	uuidv7 := uuid.Must(uuid.NewV7()).String()
+	return strings.ReplaceAll(uuidv7, "-", "") + padding
 }
 
-// allNum checks whether id consists of only numbers (0-9).
-func allNum(id string) bool {
-	for _, c := range []byte(id) {
-		if c > '9' || c < '0' {
-			return false
-		}
+// UUIDv7 format (with hyphens):
+//
+//	UUIDv7: 01956c20-e1a6-73bd-959f-f5d3bcd6bd77 36 chars
+//	UUIDv7: 01956c20e1a673bd959ff5d3bcd6bd77     32 chars (with hyphens removed)
+//	        │           ││
+//	        │           │└────────────────────── Random Data (Remaining Bits, 19 characters)
+//	        │           └─────────────────────── UUID Version (v7, 4-bit, 1 character)
+//	        └─────────────────────────────────── Timestamp (Milliseconds since Unix epoch, 48 bit, 12 characters)
+const shortIDUUIDSuffix = "7aaaaaaaaaaaaaaaaaaa"
+
+func toUUID(id string) (uuid.UUID, error) {
+	if len(id) == shortLen {
+		// short ID is only the timestamp: append the UUID version (v7),
+		// and a fixed "random" suffix" to allow parsing as UUIDv7
+		return uuid.Parse(id + shortIDUUIDSuffix)
 	}
-	return true
+	return uuid.Parse(id[:32])
+}
+
+func getTimestamp(id string) time.Time {
+	uuidV7, err := toUUID(id)
+	if err != nil {
+		panic(err)
+	}
+	return time.Unix(uuidV7.Time().UnixTime())
 }

--- a/pkg/stringid/stringid_test.go
+++ b/pkg/stringid/stringid_test.go
@@ -1,7 +1,11 @@
 package stringid // import "github.com/docker/docker/pkg/stringid"
 
 import (
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestGenerateRandomID(t *testing.T) {
@@ -55,32 +59,25 @@ func TestTruncateID(t *testing.T) {
 	}
 }
 
-func TestAllNum(t *testing.T) {
-	tests := []struct {
-		doc, id  string
-		expected bool
-	}{
-		{
-			doc:      "mixed letters and numbers",
-			id:       "4e38e38c8ce0",
-			expected: false,
-		},
-		{
-			doc:      "letters only",
-			id:       "deadbeefcafe",
-			expected: false,
-		},
-		{
-			doc:      "numbers only",
-			id:       "012345678912",
-			expected: true,
-		},
+func TestUUIDv7(t *testing.T) {
+	idv7, err := uuid.NewV7()
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, tc := range tests {
-		t.Run(tc.doc, func(t *testing.T) {
-			if actual := allNum(tc.id); actual != tc.expected {
-				t.Errorf("expected %q to be %t, got %t, ", tc.id, !tc.expected, actual)
-			}
-		})
-	}
+	cleanID := strings.ReplaceAll(idv7.String(), "-", "")
+	fullID := cleanID + padding
+	shortID := cleanID[:shortLen]
+	t.Log("UUIDv7:       ", idv7.String(), "(", len(idv7.String()), " chars )")
+	t.Log("UUIDv7 clean: ", cleanID, "(", len(cleanID), "chars )")
+	t.Log("FULL ID:      ", fullID, "(", len(fullID), "chars )")
+	t.Log("SHORT ID:     ", shortID, "(", len(shortID), "chars )")
+	t.Log("URN:          ", idv7.URN())
+	t.Log("VERSION:      ", idv7.Version())
+	t.Log("VARIANT:      ", idv7.Variant())
+	t.Log("TIME:         ", idv7.Time())
+	t.Log("RFC3339:      ", time.Unix(idv7.Time().UnixTime()).Format(time.RFC3339Nano))
+	parsed, _ := toUUID(cleanID)
+	t.Log("Parsed:       ", parsed.String())
+	t.Log("Parsed short: ", uuid.Must(toUUID(shortID)))
+	t.Log("LEGACY:       ", GenerateRandomID())
 }


### PR DESCRIPTION
We currently use a random ID as identifier, which is either a "full length" (64 char) hexadecimal string, or truncated to 12 characters. There are no real requirements to the ID, other than it being unique for the host (we don't promise uniqueness between machines) and the truncated ID is used as default hostname for containers, therefore must only contain characters that are allowed as hostname (and not be [all-numeric]).

While there is no strict technical reason for non-truncated IDs to be 64-characters, we originally chose this length as it matched the length of a sha256 digest with the algorithm prefix (`sha256:`) removed. This allowed us to distinguish IDs from Names, and reject an ID to be used as Name in some places.

The length is currently specified in our [API specification];

> The ID of this container as a 128-bit (64-character) hexadecimal string (32 bytes).

And defined as:

    type: "string"
    minLength: 64
    maxLength: 64
    pattern: "^[0-9a-fA-F]{64}$"

We may be able to change that in future, but probably should be careful, as consumers may have the expectation for the length to be consistent.

While the current, random, ID has worked well, it also has some downsides;

- There is no (documented) uniqueness guarantee between hosts (i.e., two hosts could have a container with the same ID). This appears to be mostly documentation though, as `crypto/rand` has been used since [moby@141b5fc] (docker v0.1.1 and up).
- IDs are fully random; we have various outputs (like `docker ps`) where we default to sorting objects based on "creation" date. Currently, this means that sorting requires us to use a dedicated field (`Created`).

The latter can be somewhat confusing in situations where we present the objects, but (to save terminal real-estate) don't present the "Created" field itself, in which case order _appears_ random.

The "Created" column also isn't always useful for other tools to sort; depending on the format in which the date/time is presented, sorting is not possible, unless parsing the timestamp.

Ideally, we'd be using an ID that is:

- Globally unique, so that an object can be uniquely referenced, even in situations where objects are aggregated from multiple hosts (such as in a swarm cluster, or when managing multiple hosts).
- Sortable, so that sorting objects based on ID would sort them on date created (this allows selecting, for example, the "last container" that was created, even without using custom options like `--last int` on `docker ps` / `docker container ls`.
- Performant enough to replace the current implementation.
- Usable as `hostname` (in truncated form).
- Preferably short, so that the ID column doesn't have to be truncated to save space, and so that selecting the ID "just works" to refer to the object (container) unambiguously.
- Ideally "somewhat" human friendly (stretch goal: being able to read and memorize the ID).

To (more formally) solve the first issue (global uniqueness), we could use a UUID instead. However, the commonly used UUIDv4 is fully random, which won't solve the other issues.

Using an incremental ID would solve the second issue, but would require keeping track of an index (which may impact performance and add complexity). and, if numeric, would not be usable as hostname (which could be worked around by using a prefix).

There may be a new options though; UUIDv7 *which formalised in 2024, and now defined in [RFC 9562, section 5.7]), or [ULID] ("Universally Unique Lexicographically Sortable Identifier").

Both options;

- Have a time-based component, and are sortable
- Allow extracting the time, with millisecond precision.
- Have implementations in Go; for UUIDv7, we already use github.com/google/uuid, which includes support for UUIDv7.

ULIDs have the advantage of being shorter (26 characters versus 36 (or 32 with hyphens removed) as their canonical format uses Crockford's base32.

It's possible to present a ULID in UUID format, but it won't validate as a valid UUID.

Examples;

- ULID:   01BX5ZZKBKACTAV9WEVGEMMVRY (26 chars, case-insensitive)
- UUIDv7: 01956b3afbf67445a81699f9dc8de52c (32  chars with hyphens stripped)
- UUIDv7: 01956b3a-fbf6-7445-a816-99f9dc8de52c (36 chars, canonical format)

With regards to the (12-char) prefix being all-numeric; while _possible_, this won't happen within 200 Years, so not something we need to account for.

Which leaves the length: we can decide to update the API specification to define the length to be different, but add a suffix to the UUID for backward compatibility (for older API versions, or just by default). Using a fixed, documented suffix allows us to trim if to get the original UUID.

There is one caveat; our short-ID length (12-characters) happens to be the same length as is used for the timestamp in UUIDv7 (48-bit, 12 characters), which means that our short-ID will effectively be only the timestamp (with 1 millisecond precision), without randomness added. This could result in collisions when using short ID if objects are created within the same 1 ms second timeframe.

ULIDs may be better suited for that, because they only require 10 characters to encode the timestamp (due to their use of base32).

This patch:

- changes stringid.GenerateRandomID() to produce a UUIDv7 with suffix
- adds some utilities for parsing (still work in progress)

[all-numeric]: https://github.com/moby/moby/blob/v28.0.1/pkg/stringid/stringid.go#L41-L50
[API specification]: https://github.com/moby/moby/blob/v28.0.1/api/swagger.yaml#L5132-L5145
[moby@141b5fc]: https://github.com/moby/moby/commit/141b5fc7d77fbe99fd42fb603688b842a5be34dd
[RFC 9562, section 5.7]: https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-7
[ULID]: https://github.com/ulid/spec

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

