### PR TITLE
c8d/pull: Use containerd transfer service

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"strings"
 	"time"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	c8dimages "github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes/docker"
-	"github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/transfer/image"
+	"github.com/containerd/containerd/v2/core/transfer/registry"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -23,9 +21,9 @@ import (
 	"github.com/docker/docker/internal/metrics"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/docker/docker/pkg/stringid"
+	dockerregistry "github.com/docker/docker/registry"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // PullImage initiates a pull operation. baseRef is the image to pull.
@@ -76,177 +74,96 @@ func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, p
 	return nil
 }
 
-func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output) error {
-	var opts []containerd.RemoteOpt
-	if platform != nil {
-		opts = append(opts, containerd.WithPlatform(platforms.Format(*platform)))
-	}
+func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output) (retErr error) {
+	var oldImage, newImage *c8dimages.Image
+	if img, err := i.images.Get(ctx, ref.String()); err != nil {
+		if !cerrdefs.IsNotFound(err) {
+			return err
+		}
+	} else {
+		oldImage = &img
 
-	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig, ref)
-	opts = append(opts, containerd.WithResolver(resolver))
-
-	oldImage, err := i.resolveImage(ctx, ref.String())
-	if err != nil && !errdefs.IsNotFound(err) {
-		return err
-	}
-
-	// Will be set to the new image after pull succeeds.
-	var outNewImg containerd.Image
-
-	if oldImage.Target.Digest != "" {
-		err = i.leaseContent(ctx, i.content, oldImage.Target)
+		// Handle dangling images
+		err = i.leaseContent(ctx, i.content, img.Target)
 		if err != nil {
 			return errdefs.System(fmt.Errorf("failed to lease content: %w", err))
 		}
-
-		// If the pulled image is different than the old image, we will keep the old image as a dangling image.
 		defer func() {
-			if outNewImg != nil {
-				if outNewImg.Target().Digest != oldImage.Target.Digest {
-					if err := i.ensureDanglingImage(ctx, oldImage); err != nil {
-						log.G(ctx).WithError(err).Warn("failed to keep the previous image as dangling")
-					}
+			if retErr != nil {
+				return
+			}
+
+			// Delete the dangling image if it exists.
+			err := i.images.Delete(context.WithoutCancel(ctx), danglingImageName(oldImage.Target.Digest))
+			if err != nil && !cerrdefs.IsNotFound(err) {
+				log.G(ctx).WithError(err).Warn("unexpected error while removing outdated dangling image reference")
+			}
+
+			// If the pulled image is different than the old image, we will keep the old image as a dangling image.
+			if newImage != nil && newImage.Target.Digest != oldImage.Target.Digest {
+				if err := i.ensureDanglingImage(ctx, *oldImage); err != nil {
+					log.G(ctx).WithError(err).Warn("failed to keep the previous image as dangling")
 				}
 			}
 		}()
 	}
 
-	p := platforms.Default()
-	if platform != nil {
-		p = platforms.Only(*platform)
+	allPlatforms := false
+	var sopts []image.StoreOpt
+
+	if platform == nil {
+		p := platforms.DefaultSpec()
+		platform = &p
 	}
 
-	jobs := newJobs()
-	opts = append(opts, containerd.WithImageHandler(c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		if showBlobProgress(desc) {
-			jobs.Add(desc)
-		}
-		return nil, nil
-	})))
-
-	pp := &pullProgress{
-		store:       i.content,
-		snapshotter: i.snapshotterService(i.snapshotter),
-		showExists:  true,
+	sopts = append(sopts, image.WithUnpack(*platform, i.snapshotter))
+	if !allPlatforms {
+		sopts = append(sopts, image.WithPlatforms(*platform))
 	}
-	finishProgress := jobs.showProgress(ctx, out, pp)
 
-	defer func() {
-		finishProgress()
+	// Temporariy disabled for consistency with pre-transfer service pull
+	// sopts = append(sopts, image.WithAllMetadata)
 
-		// Send final status message after the progress updater has finished.
-		// Otherwise the layer/manifest progress messages may arrive AFTER the
-		// status message have been sent, so they won't update the previous
-		// progress leaving stale progress like:
-		// 70f5ac315c5a: Downloading [>       ]       0B/3.19kB
-		// Digest: sha256:4f53e2564790c8e7856ec08e384732aa38dc43c52f02952483e3f003afbf23db
-		// 70f5ac315c5a: Download complete
-		// Status: Downloaded newer image for hello-world:latest
-		// docker.io/library/hello-world:latest
-		if outNewImg != nil {
-			img := outNewImg
-			progress.Message(out, "", "Digest: "+img.Target().Digest.String())
-			newer := oldImage.Target.Digest != img.Target().Digest
-			writeStatus(out, reference.FamiliarString(ref), newer)
-		}
-	}()
-
-	var sentPullingFrom, sentSchema1Deprecation bool
-	ah := c8dimages.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-		if desc.MediaType == c8dimages.MediaTypeDockerSchema1Manifest && !sentSchema1Deprecation {
-			err := distribution.DeprecatedSchema1ImageError(ref)
-			if os.Getenv("DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE") == "" {
-				log.G(context.TODO()).Warn(err.Error())
-				return nil, err
-			}
-			progress.Message(out, "", err.Error())
-			sentSchema1Deprecation = true
-		}
-		if c8dimages.IsLayerType(desc.MediaType) {
-			id := stringid.TruncateID(desc.Digest.String())
-			progress.Update(out, id, "Pulling fs layer")
-		}
-		if c8dimages.IsManifestType(desc.MediaType) {
-			if !sentPullingFrom {
-				var tagOrDigest string
-				if tagged, ok := ref.(reference.Tagged); ok {
-					tagOrDigest = tagged.Tag()
-				} else {
-					tagOrDigest = ref.String()
-				}
-				progress.Message(out, tagOrDigest, "Pulling from "+reference.Path(ref))
-				sentPullingFrom = true
-			}
-
-			available, _, _, missing, err := c8dimages.Check(ctx, i.content, desc, p)
-			if err != nil {
-				return nil, err
-			}
-			// If we already have all the contents pull shouldn't show any layer
-			// download progress, not even a "Already present" message.
-			if available && len(missing) == 0 {
-				pp.hideLayers = true
-			}
-		}
-		return nil, nil
-	})
-	opts = append(opts, containerd.WithImageHandler(ah))
-
-	opts = append(opts, containerd.WithPullUnpack)
-	// TODO(thaJeztah): we may have to pass the snapshotter to use if the pull is part of a "docker run" (container create -> pull image if missing). See https://github.com/moby/moby/issues/45273
-	opts = append(opts, containerd.WithPullSnapshotter(i.snapshotter))
-
-	// AppendInfoHandlerWrapper will annotate the image with basic information like manifest and layer digests as labels;
-	// this information is used to enable remote snapshotters like nydus and stargz to query a registry.
-	// This is also needed for the pull progress to detect the `Extracting` status.
-	infoHandler := snapshotters.AppendInfoHandlerWrapper(ref.String())
-	opts = append(opts, containerd.WithImageHandlerWrapper(infoHandler))
-
-	// Allow pulling application/vnd.docker.distribution.manifest.v1+prettyjws images
-	// by converting them to OCI manifests.
-	opts = append(opts, containerd.WithSchema1Conversion) //nolint:staticcheck // Ignore SA1019: containerd.WithSchema1Conversion is deprecated: use Schema 2 or OCI images.
-
-	img, err := i.client.Pull(ctx, ref.String(), opts...)
+	reg, err := registry.NewOCIRegistry(ctx, ref.String(),
+		registry.WithHeaders(metaHeaders),
+		registry.WithCredentials(authConfigCreds{authConfig}),
+	)
 	if err != nil {
-		if errors.Is(err, docker.ErrInvalidAuthorization) {
-			// Match error returned by containerd.
-			// https://github.com/containerd/containerd/blob/v1.7.8/remotes/docker/authorizer.go#L189-L191
-			if strings.Contains(err.Error(), "no basic auth credentials") {
-				return err
-			}
-			return errdefs.NotFound(fmt.Errorf("pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(ref)))
-		}
-		if cerrdefs.IsNotFound(err) {
-			// Transform "no match for platform in manifest" error returned by containerd into
-			// the same message as the graphdrivers backend.
-			// The one returned by containerd doesn't contain the platform and is much less informative.
-			if strings.Contains(err.Error(), "platform") {
-				platformStr := platforms.DefaultString()
-				if platform != nil {
-					platformStr = platforms.Format(*platform)
-				}
-				return errdefs.NotFound(fmt.Errorf("no matching manifest for %s in the manifest list entries: %w", platformStr, err))
-			}
-		}
-		return translateRegistryError(ctx, err)
+		return err
+	}
+	is := image.NewStore(ref.String(), sopts...)
+
+	pr := &transferProgress{
+		tracked: map[digest.Digest]struct{}{},
+
+		// TODO: Show extract progress
+		// Needs a separate goroutine and synchronizing with the transfer progress
+		// writing to the out stream.
+		// Also needs https://github.com/containerd/containerd/pull/11195
+		extract: &extractProgress{
+			snapshotter: i.snapshotterService(i.snapshotter),
+		},
 	}
 
-	logger := log.G(ctx).WithFields(log.Fields{
-		"digest": img.Target().Digest,
-		"remote": ref.String(),
-	})
-	logger.Info("image pulled")
-
-	// The pull succeeded, so try to remove any dangling image we have for this target
-	err = i.images.Delete(context.WithoutCancel(ctx), danglingImageName(img.Target().Digest))
-	if err != nil && !cerrdefs.IsNotFound(err) {
-		// Image pull succeeded, but cleaning up the dangling image failed. Ignore the
-		// error to not mark the pull as failed.
-		logger.WithError(err).Warn("unexpected error while removing outdated dangling image reference")
+	topts := []transfer.Opt{
+		transfer.WithProgress(func(p transfer.Progress) {
+			pr.TransferProgress(ctx, out, p)
+		}),
 	}
+
+	if err := i.transfer.Transfer(ctx, reg, is, topts...); err != nil {
+		return err
+	}
+
+	if i, err := i.images.Get(ctx, ref.String()); err == nil {
+		newImage = &i
+	}
+
+	// Print the new image digest and status message.
+	progress.Message(out, "", "Digest: "+newImage.Target.Digest.String())
+	writeStatus(out, reference.FamiliarString(ref), oldImage == nil || oldImage.Target.Digest != newImage.Target.Digest)
 
 	i.LogImageEvent(ctx, reference.FamiliarString(ref), reference.FamiliarName(ref), events.ActionPull)
-	outNewImg = img
 	return nil
 }
 
@@ -260,4 +177,50 @@ func writeStatus(out progress.Output, requestedTag string, newerDownloaded bool)
 	} else {
 		progress.Message(out, "", "Status: Image is up to date for "+requestedTag)
 	}
+}
+
+type authConfigCreds struct {
+	*registrytypes.AuthConfig
+}
+
+func (c authConfigCreds) GetCredentials(ctx context.Context, refString, host string) (registry.Credentials, error) {
+	if host == dockerregistry.DefaultRegistryHost {
+		host = dockerregistry.IndexHostname
+	}
+
+	cfgHost := dockerregistry.ConvertToHostname(c.ServerAddress)
+	if cfgHost == "" {
+		if ref, err := reference.ParseNormalizedNamed(refString); err != nil {
+			cfgHost = refString
+		} else {
+			cfgHost = reference.Domain(ref)
+		}
+	}
+	if cfgHost == dockerregistry.IndexName || cfgHost == dockerregistry.DefaultRegistryHost {
+		cfgHost = dockerregistry.IndexHostname
+	}
+
+	if host == cfgHost {
+		if c.RegistryToken != "" {
+			return registry.Credentials{
+				Host:   c.ServerAddress,
+				Header: "Bearer " + c.RegistryToken,
+			}, nil
+		}
+		if c.IdentityToken != "" {
+			return registry.Credentials{
+				Host:   c.ServerAddress,
+				Secret: c.IdentityToken,
+			}, nil
+		}
+		if c.Password != "" {
+			return registry.Credentials{
+				Host:     c.ServerAddress,
+				Username: c.Username,
+				Secret:   c.Password,
+			}, nil
+		}
+	}
+
+	return registry.Credentials{}, nil
 }

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/transfer"
 	"github.com/containerd/containerd/v2/pkg/snapshotters"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -111,12 +113,10 @@ func (j *jobs) Jobs() []ocispec.Descriptor {
 }
 
 type pullProgress struct {
-	store       content.Store
-	showExists  bool
-	hideLayers  bool
-	snapshotter snapshots.Snapshotter
-	layers      []ocispec.Descriptor
-	unpackStart map[digest.Digest]time.Time
+	store      content.Store
+	showExists bool
+	hideLayers bool
+	extract    *extractProgress
 }
 
 func (p *pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out progress.Output, start time.Time) error {
@@ -177,6 +177,39 @@ func (p *pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 			ongoing.Remove(j)
 		}
 	}
+
+	if p.extract != nil {
+		if err := p.extract.UpdateProgress(ctx, out); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *pullProgress) finished(ctx context.Context, out progress.Output, desc ocispec.Descriptor) {
+	if c8dimages.IsLayerType(desc.MediaType) {
+		p.extract.AddLayer(desc)
+	}
+}
+
+type extractProgress struct {
+	snapshotter snapshots.Snapshotter
+	mut         sync.Mutex
+	layers      []ocispec.Descriptor
+	unpackStart map[digest.Digest]time.Time
+}
+
+func (p *extractProgress) AddLayer(desc ocispec.Descriptor) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	p.layers = append(p.layers, desc)
+}
+
+func (p *extractProgress) UpdateProgress(ctx context.Context, out progress.Output) error {
+	p.mut.Lock()
+	defer p.mut.Unlock()
 
 	var committedIdx []int
 	for idx, desc := range p.layers {
@@ -258,12 +291,6 @@ func findMatchingSnapshot(ctx context.Context, sn snapshots.Snapshotter, layerDe
 	}
 
 	return *matchingSnapshot, nil
-}
-
-func (p *pullProgress) finished(ctx context.Context, out progress.Output, desc ocispec.Descriptor) {
-	if c8dimages.IsLayerType(desc.MediaType) {
-		p.layers = append(p.layers, desc)
-	}
 }
 
 type pushProgress struct {
@@ -357,5 +384,124 @@ func showBlobProgress(desc ocispec.Descriptor) bool {
 		return false
 	default:
 		return true
+	}
+}
+
+type transferProgress struct {
+	mut     sync.Mutex
+	tracked map[digest.Digest]struct{}
+	extract *extractProgress
+}
+
+func (p *transferProgress) TransferProgress(ctx context.Context, out progress.Output, pr transfer.Progress) {
+	log.G(ctx).WithFields(log.Fields{
+		"event": pr.Event,
+		"name":  pr.Name,
+	}).Debug("transfer progress")
+
+	if strings.HasPrefix(pr.Event, "fetching image content") {
+		log.G(ctx).WithFields(log.Fields{
+			"event":    pr.Event,
+			"name":     pr.Name,
+			"parents":  pr.Parents,
+			"progress": pr.Progress,
+			"total":    pr.Total,
+			"desc":     pr.Desc,
+		}).Debug("pulling from")
+
+		ref, err := reference.ParseNormalizedNamed(pr.Name)
+		if err != nil {
+			progress.Message(out, pr.Name, "Pulling from "+pr.Name)
+			return
+		}
+
+		var tagOrDigest string
+		if digested, ok := ref.(reference.Digested); ok {
+			tagOrDigest = digested.Digest().String()
+		} else if tagged, ok := ref.(reference.Tagged); ok {
+			tagOrDigest = tagged.Tag()
+		} else {
+			tagOrDigest = ref.String()
+		}
+
+		progress.Message(out, tagOrDigest, "Pulling from "+reference.Path(ref))
+		return
+	}
+
+	if pr.Desc == nil {
+		return
+	}
+
+	id := stringid.TruncateID(pr.Desc.Digest.Encoded())
+
+	switch pr.Event {
+	case "waiting":
+		desc := *pr.Desc
+
+		if !showBlobProgress(desc) {
+			return
+		}
+		p.mut.Lock()
+		if p.tracked == nil {
+			p.tracked = make(map[digest.Digest]struct{})
+		}
+		p.tracked[desc.Digest] = struct{}{}
+		p.mut.Unlock()
+
+		out.WriteProgress(progress.Progress{
+			ID:     id,
+			Action: "Waiting",
+		})
+		return
+	}
+
+	p.mut.Lock()
+	_, isTracked := p.tracked[pr.Desc.Digest]
+	p.mut.Unlock()
+
+	if !isTracked {
+		return
+	}
+
+	switch pr.Event {
+	case "saved":
+		p.mut.Lock()
+		delete(p.tracked, pr.Desc.Digest)
+		p.mut.Unlock()
+		return
+	case "downloading":
+		if pr.Desc == nil {
+			return
+		}
+		desc := *pr.Desc
+
+		action := "Downloading"
+		if c8dimages.IsLayerType(desc.MediaType) {
+			action = "Pulling layer fs"
+		}
+		out.WriteProgress(progress.Progress{
+			ID:      id,
+			Action:  action,
+			Current: pr.Progress,
+			Total:   pr.Total,
+		})
+	case "complete":
+		out.WriteProgress(progress.Progress{
+			ID:         id,
+			Action:     "Download complete",
+			HideCounts: true,
+		})
+
+		if p.extract != nil {
+			if c8dimages.IsLayerType(pr.Desc.MediaType) {
+				p.extract.AddLayer(*pr.Desc)
+			}
+		}
+	case "already exists":
+		out.WriteProgress(progress.Progress{
+			ID:         id,
+			Action:     "Already exists",
+			HideCounts: true,
+		})
 	}
 }

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -10,6 +10,9 @@ import (
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/transfer/local"
+	"github.com/containerd/containerd/v2/core/unpack"
 	"github.com/containerd/containerd/v2/plugins"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -38,28 +41,56 @@ type ImageService struct {
 	pruneRunning        atomic.Bool
 	refCountMounter     snapshotter.Mounter
 	idMapping           user.IdentityMapping
+	transfer            transfer.Transferrer
 
 	// defaultPlatformOverride is used in tests to override the host platform.
 	defaultPlatformOverride platforms.MatchComparer
 }
 
 type ImageServiceConfig struct {
-	Client          *containerd.Client
-	Containers      container.Store
-	Snapshotter     string
-	RegistryHosts   docker.RegistryHosts
-	Registry        distribution.RegistryResolver
-	EventsService   *daemonevents.Events
-	RefCountMounter snapshotter.Mounter
-	IDMapping       user.IdentityMapping
+	Client                 *containerd.Client
+	Containers             container.Store
+	Snapshotter            string
+	RegistryHosts          docker.RegistryHosts
+	Registry               distribution.RegistryResolver
+	EventsService          *daemonevents.Events
+	RefCountMounter        snapshotter.Mounter
+	IDMapping              user.IdentityMapping
+	MaxConcurrentDownloads int
+	MaxConcurrentUploads   int
 }
 
 // NewService creates a new ImageService.
 func NewService(config ImageServiceConfig) *ImageService {
+	client := config.Client
+	content := client.ContentStore()
+	images := client.ImageService()
+
+	ts := local.NewTransferService(content, images, local.TransferConfig{
+		MaxConcurrentDownloads:      config.MaxConcurrentDownloads,
+		MaxConcurrentUploadedLayers: config.MaxConcurrentUploads,
+		UnpackPlatforms: []unpack.Platform{
+			{
+				Platform:       platforms.Default(),
+				SnapshotterKey: config.Snapshotter,
+				Snapshotter:    config.Client.SnapshotService(config.Snapshotter),
+				Applier:        config.Client.DiffService(),
+				// TODO(vvoland): Pass extra snapshots annotations
+				// Needs: https://github.com/containerd/containerd/pull/11195
+				// SnapshotterExports: map[string]string{
+				// 	"enable_remote_snapshot_annotations": "true",
+				// },
+
+			},
+		},
+		RegistryConfigPath: "/etc/docker",
+	})
+
 	return &ImageService{
-		client:  config.Client,
-		images:  config.Client.ImageService(),
-		content: config.Client.ContentStore(),
+		client:   client,
+		images:   images,
+		content:  content,
+		transfer: ts,
 		snapshotterServices: map[string]snapshots.Snapshotter{
 			config.Snapshotter: config.Client.SnapshotService(config.Snapshotter),
 		},

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1066,14 +1066,16 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			return nil, err
 		}
 		d.imageService = ctrd.NewService(ctrd.ImageServiceConfig{
-			Client:          d.containerdClient,
-			Containers:      d.containers,
-			Snapshotter:     driverName,
-			RegistryHosts:   d.RegistryHosts,
-			Registry:        d.registryService,
-			EventsService:   d.EventsService,
-			IDMapping:       idMapping,
-			RefCountMounter: snapshotter.NewMounter(config.Root, driverName, idMapping),
+			Client:                 d.containerdClient,
+			Containers:             d.containers,
+			Snapshotter:            driverName,
+			RegistryHosts:          d.RegistryHosts,
+			Registry:               d.registryService,
+			EventsService:          d.EventsService,
+			IDMapping:              idMapping,
+			MaxConcurrentDownloads: config.MaxConcurrentDownloads,
+			MaxConcurrentUploads:   config.MaxConcurrentUploads,
+			RefCountMounter:        snapshotter.NewMounter(config.Root, driverName, idMapping),
 		})
 	} else {
 		layerStore, err := layer.NewStoreFromOptions(layer.StoreOptions{

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/image/imagestore.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/image/imagestore.go
@@ -1,0 +1,470 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package image
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/typeurl/v2"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/api/types"
+	transfertypes "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/archive"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/streaming"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/transfer/plugins"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+)
+
+func init() {
+	// TODO: Move this to separate package?
+	plugins.Register(&transfertypes.ImageStore{}, &Store{}) // TODO: Rename ImageStoreDestination
+}
+
+type Store struct {
+	imageName     string
+	imageLabels   map[string]string
+	platforms     []ocispec.Platform
+	allMetadata   bool
+	labelMap      func(ocispec.Descriptor) []string
+	manifestLimit int
+
+	// extraReferences are used to store or lookup multiple references
+	extraReferences []Reference
+
+	unpacks []transfer.UnpackConfiguration
+}
+
+// Reference is used to create or find a reference for an image
+type Reference struct {
+	Name string
+
+	// IsPrefix determines whether the Name should be considered
+	// a prefix (without tag or digest).
+	// For lookup, this may allow matching multiple tags.
+	// For store, this must have a tag or digest added.
+	IsPrefix bool
+
+	// AllowOverwrite allows overwriting or ignoring the name if
+	// another reference is provided (such as through an annotation).
+	// Only used if IsPrefix is true.
+	AllowOverwrite bool
+
+	// AddDigest adds the manifest digest to the reference.
+	// For lookup, this allows matching tags with any digest.
+	// For store, this allows adding the digest to the name.
+	// Only used if IsPrefix is true.
+	AddDigest bool
+
+	// SkipNamedDigest only considers digest references which do not
+	// have a non-digested named reference.
+	// For lookup, this will deduplicate digest references when there is a named match.
+	// For store, this only adds this digest reference when there is no matching full
+	// name reference from the prefix.
+	// Only used if IsPrefix is true.
+	SkipNamedDigest bool
+}
+
+// StoreOpt defines options when configuring an image store source or destination
+type StoreOpt func(*Store)
+
+// WithImageLabels are the image labels to apply to a new image
+func WithImageLabels(labels map[string]string) StoreOpt {
+	return func(s *Store) {
+		s.imageLabels = labels
+	}
+}
+
+// WithPlatforms specifies which platforms to fetch content for
+func WithPlatforms(p ...ocispec.Platform) StoreOpt {
+	return func(s *Store) {
+		s.platforms = append(s.platforms, p...)
+	}
+}
+
+// WithManifestLimit defines the max number of manifests to fetch
+func WithManifestLimit(limit int) StoreOpt {
+	return func(s *Store) {
+		s.manifestLimit = limit
+	}
+}
+
+func WithAllMetadata(s *Store) {
+	s.allMetadata = true
+}
+
+// WithNamedPrefix uses a named prefix to references images which only have a tag name
+// reference in the annotation or check full references annotations against. Images
+// with no reference resolved from matching annotations will not be stored.
+// - name: image name prefix to append a tag to or check full name references with
+// - allowOverwrite: allows the tag to be overwritten by full name reference inside
+// the image which does not have name as the prefix
+func WithNamedPrefix(name string, allowOverwrite bool) StoreOpt {
+	ref := Reference{
+		Name:           name,
+		IsPrefix:       true,
+		AllowOverwrite: allowOverwrite,
+	}
+	return func(s *Store) {
+		s.extraReferences = append(s.extraReferences, ref)
+	}
+}
+
+// WithDigestRef uses a named prefix to references images which only have a tag name
+// reference in the annotation or check full references annotations against and
+// additionally may add a digest reference. Images with no references resolved
+// from matching annotations may be stored by digest.
+// - name: image name prefix to append a tag to or check full name references with
+// - allowOverwrite: allows the tag to be overwritten by full name reference inside
+// the image which does not have name as the prefix
+// - skipNamed: is set if no digest reference should be created if a named reference
+// is successfully resolved from the annotations.
+func WithDigestRef(name string, allowOverwrite bool, skipNamed bool) StoreOpt {
+	ref := Reference{
+		Name:            name,
+		IsPrefix:        true,
+		AllowOverwrite:  allowOverwrite,
+		AddDigest:       true,
+		SkipNamedDigest: skipNamed,
+	}
+	return func(s *Store) {
+		s.extraReferences = append(s.extraReferences, ref)
+	}
+}
+
+func WithExtraReference(name string) StoreOpt {
+	ref := Reference{
+		Name: name,
+	}
+	return func(s *Store) {
+		s.extraReferences = append(s.extraReferences, ref)
+	}
+}
+
+// WithUnpack specifies a platform to unpack for and an optional snapshotter to use
+func WithUnpack(p ocispec.Platform, snapshotter string) StoreOpt {
+	return func(s *Store) {
+		s.unpacks = append(s.unpacks, transfer.UnpackConfiguration{
+			Platform:    p,
+			Snapshotter: snapshotter,
+		})
+	}
+}
+
+// NewStore creates a new image store source or Destination
+func NewStore(image string, opts ...StoreOpt) *Store {
+	s := &Store{
+		imageName: image,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+func (is *Store) String() string {
+	return fmt.Sprintf("Local Image Store (%s)", is.imageName)
+}
+
+func (is *Store) ImageFilter(h images.HandlerFunc, cs content.Store) images.HandlerFunc {
+	var p platforms.MatchComparer
+	if len(is.platforms) == 0 {
+		p = platforms.All
+	} else {
+		p = platforms.Ordered(is.platforms...)
+	}
+	h = images.SetChildrenMappedLabels(cs, h, is.labelMap)
+	if is.allMetadata {
+		// Filter manifests by platforms but allow to handle manifest
+		// and configuration for not-target platforms
+		h = remotes.FilterManifestByPlatformHandler(h, p)
+	} else {
+		// Filter children by platforms if specified.
+		h = images.FilterPlatforms(h, p)
+	}
+
+	// Sort and limit manifests if a finite number is needed
+	if is.manifestLimit > 0 {
+		h = images.LimitManifests(h, p, is.manifestLimit)
+	}
+	return h
+}
+
+func (is *Store) Store(ctx context.Context, desc ocispec.Descriptor, store images.Store) ([]images.Image, error) {
+	var imgs []images.Image
+
+	// If import ref type, store references from annotation or prefix
+	if refSource, ok := desc.Annotations["io.containerd.import.ref-source"]; ok {
+		switch refSource {
+		case "annotation":
+			for _, ref := range is.extraReferences {
+				// Only use prefix references for annotation matching
+				if !ref.IsPrefix {
+					continue
+				}
+
+				var nameT func(string) string
+				if ref.AllowOverwrite {
+					nameT = archive.AddRefPrefix(ref.Name)
+				} else {
+					nameT = archive.FilterRefPrefix(ref.Name)
+				}
+				name := imageName(desc.Annotations, nameT)
+
+				if name == "" {
+					// If digested, add digest reference
+					if ref.AddDigest {
+						imgs = append(imgs, images.Image{
+							Name:   fmt.Sprintf("%s@%s", ref.Name, desc.Digest),
+							Target: desc,
+							Labels: is.imageLabels,
+						})
+					}
+					continue
+				}
+
+				imgs = append(imgs, images.Image{
+					Name:   name,
+					Target: desc,
+					Labels: is.imageLabels,
+				})
+
+				// If a named reference was found and SkipNamedDigest is true, do
+				// not use this reference
+				if ref.AddDigest && !ref.SkipNamedDigest {
+					imgs = append(imgs, images.Image{
+						Name:   fmt.Sprintf("%s@%s", ref.Name, desc.Digest),
+						Target: desc,
+						Labels: is.imageLabels,
+					})
+				}
+			}
+		default:
+			return nil, fmt.Errorf("ref source not supported: %w", errdefs.ErrInvalidArgument)
+		}
+		delete(desc.Annotations, "io.containerd.import.ref-source")
+	} else {
+		if is.imageName != "" {
+			imgs = append(imgs, images.Image{
+				Name:   is.imageName,
+				Target: desc,
+				Labels: is.imageLabels,
+			})
+		}
+
+		// If extra references, store all complete references (skip prefixes)
+		for _, ref := range is.extraReferences {
+			if ref.IsPrefix {
+				continue
+			}
+			name := ref.Name
+			if ref.AddDigest {
+				name = fmt.Sprintf("%s@%s", name, desc.Digest)
+			}
+			imgs = append(imgs, images.Image{
+				Name:   name,
+				Target: desc,
+				Labels: is.imageLabels,
+			})
+		}
+	}
+
+	if len(imgs) == 0 {
+		return nil, fmt.Errorf("no image name found: %w", errdefs.ErrNotFound)
+	}
+
+	for i := 0; i < len(imgs); {
+		if created, err := store.Create(ctx, imgs[i]); err != nil {
+			if !errdefs.IsAlreadyExists(err) {
+				return nil, err
+			}
+
+			updated, err := store.Update(ctx, imgs[i])
+			if err != nil {
+				// if image was removed, try create again
+				if errdefs.IsNotFound(err) {
+					// Keep trying same image
+					continue
+				}
+				return nil, err
+			}
+
+			imgs[i] = updated
+		} else {
+			imgs[i] = created
+		}
+
+		i++
+	}
+
+	return imgs, nil
+}
+
+func (is *Store) Get(ctx context.Context, store images.Store) (images.Image, error) {
+	return store.Get(ctx, is.imageName)
+}
+
+func (is *Store) Lookup(ctx context.Context, store images.Store) ([]images.Image, error) {
+	var imgs []images.Image
+	if is.imageName != "" {
+		img, err := store.Get(ctx, is.imageName)
+		if err != nil {
+			return nil, err
+		}
+		imgs = append(imgs, img)
+	}
+	for _, ref := range is.extraReferences {
+		if ref.IsPrefix {
+			return nil, fmt.Errorf("prefix lookup on export not implemented: %w", errdefs.ErrNotImplemented)
+		}
+		img, err := store.Get(ctx, ref.Name)
+		if err != nil {
+			return nil, err
+		}
+		imgs = append(imgs, img)
+	}
+	return imgs, nil
+}
+
+func (is *Store) Platforms() []ocispec.Platform {
+	return is.platforms
+}
+
+func (is *Store) UnpackPlatforms() []transfer.UnpackConfiguration {
+	unpacks := make([]transfer.UnpackConfiguration, len(is.unpacks))
+	for i, uc := range is.unpacks {
+		unpacks[i].Snapshotter = uc.Snapshotter
+		unpacks[i].Platform = uc.Platform
+	}
+	return unpacks
+}
+
+func (is *Store) MarshalAny(context.Context, streaming.StreamCreator) (typeurl.Any, error) {
+	s := &transfertypes.ImageStore{
+		Name:            is.imageName,
+		Labels:          is.imageLabels,
+		ManifestLimit:   uint32(is.manifestLimit),
+		AllMetadata:     is.allMetadata,
+		Platforms:       types.OCIPlatformToProto(is.platforms),
+		ExtraReferences: referencesToProto(is.extraReferences),
+		Unpacks:         unpackToProto(is.unpacks),
+	}
+	return typeurl.MarshalAny(s)
+}
+
+func (is *Store) UnmarshalAny(ctx context.Context, sm streaming.StreamGetter, a typeurl.Any) error {
+	var s transfertypes.ImageStore
+	if err := typeurl.UnmarshalTo(a, &s); err != nil {
+		return err
+	}
+
+	is.imageName = s.Name
+	is.imageLabels = s.Labels
+	is.manifestLimit = int(s.ManifestLimit)
+	is.allMetadata = s.AllMetadata
+	is.platforms = types.OCIPlatformFromProto(s.Platforms)
+	is.extraReferences = referencesFromProto(s.ExtraReferences)
+	is.unpacks = unpackFromProto(s.Unpacks)
+
+	return nil
+}
+
+func referencesToProto(references []Reference) []*transfertypes.ImageReference {
+	ir := make([]*transfertypes.ImageReference, len(references))
+	for i := range references {
+		r := transfertypes.ImageReference{
+			Name:            references[i].Name,
+			IsPrefix:        references[i].IsPrefix,
+			AllowOverwrite:  references[i].AllowOverwrite,
+			AddDigest:       references[i].AddDigest,
+			SkipNamedDigest: references[i].SkipNamedDigest,
+		}
+
+		ir[i] = &r
+	}
+	return ir
+}
+
+func referencesFromProto(references []*transfertypes.ImageReference) []Reference {
+	or := make([]Reference, len(references))
+	for i := range references {
+		or[i].Name = references[i].Name
+		or[i].IsPrefix = references[i].IsPrefix
+		or[i].AllowOverwrite = references[i].AllowOverwrite
+		or[i].AddDigest = references[i].AddDigest
+		or[i].SkipNamedDigest = references[i].SkipNamedDigest
+	}
+	return or
+}
+func unpackToProto(uc []transfer.UnpackConfiguration) []*transfertypes.UnpackConfiguration {
+	auc := make([]*transfertypes.UnpackConfiguration, len(uc))
+	for i := range uc {
+		p := types.Platform{
+			OS:           uc[i].Platform.OS,
+			Architecture: uc[i].Platform.Architecture,
+			Variant:      uc[i].Platform.Variant,
+		}
+		auc[i] = &transfertypes.UnpackConfiguration{
+			Platform:    &p,
+			Snapshotter: uc[i].Snapshotter,
+		}
+	}
+	return auc
+}
+
+func unpackFromProto(auc []*transfertypes.UnpackConfiguration) []transfer.UnpackConfiguration {
+	uc := make([]transfer.UnpackConfiguration, len(auc))
+	for i := range auc {
+		uc[i].Snapshotter = auc[i].Snapshotter
+		if auc[i].Platform != nil {
+			uc[i].Platform.OS = auc[i].Platform.OS
+			uc[i].Platform.Architecture = auc[i].Platform.Architecture
+			uc[i].Platform.Variant = auc[i].Platform.Variant
+		}
+	}
+	return uc
+}
+
+func imageName(annotations map[string]string, cleanup func(string) string) string {
+	name := annotations[images.AnnotationImageName]
+	if name != "" {
+		if cleanup != nil {
+			// containerd reference name should be full reference and not
+			// modified, if it is incomplete or does not match a specified
+			// prefix, do not use the reference
+			if cleanName := cleanup(name); cleanName != name {
+				name = ""
+			}
+		}
+		return name
+	}
+	name = annotations[ocispec.AnnotationRefName]
+	if name != "" {
+		if cleanup != nil {
+			name = cleanup(name)
+		}
+	}
+	return name
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/local/export.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/local/export.go
@@ -1,0 +1,64 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/transfer"
+)
+
+func (ts *localTransferService) exportStream(ctx context.Context, ig transfer.ImageGetter, is transfer.ImageExporter, tops *transfer.Config) error {
+	ctx, done, err := ts.withLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: "Exporting",
+		})
+	}
+
+	var imgs []images.Image
+	if il, ok := ig.(transfer.ImageLookup); ok {
+		imgs, err = il.Lookup(ctx, ts.images)
+		if err != nil {
+			return err
+		}
+	} else {
+		img, err := ig.Get(ctx, ts.images)
+		if err != nil {
+			return err
+		}
+		imgs = append(imgs, img)
+	}
+
+	err = is.Export(ctx, ts.content, imgs)
+	if err != nil {
+		return err
+	}
+
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: "Completed export",
+		})
+	}
+	return nil
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/local/import.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/local/import.go
@@ -1,0 +1,170 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/unpack"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+)
+
+func (ts *localTransferService) importStream(ctx context.Context, i transfer.ImageImporter, is transfer.ImageStorer, tops *transfer.Config) error {
+	ctx, done, err := ts.withLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: "Importing",
+		})
+	}
+
+	index, err := i.Import(ctx, ts.content)
+	if err != nil {
+		return err
+	}
+
+	var (
+		descriptors []ocispec.Descriptor
+		handler     images.Handler
+		unpacker    *unpack.Unpacker
+	)
+
+	// If save index, add index
+	descriptors = append(descriptors, index)
+
+	var handlerFunc images.HandlerFunc = func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		// Only save images at top level
+		if desc.Digest != index.Digest {
+			return images.Children(ctx, ts.content, desc)
+		}
+
+		p, err := content.ReadBlob(ctx, ts.content, desc)
+		if err != nil {
+			return nil, err
+		}
+
+		var idx ocispec.Index
+		if err := json.Unmarshal(p, &idx); err != nil {
+			return nil, err
+		}
+
+		for _, m := range idx.Manifests {
+			m.Annotations = mergeMap(m.Annotations, map[string]string{"io.containerd.import.ref-source": "annotation"})
+			descriptors = append(descriptors, m)
+		}
+
+		return idx.Manifests, nil
+	}
+
+	if f, ok := is.(transfer.ImageFilterer); ok {
+		handlerFunc = f.ImageFilter(handlerFunc, ts.content)
+	}
+
+	handler = images.Handlers(handlerFunc)
+
+	// First find suitable platforms to unpack into
+	// If image storer is also an unpacker type, i.e implemented UnpackPlatforms() func
+	if iu, ok := is.(transfer.ImageUnpacker); ok {
+		unpacks := iu.UnpackPlatforms()
+		if len(unpacks) > 0 {
+			uopts := []unpack.UnpackerOpt{}
+			for _, u := range unpacks {
+				matched, mu := getSupportedPlatform(u, ts.config.UnpackPlatforms)
+				if matched {
+					uopts = append(uopts, unpack.WithUnpackPlatform(mu))
+				}
+			}
+
+			if ts.config.DuplicationSuppressor != nil {
+				uopts = append(uopts, unpack.WithDuplicationSuppressor(ts.config.DuplicationSuppressor))
+			}
+			unpacker, err = unpack.NewUnpacker(ctx, ts.content, uopts...)
+			if err != nil {
+				return fmt.Errorf("unable to initialize unpacker: %w", err)
+			}
+			handler = unpacker.Unpack(handler)
+		}
+	}
+
+	if err := images.WalkNotEmpty(ctx, handler, index); err != nil {
+		if unpacker != nil {
+			// wait for unpacker to cleanup
+			unpacker.Wait()
+		}
+		// TODO: Handle Not Empty as a special case on the input
+		return err
+	}
+
+	if unpacker != nil {
+		if _, err = unpacker.Wait(); err != nil {
+			return err
+		}
+	}
+
+	for _, desc := range descriptors {
+		desc := desc
+		imgs, err := is.Store(ctx, desc, ts.images)
+		if err != nil {
+			if errdefs.IsNotFound(err) {
+				log.G(ctx).Infof("No images store for %s", desc.Digest)
+				continue
+			}
+			return err
+		}
+
+		if tops.Progress != nil {
+			for _, img := range imgs {
+				tops.Progress(transfer.Progress{
+					Event: "saved",
+					Name:  img.Name,
+					Desc:  &desc,
+				})
+			}
+		}
+	}
+
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: "Completed import",
+		})
+	}
+
+	return nil
+}
+
+func mergeMap(m1, m2 map[string]string) map[string]string {
+	merged := make(map[string]string, len(m1)+len(m2))
+	for k, v := range m1 {
+		merged[k] = v
+	}
+	for k, v := range m2 {
+		merged[k] = v
+	}
+	return merged
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/local/progress.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/local/progress.go
@@ -1,0 +1,281 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/log"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type ProgressTracker struct {
+	root          string
+	transferState string
+	added         chan jobUpdate
+	waitC         chan struct{}
+
+	parents map[digest.Digest][]ocispec.Descriptor
+	parentL sync.Mutex
+}
+
+type jobState uint8
+
+const (
+	jobAdded jobState = iota
+	jobInProgress
+	jobComplete
+)
+
+type jobStatus struct {
+	state    jobState
+	name     string
+	parents  []string
+	progress int64
+	desc     ocispec.Descriptor
+}
+
+type jobUpdate struct {
+	desc   ocispec.Descriptor
+	exists bool
+	//children []ocispec.Descriptor
+}
+
+type ActiveJobs interface {
+	Status(string) (content.Status, bool)
+}
+
+type StatusTracker interface {
+	Active(context.Context, ...string) (ActiveJobs, error)
+	Check(context.Context, digest.Digest) (bool, error)
+}
+
+// NewProgressTracker tracks content download progress
+func NewProgressTracker(root, transferState string) *ProgressTracker {
+	return &ProgressTracker{
+		root:          root,
+		transferState: transferState,
+		added:         make(chan jobUpdate, 1),
+		waitC:         make(chan struct{}),
+		parents:       map[digest.Digest][]ocispec.Descriptor{},
+	}
+}
+
+func (j *ProgressTracker) HandleProgress(ctx context.Context, pf transfer.ProgressFunc, pt StatusTracker) {
+	defer close(j.waitC)
+	// Instead of ticker, just delay
+	jobs := map[digest.Digest]*jobStatus{}
+	tc := time.NewTicker(time.Millisecond * 300)
+	defer tc.Stop()
+
+	update := func() {
+		// TODO: Filter by references
+		active, err := pt.Active(ctx)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("failed to get statuses for progress")
+		}
+		for dgst, job := range jobs {
+			if job.state != jobComplete {
+				status, ok := active.Status(job.name)
+				if ok {
+					if status.Offset > job.progress {
+						pf(transfer.Progress{
+							Event:    j.transferState,
+							Name:     job.name,
+							Parents:  job.parents,
+							Progress: status.Offset,
+							Total:    status.Total,
+							Desc:     &job.desc,
+						})
+						job.progress = status.Offset
+						job.state = jobInProgress
+						jobs[dgst] = job
+					}
+				} else {
+					ok, err := pt.Check(ctx, job.desc.Digest)
+					if err != nil {
+						log.G(ctx).WithError(err).Error("failed to get statuses for progress")
+					} else if ok {
+						pf(transfer.Progress{
+							Event:    "complete",
+							Name:     job.name,
+							Parents:  job.parents,
+							Progress: job.desc.Size,
+							Total:    job.desc.Size,
+							Desc:     &job.desc,
+						})
+
+					}
+					job.state = jobComplete
+					jobs[dgst] = job
+				}
+			}
+		}
+	}
+	for {
+		select {
+		case update := <-j.added:
+			job, ok := jobs[update.desc.Digest]
+			if !ok {
+
+				// Only captures the parents defined before,
+				// could handle parent updates in same thread
+				// if there is a synchronization issue
+				var parents []string
+				j.parentL.Lock()
+				for _, parent := range j.parents[update.desc.Digest] {
+					parents = append(parents, remotes.MakeRefKey(ctx, parent))
+				}
+				j.parentL.Unlock()
+				if len(parents) == 0 {
+					parents = []string{j.root}
+				}
+				name := remotes.MakeRefKey(ctx, update.desc)
+
+				job = &jobStatus{
+					state:   jobAdded,
+					name:    name,
+					parents: parents,
+					desc:    update.desc,
+				}
+				jobs[update.desc.Digest] = job
+				pf(transfer.Progress{
+					Event:   "waiting",
+					Name:    name,
+					Parents: parents,
+					//Digest:   desc.Digest.String(),
+					Progress: 0,
+					Total:    update.desc.Size,
+					Desc:     &job.desc,
+				})
+			}
+			if update.exists {
+				pf(transfer.Progress{
+					Event:    "already exists",
+					Name:     remotes.MakeRefKey(ctx, update.desc),
+					Progress: update.desc.Size,
+					Total:    update.desc.Size,
+					Desc:     &job.desc,
+				})
+				job.state = jobComplete
+				job.progress = job.desc.Size
+			}
+
+		case <-tc.C:
+			update()
+			// Next timer?
+		case <-ctx.Done():
+			update()
+			return
+		}
+	}
+}
+
+// Add adds a descriptor to be tracked
+func (j *ProgressTracker) Add(desc ocispec.Descriptor) {
+	if j == nil {
+		return
+	}
+	j.added <- jobUpdate{
+		desc: desc,
+	}
+}
+
+func (j *ProgressTracker) MarkExists(desc ocispec.Descriptor) {
+	if j == nil {
+		return
+	}
+	j.added <- jobUpdate{
+		desc:   desc,
+		exists: true,
+	}
+
+}
+
+// AddChildren adds hierarchy information
+func (j *ProgressTracker) AddChildren(desc ocispec.Descriptor, children []ocispec.Descriptor) {
+	if j == nil || len(children) == 0 {
+		return
+	}
+	j.parentL.Lock()
+	defer j.parentL.Unlock()
+	for _, child := range children {
+		j.parents[child.Digest] = append(j.parents[child.Digest], desc)
+	}
+
+}
+
+func (j *ProgressTracker) Wait() {
+	// timeout rather than rely on cancel
+	timeout := time.After(10 * time.Second)
+	select {
+	case <-timeout:
+	case <-j.waitC:
+	}
+}
+
+type contentActive struct {
+	active []content.Status
+}
+
+func (c *contentActive) Status(ref string) (content.Status, bool) {
+	idx := sort.Search(len(c.active), func(i int) bool { return c.active[i].Ref >= ref })
+	if idx < len(c.active) && c.active[idx].Ref == ref {
+		return c.active[idx], true
+	}
+
+	return content.Status{}, false
+}
+
+type contentStatusTracker struct {
+	cs content.Store
+}
+
+func NewContentStatusTracker(cs content.Store) StatusTracker {
+	return &contentStatusTracker{
+		cs: cs,
+	}
+}
+
+func (c *contentStatusTracker) Active(ctx context.Context, _ ...string) (ActiveJobs, error) {
+	active, err := c.cs.ListStatuses(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("failed to list statuses for progress")
+	}
+	sort.Slice(active, func(i, j int) bool {
+		return active[i].Ref < active[j].Ref
+	})
+
+	return &contentActive{
+		active: active,
+	}, nil
+}
+
+func (c *contentStatusTracker) Check(ctx context.Context, dgst digest.Digest) (bool, error) {
+	_, err := c.cs.Info(ctx, dgst)
+	if err == nil {
+		return true, nil
+	}
+	return false, nil
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/local/pull.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/local/pull.go
@@ -1,0 +1,294 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/unpack"
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func (ts *localTransferService) pull(ctx context.Context, ir transfer.ImageFetcher, is transfer.ImageStorer, tops *transfer.Config) error {
+	ctx, done, err := ts.withLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: fmt.Sprintf("Resolving from %s", ir),
+		})
+	}
+
+	name, desc, err := ir.Resolve(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve image: %w", err)
+	}
+	if desc.MediaType == images.MediaTypeDockerSchema1Manifest {
+		// Explicitly call out schema 1 as deprecated and not supported
+		return fmt.Errorf("schema 1 image manifests are no longer supported: %w", errdefs.ErrInvalidArgument)
+	}
+
+	// Verify image before pulling.
+	for vfName, vf := range ts.config.Verifiers {
+		logger := log.G(ctx).WithFields(log.Fields{
+			"name":     name,
+			"digest":   desc.Digest.String(),
+			"verifier": vfName,
+		})
+		logger.Debug("Verifying image pull")
+
+		jdg, err := vf.VerifyImage(ctx, name, desc)
+		if err != nil {
+			logger.WithError(err).Error("No judgement received from verifier")
+			return fmt.Errorf("blocking pull of %v with digest %v: image verifier %v returned error: %w", name, desc.Digest.String(), vfName, err)
+		}
+		logger = logger.WithFields(log.Fields{
+			"ok":     jdg.OK,
+			"reason": jdg.Reason,
+		})
+
+		if !jdg.OK {
+			logger.Warn("Image verifier blocked pull")
+			return fmt.Errorf("image verifier %s blocked pull of %v with digest %v for reason: %v", vfName, name, desc.Digest.String(), jdg.Reason)
+		}
+		logger.Debug("Image verifier allowed pull")
+	}
+
+	// TODO: Handle already exists
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: fmt.Sprintf("Pulling from %s", ir),
+		})
+		tops.Progress(transfer.Progress{
+			Event: "fetching image content",
+			Name:  name,
+			// Digest: img.Target.Digest.String(),
+		})
+	}
+
+	fetcher, err := ir.Fetcher(ctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to get fetcher for %q: %w", name, err)
+	}
+
+	var (
+		handler images.Handler
+
+		baseHandlers []images.Handler
+
+		unpacker *unpack.Unpacker
+
+		// has a config media type bug (distribution#1622)
+		hasMediaTypeBug1622 bool
+
+		store           = ts.content
+		progressTracker *ProgressTracker
+	)
+
+	ctx, cancel := context.WithCancel(ctx)
+	if tops.Progress != nil {
+		progressTracker = NewProgressTracker(name, "downloading") // Pass in first name as root
+		go progressTracker.HandleProgress(ctx, tops.Progress, NewContentStatusTracker(store))
+		defer progressTracker.Wait()
+	}
+	defer cancel()
+
+	// Get all the children for a descriptor
+	childrenHandler := images.ChildrenHandler(store)
+
+	if f, ok := is.(transfer.ImageFilterer); ok {
+		childrenHandler = f.ImageFilter(childrenHandler, store)
+	}
+
+	checkNeedsFix := images.HandlerFunc(
+		func(_ context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+			// set to true if there is application/octet-stream media type
+			if desc.MediaType == docker.LegacyConfigMediaType {
+				hasMediaTypeBug1622 = true
+			}
+
+			return []ocispec.Descriptor{}, nil
+		},
+	)
+
+	appendDistSrcLabelHandler, err := docker.AppendDistributionSourceLabel(store, name)
+	if err != nil {
+		return err
+	}
+
+	// Set up baseHandlers from service configuration if present or create a new one
+	if ts.config.BaseHandlers != nil {
+		baseHandlers = ts.config.BaseHandlers
+	} else {
+		baseHandlers = []images.Handler{}
+	}
+
+	if tops.Progress != nil {
+		baseHandlers = append(baseHandlers, images.HandlerFunc(
+			func(_ context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				progressTracker.Add(desc)
+
+				return []ocispec.Descriptor{}, nil
+			},
+		))
+
+		baseChildrenHandler := childrenHandler
+		childrenHandler = images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (children []ocispec.Descriptor, err error) {
+			children, err = baseChildrenHandler(ctx, desc)
+			if err != nil {
+				return
+			}
+			progressTracker.AddChildren(desc, children)
+			return
+		})
+	}
+
+	handler = images.Handlers(append(baseHandlers,
+		fetchHandler(store, fetcher, progressTracker),
+		checkNeedsFix,
+		childrenHandler, // List children to track hierarchy
+		appendDistSrcLabelHandler,
+	)...)
+
+	// First find suitable platforms to unpack into
+	// If image storer is also an unpacker type, i.e implemented UnpackPlatforms() func
+	if iu, ok := is.(transfer.ImageUnpacker); ok {
+		unpacks := iu.UnpackPlatforms()
+		if len(unpacks) > 0 {
+			uopts := []unpack.UnpackerOpt{}
+			// Only unpack if requested unpackconfig matches default/supported unpackconfigs
+			for _, u := range unpacks {
+				matched, mu := getSupportedPlatform(u, ts.config.UnpackPlatforms)
+				if matched {
+					uopts = append(uopts, unpack.WithUnpackPlatform(mu))
+				}
+			}
+
+			if ts.limiterD != nil {
+				uopts = append(uopts, unpack.WithLimiter(ts.limiterD))
+			}
+
+			if ts.config.DuplicationSuppressor != nil {
+				uopts = append(uopts, unpack.WithDuplicationSuppressor(ts.config.DuplicationSuppressor))
+			}
+
+			unpacker, err = unpack.NewUnpacker(ctx, ts.content, uopts...)
+			if err != nil {
+				return fmt.Errorf("unable to initialize unpacker: %w", err)
+			}
+			handler = unpacker.Unpack(handler)
+		}
+	}
+
+	if err := images.Dispatch(ctx, handler, ts.limiterD, desc); err != nil {
+		if unpacker != nil {
+			// wait for unpacker to cleanup
+			unpacker.Wait()
+		}
+		return err
+	}
+
+	// NOTE(fuweid): unpacker defers blobs download. before create image
+	// record in ImageService, should wait for unpacking(including blobs
+	// download).
+	if unpacker != nil {
+		if _, err = unpacker.Wait(); err != nil {
+			return err
+		}
+		// TODO: Check results to make sure unpack was successful
+	}
+
+	if hasMediaTypeBug1622 {
+		if desc, err = docker.ConvertManifest(ctx, store, desc); err != nil {
+			return err
+		}
+	}
+
+	imgs, err := is.Store(ctx, desc, ts.images)
+	if err != nil {
+		return err
+	}
+
+	if tops.Progress != nil {
+		for _, img := range imgs {
+			tops.Progress(transfer.Progress{
+				Event: "saved",
+				Name:  img.Name,
+			})
+		}
+	}
+
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: fmt.Sprintf("Completed pull from %s", ir),
+		})
+	}
+
+	return nil
+}
+
+func fetchHandler(ingester content.Ingester, fetcher remotes.Fetcher, pt *ProgressTracker) images.HandlerFunc {
+	return func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
+			"digest":    desc.Digest,
+			"mediatype": desc.MediaType,
+			"size":      desc.Size,
+		}))
+
+		if desc.MediaType == images.MediaTypeDockerSchema1Manifest {
+			return nil, fmt.Errorf("%v not supported", desc.MediaType)
+		}
+		err := remotes.Fetch(ctx, ingester, fetcher, desc)
+		if errdefs.IsAlreadyExists(err) {
+			pt.MarkExists(desc)
+			return nil, nil
+		}
+		return nil, err
+	}
+}
+
+// getSupportedPlatform returns a matched platform comparing input UnpackConfiguration to the supported platform/snapshotter combinations
+// If input platform didn't specify snapshotter, default will be used if there is a match on platform.
+func getSupportedPlatform(uc transfer.UnpackConfiguration, supportedPlatforms []unpack.Platform) (bool, unpack.Platform) {
+	var u unpack.Platform
+	for _, sp := range supportedPlatforms {
+		// If both platform and snapshotter match, return the supportPlatform
+		// If platform matched and SnapshotterKey is empty, we assume client didn't pass SnapshotterKey
+		// use default Snapshotter
+		if sp.Platform.Match(uc.Platform) {
+			// Assume sp.SnapshotterKey is not empty
+			if uc.Snapshotter == sp.SnapshotterKey {
+				return true, sp
+			} else if uc.Snapshotter == "" && sp.SnapshotterKey == defaults.DefaultSnapshotter {
+				return true, sp
+			}
+		}
+	}
+	return false, u
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/local/push.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/local/push.go
@@ -1,0 +1,264 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func (ts *localTransferService) push(ctx context.Context, ig transfer.ImageGetter, p transfer.ImagePusher, tops *transfer.Config) error {
+	matcher := platforms.All
+	if ipg, ok := ig.(transfer.ImagePlatformsGetter); ok {
+		if ps := ipg.Platforms(); len(ps) > 0 {
+			matcher = platforms.Any(ps...)
+		}
+	}
+
+	img, err := ig.Get(ctx, ts.images)
+	if err != nil {
+		return err
+	}
+
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: fmt.Sprintf("Pushing to %s", p),
+		})
+		tops.Progress(transfer.Progress{
+			Event: "pushing content",
+			Name:  img.Name,
+			//Digest: img.Target.Digest.String(),
+			Desc: &img.Target,
+		})
+	}
+
+	var pusher remotes.Pusher
+	pusher, err = p.Pusher(ctx, img.Target)
+	if err != nil {
+		return err
+	}
+
+	var wrapper func(images.Handler) images.Handler
+
+	ctx, cancel := context.WithCancel(ctx)
+	if tops.Progress != nil {
+		progressTracker := NewProgressTracker(img.Name, "uploading") //Pass in first name as root
+
+		p := newProgressPusher(pusher, progressTracker)
+		go progressTracker.HandleProgress(ctx, tops.Progress, p)
+		defer progressTracker.Wait()
+		wrapper = p.WrapHandler
+		pusher = p
+	}
+	defer cancel()
+
+	// TODO: Add handler to track parents
+	/*
+		// TODO: Add handlers
+		if len(pushCtx.BaseHandlers) > 0 {
+			wrapper = func(h images.Handler) images.Handler {
+				h = images.Handlers(append(pushCtx.BaseHandlers, h)...)
+				if pushCtx.HandlerWrapper != nil {
+					h = pushCtx.HandlerWrapper(h)
+				}
+				return h
+			}
+		} else if pushCtx.HandlerWrapper != nil {
+			wrapper = pushCtx.HandlerWrapper
+		}
+	*/
+	if err := remotes.PushContent(ctx, pusher, img.Target, ts.content, ts.limiterU, matcher, wrapper); err != nil {
+		return err
+	}
+	if tops.Progress != nil {
+		tops.Progress(transfer.Progress{
+			Event: "pushed content",
+			Name:  img.Name,
+			//Digest: img.Target.Digest.String(),
+			Desc: &img.Target,
+		})
+		tops.Progress(transfer.Progress{
+			Event: fmt.Sprintf("Completed push to %s", p),
+			Desc:  &img.Target,
+		})
+	}
+
+	return nil
+}
+
+type progressPusher struct {
+	remotes.Pusher
+	progress *ProgressTracker
+
+	status *pushStatus
+}
+
+type pushStatus struct {
+	l        sync.Mutex
+	statuses map[string]content.Status
+	complete map[digest.Digest]struct{}
+}
+
+func newProgressPusher(pusher remotes.Pusher, progress *ProgressTracker) *progressPusher {
+	return &progressPusher{
+		Pusher:   pusher,
+		progress: progress,
+		status: &pushStatus{
+			statuses: map[string]content.Status{},
+			complete: map[digest.Digest]struct{}{},
+		},
+	}
+
+}
+
+func (p *progressPusher) WrapHandler(h images.Handler) images.Handler {
+	return images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) (subdescs []ocispec.Descriptor, err error) {
+		p.progress.Add(desc)
+		subdescs, err = h.Handle(ctx, desc)
+		p.progress.AddChildren(desc, subdescs)
+		return
+	})
+}
+
+func (p *progressPusher) Push(ctx context.Context, d ocispec.Descriptor) (content.Writer, error) {
+	ref := remotes.MakeRefKey(ctx, d)
+	p.status.add(ref, d)
+	var cw content.Writer
+	var err error
+	if cs, ok := p.Pusher.(content.Ingester); ok {
+		cw, err = content.OpenWriter(ctx, cs, content.WithRef(ref), content.WithDescriptor(d))
+	} else {
+		cw, err = p.Pusher.Push(ctx, d)
+	}
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			p.progress.MarkExists(d)
+			p.status.markComplete(ref, d)
+		}
+		return nil, err
+	}
+
+	return &progressWriter{
+		Writer:   cw,
+		ref:      ref,
+		desc:     d,
+		status:   p.status,
+		progress: p.progress,
+	}, nil
+}
+
+func (ps *pushStatus) update(ref string, delta int) {
+	ps.l.Lock()
+	status, ok := ps.statuses[ref]
+	if ok {
+		if delta > 0 {
+			status.Offset += int64(delta)
+		} else if delta < 0 {
+			status.Offset = 0
+		}
+		ps.statuses[ref] = status
+	}
+	ps.l.Unlock()
+}
+
+func (ps *pushStatus) add(ref string, d ocispec.Descriptor) {
+	status := content.Status{
+		Ref:       ref,
+		Offset:    0,
+		Total:     d.Size,
+		StartedAt: time.Now(),
+	}
+	ps.l.Lock()
+	_, ok := ps.statuses[ref]
+	_, complete := ps.complete[d.Digest]
+	if !ok && !complete {
+		ps.statuses[ref] = status
+	}
+	ps.l.Unlock()
+}
+func (ps *pushStatus) markComplete(ref string, d ocispec.Descriptor) {
+	ps.l.Lock()
+	_, ok := ps.statuses[ref]
+	if ok {
+		delete(ps.statuses, ref)
+	}
+	ps.complete[d.Digest] = struct{}{}
+	ps.l.Unlock()
+
+}
+
+func (ps *pushStatus) Status(name string) (content.Status, bool) {
+	ps.l.Lock()
+	status, ok := ps.statuses[name]
+	ps.l.Unlock()
+	return status, ok
+}
+
+func (ps *pushStatus) Check(ctx context.Context, dgst digest.Digest) (bool, error) {
+	ps.l.Lock()
+	_, ok := ps.complete[dgst]
+	ps.l.Unlock()
+	return ok, nil
+}
+
+func (p *progressPusher) Active(ctx context.Context, _ ...string) (ActiveJobs, error) {
+	return p.status, nil
+}
+
+func (p *progressPusher) Check(ctx context.Context, dgst digest.Digest) (bool, error) {
+	return p.status.Check(ctx, dgst)
+}
+
+type progressWriter struct {
+	content.Writer
+	ref      string
+	desc     ocispec.Descriptor
+	status   *pushStatus
+	progress *ProgressTracker
+}
+
+func (pw *progressWriter) Write(p []byte) (n int, err error) {
+	n, err = pw.Writer.Write(p)
+	if err != nil {
+		// TODO: Handle reset error to reset progress
+		return
+	}
+	pw.status.update(pw.ref, n)
+	return
+}
+func (pw *progressWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	err := pw.Writer.Commit(ctx, size, expected, opts...)
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			pw.progress.MarkExists(pw.desc)
+		}
+		// TODO: Handle reset error to reset progress
+	}
+	pw.status.markComplete(pw.ref, pw.desc)
+	return err
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/local/tag.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/local/tag.go
@@ -1,0 +1,39 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/v2/core/transfer"
+)
+
+func (ts *localTransferService) tag(ctx context.Context, ig transfer.ImageGetter, is transfer.ImageStorer, tops *transfer.Config) error {
+	ctx, done, err := ts.withLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
+	img, err := ig.Get(ctx, ts.images)
+	if err != nil {
+		return err
+	}
+
+	_, err = is.Store(ctx, img.Target, ts.images)
+	return err
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/local/transfer.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/local/transfer.go
@@ -1,0 +1,192 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/containerd/typeurl/v2"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/unpack"
+	"github.com/containerd/containerd/v2/internal/kmutex"
+	"github.com/containerd/containerd/v2/pkg/imageverifier"
+	"github.com/containerd/errdefs"
+)
+
+type localTransferService struct {
+	content content.Store
+	images  images.Store
+	// limiter for upload
+	limiterU *semaphore.Weighted
+	// limiter for download operation
+	limiterD *semaphore.Weighted
+	config   TransferConfig
+}
+
+func NewTransferService(cs content.Store, is images.Store, tc TransferConfig) transfer.Transferrer {
+	ts := &localTransferService{
+		content: cs,
+		images:  is,
+		config:  tc,
+	}
+	if tc.MaxConcurrentUploadedLayers > 0 {
+		ts.limiterU = semaphore.NewWeighted(int64(tc.MaxConcurrentUploadedLayers))
+	}
+	if tc.MaxConcurrentDownloads > 0 {
+		ts.limiterD = semaphore.NewWeighted(int64(tc.MaxConcurrentDownloads))
+	}
+	return ts
+}
+
+func (ts *localTransferService) Transfer(ctx context.Context, src interface{}, dest interface{}, opts ...transfer.Opt) error {
+	topts := &transfer.Config{}
+	for _, opt := range opts {
+		opt(topts)
+	}
+
+	// Figure out matrix of whether source destination combination is supported
+	switch s := src.(type) {
+	case transfer.ImageFetcher:
+		switch d := dest.(type) {
+		case transfer.ImageStorer:
+			return ts.pull(ctx, s, d, topts)
+		}
+	case transfer.ImageGetter:
+		switch d := dest.(type) {
+		case transfer.ImagePusher:
+			return ts.push(ctx, s, d, topts)
+		case transfer.ImageExporter:
+			return ts.exportStream(ctx, s, d, topts)
+		case transfer.ImageStorer:
+			return ts.tag(ctx, s, d, topts)
+		}
+	case transfer.ImageImporter:
+		switch d := dest.(type) {
+		case transfer.ImageExportStreamer:
+			return ts.echo(ctx, s, d, topts)
+		case transfer.ImageStorer:
+			// TODO: verify imports with ImageVerifiers?
+			return ts.importStream(ctx, s, d, topts)
+		}
+	}
+	return fmt.Errorf("unable to transfer from %s to %s: %w", name(src), name(dest), errdefs.ErrNotImplemented)
+}
+
+func name(t interface{}) string {
+	switch s := t.(type) {
+	case fmt.Stringer:
+		return s.String()
+	case typeurl.Any:
+		return s.GetTypeUrl()
+	default:
+		return fmt.Sprintf("%T", t)
+	}
+}
+
+// echo is mostly used for testing, it implements an import->export which is
+// a no-op which only roundtrips the bytes.
+func (ts *localTransferService) echo(ctx context.Context, i transfer.ImageImporter, e transfer.ImageExportStreamer, tops *transfer.Config) error {
+	iis, ok := i.(transfer.ImageImportStreamer)
+	if !ok {
+		return fmt.Errorf("echo requires access to raw stream: %w", errdefs.ErrNotImplemented)
+	}
+	r, _, err := iis.ImportStream(ctx)
+	if err != nil {
+		return err
+	}
+	wc, _, err := e.ExportStream(ctx)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Use fixed buffer? Send write progress?
+	_, err = io.Copy(wc, r)
+	if werr := wc.Close(); werr != nil && err == nil {
+		err = werr
+	}
+	return err
+}
+
+// WithLease attaches a lease on the context
+func (ts *localTransferService) withLease(ctx context.Context, opts ...leases.Opt) (context.Context, func(context.Context) error, error) {
+	nop := func(context.Context) error { return nil }
+
+	_, ok := leases.FromContext(ctx)
+	if ok {
+		return ctx, nop, nil
+	}
+
+	ls := ts.config.Leases
+	if ls == nil {
+		return ctx, nop, nil
+	}
+
+	if len(opts) == 0 {
+		// Use default lease configuration if no options provided
+		opts = []leases.Opt{
+			leases.WithRandomID(),
+			leases.WithExpiration(24 * time.Hour),
+		}
+	}
+
+	l, err := ls.Create(ctx, opts...)
+	if err != nil {
+		return ctx, nop, err
+	}
+
+	ctx = leases.WithLease(ctx, l.ID)
+	return ctx, func(ctx context.Context) error {
+		return ls.Delete(ctx, l)
+	}, nil
+}
+
+type TransferConfig struct {
+	// Leases manager is used to create leases during operations if none, exists
+	Leases leases.Manager
+
+	// MaxConcurrentDownloads is the max concurrent content downloads for pull.
+	MaxConcurrentDownloads int
+	// MaxConcurrentUploadedLayers is the max concurrent uploads for push
+	MaxConcurrentUploadedLayers int
+
+	// DuplicationSuppressor is used to make sure that there is only one
+	// in-flight fetch request or unpack handler for a given descriptor's
+	// digest or chain ID.
+	DuplicationSuppressor kmutex.KeyedLocker
+
+	// BaseHandlers are a set of handlers which get are called on dispatch.
+	// These handlers always get called before any operation specific
+	// handlers.
+	BaseHandlers []images.Handler
+
+	// UnpackPlatforms are used to specify supported combination of platforms and snapshotters
+	UnpackPlatforms []unpack.Platform
+
+	// ImageVerifiers verify the image before saving into the image store.
+	Verifiers map[string]imageverifier.ImageVerifier
+
+	// RegistryConfigPath is a path to the root directory containing registry-specific configurations
+	RegistryConfigPath string
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/plugins/plugins.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/plugins/plugins.go
@@ -1,0 +1,63 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package plugins
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/typeurl/v2"
+)
+
+var register = struct {
+	sync.RWMutex
+	r map[string]reflect.Type
+}{}
+
+func Register(apiObject, transferObject interface{}) {
+	url, err := typeurl.TypeURL(apiObject)
+	if err != nil {
+		panic(err)
+	}
+	// Lock
+	register.Lock()
+	defer register.Unlock()
+	if register.r == nil {
+		register.r = map[string]reflect.Type{}
+	}
+	if _, ok := register.r[url]; ok {
+		panic(fmt.Sprintf("url already registered: %v", url))
+	}
+	t := reflect.TypeOf(transferObject)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	register.r[url] = t
+}
+
+func ResolveType(any typeurl.Any) (interface{}, error) {
+	register.RLock()
+	defer register.RUnlock()
+	if register.r != nil {
+		if t, ok := register.r[any.GetTypeUrl()]; ok {
+			return reflect.New(t).Interface(), nil
+		}
+	}
+	return nil, fmt.Errorf("%v not registered: %w", any.GetTypeUrl(), errdefs.ErrNotFound)
+}

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/registry/registry.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/registry/registry.go
@@ -1,0 +1,350 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	transfertypes "github.com/containerd/containerd/api/types/transfer"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/containerd/v2/core/remotes/docker/config"
+	"github.com/containerd/containerd/v2/core/streaming"
+	"github.com/containerd/containerd/v2/core/transfer"
+	"github.com/containerd/containerd/v2/core/transfer/plugins"
+	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
+	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func init() {
+	// TODO: Move this to separate package?
+	plugins.Register(&transfertypes.OCIRegistry{}, &OCIRegistry{})
+}
+
+type registryOpts struct {
+	headers       http.Header
+	creds         CredentialHelper
+	hostDir       string
+	defaultScheme string
+}
+
+// Opt sets registry-related configurations.
+type Opt func(o *registryOpts) error
+
+// WithHeaders configures HTTP request header fields sent by the resolver.
+func WithHeaders(headers http.Header) Opt {
+	return func(o *registryOpts) error {
+		o.headers = headers
+		return nil
+	}
+}
+
+// WithCredentials configures a helper that provides credentials for a host.
+func WithCredentials(creds CredentialHelper) Opt {
+	return func(o *registryOpts) error {
+		o.creds = creds
+		return nil
+	}
+}
+
+// WithHostDir specifies the host configuration directory.
+func WithHostDir(hostDir string) Opt {
+	return func(o *registryOpts) error {
+		o.hostDir = hostDir
+		return nil
+	}
+}
+
+// WithDefaultScheme specifies the default scheme for registry configuration
+func WithDefaultScheme(s string) Opt {
+	return func(o *registryOpts) error {
+		o.defaultScheme = s
+		return nil
+	}
+}
+
+// NewOCIRegistry initializes with hosts, authorizer callback, and headers
+func NewOCIRegistry(ctx context.Context, ref string, opts ...Opt) (*OCIRegistry, error) {
+	var ropts registryOpts
+	for _, o := range opts {
+		if err := o(&ropts); err != nil {
+			return nil, err
+		}
+	}
+	hostOptions := config.HostOptions{}
+	if ropts.hostDir != "" {
+		hostOptions.HostDir = config.HostDirFromRoot(ropts.hostDir)
+	}
+	if ropts.creds != nil {
+		// TODO: Support bearer
+		hostOptions.Credentials = func(host string) (string, string, error) {
+			c, err := ropts.creds.GetCredentials(context.Background(), ref, host)
+			if err != nil {
+				return "", "", err
+			}
+
+			return c.Username, c.Secret, nil
+		}
+	}
+	if ropts.defaultScheme != "" {
+		hostOptions.DefaultScheme = ropts.defaultScheme
+	}
+	resolver := docker.NewResolver(docker.ResolverOptions{
+		Hosts:   config.ConfigureHosts(ctx, hostOptions),
+		Headers: ropts.headers,
+	})
+	return &OCIRegistry{
+		reference:     ref,
+		headers:       ropts.headers,
+		creds:         ropts.creds,
+		resolver:      resolver,
+		hostDir:       ropts.hostDir,
+		defaultScheme: ropts.defaultScheme,
+	}, nil
+}
+
+// From stream
+type CredentialHelper interface {
+	GetCredentials(ctx context.Context, ref, host string) (Credentials, error)
+}
+
+type Credentials struct {
+	Host     string
+	Username string
+	Secret   string
+	Header   string
+}
+
+// OCI
+type OCIRegistry struct {
+	reference string
+
+	headers http.Header
+	creds   CredentialHelper
+
+	resolver remotes.Resolver
+
+	hostDir string
+
+	defaultScheme string
+
+	// This could be an interface which returns resolver?
+	// Resolver could also be a plug-able interface, to call out to a program to fetch?
+}
+
+func (r *OCIRegistry) String() string {
+	return fmt.Sprintf("OCI Registry (%s)", r.reference)
+}
+
+func (r *OCIRegistry) Image() string {
+	return r.reference
+}
+
+func (r *OCIRegistry) Resolve(ctx context.Context) (name string, desc ocispec.Descriptor, err error) {
+	return r.resolver.Resolve(ctx, r.reference)
+}
+
+func (r *OCIRegistry) Fetcher(ctx context.Context, ref string) (transfer.Fetcher, error) {
+	return r.resolver.Fetcher(ctx, ref)
+}
+
+func (r *OCIRegistry) Pusher(ctx context.Context, desc ocispec.Descriptor) (transfer.Pusher, error) {
+	var ref = r.reference
+	// Annotate ref with digest to push only push tag for single digest
+	if !strings.Contains(ref, "@") {
+		ref = ref + "@" + desc.Digest.String()
+	}
+	return r.resolver.Pusher(ctx, ref)
+}
+
+func (r *OCIRegistry) MarshalAny(ctx context.Context, sm streaming.StreamCreator) (typeurl.Any, error) {
+	res := &transfertypes.RegistryResolver{}
+	if r.headers != nil {
+		res.Headers = map[string]string{}
+		for k := range r.headers {
+			res.Headers[k] = r.headers.Get(k)
+		}
+	}
+	if r.creds != nil {
+		sid := tstreaming.GenerateID("creds")
+		stream, err := sm.Create(ctx, sid)
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			// Check for context cancellation as well
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				req, err := stream.Recv()
+				if err != nil {
+					// If not EOF, log error
+					return
+				}
+
+				var s transfertypes.AuthRequest
+				if err := typeurl.UnmarshalTo(req, &s); err != nil {
+					log.G(ctx).WithError(err).Error("failed to unmarshal credential request")
+					continue
+				}
+				creds, err := r.creds.GetCredentials(ctx, s.Reference, s.Host)
+				if err != nil {
+					log.G(ctx).WithError(err).Error("failed to get credentials")
+					continue
+				}
+				var resp transfertypes.AuthResponse
+				if creds.Header != "" {
+					resp.AuthType = transfertypes.AuthType_HEADER
+					resp.Secret = creds.Header
+				} else if creds.Username != "" {
+					resp.AuthType = transfertypes.AuthType_CREDENTIALS
+					resp.Username = creds.Username
+					resp.Secret = creds.Secret
+				} else {
+					resp.AuthType = transfertypes.AuthType_REFRESH
+					resp.Secret = creds.Secret
+				}
+
+				a, err := typeurl.MarshalAny(&resp)
+				if err != nil {
+					log.G(ctx).WithError(err).Error("failed to marshal credential response")
+					continue
+				}
+
+				if err := stream.Send(a); err != nil {
+					if !errors.Is(err, io.EOF) {
+						log.G(ctx).WithError(err).Error("unexpected send failure")
+					}
+					return
+				}
+			}
+
+		}()
+		res.AuthStream = sid
+	}
+	res.HostDir = r.hostDir
+	res.DefaultScheme = r.defaultScheme
+	s := &transfertypes.OCIRegistry{
+		Reference: r.reference,
+		Resolver:  res,
+	}
+
+	return typeurl.MarshalAny(s)
+}
+
+func (r *OCIRegistry) UnmarshalAny(ctx context.Context, sm streaming.StreamGetter, a typeurl.Any) error {
+	var s transfertypes.OCIRegistry
+	if err := typeurl.UnmarshalTo(a, &s); err != nil {
+		return err
+	}
+
+	hostOptions := config.HostOptions{}
+	if s.Resolver != nil {
+		if s.Resolver.HostDir != "" {
+			hostOptions.HostDir = config.HostDirFromRoot(s.Resolver.HostDir)
+		}
+		if s.Resolver.DefaultScheme != "" {
+			hostOptions.DefaultScheme = s.Resolver.DefaultScheme
+		}
+		if sid := s.Resolver.AuthStream; sid != "" {
+			stream, err := sm.Get(ctx, sid)
+			if err != nil {
+				log.G(ctx).WithError(err).WithField("stream", sid).Debug("failed to get auth stream")
+				return err
+			}
+			r.creds = &credCallback{
+				stream: stream,
+			}
+			hostOptions.Credentials = func(host string) (string, string, error) {
+				c, err := r.creds.GetCredentials(context.Background(), s.Reference, host)
+				if err != nil {
+					return "", "", err
+				}
+
+				return c.Username, c.Secret, nil
+			}
+		}
+		r.headers = http.Header{}
+		for k, v := range s.Resolver.Headers {
+			r.headers.Add(k, v)
+		}
+	}
+
+	r.reference = s.Reference
+	r.resolver = docker.NewResolver(docker.ResolverOptions{
+		Hosts:   config.ConfigureHosts(ctx, hostOptions),
+		Headers: r.headers,
+	})
+
+	return nil
+}
+
+type credCallback struct {
+	sync.Mutex
+	stream streaming.Stream
+}
+
+func (cc *credCallback) GetCredentials(ctx context.Context, ref, host string) (Credentials, error) {
+	cc.Lock()
+	defer cc.Unlock()
+
+	ar := &transfertypes.AuthRequest{
+		Host:      host,
+		Reference: ref,
+	}
+	anyType, err := typeurl.MarshalAny(ar)
+	if err != nil {
+		return Credentials{}, err
+	}
+	if err := cc.stream.Send(anyType); err != nil {
+		return Credentials{}, err
+	}
+	resp, err := cc.stream.Recv()
+	if err != nil {
+		return Credentials{}, err
+	}
+	var s transfertypes.AuthResponse
+	if err := typeurl.UnmarshalTo(resp, &s); err != nil {
+		return Credentials{}, err
+	}
+	creds := Credentials{
+		Host: host,
+	}
+	switch s.AuthType {
+	case transfertypes.AuthType_CREDENTIALS:
+		creds.Username = s.Username
+		creds.Secret = s.Secret
+	case transfertypes.AuthType_REFRESH:
+		creds.Secret = s.Secret
+	case transfertypes.AuthType_HEADER:
+		creds.Header = s.Secret
+	}
+
+	return creds, nil
+}

