### PR TITLE
registry: rewrite ParseRepositoryInfo to not depend on IndexInfo

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -412,5 +412,70 @@ func newRepositoryInfo(config *serviceConfig, name reference.Named) *RepositoryI
 //
 // It is used by the Docker cli to interact with registry-related endpoints.
 func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
-	return newRepositoryInfo(emptyServiceConfig, reposName), nil
+	indexName := normalizeIndexName(reference.Domain(reposName))
+	if indexName == IndexName {
+		officialRepo := !strings.ContainsRune(reference.FamiliarName(reposName), '/')
+		return &RepositoryInfo{
+			Name: reference.TrimNamed(reposName),
+			Index: &registry.IndexInfo{
+				Name:     IndexName,
+				Mirrors:  []string{},
+				Secure:   true,
+				Official: true,
+			},
+			Official: officialRepo,
+		}, nil
+	}
+
+	insecure := false
+	if isInsecure(indexName) {
+		insecure = true
+	}
+
+	return &RepositoryInfo{
+		Name: reference.TrimNamed(reposName),
+		Index: &registry.IndexInfo{
+			Name:    indexName,
+			Mirrors: []string{},
+			Secure:  !insecure,
+		},
+	}, nil
+}
+
+// isInsecure is used to detect whether a registry domain or IP-address is allowed
+// to use an insecure (non-TLS, or self-signed cert) connection according to the
+// defaults, which allows for insecure connections with registries running on a
+// loopback address ("localhost", "::1/128", "127.0.0.0/8").
+//
+// It is used in situations where we don't have access to the daemon's configuration,
+// for example, when used from the client / CLI.
+func isInsecure(hostNameOrIP string) bool {
+	// Attempt to strip port if present; this also strips brackets for
+	// IPv6 addresses with a port (e.g. "[::1]:5000").
+	//
+	// This is best-effort; we'll continue using the address as-is if it fails.
+	if host, _, err := net.SplitHostPort(hostNameOrIP); err == nil {
+		hostNameOrIP = host
+	}
+	if hostNameOrIP == "127.0.0.1" || hostNameOrIP == "::1" || strings.EqualFold(hostNameOrIP, "localhost") {
+		// Fast path; no need to resolve these, assuming nobody overrides
+		// "localhost" for anything else than a loopback address (sorry, not sorry).
+		return true
+	}
+
+	var addresses []net.IP
+	if ip := net.ParseIP(hostNameOrIP); ip != nil {
+		addresses = append(addresses, ip)
+	} else {
+		// Try to resolve the host's IP-addresses.
+		addrs, _ := lookupIP(hostNameOrIP)
+		addresses = append(addresses, addrs...)
+	}
+
+	for _, addr := range addresses {
+		if addr.IsLoopback() {
+			return true
+		}
+	}
+	return false
 }

--- a/registry/config.go
+++ b/registry/config.go
@@ -56,37 +56,6 @@ var (
 		Host:   DefaultRegistryHost,
 	}
 
