### PR TITLE
pkg/atomicwriter: New(): prevent creating temp-file on errors, and use absolute paths

### DIFF
--- a/pkg/atomicwriter/atomicwriter.go
+++ b/pkg/atomicwriter/atomicwriter.go
@@ -11,12 +11,12 @@ import (
 // destination path. Writing and closing concurrently is not allowed.
 // NOTE: umask is not considered for the file's permissions.
 func New(filename string, perm os.FileMode) (io.WriteCloser, error) {
-	f, err := os.CreateTemp(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
+	abspath, err := filepath.Abs(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	abspath, err := filepath.Abs(filename)
+	f, err := os.CreateTemp(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/atomicwriter/atomicwriter.go
+++ b/pkg/atomicwriter/atomicwriter.go
@@ -16,7 +16,7 @@ func New(filename string, perm os.FileMode) (io.WriteCloser, error) {
 		return nil, err
 	}
 
-	f, err := os.CreateTemp(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
+	f, err := os.CreateTemp(filepath.Dir(abspath), ".tmp-"+filepath.Base(filename))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### pkg/atomicwriter: New(): prevent creating temp-file on errors

The temp-file was created before trying to make the given filename an
absolute path. Reverse the order of code so that we don't create
a temp-file if an error happens.

### pkg/atomicwriter: New(): use absolute path for temp-file

Use an absolute path for both the temp-file and the destination-file.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

