### PR TITLE
daemon, api/router: minor cleanups in attach and logging code

### DIFF
--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -88,7 +88,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 	}
 
 	if err := daemon.containerAttach(ctr, &cfg, req.Logs, req.Stream); err != nil {
-		fmt.Fprintf(outStream, "Error attaching: %s\n", err)
+		_, _ = fmt.Fprintln(outStream, "Error attaching:", err)
 	}
 	return nil
 }

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -33,12 +33,10 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 		return err
 	}
 	if ctr.IsPaused() {
-		err := fmt.Errorf("container %s is paused, unpause the container before attach", prefixOrName)
-		return errdefs.Conflict(err)
+		return errdefs.Conflict(fmt.Errorf("container %s is paused, unpause the container before attach", prefixOrName))
 	}
 	if ctr.IsRestarting() {
-		err := fmt.Errorf("container %s is restarting, wait until the container is running", prefixOrName)
-		return errdefs.Conflict(err)
+		return errdefs.Conflict(fmt.Errorf("container %s is restarting, wait until the container is running", prefixOrName))
 	}
 
 	cfg := stream.AttachConfig{
@@ -50,8 +48,6 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 		DetachKeys: keys,
 	}
 	ctr.StreamConfig.AttachStreams(&cfg)
-
-	multiplexed := !ctr.Config.Tty && req.MuxStreams
 
 	clientCtx, closeNotify := context.WithCancel(context.Background())
 	defer closeNotify()
@@ -68,6 +64,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 		}
 	}()
 
+	multiplexed := !ctr.Config.Tty && req.MuxStreams
 	inStream, outStream, errStream, err := req.GetStreams(multiplexed, closeNotify)
 	if err != nil {
 		return err

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -173,9 +173,9 @@ func (daemon *Daemon) containerAttach(ctr *container.Container, cfg *stream.Atta
 	if cfg.Stdin != nil {
 		r, w := io.Pipe()
 		go func(stdin io.ReadCloser) {
-			defer w.Close()
-			defer log.G(context.TODO()).Debug("Closing buffered stdin pipe")
 			io.Copy(w, stdin)
+			log.G(context.TODO()).Debug("Closing buffered stdin pipe")
+			w.Close()
 		}(cfg.Stdin)
 		cfg.Stdin = r
 	}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -72,7 +72,6 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 		return nil, false, logger.ErrReadLogsNotSupported{}
 	}
 
-	follow := config.Follow && !cLogCreated
 	tailLines, err := strconv.Atoi(config.Tail)
 	if err != nil {
 		tailLines = -1
@@ -96,14 +95,13 @@ func (daemon *Daemon) ContainerLogs(ctx context.Context, containerName string, c
 		until = time.Unix(s, n)
 	}
 
-	readConfig := logger.ReadConfig{
+	follow := config.Follow && !cLogCreated
+	logs := logReader.ReadLogs(ctx, logger.ReadConfig{
 		Since:  since,
 		Until:  until,
 		Tail:   tailLines,
 		Follow: follow,
-	}
-
-	logs := logReader.ReadLogs(ctx, readConfig)
+	})
 
 	// past this point, we can't possibly return any errors, so we can just
 	// start a goroutine and return to tell the caller not to expect errors


### PR DESCRIPTION
### daemon: daemon.containerAttach: rename vars for clarity and prevent shadow

- rename var that shadowed argument
- use consistent name for container arg; We use `ctr` as short name in most
  places; use the same name to make the code slightly more readable.
- rename "logs" argument to prevent it being confused with a logs import
  and to more clearly indicate its a bool

### daemon: daemon.containerAttach: remove redundant defers

Both these defers were defined in the closure, and would be executed
at the end of the goroutine; inline them to prevent them being confused
for being executed after the function starting the goroutine.

### daemon: daemon.ContainerLogs: move vars closer to where used

- remove intermediate variable that was only used once
- move "follow" variable to where it's used; keeping an intermediate
  variable for now, as the logic related to "follow" and "created"
  could use some comment / documentation.

### daemon: daemon.ContainerAttach: move vars closer to where used

- remove intermediate err vars
- move "multiplexed" variable closer to where used


### daemon: daemon.ContainerAttach: use Println instead of Printf

### daemon: daemon.containerAttach: use structured logs


### api/router: postContainersAttach, wsContainersAttach: minor cleanups

- remove intermediate variables that were only used once
- move variables closer to where used


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

