### PR TITLE
integration/container: Deflake TestWaitBlocked and TestWaitRestartedContainer

### DIFF
--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -210,7 +210,7 @@ func TestWaitRestartedContainer(t *testing.T) {
 			// Container is running now, wait for exit
 			waitResC, errC := cli.ContainerWait(ctx, containerID, tc.waitCond)
 
-			timeout := 5
+			timeout := 10
 			// On Windows it will always timeout, because our process won't receive SIGTERM
 			// Skip to force killing immediately
 			if isWindowDaemon {

--- a/integration/container/wait_test.go
+++ b/integration/container/wait_test.go
@@ -80,7 +80,8 @@ func TestWaitBlocked(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			t.Parallel()
+			// TODO(vvoland): Verify why this helps for flakiness
+			// t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			containerID := container.Run(ctx, t, cli, container.WithCmd("sh", "-c", tc.cmd))
 			waitResC, errC := cli.ContainerWait(ctx, containerID, "")
@@ -129,7 +130,8 @@ func TestWaitConditions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			t.Parallel()
+			// TODO(vvoland): Verify why this helps for flakiness
+			// t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			opts := append([]func(*container.TestContainerConfig){
 				container.WithCmd("sh", "-c", "read -r; exit 99"),
@@ -200,7 +202,8 @@ func TestWaitRestartedContainer(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			t.Parallel()
+			// TODO(vvoland): Verify why this helps for flakiness
+			// t.Parallel()
 			ctx := testutil.StartSpan(ctx, t)
 			containerID := container.Run(ctx, t, cli,
 				container.WithCmd("sh", "-c", "trap 'exit 5' SIGTERM; while true; do sleep 0.1; done"),


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/49595
- fix: https://github.com/moby/moby/issues/48983

Remove Parallel execution and increase stop timeout seems to help.

