### PR TITLE
registry: deprecate SetCertsDir, HostCertsDir

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -4,13 +4,9 @@ package main
 
 import (
 	"net"
-	"path/filepath"
 
 	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/opts"
-	"github.com/docker/docker/pkg/homedir"
-	"github.com/docker/docker/pkg/rootless"
-	"github.com/docker/docker/registry"
 	"github.com/spf13/pflag"
 )
 
@@ -58,15 +54,4 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	// Note that conf.BridgeConfig.UserlandProxyPath and honorXDG are configured according to the value of rootless.RunningWithRootlessKit, not the value of --rootless.
 	flags.BoolVar(&conf.Rootless, "rootless", conf.Rootless, "Enable rootless mode; typically used with RootlessKit")
 	flags.StringVar(&conf.CgroupNamespaceMode, "default-cgroupns-mode", conf.CgroupNamespaceMode, `Default mode for containers cgroup namespace ("host" | "private")`)
-}
-
-// configureCertsDir configures registry.CertsDir() depending on if the daemon
-// is running in rootless mode or not.
-func configureCertsDir() {
-	if rootless.RunningWithRootlessKit() {
-		configHome, err := homedir.GetConfigHome()
-		if err == nil {
-			registry.SetCertsDir(filepath.Join(configHome, "docker/certs.d"))
-		}
-	}
 }

--- a/cmd/dockerd/docker.go
+++ b/cmd/dockerd/docker.go
@@ -79,7 +79,6 @@ func newDaemonCommand() (*cobra.Command, error) {
 	flags := cmd.Flags()
 	flags.BoolP("version", "v", false, "Print version information and quit")
 	flags.StringVar(&opts.configFile, "config-file", opts.configFile, "Daemon configuration file")
-	configureCertsDir()
 	opts.installFlags(flags)
 	installConfigFlags(opts.daemonConfig, flags)
 	installServiceFlags(flags)

--- a/registry/config.go
+++ b/registry/config.go
@@ -114,7 +114,7 @@ func setCertsDir(dir string) string {
 			// for docker/cli.
 			//
 			// [rootless.RunningWithRootlessKit]: https://github.com/moby/moby/blob/b4bdf12daec84caaf809a639f923f7370d4926ad/pkg/rootless/rootless.go#L5-L8
-			if configHome, err := homedir.GetConfigHome(); err == nil {
+			if configHome, _ := homedir.GetConfigHome(); configHome != "" {
 				certsDir = filepath.Join(configHome, "docker/certs.d")
 				return
 			}
@@ -135,6 +135,7 @@ func SetCertsDir(path string) {
 
 // CertsDir is the directory where certificates are stored.
 func CertsDir() string {
+	// call setCertsDir with an empty path to synchronise with [SetCertsDir]
 	return setCertsDir("")
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -18,7 +18,14 @@ import (
 )
 
 // HostCertsDir returns the config directory for a specific host.
+//
+// Deprecated: this function was only used internally, and will be removed in a future release.
 func HostCertsDir(hostname string) string {
+	return hostCertsDir(hostname)
+}
+
+// hostCertsDir returns the config directory for a specific host.
+func hostCertsDir(hostname string) string {
 	return filepath.Join(CertsDir(), cleanPath(hostname))
 }
 
@@ -26,11 +33,10 @@ func HostCertsDir(hostname string) string {
 func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 	// PreferredServerCipherSuites should have no effect
 	tlsConfig := tlsconfig.ServerDefault()
-
 	tlsConfig.InsecureSkipVerify = !isSecure
 
 	if isSecure {
-		hostDir := HostCertsDir(hostname)
+		hostDir := hostCertsDir(hostname)
 		log.G(context.TODO()).Debugf("hostDir: %s", hostDir)
 		if err := ReadCertsDirectory(tlsConfig, hostDir); err != nil {
 			return nil, err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -29,7 +29,7 @@ func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 
 	tlsConfig.InsecureSkipVerify = !isSecure
 
-	if isSecure && CertsDir() != "" {
+	if isSecure {
 		hostDir := HostCertsDir(hostname)
 		log.G(context.TODO()).Debugf("hostDir: %s", hostDir)
 		if err := ReadCertsDirectory(tlsConfig, hostDir); err != nil {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5876
- relates to https://github.com/docker/buildx/pull/3033


### registry: deprecate SetCertsDir

This function had to be called both in the daemon startup, as well as
the CLI startup. Which, in case of the cli, meant that the registry
package became a required dependency for all CLI-plugins.

Make the package itself aware of situations where it's running with
rootlessKit enabled. Altogether we should get rid of this package-level
variable, and instead store this in our configuration, and pass through
where it's used.


### registry: always set a non-empty CertDir

[homedir.GetConfigHome] only returns an error if the value is empty,
so we can check for a non-empty value instead of an error, which also
means that this value would never be empty.

[homedir.GetConfigHome]: https://github.com/moby/moby/blob/b4bdf12daec84caaf809a639f923f7370d4926ad/pkg/homedir/homedir_linux.go#L86-L95


### registry: remove uses of exported HostCertsDir

This function was only used internally, but it still has at least one
external consumer.

### registry: ReadCertsDirectory: don't process same file multiple times

This function needs more cleaning up, because hitting either a ".cert" or
a ".key" file means that we're doing an extra loop over all files to see
if the corresponding file is also present, but let's start with only
processing each file once by using a switch;

https://github.com/moby/moby/blob/b4bdf12daec84caaf809a639f923f7370d4926ad/registry/registry.go#L81
https://github.com/moby/moby/blob/b4bdf12daec84caaf809a639f923f7370d4926ad/registry/registry.go#L94
https://github.com/moby/moby/blob/b4bdf12daec84caaf809a639f923f7370d4926ad/registry/registry.go#L43-L50



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: `registry`: deprecate `SetCertsDir`: the cert-directory is now automatically selected when running with RootlessKit, and should no longer be set manually.
Go SDK: `registry`: deprecate `HostCertsDir`: this function was only used internally and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

