### PR TITLE
Fix removal of legacy links

### DIFF
--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -899,6 +899,12 @@ func (ep *Endpoint) sbLeave(ctx context.Context, sb *Sandbox, force bool) error 
 		log.G(ctx).WithError(err).Warn("Failed to clean up network resources on container disconnect")
 	}
 
+	// Even if the interface was initially created in the container's namespace, it's
+	// now been moved out. When a legacy link is deleted, the Endpoint is removed and
+	// then re-added to the Sandbox. So, to make sure the re-add works, note that the
+	// interface is now outside the container's netns.
+	ep.iface.createdInContainer = false
+
 	// Update the store about the sandbox detach only after we
 	// have completed sb.clearNetworkResources above to avoid
 	// spurious logs when cleaning up the sandbox when the daemon


### PR DESCRIPTION
**- What I did**

- fix a bug introduced by https://github.com/moby/moby/pull/49302

It's possible to remove a legacy link from running containers. When that happens, the Sandbox's Endpoints are removed and re-added.

Since commit 65120d5 ("Create bridge veth in container netns") the veth device has been created in the container's netns. When that happens, a flag is set on the Endpoint to note that it does not need to be moved into the netns.

But, during the Leave/Join (Sandbox.Refresh) the veth is moved out of the netns.

It looked like this was covered by `integration-cli` test `DockerDaemonSuite/TestDaemonLinksIpTablesRulesWhenLinkAndUnlink` ... but that test didn't actually check anything worked. (Found while removing/replacing integration-cli tests that inspect iptables rules directly, because they won't work with nftables.)

**- How I did it**

Clear the flag that says the veth is already in the container during the Leave, to note that it needs to be moved back in during the Join.

**- How to verify it**

New integration test.

**- Human readable description for the release notes**
```markdown changelog
- Fix an issue with removal of a `--link` from a container in the default bridge network.
```
