### PR TITLE
Unit test the bridge driver in terms of its firewaller

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -509,7 +509,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 	}
 
 	var err error
-	d.firewaller, err = iptabler.NewIptabler(context.Background(), firewaller.Config{
+	d.firewaller, err = newFirewaller(context.Background(), firewaller.Config{
 		IPv4:               config.EnableIPTables,
 		IPv6:               config.EnableIP6Tables,
 		Hairpin:            !config.EnableUserlandProxy || config.UserlandProxyPath == "",
@@ -535,6 +535,10 @@ func (d *driver) configure(option map[string]interface{}) error {
 	d.Unlock()
 
 	return d.initStore()
+}
+
+var newFirewaller = func(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
+	return iptabler.NewIptabler(ctx, config)
 }
 
 func (d *driver) getNetwork(id string) (*bridgeNetwork, error) {

--- a/libnetwork/drivers/bridge/internal/firewaller/stub.go
+++ b/libnetwork/drivers/bridge/internal/firewaller/stub.go
@@ -1,0 +1,180 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22 && linux
+
+package firewaller
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+
+	"github.com/docker/docker/libnetwork/types"
+)
+
+// StubFirewaller implements a Firewaller for unit tests. It just tracks what it's been asked for.
+type StubFirewaller struct {
+	Config
+	Networks map[string]*StubFirewallerNetwork
+	FFD      map[IPVersion]bool // filter forward drop
+}
+
+func NewStubFirewaller(config Config) *StubFirewaller {
+	return &StubFirewaller{
+		Config: config,
+		// A real Firewaller shouldn't hold on to its own networks, the bridge driver is doing that.
+		// But, for unit tests cross-checking the driver, this is useful.
+		Networks: make(map[string]*StubFirewallerNetwork),
+		FFD:      make(map[IPVersion]bool),
+	}
+}
+
+func (fw *StubFirewaller) NewNetwork(_ context.Context, nc NetworkConfig) (Network, error) {
+	if _, ok := fw.Networks[nc.IfName]; ok {
+		return nil, fmt.Errorf("StubFirewaller: network with IfName %q already exists", nc.IfName)
+	}
+	nw := &StubFirewallerNetwork{
+		NetworkConfig: nc,
+		Endpoints:     map[stubEndpoint]struct{}{},
+		parent:        fw,
+	}
+	fw.Networks[nc.IfName] = nw
+	return nw, nil
+}
+
+func (fw *StubFirewaller) FilterForwardDrop(_ context.Context, ipv IPVersion) error {
+	fw.FFD[ipv] = true
+	return nil
+}
+
+type stubFirewallerLink struct {
+	parentIP netip.Addr
+	childIP  netip.Addr
+	ports    []types.TransportPort
+}
+
+type stubEndpoint struct {
+	addr4 netip.Addr
+	addr6 netip.Addr
+}
+
+type StubFirewallerNetwork struct {
+	NetworkConfig
+	Deleted   bool
+	Endpoints map[stubEndpoint]struct{}
+	Ports     []types.PortBinding
+	Links     []stubFirewallerLink
+
+	parent *StubFirewaller
+}
+
+func (nw *StubFirewallerNetwork) ReapplyNetworkLevelRules(_ context.Context) error {
+	return nil
+}
+
+func (nw *StubFirewallerNetwork) DelNetworkLevelRules(_ context.Context) error {
+	if _, ok := nw.parent.Networks[nw.IfName]; !ok {
+		return fmt.Errorf("StubFirewaller: DelNetworkLevelRules: network '%s' does not exist", nw.IfName)
+	}
+	// A real firewaller may not report an error if network rules are deleted without
+	// per-endpoint/port/link rules being deleted first, the bridge driver is responsible
+	// for tracking all that - and it may not be an error if, for example, the driver
+	// knows the rules have already been deleted by a firewalld reload. So, this may be
+	// wrong for some tests but, for now, cross-check the deletion.
+	if len(nw.Endpoints) != 0 {
+		return fmt.Errorf("StubFirewaller: DelNetworkLevelRules: network '%s' still has endpoints", nw.IfName)
+	}
+	if len(nw.Ports) != 0 {
+		return fmt.Errorf("StubFirewaller: DelNetworkLevelRules: network '%s' still has ports", nw.IfName)
+	}
+	if len(nw.Links) != 0 {
+		return fmt.Errorf("StubFirewaller: DelNetworkLevelRules: network '%s' still has links", nw.IfName)
+	}
+	delete(nw.parent.Networks, nw.IfName)
+	return nil
+}
+
+func (nw *StubFirewallerNetwork) AddEndpoint(_ context.Context, epIPv4, epIPv6 netip.Addr) error {
+	ep := stubEndpoint{addr4: epIPv4, addr6: epIPv6}
+	if _, ok := nw.Endpoints[ep]; ok {
+		return fmt.Errorf("StubFirewaller: AddEndpoint: %s/%s already exists", epIPv4, epIPv6)
+	}
+	nw.Endpoints[ep] = struct{}{}
+	return nil
+}
+
+func (nw *StubFirewallerNetwork) DelEndpoint(_ context.Context, epIPv4, epIPv6 netip.Addr) error {
+	ep := stubEndpoint{addr4: epIPv4, addr6: epIPv6}
+	if _, ok := nw.Endpoints[ep]; !ok {
+		return fmt.Errorf("StubFirewaller: DelEndpoint: %s/%s does not exist", epIPv4, epIPv6)
+	}
+	delete(nw.Endpoints, ep)
+	return nil
+}
+
+func (nw *StubFirewallerNetwork) AddPorts(_ context.Context, pbs []types.PortBinding) error {
+	for _, pb := range pbs {
+		if nw.PortExists(pb) {
+			return nil
+		}
+		nw.Ports = append(nw.Ports, pb.GetCopy())
+	}
+	return nil
+}
+
+func (nw *StubFirewallerNetwork) DelPorts(_ context.Context, pbs []types.PortBinding) error {
+	for _, pb := range pbs {
+		nw.Ports = slices.DeleteFunc(nw.Ports, func(p types.PortBinding) bool {
+			return p.Equal(&pb)
+		})
+	}
+	return nil
+}
+
+func (nw *StubFirewallerNetwork) AddLink(_ context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort) error {
+	if nw.LinkExists(parentIP, childIP, ports) {
+		return nil
+	}
+	nw.Links = append(nw.Links, stubFirewallerLink{
+		parentIP: parentIP,
+		childIP:  childIP,
+		ports: func() []types.TransportPort {
+			res := make([]types.TransportPort, 0, len(ports))
+			for _, p := range ports {
+				res = append(res, p.GetCopy())
+			}
+			return res
+		}(),
+	})
+	return nil
+}
+
+func (nw *StubFirewallerNetwork) DelLink(_ context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort) {
+	nw.Links = slices.DeleteFunc(nw.Links, func(l stubFirewallerLink) bool {
+		return matchLink(l, parentIP, childIP, ports)
+	})
+}
+
+func (nw *StubFirewallerNetwork) PortExists(pb types.PortBinding) bool {
+	return slices.ContainsFunc(nw.Ports, func(p types.PortBinding) bool {
+		return p.Equal(&pb)
+	})
+}
+
+func (nw *StubFirewallerNetwork) LinkExists(parentIP, childIP netip.Addr, ports []types.TransportPort) bool {
+	return slices.ContainsFunc(nw.Links, func(l stubFirewallerLink) bool {
+		return matchLink(l, parentIP, childIP, ports)
+	})
+}
+
+func matchLink(l stubFirewallerLink, parentIP, childIP netip.Addr, ports []types.TransportPort) bool {
+	if len(l.ports) != len(ports) {
+		return false
+	}
+	for i, p := range l.ports {
+		if !p.Equal(&ports[i]) {
+			return false
+		}
+	}
+	return (l.parentIP == parentIP) && (l.childIP == childIP)
+}

--- a/libnetwork/types/types.go
+++ b/libnetwork/types/types.go
@@ -117,6 +117,16 @@ func (p *PortBinding) GetCopy() PortBinding {
 	}
 }
 
+// Equal returns true if o has the same values as p, else false.
+func (p *PortBinding) Equal(o *PortBinding) bool {
+	return p.Proto == o.Proto &&
+		p.IP.Equal(o.IP) &&
+		p.Port == o.Port &&
+		p.HostIP.Equal(o.HostIP) &&
+		p.HostPort == o.HostPort &&
+		p.HostPortEnd == o.HostPortEnd
+}
+
 // String returns the PortBinding structure in the form "HostIP:HostPort:IP:Port/Proto",
 // omitting un-set fields apart from Port.
 func (p PortBinding) String() string {


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49635
- related to https://github.com/moby/moby/issues/49636

Unit test the bridge driver in terms of its Firewaller - don't inspect iptables rules, because the driver's Firewaller won't
always be an iptabler.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```
