### PR TITLE
libnet: fix duplicated port mappings in overlay networks

### DIFF
--- a/integration/network/overlay/overlay_test.go
+++ b/integration/network/overlay/overlay_test.go
@@ -3,16 +3,23 @@
 package overlay // import "github.com/docker/docker/integration/network/overlay"
 
 import (
+	"fmt"
+	"net"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
+	networktypes "github.com/docker/docker/api/types/network"
+	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration/internal/container"
-	net "github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/integration/internal/network"
+	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -30,13 +37,13 @@ func TestEndpointWithCustomIfname(t *testing.T) {
 
 	// create a network specifying the desired sub-interface name
 	const netName = "overlay-custom-ifname"
-	net.CreateNoError(ctx, t, apiClient, netName,
-		net.WithDriver("overlay"),
-		net.WithAttachable())
+	network.CreateNoError(ctx, t, apiClient, netName,
+		network.WithDriver("overlay"),
+		network.WithAttachable())
 
 	ctrID := container.Run(ctx, t, apiClient,
 		container.WithCmd("ip", "-o", "link", "show", "foobar"),
-		container.WithEndpointSettings(netName, &network.EndpointSettings{
+		container.WithEndpointSettings(netName, &networktypes.EndpointSettings{
 			DriverOpts: map[string]string{
 				netlabel.Ifname: "foobar",
 			},
@@ -46,4 +53,58 @@ func TestEndpointWithCustomIfname(t *testing.T) {
 	out, err := container.Output(ctx, apiClient, ctrID)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.Contains(out.Stdout, ": foobar@if"), "expected ': foobar@if' in 'ip link show':\n%s", out.Stdout)
+}
+
+// TestHostPortMappings checks that, when a Swarm task has ports mappings in
+// host mode, the ContainerList API endpoint reports the right number of ports.
+//
+// Regression test for https://github.com/moby/moby/issues/49719
+func TestHostPortMappings(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "rootless mode doesn't support overlay networks")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+
+	d.SwarmInit(ctx, t, swarmtypes.InitRequest{AdvertiseAddr: "127.0.0.1:2377"})
+	defer d.SwarmLeave(ctx, t, true)
+
+	apiClient := d.NewClientT(t)
+
+	const netName = "testnet1"
+	network.CreateNoError(ctx, t, apiClient, netName,
+		network.WithDriver("overlay"),
+		network.WithAttachable())
+
+	svcID := swarm.CreateService(ctx, t, d,
+		swarm.ServiceWithNetwork(netName),
+		swarm.ServiceWithEndpoint(&swarmtypes.EndpointSpec{
+			Ports: []swarmtypes.PortConfig{
+				{Protocol: swarmtypes.PortConfigProtocolTCP, TargetPort: 80, PublishedPort: 80, PublishMode: swarmtypes.PortConfigPublishModeHost},
+			},
+		}))
+	defer apiClient.ServiceRemove(ctx, svcID)
+
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, svcID, 1), swarm.ServicePoll)
+
+	ctrs, err := apiClient.ContainerList(ctx, containertypes.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(ctrs))
+
+	var addrs []string
+	for _, port := range ctrs[0].Ports {
+		addrs = append(addrs, fmt.Sprintf("%s:%d/%s", net.JoinHostPort(port.IP, strconv.Itoa(int(port.PublicPort))), port.PrivatePort, port.Type))
+	}
+
+	assert.Check(t, len(addrs) >= 1 && len(addrs) <= 2)
+
+	exp := []string{"0.0.0.0:80:80/tcp"}
+	if len(addrs) > 1 {
+		exp = append(exp, "[::]:80:80/tcp")
+	}
+
+	slices.Sort(addrs)
+	assert.DeepEqual(t, exp, addrs)
 }

--- a/libnetwork/endpoint_info_unix.go
+++ b/libnetwork/endpoint_info_unix.go
@@ -11,12 +11,6 @@ func (ep *Endpoint) DriverInfo() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	if sb, ok := ep.getSandbox(); ok {
-		if gwep := sb.getEndpointInGWNetwork(); gwep != nil && gwep.ID() != ep.ID() {
-			return gwep.DriverInfo()
-		}
-	}
-
 	n, err := ep.getNetworkFromStore()
 	if err != nil {
 		return nil, fmt.Errorf("could not find network in store for driver info: %v", err)


### PR DESCRIPTION
- Fixes moby/moby#49719

**- What I did**

Since commit f2a183a99, `getEndpointPortMapInfo` is called for all the endpoints of a container to get its complete list of port mappings. This is required as multiple endpoints might publish different ports (e.g. IPv4-only and IPv6-only endpoints mapping an IPv4 and an IPv6 port).

`getEndpointPortMapInfo` calls `(*Endpoint).DriverInfo()` which has a dodgy behavior: if the endpoint is part of a sandbox that also has an endpoint for the `docker_gwbridge` network, then `(*Endpoint).DriverInfo()` returns the DriverInfo of that `docker_gwbridge` endpoint in place of the current Endpoint's DriverInfo.

On overlay networks, host port-mappings are made through the `docker_gwbridge` network (which is automatically attached to all Swarm tasks). This results in duplicated port mappings reported for all Swarm containers.

Since `getEndpointPortMapInfo` is the only place where `(*Endpoint).DriverInfo()` is called, just remove that dodgy behavior.

`(*Endpoint).DriverInfo()` has an OS-specific implementation. Unlike the Linux implementation, on Windows, `DriverInfo()` returns the DriverInfo of the gateway endpoint _in addition_ to the current Endpoint's DriverInfo. So it shouldn't be affected by this bug -- don't touch it.

**- How to verify it**

A new integration test is added. This can also be verified manually with:

```
$ docker swarm init --advertise-addr=127.0.0.1:2377
$ docker network create -d overlay --scope swarm --attachable testnet1
$ docker service create --network testnet1 --name fooabr --publish=published=80,target=80,mode=host busybox top
$ docker ps
CONTAINER ID   IMAGE            COMMAND   CREATED         STATUS         PORTS                                                                      NAMES
6309cdab49d8   busybox:latest   "top"     7 seconds ago   Up 6 seconds   0.0.0.0:80->80/tcp, [::]:80->80/tcp, 0.0.0.0:80->80/tcp, [::]:80->80/tcp   fooabr.1.kmtim0i5nj0an5cjf7tca9eps
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix a bug causing host port-mappings on Swarm containers to be duplicated on `docker ps` and `docker inspect`
```

