### PR TITLE
integration-cli: minor fixes

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -91,8 +91,8 @@ func (s *DockerAPISuite) TestPostContainersAttachContainerNotFound(c *testing.T)
 func (s *DockerAPISuite) TestGetContainersWsAttachContainerNotFound(c *testing.T) {
 	ctx := testutil.GetContext(c)
 	res, body, err := request.Get(ctx, "/containers/doesnotexist/attach/ws")
-	assert.Equal(c, res.StatusCode, http.StatusNotFound)
 	assert.NilError(c, err)
+	assert.Equal(c, res.StatusCode, http.StatusNotFound)
 	b, err := request.ReadBody(body)
 	assert.NilError(c, err)
 	expected := "No such container: doesnotexist"
@@ -207,7 +207,7 @@ func (s *DockerAPISuite) TestPostContainersAttach(c *testing.T) {
 	assert.NilError(c, err)
 
 	defer resp.Conn.Close()
-	resp.Conn.SetReadDeadline(time.Now().Add(time.Second))
+	assert.NilError(c, resp.Conn.SetReadDeadline(time.Now().Add(time.Second)))
 
 	_, err = resp.Conn.Write([]byte("success"))
 	assert.NilError(c, err)

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -122,7 +122,6 @@ RUN echo 'right'
 	assert.NilError(c, err)
 	assert.Equal(c, res.StatusCode, http.StatusOK)
 
-	defer body.Close()
 	content, err := request.ReadBody(body)
 	assert.NilError(c, err)
 

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -59,7 +59,6 @@ func (s *DockerAPISuite) TestAPIClientVersionOldNotSupported(c *testing.T) {
 
 	resp, body, err := request.Get(testutil.GetContext(c), "/v"+version+"/version")
 	assert.NilError(c, err)
-	defer body.Close()
 	assert.Equal(c, resp.StatusCode, http.StatusBadRequest)
 	expected := fmt.Sprintf("client version %s is too old. Minimum supported API version is %s, please upgrade your client to a newer version", version, testEnv.DaemonVersion.MinAPIVersion)
 	b, err := request.ReadBody(body)


### PR DESCRIPTION
### integration-cli: fix some unhandled errors

### integration-cli: fix duplicate close of body

request.ReadBody already closes the body;

    time="2025-03-20T19:08:25Z" level=error msg="subsequent attempt to close ReadCloserWrapper"


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

