### PR TITLE
Partially revert "libnet: remove struct endpointCnt"

### DIFF
--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -600,7 +600,7 @@ func (c *Controller) NewNetwork(ctx context.Context, networkType, name string, i
 		defer func() {
 			if retErr == nil && !skipCfgEpCount {
 				if err := configNetwork.getEpCnt().IncEndpointCnt(); err != nil {
-					log.G(context.TODO()).Warnf("Failed to update reference count for configuration network %q on creation of network %q: %v", configNetwork.Name(), nw.name, err)
+					log.G(ctx).Warnf("Failed to update reference count for configuration network %q on creation of network %q: %v", configNetwork.Name(), nw.name, err)
 				}
 			}
 		}()
@@ -705,13 +705,13 @@ addToStore:
 	// end up with a datastore containing a network and not an epCnt,
 	// in case of an ungraceful shutdown during this function call.
 	epCnt := &endpointCnt{n: nw}
-	if err := c.updateToStore(context.TODO(), epCnt); err != nil {
+	if err := c.updateToStore(ctx, epCnt); err != nil {
 		return nil, err
 	}
 	defer func() {
 		if retErr != nil {
 			if err := c.deleteFromStore(epCnt); err != nil {
-				log.G(context.TODO()).Warnf("could not rollback from store, epCnt %v on failure (%v): %v", epCnt, retErr, err)
+				log.G(ctx).Warnf("could not rollback from store, epCnt %v on failure (%v): %v", epCnt, retErr, err)
 			}
 		}
 	}()

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -1053,6 +1053,10 @@ func (ep *Endpoint) Delete(ctx context.Context, force bool) error {
 
 	ep.releaseAddress()
 
+	if err := n.getEpCnt().DecEndpointCnt(); err != nil {
+		log.G(ctx).Warnf("failed to decrement endpoint count for ep %s: %v", ep.ID(), err)
+	}
+
 	return nil
 }
 
@@ -1399,6 +1403,20 @@ func (c *Controller) cleanupLocalEndpoints() error {
 			log.G(context.TODO()).Infof("Removing stale endpoint %s (%s)", ep.name, ep.id)
 			if err := ep.Delete(context.WithoutCancel(context.TODO()), true); err != nil {
 				log.G(context.TODO()).Warnf("Could not delete local endpoint %s during endpoint cleanup: %v", ep.name, err)
+			}
+		}
+
+		epl, err = n.getEndpointsFromStore()
+		if err != nil {
+			log.G(context.TODO()).Warnf("Could not get list of endpoints in network %s for count update: %v", n.name, err)
+			continue
+		}
+
+		epCnt := n.getEpCnt().EndpointCnt()
+		if epCnt != uint64(len(epl)) {
+			log.G(context.TODO()).Infof("Fixing inconsistent endpoint_cnt for network %s. Expected=%d, Actual=%d", n.name, len(epl), epCnt)
+			if err := n.getEpCnt().setCnt(uint64(len(epl))); err != nil {
+				log.G(context.TODO()).WithField("network", n.name).WithError(err).Warn("Error while fixing inconsistent endpoint_cnt for network")
 			}
 		}
 	}

--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -1,0 +1,178 @@
+package libnetwork
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/docker/docker/libnetwork/datastore"
+)
+
+// endpointCnt was used to refcount network-endpoint relationships. It's
+// unused since v28.1, and kept around only to ensure that users can properly
+// downgrade.
+//
+// TODO(aker): remove this struct in v30.
+type endpointCnt struct {
+	n        *Network
+	Count    uint64
+	dbIndex  uint64
+	dbExists bool
+	sync.Mutex
+}
+
+const epCntKeyPrefix = "endpoint_count"
+
+func (ec *endpointCnt) Key() []string {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return []string{epCntKeyPrefix, ec.n.id}
+}
+
+func (ec *endpointCnt) KeyPrefix() []string {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return []string{epCntKeyPrefix, ec.n.id}
+}
+
+func (ec *endpointCnt) Value() []byte {
+	ec.Lock()
+	defer ec.Unlock()
+
+	b, err := json.Marshal(ec)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func (ec *endpointCnt) SetValue(value []byte) error {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return json.Unmarshal(value, &ec)
+}
+
+func (ec *endpointCnt) Index() uint64 {
+	ec.Lock()
+	defer ec.Unlock()
+	return ec.dbIndex
+}
+
+func (ec *endpointCnt) SetIndex(index uint64) {
+	ec.Lock()
+	ec.dbIndex = index
+	ec.dbExists = true
+	ec.Unlock()
+}
+
+func (ec *endpointCnt) Exists() bool {
+	ec.Lock()
+	defer ec.Unlock()
+	return ec.dbExists
+}
+
+func (ec *endpointCnt) Skip() bool {
+	ec.Lock()
+	defer ec.Unlock()
+	return !ec.n.persist
+}
+
+func (ec *endpointCnt) New() datastore.KVObject {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return &endpointCnt{
+		n: ec.n,
+	}
+}
+
+func (ec *endpointCnt) CopyTo(o datastore.KVObject) error {
+	ec.Lock()
+	defer ec.Unlock()
+
+	dstEc := o.(*endpointCnt)
+	dstEc.n = ec.n
+	dstEc.Count = ec.Count
+	dstEc.dbExists = ec.dbExists
+	dstEc.dbIndex = ec.dbIndex
+
+	return nil
+}
+
+func (ec *endpointCnt) EndpointCnt() uint64 {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return ec.Count
+}
+
+func (ec *endpointCnt) updateStore() error {
+	c := ec.n.getController()
+	// make a copy of count and n to avoid being overwritten by store.GetObject
+	count := ec.EndpointCnt()
+	n := ec.n
+	for {
+		if err := c.updateToStore(context.TODO(), ec); err == nil || err != datastore.ErrKeyModified {
+			return err
+		}
+		if err := c.store.GetObject(ec); err != nil {
+			return fmt.Errorf("could not update the kvobject to latest on endpoint count update: %v", err)
+		}
+		ec.Lock()
+		ec.Count = count
+		ec.n = n
+		ec.Unlock()
+	}
+}
+
+func (ec *endpointCnt) setCnt(cnt uint64) error {
+	ec.Lock()
+	ec.Count = cnt
+	ec.Unlock()
+	return ec.updateStore()
+}
+
+func (ec *endpointCnt) atomicIncDecEpCnt(inc bool) error {
+	store := ec.n.getController().store
+
+	tmp := &endpointCnt{n: ec.n}
+	if err := store.GetObject(tmp); err != nil {
+		return err
+	}
+retry:
+	ec.Lock()
+	if inc {
+		ec.Count++
+	} else {
+		if ec.Count > 0 {
+			ec.Count--
+		}
+	}
+	ec.Unlock()
+
+	if err := ec.n.getController().updateToStore(context.TODO(), ec); err != nil {
+		if err == datastore.ErrKeyModified {
+			if err := store.GetObject(ec); err != nil {
+				return fmt.Errorf("could not update the kvobject to latest when trying to atomic add endpoint count: %v", err)
+			}
+
+			goto retry
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (ec *endpointCnt) IncEndpointCnt() error {
+	return ec.atomicIncDecEpCnt(true)
+}
+
+func (ec *endpointCnt) DecEndpointCnt() error {
+	return ec.atomicIncDecEpCnt(false)
+}


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/49736
- https://github.com/moby/moby/pull/49773
- https://github.com/moby/moby/pull/49769

**- What I did**

This change was causing a panic when downgrading from RC1 to an older Engine release.

We still want to keep the new endpoint / network caching behavior introduced in that commit as it might fix some instances of the 'has active endpoints' bug, and it's needed for the error message improvement made in 241d685.

So, instead of doing a full revert of commit 51d7f95c4b364d564d4653a7915112120385e7cd, restore the endpointCnt struct and persist it, but do not use it to determine if a network is in use.

Moreover, commit 78be7ebad added a Context arg to `NewNetwork`, so use it in the code re-introduced.

For reference, here's the observed stack trace:

```
goroutine 1 [running, locked to thread]:
github.com/docker/docker/libnetwork.(*endpointCnt).EndpointCnt(0x4000922cd0?)
	/root/build-deb/engine/libnetwork/endpoint_cnt.go:102 +0x24
github.com/docker/docker/libnetwork.(*Network).delete(0x400049f580?, 0x0, 0x0)
	/root/build-deb/engine/libnetwork/network.go:1048 +0x248
github.com/docker/docker/libnetwork.(*Network).Delete(0x40008aae00, {0x0, 0x0, 0x8?})
	/root/build-deb/engine/libnetwork/network.go:1012 +0x78
github.com/docker/docker/daemon.configureNetworking(0x40009540e0, 0x400047a608)
	/root/build-deb/engine/daemon/daemon_unix.go:884 +0x128
github.com/docker/docker/daemon.(*Daemon).initNetworkController(0x4000455d48, 0x400047a608, 0x40006895c0)
	/root/build-deb/engine/daemon/daemon_unix.go:858 +0x128
github.com/docker/docker/daemon.(*Daemon).restore(0x4000455d48, 0x400047a608)
 	/root/build-deb/engine/daemon/daemon.go:524 +0x518
```

**- How to verify it**

To observe the issue:

- Start the Engine from v28.1.0-rc.1
- Then, start the Engine from v28.0.4 and observe the panic

And to test the failure (you need to delete `/var/lib/docker/network/files/local-kv.db` first):

- Start the Engine from this branch
- Then, start the Engine from v28.0.4 -- it should not panic this time

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Make sure older Engine versions won't panic when downgrading from v28.1.
```
