### PR TITLE
containerd: prioritize non-dangling images with image list

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -130,11 +130,13 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 		}
 
 		dgst := img.Target.Digest
-		uniqueImages[dgst] = img
-
 		if isDangling {
+			if _, ok := uniqueImages[dgst]; !ok {
+				uniqueImages[dgst] = img
+			}
 			continue
 		}
+		uniqueImages[dgst] = img
 
 		ref, err := reference.ParseNormalizedNamed(img.Name)
 		if err != nil {


### PR DESCRIPTION

When listing images, prioritize the tagged version. When computing the
unique images, the last returned image would be used as a base and repo
tags would be merged into it.

This makes it so `RepoDigests` has the correct value when there is both
a dangling and non-dangling version of the same image.
