### PR TITLE
distribution: cleanup tests, and remove unused fields

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -155,7 +155,6 @@ func (p *pusher) pushTag(ctx context.Context, ref reference.NamedTagged, id dige
 		hmacKey:         hmacKey,
 		repoName:        p.repoName,
 		ref:             p.ref,
-		endpoint:        p.endpoint,
 		repo:            p.repo,
 		pushState:       &p.pushState,
 	}
@@ -276,7 +275,6 @@ type pushDescriptor struct {
 	hmacKey          []byte
 	repoName         reference.Named
 	ref              reference.Named
-	endpoint         registry.APIEndpoint
 	repo             distribution.Repository
 	pushState        *pushState
 	remoteDescriptor distribution.Descriptor

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -82,7 +82,8 @@ func (p *pusher) push(ctx context.Context) (err error) {
 	}
 
 	if err = p.pushRepository(ctx); err != nil {
-		if continueOnError(err, p.endpoint.Mirror) {
+		// [Service.LookupPushEndpoints] never returns mirror endpoint.
+		if continueOnError(err, false) {
 			return fallbackError{
 				err:         err,
 				transportOK: true,


### PR DESCRIPTION
### distribution: cleanup some tests and add missing error-checks

- use gotest.tools for assertions
- remove some debug-logs

### distribution: pushDescriptor: remove unused endpoint field

### distribution: pusher.push(): don't use APIEndpoint.Mirror field

Unlike the equivalent for pulling images, [Service.LookupPushEndpoints]
never returns mirror endpoints, as it calls [Service.lookupV2Endpoints]
with "includeMirrors=false", so we should not use this field, and
unconditionally handle errors without the additional fallbacks that
we consider for pulling images from a mirror.

[Service.LookupPushEndpoints]: https://github.com/moby/moby/blob/cea56c1d9c2fae5831f38ae88fba593206985b2b/registry/service.go#L134-L139
[Service.lookupV2Endpoints]: https://github.com/moby/moby/blob/cea56c1d9c2fae5831f38ae88fba593206985b2b/registry/service_v2.go#L10-L40


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

