### PR TITLE
containerd: change default handling of dangling images

### DIFF
--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -105,7 +105,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 				if err != nil {
 					return nil, err
 				}
-				if nn, err := reference.ParseNormalizedNamed(ref.Name); err == nil {
+				if nn, err := reference.ParseNormalizedNamed(ref.Name); err == nil && !isDanglingImage(ref) {
 					familiarRef := reference.FamiliarString(nn)
 					i.logImageEvent(ref, familiarRef, events.ActionUnTag)
 					records = append(records, imagetypes.DeleteResponse{Untagged: familiarRef})
@@ -136,7 +136,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 				if err != nil {
 					return nil, err
 				}
-				if nn, err := reference.ParseNormalizedNamed(ref.Name); err == nil {
+				if nn, err := reference.ParseNormalizedNamed(ref.Name); err == nil && !isDanglingImage(ref) {
 					familiarRef := reference.FamiliarString(nn)
 					i.logImageEvent(ref, familiarRef, events.ActionUnTag)
 					records = append(records, imagetypes.DeleteResponse{Untagged: familiarRef})
@@ -190,8 +190,11 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 				return nil, err
 			}
 
-			i.logImageEvent(*img, familiarRef, events.ActionUnTag)
-			records := []imagetypes.DeleteResponse{{Untagged: familiarRef}}
+			var records []imagetypes.DeleteResponse
+			if !isDanglingImage(*img) {
+				i.logImageEvent(*img, familiarRef, events.ActionUnTag)
+				records = []imagetypes.DeleteResponse{{Untagged: familiarRef}}
+			}
 			return records, nil
 		}
 	}

--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -80,14 +80,12 @@ func (i *ImageService) createOrReplaceImage(ctx context.Context, newImg c8dimage
 	})
 	logger.Info("image created")
 
-	if !creatingDangling {
-		defer i.LogImageEvent(ctx, string(newImg.Target.Digest), imageFamiliarName(newImg), events.ActionTag)
+	if err := i.ensureDanglingImage(ctx, newImg); err != nil {
+		logger.WithError(err).Warn("failed to mark new image as dangling")
+	}
 
-		if err := i.images.Delete(ctx, danglingName); err != nil {
-			if !cerrdefs.IsNotFound(err) {
-				logger.WithError(err).Warn("unexpected error when deleting dangling image")
-			}
-		}
+	if !creatingDangling {
+		i.LogImageEvent(ctx, string(newImg.Target.Digest), imageFamiliarName(newImg), events.ActionTag)
 	}
 
 	return nil


### PR DESCRIPTION

This changes the default handling of dangling images so they always exist when
an image is created rather than being created right before an image is to be
overwritten. This primarily affects `import`, `load`, and `pull`.

Fixes #48907.
