### PR TITLE
profiles/seccomp: use stdlib for asserting, remove "// import" comments 

### DIFF
--- a/profiles/seccomp/default_linux.go
+++ b/profiles/seccomp/default_linux.go
@@ -1,4 +1,4 @@
-package seccomp // import "github.com/docker/docker/profiles/seccomp"
+package seccomp
 
 import (
 	"github.com/opencontainers/runtime-spec/specs-go"

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -1,4 +1,4 @@
-package seccomp // import "github.com/docker/docker/profiles/seccomp"
+package seccomp
 
 import (
 	"encoding/json"

--- a/profiles/seccomp/seccomp_linux.go
+++ b/profiles/seccomp/seccomp_linux.go
@@ -1,6 +1,6 @@
 //go:generate go run -tags 'seccomp' generate.go
 
-package seccomp // import "github.com/docker/docker/profiles/seccomp"
+package seccomp
 
 import (
 	"encoding/json"

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package seccomp // import "github.com/docker/docker/profiles/seccomp"
+package seccomp
 
 import (
 	"encoding/json"


### PR DESCRIPTION
- relates to https://github.com/moby/sys/pull/189

### profiles/seccomp: use stdlib for asserting

We are considering moving the seccomp profile to a separate module,
so reducing the list of dependencies for this package.

### profiles/seccomp: remove "// import" comments

We are considering moving the seccomp profile to a separate module,
so removing these comments in preparation. These comments are ignored
already when building in go module mode, so have little benefits.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

