### PR TITLE
Add systemd-sysusers contrib configuration

### DIFF
--- a/contrib/systemd-sysusers/docker.conf
+++ b/contrib/systemd-sysusers/docker.conf
@@ -1,0 +1,9 @@
+#
+# WARNING: the docker group grants root-level privileges
+#
+# For details on how this impacts security in your system, see:
+#
+#    https://docs.docker.com/go/attack-surface/
+#    https://docs.docker.com/go/daemon-access/
+#
+g	docker	-


### PR DESCRIPTION
Part of https://github.com/docker/docker-ce-packaging/issues/1186

Adds the required systemd-sysusers configuration to the moby/moby repo.  This will be used by downstream package maintainers (RPM, DEB etc) as a replacement to the `groupadd` postinstall commands.

It's generally recommended to use sysusers since it is more of a declarative method of defining these service accounts and groups.

This configuration file specifies a group ("g") named "docker" should be created with an automatic GID
allocation ("-").

This has been tested locally by placing the file inside `/usr/lib/sysusers.d` and confirming the user is created successfully after running `sudo systemd-sysusers`.
