### PR TITLE
Dockerfile: verify the git tags with the hashes

### DIFF
--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,13 +15,31 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.7.27}"
+: "${CONTAINERD_VERSION:=v1.7.27@05044ec0a9a75232cad458027ca83437aae3f4da}"
+
+git_checkout_tag_with_hash() {
+	TAG="$(echo "$1" | cut -d@ -f1)"
+	HASH=""
+	case "$1" in
+		*@*)
+			HASH="$(echo "$1" | cut -d@ -f2)"
+			;;
+	esac
+	git checkout "$TAG"
+	HEAD="$(git rev-parse HEAD)"
+	if [ -z "$HASH" ]; then
+		echo >&2 "WARNING: ${TAG}: commit hash was not specified (got ${HEAD})"
+	elif [ "$HEAD" != "$HASH" ]; then
+		echo >&2 "ERROR: ${TAG}: expected ${HASH}, got ${HEAD}"
+		exit 1
+	fi
+}
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"
 	git clone https://github.com/containerd/containerd.git "$GOPATH/src/github.com/containerd/containerd"
 	cd "$GOPATH/src/github.com/containerd/containerd"
-	git checkout -q "$CONTAINERD_VERSION"
+	git_checkout_tag_with_hash "$CONTAINERD_VERSION"
 
 	export BUILDTAGS='netgo osusergo static_build'
 	export EXTRA_FLAGS=${GO_BUILDMODE}

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -2,6 +2,8 @@
 
 : ${DOCKERCLI_CHANNEL:=stable}
 : ${DOCKERCLI_VERSION:=18.06.3-ce}
+# TODO: verify the hashes of the binaries and the git repo
+# (although dockercli installed in thie script is used only for running tests)
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update vendor.mod and Dockerfile accordingly.
-: "${ROOTLESSKIT_VERSION:=v2.3.4}"
+: "${ROOTLESSKIT_VERSION:=v2.3.4@59a459df858d39ad5f4eafa305545907bf0c48ab}"
 
 install_rootlesskit() {
 	case "$1" in
@@ -27,5 +27,6 @@ install_rootlesskit_dynamic() {
 
 _install_rootlesskit() (
 	echo "Install rootlesskit version ${ROOTLESSKIT_VERSION}"
-	GOBIN="${PREFIX}" GO111MODULE=on go install ${BUILD_MODE} -ldflags="$ROOTLESSKIT_LDFLAGS" "github.com/rootless-containers/rootlesskit/v2/cmd/rootlesskit@${ROOTLESSKIT_VERSION}"
+	COMMIT="$(echo "${ROOTLESSKIT_VERSION}" | cut -d@ -f2)"
+	GOBIN="${PREFIX}" GO111MODULE=on go install ${BUILD_MODE} -ldflags="$ROOTLESSKIT_LDFLAGS" "github.com/rootless-containers/rootlesskit/v2/cmd/rootlesskit@${COMMIT}"
 )

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,25 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.2.6}"
+: "${RUNC_VERSION:=v1.2.6@e89a29929c775025419ab0d218a43588b4c12b9a}"
+
+git_checkout_tag_with_hash() {
+	TAG="$(echo "$1" | cut -d@ -f1)"
+	HASH=""
+	case "$1" in
+		*@*)
+			HASH="$(echo "$1" | cut -d@ -f2)"
+			;;
+	esac
+	git checkout "$TAG"
+	HEAD="$(git rev-parse HEAD)"
+	if [ -z "$HASH" ]; then
+		echo >&2 "WARNING: ${TAG}: commit hash was not specified (got ${HEAD})"
+	elif [ "$HEAD" != "$HASH" ]; then
+		echo >&2 "ERROR: ${TAG}: expected ${HASH}, got ${HEAD}"
+		exit 1
+	fi
+}
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"
@@ -17,7 +35,7 @@ install_runc() {
 	echo "Install runc version $RUNC_VERSION (build tags: $RUNC_BUILDTAGS)"
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
-	git checkout -q "$RUNC_VERSION"
+	git_checkout_tag_with_hash "$RUNC_VERSION"
 	if [ -z "$1" ]; then
 		target=static
 	else

--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -3,13 +3,31 @@
 # TINI_VERSION specifies the version of tini (docker-init) to build, and install
 # from the https://github.com/krallin/tini repository. This binary is used
 # when starting containers with the `--init` option.
-: "${TINI_VERSION:=v0.19.0}"
+: "${TINI_VERSION:=v0.19.0@de40ad007797e0dcd8b7126f27bb87401d224240}"
+
+git_checkout_tag_with_hash() {
+	TAG="$(echo "$1" | cut -d@ -f1)"
+	HASH=""
+	case "$1" in
+		*@*)
+			HASH="$(echo "$1" | cut -d@ -f2)"
+			;;
+	esac
+	git checkout "$TAG"
+	HEAD="$(git rev-parse HEAD)"
+	if [ -z "$HASH" ]; then
+		echo >&2 "WARNING: ${TAG}: commit hash was not specified (got ${HEAD})"
+	elif [ "$HEAD" != "$HASH" ]; then
+		echo >&2 "ERROR: ${TAG}: expected ${HASH}, got ${HEAD}"
+		exit 1
+	fi
+}
 
 install_tini() {
 	echo "Install tini version $TINI_VERSION"
 	git clone https://github.com/krallin/tini.git "$GOPATH/tini"
 	cd "$GOPATH/tini"
-	git checkout -q "$TINI_VERSION"
+	git_checkout_tag_with_hash "$TINI_VERSION"
 	cmake .
 	make tini-static
 	mkdir -p "${PREFIX}"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Verify the tags of containerd*, runc, tini, and rootlesskit with their commit hashes for tolerance to compromise of the tags.

These binaries are depeneded by docker-ce-packaging here: https://github.com/docker/docker-ce-packaging/blob/7e726fa319c261676d06b6ae10c04a3df80e4c48/static/Makefile#L43-L58

**- How I did it**

Used https://github.com/containerd/nerdctl/blob/v2.0.4/hack/git-checkout-tag-with-hash.sh

**- How to verify it**

Build `Dockerfile` and `Dockerfile.simple`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

