### PR TITLE
runconfig/errors: split `ErrConflictHostNetwork`

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -173,7 +173,7 @@ func (daemon *Daemon) updateNetworkSettings(ctr *container.Container, n *libnetw
 	}
 
 	if !ctr.HostConfig.NetworkMode.IsHost() && containertypes.NetworkMode(n.Type()).IsHost() {
-		return runconfig.ErrConflictHostNetwork
+		return runconfig.ErrConflictConnectToHostNetwork
 	}
 
 	for s, v := range ctr.NetworkSettings.Networks {
@@ -1053,7 +1053,7 @@ func (daemon *Daemon) DisconnectFromNetwork(ctx context.Context, ctr *container.
 		delete(ctr.NetworkSettings.Networks, networkName)
 	} else if err == nil {
 		if ctr.HostConfig.NetworkMode.IsHost() && containertypes.NetworkMode(n.Type()).IsHost() {
-			return runconfig.ErrConflictHostNetwork
+			return runconfig.ErrConflictDisconnectFromHostNetwork
 		}
 
 		if err := daemon.disconnectFromNetwork(ctx, ctr, n, false); err != nil {

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1155,7 +1155,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkConnectToHostFromOtherNetwork(c *t
 	cli.DockerCmd(c, "network", "disconnect", "bridge", "container1")
 	out, _, err := dockerCmdWithError("network", "connect", "host", "container1")
 	assert.ErrorContains(c, err, "", out)
-	assert.Assert(c, is.Contains(out, runconfig.ErrConflictHostNetwork.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictConnectToHostNetwork.Error()))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkDisconnectFromHost(c *testing.T) {
@@ -1163,7 +1163,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkDisconnectFromHost(c *testing.T) {
 	cli.WaitRun(c, "container1")
 	out, _, err := dockerCmdWithError("network", "disconnect", "host", "container1")
 	assert.Assert(c, err != nil, "Should err out disconnect from host")
-	assert.Assert(c, is.Contains(out, runconfig.ErrConflictHostNetwork.Error()))
+	assert.Assert(c, is.Contains(out, runconfig.ErrConflictDisconnectFromHostNetwork.Error()))
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkConnectWithPortMapping(c *testing.T) {

--- a/runconfig/errors.go
+++ b/runconfig/errors.go
@@ -5,8 +5,10 @@ const (
 	ErrConflictContainerNetworkAndLinks validationError = "conflicting options: container type network can't be used with links. This would result in undefined behavior"
 	// ErrConflictSharedNetwork conflict between private and other networks
 	ErrConflictSharedNetwork validationError = "container sharing network namespace with another container or host cannot be connected to any other network"
-	// ErrConflictHostNetwork conflict from being disconnected from host network or connected to host network.
-	ErrConflictHostNetwork validationError = "container cannot be disconnected from host network or connected to host network"
+	// ErrConflictConnectToHostNetwork error when attempting to connect a container to host network when not in host network mode
+	ErrConflictConnectToHostNetwork validationError = "cannot connect container to host network - container must be created in host network mode"
+	// ErrConflictDisconnectFromHostNetwork error when attempting to disconnect a container from host network when in host network mode
+	ErrConflictDisconnectFromHostNetwork validationError = "cannot disconnect container from host network - container was created in host network mode"
 	// ErrConflictNoNetwork conflict between private and other networks
 	ErrConflictNoNetwork validationError = "container cannot be connected to multiple networks with one of the networks in private (none) mode"
 	// ErrConflictNetworkAndDNS conflict between --dns and the network mode


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #49604

Split the `ErrConflictHostNetwork` error into two distinct errors:

1. `ErrConflictConnectToHostNetwork` when attempting to change the
   network mode of a running container from a different mode to `host`
2. `ErrConflictDisconnectFromHostNetwork` when the network mode of a
   running container is `host` and attempting to disconnect from `host`

This commit clarifies error messaging by differentiating between the two
errors, making it clearer which operation failed and how to fix it.

**- How I did it**

- Added the new errors to `runconfig/errors.go`.
- Updated references to the old error in `daemon/container_operations.go` to point to the new errors.
- Updated tests in `integration-cli/docker_cli_network_unix_test.go` to assert on the new errors.

**- How to verify it**

Run the updated tests in `integration-cli/docker_cli_network_unix_test.go`.

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog
runconfig/errors: split `ErrConflictHostNetwork` into `ErrConflictConnectToHostNetwork` and `ErrConflictDisconnectFromHostNetwork`
```

**- A picture of a cute animal (not mandatory but encouraged)** :whale:
