### PR TITLE
libnet/d/bridge: trace createNetwork

### DIFF
--- a/api/server/router/network/backend.go
+++ b/api/server/router/network/backend.go
@@ -12,7 +12,7 @@ import (
 // to provide network specific functionality.
 type Backend interface {
 	GetNetworks(filters.Args, backend.NetworkListConfig) ([]network.Inspect, error)
-	CreateNetwork(nc network.CreateRequest) (*network.CreateResponse, error)
+	CreateNetwork(ctx context.Context, nc network.CreateRequest) (*network.CreateResponse, error)
 	ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
 	DeleteNetwork(networkID string) error

--- a/api/server/router/network/network_routes.go
+++ b/api/server/router/network/network_routes.go
@@ -223,7 +223,7 @@ func (n *networkRouter) postNetworkCreate(ctx context.Context, w http.ResponseWr
 	// validate the configuration. The network will not be created but, if the
 	// configuration is valid, ManagerRedirectError will be returned and handled
 	// below.
-	nw, err := n.backend.CreateNetwork(create)
+	nw, err := n.backend.CreateNetwork(ctx, create)
 	if err != nil {
 		if _, ok := err.(libnetwork.ManagerRedirectError); !ok {
 			return err

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -868,14 +868,14 @@ func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes 
 func configureNetworking(controller *libnetwork.Controller, conf *config.Config) error {
 	// Create predefined network "none"
 	if n, _ := controller.NetworkByName(network.NetworkNone); n == nil {
-		if _, err := controller.NewNetwork("null", network.NetworkNone, "", libnetwork.NetworkOptionPersist(true)); err != nil {
+		if _, err := controller.NewNetwork(context.TODO(), "null", network.NetworkNone, "", libnetwork.NetworkOptionPersist(true)); err != nil {
 			return errors.Wrapf(err, `error creating default %q network`, network.NetworkNone)
 		}
 	}
 
 	// Create predefined network "host"
 	if n, _ := controller.NetworkByName(network.NetworkHost); n == nil {
-		if _, err := controller.NewNetwork("host", network.NetworkHost, "", libnetwork.NetworkOptionPersist(true)); err != nil {
+		if _, err := controller.NewNetwork(context.TODO(), "host", network.NetworkHost, "", libnetwork.NetworkOptionPersist(true)); err != nil {
 			return errors.Wrapf(err, `error creating default %q network`, network.NetworkHost)
 		}
 	}
@@ -1009,7 +1009,7 @@ func initBridgeDriver(controller *libnetwork.Controller, cfg config.BridgeConfig
 	}
 
 	// Initialize default network on "bridge" with the same name
-	_, err = controller.NewNetwork("bridge", network.NetworkBridge, "",
+	_, err = controller.NewNetwork(context.TODO(), "bridge", network.NetworkBridge, "",
 		libnetwork.NetworkOptionEnableIPv4(true),
 		libnetwork.NetworkOptionEnableIPv6(cfg.EnableIPv6),
 		libnetwork.NetworkOptionDriverOpts(netOption),

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/docker/daemon/initlayer"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/nlwrap"
+	"github.com/docker/docker/internal/otelutil"
 	"github.com/docker/docker/internal/usergroup"
 	"github.com/docker/docker/libcontainerd/remote"
 	"github.com/docker/docker/libnetwork"
@@ -51,6 +52,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
+	"go.opentelemetry.io/otel/baggage"
 	"golang.org/x/sys/unix"
 )
 
@@ -849,7 +851,9 @@ func (daemon *Daemon) initNetworkController(cfg *config.Config, activeSandboxes 
 		return err
 	}
 
-	ctx := context.TODO()
+	ctx := baggage.ContextWithBaggage(context.TODO(), otelutil.MustNewBaggage(
+		otelutil.MustNewMemberRaw(otelutil.TriggerKey, "daemon.initNetworkController"),
+	))
 	daemon.netController, err = libnetwork.New(ctx, netOptions...)
 	if err != nil {
 		return fmt.Errorf("error obtaining controller instance: %v", err)

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -237,7 +237,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 	if err != nil {
 		return err
 	}
-	daemon.netController, err = libnetwork.New(netOptions...)
+	daemon.netController, err = libnetwork.New(context.TODO(), netOptions...)
 	if err != nil {
 		return errors.Wrap(err, "error obtaining controller instance")
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -279,7 +279,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 					log.G(context.TODO()).Errorf("Error occurred when removing network %v", err)
 				}
 
-				_, err := daemon.netController.NewNetwork("nat", name, id,
+				_, err := daemon.netController.NewNetwork(context.TODO(), "nat", name, id,
 					libnetwork.NetworkOptionGeneric(options.Generic{
 						netlabel.GenericData: netOption,
 					}),
@@ -301,7 +301,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		}
 	}
 
-	_, err = daemon.netController.NewNetwork("null", "none", "", libnetwork.NetworkOptionPersist(false))
+	_, err = daemon.netController.NewNetwork(context.TODO(), "null", "none", "", libnetwork.NetworkOptionPersist(false))
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		}
 
 		v6Conf := []*libnetwork.IpamConf{}
-		_, err := daemon.netController.NewNetwork(strings.ToLower(v.Type), name, nid,
+		_, err := daemon.netController.NewNetwork(context.TODO(), strings.ToLower(v.Type), name, nid,
 			libnetwork.NetworkOptionGeneric(options.Generic{
 				netlabel.GenericData: netOption,
 				netlabel.EnableIPv4:  true,
@@ -430,7 +430,7 @@ func initBridgeDriver(controller *libnetwork.Controller, config config.BridgeCon
 		ipamOption = libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil)
 	}
 
-	_, err := controller.NewNetwork(network.DefaultNetwork, network.DefaultNetwork, "",
+	_, err := controller.NewNetwork(context.TODO(), network.DefaultNetwork, network.DefaultNetwork, "",
 		libnetwork.NetworkOptionGeneric(options.Generic{
 			netlabel.GenericData: netOption,
 			netlabel.EnableIPv4:  true,

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -203,7 +203,7 @@ func (daemon *Daemon) setupIngress(cfg *config.Config, create *clustertypes.Netw
 		daemon.releaseIngress(staleID)
 	}
 
-	if _, err := daemon.createNetwork(cfg, create.CreateRequest, create.ID, true); err != nil {
+	if _, err := daemon.createNetwork(context.TODO(), cfg, create.CreateRequest, create.ID, true); err != nil {
 		// If it is any other error other than already
 		// exists error log error and return.
 		if _, ok := err.(libnetwork.NetworkNameError); !ok {
@@ -273,16 +273,16 @@ func (daemon *Daemon) WaitForDetachment(ctx context.Context, networkName, networ
 
 // CreateManagedNetwork creates an agent network.
 func (daemon *Daemon) CreateManagedNetwork(create clustertypes.NetworkCreateRequest) error {
-	_, err := daemon.createNetwork(&daemon.config().Config, create.CreateRequest, create.ID, true)
+	_, err := daemon.createNetwork(context.TODO(), &daemon.config().Config, create.CreateRequest, create.ID, true)
 	return err
 }
 
 // CreateNetwork creates a network with the given name, driver and other optional parameters
-func (daemon *Daemon) CreateNetwork(create networktypes.CreateRequest) (*networktypes.CreateResponse, error) {
-	return daemon.createNetwork(&daemon.config().Config, create, "", false)
+func (daemon *Daemon) CreateNetwork(ctx context.Context, create networktypes.CreateRequest) (*networktypes.CreateResponse, error) {
+	return daemon.createNetwork(ctx, &daemon.config().Config, create, "", false)
 }
 
-func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.CreateRequest, id string, agent bool) (*networktypes.CreateResponse, error) {
+func (daemon *Daemon) createNetwork(ctx context.Context, cfg *config.Config, create networktypes.CreateRequest, id string, agent bool) (*networktypes.CreateResponse, error) {
 	if network.IsPredefined(create.Name) {
 		return nil, PredefinedNetworkError(create.Name)
 	}
@@ -304,7 +304,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.Crea
 	if defaultOpts, ok := cfg.DefaultNetworkOpts[driver]; create.ConfigFrom == nil && ok {
 		for k, v := range defaultOpts {
 			if _, ok := networkOptions[k]; !ok {
-				log.G(context.TODO()).WithFields(log.Fields{"driver": driver, "network": id, k: v}).Debug("Applying network default option")
+				log.G(ctx).WithFields(log.Fields{"driver": driver, "network": id, k: v}).Debug("Applying network default option")
 				networkOptions[k] = v
 			}
 		}
@@ -359,7 +359,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.Crea
 			// By dropping errors for agent networks, existing swarm-scoped networks also
 			// continue to behave as they did before upgrade - but new networks are still
 			// validated.
-			log.G(context.TODO()).WithFields(log.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"error":   err,
 				"network": create.Name,
 			}).Warn("Continuing with validation errors in agent IPAM")
@@ -398,7 +398,7 @@ func (daemon *Daemon) createNetwork(cfg *config.Config, create networktypes.Crea
 		nwOptions = append(nwOptions, libnetwork.NetworkOptionLBEndpoint(nodeIP))
 	}
 
-	n, err := c.NewNetwork(driver, create.Name, id, nwOptions...)
+	n, err := c.NewNetwork(ctx, driver, create.Name, id, nwOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/oci_linux_test.go
+++ b/daemon/oci_linux_test.go
@@ -28,7 +28,7 @@ func setupFakeDaemon(t *testing.T, c *container.Container) *Daemon {
 	err := os.MkdirAll(rootfs, 0o755)
 	assert.NilError(t, err)
 
-	netController, err := libnetwork.New(nwconfig.OptionDataDir(t.TempDir()))
+	netController, err := libnetwork.New(context.Background(), nwconfig.OptionDataDir(t.TempDir()))
 	assert.NilError(t, err)
 
 	d := &Daemon{

--- a/daemon/reload_test.go
+++ b/daemon/reload_test.go
@@ -1,6 +1,7 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -310,7 +311,7 @@ func TestDaemonReloadNetworkDiagnosticPort(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	controller, err := libnetwork.New(netOptions...)
+	controller, err := libnetwork.New(context.Background(), netOptions...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/otelutil/baggage.go
+++ b/internal/otelutil/baggage.go
@@ -1,0 +1,43 @@
+package otelutil
+
+import (
+	"context"
+
+	"github.com/containerd/log"
+	"go.opentelemetry.io/otel/baggage"
+)
+
+// TriggerKey is the key used for the 'trigger' member in the baggage. It is
+// used to know what triggered a code path (e.g. API call, libnet init, etc...)
+const TriggerKey = "trigger"
+
+// MustNewBaggage creates an OTel Baggage containing the provided members. It
+// panics if the baggage cannot be created.
+//
+// DO NOT USE this function with dynamic values.
+func MustNewBaggage(members ...baggage.Member) baggage.Baggage {
+	b, err := baggage.New(members...)
+	if err != nil {
+		log.G(context.Background()).WithFields(log.Fields{
+			"error":   err,
+			"members": members,
+		}).Fatal("OTel baggage creation failure")
+	}
+	return b
+}
+
+// MustNewMemberRaw creates an OTel Baggage member with the provided key and
+// value. It panics if the key or value aren't valid UTF-8 strings.
+//
+// DO NOT USE this function with dynamic key/value.
+func MustNewMemberRaw(key, value string) baggage.Member {
+	m, err := baggage.NewMemberRaw(key, value)
+	if err != nil {
+		log.G(context.Background()).WithFields(log.Fields{
+			"error": err,
+			"key":   key,
+			"value": value,
+		}).Fatal("OTel baggage member creation failure")
+	}
+	return m
+}

--- a/internal/otelutil/provider.go
+++ b/internal/otelutil/provider.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/moby/buildkit/util/tracing/detect"
+	"go.opentelemetry.io/contrib/processors/baggagecopy"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -31,6 +33,7 @@ func NewTracerProvider(ctx context.Context, allowNoop bool) (trace.TracerProvide
 		sdktrace.WithResource(resource.Default()),
 		sdktrace.WithSyncer(detect.Recorder),
 		sdktrace.WithBatcher(exp),
+		sdktrace.WithSpanProcessor(baggagecopy.NewSpanProcessor(func(member baggage.Member) bool { return true })),
 	)
 	return tp, tp.Shutdown
 }

--- a/internal/otelutil/status.go
+++ b/internal/otelutil/status.go
@@ -1,0 +1,17 @@
+package otelutil
+
+import (
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// RecordStatus records the status of a span based on the error provided.
+//
+// If err is nil, the span status is unmodified. If err is not nil, the span
+// takes status Error, and the error message is recorded.
+func RecordStatus(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+}

--- a/libnetwork/cnmallocator/manager.go
+++ b/libnetwork/cnmallocator/manager.go
@@ -28,7 +28,7 @@ func (d *manager) NetworkFree(id string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *manager) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *manager) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/default_gateway_linux.go
+++ b/libnetwork/default_gateway_linux.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -14,7 +15,7 @@ func getPlatformOption() EndpointOption {
 }
 
 func (c *Controller) createGWNetwork() (*Network, error) {
-	n, err := c.NewNetwork("bridge", libnGWNetwork, "",
+	n, err := c.NewNetwork(context.TODO(), "bridge", libnGWNetwork, "",
 		NetworkOptionDriverOpts(map[string]string{
 			bridge.BridgeName:         libnGWNetwork,
 			bridge.EnableICC:          strconv.FormatBool(false),

--- a/libnetwork/default_gateway_linux.go
+++ b/libnetwork/default_gateway_linux.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/docker/docker/internal/otelutil"
 	"github.com/docker/docker/libnetwork/drivers/bridge"
+	"go.opentelemetry.io/otel/baggage"
 )
 
 const libnGWNetwork = "docker_gwbridge"
@@ -15,7 +17,11 @@ func getPlatformOption() EndpointOption {
 }
 
 func (c *Controller) createGWNetwork() (*Network, error) {
-	n, err := c.NewNetwork(context.TODO(), "bridge", libnGWNetwork, "",
+	ctx := baggage.ContextWithBaggage(context.TODO(), otelutil.MustNewBaggage(
+		otelutil.MustNewMemberRaw(otelutil.TriggerKey, "libnetwork.Controller.createGWNetwork"),
+	))
+
+	n, err := c.NewNetwork(ctx, "bridge", libnGWNetwork, "",
 		NetworkOptionDriverOpts(map[string]string{
 			bridge.BridgeName:         libnGWNetwork,
 			bridge.EnableICC:          strconv.FormatBool(false),

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -30,7 +30,7 @@ type Driver interface {
 	// notification when a CRUD operation is performed on any
 	// entry in that table. This will be ignored for local scope
 	// drivers.
-	CreateNetwork(nid string, options map[string]interface{}, nInfo NetworkInfo, ipV4Data, ipV6Data []IPAMData) error
+	CreateNetwork(ctx context.Context, nid string, options map[string]interface{}, nInfo NetworkInfo, ipV4Data, ipV6Data []IPAMData) error
 
 	// DeleteNetwork invokes the driver method to delete network passing
 	// the network id.

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -49,6 +49,8 @@ const (
 	DefaultGatewayV6AuxKey = "DefaultGatewayIPv6"
 )
 
+const spanPrefix = "libnetwork.drivers.bridge"
+
 type (
 	iptableCleanFunc   func() error
 	iptablesCleanFuncs []iptableCleanFunc
@@ -810,7 +812,7 @@ func (d *driver) checkConflict(config *networkConfiguration) error {
 }
 
 func (d *driver) createNetwork(ctx context.Context, config *networkConfiguration) (err error) {
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.createNetwork", trace.WithAttributes(
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".createNetwork", trace.WithAttributes(
 		attribute.Bool("bridge.enable_ipv4", config.EnableIPv4),
 		attribute.Bool("bridge.enable_ipv6", config.EnableIPv6),
 		attribute.Bool("bridge.icc", config.EnableICC),
@@ -1036,7 +1038,7 @@ func (d *driver) deleteNetwork(nid string) error {
 }
 
 func addToBridge(ctx context.Context, nlh nlwrap.Handle, ifaceName, bridgeName string) error {
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.addToBridge", trace.WithAttributes(
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".addToBridge", trace.WithAttributes(
 		attribute.String("ifaceName", ifaceName),
 		attribute.String("bridgeName", bridgeName)))
 	defer span.End()
@@ -1066,7 +1068,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		return errors.New("invalid interface info passed")
 	}
 
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.CreateEndpoint", trace.WithAttributes(
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".CreateEndpoint", trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid)))
 	defer span.End()
@@ -1275,7 +1277,7 @@ func createVeth(ctx context.Context, hostIfName, containerIfName string, ifInfo 
 }
 
 func (d *driver) linkUp(ctx context.Context, host netlink.Link) error {
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.linkUp", trace.WithAttributes(
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".linkUp", trace.WithAttributes(
 		attribute.String("host", host.Attrs().Name)))
 	defer span.End()
 
@@ -1404,7 +1406,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, erro
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
 func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, epOpts, sbOpts map[string]interface{}) error {
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.Join", trace.WithAttributes(
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".Join", trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid),
 		attribute.String("sboxKey", sboxKey)))
@@ -1476,7 +1478,7 @@ func (d *driver) Leave(nid, eid string) error {
 }
 
 func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid string, options map[string]interface{}) error {
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.ProgramExternalConnectivity", trace.WithAttributes(
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".ProgramExternalConnectivity", trace.WithAttributes(
 		attribute.String("nid", nid),
 		attribute.String("eid", eid)))
 	defer span.End()

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -280,7 +280,7 @@ func TestCreateFullOptions(t *testing.T) {
 			AuxAddresses: map[string]*net.IPNet{DefaultGatewayV4AuxKey: defgw},
 		},
 	}
-	err := d.CreateNetwork("dummy", netOption, nil, ipdList, getIPv6Data(t))
+	err := d.CreateNetwork(context.Background(), "dummy", netOption, nil, ipdList, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestCreateNoConfig(t *testing.T) {
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = netconfig
 
-	if err := d.CreateNetwork("dummy", genericOption, nil, getIPv4Data(t), nil); err != nil {
+	if err := d.CreateNetwork(context.Background(), "dummy", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 }
@@ -356,7 +356,7 @@ func TestCreateFullOptionsLabels(t *testing.T) {
 		},
 	}
 
-	err := d.CreateNetwork("dummy", netOption, nil, ipdList, ipd6List)
+	err := d.CreateNetwork(context.Background(), "dummy", netOption, nil, ipdList, ipd6List)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -510,11 +510,11 @@ func TestCreate(t *testing.T) {
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = netconfig
 
-	if err := d.CreateNetwork("dummy", genericOption, nil, getIPv4Data(t), nil); err != nil {
+	if err := d.CreateNetwork(context.Background(), "dummy", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
-	err := d.CreateNetwork("dummy", genericOption, nil, getIPv4Data(t), nil)
+	err := d.CreateNetwork(context.Background(), "dummy", genericOption, nil, getIPv4Data(t), nil)
 	if err == nil {
 		t.Fatal("Expected bridge driver to refuse creation of second network with default name")
 	}
@@ -536,7 +536,7 @@ func TestCreateFail(t *testing.T) {
 	genericOption := make(map[string]interface{})
 	genericOption[netlabel.GenericData] = netconfig
 
-	if err := d.CreateNetwork("dummy", genericOption, nil, getIPv4Data(t), nil); err == nil {
+	if err := d.CreateNetwork(context.Background(), "dummy", genericOption, nil, getIPv4Data(t), nil); err == nil {
 		t.Fatal("Bridge creation was expected to fail")
 	}
 }
@@ -559,7 +559,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 	config1 := &networkConfiguration{BridgeName: "net_test_1", EnableIPv4: true}
 	genericOption = make(map[string]interface{})
 	genericOption[netlabel.GenericData] = config1
-	if err := d.CreateNetwork("1", genericOption, nil, getIPv4Data(t), nil); err != nil {
+	if err := d.CreateNetwork(context.Background(), "1", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
@@ -567,7 +567,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 
 	config2 := &networkConfiguration{BridgeName: "net_test_2", EnableIPv4: true}
 	genericOption[netlabel.GenericData] = config2
-	if err := d.CreateNetwork("2", genericOption, nil, getIPv4Data(t), nil); err != nil {
+	if err := d.CreateNetwork(context.Background(), "2", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
@@ -575,7 +575,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 
 	config3 := &networkConfiguration{BridgeName: "net_test_3", EnableIPv4: true}
 	genericOption[netlabel.GenericData] = config3
-	if err := d.CreateNetwork("3", genericOption, nil, getIPv4Data(t), nil); err != nil {
+	if err := d.CreateNetwork(context.Background(), "3", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
@@ -583,7 +583,7 @@ func TestCreateMultipleNetworks(t *testing.T) {
 
 	config4 := &networkConfiguration{BridgeName: "net_test_4", EnableIPv4: true}
 	genericOption[netlabel.GenericData] = config4
-	if err := d.CreateNetwork("4", genericOption, nil, getIPv4Data(t), nil); err != nil {
+	if err := d.CreateNetwork(context.Background(), "4", genericOption, nil, getIPv4Data(t), nil); err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 
@@ -805,7 +805,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 	genericOption[netlabel.GenericData] = netconfig
 
 	ipdList := getIPv4Data(t)
-	err = d.CreateNetwork("net1", genericOption, nil, ipdList, nil)
+	err = d.CreateNetwork(context.Background(), "net1", genericOption, nil, ipdList, nil)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -908,7 +908,7 @@ func TestLinkContainers(t *testing.T) {
 	genericOption[netlabel.GenericData] = netconfig
 
 	ipdList := getIPv4Data(t)
-	err := d.CreateNetwork("net1", genericOption, nil, ipdList, nil)
+	err := d.CreateNetwork(context.Background(), "net1", genericOption, nil, ipdList, nil)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -1218,7 +1218,7 @@ func TestSetDefaultGw(t *testing.T) {
 		},
 	}
 
-	err := d.CreateNetwork("dummy", option, nil, ipam4, ipam6)
+	err := d.CreateNetwork(context.Background(), "dummy", option, nil, ipam4, ipam6)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -1341,7 +1341,7 @@ func TestCreateWithExistingBridge(t *testing.T) {
 	// Set network gateway to X.X.X.1
 	ipv4Data[0].Gateway.IP[len(ipv4Data[0].Gateway.IP)-1] = 1
 
-	if err := d.CreateNetwork(brName, genericOption, nil, ipv4Data, nil); err != nil {
+	if err := d.CreateNetwork(context.Background(), brName, genericOption, nil, ipv4Data, nil); err != nil {
 		t.Fatalf("Failed to create bridge network: %v", err)
 	}
 
@@ -1388,11 +1388,11 @@ func TestCreateParallel(t *testing.T) {
 			config := &networkConfiguration{BridgeName: name, EnableIPv4: true}
 			genericOption := make(map[string]interface{})
 			genericOption[netlabel.GenericData] = config
-			if err := d.CreateNetwork(name, genericOption, nil, ipV4Data, nil); err != nil {
+			if err := d.CreateNetwork(context.Background(), name, genericOption, nil, ipV4Data, nil); err != nil {
 				ch <- fmt.Errorf("failed to create %s", name)
 				return
 			}
-			if err := d.CreateNetwork(name, genericOption, nil, ipV4Data, nil); err == nil {
+			if err := d.CreateNetwork(context.Background(), name, genericOption, nil, ipV4Data, nil); err == nil {
 				ch <- fmt.Errorf("failed was able to create overlap %s", name)
 				return
 			}

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -90,7 +90,7 @@ func (d *driver) populateEndpoints() error {
 }
 
 func (d *driver) storeUpdate(ctx context.Context, kvObject datastore.KVObject) error {
-	ctx, span := otel.Tracer("").Start(ctx, "libnetwork.drivers.bridge.storeUpdate", trace.WithAttributes(
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".storeUpdate", trace.WithAttributes(
 		attribute.String("kvObject", fmt.Sprintf("%+v", kvObject.Key()))))
 	defer span.End()
 

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -51,7 +51,7 @@ func (d *driver) populateNetworks() error {
 
 	for _, kvo := range kvol {
 		ncfg := kvo.(*networkConfiguration)
-		if err = d.createNetwork(ncfg); err != nil {
+		if err = d.createNetwork(context.TODO(), ncfg); err != nil {
 			log.G(context.TODO()).Warnf("could not create bridge network for id %s bridge name %s while booting up from persistent state: %v", ncfg.ID, ncfg.BridgeName, err)
 		}
 		log.G(context.TODO()).Debugf("Network (%.7s) restored", ncfg.ID)

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -28,7 +28,7 @@ func (d *driver) NetworkFree(id string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -31,7 +31,7 @@ func TestLinkCreate(t *testing.T) {
 
 	ipdList := getIPv4Data(t)
 	ipd6List := getIPv6Data(t)
-	err = d.CreateNetwork("dummy", option, nil, ipdList, ipd6List)
+	err = d.CreateNetwork(context.Background(), "dummy", option, nil, ipdList, ipd6List)
 	assert.NilError(t, err, "Failed to create bridge")
 
 	te := newTestEndpoint46(ipdList[0].Pool, ipd6List[0].Pool, 10)
@@ -91,7 +91,7 @@ func TestLinkCreateTwo(t *testing.T) {
 	}
 
 	ipdList := getIPv4Data(t)
-	err = d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
+	err = d.CreateNetwork(context.Background(), "dummy", option, nil, ipdList, getIPv6Data(t))
 	assert.NilError(t, err, "Failed to create bridge")
 
 	te1 := newTestEndpoint(ipdList[0].Pool, 11)
@@ -118,7 +118,7 @@ func TestLinkCreateNoEnableIPv6(t *testing.T) {
 	}
 
 	ipdList := getIPv4Data(t)
-	err = d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
+	err = d.CreateNetwork(context.Background(), "dummy", option, nil, ipdList, getIPv6Data(t))
 	assert.NilError(t, err, "Failed to create bridge")
 
 	te := newTestEndpoint(ipdList[0].Pool, 30)
@@ -144,7 +144,7 @@ func TestLinkDelete(t *testing.T) {
 	}
 
 	ipdList := getIPv4Data(t)
-	err = d.CreateNetwork("dummy", option, nil, ipdList, getIPv6Data(t))
+	err = d.CreateNetwork(context.Background(), "dummy", option, nil, ipdList, getIPv6Data(t))
 	assert.NilError(t, err, "Failed to create bridge")
 
 	te := newTestEndpoint(ipdList[0].Pool, 30)

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -56,7 +56,7 @@ func TestPortMappingConfig(t *testing.T) {
 	}
 
 	ipdList4 := getIPv4Data(t)
-	err := d.CreateNetwork("dummy", netOptions, nil, ipdList4, getIPv6Data(t))
+	err := d.CreateNetwork(context.Background(), "dummy", netOptions, nil, ipdList4, getIPv6Data(t))
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestPortMappingV6Config(t *testing.T) {
 
 	ipdList4 := getIPv4Data(t)
 	ipdList6 := getIPv6Data(t)
-	err := d.CreateNetwork("dummy", netOptions, nil, ipdList4, ipdList6)
+	err := d.CreateNetwork(context.Background(), "dummy", netOptions, nil, ipdList4, ipdList6)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}

--- a/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_ip_tables_linux_test.go
@@ -381,7 +381,7 @@ func TestOutgoingNATRules(t *testing.T) {
 				nc.AddressIPv6 = nil
 				ipv6Data = nil
 			}
-			if err := r.d.CreateNetwork("nattest", map[string]interface{}{netlabel.GenericData: nc}, nil, ipv4Data, ipv6Data); err != nil {
+			if err := r.d.CreateNetwork(context.Background(), "nattest", map[string]interface{}{netlabel.GenericData: nc}, nil, ipv4Data, ipv6Data); err != nil {
 				t.Fatal(err)
 			}
 			defer func() {

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -38,7 +38,7 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 	return "", nil
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	d.Lock()
 	defer d.Unlock()
 

--- a/libnetwork/drivers/host/host_test.go
+++ b/libnetwork/drivers/host/host_test.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/types"
@@ -13,7 +14,7 @@ func TestDriver(t *testing.T) {
 		t.Fatal("Unexpected network type returned by driver")
 	}
 
-	err := d.CreateNetwork("first", nil, nil, nil, nil)
+	err := d.CreateNetwork(context.Background(), "first", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +23,7 @@ func TestDriver(t *testing.T) {
 		t.Fatal("Unexpected network id stored")
 	}
 
-	err = d.CreateNetwork("second", nil, nil, nil, nil)
+	err = d.CreateNetwork(context.Background(), "second", nil, nil, nil, nil)
 	if err == nil {
 		t.Fatal("Second network creation should fail on this driver")
 	}

--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -17,7 +17,7 @@ import (
 )
 
 // CreateNetwork the network for the specified driver type
-func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	kv, err := kernel.GetKernelVersion()
 	if err != nil {
 		return fmt.Errorf("failed to check kernel version for ipvlan driver support: %v", err)

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -28,7 +28,7 @@ func (d *driver) NetworkFree(id string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -16,7 +16,7 @@ import (
 )
 
 // CreateNetwork the network for the specified driver type
-func (d *driver) CreateNetwork(nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, nid string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	// reject a null v4 network if ipv4 is required
 	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
 		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -28,7 +28,7 @@ func (d *driver) NetworkFree(id string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -38,7 +38,7 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 	return "", nil
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	d.Lock()
 	defer d.Unlock()
 

--- a/libnetwork/drivers/null/null_test.go
+++ b/libnetwork/drivers/null/null_test.go
@@ -1,6 +1,7 @@
 package null
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/docker/libnetwork/types"
@@ -13,7 +14,7 @@ func TestDriver(t *testing.T) {
 		t.Fatalf("Unexpected network type returned by driver")
 	}
 
-	err := d.CreateNetwork("first", nil, nil, nil, nil)
+	err := d.CreateNetwork(context.Background(), "first", nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +23,7 @@ func TestDriver(t *testing.T) {
 		t.Fatalf("Unexpected network id stored")
 	}
 
-	err = d.CreateNetwork("second", nil, nil, nil, nil)
+	err = d.CreateNetwork(context.Background(), "second", nil, nil, nil, nil)
 	if err == nil {
 		t.Fatalf("Second network creation should fail on this driver")
 	}

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -79,7 +79,7 @@ func (d *driver) NetworkFree(id string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	if id == "" {
 		return fmt.Errorf("invalid network id")
 	}

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -162,7 +162,7 @@ func (n *network) releaseVxlanID() {
 	}
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -162,7 +162,7 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 	return "", nil
 }
 
-func (d *driver) CreateNetwork(id string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	create := &api.CreateNetworkRequest{
 		NetworkID: id,
 		Options:   options,

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -459,7 +459,7 @@ func TestRemoteDriver(t *testing.T) {
 	}
 
 	netID := "dummy-network"
-	err = d.CreateNetwork(netID, map[string]interface{}{}, nil, nil, nil)
+	err = d.CreateNetwork(context.Background(), netID, map[string]interface{}{}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/drivers/windows/overlay/ov_network_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_network_windows.go
@@ -60,7 +60,7 @@ func (d *driver) NetworkFree(id string) error {
 	return types.NotImplementedErrorf("not implemented")
 }
 
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	var (
 		networkName   string
 		interfaceName string
@@ -84,10 +84,10 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 
 	existingNetwork := d.network(id)
 	if existingNetwork != nil {
-		log.G(context.TODO()).Debugf("Network preexists. Deleting %s", id)
+		log.G(ctx).Debugf("Network preexists. Deleting %s", id)
 		err := d.DeleteNetwork(id)
 		if err != nil {
-			log.G(context.TODO()).Errorf("Error deleting stale network %s", err.Error())
+			log.G(ctx).Errorf("Error deleting stale network %s", err.Error())
 		}
 	}
 

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -281,7 +281,7 @@ func (d *driver) createNetwork(config *networkConfiguration) *hnsNetwork {
 }
 
 // Create a new network
-func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	if _, err := d.getNetwork(id); err == nil {
 		return types.ForbiddenErrorf("network %s exists", id)
 	}
@@ -371,7 +371,7 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		}
 
 		configuration := string(configurationb)
-		log.G(context.TODO()).Debugf("HNSNetwork Request =%v Address Space=%v", configuration, subnets)
+		log.G(ctx).Debugf("HNSNetwork Request =%v Address Space=%v", configuration, subnets)
 
 		hnsresponse, err := hcsshim.HNSNetworkRequest("POST", "", configuration)
 		if err != nil {
@@ -416,15 +416,15 @@ func (d *driver) CreateNetwork(id string, option map[string]interface{}, nInfo d
 		if endpoints, err := hcsshim.HNSListEndpointRequest(); err == nil {
 			for _, ep := range endpoints {
 				if ep.VirtualNetwork == config.HnsID {
-					log.G(context.TODO()).Infof("Removing stale HNS endpoint %s", ep.Id)
+					log.G(ctx).Infof("Removing stale HNS endpoint %s", ep.Id)
 					_, err = hcsshim.HNSEndpointRequest("DELETE", ep.Id, "")
 					if err != nil {
-						log.G(context.TODO()).Warnf("Error removing HNS endpoint %s", ep.Id)
+						log.G(ctx).Warnf("Error removing HNS endpoint %s", ep.Id)
 					}
 				}
 			}
 		} else {
-			log.G(context.TODO()).Warnf("Error listing HNS endpoints for network %s", config.HnsID)
+			log.G(ctx).Warnf("Error listing HNS endpoints for network %s", config.HnsID)
 		}
 
 		n.created = true

--- a/libnetwork/drivers/windows/windows_test.go
+++ b/libnetwork/drivers/windows/windows_test.go
@@ -33,7 +33,7 @@ func testNetwork(networkType string, t *testing.T) {
 		},
 	}
 
-	err = d.CreateNetwork("dummy", netOption, nil, ipdList, nil)
+	err = d.CreateNetwork(context.Background(), "dummy", netOption, nil, ipdList, nil)
 	if err != nil {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}

--- a/libnetwork/endpoint_store_test.go
+++ b/libnetwork/endpoint_store_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEndpointStore(t *testing.T) {
 	configOption := config.OptionDataDir(t.TempDir())
-	c, err := New(configOption)
+	c, err := New(context.Background(), configOption)
 	assert.NilError(t, err)
 	defer c.Stop()
 

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -1,6 +1,7 @@
 package libnetwork
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -60,6 +61,7 @@ func TestUserChain(t *testing.T) {
 			defer resetIptables(t)
 
 			c, err := New(
+				context.Background(),
 				config.OptionDataDir(t.TempDir()),
 				config.OptionDriverConfig("bridge", map[string]any{
 					netlabel.GenericData: options.Generic{

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -322,7 +322,7 @@ func compareNwLists(a, b []*net.IPNet) bool {
 func TestAuxAddresses(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(config.OptionDataDir(t.TempDir()))
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +398,7 @@ func TestUpdateSvcRecord(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			defer netnsutils.SetupTestOSContext(t)()
-			ctrlr, err := New(config.OptionDataDir(t.TempDir()))
+			ctrlr, err := New(context.Background(), config.OptionDataDir(t.TempDir()))
 			assert.NilError(t, err)
 			defer ctrlr.Stop()
 
@@ -477,7 +477,7 @@ func TestSRVServiceQuery(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(config.OptionDataDir(t.TempDir()),
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
@@ -578,7 +578,7 @@ func TestServiceVIPReuse(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(config.OptionDataDir(t.TempDir()),
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
@@ -699,7 +699,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	defer netnsutils.SetupTestOSContext(t)()
 
-	c, err := New(config.OptionDataDir(t.TempDir()))
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -416,7 +416,7 @@ func TestUpdateSvcRecord(t *testing.T) {
 				assert.NilError(t, err)
 				ipam6 = []*IpamConf{{PreferredPool: net6.String()}}
 			}
-			n, err := ctrlr.NewNetwork("bridge", "net1", "", nil,
+			n, err := ctrlr.NewNetwork(context.Background(), "bridge", "net1", "", nil,
 				NetworkOptionEnableIPv4(tc.addr4 != ""),
 				NetworkOptionEnableIPv6(tc.addr6 != ""),
 				NetworkOptionIpam(defaultipam.DriverName, "", ipam4, ipam6, nil),
@@ -484,7 +484,7 @@ func TestSRVServiceQuery(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "net1", "",
+	n, err := c.NewNetwork(context.Background(), "bridge", "net1", "",
 		NetworkOptionEnableIPv4(true),
 	)
 	if err != nil {
@@ -585,7 +585,7 @@ func TestServiceVIPReuse(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "net1", "", nil,
+	n, err := c.NewNetwork(context.Background(), "bridge", "net1", "", nil,
 		NetworkOptionEnableIPv4(true),
 	)
 	if err != nil {
@@ -712,10 +712,10 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 	// Test whether ipam state release is invoked  on network create failure from net driver
 	// by checking whether subsequent network creation requesting same gateway IP succeeds
 	ipamOpt := NetworkOptionIpam(defaultipam.DriverName, "", []*IpamConf{{PreferredPool: "10.34.0.0/16", Gateway: "10.34.255.254"}}, nil, nil)
-	_, err = c.NewNetwork(badDriverName, "badnet1", "", ipamOpt)
+	_, err = c.NewNetwork(context.Background(), badDriverName, "badnet1", "", ipamOpt)
 	assert.Check(t, is.ErrorContains(err, "I will not create any network"))
 
-	gnw, err := c.NewNetwork("bridge", "goodnet1", "",
+	gnw, err := c.NewNetwork(context.Background(), "bridge", "goodnet1", "",
 		NetworkOptionEnableIPv4(true),
 		ipamOpt,
 	)
@@ -728,7 +728,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	// Now check whether ipam release works on endpoint creation failure
 	bd.failNetworkCreation = false
-	bnw, err := c.NewNetwork(badDriverName, "badnet2", "",
+	bnw, err := c.NewNetwork(context.Background(), badDriverName, "badnet2", "",
 		NetworkOptionEnableIPv4(true),
 		ipamOpt,
 	)
@@ -747,7 +747,7 @@ func TestIpamReleaseOnNetDriverFailures(t *testing.T) {
 
 	// Now create good bridge network with different gateway
 	ipamOpt2 := NetworkOptionIpam(defaultipam.DriverName, "", []*IpamConf{{PreferredPool: "10.35.0.0/16", Gateway: "10.35.255.253"}}, nil, nil)
-	gnw, err = c.NewNetwork("bridge", "goodnet2", "",
+	gnw, err = c.NewNetwork(context.Background(), "bridge", "goodnet2", "",
 		NetworkOptionEnableIPv4(true),
 		ipamOpt2,
 	)
@@ -784,7 +784,7 @@ func badDriverRegister(reg driverapi.Registerer) error {
 	return reg.RegisterDriver(badDriverName, &bd, driverapi.Capability{DataScope: scope.Local})
 }
 
-func (b *badDriver) CreateNetwork(nid string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+func (b *badDriver) CreateNetwork(ctx context.Context, nid string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	if b.failNetworkCreation {
 		return fmt.Errorf("I will not create any network")
 	}

--- a/libnetwork/libnetwork_linux_test.go
+++ b/libnetwork/libnetwork_linux_test.go
@@ -46,6 +46,7 @@ const (
 func newController(t *testing.T) *libnetwork.Controller {
 	t.Helper()
 	c, err := libnetwork.New(
+		context.Background(),
 		config.OptionDataDir(t.TempDir()),
 		config.OptionDriverConfig(bridgeNetType, map[string]interface{}{
 			netlabel.GenericData: options.Generic{
@@ -888,7 +889,7 @@ func TestInvalidRemoteDriver(t *testing.T) {
 	err = os.WriteFile(filepath.Join(specPath, "invalid-network-driver.spec"), []byte(server.URL), 0o644)
 	assert.NilError(t, err)
 
-	ctrlr, err := libnetwork.New(config.OptionDataDir(t.TempDir()))
+	ctrlr, err := libnetwork.New(context.Background(), config.OptionDataDir(t.TempDir()))
 	assert.NilError(t, err)
 	defer ctrlr.Stop()
 

--- a/libnetwork/network_store_test.go
+++ b/libnetwork/network_store_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNetworkStore(t *testing.T) {
 	configOption := config.OptionDataDir(t.TempDir())
-	c, err := New(configOption)
+	c, err := New(context.Background(), configOption)
 	assert.NilError(t, err)
 	defer c.Stop()
 

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -23,7 +23,7 @@ func TestDNSIPQuery(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "dtnet1", "", NetworkOptionEnableIPv4(true))
+	n, err := c.NewNetwork(context.Background(), "bridge", "dtnet1", "", NetworkOptionEnableIPv4(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestDNSProxyServFail(t *testing.T) {
 	}
 	defer c.Stop()
 
-	n, err := c.NewNetwork("bridge", "dtnet2", "", NetworkOptionEnableIPv4(true))
+	n, err := c.NewNetwork(context.Background(), "bridge", "dtnet2", "", NetworkOptionEnableIPv4(true))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libnetwork/resolver_unix_test.go
+++ b/libnetwork/resolver_unix_test.go
@@ -16,7 +16,7 @@ import (
 // test only works on linux
 func TestDNSIPQuery(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
-	c, err := New(config.OptionDataDir(t.TempDir()),
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +114,8 @@ func TestDNSProxyServFail(t *testing.T) {
 	osctx := netnsutils.SetupTestOSContextEx(t)
 	defer osctx.Cleanup(t)
 
-	c, err := New(config.OptionDataDir(t.TempDir()),
+	c, err := New(context.Background(),
+		config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	if err != nil {
 		t.Fatal(err)

--- a/libnetwork/sandbox_dns_unix_test.go
+++ b/libnetwork/sandbox_dns_unix_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDNSOptions(t *testing.T) {
-	c, err := New(config.OptionDataDir(t.TempDir()))
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()))
 	assert.NilError(t, err)
 
 	sb, err := c.NewSandbox(context.Background(), "cnt1", nil)

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -22,6 +22,7 @@ import (
 func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network) {
 	const netType = "bridge"
 	c, err := New(
+		context.Background(),
 		config.OptionDataDir(t.TempDir()),
 		config.OptionDriverConfig(netType, map[string]any{
 			netlabel.GenericData: options.Generic{"EnableIPForwarding": true},

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -48,7 +48,7 @@ func getTestEnv(t *testing.T, opts ...[]NetworkOption) (*Controller, []*Network)
 			}),
 		}
 		newOptions = append(newOptions, opt...)
-		n, err := c.NewNetwork(netType, name, "", newOptions...)
+		n, err := c.NewNetwork(context.Background(), netType, name, "", newOptions...)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/libnetwork/service_common_unix_test.go
+++ b/libnetwork/service_common_unix_test.go
@@ -3,6 +3,7 @@
 package libnetwork
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -24,11 +25,11 @@ func TestCleanupServiceDiscovery(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	n1, err := c.NewNetwork("bridge", "net1", "", NetworkOptionEnableIPv4(true))
+	n1, err := c.NewNetwork(context.Background(), "bridge", "net1", "", NetworkOptionEnableIPv4(true))
 	assert.NilError(t, err)
 	defer cleanup(n1)
 
-	n2, err := c.NewNetwork("bridge", "net2", "", NetworkOptionEnableIPv4(true))
+	n2, err := c.NewNetwork(context.Background(), "bridge", "net2", "", NetworkOptionEnableIPv4(true))
 	assert.NilError(t, err)
 	defer cleanup(n2)
 

--- a/libnetwork/service_common_unix_test.go
+++ b/libnetwork/service_common_unix_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCleanupServiceDiscovery(t *testing.T) {
 	defer netnsutils.SetupTestOSContext(t)()
-	c, err := New(config.OptionDataDir(t.TempDir()),
+	c, err := New(context.Background(), config.OptionDataDir(t.TempDir()),
 		config.OptionDefaultAddressPoolConfig(ipamutils.GetLocalScopeDefaultNetworks()))
 	assert.NilError(t, err)
 	defer c.Stop()

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -22,7 +22,7 @@ func TestNoPersist(t *testing.T) {
 		t.Fatalf("Error creating new controller: %v", err)
 	}
 	defer testController.Stop()
-	nw, err := testController.NewNetwork("host", "host", "", NetworkOptionPersist(false))
+	nw, err := testController.NewNetwork(context.Background(), "host", "host", "", NetworkOptionPersist(false))
 	if err != nil {
 		t.Fatalf(`Error creating default "host" network: %v`, err)
 	}

--- a/libnetwork/store_linux_test.go
+++ b/libnetwork/store_linux_test.go
@@ -17,7 +17,7 @@ func TestBoltdbBackend(t *testing.T) {
 
 func TestNoPersist(t *testing.T) {
 	configOption := config.OptionDataDir(t.TempDir())
-	testController, err := New(configOption)
+	testController, err := New(context.Background(), configOption)
 	if err != nil {
 		t.Fatalf("Error creating new controller: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestNoPersist(t *testing.T) {
 
 	// Create a new controller using the same database-file. The network
 	// should not have persisted.
-	testController, err = New(configOption)
+	testController, err = New(context.Background(), configOption)
 	if err != nil {
 		t.Fatalf("Error creating new controller: %v", err)
 	}

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -18,7 +18,7 @@ func testLocalBackend(t *testing.T, path, bucket string) {
 		}),
 	}
 
-	testController, err := New(cfgOptions...)
+	testController, err := New(context.Background(), cfgOptions...)
 	if err != nil {
 		t.Fatalf("Error new controller: %v", err)
 	}
@@ -52,7 +52,7 @@ func testLocalBackend(t *testing.T, path, bucket string) {
 	testController.Stop()
 
 	// test restore of local store
-	testController, err = New(cfgOptions...)
+	testController, err = New(context.Background(), cfgOptions...)
 	if err != nil {
 		t.Fatalf("Error creating controller: %v", err)
 	}

--- a/libnetwork/store_test.go
+++ b/libnetwork/store_test.go
@@ -23,7 +23,7 @@ func testLocalBackend(t *testing.T, path, bucket string) {
 		t.Fatalf("Error new controller: %v", err)
 	}
 	defer testController.Stop()
-	nw, err := testController.NewNetwork("host", "host", "")
+	nw, err := testController.NewNetwork(context.Background(), "host", "host", "")
 	if err != nil {
 		t.Fatalf(`Error creating default "host" network: %v`, err)
 	}

--- a/vendor.mod
+++ b/vendor.mod
@@ -100,6 +100,7 @@ require (
 	go.etcd.io/bbolt v1.3.11
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.56.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
+	go.opentelemetry.io/contrib/processors/baggagecopy v0.4.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -614,6 +614,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.
 go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.56.0/go.mod h1:3qi2EEwMgB4xnKgPLqsDP3j9qxnHDZeHsnAxfjQqTko=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0 h1:UP6IpuHFkUgOQL9FFQFrZ+5LiwhhYRbi7VZSIx6Nj5s=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0/go.mod h1:qxuZLtbq5QDtdeSHsS7bcf6EH6uO6jUAgk764zd3rhM=
+go.opentelemetry.io/contrib/processors/baggagecopy v0.4.0 h1:SUsGRzllvPRJK6VKn1S3lsItIoQaLvExUh63cD+J+D8=
+go.opentelemetry.io/contrib/processors/baggagecopy v0.4.0/go.mod h1:68LCyaHcLhUf3tciKAAbSFKkr4Pkrt24ei0/xHm0No8=
 go.opentelemetry.io/otel v1.31.0 h1:NsJcKPIW0D0H3NgzPDHmo0WW6SptzPdqg/L1zsIm2hY=
 go.opentelemetry.io/otel v1.31.0/go.mod h1:O0C14Yl9FgkjqcCZAsE053C13OaddMYr/hz6clDkEJE=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.31.0 h1:FZ6ei8GFW7kyPYdxJaV2rgI6M+4tvZzhYsQ2wgyVC08=

--- a/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/LICENSE
+++ b/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/doc.go
+++ b/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/doc.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package baggagecopy is an OpenTelemetry [Span Processor] that reads key/values
+// stored in [Baggage] in the starting span's parent context and adds them as
+// attributes to the span.
+//
+// Keys and values added to Baggage will appear on all subsequent child spans for
+// a trace within this service and will be propagated to external services via
+// propagation headers.
+// If the external services also have a Baggage span processor, the keys and
+// values will appear in those child spans as well.
+//
+// Do not put sensitive information in Baggage.
+//
+// # Usage
+//
+// Add the span processor when configuring the tracer provider.
+//
+// The convenience function [AllowAllBaggageKeys] is provided to
+// allow all baggage keys to be copied to the span. Alternatively, you can
+// provide a custom baggage key predicate to select which baggage keys you want
+// to copy.
+//
+// [Span Processor]: https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor
+// [Baggage]: https://opentelemetry.io/docs/specs/otel/api/baggage
+package baggagecopy // import "go.opentelemetry.io/contrib/processors/baggagecopy"

--- a/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/processor.go
+++ b/vendor/go.opentelemetry.io/contrib/processors/baggagecopy/processor.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package baggagecopy // import "go.opentelemetry.io/contrib/processors/baggagecopy"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Filter returns true if the baggage member should be added to a span.
+type Filter func(member baggage.Member) bool
+
+// AllowAllMembers allows all baggage members to be added to a span.
+var AllowAllMembers Filter = func(baggage.Member) bool { return true }
+
+// SpanProcessor is a [trace.SpanProcessor] implementation that adds baggage
+// members onto a span as attributes.
+type SpanProcessor struct {
+	filter Filter
+}
+
+var _ trace.SpanProcessor = (*SpanProcessor)(nil)
+
+// NewSpanProcessor returns a new [SpanProcessor].
+//
+// The Baggage span processor duplicates onto a span the attributes found
+// in Baggage in the parent context at the moment the span is started.
+// The passed filter determines which baggage members are added to the span.
+//
+// If filter is nil, all baggage members will be added.
+func NewSpanProcessor(filter Filter) *SpanProcessor {
+	return &SpanProcessor{
+		filter: filter,
+	}
+}
+
+// OnStart is called when a span is started and adds span attributes for baggage contents.
+func (processor SpanProcessor) OnStart(ctx context.Context, span trace.ReadWriteSpan) {
+	filter := processor.filter
+	if filter == nil {
+		filter = AllowAllMembers
+	}
+
+	for _, member := range baggage.FromContext(ctx).Members() {
+		if filter(member) {
+			span.SetAttributes(attribute.String(member.Key(), member.Value()))
+		}
+	}
+}
+
+// OnEnd is called when span is finished and is a no-op for this processor.
+func (processor SpanProcessor) OnEnd(s trace.ReadOnlySpan) {}
+
+// Shutdown is called when the SDK shuts down and is a no-op for this processor.
+func (processor SpanProcessor) Shutdown(context.Context) error { return nil }
+
+// ForceFlush exports all ended spans to the configured Exporter that have not yet
+// been exported and is a no-op for this processor.
+func (processor SpanProcessor) ForceFlush(context.Context) error { return nil }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1288,6 +1288,9 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/request
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconv
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/internal/semconvutil
+# go.opentelemetry.io/contrib/processors/baggagecopy v0.4.0
+## explicit; go 1.22
+go.opentelemetry.io/contrib/processors/baggagecopy
 # go.opentelemetry.io/otel v1.31.0
 ## explicit; go 1.22
 go.opentelemetry.io/otel


### PR DESCRIPTION
**- What I did**

See individual commit messages for more details.

**libnet/d/bridge: trace createNetwork**

Plumb context from the API down to libnet driver method `CreateNetwork`, and add an OTel span to the bridge driver's `createNetwork` method. A few network attributes are added to that span (i.e. IPv4, IPv6, ICC, internal and MTU).

**libnet/d/bridge: trace network setup steps**

Also, trace the bridge setup steps to better understand where we're spending time. This will be helpful to know how nftables impact performance.

**libnet: New: plumb context; api, daemon, libnet: add a 'trigger' baggage member**

Finally, add a `ctx` argument to `libnetwork.New`, and use a baggage to track what triggered the bridge `createNetwork` method. This can be used to distinguish calls made during daemon initialization and calls made during custom network creation (i.e. by an API call).

**- How I did it**

- Verified if any affected callsite need `context.WithoutCancel`. All functions that now take a context are returning an error, and none of the affected callsites are part of a `defer`.
- All functions that now take a `ctx` pass it to `log.G()`. 

**- How to verify it**

For code correctness, through unit and integration tests.

For testing the new OTel spans, using the Compose stack provided by https://github.com/moby/moby/pull/47733.
