### PR TITLE
iptables: Direct routing DROP rules per-container, not per-port

### DIFF
--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
@@ -139,8 +139,8 @@ The filter and nat tables are identical to [nat mode][0]:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       6    --  !lo    *       0.0.0.0/0            127.0.0.1            tcp dpt:8080
-    2        0     0 DROP       6    --  !bridge1 *       0.0.0.0/0            192.0.2.2            tcp dpt:80
+    1        0     0 DROP       0    --  !bridge1 *       0.0.0.0/0            192.0.2.2           
+    2        0     0 DROP       6    --  !lo    *       0.0.0.0/0            127.0.0.1            tcp dpt:8080
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -151,8 +151,8 @@ The filter and nat tables are identical to [nat mode][0]:
 
     -P PREROUTING ACCEPT
     -P OUTPUT ACCEPT
+    -A PREROUTING -d 192.0.2.2/32 ! -i bridge1 -j DROP
     -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
-    -A PREROUTING -d 192.0.2.2/32 ! -i bridge1 -p tcp -m tcp --dport 80 -j DROP
     
 
 </details>

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -163,7 +163,7 @@ And the raw table:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       6    --  !bridge1 *       0.0.0.0/0            192.0.2.2            tcp dpt:80
+    1        0     0 DROP       0    --  !bridge1 *       0.0.0.0/0            192.0.2.2           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -174,7 +174,7 @@ And the raw table:
 
     -P PREROUTING ACCEPT
     -P OUTPUT ACCEPT
-    -A PREROUTING -d 192.0.2.2/32 ! -i bridge1 -p tcp -m tcp --dport 80 -j DROP
+    -A PREROUTING -d 192.0.2.2/32 ! -i bridge1 -j DROP
     
 
 </details>

--- a/integration/networking/testdata/TestSkipRawRules/skip=false_ipv4.golden
+++ b/integration/networking/testdata/TestSkipRawRules/skip=false_ipv4.golden
@@ -1,4 +1,4 @@
 -P PREROUTING ACCEPT
 -P OUTPUT ACCEPT
+-A PREROUTING -d 192.168.0.2/32 ! -i docker0 -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
--A PREROUTING -d 192.168.0.2/32 ! -i docker0 -p tcp -m tcp --dport 80 -j DROP

--- a/integration/networking/testdata/TestSkipRawRules/skip=false_ipv6.golden
+++ b/integration/networking/testdata/TestSkipRawRules/skip=false_ipv6.golden
@@ -1,3 +1,3 @@
 -P PREROUTING ACCEPT
 -P OUTPUT ACCEPT
--A PREROUTING -d fd30:1159:a755::2/128 ! -i docker0 -p tcp -m tcp --dport 80 -j DROP
+-A PREROUTING -d fd30:1159:a755::2/128 ! -i docker0 -j DROP

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -87,6 +87,13 @@ func (d *driver) populateEndpoints() error {
 			continue
 		}
 		n.endpoints[ep.id] = ep
+		netip4, netip6 := ep.netipAddrs()
+		if err := n.iptablesNetwork.AddEndpoint(context.TODO(), netip4, netip6); err != nil {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error": err,
+				"ep.id": ep.id,
+			}).Warn("Failed to restore per-endpoint firewall rules")
+		}
 		n.restorePortAllocations(ep)
 		log.G(context.TODO()).Debugf("Endpoint (%.7s) restored to network (%.7s)", ep.id, ep.nid)
 	}

