### PR TITLE
daemon: Fix giving up too early while connecting to containerd socket

### DIFF
--- a/libcontainerd/supervisor/remote_daemon.go
+++ b/libcontainerd/supervisor/remote_daemon.go
@@ -280,14 +280,19 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				continue
 			}
 
+			const connTimeout = 60 * time.Second
 			client, err = containerd.New(
 				r.GRPC.Address,
-				containerd.WithTimeout(60*time.Second),
+				containerd.WithTimeout(connTimeout),
 				containerd.WithDialOpts([]grpc.DialOption{
 					grpc.WithTransportCredentials(insecure.NewCredentials()),
 					grpc.WithContextDialer(dialer.ContextDialer),
 					grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
 					grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
+					grpc.WithConnectParams(grpc.ConnectParams{
+						// TODO: Remove after https://github.com/containerd/containerd/pull/11508
+						MinConnectTimeout: connTimeout,
+					}),
 				}),
 			)
 			if err != nil {


### PR DESCRIPTION
- related to: https://github.com/containerd/containerd/pull/11508

Explicitly set the gRPC connection params to take the timeout into account to workaround the containerd v2 client not passing down the stack.

containerd v2 replaced usages of deprecated gRPC functions but didn't pass the timeout to the actual dial connection options.

**- What I did**

**- How I did it**

**- How to verify it**
Make sure that
```bash
dockerd --debug --containerd /run/non-existing-socket.sock
```
tries to establish the connection for 60 seconds.

**- Human readable description for the release notes**
```markdown changelog
Fix the Docker daemon failing too early if the containerd socket isn't immediately available
```

**- A picture of a cute animal (not mandatory but encouraged)**

