### PR TITLE
integration-cli: Update default CLI version to v18.06.3-ce

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
 
 # cli version used for integration-cli tests
 ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
-ARG DOCKERCLI_INTEGRATION_VERSION=v17.06.2-ce
+ARG DOCKERCLI_INTEGRATION_VERSION=v18.06.3-ce
 # BUILDX_VERSION is the version of buildx to install in the dev container.
 ARG BUILDX_VERSION=0.20.1
 ARG COMPOSE_VERSION=v2.33.1

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 : ${DOCKERCLI_CHANNEL:=stable}
-: ${DOCKERCLI_VERSION:=17.06.2-ce}
+: ${DOCKERCLI_VERSION:=18.06.3-ce}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6255,7 +6255,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 						"--since", before.Format(time.RFC3339),
 					),
 					cli.WithTimeout(time.Millisecond*300),
-					cli.WithEnvironmentVariables("DOCKER_API_VERSION=v1.46"), // FIXME(thaJeztah): integration-cli runs docker CLI 17.06; we're "upgrading" the API version to a version it doesn't support here ;)
+					cli.WithEnvironmentVariables("DOCKER_API_VERSION=v1.46"), // FIXME(thaJeztah): integration-cli runs docker CLI 18.06; we're "upgrading" the API version to a version it doesn't support here ;)
 				)
 
 				stdout := cmd.Stdout()

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -52,15 +52,15 @@ func (s *DockerSwarmSuite) TestSwarmUpdate(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	spec := getSpec()
-	assert.Equal(c, spec.CAConfig.NodeCertExpiry, 30*time.Hour)
-	assert.Equal(c, spec.Dispatcher.HeartbeatPeriod, 11*time.Second)
+	assert.Check(c, is.Equal(spec.CAConfig.NodeCertExpiry, 30*time.Hour))
+	assert.Check(c, is.Equal(spec.Dispatcher.HeartbeatPeriod, 11*time.Second))
 
 	// setting anything under 30m for cert-expiry is not allowed
 	out, err = d.Cmd("swarm", "update", "--cert-expiry", "15m")
 	assert.ErrorContains(c, err, "")
 	assert.Assert(c, is.Contains(out, "minimum certificate expiry time"))
 	spec = getSpec()
-	assert.Equal(c, spec.CAConfig.NodeCertExpiry, 30*time.Hour)
+	assert.Check(c, is.Equal(spec.CAConfig.NodeCertExpiry, 30*time.Hour))
 
 	// passing an external CA (this is without starting a root rotation) does not fail
 	cli.Docker(cli.Args("swarm", "update", "--external-ca", "protocol=cfssl,url=https://something.org",
@@ -147,8 +147,8 @@ func (s *DockerSwarmSuite) TestSwarmInit(c *testing.T) {
 	cli.Docker(cli.Args("swarm", "init"), cli.Daemon(d)).Assert(c, icmd.Success)
 
 	spec = getSpec()
-	assert.Equal(c, spec.CAConfig.NodeCertExpiry, 90*24*time.Hour)
-	assert.Equal(c, spec.Dispatcher.HeartbeatPeriod, 5*time.Second)
+	assert.Check(c, is.Equal(spec.CAConfig.NodeCertExpiry, 90*24*time.Hour))
+	assert.Check(c, is.Equal(spec.Dispatcher.HeartbeatPeriod, 5*time.Second))
 }
 
 func (s *DockerSwarmSuite) TestSwarmInitIPv6(c *testing.T) {
@@ -196,7 +196,7 @@ func (s *DockerSwarmSuite) TestSwarmServiceTemplatingHostname(c *testing.T) {
 	ctx := testutil.GetContext(c)
 	d := s.AddDaemon(ctx, c, true, true)
 	hostname, err := d.Cmd("node", "inspect", "--format", "{{.Description.Hostname}}", "self")
-	assert.Assert(c, err == nil, hostname)
+	assert.NilError(c, err, hostname)
 
 	out, err := d.Cmd("service", "create", "--detach", "--no-resolve-image", "--name", "test", "--hostname", "{{.Service.Name}}-{{.Task.Slot}}-{{.Node.Hostname}}", "busybox", "top")
 	assert.NilError(c, err, out)
@@ -236,19 +236,19 @@ func (s *DockerSwarmSuite) TestSwarmServiceListFilter(c *testing.T) {
 	// We search checker.Contains with `name+" "` to prevent prefix only.
 	out, err = d.Cmd("service", "ls", "--filter", filter1)
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, name1+" "), out)
-	assert.Assert(c, !strings.Contains(out, name2+" "), out)
-	assert.Assert(c, !strings.Contains(out, name3+" "), out)
+	assert.Check(c, is.Contains(out, name1+" "))
+	assert.Check(c, !strings.Contains(out, name2+" "), out)
+	assert.Check(c, !strings.Contains(out, name3+" "), out)
 	out, err = d.Cmd("service", "ls", "--filter", filter2)
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, name1+" "), out)
-	assert.Assert(c, strings.Contains(out, name2+" "), out)
-	assert.Assert(c, !strings.Contains(out, name3+" "), out)
+	assert.Check(c, is.Contains(out, name1+" "))
+	assert.Check(c, is.Contains(out, name2+" "))
+	assert.Check(c, !strings.Contains(out, name3+" "))
 	out, err = d.Cmd("service", "ls")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, name1+" "), out)
