### PR TITLE
Dockerfile: Fetch vpnkit from moby org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 ARG XX_VERSION=1.6.1
 
-ARG VPNKIT_VERSION=0.5.0
+# VPNKIT_VERSION is the version of the vpnkit binary which is used as a fallback
+# network driver for rootless.
+ARG VPNKIT_VERSION=0.6.0
 
 # DOCKERCLI_VERSION is the version of the CLI to install in the dev-container.
 ARG DOCKERCLI_VERSION=v28.1.1
@@ -421,8 +423,8 @@ FROM scratch AS vpnkit-linux-arm
 FROM scratch AS vpnkit-linux-ppc64le
 FROM scratch AS vpnkit-linux-riscv64
 FROM scratch AS vpnkit-linux-s390x
-FROM djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-linux-amd64
-FROM djs55/vpnkit:${VPNKIT_VERSION} AS vpnkit-linux-arm64
+FROM moby/vpnkit-bin:${VPNKIT_VERSION} AS vpnkit-linux-amd64
+FROM moby/vpnkit-bin:${VPNKIT_VERSION} AS vpnkit-linux-arm64
 FROM vpnkit-linux-${TARGETARCH} AS vpnkit-linux
 FROM vpnkit-${TARGETOS} AS vpnkit
 


### PR DESCRIPTION
`moby/vpnkit` now officially pushes a binary image to `moby/vpnkit-bin` repository on Docker Hub.

Use it to fetch the vpnkit binary.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>