### PR TITLE
c8d/builder: Fix missing `image tag` event with BuildKit

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6230,7 +6230,9 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("buildkit=%v/%s", builder.buildkit, tc.name), func(t *testing.T) {
-				skip.If(t, DaemonIsWindows, "Buildkit is not supported on Windows")
+				if builder.buildkit {
+					skip.If(t, DaemonIsWindows, "Buildkit is not supported on Windows")
+				}
 
 				time.Sleep(time.Second)
 				before := time.Now()

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6209,7 +6209,9 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 				name: "no tag",
 				args: []string{},
 				check: func(t *testing.T, stdout string) {
-					assert.Check(t, is.Contains(stdout, "image create"))
+					if assert.Check(t, is.Contains(stdout, "image create")) {
+						assert.Check(t, strings.Count(stdout, "image create") == 1)
+					}
 					assert.Check(t, !strings.Contains(stdout, "image tag"))
 				},
 			},
@@ -6217,8 +6219,12 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 				name: "with tag",
 				args: []string{"-t", "testbuildemitsimagetagevent"},
 				check: func(t *testing.T, stdout string) {
-					assert.Check(t, is.Contains(stdout, "image create"))
-					assert.Check(t, is.Contains(stdout, "image tag"))
+					if assert.Check(t, is.Contains(stdout, "image create")) {
+						assert.Check(t, strings.Count(stdout, "image create") == 1)
+					}
+					if assert.Check(t, is.Contains(stdout, "image tag")) {
+						assert.Check(t, strings.Count(stdout, "image tag") == 1)
+					}
 					assert.Check(t, is.Contains(stdout, "testbuildemitsimagetagevent"))
 				},
 			},


### PR DESCRIPTION
The builder `Named` callback was not called with the containerd image store integration enabled and BuildKit due to wrong `imageexporter` output key being used.

We have a test `TestBuildEmitsEvents` that should have detected the bug, but it wasn't actually working because the CLI version used in the `integration-cli` doesn't support BuildKit.

**- How to verify it**
`TestBuildEmitsEvents`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
containerd image store: Fix `image tag` event not being emitted when building with BuildKit.
```

**- A picture of a cute animal (not mandatory but encouraged)**

