### PR TITLE
daemon: return port-mappings from all endpoints

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -785,14 +785,6 @@ func updateJoinInfo(networkSettings *network.Settings, n *libnetwork.Network, ep
 		return errors.New("invalid network settings while building port map info")
 	}
 
-	if len(networkSettings.Ports) == 0 {
-		pm, err := getEndpointPortMapInfo(ep)
-		if err != nil {
-			return err
-		}
-		networkSettings.Ports = pm
-	}
-
 	epInfo := ep.Info()
 	if epInfo == nil {
 		// It is not an error to get an empty endpoint info


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/issues/49654

**- What I did**

First two commits are small refactorings.

The third commit addresses the issue described in #49654.

**daemon: remove redundant call to getEndpointPortMapInfo**

**daemon: getEndpointPortMapInfo: err is never used**

**daemon: return port-mappings from all endpoints**

With improved IPv6 support, a dual-stack container can map a port using two different networks -- one IPv4-only, the other IPv6-only.

The daemon was updating containers' `EndpointSettings.Ports` by looking for the first network providing port-mappings. This was incorrect.

Instead, iterate over the whole list of endpoints, and merge everything together.

The function doing that, ie. `getEndpointPortMapInfo`, is also considered exposed ports, and nil the PortMap entry if an exposed port is found. However, exposed ports are always set on a bridge network, so this was erasing port-mappings found for other networks. Instead, do not consider exposed ports unless the current network is the default bridge.

**- How to verify it**

A new integration test is added.

**- Human readable description for the release notes**

```markdown changelog
Fix a bug causing `docker ps` to inconsistently report dual-stack port mappings
```

