### PR TITLE
Store an endpoint count for networks, for downgrade

### DIFF
--- a/libnetwork/endpoint_cnt.go
+++ b/libnetwork/endpoint_cnt.go
@@ -1,0 +1,102 @@
+package libnetwork
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/docker/docker/libnetwork/datastore"
+)
+
+// endpointCnt was used to refcount network-endpoint relationships. It's
+// unused since v28.1, and kept around only to ensure that users can properly
+// downgrade.
+//
+// TODO(aker): remove this struct in v30.
+type endpointCnt struct {
+	n        *Network
+	Count    uint64
+	dbIndex  uint64
+	dbExists bool
+	sync.Mutex
+}
+
+const epCntKeyPrefix = "endpoint_count"
+
+func (ec *endpointCnt) Key() []string {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return []string{epCntKeyPrefix, ec.n.id}
+}
+
+func (ec *endpointCnt) KeyPrefix() []string {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return []string{epCntKeyPrefix, ec.n.id}
+}
+
+func (ec *endpointCnt) Value() []byte {
+	ec.Lock()
+	defer ec.Unlock()
+
+	b, err := json.Marshal(ec)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func (ec *endpointCnt) SetValue(value []byte) error {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return json.Unmarshal(value, &ec)
+}
+
+func (ec *endpointCnt) Index() uint64 {
+	ec.Lock()
+	defer ec.Unlock()
+	return ec.dbIndex
+}
+
+func (ec *endpointCnt) SetIndex(index uint64) {
+	ec.Lock()
+	ec.dbIndex = index
+	ec.dbExists = true
+	ec.Unlock()
+}
+
+func (ec *endpointCnt) Exists() bool {
+	ec.Lock()
+	defer ec.Unlock()
+	return ec.dbExists
+}
+
+func (ec *endpointCnt) Skip() bool {
+	ec.Lock()
+	defer ec.Unlock()
+	return !ec.n.persist
+}
+
+func (ec *endpointCnt) New() datastore.KVObject {
+	ec.Lock()
+	defer ec.Unlock()
+
+	return &endpointCnt{
+		n: ec.n,
+	}
+}
+
+func (ec *endpointCnt) CopyTo(o datastore.KVObject) error {
+	ec.Lock()
+	defer ec.Unlock()
+
+	dstEc := o.(*endpointCnt)
+	dstEc.n = ec.n
+	dstEc.Count = ec.Count
+	dstEc.dbExists = ec.dbExists
+	dstEc.dbIndex = ec.dbIndex
+
+	return nil
+}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1113,6 +1113,20 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 	}
 
 removeFromStore:
+	// deleteFromStore performs an atomic delete operation and the
+	// Network.epCnt will help prevent any possible
+	// race between endpoint join and network delete
+	//
+	// TODO(robmry) - remove this once downgrade past 28.1.0 is no longer supported.
+	// The endpoint count is no longer used, it's created in the store to make
+	// downgrade work, versions older than 28.1.0 expect to read it and error if they
+	// can't. The stored count is not maintained, so the downgraded version will
+	// always find it's zero (which is usually correct because the daemon had
+	// stopped), but older daemons fix it on startup anyway.
+	if err = c.deleteFromStore(&endpointCnt{n: n}); err != nil {
+		log.G(context.TODO()).Debugf("Error deleting endpoint count from store for stale network %s (%s) for deletion: %v", n.Name(), n.ID(), err)
+	}
+
 	if err = c.deleteStoredNetwork(n); err != nil {
 		return fmt.Errorf("error deleting network from store: %v", err)
 	}


### PR DESCRIPTION
Alternative to:
- https://github.com/moby/moby/pull/49808

A problem with that change is it expected the count to exist on daemon startup. So, after running the 28.1.0 release candidate, the default network caused daemon startup to fail. And, a lot of the old complexity was back.

However - for downgrade to work, the count only needs to exist. It doesn't need to be correct!

So, this change just creates a zero count for a new network, deletes it with the network, and doesn't try to maintain the actual endpoint count.

To test it ...
- started a daemon built from master (without this change)
  - created a network, ran a container, stopped the daemon without letting it shut down the conainer
- started a daemon built with this change
  - checked it stopped the running container, and that I could delete the network
  - re-created the network, restarted the container, stopped the daemon with it still running
- started a 28.0.4 daemon
  - deleted the network, re-created, ran a new container, stopped the daemon with it still running
- upgraded back to this fix
  - checked network deletion again

----

@akerouanton's description from https://github.com/moby/moby/pull/49808

Related to:

- https://github.com/moby/moby/pull/49736
- https://github.com/moby/moby/pull/49773
- https://github.com/moby/moby/pull/49769

**- What I did**

This change was causing a panic when downgrading from RC1 to an older Engine release.

We still want to keep the new endpoint / network caching behavior introduced in that commit as it might fix some instances of the 'has active endpoints' bug, and it's needed for the error message improvement made in 241d685.

So, instead of doing a full revert of commit 51d7f95c4b364d564d4653a7915112120385e7cd, restore the endpointCnt struct and persist it, but do not use it to determine if a network is in use.

Moreover, commit 78be7ebad added a Context arg to `NewNetwork`, so use it in the code re-introduced.

For reference, here's the observed stack trace:

```
goroutine 1 [running, locked to thread]:
github.com/docker/docker/libnetwork.(*endpointCnt).EndpointCnt(0x4000922cd0?)
	/root/build-deb/engine/libnetwork/endpoint_cnt.go:102 +0x24
github.com/docker/docker/libnetwork.(*Network).delete(0x400049f580?, 0x0, 0x0)
	/root/build-deb/engine/libnetwork/network.go:1048 +0x248
github.com/docker/docker/libnetwork.(*Network).Delete(0x40008aae00, {0x0, 0x0, 0x8?})
	/root/build-deb/engine/libnetwork/network.go:1012 +0x78
github.com/docker/docker/daemon.configureNetworking(0x40009540e0, 0x400047a608)
	/root/build-deb/engine/daemon/daemon_unix.go:884 +0x128
github.com/docker/docker/daemon.(*Daemon).initNetworkController(0x4000455d48, 0x400047a608, 0x40006895c0)
	/root/build-deb/engine/daemon/daemon_unix.go:858 +0x128
github.com/docker/docker/daemon.(*Daemon).restore(0x4000455d48, 0x400047a608)
 	/root/build-deb/engine/daemon/daemon.go:524 +0x518
```

**- How to verify it**

To observe the issue:

- Start the Engine from v28.1.0-rc.1
- Then, start the Engine from v28.0.4 and observe the panic

And to test the failure (you need to delete `/var/lib/docker/network/files/local-kv.db` first):

- Start the Engine from this branch
- Then, start the Engine from v28.0.4 -- it should not panic this time

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Make sure older Engine versions won't panic when downgrading from v28.1.
```