### PR TITLE
pkg/atomicwriter: fix tempfiles cleanup, improve tests, and validate destination path

### DIFF
--- a/pkg/atomicwriter/atomicwriter_test.go
+++ b/pkg/atomicwriter/atomicwriter_test.go
@@ -93,8 +93,14 @@ func TestNew(t *testing.T) {
 						t.Errorf("Unexpected file name for temp-file: %s", tmpFileName)
 					}
 
+					// Closing the writer without writing should clean up the temp-file,
+					// and should not replace the destination file.
 					if err = writer.Close(); err != nil {
 						t.Errorf("Error closing writer: %v", err)
+					}
+					assertFileCount(t, actualParentDir, origFileCount)
+					if tc == "existing-file" {
+						assertFile(t, fileName, []byte("original content"), testMode())
 					}
 				})
 			}

--- a/pkg/atomicwriter/atomicwriter_test.go
+++ b/pkg/atomicwriter/atomicwriter_test.go
@@ -120,9 +120,40 @@ func TestNewInvalid(t *testing.T) {
 			t.Errorf("Should produce a 'not found' error, but got %[1]T (%[1]v)", err)
 		}
 	})
+	t.Run("empty filename", func(t *testing.T) {
+		writer, err := New("", testMode())
+		if writer != nil {
+			t.Errorf("Should not have created writer")
+		}
+		if err == nil || err.Error() != "file name is empty" {
+			t.Errorf("Should produce a 'file name is empty' error, but got %[1]T (%[1]v)", err)
+		}
+	})
+	t.Run("directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		writer, err := New(tmpDir, testMode())
+		if writer != nil {
+			t.Errorf("Should not have created writer")
+		}
+		if err == nil || err.Error() != "cannot write to a directory" {
+			t.Errorf("Should produce a 'cannot write to a directory' error, but got %[1]T (%[1]v)", err)
+		}
+	})
 }
 
 func TestWriteFile(t *testing.T) {
+	t.Run("empty filename", func(t *testing.T) {
+		err := WriteFile("", nil, testMode())
+		if err == nil || err.Error() != "file name is empty" {
+			t.Errorf("Should produce a 'file name is empty' error, but got %[1]T (%[1]v)", err)
+		}
+	})
+	t.Run("write to directory", func(t *testing.T) {
+		err := WriteFile(t.TempDir(), nil, testMode())
+		if err == nil || err.Error() != "cannot write to a directory" {
+			t.Errorf("Should produce a 'cannot write to a directory' error, but got %[1]T (%[1]v)", err)
+		}
+	})
 	t.Run("write to file", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		fileName := filepath.Join(tmpDir, "test.txt")


### PR DESCRIPTION
### pkg/atomicwriter: some cleanups in tests

- rename tests to match the function tested
- remove init func in favor or a test-helper
- rename some vars to prevent shadowing
- update example values to be more descriptive
- add a utility for asserting file content and mode

### pkg/atomicwriter: add separate tests for New()

We were testing this function implicitly through `TestWriteFile`, but
not verifying the behavior of `New` in isolation. Add separate tests
for this function.

### pkg/atomicwriter: don't overwrite destination on close without write

Creating a writer (`atomicwriter.New()`) and closing it without a write
ever happening, would replace the destination file with an empty file.

This patch adds a check whether a write was performed (either successful
or unsuccessful); if no write happened, we cleanup the tempfile without
replacing the destination file.

### pkg/atomicwriter: add additional test-cases

- test errors returned for non-existing destination
- test that files are cleaned up after
- test writing to a symlinked file (to be fixed)

### pkg/atomicwrite: validate destination path

- Disallow empty filenames
- Don't allow writing to a directory
- Return early if parent dir doesn't exist
- TBD: do we want to allow symlinks to be followed, or disallow?

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

