### PR TITLE
Put bridge driver's top-level iptables config in a separate object

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1260,13 +1260,9 @@ func TestCleanupIptableRules(t *testing.T) {
 	}
 
 	ipVersions := []iptables.IPVersion{iptables.IPv4, iptables.IPv6}
-	configs := map[iptables.IPVersion]configuration{
-		iptables.IPv4: {EnableIPTables: true},
-		iptables.IPv6: {EnableIP6Tables: true},
-	}
 
 	for _, version := range ipVersions {
-		err := setupIPChains(configs[version], version)
+		err := setupIPChains(version, true)
 		assert.NilError(t, err, "version:%s", version)
 
 		iptable := iptables.GetIptable(version)

--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -792,11 +792,11 @@ func (n *iptablesNetwork) modPorts(ctx context.Context, pbs []types.PortBinding,
 
 func (n *iptablesNetwork) setPerPortIptables(ctx context.Context, b types.PortBinding, enable bool) error {
 	v := iptables.IPv4
-	enabled := n.Enable4
+	enabled := n.fw.IPv4
 	config := n.Config4
 	if b.IP.To4() == nil {
 		v = iptables.IPv6
-		enabled = n.Enable6
+		enabled = n.fw.IPv6
 		config = n.Config6
 	}
 
@@ -851,7 +851,7 @@ func (n *iptablesNetwork) setPerPortNAT(ipv iptables.IPVersion, b types.PortBind
 		"-j", "DNAT",
 		"--to-destination", net.JoinHostPort(b.IP.String(), strconv.Itoa(int(b.Port))),
 	}
-	if !n.Hairpin {
+	if !n.fw.Hairpin {
 		args = append(args, "!", "-i", n.IfName)
 	}
 	if ipv == iptables.IPv6 {
@@ -869,7 +869,7 @@ func (n *iptablesNetwork) setPerPortNAT(ipv iptables.IPVersion, b types.PortBind
 		"--dport", strconv.Itoa(int(b.Port)),
 		"-j", "MASQUERADE",
 	}}
-	if err := appendOrDelChainRule(rule, "MASQUERADE", n.Hairpin && enable); err != nil {
+	if err := appendOrDelChainRule(rule, "MASQUERADE", n.fw.Hairpin && enable); err != nil {
 		return err
 	}
 

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -157,11 +157,11 @@ func assertIPTableChainProgramming(rule iptables.Rule, descr string, t *testing.
 func assertChainConfig(d *driver, t *testing.T) {
 	var err error
 
-	err = setupIPChains(d.config, iptables.IPv4)
+	err = setupIPChains(iptables.IPv4, !d.config.EnableUserlandProxy)
 	assert.NilError(t, err)
 
 	if d.config.EnableIP6Tables {
-		err = setupIPChains(d.config, iptables.IPv6)
+		err = setupIPChains(iptables.IPv6, !d.config.EnableUserlandProxy)
 		assert.NilError(t, err)
 	}
 }
@@ -462,7 +462,7 @@ func TestMirroredWSL2Workaround(t *testing.T) {
 				config.UserlandProxyPath = "some-proxy"
 				config.EnableUserlandProxy = true
 			}
-			err := setupIPChains(config, iptables.IPv4)
+			err := setupIPChains(iptables.IPv4, !tc.userlandProxy)
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(mirroredWSL2Rule().Exists(), tc.expLoopback0Rule))
 		})


### PR DESCRIPTION
**- What I did**

Split the bridge driver's top-level iptables config into a separate object.

This is  step towards the `Firewaller` interface, that'll allow the bridge to have iptables/nftables/firewalld backends:
- https://github.com/moby/moby/issues/49635

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```