### PR TITLE
WIP: gha: update remaining 20.04 uses, and disable some

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -219,7 +219,7 @@ jobs:
           retention-days: 1
 
   integration-flaky:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -264,9 +264,9 @@ jobs:
         with:
           script: |
             let includes = [
-              { os: 'ubuntu-20.04', mode: '' },
-              { os: 'ubuntu-20.04', mode: 'rootless' },
-              { os: 'ubuntu-20.04', mode: 'systemd' },
+              // { os: 'ubuntu-20.04', mode: '' }, // FIXME: temporarily disabled during brownouts of ubuntu 20.04; https://github.com/moby/moby/pull/49579
+              // { os: 'ubuntu-20.04', mode: 'rootless' }, // FIXME: temporarily disabled during brownouts of ubuntu 20.04; https://github.com/moby/moby/pull/49579
+              // { os: 'ubuntu-20.04', mode: 'systemd' }, // FIXME: temporarily disabled during brownouts of ubuntu 20.04; https://github.com/moby/moby/pull/49579
               { os: 'ubuntu-24.04', mode: '' },
               { os: 'ubuntu-22.04', mode: 'rootless' },
               // { os: 'ubuntu-24.04', mode: 'rootless' },  // FIXME: https://github.com/moby/moby/pull/49579#issuecomment-2698622223
@@ -485,7 +485,7 @@ jobs:
           echo ${{ steps.set.outputs.matrix }}
 
   integration-cli:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     needs:

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -75,7 +75,7 @@ dockerd="dockerd"
 if [ -f "/sys/fs/cgroup/cgroup.controllers" ]; then
 	if [ -z "$TEST_IGNORE_CGROUP_CHECK" ] && [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then
 		echo >&2 '# cgroup v2 requires TEST_SKIP_INTEGRATION_CLI to be set'
-		exit 1
+#		exit 1
 	fi
 fi
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49579
- relates to https://github.com/moby/moby/issues/49576
- relates to https://github.com/moby/moby/issues/44084




Also disabling the TEST_SKIP_INTEGRATION_CLI check to see what tests are cgroupsv1-specific (and may need a t.Skip).


**- A picture of a cute animal (not mandatory but encouraged)**

