### PR TITLE
pkg/atomicwriter: disallow symlinks for now, add more tests and touch-up GoDoc

### DIFF
--- a/pkg/atomicwriter/atomicwriter.go
+++ b/pkg/atomicwriter/atomicwriter.go
@@ -1,3 +1,5 @@
+// Package atomicwriter provides utilities to perform atomic writes to a
+// file or set of files.
 package atomicwriter
 
 import (

--- a/pkg/atomicwriter/atomicwriter.go
+++ b/pkg/atomicwriter/atomicwriter.go
@@ -58,8 +58,7 @@ func validateFileMode(mode os.FileMode) error {
 	case mode&os.ModeSticky != 0:
 		return errors.New("cannot write to a sticky bit file")
 	default:
-		// Unknown file mode; let's assume it works
-		return nil
+		return fmt.Errorf("unknown file mode: %[1]s (%#[1]o)", mode)
 	}
 }
 


### PR DESCRIPTION
- Addresses comments left on https://github.com/moby/sys/pull/185

---


### pkg/atomicwriter: disallow symlinked files for now

The implementation uses "os.Rename" to move the temporary file to
the destination, which does not follow symlinks, and because of this
would replace a symlink with a file.

We can consider adding support for symlinked files in future, so that
WriteFile can be used as a drop-in replacement for `os.WriteFile()`
but in the meantime, let's produce an error so that nobody can depend
on this.

### pkg/atomicwriter: error on unknown file-modes

Previously, we were silently discarding this situation and hoping that
it would work; let's produce an error instead (we can add additional
filemodes when they arrive and if we need them)

### pkg/atomicwriter: add test for parent dir not being a directory

While the target-file does not have to exist, its parent must, and must
be a directory. This adds a test-case to verify the behavior if the
parent is not a directory.


### pkg/atomicwriter: return early if parent directory is invalid

Rewrite `validateDestination` to first check if the destination path
exists. This slightly simplifies the logic (allowing returning
early in each step of the validation) and slightly improves the
error produced.

Before this, the error confusingly would mention the full path
not being a directory. While this _does_ match what `os.Writefile`
would return, it's .. confusing:

    failed to stat output path: lstat ./not-a-dir/new-file.txt: not a directory

After this, the error would mention the directory that doesn't exist:

    invalid output path: stat ./not-a-dir: not a directory

A slight optimization is made as well, now checking for _both_ "."
and ".." as special case, as either path should exist given any current
working directory (unless the working directory has been deleted, but we'd
fail further down the line).

With this change in order, we can also merge `validateFileMode` into
`validateDestination`.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

