### PR TITLE
layer: remove StoreOptions.MetadataStorePathTemplate

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1071,12 +1071,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		})
 	} else {
 		layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{
-			Root:                      cfgStore.Root,
-			MetadataStorePathTemplate: filepath.Join(cfgStore.Root, "image", "%s", "layerdb"),
-			GraphDriver:               driverName,
-			GraphDriverOptions:        cfgStore.GraphOptions,
-			IDMapping:                 idMapping,
-			ExperimentalEnabled:       cfgStore.Experimental,
+			Root:                cfgStore.Root,
+			GraphDriver:         driverName,
+			GraphDriverOptions:  cfgStore.GraphOptions,
+			IDMapping:           idMapping,
+			ExperimentalEnabled: cfgStore.Experimental,
 		})
 		if err != nil {
 			return nil, err

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -47,12 +47,11 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	client := d.NewClientT(t)
 
 	layerStore, _ := layer.NewStoreFromOptions(layer.StoreOptions{
-		Root:                      d.Root,
-		MetadataStorePathTemplate: filepath.Join(d.RootDir(), "image", "%s", "layerdb"),
-		GraphDriver:               d.StorageDriver(),
-		GraphDriverOptions:        nil,
-		IDMapping:                 idtools.IdentityMapping{},
-		ExperimentalEnabled:       false,
+		Root:                d.Root,
+		GraphDriver:         d.StorageDriver(),
+		GraphDriverOptions:  nil,
+		IDMapping:           idtools.IdentityMapping{},
+		ExperimentalEnabled: false,
 	})
 	i := images.NewImageService(images.ImageServiceConfig{
 		LayerStore: layerStore,

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -43,12 +43,11 @@ type layerStore struct {
 
 // StoreOptions are the options used to create a new Store instance
 type StoreOptions struct {
-	Root                      string
-	MetadataStorePathTemplate string
-	GraphDriver               string
-	GraphDriverOptions        []string
-	IDMapping                 idtools.IdentityMapping
-	ExperimentalEnabled       bool
+	Root                string
+	GraphDriver         string
+	GraphDriverOptions  []string
+	IDMapping           idtools.IdentityMapping
+	ExperimentalEnabled bool
 }
 
 // NewStoreFromOptions creates a new Store instance
@@ -67,9 +66,9 @@ func NewStoreFromOptions(options StoreOptions) (Store, error) {
 	}
 	log.G(context.TODO()).Debugf("Initialized graph driver %s", driver)
 
-	root := fmt.Sprintf(options.MetadataStorePathTemplate, driver)
-
-	return newStoreFromGraphDriver(root, driver)
+	driverName := driver.String()
+	layerDBRoot := filepath.Join(options.Root, "image", driverName, "layerdb")
+	return newStoreFromGraphDriver(layerDBRoot, driver)
 }
 
 // newStoreFromGraphDriver creates a new Store instance using the provided


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/18877

### layer: remove StoreOptions.MetadataStorePathTemplate

This field was added to allow templating the storage-location of the storage driver as part of a refactor in f5916b10ae02c7db83052a97205ac345a3d96300.

In practice, the template is never customized, and always set to; `/<data-root>/image/<driver-name>/layerdb`, where `<driver-name>` is passed in by the driver.

This patch removes the field and its uses.

- https://github.com/moby/moby/blob/00ab386b5a2ebcf85b6a03b800f593c3a140c6a8/daemon/daemon.go#L1074-L1075
- https://github.com/moby/moby/blob/00ab386b5a2ebcf85b6a03b800f593c3a140c6a8/integration/image/remove_unix_test.go#L50-L51


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

