### PR TITLE
container/wait: Fix early return for containers in Created state

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -234,6 +234,11 @@ func (s *State) Wait(ctx context.Context, condition WaitCondition) <-chan StateS
 }
 
 func (s *State) conditionAlreadyMet(condition WaitCondition) bool {
+	// If the container is in the "created" state, it hasn't had any chance to
+	// run yet, so no state change was possible yet.
+	if s.StartedAt.IsZero() {
+		return false
+	}
 	switch condition {
 	case WaitConditionNotRunning:
 		return !s.Running

--- a/container/state_test.go
+++ b/container/state_test.go
@@ -53,10 +53,13 @@ func TestStateRunStop(t *testing.T) {
 		// shouldn't take more than 50 milliseconds.
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
-		// Expectx exit code to be i-1 since it should be the exit
-		// code from the previous loop or 0 for the created state.
-		if status := <-s.Wait(ctx, WaitConditionNotRunning); status.ExitCode() != i-1 {
-			t.Fatalf("ExitCode %v, expected %v, err %q", status.ExitCode(), i-1, status.Err())
+
+		if i != 1 {
+			// Expectx exit code to be i-1 since it should be the exit
+			// code from the previous loop or 0 for the created state.
+			if status := <-s.Wait(ctx, WaitConditionNotRunning); status.ExitCode() != i-1 {
+				t.Fatalf("ExitCode %v, expected %v, err %q", status.ExitCode(), i-1, status.Err())
+			}
 		}
 
 		// A wait with WaitConditionNextExit should block until the


### PR DESCRIPTION
Fixed an issue where `Wait` would incorrectly return immediately when called on a container in "created" state with `WaitConditionNotRunning`. The root cause was that the function checking if the condition was already met didn't properly handle the special case of containers that haven't started yet.

When a container is in "created" state, it hasn't had any chance to run, so no state change was possible yet. Even though the container is technically "not running", we shouldn't consider the wait condition as already met, as the container might still start and run in the future.

The fix adds a check for `StartedAt.IsZero()` which indicates a container that hasn't started yet, ensuring that we properly wait for these containers rather than returning immediately.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

