### PR TITLE
[28.1 backport] bridge: Add a missing error check for firewaller setup

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -512,7 +512,9 @@ func (d *driver) configure(option map[string]interface{}) error {
 		IPv6:    config.EnableIP6Tables,
 		Hairpin: !config.EnableUserlandProxy || config.UserlandProxyPath == "",
 	}
-	d.firewaller.init()
+	if err := d.firewaller.init(); err != nil {
+		return err
+	}
 	iptables.OnReloaded(d.handleFirewalldReload)
 
 	var pdc portDriverClient


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/49806

**- What I did**

Added a missing error check for firewaller setup that got lost in commit 29e0db2.
- Bug introduced in https://github.com/moby/moby/pull/49765

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

