### PR TITLE
Allow direct routing to container ports from trusted interfaces

### DIFF
--- a/cmd/dockerd/config_unix.go
+++ b/cmd/dockerd/config_unix.go
@@ -38,6 +38,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IPVar(&conf.BridgeConfig.DefaultIP, "ip", net.IPv4zero, "Host IP for port publishing from the default bridge network")
 	flags.BoolVar(&conf.BridgeConfig.EnableUserlandProxy, "userland-proxy", true, "Use userland proxy for loopback traffic")
 	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", conf.BridgeConfig.UserlandProxyPath, "Path to the userland proxy binary")
+	flags.BoolVar(&conf.BridgeConfig.AllowDirectRouting, "allow-direct-routing", false, "Allow remote access to published ports on container IP addresses")
 	flags.StringVar(&conf.CgroupParent, "cgroup-parent", "", "Set parent cgroup for all containers")
 	flags.StringVar(&conf.RemappedRoot, "userns-remap", "", "User/Group setting for user namespaces")
 	flags.BoolVar(&conf.LiveRestoreEnabled, "live-restore", false, "Enable live restore of docker when containers are still running")

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -48,6 +48,7 @@ type BridgeConfig struct {
 	EnableIPMasq             bool   `json:"ip-masq,omitempty"`
 	EnableUserlandProxy      bool   `json:"userland-proxy,omitempty"`
 	UserlandProxyPath        string `json:"userland-proxy-path,omitempty"`
+	AllowDirectRouting       bool   `json:"allow-direct-routing,omitempty"`
 }
 
 // DefaultBridgeConfig stores all the parameters for the default bridge network.

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -933,6 +933,7 @@ func driverOptions(config *config.Config) nwconfig.Option {
 			"EnableIP6Tables":          config.BridgeConfig.EnableIP6Tables,
 			"EnableUserlandProxy":      config.BridgeConfig.EnableUserlandProxy,
 			"UserlandProxyPath":        config.BridgeConfig.UserlandProxyPath,
+			"AllowDirectRouting":       config.BridgeConfig.AllowDirectRouting,
 			"Rootless":                 config.Rootless,
 		},
 	})

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -66,6 +66,7 @@ type configuration struct {
 	EnableUserlandProxy      bool
 	UserlandProxyPath        string
 	Rootless                 bool
+	AllowDirectRouting       bool
 }
 
 // networkConfiguration for network specific configuration
