### PR TITLE
API: /info: remove BridgeNfIptables, BridgeNfIp6tables fields

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -122,6 +122,13 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 			info.ContainerdCommit.Expected = info.ContainerdCommit.ID //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
 			info.RuncCommit.Expected = info.RuncCommit.ID             //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
 			info.InitCommit.Expected = info.InitCommit.ID             //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
+
+			// These fields are omitted in > API 1.49, and always false
+			// older API versions.
+			info.ExtraFields = map[string]any{
+				"BridgeNfIptables":  json.RawMessage("false"),
+				"BridgeNfIp6tables": json.RawMessage("false"),
+			}
 		}
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -1,6 +1,11 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package system
 
 import (
+	"encoding/json"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
@@ -29,8 +34,6 @@ type Info struct {
 	CPUSet             bool
 	PidsLimit          bool
 	IPv4Forwarding     bool
-	BridgeNfIptables   bool `json:"BridgeNfIptables"`  // Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
-	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"` // Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
 	Debug              bool
 	NFd                int
 	OomKillDisable     bool
@@ -83,6 +86,26 @@ type Info struct {
 	// messages for the user, and are not intended to be parsed / used for
 	// other purposes, as they do not have a fixed format.
 	Warnings []string
+
+	// ExtraFields is for internal use to include deprecated fields on older API versions.
+	ExtraFields map[string]any `json:"-"`
+}
+
+// MarshalJSON implements a custom marshaler to include legacy fields
+// in API responses.
+func (sc *Info) MarshalJSON() ([]byte, error) {
+	type tmp Info
+	base, err := json.Marshal((*tmp)(sc))
+	if err != nil {
+		return nil, err
+	}
+	var merged map[string]any
+	_ = json.Unmarshal(base, &merged)
+
+	for k, v := range sc.ExtraFields {
+		merged[k] = v
+	}
+	return json.Marshal(merged)
 }
 
 // ContainerdInfo holds information about the containerd instance used by the daemon.

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -29,6 +29,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * Deprecated: The `ContainerdCommit.Expected`, `RuncCommit.Expected`, and
   `InitCommit.Expected` fields in the `GET /info` endpoint were deprecated
   in API v1.48, and are now omitted in API v1.49.
+* Deprecated: The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the
+  `GET /info` response were deprecated in API v1.48, and are now omitted
+  in API v1.49.
 
 ## v1.48 API changes
 

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -3,9 +3,13 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -46,4 +50,57 @@ func TestInfoBinaryCommits(t *testing.T) {
 		assert.Check(t, "N/A" != info.RuncCommit.ID)
 		assert.Check(t, is.Equal(info.RuncCommit.Expected, info.RuncCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
 	})
+}
+
+func TestInfoLegacyFields(t *testing.T) {
+	ctx := setupTest(t)
+
+	const notPresent = "expected field to not be present"
+
+	tests := []struct {
+		name           string
+		url            string
+		expectedFields map[string]any
+	}{
+		{
+			name: "api v1.48 legacy bridge-nftables",
+			url:  "/v1.48/info",
+			expectedFields: map[string]any{
+				"BridgeNfIp6tables": false,
+				"BridgeNfIptables":  false,
+			},
+		},
+		{
+			name: "api v1.49 legacy bridge-nftables",
+			url:  "/v1.49/info",
+			expectedFields: map[string]any{
+				"BridgeNfIp6tables": notPresent,
+				"BridgeNfIptables":  notPresent,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, _, err := request.Get(ctx, tc.url)
+			assert.NilError(t, err)
+			assert.Equal(t, res.StatusCode, http.StatusOK)
+			body, err := io.ReadAll(res.Body)
+			assert.NilError(t, err)
+
+			actual := map[string]any{}
+			err = json.Unmarshal(body, &actual)
+			assert.NilError(t, err, string(body))
+
+			for field, expectedValue := range tc.expectedFields {
+				if expectedValue == notPresent {
+					_, found := actual[field]
+					assert.Assert(t, !found, "field %s should not be present", field)
+				} else {
+					_, found := actual[field]
+					assert.Assert(t, found, "field %s should be present", field)
+					assert.Check(t, is.DeepEqual(actual[field], expectedValue))
+				}
+			}
+		})
+	}
 }

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -24,16 +24,6 @@ type SysInfo struct {
 	// Whether IPv4 forwarding is supported or not, if this was disabled, networking will not work
 	IPv4ForwardingDisabled bool
 
-	// Whether bridge-nf-call-iptables is supported or not
-	//
-	// Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
-	BridgeNFCallIPTablesDisabled bool
-
-	// Whether bridge-nf-call-ip6tables is supported or not
-	//
-	// Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
-	BridgeNFCallIP6TablesDisabled bool
-
 	// Whether the cgroup has the mountpoint of "devices" or not
 	CgroupDevicesEnabled bool
 


### PR DESCRIPTION
The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the `GET /info` response were deprecated in API v1.48, and are now omitted in API v1.49.

With this patch, old API version continue to return the field:

    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.48/info | jq .BridgeNfIp6tables
    false

    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.48/info | jq .BridgeNfIptables
    false

Omitting the field in API v1.49 and above

    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.49/info | jq .BridgeNfIp6tables
    null

    curl -s --unix-socket /var/run/docker.sock http://localhost/v1.49/info | jq .BridgeNfIptables
    null

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Deprecated: The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the `GET /info` response were deprecated in API v1.48, and are now omitted in API v1.49.
```

**- A picture of a cute animal (not mandatory but encouraged)**

