### PR TITLE
cmd/dockerd: assorted cleanups on config handling

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -281,7 +281,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 
 	c, err := createAndStartCluster(d, cli.Config)
 	if err != nil {
-		log.G(ctx).WithError(err).Fatalf("Error starting cluster component")
+		return fmt.Errorf("failed to start cluster component: %w", err)
 	}
 
 	// Restart all autostart containers which has a swarm endpoint

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -766,19 +766,19 @@ func initMiddlewares(_ context.Context, s *apiserver.Server, cfg *config.Config,
 	return authzMiddleware, nil
 }
 
-func (cli *daemonCLI) getContainerdDaemonOpts() ([]supervisor.DaemonOpt, error) {
+func getContainerdDaemonOpts(cfg *config.Config) ([]supervisor.DaemonOpt, error) {
 	var opts []supervisor.DaemonOpt
-	if cli.Debug {
+	if cfg.Debug {
 		opts = append(opts, supervisor.WithLogLevel("debug"))
 	} else {
-		opts = append(opts, supervisor.WithLogLevel(cli.LogLevel))
+		opts = append(opts, supervisor.WithLogLevel(cfg.LogLevel))
 	}
 
-	if logFormat := cli.Config.LogFormat; logFormat != "" {
+	if logFormat := cfg.LogFormat; logFormat != "" {
 		opts = append(opts, supervisor.WithLogFormat(logFormat))
 	}
 
-	if !cli.CriContainerd {
+	if !cfg.CriContainerd {
 		// CRI support in the managed daemon is currently opt-in.
 		//
 		// It's disabled by default, originally because it was listening on
@@ -1045,7 +1045,7 @@ func (cli *daemonCLI) initializeContainerd(ctx context.Context) (func(time.Durat
 	}
 
 	log.G(ctx).Info("containerd not running, starting managed containerd")
-	opts, err := cli.getContainerdDaemonOpts()
+	opts, err := getContainerdDaemonOpts(cli.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate containerd options")
 	}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -1040,7 +1040,7 @@ func (cli *daemonCLI) initializeContainerd(ctx context.Context) (func(time.Durat
 	}
 	if ok {
 		// detected a system containerd at the given address.
-		cli.ContainerdAddr = systemContainerdAddr
+		cli.Config.ContainerdAddr = systemContainerdAddr
 		return nil, nil
 	}
 
@@ -1050,11 +1050,11 @@ func (cli *daemonCLI) initializeContainerd(ctx context.Context) (func(time.Durat
 		return nil, errors.Wrap(err, "failed to generate containerd options")
 	}
 
-	r, err := supervisor.Start(ctx, filepath.Join(cli.Root, "containerd"), filepath.Join(cli.ExecRoot, "containerd"), opts...)
+	r, err := supervisor.Start(ctx, filepath.Join(cli.Config.Root, "containerd"), filepath.Join(cli.Config.ExecRoot, "containerd"), opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start containerd")
 	}
-	cli.ContainerdAddr = r.Address()
+	cli.Config.ContainerdAddr = r.Address()
 
 	// Try to wait for containerd to shutdown
 	return r.WaitTimeout, nil

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -941,7 +941,7 @@ func createAndStartCluster(cli *daemonCLI, d *daemon.Daemon) (*cluster.Cluster, 
 		DefaultAdvertiseAddr:   cli.Config.SwarmDefaultAdvertiseAddr,
 		RaftHeartbeatTick:      cli.Config.SwarmRaftHeartbeatTick,
 		RaftElectionTick:       cli.Config.SwarmRaftElectionTick,
-		RuntimeRoot:            cli.getSwarmRunRoot(),
+		RuntimeRoot:            getSwarmRunRoot(cli.Config),
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -198,8 +198,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 		// httpServer.Shutdown() will return immediately,
 		// which is what we want.
 		<-cli.apiShutdown
-		err := httpServer.Shutdown(apiShutdownCtx)
-		if err != nil {
+		if err := httpServer.Shutdown(apiShutdownCtx); err != nil {
 			log.G(ctx).WithError(err).Error("Error shutting down http server")
 		}
 		close(apiShutdownDone)
@@ -217,8 +216,8 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 			// cli.start() has returned without cli.stop() being called,
 			// e.g. because the daemon failed to start.
 			// Stop the HTTP server with no grace period.
-			if closeErr := httpServer.Close(); closeErr != nil {
-				log.G(ctx).WithError(closeErr).Error("Error closing http server")
+			if err := httpServer.Close(); err != nil {
+				log.G(ctx).WithError(err).Error("Error closing http server")
 			}
 		}
 	}()

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -281,7 +281,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 		return errors.Wrap(err, "failed to start metrics server")
 	}
 
-	c, err := createAndStartCluster(cli, d)
+	c, err := createAndStartCluster(d, cli.Config)
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("Error starting cluster component")
 	}
@@ -928,20 +928,20 @@ func loadListeners(cfg *config.Config, tlsConfig *tls.Config) ([]net.Listener, [
 	return lss, hosts, nil
 }
 
-func createAndStartCluster(cli *daemonCLI, d *daemon.Daemon) (*cluster.Cluster, error) {
+func createAndStartCluster(d *daemon.Daemon, cfg *config.Config) (*cluster.Cluster, error) {
 	name, _ := os.Hostname()
 	c, err := cluster.New(cluster.Config{
-		Root:                   cli.Config.Root,
+		Root:                   cfg.Root,
 		Name:                   name,
 		Backend:                d,
 		VolumeBackend:          d.VolumesService(),
 		ImageBackend:           d.ImageBackend(),
 		PluginBackend:          d.PluginManager(),
 		NetworkSubnetsProvider: d,
-		DefaultAdvertiseAddr:   cli.Config.SwarmDefaultAdvertiseAddr,
-		RaftHeartbeatTick:      cli.Config.SwarmRaftHeartbeatTick,
-		RaftElectionTick:       cli.Config.SwarmRaftElectionTick,
-		RuntimeRoot:            getSwarmRunRoot(cli.Config),
+		DefaultAdvertiseAddr:   cfg.SwarmDefaultAdvertiseAddr,
+		RaftHeartbeatTick:      cfg.SwarmRaftHeartbeatTick,
+		RaftElectionTick:       cfg.SwarmRaftElectionTick,
+		RuntimeRoot:            getSwarmRunRoot(cfg),
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/dockerd/daemon_linux.go
+++ b/cmd/dockerd/daemon_linux.go
@@ -41,8 +41,8 @@ func notifyStopping() {
 	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)
 }
 
-func validateCPURealtimeOptions(config *config.Config) error {
-	if config.CPURealtimePeriod == 0 && config.CPURealtimeRuntime == 0 {
+func validateCPURealtimeOptions(cfg *config.Config) error {
+	if cfg.CPURealtimePeriod == 0 && cfg.CPURealtimeRuntime == 0 {
 		return nil
 	}
 	if cdcgroups.Mode() == cdcgroups.Unified {

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -115,7 +115,7 @@ func newCgroupParent(cfg *config.Config) string {
 }
 
 func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) error, error) {
-	if cli.ContainerdAddr != "" {
+	if cli.Config.ContainerdAddr != "" {
 		// use system containerd at the given address.
 		return nil, nil
 	}

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -66,8 +66,8 @@ func (cli *daemonCLI) setupConfigReloadTrap() {
 
 // getSwarmRunRoot gets the root directory for swarm to store runtime state
 // For example, the control socket
-func (cli *daemonCLI) getSwarmRunRoot() string {
-	return filepath.Join(cli.Config.ExecRoot, "swarm")
+func getSwarmRunRoot(cfg *config.Config) string {
+	return filepath.Join(cfg.ExecRoot, "swarm")
 }
 
 // allocateDaemonPort ensures that there are no containers

--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -99,14 +99,14 @@ func allocateDaemonPort(addr string) error {
 	return nil
 }
 
-func newCgroupParent(config *config.Config) string {
+func newCgroupParent(cfg *config.Config) string {
 	cgroupParent := "docker"
-	useSystemd := daemon.UsingSystemd(config)
+	useSystemd := daemon.UsingSystemd(cfg)
 	if useSystemd {
 		cgroupParent = "system.slice"
 	}
-	if config.CgroupParent != "" {
-		cgroupParent = config.CgroupParent
+	if cfg.CgroupParent != "" {
+		cgroupParent = cfg.CgroupParent
 	}
 	if useSystemd {
 		cgroupParent = cgroupParent + ":" + "docker" + ":"

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -101,13 +101,13 @@ func newCgroupParent(*config.Config) string {
 }
 
 func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) error, error) {
-	defer func() { system.EnableContainerdRuntime(cli.ContainerdAddr) }()
+	defer func() { system.EnableContainerdRuntime(cli.Config.ContainerdAddr) }()
 
-	if cli.ContainerdAddr != "" {
+	if cli.Config.ContainerdAddr != "" {
 		return nil, nil
 	}
 
-	if cli.DefaultRuntime != config.WindowsV2RuntimeName {
+	if cli.Config.DefaultRuntime != config.WindowsV2RuntimeName {
 		return nil, nil
 	}
 

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -24,13 +24,13 @@ func getDefaultDaemonConfigFile() string {
 }
 
 // setPlatformOptions applies platform-specific CLI configuration options.
-func setPlatformOptions(conf *config.Config) error {
-	if conf.Pidfile == "" {
+func setPlatformOptions(cfg *config.Config) error {
+	if cfg.Pidfile == "" {
 		// On Windows, the pid-file location is relative to the daemon's data-root,
 		// which is configurable, so we cannot use a fixed default location.
 		// Instead, we set the location here, after we parsed command-line flags
 		// and loaded the configuration file (if any).
-		conf.Pidfile = filepath.Join(conf.Root, "docker.pid")
+		cfg.Pidfile = filepath.Join(cfg.Root, "docker.pid")
 	}
 	return nil
 }
@@ -96,7 +96,7 @@ func allocateDaemonPort(addr string) error {
 	return nil
 }
 
-func newCgroupParent(config *config.Config) string {
+func newCgroupParent(*config.Config) string {
 	return ""
 }
 

--- a/cmd/dockerd/daemon_windows.go
+++ b/cmd/dockerd/daemon_windows.go
@@ -88,7 +88,7 @@ func (cli *daemonCLI) setupConfigReloadTrap() {
 
 // getSwarmRunRoot gets the root directory for swarm to store runtime state
 // For example, the control socket
-func (cli *daemonCLI) getSwarmRunRoot() string {
+func getSwarmRunRoot(*config.Config) string {
 	return ""
 }
 

--- a/cmd/dockerd/options.go
+++ b/cmd/dockerd/options.go
@@ -92,9 +92,9 @@ func defaultCertPath() string {
 }
 
 // newDaemonOptions returns a new daemonFlags
-func newDaemonOptions(config *config.Config) *daemonOptions {
+func newDaemonOptions(cfg *config.Config) *daemonOptions {
 	return &daemonOptions{
-		daemonConfig: config,
+		daemonConfig: cfg,
 		configFile:   getDefaultDaemonConfigFile(),
 	}
 }


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49549/
- :point_up: some more coming after this 😅 

---

### cmd/dockerd: rename vars that shadowed imports

Also use a consistent name for "config" arguments.

### cmd/dockerd: rewrite getSwarmRunRoot to a regular func

This method only required the config to be passed; rewrite it to a
regular func that accepts the config.

### cmd/dockerd: createAndStartCluster: change to accept Config

This function took the whole daemon CLI as argument, but only needed
the config; change the signature to accept that.

### cmd/dockerd: rewrite getContainerdDaemonOpts to a func

This method only depended on the CLI config; rewrite it to a
regular function, returning the opts to use for the containerd
daemon.

### cmd/dockerd: explicitly access Config fields

Explicitly access config field through the Config field, instead
of the top-level "cli". This allows spotting locations where we don't
depend on the CLI, but really just the Config.

### cmd/dockerd: daemonCLI.start: don't log warnings before failing

This function could produce various logs ("Running in rootless mode") at
the start, but further steps could still fail (such as running with
RootlessKit, but not being configured as rootless).

This patch moves the informational / warning logs further down, so that
we don't produce logs before failing.

### cmd/dockerd: daemonCLI.start: return error instead of log.Fatal

We return errors in this function, except for this one, which was logged
as Fatal. If we want errors to be logged, we should probably do so in
the function calling daemonCLI.start.


### cmd/dockerd: daemonCLI.start: scope local errors

Scope errors locally and don't use special names if there's no reason
for it.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

