### PR TITLE
registry: remove deprecated ServiceConfig.AllowNondistributableArtifacts

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -13,12 +13,9 @@ import (
 // installCommonConfigFlags adds flags to the pflag.FlagSet to configure the daemon
 func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	var (
-		allowNonDistributable = opts.NewNamedListOptsRef("allow-nondistributable-artifacts", &conf.AllowNondistributableArtifacts, registry.ValidateIndexName)
-		registryMirrors       = opts.NewNamedListOptsRef("registry-mirrors", &conf.Mirrors, registry.ValidateMirror)
-		insecureRegistries    = opts.NewNamedListOptsRef("insecure-registries", &conf.InsecureRegistries, registry.ValidateIndexName)
+		registryMirrors    = opts.NewNamedListOptsRef("registry-mirrors", &conf.Mirrors, registry.ValidateMirror)
+		insecureRegistries = opts.NewNamedListOptsRef("insecure-registries", &conf.InsecureRegistries, registry.ValidateIndexName)
 	)
-	flags.Var(allowNonDistributable, "allow-nondistributable-artifacts", "Allow push of nondistributable artifacts to registry")
-	_ = flags.MarkDeprecated("allow-nondistributable-artifacts", "Pushing nondistributable artifacts is now enabled by default. ")
 	flags.Var(registryMirrors, "registry-mirror", "Preferred Docker registry mirror")
 	flags.Var(insecureRegistries, "insecure-registry", "Enable insecure registry communication")
 
@@ -77,6 +74,9 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Var(opts.NewNamedListOptsRef("cdi-spec-dirs", &conf.CDISpecDirs, nil), "cdi-spec-dir", "CDI specification directories to use")
 
 	// Deprecated flags / options
+	allowNonDistributable := opts.NewNamedListOptsRef("allow-nondistributable-artifacts", &([]string{}), registry.ValidateIndexName)
+	flags.Var(allowNonDistributable, "allow-nondistributable-artifacts", "Allow push of nondistributable artifacts to registry")
+	_ = flags.MarkDeprecated("allow-nondistributable-artifacts", "Pushing nondistributable artifacts is now enabled by default. ")
 
 	// TODO(thaJeztah): option is used to produce error when used; remove in next release
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API; deprecated: this feature was deprecated in 27.0, and now removed")

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -661,11 +661,6 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		return nil, err
 	}
 
-	if len(conf.AllowNondistributableArtifacts) > 0 {
-		// TODO(thaJeztah): move to config.Validate and change into an error for v29.0 and remove in v30.0.
-		log.G(context.TODO()).Warn(`DEPRECATED: The "allow-nondistributable-artifacts" config parameter is deprecated and always enabled; this option will be removed in the next release`)
-	}
-
 	return conf, nil
 }
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -93,7 +93,8 @@ var skipValidateOptions = map[string]bool{
 	"builder":  true,
 
 	// Deprecated options that are safe to ignore if present.
-	"deprecated-key-path": true,
+	"deprecated-key-path":              true,
+	"allow-nondistributable-artifacts": true,
 }
 
 // skipDuplicates contains configuration keys that

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -91,7 +91,8 @@ var flatOptions = map[string]bool{
 var skipValidateOptions = map[string]bool{
 	"features": true,
 	"builder":  true,
-	// Corresponding flag has been removed because it was already unusable
+
+	// Deprecated options that are safe to ignore if present.
 	"deprecated-key-path": true,
 }
 

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -379,6 +379,10 @@ func TestDaemonLegacyOptions(t *testing.T) {
 			name:       "deprecated-key-path",
 			configJSON: `{"deprecated-key-path": "/etc/docker/key.json"}`,
 		},
+		{
+			name:       "allow-nondistributable-artifacts",
+			configJSON: `{"allow-nondistributable-artifacts": ["127.0.0.0/8", "10.10.1.11:5000", "10.10.1.22:5000", "registry.example.com", "registry.example.com"]}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -365,3 +365,30 @@ func TestDaemonConfigurationHostGatewayIP(t *testing.T) {
 		})
 	}
 }
+
+// TestDaemonLegacyOptions verifies that loading config files containing
+// deprecated / legacy options does not prevent the daemon from loading
+// the config (some options may have an explicit error, and can be tested
+// separately).
+func TestDaemonLegacyOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		configJSON string
+	}{
+		{
+			name:       "deprecated-key-path",
+			configJSON: `{"deprecated-key-path": "/etc/docker/key.json"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configFile := makeConfigFile(t, tc.configJSON)
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			c, err := New()
+			assert.NilError(t, err)
+			_, err = MergeDaemonConfigurations(c, flags, configFile)
+			assert.NilError(t, err)
+		})
+	}
+}

--- a/registry/config.go
+++ b/registry/config.go
@@ -19,8 +19,6 @@ import (
 
 // ServiceOptions holds command line options.
 type ServiceOptions struct {
-	AllowNondistributableArtifacts []string `json:"allow-nondistributable-artifacts,omitempty"` // Deprecated: non-distributable artifacts are deprecated and enabled by default. This field will be removed in the next release.
-
 	Mirrors            []string `json:"registry-mirrors,omitempty"`
 	InsecureRegistries []string `json:"insecure-registries,omitempty"`
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49065

This option was deprecated in 1932091e21b64abc52b42320393b0ac5f6921668, and is no longer used. It was only kept to allow priniting a deprecation warning if the config would happen to have the field set.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

