### PR TITLE
c8d/pull: Don't use `WithPullUnpack` with overlayfs

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -192,9 +192,12 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	})
 	opts = append(opts, containerd.WithImageHandler(ah))
 
-	opts = append(opts, containerd.WithPullUnpack)
 	// TODO(thaJeztah): we may have to pass the snapshotter to use if the pull is part of a "docker run" (container create -> pull image if missing). See https://github.com/moby/moby/issues/45273
-	opts = append(opts, containerd.WithPullSnapshotter(i.snapshotter))
+	usePullUnpack := i.snapshotter != "overlayfs"
+	if usePullUnpack {
+		opts = append(opts, containerd.WithPullUnpack)
+		opts = append(opts, containerd.WithPullSnapshotter(i.snapshotter))
+	}
 
 	// AppendInfoHandlerWrapper will annotate the image with basic information like manifest and layer digests as labels;
 	// this information is used to enable remote snapshotters like nydus and stargz to query a registry.
@@ -235,6 +238,13 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 		"digest": img.Target().Digest,
 		"remote": ref.String(),
 	})
+	if !usePullUnpack {
+		err := img.Unpack(ctx, i.snapshotter)
+		if err != nil {
+			logger.WithError(err).Warn("failed to unpack image")
+		}
+	}
+
 	logger.Info("image pulled")
 
 	// The pull succeeded, so try to remove any dangling image we have for this target


### PR DESCRIPTION
It's only needed for remote snapshotters.

NOTE: This breaks `Extracting` status because without `PullUnpack` snapshots don't get the special labels that allow to correlate snapshot with a layer blob: https://github.com/moby/moby/blob/325076df0c761c126ea7974e508e0563c3452fde/vendor/github.com/containerd/containerd/v2/pkg/snapshotters/annotations.go#L31-L45


**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

