### PR TITLE
client: add API-version dependent validation for mount options

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -3,6 +3,7 @@ package client // import "github.com/docker/docker/client"
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"path"
 	"sort"
@@ -53,6 +54,19 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 		if platform != nil && platform.OS == "linux" && versions.LessThan(cli.ClientVersion(), "1.42") {
 			// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
 			hostConfig.ConsoleSize = [2]uint{0, 0}
+		}
+		if versions.LessThan(cli.ClientVersion(), "1.44") {
+			for _, m := range hostConfig.Mounts {
+				if m.BindOptions != nil {
+					// ReadOnlyNonRecursive can be safely ignored when API < 1.44
+					if m.BindOptions.ReadOnlyForceRecursive {
+						return response, errors.New("bind-recursive=readonly requires API v1.44 or later")
+					}
+					if m.BindOptions.NonRecursive && versions.LessThan(cli.ClientVersion(), "1.40") {
+						return response, errors.New("bind-recursive=disabled requires API v1.40 or later")
+					}
+				}
+			}
 		}
 
 		hostConfig.CapAdd = normalizeCapabilities(hostConfig.CapAdd)

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -37,6 +37,11 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 	if err := validateServiceSpec(service); err != nil {
 		return response, err
 	}
+	if versions.LessThan(cli.version, "1.30") {
+		if err := validateAPIVersion(service, cli.version); err != nil {
+			return response, err
+		}
+	}
 
 	// ensure that the image is tagged
 	var resolveWarning string
@@ -188,6 +193,21 @@ func validateServiceSpec(s swarm.ServiceSpec) error {
 	}
 	if s.TaskTemplate.ContainerSpec != nil && (s.TaskTemplate.Runtime != "" && s.TaskTemplate.Runtime != swarm.RuntimeContainer) {
 		return errors.New("mismatched runtime with container spec")
+	}
+	return nil
+}
+
+func validateAPIVersion(c swarm.ServiceSpec, apiVersion string) error {
+	for _, m := range c.TaskTemplate.ContainerSpec.Mounts {
+		if m.BindOptions != nil {
+			if m.BindOptions.NonRecursive && versions.LessThan(apiVersion, "1.40") {
+				return errors.Errorf("bind-recursive=disabled requires API v1.40 or later")
+			}
+			// ReadOnlyNonRecursive can be safely ignored when API < 1.44
+			if m.BindOptions.ReadOnlyForceRecursive && versions.LessThan(apiVersion, "1.44") {
+				return errors.Errorf("bind-recursive=readonly requires API v1.44 or later")
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4316

[docker/cli@fc6976d] added support for recursive readonly mounts in the CLI, adding a ValidateMountWithAPIVersion utility to verify if options used were supported by the API version.

We usually keep API-version dependent checks in the client, so that docker/cli (and other users of the client) don't have to implement their own validation for these.

This patch moves the functionality of ValidateMountWithAPIVersion to the client.

Once the docker/cli vendoring was updated, we can remove the utility there.

[docker/cli@fc6976d]: https://github.com/docker/cli/commit/fc6976db45e24cc2baff50d806402ae2a8468a13

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

