### PR TITLE
Combine bridge firewalld reload calls

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -939,9 +939,10 @@ func (d *driver) createNetwork(config *networkConfiguration) (err error) {
 
 		// We want to track firewalld configuration so that
 		// if it is started/reloaded, the rules can be applied correctly
-		{config.EnableIPv4 && d.config.EnableIPTables, network.setupFirewalld},
-		// same for IPv6
-		{config.EnableIPv6 && d.config.EnableIP6Tables, network.setupFirewalld6},
+		{
+			(config.EnableIPv4 && d.config.EnableIPTables) || (config.EnableIPv6 && d.config.EnableIP6Tables),
+			network.setupFirewalld,
+		},
 
 		// Setup DefaultGatewayIPv4
 		{config.DefaultGatewayIPv4 != nil, setupGatewayIPv4},

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -962,15 +962,7 @@ func rawRulesDisabled(ctx context.Context) bool {
 	return false
 }
 
-func (n *bridgeNetwork) reapplyPerPortIptables4() {
-	n.reapplyPerPortIptables(func(b portBinding) bool { return b.IP.To4() != nil })
-}
-
-func (n *bridgeNetwork) reapplyPerPortIptables6() {
-	n.reapplyPerPortIptables(func(b portBinding) bool { return b.IP.To4() == nil })
-}
-
-func (n *bridgeNetwork) reapplyPerPortIptables(needsReconfig func(portBinding) bool) {
+func (n *bridgeNetwork) reapplyPerPortIptables() {
 	n.Lock()
 	var allPBs []portBinding
 	for _, ep := range n.endpoints {
@@ -979,10 +971,8 @@ func (n *bridgeNetwork) reapplyPerPortIptables(needsReconfig func(portBinding) b
 	n.Unlock()
 
 	for _, b := range allPBs {
-		if needsReconfig(b) {
-			if err := n.setPerPortIptables(context.Background(), b, true); err != nil {
-				log.G(context.TODO()).Warnf("Failed to reconfigure iptables on firewalld reload %s: %s", b, err)
-			}
+		if err := n.setPerPortIptables(context.Background(), b, true); err != nil {
+			log.G(context.TODO()).Warnf("Failed to reconfigure iptables on firewalld reload %s: %s", b, err)
 		}
 	}
 }

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux.go
@@ -192,16 +192,6 @@ func setupIPChains(config configuration, version iptables.IPVersion) (retErr err
 }
 
 func (n *bridgeNetwork) setupIP4Tables(config *networkConfiguration, i *bridgeInterface) error {
-	d := n.driver
-	d.Lock()
-	driverConfig := d.config
-	d.Unlock()
-
-	// Sanity check.
-	if !driverConfig.EnableIPTables {
-		return errors.New("Cannot program chains, EnableIPTable is disabled")
-	}
-
 	maskedAddrv4 := &net.IPNet{
 		IP:   i.bridgeIPv4.IP.Mask(i.bridgeIPv4.Mask),
 		Mask: i.bridgeIPv4.Mask,
@@ -210,21 +200,10 @@ func (n *bridgeNetwork) setupIP4Tables(config *networkConfiguration, i *bridgeIn
 }
 
 func (n *bridgeNetwork) setupIP6Tables(config *networkConfiguration, i *bridgeInterface) error {
-	d := n.driver
-	d.Lock()
-	driverConfig := d.config
-	d.Unlock()
-
-	// Sanity check.
-	if !driverConfig.EnableIP6Tables {
-		return errors.New("Cannot program chains, EnableIP6Tables is disabled")
-	}
-
 	maskedAddrv6 := &net.IPNet{
 		IP:   i.bridgeIPv6.IP.Mask(i.bridgeIPv6.Mask),
 		Mask: i.bridgeIPv6.Mask,
 	}
-
 	return n.setupIPTables(iptables.IPv6, maskedAddrv6, config, i)
 }
 


### PR DESCRIPTION
**- What I did**

Simplify firewalld reload handling for per-network rules by combining IPv4/IPv6 handling, and removing unnecessary checks.

This is a very small first-step towards:
- https://github.com/moby/moby/issues/49635

(So, it can go into 28.0.2, if it's merged we want to merge from master to 28.x rather than cherry-pick. But, it's not needed for 28.0.2 so I've not used that milestone for now.)

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

