### PR TITLE
registry: Service.Auth: remove statusMessage return

### DIFF
--- a/daemon/auth.go
+++ b/daemon/auth.go
@@ -9,6 +9,5 @@ import (
 
 // AuthenticateToRegistry checks the validity of credentials in authConfig
 func (daemon *Daemon) AuthenticateToRegistry(ctx context.Context, authConfig *registry.AuthConfig) (string, error) {
-	_, token, err := daemon.registryService.Auth(ctx, authConfig, dockerversion.DockerUserAgent(ctx))
-	return token, err
+	return daemon.registryService.Auth(ctx, authConfig, dockerversion.DockerUserAgent(ctx))
 }


### PR DESCRIPTION
It's set to a fixed string, which can be set in the API instead.

Note that docker/cli uses this method as well, so will require changes when updating.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

