### PR TITLE
registry: session.searchRepositories: pass through context

### DIFF
--- a/registry/search.go
+++ b/registry/search.go
@@ -84,7 +84,6 @@ func (s *Service) Search(ctx context.Context, searchFilters filters.Args, term s
 }
 
 func (s *Service) searchUnfiltered(ctx context.Context, term string, limit int, authConfig *registry.AuthConfig, headers http.Header) (*registry.SearchResults, error) {
-	// TODO Use ctx when searching for repositories
 	if hasScheme(term) {
 		return nil, invalidParamf("invalid repository name: repository name (%s) should not have a scheme", term)
 	}
@@ -131,7 +130,7 @@ func (s *Service) searchUnfiltered(ctx context.Context, term string, limit int, 
 		}
 	}
 
-	return newSession(client, endpoint).searchRepositories(remoteName, limit)
+	return newSession(client, endpoint).searchRepositories(ctx, remoteName, limit)
 }
 
 // splitReposSearchTerm breaks a search term into an index name and remote name

--- a/registry/search_session.go
+++ b/registry/search_session.go
@@ -213,7 +213,7 @@ func newSession(client *http.Client, endpoint *v1Endpoint) *session {
 const defaultSearchLimit = 25
 
 // searchRepositories performs a search against the remote repository
-func (r *session) searchRepositories(term string, limit int) (*registry.SearchResults, error) {
+func (r *session) searchRepositories(ctx context.Context, term string, limit int) (*registry.SearchResults, error) {
 	if limit == 0 {
 		limit = defaultSearchLimit
 	}
@@ -221,9 +221,9 @@ func (r *session) searchRepositories(term string, limit int) (*registry.SearchRe
 		return nil, invalidParamf("limit %d is outside the range of [1, 100]", limit)
 	}
 	u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(fmt.Sprintf("%d", limit))
-	log.G(context.TODO()).WithField("url", u).Debug("searchRepositories")
+	log.G(ctx).WithField("url", u).Debug("searchRepositories")
 
-	req, err := http.NewRequest(http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, invalidParamWrapf(err, "error building request")
 	}

--- a/registry/search_test.go
+++ b/registry/search_test.go
@@ -70,7 +70,7 @@ func (tr debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 func TestSearchRepositories(t *testing.T) {
 	r := spawnTestRegistrySession(t)
-	results, err := r.searchRepositories("fakequery", 25)
+	results, err := r.searchRepositories(context.Background(), "fakequery", 25)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION


**- A picture of a cute animal (not mandatory but encouraged)**

