### PR TITLE
Dockerfile.simple: avoid `Could not find installer for "proxy"`

### DIFF
--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -35,10 +35,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		vim-common \
 	&& rm -rf /var/lib/apt/lists/*
 
-# Install runc, containerd, tini and docker-proxy
+# Install runc, containerd, and tini
 # Please edit hack/dockerfile/install/<name>.installer to update them.
 COPY hack/dockerfile/install hack/dockerfile/install
-RUN for i in runc containerd tini proxy dockercli; \
+RUN set -e; for i in runc containerd tini dockercli; \
 		do hack/dockerfile/install/install.sh $i; \
 	done
 ENV PATH=/usr/local/cli:$PATH


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Avoid `Could not find installer for "proxy"` error.

`Could not find installer for "proxy"` error had been ignored due to lack of `set -e`

**- How I did it**

Removed `proxy` and added `set -e`

**- How to verify it**

Build `Dockerfile.simple`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

