### PR TITLE
api: bump API version to 1.49

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of the current REST API.
-	DefaultVersion = "1.48"
+	DefaultVersion = "1.49"
 
 	// MinSupportedAPIVersion is the minimum API version that can be supported
 	// by the API server, specified as "major.minor". Note that the daemon

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.48"
+basePath: "/v1.49"
 info:
   title: "Docker Engine API"
-  version: "1.48"
+  version: "1.49"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.48) is used.
-    For example, calling `/info` is the same as calling `/v1.48/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.49) is used.
+    For example, calling `/info` is the same as calling `/v1.49/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,10 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.49 API changes
+
+[Docker Engine API v1.49](https://docs.docker.com/reference/api/engine/version/v1.49/) documentation
+
 ## v1.48 API changes
 
 [Docker Engine API v1.48](https://docs.docker.com/reference/api/engine/version/v1.48/) documentation


### PR DESCRIPTION

```markdown changelog
Update API version to [v1.49](https://docs.docker.com/engine/api/v1.49/)
```

**- A picture of a cute animal (not mandatory but encouraged)**

