### PR TITLE
integration/TestStopContainerWithTimeout: Attempt to fix flakiness

### DIFF
--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -95,7 +95,8 @@ func TestStopContainerWithTimeout(t *testing.T) {
 
 	for _, tc := range testData {
 		t.Run(tc.doc, func(t *testing.T) {
-			t.Parallel()
+			// TODO(vvoland): Investigate why it helps
+			// t.Parallel()
 			id := container.Run(ctx, t, apiClient, testCmd)
 
 			err := apiClient.ContainerStop(ctx, id, containertypes.StopOptions{Timeout: &tc.timeout})


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/49206

I suspect that the cause of flakiness might be the same as in: https://github.com/moby/moby/pull/49618 where removing Parallel helped.

Let me confirm this.