### PR TITLE
Dockerfile: disable saving Golang telemetry in dev-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ COPY --from=build-dummy /build /build
 # base
 FROM --platform=$BUILDPLATFORM ${GOLANG_IMAGE} AS base
 COPY --from=xx / /
+# Disable collecting local telemetry, as collected by Go and Delve;
+#
+# - https://github.com/go-delve/delve/blob/v1.24.1/CHANGELOG.md#1231-2024-09-23
+# - https://go.dev/doc/telemetry#background
+RUN go telemetry off && [ "$(go telemetry)" = "off" ] || { echo "Failed to disable Go telemetry"; exit 1; }
 RUN echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN apt-get update && apt-get install --no-install-recommends -y file
 ENV GO111MODULE=off


### PR DESCRIPTION
Disable collecting local telemetry, as collected by Go and Delve;

- https://github.com/go-delve/delve/blob/v1.24.1/CHANGELOG.md#1231-2024-09-23
- https://go.dev/doc/telemetry#background

Telemetry is only collected, and not sent by default, so let's skip producing it in the first place, as the dev-container is an ephemeral environment, and this telemetry is not used.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

