### PR TITLE
Drop "-o com.docker.network.enable_ipv[46]" if overridden

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -318,6 +318,9 @@ func (daemon *Daemon) createNetwork(ctx context.Context, cfg *config.Config, cre
 	enableIPv4 := true
 	if create.EnableIPv4 != nil {
 		enableIPv4 = *create.EnableIPv4
+		// Make sure there's no conflicting DefaultNetworkOpts value (it'd be ignored but
+		// would look wrong in inspect output).
+		delete(networkOptions, netlabel.EnableIPv4)
 	} else if v, ok := networkOptions[netlabel.EnableIPv4]; ok {
 		var err error
 		if enableIPv4, err = strconv.ParseBool(v); err != nil {
@@ -328,6 +331,9 @@ func (daemon *Daemon) createNetwork(ctx context.Context, cfg *config.Config, cre
 	var enableIPv6 bool
 	if create.EnableIPv6 != nil {
 		enableIPv6 = *create.EnableIPv6
+		// Make sure there's no conflicting DefaultNetworkOpts value (it'd be ignored but
+		// would look wrong in inspect output).
+		delete(networkOptions, netlabel.EnableIPv6)
 	} else if v, ok := networkOptions[netlabel.EnableIPv6]; ok {
 		var err error
 		if enableIPv6, err = strconv.ParseBool(v); err != nil {


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/pull/47867 (`enable_ipv6` / `--ipv6`)
- related to https://github.com/moby/moby/pull/48271 (`enable_ipv4` / `--ipv4`)

When a network is created with `-o com.docker.network.enable_ipv4` (including via `default-network-opts` in daemon config), and EnableIPv4 is present in the API request (including when CLI option `--ipv4` is used) - the top-level API value is used and the `-o` is ignored.

But, the `-o` still shows up in `Options` in inspect output, which is confusing if the values are different.

Ditto for `enable_ipv6` and option `--ipv6`.

For example ...
```
# docker network create --ipv4=false --ipv6 b6
ea36bf0f04afc105a0a88c2bfba83cbc30967a463514f7b75d20c5046cb1ab6e
# docker network inspect b6
[
    {
        "Name": "b6",
        [...]
        "EnableIPv4": false,
        "EnableIPv6": true,
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "fd1c:c5b3:150a::/64",
                    "Gateway": "fd1c:c5b3:150a::1"
                }
            ]
        },
        [...]
        "Options": {
            "com.docker.network.enable_ipv4": "true",
            "com.docker.network.enable_ipv6": "false"
        },
        "Labels": {}
    }
]
```

Docker Desktop v4.42 sets these options in `default-network-opts`, see https://github.com/docker/cli/issues/2899#issuecomment-2829943273.

**- How I did it**

Drop the "-o" if the corresponding top-level API option is set.

**- How to verify it**

New integration test.

With the fix, the `Options` value in the example above becomes `{}`.

**- Human readable description for the release notes**
```markdown changelog
- Do not display network options `com.docker.network.enable_ipv4` or `com.docker.network.enable_ipv6` in inspect output if they have been overridden by `EnableIPv4` or `EnableIPv6` in the network create request.
```