### PR TITLE
integration-cli: Update default CLI version to v23.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
 
 # cli version used for integration-cli tests
 ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
-ARG DOCKERCLI_INTEGRATION_VERSION=v17.06.2-ce
+ARG DOCKERCLI_INTEGRATION_VERSION=v23.0.15
 # BUILDX_VERSION is the version of buildx to install in the dev container.
 ARG BUILDX_VERSION=0.20.1
 ARG COMPOSE_VERSION=v2.33.1

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 : ${DOCKERCLI_CHANNEL:=stable}
-: ${DOCKERCLI_VERSION:=17.06.2-ce}
+: ${DOCKERCLI_VERSION:=23.0.15}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6247,7 +6247,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 						"--since", before.Format(time.RFC3339),
 					),
 					cli.WithTimeout(time.Millisecond*300),
-					cli.WithEnvironmentVariables("DOCKER_API_VERSION=v1.46"), // FIXME(thaJeztah): integration-cli runs docker CLI 17.06; we're "upgrading" the API version to a version it doesn't support here ;)
+					cli.WithEnvironmentVariables("DOCKER_API_VERSION=v1.46"), // FIXME(thaJeztah): integration-cli runs docker CLI 23.0; we're "upgrading" the API version to a version it doesn't support here ;)
 				)
 
 				stdout := cmd.Stdout()


### PR DESCRIPTION
- alternative to: https://github.com/moby/moby/pull/49677

This updates the Docker CLI version used for integration-cli tests from v17.06.2-ce to v23.0.15.

v17 is long EOL and nobody _should_ use it in 2025.

Switch the CLI version used in the deprecated integration-cli test suite to use a CLI version from the oldest release branch that is still maintained (23.0).