### PR TITLE
Dockerfile: update containerd binary to v1.7.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.7.26
+ARG CONTAINERD_VERSION=v1.7.27
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -164,7 +164,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 ARG GO_VERSION=1.23.7
 ARG GOTESTSUM_VERSION=v1.12.0
 ARG GOWINRES_VERSION=v0.3.1
-ARG CONTAINERD_VERSION=v1.7.26
+ARG CONTAINERD_VERSION=v1.7.27
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.7.26}"
+: "${CONTAINERD_VERSION:=v1.7.27}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
**- What I did**

* full diff: https://github.com/containerd/containerd/compare/v1.7.26...v1.7.27
* release notes: https://github.com/containerd/containerd/releases/tag/v1.7.27

Welcome to the v1.7.27 release of containerd!

The twenty-seventh patch release for containerd 1.7 contains various fixes
and updates.

Highlights
Fix integer overflow in User ID handling ([GHSA-265r-hfxg-fhmg](https://github.com/containerd/containerd/security/advisories/GHSA-265r-hfxg-fhmg))
Update image type checks to avoid unnecessary logs for attestations (https://github.com/containerd/containerd/pull/11538)

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update containerd (static binaries only) to [v1.7.27](https://www.github.com/containerd/containerd/releases/tag/v1.7.27)
```

**- A picture of a cute animal (not mandatory but encouraged)**

