### PR TITLE
Update `interface{}` to `any`

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -435,7 +435,7 @@ type containerByIDIndexer struct{}
 const terminator = "\x00"
 
 // FromObject implements the memdb.SingleIndexer interface for Container objects
-func (e *containerByIDIndexer) FromObject(obj interface{}) (bool, []byte, error) {
+func (e *containerByIDIndexer) FromObject(obj any) (bool, []byte, error) {
 	c, ok := obj.(*Container)
 	if !ok {
 		return false, nil, fmt.Errorf("%T is not a Container", obj)
@@ -445,7 +445,7 @@ func (e *containerByIDIndexer) FromObject(obj interface{}) (bool, []byte, error)
 }
 
 // FromArgs implements the memdb.Indexer interface
-func (e *containerByIDIndexer) FromArgs(args ...interface{}) ([]byte, error) {
+func (e *containerByIDIndexer) FromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("must provide only a single argument")
 	}
@@ -457,7 +457,7 @@ func (e *containerByIDIndexer) FromArgs(args ...interface{}) ([]byte, error) {
 	return []byte(arg + terminator), nil
 }
 
-func (e *containerByIDIndexer) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (e *containerByIDIndexer) PrefixFromArgs(args ...any) ([]byte, error) {
 	val, err := e.FromArgs(args...)
 	if err != nil {
 		return nil, err
@@ -470,7 +470,7 @@ func (e *containerByIDIndexer) PrefixFromArgs(args ...interface{}) ([]byte, erro
 // namesByNameIndexer is used to index container name associations by name.
 type namesByNameIndexer struct{}
 
-func (e *namesByNameIndexer) FromObject(obj interface{}) (bool, []byte, error) {
+func (e *namesByNameIndexer) FromObject(obj any) (bool, []byte, error) {
 	n, ok := obj.(nameAssociation)
 	if !ok {
 		return false, nil, fmt.Errorf(`%T does not have type "nameAssociation"`, obj)
@@ -480,7 +480,7 @@ func (e *namesByNameIndexer) FromObject(obj interface{}) (bool, []byte, error) {
 	return true, []byte(n.name + terminator), nil
 }
 
-func (e *namesByNameIndexer) FromArgs(args ...interface{}) ([]byte, error) {
+func (e *namesByNameIndexer) FromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("must provide only a single argument")
 	}
@@ -495,7 +495,7 @@ func (e *namesByNameIndexer) FromArgs(args ...interface{}) ([]byte, error) {
 // namesByContainerIDIndexer is used to index container names by container ID.
 type namesByContainerIDIndexer struct{}
 
-func (e *namesByContainerIDIndexer) FromObject(obj interface{}) (bool, []byte, error) {
+func (e *namesByContainerIDIndexer) FromObject(obj any) (bool, []byte, error) {
 	n, ok := obj.(nameAssociation)
 	if !ok {
 		return false, nil, fmt.Errorf(`%T does not have type "nameAssociation"`, obj)
@@ -505,7 +505,7 @@ func (e *namesByContainerIDIndexer) FromObject(obj interface{}) (bool, []byte, e
 	return true, []byte(n.containerID + terminator), nil
 }
 
-func (e *namesByContainerIDIndexer) FromArgs(args ...interface{}) ([]byte, error) {
+func (e *namesByContainerIDIndexer) FromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("must provide only a single argument")
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -263,7 +263,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 
 	removeContainers := make(map[string]*container.Container)
 	restartContainers := make(map[*container.Container]chan struct{})
-	activeSandboxes := make(map[string]interface{})
+	activeSandboxes := make(map[string]any)
 
 	for _, c := range containers {
 		group.Add(1)
@@ -967,7 +967,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 		var (
 			shim     string
-			shimOpts interface{}
+			shimOpts any
 		)
 		if runtime.GOOS != "windows" {
 			shim, shimOpts, err = rts.Get("")
@@ -1446,7 +1446,7 @@ func isBridgeNetworkDisabled(conf *config.Config) bool {
 	return conf.BridgeConfig.Iface == config.DisableNetworkBridge
 }
 
-func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.PluginGetter, hostID string, activeSandboxes map[string]interface{}) ([]nwconfig.Option, error) {
+func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.PluginGetter, hostID string, activeSandboxes map[string]any) ([]nwconfig.Option, error) {
 	options := []nwconfig.Option{
 		nwconfig.OptionDataDir(filepath.Join(conf.Root, config.LibnetDataPath)),
 		nwconfig.OptionExecRoot(conf.GetExecRoot()),

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -842,7 +842,7 @@ func configureKernelSecuritySupport(config *config.Config, driverName string) er
 // initNetworkController initializes the libnetwork controller and configures
 // network settings. If there's active sandboxes, configuration changes will not
 // take effect.
-func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes map[string]interface{}) error {
+func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes map[string]any) error {
 	netOptions, err := daemon.networkOptions(cfg, daemon.PluginStore, daemon.id, activeSandboxes)
 	if err != nil {
 		return err

--- a/libnetwork/config/config.go
+++ b/libnetwork/config/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	NetworkControlPlaneMTU int
 	DefaultAddressPool     []*ipamutils.NetworkToSplit
 	DatastoreBucket        string
-	ActiveSandboxes        map[string]interface{}
+	ActiveSandboxes        map[string]any
 	PluginGetter           plugingetter.PluginGetter
 }
 
@@ -149,7 +149,7 @@ func OptionNetworkControlPlaneMTU(exp int) Option {
 
 // OptionActiveSandboxes function returns an option setter for passing the sandboxes
 // which were active during previous daemon life
-func OptionActiveSandboxes(sandboxes map[string]interface{}) Option {
+func OptionActiveSandboxes(sandboxes map[string]any) Option {
 	return func(c *Config) {
 		c.ActiveSandboxes = sandboxes
 	}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -132,7 +132,7 @@ type IpamInfo struct {
 
 // MarshalJSON encodes IpamInfo into json message
 func (i *IpamInfo) MarshalJSON() ([]byte, error) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"PoolID": i.PoolID,
 	}
 	v, err := json.Marshal(&i.IPAMData)
@@ -150,7 +150,7 @@ func (i *IpamInfo) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON decodes json message into PoolData
 func (i *IpamInfo) UnmarshalJSON(data []byte) error {
 	var (
-		m   map[string]interface{}
+		m   map[string]any
 		err error
 	)
 	if err = json.Unmarshal(data, &m); err != nil {
@@ -387,10 +387,10 @@ func (n *Network) validateConfiguration() error {
 			if data, ok := n.generic[netlabel.GenericData]; ok {
 				var (
 					driverOptions map[string]string
-					opts          interface{}
+					opts          any
 				)
 				switch t := data.(type) {
-				case map[string]interface{}, map[string]string:
+				case map[string]any, map[string]string:
 					opts = t
 				}
 				ba, err := json.Marshal(opts)
@@ -580,7 +580,7 @@ func (n *Network) advertiseAddrInterval() (time.Duration, bool) {
 
 // TODO : Can be made much more generic with the help of reflection (but has some golang limitations)
 func (n *Network) MarshalJSON() ([]byte, error) {
-	netMap := make(map[string]interface{})
+	netMap := make(map[string]any)
 	netMap["name"] = n.name
 	netMap["id"] = n.id
 	netMap["created"] = n.created
@@ -639,7 +639,7 @@ func (n *Network) MarshalJSON() ([]byte, error) {
 
 // TODO : Can be made much more generic with the help of reflection (but has some golang limitations)
 func (n *Network) UnmarshalJSON(b []byte) (err error) {
-	var netMap map[string]interface{}
+	var netMap map[string]any
 	if err := json.Unmarshal(b, &netMap); err != nil {
 		return err
 	}
@@ -662,7 +662,7 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 
 	// if we weren't unmarshaling to netMap we could simply set n.labels
 	// unfortunately, we can't because map[string]interface{} != map[string]string
-	if labels, ok := netMap["labels"].(map[string]interface{}); ok {
+	if labels, ok := netMap["labels"].(map[string]any); ok {
 		n.labels = make(map[string]string, len(labels))
 		for label, value := range labels {
 			n.labels[label] = value.(string)
@@ -670,7 +670,7 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 	}
 
 	if v, ok := netMap["ipamOptions"]; ok {
-		if iOpts, ok := v.(map[string]interface{}); ok {
+		if iOpts, ok := v.(map[string]any); ok {
 			n.ipamOptions = make(map[string]string, len(iOpts))
 			for k, v := range iOpts {
 				n.ipamOptions[k] = v.(string)
@@ -679,7 +679,7 @@ func (n *Network) UnmarshalJSON(b []byte) (err error) {
 	}
 
 	if v, ok := netMap["generic"]; ok {
-		n.generic = v.(map[string]interface{})
+		n.generic = v.(map[string]any)
 		// Restore opts in their map[string]string form
 		if v, ok := n.generic[netlabel.GenericData]; ok {
 			var lmap map[string]string
@@ -768,10 +768,10 @@ type NetworkOption func(n *Network)
 
 // NetworkOptionGeneric function returns an option setter for a Generic option defined
 // in a Dictionary of Key-Value pair
-func NetworkOptionGeneric(generic map[string]interface{}) NetworkOption {
+func NetworkOptionGeneric(generic map[string]any) NetworkOption {
 	return func(n *Network) {
 		if n.generic == nil {
-			n.generic = make(map[string]interface{})
+			n.generic = make(map[string]any)
 		}
 		if val, ok := generic[netlabel.EnableIPv4]; ok {
 			n.enableIPv4 = val.(bool)
@@ -807,7 +807,7 @@ func NetworkOptionPersist(persist bool) NetworkOption {
 func NetworkOptionEnableIPv4(enableIPv4 bool) NetworkOption {
 	return func(n *Network) {
 		if n.generic == nil {
-			n.generic = make(map[string]interface{})
+			n.generic = make(map[string]any)
 		}
 		n.enableIPv4 = enableIPv4
 		n.generic[netlabel.EnableIPv4] = enableIPv4
@@ -818,7 +818,7 @@ func NetworkOptionEnableIPv4(enableIPv4 bool) NetworkOption {
 func NetworkOptionEnableIPv6(enableIPv6 bool) NetworkOption {
 	return func(n *Network) {
 		if n.generic == nil {
-			n.generic = make(map[string]interface{})
+			n.generic = make(map[string]any)
 		}
 		n.enableIPv6 = enableIPv6
 		n.generic[netlabel.EnableIPv6] = enableIPv6
@@ -830,7 +830,7 @@ func NetworkOptionEnableIPv6(enableIPv6 bool) NetworkOption {
 func NetworkOptionInternalNetwork() NetworkOption {
 	return func(n *Network) {
 		if n.generic == nil {
-			n.generic = make(map[string]interface{})
+			n.generic = make(map[string]any)
 		}
 		n.internal = true
 		n.generic[netlabel.Internal] = true
@@ -879,7 +879,7 @@ func NetworkOptionLBEndpoint(ip net.IP) NetworkOption {
 func NetworkOptionDriverOpts(opts map[string]string) NetworkOption {
 	return func(n *Network) {
 		if n.generic == nil {
-			n.generic = make(map[string]interface{})
+			n.generic = make(map[string]any)
 		}
 		if opts == nil {
 			opts = make(map[string]string)
@@ -1207,7 +1207,7 @@ func (n *Network) CreateEndpoint(ctx context.Context, name string, options ...En
 func (n *Network) createEndpoint(ctx context.Context, name string, options ...EndpointOption) (*Endpoint, error) {
 	var err error
 
-	ep := &Endpoint{name: name, generic: make(map[string]interface{}), iface: &EndpointInterface{}}
+	ep := &Endpoint{name: name, generic: make(map[string]any), iface: &EndpointInterface{}}
 	ep.id = stringid.GenerateRandomID()
 
 	// Initialize ep.network with a possibly stale copy of n. We need this to get network from

--- a/libnetwork/options/options.go
+++ b/libnetwork/options/options.go
@@ -53,7 +53,7 @@ type Generic map[string]any
 //
 // The return value is of the same type than the model (including a potential
 // pointer qualifier).
-func GenerateFromModel(options Generic, model interface{}) (interface{}, error) {
+func GenerateFromModel(options Generic, model any) (any, error) {
 	modType := reflect.TypeOf(model)
 
 	// If the model is of pointer type, we need to dereference for New.

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -91,7 +91,7 @@ type resolvConfPathConfig struct {
 type containerConfig struct {
 	hostsPathConfig
 	resolvConfPathConfig
-	generic           map[string]interface{}
+	generic           map[string]any
 	useDefaultSandBox bool
 	useExternalKey    bool
 	exposedPorts      []types.TransportPort
@@ -116,10 +116,10 @@ func (sb *Sandbox) Key() string {
 }
 
 // Labels returns the sandbox's labels.
-func (sb *Sandbox) Labels() map[string]interface{} {
+func (sb *Sandbox) Labels() map[string]any {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
-	opts := make(map[string]interface{}, len(sb.config.generic))
+	opts := make(map[string]any, len(sb.config.generic))
 	for k, v := range sb.config.generic {
 		opts[k] = v
 	}
@@ -270,9 +270,9 @@ func (sb *Sandbox) Refresh(ctx context.Context, options ...SandboxOption) error 
 	return nil
 }
 
-func (sb *Sandbox) UpdateLabels(labels map[string]interface{}) {
+func (sb *Sandbox) UpdateLabels(labels map[string]any) {
 	if sb.config.generic == nil {
-		sb.config.generic = make(map[string]interface{}, len(labels))
+		sb.config.generic = make(map[string]any, len(labels))
 	}
 	for k, v := range labels {
 		sb.config.generic[k] = v

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -38,14 +38,14 @@ import (
 
 // LogT is the subset of the testing.TB interface used by the daemon.
 type LogT interface {
-	Logf(string, ...interface{})
+	Logf(string, ...any)
 }
 
 // nopLog is a no-op implementation of LogT that is used in daemons created by
 // NewDaemon (where no testing.TB is available).
 type nopLog struct{}
 
-func (nopLog) Logf(string, ...interface{}) {}
+func (nopLog) Logf(string, ...any) {}
 
 const (
 	defaultDockerdBinary         = "dockerd"


### PR DESCRIPTION
Go 1.18 introduced `any` alias as a replacement for `interface{}`.