### PR TITLE
Add missing platform parameter to ImageGet api docs and add it under Image tag

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10571,6 +10571,16 @@ paths:
           type: "array"
           items:
             type: "string"
+        - name: "platform"
+          type: "string"
+          in: "query"
+          description: |
+            JSON encoded OCI platform describing a platform which will be used
+            to select a platform-specific image to be saved if the image is
+            multi-platform.
+            If not provided, the full multi-platform image will be saved.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
       tags: ["Image"]
   /images/load:
     post:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10537,6 +10537,7 @@ paths:
             If not provided, the full multi-platform image will be saved.
 
             Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
+      tags: ["Image"]
   /images/get:
     get:
       summary: "Export several images"


### PR DESCRIPTION
Two api documentation fixes:

1. Add missing `platform` parameter to ImageGetAll api docs, added in https://github.com/moby/moby/pull/48295
2. Move ImageGet operation under Image tag, thinking removed in https://github.com/moby/moby/pull/48295/files#diff-f8dfad091f6542b4f85362389dd5c0d66d7c02f86e7303e8cee8277b946b172cL9950 by accident.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