--- a/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package iptabler
+
+import (
+	"context"
+	"net/netip"
+
+	"github.com/docker/docker/libnetwork/iptables"
+)
+
+func (n *Network) AddEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
+	return n.modEndpoint(ctx, epIPv4, epIPv6, true)
+}
+
+func (n *Network) DelEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
+	return n.modEndpoint(ctx, epIPv4, epIPv6, false)
+}
+
+func (n *Network) modEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr, enable bool) error {
+	if n.ipt.IPv4 && epIPv4.IsValid() {
+		if err := n.filterDirectAccess(ctx, iptables.IPv4, n.Config4, epIPv4, enable); err != nil {
+			return err
+		}
+	}
+	if n.ipt.IPv6 && epIPv6.IsValid() {
+		if err := n.filterDirectAccess(ctx, iptables.IPv6, n.Config6, epIPv6, enable); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// filterDirectAccess drops packets addressed directly to the container's IP address,
+// when direct routing is not permitted by network configuration.
+//
+// It is a no-op if:
+//   - the network is internal
+//   - gateway mode is "nat-unprotected" or "routed".
+//   - "raw" rules are disabled (possibly because the host doesn't have the necessary
+//     kernel support).
+//
+// Packets originating on the bridge's own interface and addressed directly to the
+// container are allowed - the host always has direct access to its own containers
+// (it doesn't need to use the port mapped to its own addresses, although it can).
+func (n *Network) filterDirectAccess(ctx context.Context, ipv iptables.IPVersion, config NetworkConfigFam, epIP netip.Addr, enable bool) error {
+	if n.Internal || config.Unprotected || config.Routed {
+		return nil
+	}
+	// For config that may change between daemon restarts, make sure rules are
+	// removed - if the container was left running when the daemon stopped, and
+	// direct routing has since been disabled, the rules need to be deleted when
+	// cleanup happens on restart. This also means a change in config over a
+	// live-restore restart will take effect.
+	if rawRulesDisabled(ctx) {
+		enable = false
+	}
+	accept := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
+		"-d", epIP.String(),
+		"!", "-i", n.IfName,
+		"-j", "DROP",
+	}}
+	return appendOrDelChainRule(accept, "DIRECT ACCESS FILTERING - DROP", enable)
+}


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/pull/49325
- related to https://github.com/moby/moby/issues/49792

Commit 27adcd596baff0d365d58c495c3b5e5e1d3bb54a ("libnet/d/bridge: drop connections to lo mappings, and direct remote connections") introduced an iptables rule to drop 'direct' remote connections made to the container's IP address - for each published port on the container.

The normal filter-FORWARD rules would then drop packets sent directly to unpublished ports. This rule was only created along with the rest of port publishing (when a container's endpoint was selected as its gateway). Until then, all packets addressed directly to the container's ports were dropped by the filter-FORWARD rules.

But, the rule doesn't need to be per-port. Just drop packets sent directly to a container's address unless they originate on the host.

That means fewer rules, that can be created along with the endpoint (then directly-routed packets get dropped at the same point whether or not the endpoint is currently the gateway - very slightly earlier than when it's not the gateway).

This is in prep for adding a "trusted interfaces" option, for https://github.com/moby/moby/issues/49792 - it'll only be necessary to add a rule for each interface, not rules per-port-per-interface.

**- How I did it**

**- How to verify it**

Existing tests.

For upgrade ...

- With an old daemon, started a container and checked the old rule was present...
```
# docker run --rm -d -p 8080:80 busybox sleep infinity
a5ab81545582dbbe3845b95772ee3e511fd5c80efc06f32ea2e8ad39b23dadd8
# iptables -nvL -t raw
Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 DROP       6    --  !docker0 *       0.0.0.0/0            172.18.0.2           tcp dpt:80

Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
```
- Killed the daemon without giving it a chance to delete the container. Started a daemon with this fix, checked it removed the old rule. Started a new container, checked it had the new rule (with `prot=0`, and no `dpt`) ...
```
root@2fe41fa1f399:/go/src/github.com/docker/docker# docker run --rm -d -p 8080:80 busybox sleep infinity
aad7369841c691c016dda6b518e31b89f963e79117646b5c1729e02a5906c413
root@2fe41fa1f399:/go/src/github.com/docker/docker# iptables -nvL -t raw
Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 DROP       0    --  !docker0 *       0.0.0.0/0            172.18.0.2

Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
```
- Repeated that, but with live-restore enabled.

**- Human readable description for the release notes**
```markdown changelog

```
