### PR TITLE
cleanup ignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
-.git
-bundles/
-cli/winresources/**/winres.json
-cli/winresources/**/*.syso
+/.git
+
+# build artifacts
+/bundles/
+/cli/winresources/dockerd/winres.json
+/cli/winresources/dockerd/*.syso

--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,9 @@ thumbs.db
 .editorconfig
 
 # build artifacts
-bundles/
-cli/winresources/*/*.syso
-cli/winresources/*/winres.json
-contrib/builder/rpm/*/changelog
+/bundles/
+/cli/winresources/dockerd/*.syso
+/cli/winresources/dockerd/winres.json
 
 # ci artifacts
 *.exe


### PR DESCRIPTION
- We now only use winresources for the dockerd binary, so we can reduce some uses of wildcards
- Use explicit ("/") to indicate these should only be ignored relative to the root of the repository and build-context
- Remove remnant ignore for rpm builds


**- A picture of a cute animal (not mandatory but encouraged)**

