### PR TITLE
registry: wire up context in some places

### DIFF
--- a/registry/search.go
+++ b/registry/search.go
@@ -99,7 +99,7 @@ func (s *Service) searchUnfiltered(ctx context.Context, term string, limit int, 
 		remoteName = strings.TrimPrefix(remoteName, "library/")
 	}
 
-	endpoint, err := newV1Endpoint(index, headers)
+	endpoint, err := newV1Endpoint(ctx, index, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -50,7 +51,10 @@ func newV1Endpoint(ctx context.Context, index *registry.IndexInfo, headers http.
 
 	// Try HTTPS ping to registry
 	endpoint.URL.Scheme = "https"
-	if _, err := endpoint.ping(); err != nil {
+	if _, err := endpoint.ping(ctx); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		if endpoint.IsSecure {
 			// If registry is secure and HTTPS failed, show user the error and tell them about `--insecure-registry`
 			// in case that's what they need. DO NOT accept unknown CA certificates, and DO NOT fall back to HTTP.
@@ -60,7 +64,7 @@ func newV1Endpoint(ctx context.Context, index *registry.IndexInfo, headers http.
 		// registry is insecure and HTTPS failed, fallback to HTTP.
 		log.G(ctx).WithError(err).Debugf("error from registry %q marked as insecure - insecurely falling back to HTTP", endpoint)
 		endpoint.URL.Scheme = "http"
-		if _, err2 := endpoint.ping(); err2 != nil {
+		if _, err2 := endpoint.ping(ctx); err2 != nil {
 			return nil, invalidParamf("invalid registry endpoint %q. HTTPS attempt: %v. HTTP attempt: %v", endpoint, err, err2)
 		}
 	}
@@ -109,7 +113,7 @@ func (e *v1Endpoint) String() string {
 }
 
 // ping returns a v1PingResult which indicates whether the registry is standalone or not.
-func (e *v1Endpoint) ping() (v1PingResult, error) {
+func (e *v1Endpoint) ping(ctx context.Context) (v1PingResult, error) {
 	if e.String() == IndexServer {
 		// Skip the check, we know this one is valid
 		// (and we never want to fallback to http in case of error)
@@ -117,14 +121,17 @@ func (e *v1Endpoint) ping() (v1PingResult, error) {
 	}
 
 	pingURL := e.String() + "_ping"
-	log.G(context.TODO()).WithField("url", pingURL).Debug("attempting v1 ping for registry endpoint")
-	req, err := http.NewRequest(http.MethodGet, pingURL, nil)
+	log.G(ctx).WithField("url", pingURL).Debug("attempting v1 ping for registry endpoint")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pingURL, nil)
 	if err != nil {
 		return v1PingResult{}, invalidParam(err)
 	}
 
 	resp, err := e.client.Do(req)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return v1PingResult{}, err
+		}
 		return v1PingResult{}, invalidParam(err)
 	}
 
@@ -136,7 +143,7 @@ func (e *v1Endpoint) ping() (v1PingResult, error) {
 		if v == "1" || strings.EqualFold(v, "true") {
 			info.Standalone = true
 		}
-		log.G(context.TODO()).Debugf("v1PingResult.Standalone (from X-Docker-Registry-Standalone header): %t", info.Standalone)
+		log.G(ctx).Debugf("v1PingResult.Standalone (from X-Docker-Registry-Standalone header): %t", info.Standalone)
 		return info, nil
 	}
 
@@ -146,11 +153,11 @@ func (e *v1Endpoint) ping() (v1PingResult, error) {
 		Standalone: true,
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		log.G(context.TODO()).WithError(err).Debug("error unmarshaling _ping response")
+		log.G(ctx).WithError(err).Debug("error unmarshaling _ping response")
 		// don't stop here. Just assume sane defaults
 	}
 
-	log.G(context.TODO()).Debugf("v1PingResult.Standalone: %t", info.Standalone)
+	log.G(ctx).Debugf("v1PingResult.Standalone: %t", info.Standalone)
 	return info, nil
 }
 

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -31,8 +31,8 @@ type v1Endpoint struct {
 
 // newV1Endpoint parses the given address to return a registry endpoint.
 // TODO: remove. This is only used by search.
-func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint, error) {
-	tlsConfig, err := newTLSConfig(context.TODO(), index.Name, index.Secure)
+func newV1Endpoint(ctx context.Context, index *registry.IndexInfo, headers http.Header) (*v1Endpoint, error) {
+	tlsConfig, err := newTLSConfig(ctx, index.Name, index.Secure)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint,
 		}
 
 		// registry is insecure and HTTPS failed, fallback to HTTP.
-		log.G(context.TODO()).WithError(err).Debugf("error from registry %q marked as insecure - insecurely falling back to HTTP", endpoint)
+		log.G(ctx).WithError(err).Debugf("error from registry %q marked as insecure - insecurely falling back to HTTP", endpoint)
 		endpoint.URL.Scheme = "http"
 		if _, err2 := endpoint.ping(); err2 != nil {
 			return nil, invalidParamf("invalid registry endpoint %q. HTTPS attempt: %v. HTTP attempt: %v", endpoint, err, err2)

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -32,7 +32,7 @@ type v1Endpoint struct {
 // newV1Endpoint parses the given address to return a registry endpoint.
 // TODO: remove. This is only used by search.
 func newV1Endpoint(index *registry.IndexInfo, headers http.Header) (*v1Endpoint, error) {
-	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
+	tlsConfig, err := newTLSConfig(context.TODO(), index.Name, index.Secure)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/search_endpoint_v1_test.go
+++ b/registry/search_endpoint_v1_test.go
@@ -1,6 +1,7 @@
 package registry // import "github.com/docker/docker/registry"
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,7 +14,7 @@ import (
 
 func TestV1EndpointPing(t *testing.T) {
 	testPing := func(index *registry.IndexInfo, expectedStandalone bool, assertMessage string) {
-		ep, err := newV1Endpoint(index, nil)
+		ep, err := newV1Endpoint(context.Background(), index, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -33,7 +34,7 @@ func TestV1EndpointPing(t *testing.T) {
 func TestV1Endpoint(t *testing.T) {
 	// Simple wrapper to fail test if err != nil
 	expandEndpoint := func(index *registry.IndexInfo) *v1Endpoint {
-		endpoint, err := newV1Endpoint(index, nil)
+		endpoint, err := newV1Endpoint(context.Background(), index, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -42,14 +43,14 @@ func TestV1Endpoint(t *testing.T) {
 
 	assertInsecureIndex := func(index *registry.IndexInfo) {
 		index.Secure = true
-		_, err := newV1Endpoint(index, nil)
+		_, err := newV1Endpoint(context.Background(), index, nil)
 		assert.ErrorContains(t, err, "insecure-registry", index.Name+": Expected insecure-registry  error for insecure index")
 		index.Secure = false
 	}
 
 	assertSecureIndex := func(index *registry.IndexInfo) {
 		index.Secure = true
-		_, err := newV1Endpoint(index, nil)
+		_, err := newV1Endpoint(context.Background(), index, nil)
 		assert.ErrorContains(t, err, "certificate signed by unknown authority", index.Name+": Expected cert error for secure index")
 		index.Secure = false
 	}
@@ -96,7 +97,7 @@ func TestV1Endpoint(t *testing.T) {
 	}
 	for _, address := range badEndpoints {
 		index.Name = address
-		_, err := newV1Endpoint(index, nil)
+		_, err := newV1Endpoint(context.Background(), index, nil)
 		assert.Check(t, err != nil, "Expected error while expanding bad endpoint: %s", address)
 	}
 }
@@ -162,7 +163,7 @@ func TestV1EndpointValidate(t *testing.T) {
 	testServer := httptest.NewServer(requireBasicAuthHandler)
 	defer testServer.Close()
 
-	testEndpoint, err := newV1Endpoint(&registry.IndexInfo{Name: testServer.URL}, nil)
+	testEndpoint, err := newV1Endpoint(context.Background(), &registry.IndexInfo{Name: testServer.URL}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/search_endpoint_v1_test.go
+++ b/registry/search_endpoint_v1_test.go
@@ -18,7 +18,7 @@ func TestV1EndpointPing(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		regInfo, err := ep.ping()
+		regInfo, err := ep.ping(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/registry/search_session.go
+++ b/registry/search_session.go
@@ -179,7 +179,7 @@ func authorizeClient(client *http.Client, authConfig *registry.AuthConfig, endpo
 	// If we're working with a standalone private registry over HTTPS, send Basic Auth headers
 	// alongside all our requests.
 	if endpoint.String() != IndexServer && endpoint.URL.Scheme == "https" {
-		info, err := endpoint.ping()
+		info, err := endpoint.ping(context.TODO())
 		if err != nil {
 			return err
 		}

--- a/registry/search_test.go
+++ b/registry/search_test.go
@@ -17,7 +17,7 @@ import (
 
 func spawnTestRegistrySession(t *testing.T) *session {
 	authConfig := &registry.AuthConfig{}
-	endpoint, err := newV1Endpoint(makeIndex("/v1/"), nil)
+	endpoint, err := newV1Endpoint(context.Background(), makeIndex("/v1/"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -1,6 +1,7 @@
 package registry // import "github.com/docker/docker/registry"
 
 import (
+	"context"
 	"net/url"
 	"strings"
 
@@ -8,6 +9,7 @@ import (
 )
 
 func (s *Service) lookupV2Endpoints(hostname string, includeMirrors bool) ([]APIEndpoint, error) {
+	ctx := context.TODO()
 	var endpoints []APIEndpoint
 	if hostname == DefaultNamespace || hostname == IndexHostname {
 		if includeMirrors {
@@ -19,7 +21,8 @@ func (s *Service) lookupV2Endpoints(hostname string, includeMirrors bool) ([]API
 				if err != nil {
 					return nil, invalidParam(err)
 				}
-				mirrorTLSConfig, err := newTLSConfig(mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
+				// TODO(thaJeztah); this should all be memoized when loading the config. We're resolving mirrors and loading TLS config every time.
+				mirrorTLSConfig, err := newTLSConfig(ctx, mirrorURL.Host, s.config.isSecureIndex(mirrorURL.Host))
 				if err != nil {
 					return nil, err
 				}
@@ -39,7 +42,7 @@ func (s *Service) lookupV2Endpoints(hostname string, includeMirrors bool) ([]API
 		return endpoints, nil
 	}
 
-	tlsConfig, err := newTLSConfig(hostname, s.config.isSecureIndex(hostname))
+	tlsConfig, err := newTLSConfig(ctx, hostname, s.config.isSecureIndex(hostname))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### registry: ReadCertsDirectory: internalize, and pass context

- Split the implementation from the exported function (exported
  function is still used by the CLI for Docker Content Trust).
- Pass through context to allow handling context-cancellation
  once wired up in callers.

### registry: newV1Endpoint: pass through context

### registry: v1Endpoint.ping: pass through context


**- A picture of a cute animal (not mandatory but encouraged)**

