### PR TITLE
docs: add nftables upgrade/downgrade & enable/disable notes (fixes #4…

### DIFF
--- a/docs/api/v1.49.yaml
+++ b/docs/api/v1.49.yaml
@@ -6944,6 +6944,20 @@ definitions:
   FirewallInfo:
     description: |
       Information about the daemon's firewalling configuration.
+ 
+ **Upgrade/Downgrade:**
+  - Upgrading from a Docker Engine release using `iptables` to one using `nftables` may require:
+    - Flushing legacy iptables rules: `iptables -F`
+    - Loading nftables rules via your `nftables.conf`: `nft -f /etc/nftables.conf`
+  - Downgrading back to iptables requires:
+    - Flushing nftables rules: `nft flush ruleset`
+    - Re-applying iptables rules as needed.
+
+  **Enabling/Disabling:**
+  - Control the firewall backend with these daemon flags:
+    - `--iptables` (legacy iptables driver; default: `true`)
+    - `--nftables` (nftables driver; default: `false`, experimental)
+
 
       This field is currently only used on Linux, and omitted on other platforms.
     type: "object"


### PR DESCRIPTION
This PR injects Upgrade/Downgrade and Enabling/Disabling notes into the FirewallInfo definition.
Fixes #49644.
