### PR TITLE
registry: minor fixes and cleanups

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -417,7 +417,6 @@ func newRepositoryInfo(config *serviceConfig, name reference.Named) *RepositoryI
 func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
 	indexName := normalizeIndexName(reference.Domain(reposName))
 	if indexName == IndexName {
-		officialRepo := !strings.ContainsRune(reference.FamiliarName(reposName), '/')
 		return &RepositoryInfo{
 			Name: reference.TrimNamed(reposName),
 			Index: &registry.IndexInfo{
@@ -426,13 +425,8 @@ func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
 				Secure:   true,
 				Official: true,
 			},
-			Official: officialRepo,
+			Official: !strings.ContainsRune(reference.FamiliarName(reposName), '/'),
 		}, nil
-	}
-
-	insecure := false
-	if isInsecure(indexName) {
-		insecure = true
 	}
 
 	return &RepositoryInfo{
@@ -440,7 +434,7 @@ func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
 		Index: &registry.IndexInfo{
 			Name:    indexName,
 			Mirrors: []string{},
-			Secure:  !insecure,
+			Secure:  !isInsecure(indexName),
 		},
 	}, nil
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -59,7 +59,10 @@ func hasFile(files []os.DirEntry, name string) bool {
 // provided TLS configuration.
 func ReadCertsDirectory(tlsConfig *tls.Config, directory string) error {
 	fs, err := os.ReadDir(directory)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return invalidParam(err)
 	}
 

--- a/registry/service.go
+++ b/registry/service.go
@@ -24,6 +24,9 @@ type Service struct {
 // an engine.
 func NewService(options ServiceOptions) (*Service, error) {
 	config, err := newServiceConfig(options)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Service{config: config}, err
 }


### PR DESCRIPTION
### registry: authTransport: un-export AuthConfig, RoundTripper

Don't embed these interfaces/types, and keep them internal.

### registry: NewService: return nil on error

### registry: ReadCertsDirectory: return early on error

### registry: ParseRepositoryInfo: remove some intermediate vars


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

