### PR TITLE
registry: deprecate APIEndpoint.Official field

### DIFF
--- a/registry/service.go
+++ b/registry/service.go
@@ -115,7 +115,7 @@ type APIEndpoint struct {
 	Mirror                         bool
 	URL                            *url.URL
 	AllowNondistributableArtifacts bool // Deprecated: non-distributable artifacts are deprecated and enabled by default. This field will be removed in the next release.
-	Official                       bool
+	Official                       bool // Deprecated: this field was only used internally, and will be removed in the next release.
 	TrimHostname                   bool // Deprecated: hostname is now trimmed unconditionally for remote names. This field will be removed in the next release.
 	TLSConfig                      *tls.Config
 }


### PR DESCRIPTION
This field was introduced in 19515a7ad859b28c474d81e756ac245afcd968e3 when the registry code was replaced for code vendored from docker/distribution.

It was used for v1 registries to update the "TrustStore" for signed manifests; https://github.com/moby/moby/blob/19515a7ad859b28c474d81e756ac245afcd968e3/graph/pull.go#L89-L93

Before that, it used the IndexInfo.Official field; https://github.com/moby/moby/blob/276c640be4b4335e3b8d684cb3562a56d3337b39/graph/pull.go#L94-L97

And related to "v2" registries;
https://github.com/moby/moby/commit/88fdcfef02cdc8b4fcff10cded6a89a42a360ec1


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: registry: deprecate `APIEndpoint.Official` field
```

**- A picture of a cute animal (not mandatory but encouraged)**

