### PR TITLE
Dockerfile: update cli to v28.1.1, buildx v0.33.0, compose v0.35.1, syntax: docker/dockerfile:1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG XX_VERSION=1.6.1
 ARG VPNKIT_VERSION=0.5.0
 
 # DOCKERCLI_VERSION is the version of the CLI to install in the dev-container.
-ARG DOCKERCLI_VERSION=v28.0.1
+ARG DOCKERCLI_VERSION=v28.1.1
 ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
 
 # cli version used for integration-cli tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
 # cli version used for integration-cli tests
 ARG DOCKERCLI_INTEGRATION_REPOSITORY="https://github.com/docker/cli.git"
 ARG DOCKERCLI_INTEGRATION_VERSION=v18.06.3-ce
+
 # BUILDX_VERSION is the version of buildx to install in the dev container.
-ARG BUILDX_VERSION=0.20.1
+ARG BUILDX_VERSION=0.23.0
 ARG COMPOSE_VERSION=v2.33.1
 
 ARG SYSTEMD="false"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.23.8
 ARG BASE_DEBIAN_DISTRO="bookworm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ ARG DOCKERCLI_INTEGRATION_VERSION=v18.06.3-ce
 
 # BUILDX_VERSION is the version of buildx to install in the dev container.
 ARG BUILDX_VERSION=0.23.0
-ARG COMPOSE_VERSION=v2.33.1
+
+# COMPOSE_VERSION is the version of compose to install in the dev container.
+ARG COMPOSE_VERSION=v2.35.1
 
 ARG SYSTEMD="false"
 ARG FIREWALLD="false"


### PR DESCRIPTION
### Dockerfile: don't pin syntax to 1.7

The syntax was pinned for 1.7 in f696e0d2a7203c20e96466e10584202e2d50ab02
possibly because it was not yet promoted as "latest stable" at the
time.

I don't think we need to pin to an old version, and just go with
the latest, so that we can use the latest features provided.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

