### PR TITLE
Bridge: factor out creation of network-level iptables rules

### DIFF
--- a/libnetwork/drivers/bridge/setup_firewalld.go
+++ b/libnetwork/drivers/bridge/setup_firewalld.go
@@ -9,12 +9,7 @@ import (
 func (n *bridgeNetwork) setupFirewalld(config *networkConfiguration, i *bridgeInterface) error {
 	// FIXME(robmry) - these reload functions aren't deleted when the network is deleted.
 	//  So, a firewalld reload leads to creation of zombie rules belonging to those networks.
-	if n.driver.config.EnableIPTables && config.EnableIPv4 {
-		iptables.OnReloaded(func() { n.setupIP4Tables(config, i) })
-	}
-	if n.driver.config.EnableIP6Tables && config.EnableIPv6 {
-		iptables.OnReloaded(func() { n.setupIP6Tables(config, i) })
-	}
+	iptables.OnReloaded(func() { n.iptablesNetwork.reapplyNetworkLevelRules() })
 	iptables.OnReloaded(n.reapplyPerPortIptables)
 	return nil
 }

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -170,19 +170,13 @@ func assertChainConfig(d *driver, t *testing.T) {
 func assertBridgeConfig(config *networkConfiguration, br *bridgeInterface, d *driver, t *testing.T) {
 	nw := bridgeNetwork{
 		config: config,
+		driver: d,
+		bridge: br,
 	}
-	nw.driver = d
 
-	// Attempt programming of ip tables.
-	err := nw.setupIP4Tables(config, br)
-	if err != nil {
-		t.Fatalf("%v", err)
-	}
-	if d.config.EnableIP6Tables {
-		if err := nw.setupIP6Tables(config, br); err != nil {
-			t.Fatalf("%v", err)
-		}
-	}
+	fwn, err := nw.newIptablesNetwork()
+	assert.NilError(t, err)
+	assert.Check(t, fwn != nil, "no firewaller network")
 }
 
 // Regression test for https://github.com/moby/moby/issues/46445


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49635

Create an iptablesNetwork containing all the info needed to set up per-network iptables rules, give it methods to do create the rules, and use it instead of per-rule-type calls from driver.createNetwork().

(Milestone 28.1.0, because it doesn't need to go in a patch release - but, it can do if the next patch release is merged from master.)

**- How I did it**

All in-place at the moment, to make the changes reviewable ... but `iptablesNetwork` will end up in its own package after a couple more PRs. (So, elements of structs like `networkConfig` don't need to be exported here - but, bear with me!)

**- How to verify it**

Existing tests - no functional change.

**- Human readable description for the release notes**
```markdown changelog

```