-	// ipv6Loopback is the CIDR for the IPv6 loopback address ("::1"); "::1/128"
-	ipv6Loopback = &net.IPNet{
-		IP:   net.IPv6loopback,
-		Mask: net.CIDRMask(128, 128),
-	}
-
-	// ipv4Loopback is the CIDR for IPv4 loopback addresses ("127.0.0.0/8")
-	ipv4Loopback = &net.IPNet{
-		IP:   net.IPv4(127, 0, 0, 0),
-		Mask: net.CIDRMask(8, 32),
-	}
-
-	// emptyServiceConfig is a default service-config for situations where
-	// no config-file is available (e.g. when used in the CLI). It won't
-	// have mirrors configured, but does have the default insecure registry
-	// CIDRs for loopback interfaces configured.
-	emptyServiceConfig = &serviceConfig{
-		IndexConfigs: map[string]*registry.IndexInfo{
-			IndexName: {
-				Name:     IndexName,
-				Mirrors:  []string{},
-				Secure:   true,
-				Official: true,
-			},
-		},
-		InsecureRegistryCIDRs: []*registry.NetIPNet{
-			(*registry.NetIPNet)(ipv6Loopback),
-			(*registry.NetIPNet)(ipv4Loopback),
-		},
-	}
-
 	validHostPortRegex = lazyregexp.New(`^` + reference.DomainRegexp.String() + `$`)
 
 	// certsDir is used to override defaultCertsDir.

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -331,6 +331,38 @@ func TestParseRepositoryInfo(t *testing.T) {
 
 func TestNewIndexInfo(t *testing.T) {
 	overrideLookupIP(t)
+
+	// ipv6Loopback is the CIDR for the IPv6 loopback address ("::1"); "::1/128"
+	ipv6Loopback := &net.IPNet{
+		IP:   net.IPv6loopback,
+		Mask: net.CIDRMask(128, 128),
+	}
+
+	// ipv4Loopback is the CIDR for IPv4 loopback addresses ("127.0.0.0/8")
+	ipv4Loopback := &net.IPNet{
+		IP:   net.IPv4(127, 0, 0, 0),
+		Mask: net.CIDRMask(8, 32),
+	}
+
+	// emptyServiceConfig is a default service-config for situations where
+	// no config-file is available (e.g. when used in the CLI). It won't
+	// have mirrors configured, but does have the default insecure registry
+	// CIDRs for loopback interfaces configured.
+	emptyServiceConfig := &serviceConfig{
+		IndexConfigs: map[string]*registry.IndexInfo{
+			IndexName: {
+				Name:     IndexName,
+				Mirrors:  []string{},
+				Secure:   true,
+				Official: true,
+			},
+		},
+		InsecureRegistryCIDRs: []*registry.NetIPNet{
+			(*registry.NetIPNet)(ipv6Loopback),
+			(*registry.NetIPNet)(ipv4Loopback),
+		},
+	}
+
 	testIndexInfo := func(t *testing.T, config *serviceConfig, expectedIndexInfos map[string]*registry.IndexInfo) {
 		for indexName, expected := range expectedIndexInfos {
 			t.Run(indexName, func(t *testing.T) {

--- a/registry/search.go
+++ b/registry/search.go
@@ -154,5 +154,24 @@ func splitReposSearchTerm(reposName string) (string, string) {
 // for that.
 func ParseSearchIndexInfo(reposName string) (*registry.IndexInfo, error) {
 	indexName, _ := splitReposSearchTerm(reposName)
-	return newIndexInfo(emptyServiceConfig, indexName), nil
+	indexName = normalizeIndexName(indexName)
+	if indexName == IndexName {
+		return &registry.IndexInfo{
+			Name:     IndexName,
+			Mirrors:  []string{},
+			Secure:   true,
+			Official: true,
+		}, nil
+	}
+
+	insecure := false
+	if isInsecure(indexName) {
+		insecure = true
+	}
+
+	return &registry.IndexInfo{
+		Name:    indexName,
+		Mirrors: []string{},
+		Secure:  !insecure,
+	}, nil
 }


### PR DESCRIPTION
- relates tohttps://github.com/moby/moby/pull/8456
- follow-up to
    - https://github.com/moby/moby/pull/49567
    - https://github.com/moby/moby/pull/49568
    - https://github.com/moby/moby/pull/49571
    - https://github.com/moby/moby/pull/49006

### registry: rewrite ParseRepositoryInfo, ParseSearchIndexInfo to not depend on IndexInfo

This function was introduced in 568f86eb186731b907b659e4ec64bda21c2fe31d
to replace [ResolveRepositoryName]. The function was implemented to use
various parts of the registry package that were designed for the daemon
code, which was written with the assumption that it had registry-config
available from the daemon's configuration. However, `ParseRepositoryInfo`
was used in the client / CLI, which does not have this information.

To work around this problem, the code used a dummy "emptyServiceConfig"
to allow the `Insecure` and `Mirrors` fields to be propagated based on
the same defaults as used by the daemon. The `Mirrors` field would always
be empty, as there are no default mirrors, and (lacking access to the
daemon's config) the `Insecure` field would always default to registries
running on a loopback address (`::1/128`, `127.0.0.1/8`). It's worth noting
that neither the `Mirrors`, nor the `Insecure` field is used by the CLI.

This patch rewrites `ParseRepositoryInfo` to be self-contained, and not
depend on these constructs (and the `emptyServiceConfig`). For now, the
existing logic for `Insecure` is kept, but replaced by a simplified function
(`isInsecure`) with some optimizations for well-known loopback addresses
(`localhost`, `::1`, `127.0.0.1`) to prevent redundant DNS lookups or
parsing.

Note that similar changes should be made for [ParseSearchIndexInfo], which
has a similar fate and is also only used by the client / CLI.

[ResolveRepositoryName]: https://github.com/moby/moby/blob/11e47996dc3efe8b358f21b4ff243d9c3e5fa1ec/registry/registry.go#L199-L222
[ParseSearchIndexInfo]: https://github.com/moby/moby/blob/d86dd7594882e5c79fb039e83a2cfa065f6483c0/registry/search.go#L153-L162


### registry: rewrite ParseSearchIndexInfo to not depend on IndexInfo

This function was implemented to use various parts of the registry package
that were designed for the daemon code, which was written with the assumption
that it had registry-config available from the daemon's configuration.
However, `ParseSearchIndexInfo` is used by the client / CLI, which does
not have this information.

To work around this problem, the code used a dummy "emptyServiceConfig"
to allow the `Insecure` and `Mirrors` fields to be propagated based on
the same defaults as used by the daemon. The `Mirrors` field would always
be empty, as there are no default mirrors, and (lacking access to the
daemon's config) the `Insecure` field would always default to registries
running on a loopback address (`::1/128`, `127.0.0.1/8`). It's worth noting
that neither the `Mirrors`, nor the `Insecure` field is used by the CLI.

This patch rewrites `ParseSearchIndexInfo` to be self-contained, and not
depend on these constructs (and the `emptyServiceConfig`). For now, the
existing logic for `Insecure` is kept, but replaced by a simplified function
(`isInsecure`) with some optimizations for well-known loopback addresses
(`localhost`, `::1`, `127.0.0.1`) to prevent redundant DNS lookups or
parsing.

Note that similar changes should be made for [ParseRepositoryInfo], which
has a similar fate and is also only used by the client / CLI.

[ResolveRepositoryName]: https://github.com/moby/moby/blob/11e47996dc3efe8b358f21b4ff243d9c3e5fa1ec/registry/registry.go#L199-L222
[ParseRepositoryInfo]: https://github.com/moby/moby/blob/d86dd7594882e5c79fb039e83a2cfa065f6483c0/registry/config.go#L375-L381



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

