### PR TITLE
refactor and simplify various code-paths related to distribution / authentication 

### DIFF
--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -34,7 +34,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
-	registrypkg "github.com/docker/docker/registry"
 	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
@@ -144,12 +143,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 	pullRegistryAuth := &registry.AuthConfig{}
 	if len(authConfigs) > 0 {
 		// The request came with a full auth config, use it
-		repoInfo, err := i.registryService.ResolveRepository(ref)
-		if err != nil {
-			return nil, err
-		}
-
-		resolvedConfig := registrypkg.ResolveAuthConfig(authConfigs, repoInfo.Index)
+		resolvedConfig := i.registryService.ResolveAuthConfig(authConfigs, ref)
 		pullRegistryAuth = &resolvedConfig
 	}
 

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -45,7 +45,6 @@ type ImageService struct {
 }
 
 type registryResolver interface {
-	IsInsecureRegistry(host string) bool
 	ResolveRepository(name reference.Named) (*registry.RepositoryInfo, error)
 	LookupPullEndpoints(hostname string) ([]registry.APIEndpoint, error)
 	LookupPushEndpoints(hostname string) ([]registry.APIEndpoint, error)

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
 	dimages "github.com/docker/docker/daemon/images"
@@ -45,7 +46,7 @@ type ImageService struct {
 }
 
 type registryResolver interface {
-	ResolveRepository(name reference.Named) (*registry.RepositoryInfo, error)
+	ResolveAuthConfig(map[string]registrytypes.AuthConfig, reference.Named) registrytypes.AuthConfig
 	LookupPullEndpoints(hostname string) ([]registry.APIEndpoint, error)
 	LookupPushEndpoints(hostname string) ([]registry.APIEndpoint, error)
 }

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -14,15 +14,13 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
-	"github.com/distribution/reference"
-	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
 	dimages "github.com/docker/docker/daemon/images"
 	"github.com/docker/docker/daemon/snapshotter"
+	"github.com/docker/docker/distribution"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 )
 
