### PR TITLE
builder-next: fix min-free-space prune with graphdriver backend

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -303,6 +303,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 		LeaseManager:    lm,
 		ContentStore:    store,
 		GarbageCollect:  mdb.GarbageCollect,
+		Root:            root,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes https://github.com/moby/buildkit/issues/5821

Containerd backend worked already and doesn't need update.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix possible error on `docker buildx prune` with `--min-free-space`
```

**- A picture of a cute animal (not mandatory but encouraged)**

