### PR TITLE
daemon: Fix panic on Windows when restoring pre v28 container

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -81,7 +81,9 @@ func (daemon *Daemon) load(id string) (*container.Container, error) {
 	if ctr.ImagePlatform.Architecture == "" {
 		migration := daemonPlatformReader{
 			imageService: daemon.imageService,
-			content:      daemon.containerdClient.ContentStore(),
+		}
+		if daemon.containerdClient != nil {
+			migration.content = daemon.containerdClient.ContentStore()
 		}
 		migrateContainerOS(context.TODO(), migration, ctr)
 	}

--- a/daemon/migration.go
+++ b/daemon/migration.go
@@ -104,6 +104,9 @@ func (r daemonPlatformReader) ReadPlatformFromConfigByImageManifest(
 	ctx context.Context,
 	desc ocispec.Descriptor,
 ) (ocispec.Platform, error) {
+	if r.content == nil {
+		return ocispec.Platform{}, errors.New("not an containerd image store")
+	}
 	b, err := content.ReadBlob(ctx, r.content, desc)
 	if err != nil {
 		return ocispec.Platform{}, err


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/49625

The container platform migration tries to deduce the platform data from the containerd content store if it's available.

However, on Windows we currently default to a non-containerd runtime setup, so the containerd client is nil and accessing its content store paniced:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x11b48e4]

goroutine 87 [running]:
github.com/containerd/containerd/v2/client.(*Client).ContentStore(0xc0003a0008?)
	/go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/v2/client/client.go:645 +0x24
github.com/docker/docker/daemon.(*Daemon).load(0xc00026e488, {0xc000c13d40, 0x40})
	/go/src/github.com/docker/docker/daemon/container.go:84 +0x289
github.com/docker/docker/daemon.(*Daemon).restore.func1({0xc000c13d40, 0x40})
	/go/src/github.com/docker/docker/daemon/daemon.go:236 +0x207
created by github.com/docker/docker/daemon.(*Daemon).restore in goroutine 1
	/go/src/github.com/docker/docker/daemon/daemon.go:229 +0x1a7
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x11b48e4]

goroutine 90 [running]:
github.com/containerd/containerd/v2/client.(*Client).ContentStore(0xc000313608?)
	/go/src/github.com/docker/docker/vendor/github.com/containerd/containerd/v2/client/client.go:645 +0x24
github.com/docker/docker/daemon.(*Daemon).load(0xc00026e488, {0xc000c13e00, 0x40})
	/go/src/github.com/docker/docker/daemon/container.go:84 +0x289
github.com/docker/docker/daemon.(*Daemon).restore.func1({0xc000c13e00, 0x40})
	/go/src/github.com/docker/docker/daemon/daemon.go:236 +0x207
created by github.com/docker/docker/daemon.(*Daemon).restore in goroutine 1
	/go/src/github.com/docker/docker/daemon/daemon.go:229 +0x1a7
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x11b48e4]
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix the daemon failing to start on Windows when a container created before v28.0.0 was present.
```

**- A picture of a cute animal (not mandatory but encouraged)**

