### PR TITLE
layer: remove StoreOptions.ExperimentalEnabled

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1071,11 +1071,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		})
 	} else {
 		layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{
-			Root:                cfgStore.Root,
-			GraphDriver:         driverName,
-			GraphDriverOptions:  cfgStore.GraphOptions,
-			IDMapping:           idMapping,
-			ExperimentalEnabled: cfgStore.Experimental,
+			Root:               cfgStore.Root,
+			GraphDriver:        driverName,
+			GraphDriverOptions: cfgStore.GraphOptions,
+			IDMapping:          idMapping,
 		})
 		if err != nil {
 			return nil, err

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -140,7 +140,7 @@ func getDriver(name string, config Options) (Driver, error) {
 	log.G(context.TODO()).WithFields(log.Fields{"driver": name, "home-dir": config.Root}).Error("Failed to GetDriver graph")
 
 	// TODO(thaJeztah): remove in next release.
-	if config.ExperimentalEnabled && os.Getenv("DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS") != "" {
+	if os.Getenv("DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS") != "" {
 		return nil, fmt.Errorf("DEPRECATED: Support for experimental graphdriver plugins has been removed. See https://docs.docker.com/go/deprecated/")
 	}
 

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -47,11 +47,10 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	client := d.NewClientT(t)
 
 	layerStore, _ := layer.NewStoreFromOptions(layer.StoreOptions{
-		Root:                d.Root,
-		GraphDriver:         d.StorageDriver(),
-		GraphDriverOptions:  nil,
-		IDMapping:           idtools.IdentityMapping{},
-		ExperimentalEnabled: false,
+		Root:               d.Root,
+		GraphDriver:        d.StorageDriver(),
+		GraphDriverOptions: nil,
+		IDMapping:          idtools.IdentityMapping{},
 	})
 	i := images.NewImageService(images.ImageServiceConfig{
 		LayerStore: layerStore,

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -17,7 +17,6 @@ import (
 	_ "github.com/docker/docker/daemon/graphdriver/register" // register graph drivers
 	"github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/layer"
-	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fakecontext"
@@ -47,10 +46,8 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	client := d.NewClientT(t)
 
 	layerStore, _ := layer.NewStoreFromOptions(layer.StoreOptions{
-		Root:               d.Root,
-		GraphDriver:        d.StorageDriver(),
-		GraphDriverOptions: nil,
-		IDMapping:          idtools.IdentityMapping{},
+		Root:        d.Root,
+		GraphDriver: d.StorageDriver(),
 	})
 	i := images.NewImageService(images.ImageServiceConfig{
 		LayerStore: layerStore,

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -43,20 +43,18 @@ type layerStore struct {
 
 // StoreOptions are the options used to create a new Store instance
 type StoreOptions struct {
-	Root                string
-	GraphDriver         string
-	GraphDriverOptions  []string
-	IDMapping           idtools.IdentityMapping
-	ExperimentalEnabled bool
+	Root               string
+	GraphDriver        string
+	GraphDriverOptions []string
+	IDMapping          idtools.IdentityMapping
 }
 
 // NewStoreFromOptions creates a new Store instance
 func NewStoreFromOptions(options StoreOptions) (Store, error) {
 	driver, err := graphdriver.New(options.GraphDriver, graphdriver.Options{
-		Root:                options.Root,
-		DriverOptions:       options.GraphDriverOptions,
-		IDMap:               options.IDMapping,
-		ExperimentalEnabled: options.ExperimentalEnabled,
+		Root:          options.Root,
+		DriverOptions: options.GraphDriverOptions,
+		IDMap:         options.IDMapping,
 	})
 	if err != nil {
 		if options.GraphDriver != "" {


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49598


### layer: remove StoreOptions.ExperimentalEnabled

I noticed that the only reason we kept this was so that we could produce
a more targeted error for the deprecated storage-driver plugins, but it's
very unlikely someone used those, and if they did, we already had the
"DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS" added as requirement. Let's
just produce an error if that option is set (and remove that altogether in
a later release, but just that check doesn't add significant complexity).

### integration/image: TestRemoveImageGarbageCollector: don't set zero-values

This test was setting some fields to their zero / default-value, which
was redundant, and added additional imports. Remove them as they are
not needed.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

