### PR TITLE
libnet: add ep name in 'has active endpoints' error

### DIFF
--- a/libnetwork/error.go
+++ b/libnetwork/error.go
@@ -2,6 +2,7 @@ package libnetwork
 
 import (
 	"fmt"
+	"strings"
 )
 
 // ErrNoSuchNetwork is returned when a network query finds no result
@@ -27,12 +28,13 @@ func (nnr NetworkNameError) Conflict() {}
 // ActiveEndpointsError is returned when a network is deleted which has active
 // endpoints in it.
 type ActiveEndpointsError struct {
-	name string
-	id   string
+	name      string
+	id        string
+	endpoints []string
 }
 
 func (aee *ActiveEndpointsError) Error() string {
-	return fmt.Sprintf("network %s id %s has active endpoints", aee.name, aee.id)
+	return fmt.Sprintf("network %s has active endpoints (%s)", aee.name, strings.Join(aee.endpoints, ", "))
 }
 
 // Forbidden denotes the type of this error

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/sliceutil"
 	"github.com/docker/docker/libnetwork/datastore"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/internal/netiputil"
@@ -1046,7 +1047,11 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 	}
 	eps := c.findEndpoints(filterEndpointByNetworkId(n.id))
 	if !force && len(eps) > emptyCount {
-		return &ActiveEndpointsError{name: n.name, id: n.id}
+		return &ActiveEndpointsError{
+			name:      n.name,
+			id:        n.id,
+			endpoints: sliceutil.Map(eps, func(ep *Endpoint) string { return ep.name }),
+		}
 	}
 
 	if n.hasLoadBalancerEndpoint() {


### PR DESCRIPTION
- Follow-up of https://github.com/moby/moby/pull/49736
- Related to https://github.com/moby/moby/issues/17217
- Related to https://github.com/moby/moby/issues/42119

**- What I did**

There have been numerous reports of the "has active endpoints" error over the years. Historically, there were some faulty code paths that could lead to this error, but we believe they all have been fixed by now.

However, users are still facing this error from time to time. Either because they forgot that some containers are still running, or because we still have bugs lying around.

To help users figure whether this error is legitimate, and what triggers it, add endpoint names (which are just container names) to the error message.

**- How to verify it**

```
$ docker network rm testnetv6                 
Error response from daemon: error while removing network: network testnetv6 has 1 active endpoint (goofy_swartz)
exit status 1
$ docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED         STATUS         PORTS     NAMES
2e8ae9193caa   alpine    "top"     9 seconds ago   Up 8 seconds             goofy_swartz
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Improve the "has active endpoints" error message by including the name of endpoints still connected to the network being deleted
```
