### PR TITLE
Run systemd/rootless when systemd/rootless unit testing

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -83,9 +83,19 @@ jobs:
         name: Prepare
         run: |
           CACHE_DEV_SCOPE=dev
+          if [[ "${{ matrix.mode }}" == *"rootless"* ]]; then
+            # In rootless mode, tests will run in the host's namspace not the rootlesskit
+            # namespace. So, probably no different to non-rootless unit tests and can be
+            # removed from the test matrix.
+            echo "DOCKER_ROOTLESS=1" >> $GITHUB_ENV
+          fi
           if [[ "${{ matrix.mode }}" == *"firewalld"* ]]; then
             echo "DOCKER_FIREWALLD=true" >> $GITHUB_ENV
             CACHE_DEV_SCOPE="${CACHE_DEV_SCOPE}firewalld"
+          fi
+          if [[ "${{ matrix.mode }}" == *"systemd"* ]]; then
+            echo "SYSTEMD=true" >> $GITHUB_ENV
+            CACHE_DEV_SCOPE="${CACHE_DEV_SCOPE}systemd"
           fi
           echo "CACHE_DEV_SCOPE=${CACHE_DEV_SCOPE}" >> $GITHUB_ENV
       -

--- a/hack/dind
+++ b/hack/dind
@@ -52,6 +52,8 @@ if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
 fi
 
 # Mount /tmp (conditionally)
+# /tmp must be 'exec,rw', and 'dev' to allow mknod to work for the
+# pkg/archive/archive_linux_test.go tests.
 if ! mountpoint -q /tmp; then
 	mount -t tmpfs none /tmp
 fi

--- a/hack/dind-systemd
+++ b/hack/dind-systemd
@@ -19,6 +19,13 @@ if [ ! -t 0 ]; then
 	exit 1
 fi
 
+# Mount /tmp (conditionally)
+# /tmp must be 'exec,rw', and 'dev' (defaults) to allow mknod to work for the
+# pkg/archive/archive_linux_test.go tests.
+if ! mountpoint -q /tmp; then
+	mount -t tmpfs none /tmp
+fi
+
 # Change mount propagation to shared, which SystemD PID 1 would normally do
 # itself when started by the kernel. SystemD skips that when it detects it is
 # running in a container.


### PR DESCRIPTION
**- What I did**

- https://github.com/moby/moby/pull/49659
  - Spotted the firewalld tests weren't enabling firewalld, and started fixing that
  - A unit test failed with firewalld enabled, which was a clue that systemd wasn't enabled for its own tests
  - Rootless was in the same position - unit tests in rootless mode don't seem useful, but that can be dealt with separately.

#### Run systemd/rootless when systemd/rootless unit testing

**- What Pawel did**

#### hack: Fix TestOverlay* test failure in pkg/archive
The pkg/archive/archive_linux_test.go tests create a test archive content in a temporary directory. This also includes device nodes (using mknod).

Running these tests in Docker-in-Docker (dind) with systemd was failing with "operation not permitted" because the rootfs is remounted with `nodev`.

This change aligns `hack/dind-systemd` with `hack/dind` by conditionally mounting a `tmpfs` on `/tmp` (with dev enabled), to make the mknod work.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

