### PR TITLE
Don't run unit tests with mode rootless

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -47,7 +47,6 @@ jobs:
           script: |
             let includes = [
               { mode: '' },
-              { mode: 'rootless' },
               { mode: 'systemd' },
             ];
             if ("${{ inputs.storage }}" == "snapshotter") {
@@ -83,12 +82,6 @@ jobs:
         name: Prepare
         run: |
           CACHE_DEV_SCOPE=dev
-          if [[ "${{ matrix.mode }}" == *"rootless"* ]]; then
-            # In rootless mode, tests will run in the host's namspace not the rootlesskit
-            # namespace. So, probably no different to non-rootless unit tests and can be
-            # removed from the test matrix.
-            echo "DOCKER_ROOTLESS=1" >> $GITHUB_ENV
-          fi
           if [[ "${{ matrix.mode }}" == *"firewalld"* ]]; then
             echo "FIREWALLD=true" >> $GITHUB_ENV
             CACHE_DEV_SCOPE="${CACHE_DEV_SCOPE}firewalld"


### PR DESCRIPTION
**- What I did**

Dropped firewalld unit test CI workflow.

Tests will run in the host's namspace not the rootlesskit namespace. So, just duplicating the non-rootless unit tests.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

