### PR TITLE
Add missing go1.22 build constraints

### DIFF
--- a/internal/platform/platform_linux.go
+++ b/internal/platform/platform_linux.go
@@ -1,3 +1,6 @@
+// TODO(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package platform
 
 import (

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -1,3 +1,6 @@
+// TODO(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package oci // import "github.com/docker/docker/oci"
 
 import (


### PR DESCRIPTION
Some recent changes used a newer Go features.
