### PR TITLE
c8d/pull: Show progress for non-layer blobs

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -117,13 +117,12 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	}
 
 	jobs := newJobs()
-	h := c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		if c8dimages.IsLayerType(desc.MediaType) {
+	opts = append(opts, containerd.WithImageHandler(c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if showBlobProgress(desc) {
 			jobs.Add(desc)
 		}
 		return nil, nil
-	})
-	opts = append(opts, containerd.WithImageHandler(h))
+	})))
 
 	pp := &pullProgress{
 		store:       i.content,

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -149,19 +149,13 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 		return err
 	}
 
-	addLayerJobs := c8dimages.HandlerFunc(
-		func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-			switch {
-			case c8dimages.IsIndexType(desc.MediaType),
-				c8dimages.IsManifestType(desc.MediaType),
-				c8dimages.IsConfigType(desc.MediaType):
-			default:
-				jobsQueue.Add(desc)
-			}
+	addLayerJobs := c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if showBlobProgress(desc) {
+			jobsQueue.Add(desc)
+		}
 
-			return nil, nil
-		},
-	)
+		return nil, nil
+	})
 
 	handlerWrapper := func(h c8dimages.Handler) c8dimages.Handler {
 		return c8dimages.Handlers(addLayerJobs, h)


### PR DESCRIPTION
Use the same logic as push for determining whether a progress should be shown for a blob.

**How to verify**

`docker pull ai/smollm2` should show any progress

**Changelog**

```markdown changelog
containerd image store: Show pull progress for non-layer image blobs
```