### PR TITLE
vendor: github.com/opencontainers/runc v1.2.6

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -82,7 +82,7 @@ require (
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
-	github.com/opencontainers/runc v1.2.5
+	github.com/opencontainers/runc v1.2.6
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/opencontainers/selinux v1.11.1
 	github.com/pelletier/go-toml v1.9.5

--- a/vendor.sum
+++ b/vendor.sum
@@ -439,8 +439,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/opencontainers/runc v1.2.5 h1:8KAkq3Wrem8bApgOHyhRI/8IeLXIfmZ6Qaw6DNSLnA4=
-github.com/opencontainers/runc v1.2.5/go.mod h1:dOQeFo29xZKBNeRBI0B19mJtfHv68YgCTh1X+YphA+4=
+github.com/opencontainers/runc v1.2.6 h1:P7Hqg40bsMvQGCS4S7DJYhUZOISMLJOB2iGX5COWiPk=
+github.com/opencontainers/runc v1.2.6/go.mod h1:dOQeFo29xZKBNeRBI0B19mJtfHv68YgCTh1X+YphA+4=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1048,7 +1048,7 @@ github.com/opencontainers/go-digest/digestset
 github.com/opencontainers/image-spec/identity
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/opencontainers/runc v1.2.5
+# github.com/opencontainers/runc v1.2.6
 ## explicit; go 1.22
 github.com/opencontainers/runc/libcontainer/cgroups
 github.com/opencontainers/runc/libcontainer/configs


### PR DESCRIPTION
This is the sixth patch release in the 1.2.z series of runc. It primarily fixes an issue with runc exec vs time namespace, and a compatibility issue with older kernels.

* Fix a stall issue that would happen if setting `O_CLOEXEC` with `CloseExecFrom` failed.
* `runc` now properly handles joining time namespaces (such as with `runc exec`). Previously we would attempt to set the time offsets when joining, which would fail.
* Handle `EINTR` retries correctly for socket-related direct `golang.org/x/sys/unix` system calls.
* We no longer use `F_SEAL_FUTURE_WRITE` when sealing the runc binary, as it turns out this had some unfortunate bugs in older kernel versions and was never necessary in the first place.
* Remove `Fexecve` helper from `libcontainer/system`. Runc 1.2.1 removed runc-dmz, but we forgot to remove this helper added only for that.
* Use Go 1.23 for official builds, run CI with Go 1.24 and drop Ubuntu 20.04 from CI. We need to drop Ubuntu 20.04 from CI because Github Actions announced it's already deprecated and it will be discontinued soon.

full diff: https://github.com/opencontainers/runc/compare/v1.2.5...v1.2.6


**- A picture of a cute animal (not mandatory but encouraged)**