@@ -35,7 +33,7 @@ type ImageService struct {
 	snapshotterServices map[string]snapshots.Snapshotter
 	snapshotter         string
 	registryHosts       docker.RegistryHosts
-	registryService     registryResolver
+	registryService     distribution.RegistryResolver
 	eventsService       *daemonevents.Events
 	pruneRunning        atomic.Bool
 	refCountMounter     snapshotter.Mounter
@@ -45,18 +43,12 @@ type ImageService struct {
 	defaultPlatformOverride platforms.MatchComparer
 }
 
-type registryResolver interface {
-	ResolveAuthConfig(map[string]registrytypes.AuthConfig, reference.Named) registrytypes.AuthConfig
-	LookupPullEndpoints(hostname string) ([]registry.APIEndpoint, error)
-	LookupPushEndpoints(hostname string) ([]registry.APIEndpoint, error)
-}
-
 type ImageServiceConfig struct {
 	Client          *containerd.Client
 	Containers      container.Store
 	Snapshotter     string
 	RegistryHosts   docker.RegistryHosts
-	Registry        registryResolver
+	Registry        distribution.RegistryResolver
 	EventsService   *daemonevents.Events
 	RefCountMounter snapshotter.Mounter
 	IDMapping       idtools.IdentityMapping

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
-	registrypkg "github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -158,12 +157,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 	pullRegistryAuth := &registry.AuthConfig{}
 	if len(authConfigs) > 0 {
 		// The request came with a full auth config, use it
-		repoInfo, err := i.registryService.ResolveRepository(ref)
-		if err != nil {
-			return nil, err
-		}
-
-		resolvedConfig := registrypkg.ResolveAuthConfig(authConfigs, repoInfo.Index)
+		resolvedConfig := i.registryService.ResolveAuthConfig(authConfigs, ref)
 		pullRegistryAuth = &resolvedConfig
 	}
 

--- a/distribution/config.go
+++ b/distribution/config.go
@@ -78,9 +78,9 @@ type ImagePushConfig struct {
 
 // RegistryResolver is used for TLS configuration and endpoint lookup.
 type RegistryResolver interface {
+	ResolveAuthConfig(map[string]registry.AuthConfig, reference.Named) registry.AuthConfig
 	LookupPushEndpoints(hostname string) (endpoints []registrypkg.APIEndpoint, err error)
 	LookupPullEndpoints(hostname string) (endpoints []registrypkg.APIEndpoint, err error)
-	ResolveRepository(name reference.Named) (*registrypkg.RepositoryInfo, error)
 }
 
 // ImageConfigStore handles storing and getting image configurations

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -34,7 +34,7 @@ func Pull(ctx context.Context, ref reference.Named, config *ImagePullConfig, loc
 func Tags(ctx context.Context, ref reference.Named, config *Config) ([]string, error) {
 	var tags []string
 	_, err := pullEndpoints(ctx, config.RegistryService, ref, func(ctx context.Context, repoInfo registry.RepositoryInfo, endpoint registry.APIEndpoint) error {
-		repo, err := newRepository(ctx, &repoInfo, endpoint, config.MetaHeaders, config.AuthConfig, "pull")
+		repo, err := newRepository(ctx, repoInfo.Name, endpoint, config.MetaHeaders, config.AuthConfig, "pull")
 		if err != nil {
 			return err
 		}

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -20,7 +20,7 @@ import (
 func Pull(ctx context.Context, ref reference.Named, config *ImagePullConfig, local ContentStore) error {
 	repoInfo, err := pullEndpoints(ctx, config.RegistryService, ref, func(ctx context.Context, repoInfo registry.RepositoryInfo, endpoint registry.APIEndpoint) error {
 		log.G(ctx).Debugf("Trying to pull %s from %s", reference.FamiliarName(repoInfo.Name), endpoint.URL)
-		return newPuller(endpoint, &repoInfo, config, local).pull(ctx, ref)
+		return newPuller(endpoint, repoInfo.Name, config, local).pull(ctx, ref)
 	})
 
 	if err == nil {

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -20,8 +20,7 @@ import (
 func Pull(ctx context.Context, ref reference.Named, config *ImagePullConfig, local ContentStore) error {
 	repoInfo, err := pullEndpoints(ctx, config.RegistryService, ref, func(ctx context.Context, repoInfo registry.RepositoryInfo, endpoint registry.APIEndpoint) error {
 		log.G(ctx).Debugf("Trying to pull %s from %s", reference.FamiliarName(repoInfo.Name), endpoint.URL)
-		puller := newPuller(endpoint, &repoInfo, config, local)
-		return puller.pull(ctx, ref)
+		return newPuller(endpoint, &repoInfo, config, local).pull(ctx, ref)
 	})
 
 	if err == nil {

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -76,12 +76,7 @@ func addDigestReference(store refstore.Store, ref reference.Named, dgst digest.D
 func pullEndpoints(ctx context.Context, registryService RegistryResolver, ref reference.Named,
 	f func(context.Context, reference.Named, registry.APIEndpoint) error,
 ) (reference.Named, error) {
-	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := registryService.ResolveRepository(ref)
-	if err != nil {
-		return nil, err
-	}
-	repoName := repoInfo.Name
+	repoName := reference.TrimNamed(ref)
 
 	// makes sure name is not `scratch`
 	if err := validateRepoName(repoName); err != nil {

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -143,7 +143,7 @@ func (p *puller) writeStatus(requestedTag string, layersDownloaded bool) {
 type layerDescriptor struct {
 	digest          digest.Digest
 	diffID          layer.DiffID
-	repoInfo        *registry.RepositoryInfo
+	repoName        reference.Named
 	repo            distribution.Repository
 	metadataService metadata.V2MetadataService
 	tmpFile         *os.File
@@ -332,7 +332,7 @@ func (ld *layerDescriptor) truncateDownloadFile() error {
 
 func (ld *layerDescriptor) Registered(diffID layer.DiffID) {
 	// Cache mapping from this layer's DiffID to the blobsum
-	_ = ld.metadataService.Add(diffID, metadata.V2Metadata{Digest: ld.digest, SourceRepository: ld.repoInfo.Name.Name()})
+	_ = ld.metadataService.Add(diffID, metadata.V2Metadata{Digest: ld.digest, SourceRepository: ld.repoName.Name()})
 }
 
 func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *ocispec.Platform) (tagUpdated bool, err error) {
@@ -559,7 +559,7 @@ func (p *puller) pullSchema1(ctx context.Context, ref reference.Reference, unver
 
 		descriptors = append(descriptors, &layerDescriptor{
 			digest:          blobSum,
-			repoInfo:        p.repoInfo,
+			repoName:        p.repoInfo.Name,
 			repo:            p.repo,
 			metadataService: p.metadataService,
 		})
@@ -624,7 +624,7 @@ func (p *puller) pullSchema2Layers(ctx context.Context, target distribution.Desc
 		descriptors = append(descriptors, &layerDescriptor{
 			digest:          d.Digest,
 			repo:            p.repo,
-			repoInfo:        p.repoInfo,
+			repoName:        p.repoInfo.Name,
 			metadataService: p.metadataService,
 			src:             d,
 		})

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -557,14 +557,12 @@ func (p *puller) pullSchema1(ctx context.Context, ref reference.Reference, unver
 			continue
 		}
 
-		layerDescriptor := &layerDescriptor{
+		descriptors = append(descriptors, &layerDescriptor{
 			digest:          blobSum,
 			repoInfo:        p.repoInfo,
 			repo:            p.repo,
 			metadataService: p.metadataService,
-		}
-
-		descriptors = append(descriptors, layerDescriptor)
+		})
 	}
 
 	resultRootFS, release, err := p.config.DownloadManager.Download(ctx, *rootFS, descriptors, p.config.ProgressOutput)
@@ -623,15 +621,13 @@ func (p *puller) pullSchema2Layers(ctx context.Context, target distribution.Desc
 		if err := checkSupportedMediaType(d.MediaType); err != nil {
 			return "", err
 		}
-		layerDescriptor := &layerDescriptor{
+		descriptors = append(descriptors, &layerDescriptor{
 			digest:          d.Digest,
 			repo:            p.repo,
 			repoInfo:        p.repoInfo,
 			metadataService: p.metadataService,
 			src:             d,
-		}
-
-		descriptors = append(descriptors, layerDescriptor)
+		})
 	}
 
 	configChan := make(chan []byte, 1)
@@ -867,20 +863,17 @@ func (p *puller) pullManifestList(ctx context.Context, ref reference.Named, mfst
 			}
 			progress.Message(p.config.ProgressOutput, "", err.Error())
 
-			platform := toOCIPlatform(match.Platform)
-			id, _, err = p.pullSchema1(ctx, manifestRef, v, platform)
+			id, _, err = p.pullSchema1(ctx, manifestRef, v, toOCIPlatform(match.Platform))
 			if err != nil {
 				return "", "", err
 			}
 		case *schema2.DeserializedManifest:
-			platform := toOCIPlatform(match.Platform)
-			id, _, err = p.pullSchema2(ctx, manifestRef, v, platform)
+			id, _, err = p.pullSchema2(ctx, manifestRef, v, toOCIPlatform(match.Platform))
 			if err != nil {
 				return "", "", err
 			}
 		case *ocischema.DeserializedManifest:
-			platform := toOCIPlatform(match.Platform)
-			id, _, err = p.pullOCI(ctx, manifestRef, v, platform)
+			id, _, err = p.pullOCI(ctx, manifestRef, v, toOCIPlatform(match.Platform))
 			if err != nil {
 				return "", "", err
 			}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -74,8 +74,8 @@ type puller struct {
 }
 
 func (p *puller) pull(ctx context.Context, ref reference.Named) (err error) {
-	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	// TODO(thaJeztah): do we need p.repoInfo at all, as it would probably be same as ref?
+	p.repo, err = newRepository(ctx, p.repoInfo.Name, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		log.G(ctx).Warnf("Error getting v2 registry: %v", err)
 		return err

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -344,12 +344,6 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 	repoName, err := reference.ParseNormalizedNamed("testremotename")
 	assert.NilError(t, err)
 
-	repoInfo := &registry.RepositoryInfo{
-		Name: repoName,
-		Index: &registrytypes.IndexInfo{
-			Name: "testrepo",
-		},
-	}
 	imagePullConfig := &ImagePullConfig{
 		Config: Config{
 			AuthConfig: &registrytypes.AuthConfig{
@@ -358,7 +352,7 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 		},
 	}
 
-	p := newPuller(registry.APIEndpoint{URL: uri}, repoInfo, imagePullConfig, nil)
+	p := newPuller(registry.APIEndpoint{URL: uri}, repoName, imagePullConfig, nil)
 	p.repo, err = newRepository(context.Background(), repoName, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	assert.NilError(t, err)
 	return p

--- a/distribution/pull_v2_test.go
+++ b/distribution/pull_v2_test.go
@@ -341,11 +341,11 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 	uri, err := url.Parse(rawurl)
 	assert.NilError(t, err, "could not parse url from test server: %v", rawurl)
 
-	n, err := reference.ParseNormalizedNamed("testremotename")
+	repoName, err := reference.ParseNormalizedNamed("testremotename")
 	assert.NilError(t, err)
 
 	repoInfo := &registry.RepositoryInfo{
-		Name: n,
+		Name: repoName,
 		Index: &registrytypes.IndexInfo{
 			Name: "testrepo",
 		},
@@ -359,7 +359,7 @@ func testNewPuller(t *testing.T, rawurl string) *puller {
 	}
 
 	p := newPuller(registry.APIEndpoint{URL: uri}, repoInfo, imagePullConfig, nil)
-	p.repo, err = newRepository(context.Background(), p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(context.Background(), repoName, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	assert.NilError(t, err)
 	return p
 }

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -21,22 +21,18 @@ const compressionBufSize = 32768
 func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) error {
 	// FIXME: Allow to interrupt current push when new push of same image is done.
 
-	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := config.RegistryService.ResolveRepository(ref)
+	repoName := reference.TrimNamed(ref)
+
+	endpoints, err := config.RegistryService.LookupPushEndpoints(reference.Domain(repoName))
 	if err != nil {
 		return err
 	}
 
-	endpoints, err := config.RegistryService.LookupPushEndpoints(reference.Domain(repoInfo.Name))
-	if err != nil {
-		return err
-	}
+	progress.Messagef(config.ProgressOutput, "", "The push refers to repository [%s]", repoName.Name())
 
-	progress.Messagef(config.ProgressOutput, "", "The push refers to repository [%s]", repoInfo.Name.Name())
-
-	associations := config.ReferenceStore.ReferencesByName(repoInfo.Name)
+	associations := config.ReferenceStore.ReferencesByName(repoName)
 	if len(associations) == 0 {
-		return fmt.Errorf("An image does not exist locally with the tag: %s", reference.FamiliarName(repoInfo.Name))
+		return fmt.Errorf("An image does not exist locally with the tag: %s", reference.FamiliarName(repoName))
 	}
 
 	var (
@@ -56,9 +52,9 @@ func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) err
 			}
 		}
 
-		log.G(ctx).Debugf("Trying to push %s to %s", repoInfo.Name.Name(), endpoint.URL)
+		log.G(ctx).Debugf("Trying to push %s to %s", repoName.Name(), endpoint.URL)
 
-		if err := newPusher(ref, endpoint, repoInfo.Name, config).push(ctx); err != nil {
+		if err := newPusher(ref, endpoint, repoName, config).push(ctx); err != nil {
 			// Was this push cancelled? If so, don't try to fall
 			// back.
 			select {
@@ -84,12 +80,12 @@ func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) err
 			return err
 		}
 
-		config.ImageEventLogger(ctx, reference.FamiliarString(ref), reference.FamiliarName(repoInfo.Name), events.ActionPush)
+		config.ImageEventLogger(ctx, reference.FamiliarString(ref), reference.FamiliarName(repoName), events.ActionPush)
 		return nil
 	}
 
 	if lastErr == nil {
-		lastErr = fmt.Errorf("no endpoints found for %s", repoInfo.Name.Name())
+		lastErr = fmt.Errorf("no endpoints found for %s", repoName.Name())
 	}
 	return lastErr
 }

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -58,7 +58,7 @@ func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) err
 
 		log.G(ctx).Debugf("Trying to push %s to %s", repoInfo.Name.Name(), endpoint.URL)
 
-		if err := newPusher(ref, endpoint, repoInfo, config).push(ctx); err != nil {
+		if err := newPusher(ref, endpoint, repoInfo.Name, config).push(ctx); err != nil {
 			// Was this push cancelled? If so, don't try to fall
 			// back.
 			select {

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -153,7 +153,7 @@ func (p *pusher) pushTag(ctx context.Context, ref reference.NamedTagged, id dige
 	descriptorTemplate := pushDescriptor{
 		metadataService: p.metadataService,
 		hmacKey:         hmacKey,
-		repoInfo:        p.repoName,
+		repoName:        p.repoName,
 		ref:             p.ref,
 		endpoint:        p.endpoint,
 		repo:            p.repo,
@@ -274,7 +274,7 @@ type pushDescriptor struct {
 	layer            PushLayer
 	metadataService  metadata.V2MetadataService
 	hmacKey          []byte
-	repoInfo         reference.Named
+	repoName         reference.Named
 	ref              reference.Named
 	endpoint         registry.APIEndpoint
 	repo             distribution.Repository
@@ -328,7 +328,7 @@ func (pd *pushDescriptor) Upload(ctx context.Context, progressOutput progress.Ou
 	var layerUpload distribution.BlobWriter
 
 	// Attempt to find another repository in the same registry to mount the layer from to avoid an unnecessary upload
-	candidates := getRepositoryMountCandidates(pd.repoInfo, pd.hmacKey, maxMountAttempts, metaData)
+	candidates := getRepositoryMountCandidates(pd.repoName, pd.hmacKey, maxMountAttempts, metaData)
 	isUnauthorizedError := false
 	for _, mc := range candidates {
 		mountCandidate := mc
@@ -377,7 +377,7 @@ func (pd *pushDescriptor) Upload(ctx context.Context, progressOutput progress.Ou
 			// Cache mapping from this layer's DiffID to the blobsum
 			if err := pd.metadataService.TagAndAdd(diffID, pd.hmacKey, metadata.V2Metadata{
 				Digest:           err.Descriptor.Digest,
-				SourceRepository: pd.repoInfo.Name(),
+				SourceRepository: pd.repoName.Name(),
 			}); err != nil {
 				return distribution.Descriptor{}, xfer.DoNotRetry{Err: err}
 			}
@@ -496,7 +496,7 @@ func (pd *pushDescriptor) uploadUsingSession(
 	// Cache mapping from this layer's DiffID to the blobsum
 	if err := pd.metadataService.TagAndAdd(diffID, pd.hmacKey, metadata.V2Metadata{
 		Digest:           pushDigest,
-		SourceRepository: pd.repoInfo.Name(),
+		SourceRepository: pd.repoName.Name(),
 	}); err != nil {
 		return distribution.Descriptor{}, xfer.DoNotRetry{Err: err}
 	}
@@ -529,13 +529,13 @@ func (pd *pushDescriptor) layerAlreadyExists(
 	// filter the metadata
 	candidates := []metadata.V2Metadata{}
 	for _, meta := range v2Metadata {
-		if len(meta.SourceRepository) > 0 && !checkOtherRepositories && meta.SourceRepository != pd.repoInfo.Name() {
+		if len(meta.SourceRepository) > 0 && !checkOtherRepositories && meta.SourceRepository != pd.repoName.Name() {
 			continue
 		}
 		candidates = append(candidates, meta)
 	}
 	// sort the candidates by similarity
-	sortV2MetadataByLikenessAndAge(pd.repoInfo, pd.hmacKey, candidates)
+	sortV2MetadataByLikenessAndAge(pd.repoName, pd.hmacKey, candidates)
 
 	digestToMetadata := make(map[digest.Digest]*metadata.V2Metadata)
 	// an array of unique blob digests ordered from the best mount candidates to worst
@@ -560,16 +560,16 @@ func (pd *pushDescriptor) layerAlreadyExists(
 attempts:
 	for _, dgst := range layerDigests {
 		meta := digestToMetadata[dgst]
-		log.G(ctx).Debugf("Checking for presence of layer %s (%s) in %s", diffID, dgst, pd.repoInfo.Name())
+		log.G(ctx).Debugf("Checking for presence of layer %s (%s) in %s", diffID, dgst, pd.repoName.Name())
 		desc, err = pd.repo.Blobs(ctx).Stat(ctx, dgst)
 		pd.checkedDigests[meta.Digest] = struct{}{}
 		switch err {
 		case nil:
-			if m, ok := digestToMetadata[desc.Digest]; !ok || m.SourceRepository != pd.repoInfo.Name() || !metadata.CheckV2MetadataHMAC(m, pd.hmacKey) {
+			if m, ok := digestToMetadata[desc.Digest]; !ok || m.SourceRepository != pd.repoName.Name() || !metadata.CheckV2MetadataHMAC(m, pd.hmacKey) {
 				// cache mapping from this layer's DiffID to the blobsum
 				if err := pd.metadataService.TagAndAdd(diffID, pd.hmacKey, metadata.V2Metadata{
 					Digest:           desc.Digest,
-					SourceRepository: pd.repoInfo.Name(),
+					SourceRepository: pd.repoName.Name(),
 				}); err != nil {
 					return distribution.Descriptor{}, false, xfer.DoNotRetry{Err: err}
 				}
@@ -578,12 +578,12 @@ attempts:
 			exists = true
 			break attempts
 		case distribution.ErrBlobUnknown:
-			if meta.SourceRepository == pd.repoInfo.Name() {
+			if meta.SourceRepository == pd.repoName.Name() {
 				// remove the mapping to the target repository
 				pd.metadataService.Remove(*meta)
 			}
 		default:
-			log.G(ctx).WithError(err).Debugf("Failed to check for presence of layer %s (%s) in %s", diffID, dgst, pd.repoInfo.Name())
+			log.G(ctx).WithError(err).Debugf("Failed to check for presence of layer %s (%s) in %s", diffID, dgst, pd.repoName.Name())
 		}
 	}
 

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -38,12 +38,12 @@ const (
 // newPusher creates a new pusher for pushing to a v2 registry.
 // The parameters are passed through to the underlying pusher implementation for
 // use during the actual push operation.
-func newPusher(ref reference.Named, endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, config *ImagePushConfig) *pusher {
+func newPusher(ref reference.Named, endpoint registry.APIEndpoint, repoName reference.Named, config *ImagePushConfig) *pusher {
 	return &pusher{
 		metadataService: metadata.NewV2MetadataService(config.MetadataStore),
 		ref:             ref,
 		endpoint:        endpoint,
-		repoInfo:        repoInfo,
+		repoName:        repoName,
 		config:          config,
 	}
 }
@@ -52,7 +52,7 @@ type pusher struct {
 	metadataService metadata.V2MetadataService
 	ref             reference.Named
 	endpoint        registry.APIEndpoint
-	repoInfo        *registry.RepositoryInfo
+	repoName        reference.Named
 	config          *ImagePushConfig
 	repo            distribution.Repository
 
@@ -74,7 +74,7 @@ type pushState struct {
 func (p *pusher) push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, err = newRepository(ctx, p.repoInfo.Name, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	p.repo, err = newRepository(ctx, p.repoName, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		log.G(ctx).Debugf("Error getting v2 registry: %v", err)
@@ -118,7 +118,7 @@ func (p *pusher) pushRepository(ctx context.Context) (err error) {
 	}
 
 	if pushed == 0 {
-		return fmt.Errorf("no tags to push for %s", reference.FamiliarName(p.repoInfo.Name))
+		return fmt.Errorf("no tags to push for %s", reference.FamiliarName(p.repoName))
 	}
 
 	return nil
@@ -153,7 +153,7 @@ func (p *pusher) pushTag(ctx context.Context, ref reference.NamedTagged, id dige
 	descriptorTemplate := pushDescriptor{
 		metadataService: p.metadataService,
 		hmacKey:         hmacKey,
-		repoInfo:        p.repoInfo.Name,
+		repoInfo:        p.repoName,
 		ref:             p.ref,
 		endpoint:        p.endpoint,
 		repo:            p.repo,

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -74,7 +74,7 @@ type pushState struct {
 func (p *pusher) push(ctx context.Context) (err error) {
 	p.pushState.remoteLayers = make(map[layer.DiffID]distribution.Descriptor)
 
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	p.repo, err = newRepository(ctx, p.repoInfo.Name, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
 	p.pushState.hasAuthInfo = p.config.AuthConfig.RegistryToken != "" || (p.config.AuthConfig.Username != "" && p.config.AuthConfig.Password != "")
 	if err != nil {
 		log.G(ctx).Debugf("Error getting v2 registry: %v", err)

--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -398,7 +398,7 @@ func TestLayerAlreadyExists(t *testing.T) {
 		ms := &mockV2MetadataService{}
 		pd := &pushDescriptor{
 			hmacKey:  []byte(tc.hmacKey),
-			repoInfo: repoInfo,
+			repoName: repoInfo,
 			layer: &storeLayer{
 				Layer: layer.EmptyLayer,
 			},
@@ -581,7 +581,7 @@ func TestPushRegistryWhenAuthInfoEmpty(t *testing.T) {
 	}
 	pd := &pushDescriptor{
 		hmacKey:  []byte("abcd"),
-		repoInfo: repoInfo,
+		repoName: repoInfo,
 		layer: &storeLayer{
 			Layer: layer.EmptyLayer,
 		},

--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -507,7 +507,7 @@ func TestWhenEmptyAuthConfig(t *testing.T) {
 		}
 		imagePushConfig.ReferenceStore = &mockReferenceStore{}
 		repoInfo, _ := reference.ParseNormalizedNamed("xujihui1985/test.img")
-		pusher := &pusher{
+		testPusher := &pusher{
 			config: imagePushConfig,
 			repoInfo: &registrypkg.RepositoryInfo{
 				Name: repoInfo,
@@ -519,9 +519,9 @@ func TestWhenEmptyAuthConfig(t *testing.T) {
 				},
 			},
 		}
-		pusher.push(context.Background())
-		if pusher.pushState.hasAuthInfo != authInfo.expected {
-			t.Errorf("hasAuthInfo does not match expected: %t != %t", authInfo.expected, pusher.pushState.hasAuthInfo)
+		_ = testPusher.push(context.Background())
+		if testPusher.pushState.hasAuthInfo != authInfo.expected {
+			t.Errorf("hasAuthInfo does not match expected: %t != %t", authInfo.expected, testPusher.pushState.hasAuthInfo)
 		}
 	}
 }

--- a/distribution/push_v2_test.go
+++ b/distribution/push_v2_test.go
@@ -506,12 +506,10 @@ func TestWhenEmptyAuthConfig(t *testing.T) {
 			RegistryToken: authInfo.registryToken,
 		}
 		imagePushConfig.ReferenceStore = &mockReferenceStore{}
-		repoInfo, _ := reference.ParseNormalizedNamed("xujihui1985/test.img")
+		repoName, _ := reference.ParseNormalizedNamed("xujihui1985/test.img")
 		testPusher := &pusher{
-			config: imagePushConfig,
-			repoInfo: &registrypkg.RepositoryInfo{
-				Name: repoInfo,
-			},
+			config:   imagePushConfig,
+			repoName: repoName,
 			endpoint: registrypkg.APIEndpoint{
 				URL: &url.URL{
 					Scheme: "https",

--- a/distribution/registry.go
+++ b/distribution/registry.go
@@ -72,11 +72,11 @@ func init() {
 // providing timeout settings and authentication support, and also verifies the
 // remote API version.
 func newRepository(
-	ctx context.Context, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint,
+	ctx context.Context, ref reference.Named, endpoint registry.APIEndpoint,
 	metaHeaders http.Header, authConfig *registrytypes.AuthConfig, actions ...string,
 ) (distribution.Repository, error) {
 	// Trim the hostname to form the RemoteName
-	repoName := reference.Path(repoInfo.Name)
+	repoName := reference.Path(ref)
 
 	direct := &net.Dialer{
 		Timeout:   30 * time.Second,

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -40,9 +40,9 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 		t.Fatalf("could not parse url from test server: %v", err)
 	}
 
-	n, _ := reference.ParseNormalizedNamed("testremotename")
+	repoName, _ := reference.ParseNormalizedNamed("testremotename")
 	repoInfo := &registrypkg.RepositoryInfo{
-		Name: n,
+		Name: repoName,
 		Index: &registry.IndexInfo{
 			Name: "testrepo",
 		},
@@ -57,14 +57,14 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	}
 	p := newPuller(registrypkg.APIEndpoint{URL: uri}, repoInfo, imagePullConfig, nil)
 	ctx := context.Background()
-	p.repo, err = newRepository(ctx, p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = newRepository(ctx, repoName, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	log.G(ctx).Debug("About to pull")
 	// We expect it to fail, since we haven't mock'd the full registry exchange in our handler above
-	tag, _ := reference.WithTag(n, "tag_goes_here")
+	tag, _ := reference.WithTag(repoName, "tag_goes_here")
 	_ = p.pullRepository(ctx, tag)
 }
 

--- a/distribution/registry_unit_test.go
+++ b/distribution/registry_unit_test.go
@@ -41,12 +41,6 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 	}
 
 	repoName, _ := reference.ParseNormalizedNamed("testremotename")
-	repoInfo := &registrypkg.RepositoryInfo{
-		Name: repoName,
-		Index: &registry.IndexInfo{
-			Name: "testrepo",
-		},
-	}
 	imagePullConfig := &ImagePullConfig{
 		Config: Config{
 			MetaHeaders: http.Header{},
@@ -55,7 +49,7 @@ func testTokenPassThru(t *testing.T, ts *httptest.Server) {
 			},
 		},
 	}
-	p := newPuller(registrypkg.APIEndpoint{URL: uri}, repoInfo, imagePullConfig, nil)
+	p := newPuller(registrypkg.APIEndpoint{URL: uri}, repoName, imagePullConfig, nil)
 	ctx := context.Background()
 	p.repo, err = newRepository(ctx, repoName, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
 	if err != nil {

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -17,11 +17,7 @@ import (
 // It returns an error if it was unable to reach any of the registries for
 // the given reference, or if the provided reference is invalid.
 func GetRepositories(ctx context.Context, ref reference.Named, config *ImagePullConfig) ([]distribution.Repository, error) {
-	repoInfo, err := config.RegistryService.ResolveRepository(ref)
-	if err != nil {
-		return nil, errdefs.InvalidParameter(err)
-	}
-	repoName := repoInfo.Name
+	repoName := reference.TrimNamed(ref)
 	// makes sure name is not empty or `scratch`
 	if err := validateRepoName(repoName); err != nil {
 		return nil, errdefs.InvalidParameter(err)

--- a/distribution/repository.go
+++ b/distribution/repository.go
@@ -21,12 +21,13 @@ func GetRepositories(ctx context.Context, ref reference.Named, config *ImagePull
 	if err != nil {
 		return nil, errdefs.InvalidParameter(err)
 	}
+	repoName := repoInfo.Name
 	// makes sure name is not empty or `scratch`
-	if err := validateRepoName(repoInfo.Name); err != nil {
+	if err := validateRepoName(repoName); err != nil {
 		return nil, errdefs.InvalidParameter(err)
 	}
 
-	endpoints, err := config.RegistryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
+	endpoints, err := config.RegistryService.LookupPullEndpoints(reference.Domain(repoName))
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func GetRepositories(ctx context.Context, ref reference.Named, config *ImagePull
 		lastError    error
 	)
 	for _, endpoint := range endpoints {
-		repo, err := newRepository(ctx, repoInfo, endpoint, nil, config.AuthConfig, "pull")
+		repo, err := newRepository(ctx, repoName, endpoint, nil, config.AuthConfig, "pull")
 		if err != nil {
 			log.G(ctx).WithFields(log.Fields{"endpoint": endpoint.URL.String(), "error": err}).Info("endpoint")
 			lastError = err

--- a/registry/service.go
+++ b/registry/service.go
@@ -119,7 +119,14 @@ func (s *Service) ResolveRepository(name reference.Named) (*RepositoryInfo, erro
 func (s *Service) ResolveAuthConfig(authConfigs map[string]registry.AuthConfig, ref reference.Named) registry.AuthConfig {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	registryInfo := newIndexInfo(s.config, reference.Domain(ref))
+	// Simplified version of "newIndexInfo" without handling of insecure
+	// registries and mirrors, as we don't need that information to resolve
+	// the auth-config.
+	indexName := normalizeIndexName(reference.Domain(ref))
+	registryInfo, ok := s.config.IndexConfigs[indexName]
+	if !ok {
+		registryInfo = &registry.IndexInfo{Name: indexName}
+	}
 	return ResolveAuthConfig(authConfigs, registryInfo)
 }
 

--- a/registry/service.go
+++ b/registry/service.go
@@ -103,11 +103,24 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 
 // ResolveRepository splits a repository name into its components
 // and configuration of the associated registry.
+//
+// Deprecated: this function was only used internally and is no longer used. It will be removed in the next release.
 func (s *Service) ResolveRepository(name reference.Named) (*RepositoryInfo, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	// TODO(thaJeztah): remove error return as it's no longer used.
 	return newRepositoryInfo(s.config, name), nil
+}
+
+// ResolveAuthConfig looks up authentication for the given reference from the
+// given authConfigs.
+//
+// IMPORTANT: This function is for internal use and should not be used by external projects.
+func (s *Service) ResolveAuthConfig(authConfigs map[string]registry.AuthConfig, ref reference.Named) registry.AuthConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	registryInfo := newIndexInfo(s.config, reference.Domain(ref))
+	return ResolveAuthConfig(authConfigs, registryInfo)
 }
 
 // APIEndpoint represents a remote API endpoint


### PR DESCRIPTION
### distribution: remove vars that shadowed imports or types

### distribution: newRepository: don't require RepositoryInfo

This constructor only uses the name / reference, and doesn't
use any of the other properties provided in RepositoryInfo.

### distribution: layerDescriptor: don't require RepositoryInfo

This type only uses the name / reference, and doesn't use any of the
other properties provided in RepositoryInfo.

### distribution: newPuller: don't require RepositoryInfo

This constructor only uses the name / reference, and doesn't
use any of the other properties provided in RepositoryInfo

### distribution: pullEndpoints: don't require RepositoryInfo

The callback only used the name / reference

### distribution: pullEndpoints: don't return RepositoryInfo

we're only consuming the name returned.

### distribution: pullEndpoints: skip using Service.ResolveRepository

[Service.ResolveRepository] is a shallow wrapper around [newRepositoryInfo],
from which we only consume the `Name` field. That field is a direct result
of `reference.TrimNamed`, so we can replace this with that.

[Service.ResolveRepository]: https://github.com/moby/moby/blob/ecb03c4cdae6f323150fc11b303dcc5dc4d82416/registry/service.go#L106-L111
[newRepositoryInfo]: https://github.com/moby/moby/blob/ecb03c4cdae6f323150fc11b303dcc5dc4d82416/registry/config.go#L392-L408


### distribution; newPusher: don't require RepositoryInfo

This constructor only uses the name / reference, and doesn't
use any of the other properties provided in RepositoryInfo.

### distribution: Push: skip using Service.ResolveRepository

[Service.ResolveRepository] is a shallow wrapper around [newRepositoryInfo],
from which we only consume the `Name` field. That field is a direct result
of `reference.TrimNamed`, so we can replace this with that.

[Service.ResolveRepository]: https://github.com/moby/moby/blob/ecb03c4cdae6f323150fc11b303dcc5dc4d82416/registry/service.go#L106-L111
[newRepositoryInfo]: https://github.com/moby/moby/blob/ecb03c4cdae6f323150fc11b303dcc5dc4d82416/registry/config.go#L392-L408


### distribution: GetRepositories skip using Service.ResolveRepository

[Service.ResolveRepository] is a shallow wrapper around [newRepositoryInfo],
from which we only consume the `Name` field. That field is a direct result
of `reference.TrimNamed`, so we can replace this with that.

[Service.ResolveRepository]: https://github.com/moby/moby/blob/ecb03c4cdae6f323150fc11b303dcc5dc4d82416/registry/service.go#L106-L111
[newRepositoryInfo]: https://github.com/moby/moby/blob/ecb03c4cdae6f323150fc11b303dcc5dc4d82416/registry/config.go#L392-L408


### daemon/containerd: registryResolver: remove IsInsecureRegistry

It's not called anywhere, so we can remove it from this interface.

### lookup auth-config without depending on RepositoryInfo

Simplify how we lookup auth-config, as we don't need the
additional information provided by RepositoryInfo. There's
still more layers to peel off, which will be done in follow-ups.

### registry: ResolveAuthConfig: inline newIndexInfo code

inline a simplified version of "newIndexInfo" without handling of
insecure registries and mirrors, as we don't need that information
to resolve the auth-config.


### daemon/containerd: remove registryResolver interface

While it's generally better to define interfaces locally, this one
now duplicated distribution.RegistryResolver, and it's passed on
to other types which expect that interface.

Remove this (un-exported) interface to make it easier to discover
what's used where.

### distribution: pushDescriptor: rename repoInfo to repoName


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

