### PR TITLE
Only restore the default bridge on live-restore startup

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -929,6 +929,7 @@ func driverOptions(config *config.Config) nwconfig.Option {
 			"EnableUserlandProxy":      config.BridgeConfig.EnableUserlandProxy,
 			"UserlandProxyPath":        config.BridgeConfig.UserlandProxyPath,
 			"Rootless":                 config.Rootless,
+			"RestoreDefaultBridge":     config.LiveRestoreEnabled,
 		},
 	})
 }

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -62,6 +62,7 @@ type configuration struct {
 	EnableUserlandProxy      bool
 	UserlandProxyPath        string
 	Rootless                 bool
+	RestoreDefaultBridge     bool
 }
 
 // networkConfiguration for network specific configuration
@@ -994,7 +995,9 @@ func (d *driver) deleteNetwork(nid string) error {
 		// case whatever caused the failure can be fixed for a future daemon restart). But,
 		// it's not in d.networks. To prevent the driver's state from getting out of step
 		// with its parent, make sure it's not in the store before reporting that it does
-		// not exist.
+		// not exist. This also deletes the default bridge network when it's re-created
+		// on non-live-restore daemon startup (the default bridge is not restored from the
+		// store on startup, apart from on live-restore).
 		if err := d.storeDelete(&networkConfiguration{ID: nid}); err != nil && err != datastore.ErrKeyNotFound {
 			log.G(context.TODO()).WithFields(log.Fields{
 				"error":   err,

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -51,6 +51,10 @@ func (d *driver) populateNetworks() error {
 
 	for _, kvo := range kvol {
 		ncfg := kvo.(*networkConfiguration)
+		if ncfg.DefaultBridge && !d.config.RestoreDefaultBridge {
+			log.G(context.TODO()).Info("Not restoring default bridge network, it will be re-created")
+			continue
+		}
 		if err = d.createNetwork(ncfg); err != nil {
 			log.G(context.TODO()).Warnf("could not create bridge network for id %s bridge name %s while booting up from persistent state: %v", ncfg.ID, ncfg.BridgeName, err)
 		}


### PR DESCRIPTION
**- What I did**

When live-restore is not enabled, the default bridge network is restored from the store during bridge driver init, then it's deleted and re-created (in case daemon options have changed and it needs to be configured differently).

That's unnecessary - on a non-live-restore startup, don't restore the default bridge network, just create it with current config.

I've not been able to repro, but this change seems likely to remove the race with whatever's causing the issue in ...
- fix https://github.com/moby/moby/issues/49596

**- How I did it**

Tell the bridge driver not to restore the default bridge on startup, unless live-restore is enabled.

**- How to verify it**

Existing tests, including `TestDaemonRestartKillContainers`.

Killing the daemon while a container is connected to the default network still results in the container getting cleaned up on restart (including its veth, and its iptables rules get flushed anyway). Before and after this change the following is logged in this case, it's not a problem but could be tidied up ...

```
WARN[2025-03-11T12:27:25.755913460Z] Failed deleting service host entries to the running container: open : no such file or directory
WARN[2025-03-11T12:27:25.755959002Z] Error (Unable to complete atomic operation, key modified) deleting object [endpoint ee04b29344372e8d9215d2d5f47cf6b45c8db615699fd39f4095409f24e42806 fd60babf35a22f2a4f6b1d23ad8d2b1482abb1ea5b783d0ba8c07dea2026e748], retrying....
DEBU[2025-03-11T12:27:25.757100335Z] Releasing addresses for endpoint zen_varahamihira's interface on network bridge
```

Daemon startup time with only the default bridge network is improved by a very unscientific ~10%.

**- Human readable description for the release notes**
```markdown changelog
- don't restore the default bridge on startup when it will be re-created anyway.
```
