### PR TITLE
docker exec: fail early on exec create if specified user doesn't exist

### DIFF
--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -550,3 +550,8 @@ func setupWindowsDevices(devices []containertypes.DeviceMapping) (specDevices []
 
 	return specDevices, nil
 }
+
+// getUser is a no-op on Windows.
+func getUser(c *container.Container, username string) (specs.User, error) {
+	return specs.User{}, nil
+}


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/46903

Before this patch, and error would be produced when starting the exec, but the CLI would wait for the exec to complete, timing out after 10 seconds (default). With this change, an error is returned immediately when creating the exec.

Note that "technically" this check may have some TOCTOU issues, because '/etc/passwd' and '/etc/groups' may be mutated by the container in between creating the exec and starting it.

This is very likely a corner-case, but something we can consider changing in future (either allow creating an invalid exec, and checking before starting, or checking both before create and before start).

With this patch:

```bash
printf 'FROM alpine\nRUN rm -f /etc/group' | docker build -t nogroup -
ID=$(docker run -dit nogroup)

time docker exec -u 0:root $ID echo hello
Error response from daemon: unable to find group root: no matching entries in group file

real	0m0.014s
user	0m0.010s
sys	0m0.003s

# numericc uid/gid (should not require lookup);
time docker exec -u 0:0 $ID echo hello
hello

real	0m0.059s
user	0m0.007s
sys	0m0.008s

# no user specified (should not require lookup);
time docker exec $ID echo hello
hello

real	0m0.057s
user	0m0.013s
sys	0m0.008s

docker rm -fv $ID

# container that does have a valid /etc/groups

ID=$(docker run -dit alpine)
time docker exec -u 0:root $ID echo hello
hello

real	0m0.063s
user	0m0.010s
sys	0m0.009s

# non-existing user or group
time docker exec -u 0:blabla $ID echo hello
Error response from daemon: unable to find group blabla: no matching entries in group file

real	0m0.013s
user	0m0.004s
sys	0m0.009s

docker rm -fv $ID
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker exec` waiting for 10 seconds if a non-existing user or group was specified.
```

**- A picture of a cute animal (not mandatory but encouraged)**

