### PR TITLE
api: /info: omit non-distributable-artifacts fields for API >= 1.49

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package system // import "github.com/docker/docker/api/server/router/system"
 
 import (
@@ -103,8 +106,10 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		if versions.LessThan(version, "1.47") {
 			// Field is omitted in API 1.48 and up, but should still be included
 			// in older versions, even if no values are set.
-			info.RegistryConfig.AllowNondistributableArtifactsCIDRs = []*registry.NetIPNet{}
-			info.RegistryConfig.AllowNondistributableArtifactsHostnames = []string{}
+			info.RegistryConfig.ExtraFields = map[string]any{
+				"AllowNondistributableArtifactsCIDRs":     json.RawMessage(nil),
+				"AllowNondistributableArtifactsHostnames": json.RawMessage(nil),
+			}
 		}
 		if versions.LessThan(version, "1.49") {
 			// FirewallBackend field introduced in API v1.49.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -7017,32 +7017,6 @@ definitions:
     type: "object"
     x-nullable: true
     properties:
-      AllowNondistributableArtifactsCIDRs:
-        description: |
-          List of IP ranges to which nondistributable artifacts can be pushed,
-          using the CIDR syntax [RFC 4632](https://tools.ietf.org/html/4632).
-
-          <p><br /></p>
-
-          > **Deprecated**: Pushing nondistributable artifacts is now always enabled
-          > and this field is always `null`. This field will be removed in a API v1.49.
-        type: "array"
-        items:
-          type: "string"
-        example: []
-      AllowNondistributableArtifactsHostnames:
-        description: |
-          List of registry hostnames to which nondistributable artifacts can be
-          pushed, using the format `<hostname>[:<port>]` or `<IP address>[:<port>]`.
-
-          <p><br /></p>
-
-          > **Deprecated**: Pushing nondistributable artifacts is now always enabled
-          > and this field is always `null`. This field will be removed in a API v1.49.
-        type: "array"
-        items:
-          type: "string"
-        example: []
       InsecureRegistryCIDRs:
         description: |
           List of IP ranges of insecure registries, using the CIDR syntax

--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package registry // import "github.com/docker/docker/api/types/registry"
 
 import (
@@ -15,23 +18,26 @@ type ServiceConfig struct {
 	InsecureRegistryCIDRs []*NetIPNet           `json:"InsecureRegistryCIDRs"`
 	IndexConfigs          map[string]*IndexInfo `json:"IndexConfigs"`
 	Mirrors               []string
+
+	// ExtraFields is for internal use to include deprecated fields on older API versions.
+	ExtraFields map[string]any `json:"-"`
 }
 
 // MarshalJSON implements a custom marshaler to include legacy fields
 // in API responses.
-func (sc ServiceConfig) MarshalJSON() ([]byte, error) {
-	tmp := map[string]interface{}{
-		"InsecureRegistryCIDRs": sc.InsecureRegistryCIDRs,
-		"IndexConfigs":          sc.IndexConfigs,
-		"Mirrors":               sc.Mirrors,
+func (sc *ServiceConfig) MarshalJSON() ([]byte, error) {
+	type tmp ServiceConfig
+	base, err := json.Marshal((*tmp)(sc))
+	if err != nil {
+		return nil, err
 	}
-	if sc.AllowNondistributableArtifactsCIDRs != nil {
-		tmp["AllowNondistributableArtifactsCIDRs"] = nil
+	var merged map[string]any
+	_ = json.Unmarshal(base, &merged)
+
+	for k, v := range sc.ExtraFields {
+		merged[k] = v
 	}
-	if sc.AllowNondistributableArtifactsHostnames != nil {
-		tmp["AllowNondistributableArtifactsHostnames"] = nil
-	}
-	return json.Marshal(tmp)
+	return json.Marshal(merged)
 }
 
 // NetIPNet is the net.IPNet type, which can be marshalled and

--- a/api/types/registry/registry_test.go
+++ b/api/types/registry/registry_test.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package registry
 
 import (
@@ -20,8 +23,10 @@ func TestServiceConfigMarshalLegacyFields(t *testing.T) {
 	// used for API versions < 1.49.
 	t.Run("with legacy fields", func(t *testing.T) {
 		b, err := json.Marshal(&ServiceConfig{
-			AllowNondistributableArtifactsCIDRs:     []*NetIPNet{},
-			AllowNondistributableArtifactsHostnames: []string{},
+			ExtraFields: map[string]any{
+				"AllowNondistributableArtifactsCIDRs":     json.RawMessage(nil),
+				"AllowNondistributableArtifactsHostnames": json.RawMessage(nil),
+			},
 		})
 		assert.NilError(t, err)
 		const expected = `{"AllowNondistributableArtifactsCIDRs":null,"AllowNondistributableArtifactsHostnames":null,"IndexConfigs":null,"InsecureRegistryCIDRs":null,"Mirrors":null}`

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -23,6 +23,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   This option is mutually exclusive with the `manifests` option.
 * `GET /info` now returns a `FirewallBackend` containing information about
   the daemon's firewalling configuration.
+* Deprecated: The  `AllowNondistributableArtifactsCIDRs` and `AllowNondistributableArtifactsHostnames`
+  fields in the `RegistryConfig` struct in the `GET /info` response are omitted
+  in API v1.49.
 
 ## v1.48 API changes
 


### PR DESCRIPTION
- registry.ServiceConfig: add a "ExtraFields" for outputting deprecated fields.
- remove uses of AllowNondistributableArtifactsCIDRs and AllowNondistributableArtifactsHostnames

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
API: Deprecated `AllowNondistributableArtifactsCIDRs` and `AllowNondistributableArtifactsHostnames` fields in the `RegistryConfig` struct in the `GET /info` response are omitted in API v1.49.
```

**- A picture of a cute animal (not mandatory but encouraged)**

