### PR TITLE
Include per-port rules in iptablesNetwork

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -391,21 +391,6 @@ func parseErr(label, value, errString string) error {
 	return types.InvalidParameterErrorf("failed to parse %s value: %v (%s)", label, value, errString)
 }
 
-func (n *bridgeNetwork) iptablesEnabled(version iptables.IPVersion) (bool, error) {
-	n.Lock()
-	defer n.Unlock()
-	if n.driver == nil {
-		return false, types.InvalidParameterErrorf("no driver found")
-	}
-
-	n.driver.Lock()
-	defer n.driver.Unlock()
-	if version == iptables.IPv6 {
-		return n.driver.config.EnableIP6Tables, nil
-	}
-	return n.driver.config.EnableIPTables, nil
-}
-
 func (n *bridgeNetwork) newIptablesNetwork() (*iptablesNetwork, error) {
 	config4, err := makeNetworkConfigFam(n.config.HostIPv4, n.bridge.bridgeIPv4, n.gwMode(iptables.IPv4))
 	if err != nil {
@@ -449,14 +434,6 @@ func makeNetworkConfigFam(hostIP net.IP, bridgePrefix *net.IPNet, gwm gwMode) (n
 		c.Prefix = p.Masked()
 	}
 	return c, nil
-}
-
-func (n *bridgeNetwork) getNetworkBridgeName() string {
-	n.Lock()
-	config := n.config
-	n.Unlock()
-
-	return config.BridgeName
 }
 
 func (n *bridgeNetwork) getNATDisabled() (ipv4, ipv6 bool) {

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -830,6 +830,7 @@ func TestAddPortMappings(t *testing.T) {
 					GwModeIPv4: tc.gwMode4,
 					GwModeIPv6: tc.gwMode6,
 				},
+				bridge: &bridgeInterface{},
 				driver: newDriver(storeutils.NewTempStore(t)),
 			}
 			genericOption := map[string]interface{}{
@@ -843,6 +844,10 @@ func TestAddPortMappings(t *testing.T) {
 			}
 			err := n.driver.configure(genericOption)
 			assert.NilError(t, err)
+			fwn, err := n.newIptablesNetwork()
+			assert.NilError(t, err)
+			assert.Check(t, fwn != nil, "no firewaller network")
+			n.iptablesNetwork = fwn
 
 			assert.Check(t, is.Equal(n.driver.portDriverClient == nil, !tc.rootless))
 			expChildIP := func(hostIP net.IP) net.IP {

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -531,19 +531,12 @@ func TestMirroredWSL2LoopbackFiltering(t *testing.T) {
 			restoreWslinfoPath := simulateWSL2MirroredMode(t, tc.loopback0, tc.wslinfoPerm)
 			defer restoreWslinfoPath()
 
-			nw := bridgeNetwork{
-				driver: &driver{
-					config: configuration{EnableIPTables: true},
-				},
-			}
-			err := nw.filterPortMappedOnLoopback(context.TODO(), portBinding{
-				PortBinding: types.PortBinding{
-					Proto:    types.TCP,
-					IP:       net.ParseIP("127.0.0.1"),
-					HostPort: 8000,
-				},
-				childHostIP: net.ParseIP("127.0.0.1"),
-			}, true)
+			hostIP := net.ParseIP("127.0.0.1")
+			err := filterPortMappedOnLoopback(context.TODO(), types.PortBinding{
+				Proto:    types.TCP,
+				IP:       hostIP,
+				HostPort: 8000,
+			}, hostIP, true)
 			assert.NilError(t, err)
 
 			// Checking this after trying to create rules, to make sure the init code in iptables/firewalld.go has run.


### PR DESCRIPTION
**- What I did**

This is  step towards the `Firewaller` interface, that'll allow the bridge to have iptables/nftables/firewalld backends:
- https://github.com/moby/moby/issues/49635

**- How I did it**

Put the bridge driver code that adds/removed port mappings into the `iptablesNetwork` object, behind methods `AddPorts`/`DelPorts` that'll eventually be part of the `Firewaller.Network` interface.

**- How to verify it**

Existing tests, no functional change.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
