### PR TITLE
containerd: remove unleaseSnapshotsFromDeletedConfigs

### DIFF
--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -82,7 +82,7 @@ func TestRemoveByDigest(t *testing.T) {
 	assert.Assert(t, id != "")
 
 	_, err = client.ImageRemove(ctx, id, image.RemoveOptions{})
-	assert.NilError(t, err, "error reemoving %s", id)
+	assert.NilError(t, err, "error removing %s", id)
 
 	_, err = client.ImageInspect(ctx, "busybox")
 	assert.NilError(t, err, "busybox image got deleted")


### PR DESCRIPTION

Removes workaround for https://github.com/moby/buildkit/issues/3797 now
that the underlying issue is fixed.

Fixes #46858.
