### PR TITLE
contrib/rootless-setuptool: Fix iptables detection

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -152,6 +152,7 @@ init() {
 		case $iptables_version in
 			*legacy*) iptables_module="ip_tables" ;;
 		esac
+	else
 		faced_iptables_error=1
 		if [ -z "$OPT_SKIP_IPTABLES" ]; then
 			if command -v apt-get > /dev/null 2>&1; then


### PR DESCRIPTION
- related: https://github.com/moby/moby/pull/49727#discussion_r2049365900
- related: https://github.com/docker/docker-install/pull/487

Fix a logical error in the rootless setup tool where the iptables error handling was incorrectly placed. The code was setting `faced_iptables_error=1` even when iptables was available, causing unnecessary error messages and setup suggestions.

This patch correctly moves the error handling into the `else` branch so that we only report iptables errors when the command is actually unavailable.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `dockerd-rootless-setuptool.sh` incorrectly reporting missing `iptables`
```

**- A picture of a cute animal (not mandatory but encouraged)**

