### PR TITLE
libnet: de-flake TestEndpointStore and TestNetworkStore

### DIFF
--- a/libnetwork/endpoint_store_test.go
+++ b/libnetwork/endpoint_store_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/libnetwork/config"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestEndpointStore(t *testing.T) {
@@ -27,12 +28,13 @@ func TestEndpointStore(t *testing.T) {
 	err = c.storeEndpoint(context.Background(), ep2)
 	assert.NilError(t, err)
 
-	// Check that we can find both endpoints
+	// Check that we can find both endpoints, and that the returned values are
+	// not copies of the original ones.
 	found := c.findEndpoints(filterEndpointByNetworkId("testNetwork"))
 	slices.SortFunc(found, func(a, b *Endpoint) int { return strings.Compare(a.id, b.id) })
 	assert.Equal(t, len(found), 2)
-	assert.Equal(t, found[0], ep1)
-	assert.Equal(t, found[1], ep2)
+	assert.Check(t, is.Equal(found[0], ep1), "got: %s; expected: %s", found[0].id, ep1.id)
+	assert.Check(t, is.Equal(found[1], ep2), "got: %s; expected: %s", found[1].id, ep1.id)
 
 	// Delete the first endpoint
 	err = c.deleteStoredEndpoint(ep1)
@@ -41,7 +43,7 @@ func TestEndpointStore(t *testing.T) {
 	// Check that we can only find the second endpoint
 	found = c.findEndpoints(filterEndpointByNetworkId("testNetwork"))
 	assert.Equal(t, len(found), 1)
-	assert.Equal(t, found[0], ep2)
+	assert.Check(t, is.Equal(found[0], ep2), "got: %s; expected: %s", found[0].id, ep2.id)
 
 	// Store the second endpoint again
 	err = c.storeEndpoint(context.Background(), ep2)

--- a/libnetwork/endpoint_store_test.go
+++ b/libnetwork/endpoint_store_test.go
@@ -2,6 +2,8 @@ package libnetwork
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/config"
@@ -27,6 +29,7 @@ func TestEndpointStore(t *testing.T) {
 
 	// Check that we can find both endpoints
 	found := c.findEndpoints(filterEndpointByNetworkId("testNetwork"))
+	slices.SortFunc(found, func(a, b *Endpoint) int { return strings.Compare(a.id, b.id) })
 	assert.Equal(t, len(found), 2)
 	assert.Equal(t, found[0], ep1)
 	assert.Equal(t, found[1], ep2)

--- a/libnetwork/network_store_test.go
+++ b/libnetwork/network_store_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/libnetwork/config"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestNetworkStore(t *testing.T) {
@@ -26,6 +27,8 @@ func TestNetworkStore(t *testing.T) {
 	err = c.storeNetwork(context.Background(), nw2)
 	assert.NilError(t, err)
 
+	// Check that we can find both networks, and that the returned values are
+	// not copies of the original ones.
 	for _, tc := range []struct {
 		name        string
 		filter      func(nw *Network) bool
@@ -47,7 +50,7 @@ func TestNetworkStore(t *testing.T) {
 			assert.Equal(t, len(found), len(tc.expNetworks))
 			slices.SortFunc(found, func(a, b *Network) int { return strings.Compare(a.id, b.id) })
 			for i, nw := range tc.expNetworks {
-				assert.Check(t, found[i] == nw, "got: %s; expected: %s", found[i].id, nw.id)
+				assert.Check(t, is.Equal(found[i], nw), "got: %s; expected: %s", found[i].id, nw.id)
 			}
 		})
 	}
@@ -59,7 +62,7 @@ func TestNetworkStore(t *testing.T) {
 	// Check that we can only find the second network
 	found := c.findNetworks(func(nw *Network) bool { return true })
 	assert.Equal(t, len(found), 1)
-	assert.Check(t, found[0] == nw2)
+	assert.Check(t, is.Equal(found[0], nw2), "got: %s; expected: %s", found[0].id, nw2.id)
 
 	// Store the second network again
 	err = c.storeNetwork(context.Background(), nw2)

--- a/libnetwork/network_store_test.go
+++ b/libnetwork/network_store_test.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/config"
@@ -25,16 +26,6 @@ func TestNetworkStore(t *testing.T) {
 	err = c.storeNetwork(context.Background(), nw2)
 	assert.NilError(t, err)
 
-	netSorter := func(a, b *Network) int {
-		if a.name < b.name {
-			return -1
-		}
-		if a.name > b.name {
-			return 1
-		}
-		return 0
-	}
-
 	for _, tc := range []struct {
 		name        string
 		filter      func(nw *Network) bool
@@ -54,9 +45,9 @@ func TestNetworkStore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			found := c.findNetworks(tc.filter)
 			assert.Equal(t, len(found), len(tc.expNetworks))
-			slices.SortFunc(found, netSorter)
+			slices.SortFunc(found, func(a, b *Network) int { return strings.Compare(a.id, b.id) })
 			for i, nw := range tc.expNetworks {
-				assert.Check(t, found[i] == nw, "got: %s; expected: %s", found[i].name, nw.name)
+				assert.Check(t, found[i] == nw, "got: %s; expected: %s", found[i].id, nw.id)
 			}
 		})
 	}


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/49736#discussion_r2031067105

**- What I did**

- `TestEndpointStore`: sort endpoints before comparing
- `TestNetworkStore`: fix network sorting
- Address [a couple review comments](https://github.com/moby/moby/pull/49736#pullrequestreview-2746253485) left by @vvoland

**- How to verify it**

Verified both tests with `-test.count 10000`:

```
$ TESTDIRS='./libnetwork' TESTFLAGS='-test.run TestEndpointStore -test.count 10000' hack/test/unit
$ TESTDIRS='./libnetwork' TESTFLAGS='-test.run TestNetworkStore -test.count 10000' hack/test/unit
```