@@ -508,9 +509,10 @@ func (d *driver) configure(option map[string]interface{}) error {
 
 	var err error
 	d.firewaller, err = iptabler.NewIptabler(iptabler.FirewallConfig{
-		IPv4:    config.EnableIPTables,
-		IPv6:    config.EnableIP6Tables,
-		Hairpin: !config.EnableUserlandProxy || config.UserlandProxyPath == "",
+		IPv4:               config.EnableIPTables,
+		IPv6:               config.EnableIP6Tables,
+		Hairpin:            !config.EnableUserlandProxy || config.UserlandProxyPath == "",
+		AllowDirectRouting: config.AllowDirectRouting,
 	})
 	if err != nil {
 		return err

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/docker/libnetwork/options"
 	"github.com/docker/docker/libnetwork/portallocator"
 	"github.com/docker/docker/libnetwork/types"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"gotest.tools/v3/assert"
@@ -223,6 +224,35 @@ func compareBindings(a, b []portBinding) bool {
 		}
 	}
 	return true
+}
+
+func TestNetworkConfigurationMarshalling(t *testing.T) {
+	nc := &networkConfiguration{
+		ID:                    "nid",
+		BridgeName:            "bridgename",
+		EnableIPv4:            true,
+		EnableIPv6:            true,
+		EnableIPMasquerade:    true,
+		GwModeIPv4:            gwModeRouted,
+		GwModeIPv6:            gwModeIsolated,
+		EnableICC:             true,
+		TrustedHostInterfaces: []string{"foo0", "bar1"},
+		InhibitIPv4:           true,
+		Mtu:                   1234,
+		DefaultBindingIP:      net.ParseIP("192.0.2.1"),
+		DefaultBridge:         true,
+		HostIPv4:              net.ParseIP("192.0.2.2"),
+		HostIPv6:              net.ParseIP("2001:db8::1"),
+		ContainerIfacePrefix:  "baz",
+	}
+
+	b, err := json.Marshal(nc)
+	assert.Assert(t, err)
+
+	nnc := &networkConfiguration{}
+	err = json.Unmarshal(b, nnc)
+	assert.Assert(t, err)
+	assert.Check(t, is.DeepEqual(nnc, nc, cmpopts.IgnoreUnexported(networkConfiguration{})))
 }
 
 func getIPv4Data(t *testing.T) []driverapi.IPAMData {

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/internal/otelutil"
@@ -137,6 +138,7 @@ func (ncfg *networkConfiguration) MarshalJSON() ([]byte, error) {
 	nMap["GwModeIPv4"] = ncfg.GwModeIPv4
 	nMap["GwModeIPv6"] = ncfg.GwModeIPv6
 	nMap["EnableICC"] = ncfg.EnableICC
+	nMap["TrustedHostInterfaces"] = strings.Join(ncfg.TrustedHostInterfaces, ":")
 	nMap["InhibitIPv4"] = ncfg.InhibitIPv4
 	nMap["Mtu"] = ncfg.Mtu
 	nMap["Internal"] = ncfg.Internal
@@ -215,6 +217,10 @@ func (ncfg *networkConfiguration) UnmarshalJSON(b []byte) error {
 		ncfg.GwModeIPv6, _ = newGwMode(v.(string))
 	}
 	ncfg.EnableICC = nMap["EnableICC"].(bool)
+	if v, ok := nMap["TrustedHostInterfaces"]; ok {
+		s, _ := v.(string)
+		ncfg.TrustedHostInterfaces = strings.FieldsFunc(s, func(r rune) bool { return r == ':' })
+	}
 	if v, ok := nMap["InhibitIPv4"]; ok {
 		ncfg.InhibitIPv4 = v.(bool)
 	}

--- a/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
@@ -37,6 +37,7 @@ func (n *Network) modEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr, en
 // It is a no-op if:
 //   - the network is internal
 //   - gateway mode is "nat-unprotected" or "routed".
+//   - direct routing is enabled at the daemon level.
 //   - "raw" rules are disabled (possibly because the host doesn't have the necessary
 //     kernel support).
 //
@@ -54,7 +55,7 @@ func (n *Network) filterDirectAccess(ctx context.Context, ipv iptables.IPVersion
 	// direct routing has since been disabled, the rules need to be deleted when
 	// cleanup happens on restart. This also means a change in config over a
 	// live-restore restart will take effect.
-	if rawRulesDisabled(ctx) {
+	if n.ipt.AllowDirectRouting || rawRulesDisabled(ctx) {
 		enable = false
 	}
 	for _, ifName := range n.TrustedHostInterfaces {

--- a/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
@@ -35,9 +35,10 @@ const (
 )
 
 type FirewallConfig struct {
-	IPv4    bool
-	IPv6    bool
-	Hairpin bool
+	IPv4               bool
+	IPv6               bool
+	Hairpin            bool
+	AllowDirectRouting bool
 }
 
 type Iptabler struct {

--- a/libnetwork/drivers/bridge/internal/iptabler/network.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/network.go
@@ -26,12 +26,13 @@ type NetworkConfigFam struct {
 }
 
 type NetworkConfig struct {
-	IfName     string
-	Internal   bool
-	ICC        bool
-	Masquerade bool
-	Config4    NetworkConfigFam
-	Config6    NetworkConfigFam
+	IfName                string
+	Internal              bool
+	ICC                   bool
+	Masquerade            bool
+	TrustedHostInterfaces []string
+	Config4               NetworkConfigFam
+	Config6               NetworkConfigFam
 }
 
 type Network struct {

--- a/libnetwork/drivers/bridge/labels.go
+++ b/libnetwork/drivers/bridge/labels.go
@@ -23,4 +23,8 @@ const (
 
 	// DefaultBridge label
 	DefaultBridge = "com.docker.network.bridge.default_bridge"
+
+	// TrustedHostInterfaces can be used to supply a list of host interfaces that are
+	// allowed direct access to published ports on a container's address.
+	TrustedHostInterfaces = "com.docker.network.bridge.trusted_host_interfaces"
 )

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -415,6 +415,10 @@ unix://[/path/to/socket] to use.
   Use TLS and verify the remote (daemon: verify client, client: verify daemon).
   Default is **false**.
 
+**--allow-direct-routing**=**true**|**false**
+  Allow remote access to published ports on container IP addresses.
+  Default is **false**.
+
 **--userland-proxy**=**true**|**false**
   Rely on a userland proxy implementation for inter-container and
   outside-to-container loopback communications. Default is **true**.


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/49792
- related to https://github.com/moby/moby/pull/49325

Since 28.0.0, docker's iptables rules will block packets addressed to a container's address, unless they originate from the host.

The issue linked above describes a case where this is undesirable (Flannel VXLAN provides an overlay network, and packets arriving on its interface should be treated as belonging to the bridge network). The existing workarounds are:
- set env var `DOCKER_INSECURE_NO_IPTABLES_RAW=1`
  - but this enables access to published ports from any interface, for containers in all bridge networks.
  - there's no plan for an nftables equivalent for that env var, it was only added as a workaround for kernels without iptables "raw" support, and "raw" rules aren't special in nftables.
- use gateway mode `nat-unprotected`
  - but that enables routed access to any port (published or not), on any container in the network, from any network interface.

Follow-ups needed:
- update the CLI repo's `dockerd.md`
- docs updates

**- How I did it**

#### bridge: add option com.docker.network.bridge.trusted_host_interfaces

Interfaces listed have access to published ports on the container's address - enabling direct routing to the container via those interfaces. 

It accepts a colon-separated list (comma is allowed in an interface name, colon isn't).

For example:
```
docker network create -o com.docker.network.bridge.trusted_host_interfaces="flannel.1:eth42" mynet
```

(Like other options for user-defined networks, it's not possible to supply this option for the default bridge network.)

#### Add daemon option --allow-direct-routing

This daemon level option disables direct access filtering, enabling direct access to published ports on container addresses in all bridge networks, via all host interfaces.

For example, in `/etc/docker/daemon.json`:
```json
  "allow-direct-routing": true
```

It overlaps with short-term env-var workaround `DOCKER_INSECURE_NO_IPTABLES_RAW=1`, but:
- it does not allow packets sent from outside the host to reach ports published only to `127.0.0.1`.
- it will outlive iptables (the workaround was initially intended for hosts that do not have kernel support for the "raw" iptables table).

**- How to verify it**

Updated integration tests.

**- Human readable description for the release notes**
```markdown changelog
- Add daemon option `"allow-direct-routing"` to disable filtering of packets from outside the host addressed directly to containers.
- Add bridge network option `"com.docker.network.bridge.trusted_host_interfaces"`, accepting a colon-separated list of interface names. These interfaces have direct access to published ports on container IP addresses.
```