--- a/vendor/github.com/containerd/containerd/v2/pkg/imageverifier/image_verifier.go
+++ b/vendor/github.com/containerd/containerd/v2/pkg/imageverifier/image_verifier.go
@@ -1,0 +1,32 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package imageverifier
+
+import (
+	"context"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type ImageVerifier interface {
+	VerifyImage(ctx context.Context, name string, desc ocispec.Descriptor) (*Judgement, error)
+}
+
+type Judgement struct {
+	OK     bool
+	Reason string
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -362,7 +362,11 @@ github.com/containerd/containerd/v2/core/snapshots/proxy
 github.com/containerd/containerd/v2/core/streaming
 github.com/containerd/containerd/v2/core/streaming/proxy
 github.com/containerd/containerd/v2/core/transfer
+github.com/containerd/containerd/v2/core/transfer/image
+github.com/containerd/containerd/v2/core/transfer/local
+github.com/containerd/containerd/v2/core/transfer/plugins
 github.com/containerd/containerd/v2/core/transfer/proxy
+github.com/containerd/containerd/v2/core/transfer/registry
 github.com/containerd/containerd/v2/core/transfer/streaming
 github.com/containerd/containerd/v2/core/unpack
 github.com/containerd/containerd/v2/defaults
@@ -383,6 +387,7 @@ github.com/containerd/containerd/v2/pkg/epoch
 github.com/containerd/containerd/v2/pkg/filters
 github.com/containerd/containerd/v2/pkg/gc
 github.com/containerd/containerd/v2/pkg/identifiers
+github.com/containerd/containerd/v2/pkg/imageverifier
 github.com/containerd/containerd/v2/pkg/kernelversion
 github.com/containerd/containerd/v2/pkg/labels
 github.com/containerd/containerd/v2/pkg/namespaces


### PR DESCRIPTION
Switches image pull to use the transfer service and keeps the existing progress output.

Note: extraction progress doesn't work yet, it needs: https://github.com/containerd/containerd/pull/11195