### PR TITLE
client: keep image refs in canonical format where possible

### DIFF
--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -32,7 +32,7 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 		if tagged, ok := ref.(reference.Tagged); ok {
 			tag = tagged.Tag()
 		}
-		repository = reference.FamiliarName(ref)
+		repository = ref.Name()
 	}
 
 	query := url.Values{}

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -33,13 +33,15 @@ func TestContainerCommitError(t *testing.T) {
 }
 
 func TestContainerCommit(t *testing.T) {
-	expectedURL := "/commit"
-	expectedContainerID := "container_id"
-	specifiedReference := "repository_name:tag"
-	expectedRepositoryName := "repository_name"
-	expectedTag := "tag"
-	expectedComment := "comment"
-	expectedAuthor := "author"
+	const (
+		expectedURL            = "/commit"
+		expectedContainerID    = "container_id"
+		specifiedReference     = "repository_name:tag"
+		expectedRepositoryName = "docker.io/library/repository_name"
+		expectedTag            = "tag"
+		expectedComment        = "comment"
+		expectedAuthor         = "author"
+	)
 	expectedChanges := []string{"change1", "change2"}
 
 	client := &Client{

--- a/client/image_create.go
+++ b/client/image_create.go
@@ -21,7 +21,7 @@ func (cli *Client) ImageCreate(ctx context.Context, parentReference string, opti
 	}
 
 	query := url.Values{}
-	query.Set("fromImage", reference.FamiliarName(ref))
+	query.Set("fromImage", ref.Name())
 	query.Set("tag", getAPITagFromNamedRef(ref))
 	if options.Platform != "" {
 		query.Set("platform", strings.ToLower(options.Platform))

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -25,11 +25,14 @@ func TestImageCreateError(t *testing.T) {
 }
 
 func TestImageCreate(t *testing.T) {
-	expectedURL := "/images/create"
-	expectedImage := "test:5000/my_image"
-	expectedTag := "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-	expectedReference := fmt.Sprintf("%s@%s", expectedImage, expectedTag)
-	expectedRegistryAuth := "eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImRHOTBid289IiwiZW1haWwiOiJqb2huQGRvZS5jb20ifX0="
+	const (
+		expectedURL          = "/images/create"
+		expectedImage        = "docker.io/test/my_image"
+		expectedTag          = "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+		specifiedReference   = "test/my_image:latest@" + expectedTag
+		expectedRegistryAuth = "eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImRHOTBid289IiwiZW1haWwiOiJqb2huQGRvZS5jb20ifX0="
+	)
+
 	client := &Client{
 		client: newMockClient(func(r *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(r.URL.Path, expectedURL) {
@@ -58,7 +61,7 @@ func TestImageCreate(t *testing.T) {
 		}),
 	}
 
-	createResponse, err := client.ImageCreate(context.Background(), expectedReference, image.CreateOptions{
+	createResponse, err := client.ImageCreate(context.Background(), specifiedReference, image.CreateOptions{
 		RegistryAuth: expectedRegistryAuth,
 	})
 	if err != nil {

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -26,7 +26,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options image.P
 	}
 
 	query := url.Values{}
-	query.Set("fromImage", reference.FamiliarName(ref))
+	query.Set("fromImage", ref.Name())
 	if !options.All {
 		query.Set("tag", getAPITagFromNamedRef(ref))
 	}

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -29,7 +29,6 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options image.Pu
 		return nil, errors.New("cannot push a digest reference")
 	}
 
-	name := reference.FamiliarName(ref)
 	query := url.Values{}
 	if !options.All {
 		ref = reference.TagNameOnly(ref)
@@ -52,13 +51,13 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options image.Pu
 		query.Set("platform", string(pJson))
 	}
 
-	resp, err := cli.tryImagePush(ctx, name, query, options.RegistryAuth)
+	resp, err := cli.tryImagePush(ctx, ref.Name(), query, options.RegistryAuth)
 	if errdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
 		if privilegeErr != nil {
 			return nil, privilegeErr
 		}
-		resp, err = cli.tryImagePush(ctx, name, query, newAuthHeader)
+		resp, err = cli.tryImagePush(ctx, ref.Name(), query, newAuthHeader)
 	}
 	if err != nil {
 		return nil, err

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -26,7 +26,7 @@ func (cli *Client) ImageTag(ctx context.Context, source, target string) error {
 	ref = reference.TagNameOnly(ref)
 
 	query := url.Values{}
-	query.Set("repo", reference.FamiliarName(ref))
+	query.Set("repo", ref.Name())
 	if tagged, ok := ref.(reference.Tagged); ok {
 		query.Set("tag", tagged.Tag())
 	}

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -95,7 +95,7 @@ func TestImageTagHexSource(t *testing.T) {
 }
 
 func TestImageTag(t *testing.T) {
-	expectedURL := "/images/image_id/tag"
+	const expectedURL = "/images/image_id/tag"
 	tagCases := []struct {
 		reference           string
 		expectedQueryParams map[string]string
@@ -103,37 +103,37 @@ func TestImageTag(t *testing.T) {
 		{
 			reference: "repository:tag1",
 			expectedQueryParams: map[string]string{
-				"repo": "repository",
+				"repo": "docker.io/library/repository",
 				"tag":  "tag1",
 			},
 		}, {
 			reference: "another_repository:latest",
 			expectedQueryParams: map[string]string{
-				"repo": "another_repository",
+				"repo": "docker.io/library/another_repository",
 				"tag":  "latest",
 			},
 		}, {
 			reference: "another_repository",
 			expectedQueryParams: map[string]string{
-				"repo": "another_repository",
+				"repo": "docker.io/library/another_repository",
 				"tag":  "latest",
 			},
 		}, {
 			reference: "test/another_repository",
 			expectedQueryParams: map[string]string{
-				"repo": "test/another_repository",
+				"repo": "docker.io/test/another_repository",
 				"tag":  "latest",
 			},
 		}, {
 			reference: "test/another_repository:tag1",
 			expectedQueryParams: map[string]string{
-				"repo": "test/another_repository",
+				"repo": "docker.io/test/another_repository",
 				"tag":  "tag1",
 			},
 		}, {
 			reference: "test/test/another_repository:tag1",
 			expectedQueryParams: map[string]string{
-				"repo": "test/test/another_repository",
+				"repo": "docker.io/test/test/another_repository",
 				"tag":  "tag1",
 			},
 		}, {


### PR DESCRIPTION
Using "familiarname" (e.g. "ubuntu") should be mostly done for presenting image refernces to the user, but internally, we should use the canonical format where possible ("docker.io/library/ubuntu").

There's still many places where we use the familiar (short) form, but let's start with not converting references in the client.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: Keep image references in canonical format where possible
```

**- A picture of a cute animal (not mandatory but encouraged)**

