### PR TITLE
Dockerfile: upgrade Delve to v1.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,13 @@ ARG DOCKER_STATIC=1
 ARG REGISTRY_VERSION=3.0.0-rc.1
 
 # delve is currently only supported on linux/amd64 and linux/arm64;
-# https://github.com/go-delve/delve/blob/v1.8.1/pkg/proc/native/support_sentinel.go#L1-L6
-ARG DELVE_SUPPORTED=${TARGETPLATFORM#linux/amd64} DELVE_SUPPORTED=${DELVE_SUPPORTED#linux/arm64}
+# https://github.com/go-delve/delve/blob/v1.24.1/pkg/proc/native/support_sentinel.go#L1
+# https://github.com/go-delve/delve/blob/v1.24.1/pkg/proc/native/support_sentinel_linux.go#L1
+#
+# ppc64le support was added in v1.21.1, but is still experimental, and requires
+# the "-tags exp.linuxppc64le" build-tag to be set:
+# https://github.com/go-delve/delve/commit/71f12207175a1cc09668f856340d8a543c87dcca
+ARG DELVE_SUPPORTED=${TARGETPLATFORM#linux/amd64} DELVE_SUPPORTED=${DELVE_SUPPORTED#linux/arm64} DELVE_SUPPORTED=${DELVE_SUPPORTED#linux/ppc64le}
 ARG DELVE_SUPPORTED=${DELVE_SUPPORTED:+"unsupported"}
 ARG DELVE_SUPPORTED=${DELVE_SUPPORTED:-"supported"}
 
@@ -153,7 +158,7 @@ RUN git init . && git remote add origin "https://github.com/go-delve/delve.git"
 # from the https://github.com/go-delve/delve repository.
 # It can be used to run Docker with a possibility of
 # attaching debugger to it.
-ARG DELVE_VERSION=v1.23.0
+ARG DELVE_VERSION=v1.24.1
 RUN git fetch -q --depth 1 origin "${DELVE_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS delve-supported


### PR DESCRIPTION
Update to the latest version:

- https://github.com/go-delve/delve/releases/tag/v1.24.1
- https://github.com/go-delve/delve/blob/v1.24.1/CHANGELOG.md#1241-2025-03-05

Also update links to supported platforms. Delve v1.21.1 and higher now supports linux/ppc64le (added in [delve@71f1220]), but this looks to be gated behind an experimental build-tag. We could consider enabling this tag, but skipping that for now.

[delve@71f1220]: https://github.com/go-delve/delve/commit/71f12207175a1cc09668f856340d8a543c87dcca

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

