### PR TITLE
Dockerfile: update runc binary to v1.2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -279,7 +279,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.2.5
+ARG RUNC_VERSION=v1.2.6
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.2.5}"
+: "${RUNC_VERSION:=v1.2.6}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
This is the sixth patch release in the 1.2.z series of runc. It primarily fixes an issue with runc exec vs time namespace, and a compatibility issue with older kernels.

* Fix a stall issue that would happen if setting `O_CLOEXEC` with `CloseExecFrom` failed.
* `runc` now properly handles joining time namespaces (such as with `runc exec`). Previously we would attempt to set the time offsets when joining, which would fail.
* Handle `EINTR` retries correctly for socket-related direct `golang.org/x/sys/unix` system calls.
* We no longer use `F_SEAL_FUTURE_WRITE` when sealing the runc binary, as it turns out this had some unfortunate bugs in older kernel versions and was never necessary in the first place.
* Remove `Fexecve` helper from `libcontainer/system`. Runc 1.2.1 removed runc-dmz, but we forgot to remove this helper added only for that.
* Use Go 1.23 for official builds, run CI with Go 1.24 and drop Ubuntu 20.04 from CI. We need to drop Ubuntu 20.04 from CI because Github Actions announced it's already deprecated and it will be discontinued soon.

full diff: https://github.com/opencontainers/runc/compare/v1.2.5...v1.2.6

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update `runc` to [v1.2.6](https://github.com/opencontainers/runc/releases/tag/v1.2.6)
```

**- A picture of a cute animal (not mandatory but encouraged)**

