### PR TITLE
Warn when no external DNS nameservers are found

### DIFF
--- a/libnetwork/internal/resolvconf/resolvconf_test.go
+++ b/libnetwork/internal/resolvconf/resolvconf_test.go
@@ -410,6 +410,10 @@ func TestRCTransformForIntNS(t *testing.T) {
 			reqdOptions:   []string{"ndots:0", "attempts:3", "edns0", "trust-ad"},
 			expExtServers: []ExtDNSEntry{mke("127.0.0.53", true)},
 		},
+		{
+			name:  "No config",
+			input: "",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/No_config.golden
+++ b/libnetwork/internal/resolvconf/testdata/TestRCTransformForIntNS/No_config.golden
@@ -1,0 +1,5 @@
+nameserver 127.0.0.11
+
+# Based on host file: '/etc/resolv.conf' (internal resolver)
+# NO EXTERNAL NAMESERVERS DEFINED
+# Overrides: []

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -219,6 +219,11 @@ func (sb *Sandbox) restoreHostsPath() {
 }
 
 func (sb *Sandbox) setExternalResolvers(entries []resolvconf.ExtDNSEntry) {
+	if len(entries) == 0 {
+		log.G(context.TODO()).WithField("cid", sb.ContainerID()).Warn("DNS resolver has no external nameservers")
+		sb.extDNS = nil
+		return
+	}
 	sb.extDNS = make([]extDNSEntry, 0, len(entries))
 	for _, entry := range entries {
 		sb.extDNS = append(sb.extDNS, extDNSEntry{


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49647
- related to https://github.com/moby/moby/pull/48290

Since commit 925b484 ("No fallback nameservers for internal resolver"), if the host's resolv.conf has no nameservers and no servers are supplied via config, the internal resolver will not use Google's DNS - so the container will not be able to resolve external DNS requests.

That can happen when containers are "restart always/unless-stopped" and the docker daemon starts before the host's DNS is configured.

So, highlight the issue (which may not be an error, but probably is).

**- How I did it**

Include a warning in the container's resolv.conf file.

Also, log a warning - logs currently say "No non-localhost DNS nameservers are left in resolv.conf. Using default external servers". But, that's misleading because it's from an initial resolv.conf setup, before the internal resolver configured without those fallbacks - we'll drop the fallbacks completely once the default bridge has an internal resolver).

**- How to verify it**

Updated unit test.

With an empty `/etc/resolv.conf` on the host ...

```
$ docker run --rm -ti --network b4 busybox cat /etc/resolv.conf
# Generated by Docker Engine.
# This file can be edited; Docker Engine will not make further changes once it
# has been modified.

nameserver 127.0.0.11
options ndots:0

# Based on host file: '/etc/resolv.conf' (internal resolver)
# NO EXTERNAL NAMESERVERS DEFINED
# Overrides: []
# Option ndots from: internal
```

```
INFO[2025-04-17T09:49:54.159880089Z] No non-localhost DNS nameservers are left in resolv.conf. Using default external servers
WARN[2025-04-17T09:49:54.161602381Z] DNS resolver has no external nameservers      cid=1ee4ac99aac0bba02692dedbb8168e11f2300f2bba82d6126eb461c8a6c9305a
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Add a warning to a container's `/etc/resolv.conf` when no upstream DNS servers were found.
```