-	assert.Assert(c, strings.Contains(out, name2+" "), out)
-	assert.Assert(c, strings.Contains(out, name3+" "), out)
+	assert.Check(c, is.Contains(out, name1+" "))
+	assert.Check(c, is.Contains(out, name2+" "))
+	assert.Check(c, is.Contains(out, name3+" "))
 }
 
 func (s *DockerSwarmSuite) TestSwarmNodeListFilter(c *testing.T) {
@@ -264,7 +264,7 @@ func (s *DockerSwarmSuite) TestSwarmNodeListFilter(c *testing.T) {
 
 	out, err = d.Cmd("node", "ls", "--filter", filter)
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, name), out)
+	assert.Assert(c, is.Contains(out, name))
 	out, err = d.Cmd("node", "ls", "--filter", "name=none")
 	assert.NilError(c, err, out)
 	assert.Assert(c, !strings.Contains(out, name), out)
@@ -286,9 +286,9 @@ func (s *DockerSwarmSuite) TestSwarmNodeTaskListFilter(c *testing.T) {
 
 	out, err = d.Cmd("node", "ps", "--filter", filter, "self")
 	assert.NilError(c, err, out)
-	assert.Assert(c, strings.Contains(out, name+".1"), out)
-	assert.Assert(c, strings.Contains(out, name+".2"), out)
-	assert.Assert(c, strings.Contains(out, name+".3"), out)
+	assert.Check(c, is.Contains(out, name+".1"))
+	assert.Check(c, is.Contains(out, name+".2"))
+	assert.Check(c, is.Contains(out, name+".3"))
 	out, err = d.Cmd("node", "ps", "--filter", "name=none", "self")
 	assert.NilError(c, err, out)
 	assert.Assert(c, !strings.Contains(out, name+".1"), out)
@@ -315,13 +315,13 @@ func (s *DockerSwarmSuite) TestSwarmPublishAdd(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	_, err = d.CmdRetryOutOfSequence("service", "update", "--detach", "--publish-add", "80:80", "--publish-add", "80:20", name)
-	assert.ErrorContains(c, err, "")
+	assert.Check(c, is.ErrorContains(err, ""))
 
 	// this last command does not have to be retried because service inspect
 	// does not return out of sequence errors.
 	out, err = d.Cmd("service", "inspect", "--format", "{{ .Spec.EndpointSpec.Ports }}", name)
 	assert.NilError(c, err, out)
-	assert.Equal(c, strings.TrimSpace(out), "[{ tcp 80 80 ingress}]")
+	assert.Check(c, is.Equal(strings.TrimSpace(out), "[{ tcp 80 80 ingress}]"))
 }
 
 func (s *DockerSwarmSuite) TestSwarmServiceWithGroup(c *testing.T) {
@@ -344,7 +344,7 @@ func (s *DockerSwarmSuite) TestSwarmServiceWithGroup(c *testing.T) {
 
 	out, err = d.Cmd("exec", container, "id")
 	assert.NilError(c, err, out)
-	assert.Equal(c, strings.TrimSpace(out), "uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777")
+	assert.Check(c, is.Equal(strings.TrimSpace(out), "uid=0(root) gid=0(root) groups=0(root),10(wheel),29(audio),50(staff),777"))
 }
 
 func (s *DockerSwarmSuite) TestSwarmContainerAutoStart(c *testing.T) {


### PR DESCRIPTION
- alternative to: https://github.com/moby/moby/pull/49676

This updates the Docker CLI version used for integration-cli tests from v17.06.2-ce to v18.06.3-ce.

v18.06 is the first one that supports enabling BuildKit.

Personally, I'd be happy with bumping that even further (like v23), but if we really want to still test against older clients, let's use a version that supports buildkit at least.