### PR TITLE
Use container status values from api

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	containerpkg "github.com/docker/docker/container"
 	"github.com/moby/go-archive"
 )
 
@@ -41,7 +40,7 @@ type stateBackend interface {
 	ContainerStop(ctx context.Context, name string, options container.StopOptions) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig) (container.UpdateResponse, error)
-	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error)
 }
 
 // monitorBackend includes functions to implement to provide containers monitoring functionality.

--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
-	containerpkg "github.com/docker/docker/container"
 	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/netlabel"
@@ -337,7 +336,7 @@ func (c *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 	legacyRemovalWaitPre134 := false
 
 	// The wait condition defaults to "not-running".
-	waitCondition := containerpkg.WaitConditionNotRunning
+	waitCondition := container.WaitConditionNotRunning
 	if !legacyBehaviorPre130 {
 		if err := httputils.ParseForm(r); err != nil {
 			return err
@@ -345,11 +344,11 @@ func (c *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 		if v := r.Form.Get("condition"); v != "" {
 			switch container.WaitCondition(v) {
 			case container.WaitConditionNotRunning:
-				waitCondition = containerpkg.WaitConditionNotRunning
+				waitCondition = container.WaitConditionNotRunning
 			case container.WaitConditionNextExit:
-				waitCondition = containerpkg.WaitConditionNextExit
+				waitCondition = container.WaitConditionNextExit
 			case container.WaitConditionRemoved:
-				waitCondition = containerpkg.WaitConditionRemoved
+				waitCondition = container.WaitConditionRemoved
 				legacyRemovalWaitPre134 = versions.LessThan(version, "1.34")
 			default:
 				return errdefs.InvalidParameter(errors.Errorf("invalid condition: %q", v))

--- a/api/types/container/state.go
+++ b/api/types/container/state.go
@@ -1,0 +1,29 @@
+package container
+
+// StateStatus is used to return container wait results.
+// Implements exec.ExitCode interface.
+// This type is needed as State include a sync.Mutex field which make
+// copying it unsafe.
+type StateStatus struct {
+	exitCode int
+	err      error
+}
+
+// ExitCode returns current exitcode for the state.
+func (s StateStatus) ExitCode() int {
+	return s.exitCode
+}
+
+// Err returns current error for the state. Returns nil if the container had
+// exited on its own.
+func (s StateStatus) Err() error {
+	return s.err
+}
+
+// NewStateStatus returns a new StateStatus with the given exit code and error.
+func NewStateStatus(exitCode int, err error) StateStatus {
+	return StateStatus{
+		exitCode: exitCode,
+		err:      err,
+	}
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
-	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/opencontainers/go-digest"
@@ -66,7 +65,7 @@ type ExecBackend interface {
 	// ContainerStart starts a new container
 	ContainerStart(ctx context.Context, containerID string, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.
-	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error)
 }
 
 // Result is the output produced by a Builder

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
-	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
@@ -85,7 +84,7 @@ func (c *containerManager) Run(ctx context.Context, cID string, stdout, stderr i
 		return err
 	}
 
-	waitC, err := c.backend.ContainerWait(ctx, cID, containerpkg.WaitConditionNotRunning)
+	waitC, err := c.backend.ContainerWait(ctx, cID, container.WaitConditionNotRunning)
 	if err != nil {
 		close(finished)
 		logCancellationError(cancelErrCh, fmt.Sprintf("unable to begin ContainerWait: %s", err))

--- a/builder/dockerfile/mockbackend_test.go
+++ b/builder/dockerfile/mockbackend_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
-	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/opencontainers/go-digest"
@@ -50,7 +49,7 @@ func (m *MockBackend) ContainerStart(ctx context.Context, containerID string, ch
 	return nil
 }
 
-func (m *MockBackend) ContainerWait(ctx context.Context, containerID string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error) {
+func (m *MockBackend) ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.StateStatus, error) {
 	return nil, nil
 }
 

--- a/container/state_test.go
+++ b/container/state_test.go
@@ -43,7 +43,7 @@ func TestStateRunStop(t *testing.T) {
 	// within 200 milliseconds.
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	removalWait := s.Wait(ctx, WaitConditionRemoved)
+	removalWait := s.Wait(ctx, container.WaitConditionRemoved)
 
 	// Full lifecycle two times.
 	for i := 1; i <= 2; i++ {
@@ -55,7 +55,7 @@ func TestStateRunStop(t *testing.T) {
 		defer cancel()
 		// Expectx exit code to be i-1 since it should be the exit
 		// code from the previous loop or 0 for the created state.
-		if status := <-s.Wait(ctx, WaitConditionNotRunning); status.ExitCode() != i-1 {
+		if status := <-s.Wait(ctx, container.WaitConditionNotRunning); status.ExitCode() != i-1 {
 			t.Fatalf("ExitCode %v, expected %v, err %q", status.ExitCode(), i-1, status.Err())
 		}
 
@@ -64,7 +64,7 @@ func TestStateRunStop(t *testing.T) {
 		// than 100 milliseconds.
 		ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		initialWait := s.Wait(ctx, WaitConditionNextExit)
+		initialWait := s.Wait(ctx, container.WaitConditionNextExit)
 
 		// Set the state to "Running".
 		s.Lock()
@@ -87,7 +87,7 @@ func TestStateRunStop(t *testing.T) {
 		// more than 100 milliseconds.
 		ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		exitWait := s.Wait(ctx, WaitConditionNotRunning)
+		exitWait := s.Wait(ctx, container.WaitConditionNotRunning)
 
 		// Set the state to "Exited".
 		s.Lock()
@@ -139,7 +139,7 @@ func TestStateTimeoutWait(t *testing.T) {
 	// Start a wait with a timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	waitC := s.Wait(ctx, WaitConditionNotRunning)
+	waitC := s.Wait(ctx, container.WaitConditionNotRunning)
 
 	// It should timeout *before* this 200ms timer does.
 	select {
@@ -164,7 +164,7 @@ func TestStateTimeoutWait(t *testing.T) {
 	// immediately.
 	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	waitC = s.Wait(ctx, WaitConditionNotRunning)
+	waitC = s.Wait(ctx, container.WaitConditionNotRunning)
 
 	select {
 	case <-time.After(200 * time.Millisecond):
@@ -185,7 +185,7 @@ func TestCorrectStateWaitResultAfterRestart(t *testing.T) {
 	s.SetRunning(nil, nil, time.Now())
 	s.Unlock()
 
-	waitC := s.Wait(context.Background(), WaitConditionNotRunning)
+	waitC := s.Wait(context.Background(), container.WaitConditionNotRunning)
 	want := ExitStatus{ExitCode: 10, ExitedAt: time.Now()}
 
 	s.Lock()
@@ -197,8 +197,8 @@ func TestCorrectStateWaitResultAfterRestart(t *testing.T) {
 	s.Unlock()
 
 	got := <-waitC
-	if got.exitCode != want.ExitCode {
-		t.Fatalf("expected exit code %v, got %v", want.ExitCode, got.exitCode)
+	if got.ExitCode() != want.ExitCode {
+		t.Fatalf("expected exit code %v, got %v", want.ExitCode, got.ExitCode())
 	}
 }
 

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/backend"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/container/stream"
@@ -191,7 +192,7 @@ func (daemon *Daemon) containerAttach(ctr *container.Container, cfg *stream.Atta
 
 	if ctr.Config.StdinOnce && !ctr.Config.Tty {
 		// Wait for the container to stop before returning.
-		waitChan := ctr.Wait(context.Background(), container.WaitConditionNotRunning)
+		waitChan := ctr.Wait(context.Background(), containertypes.WaitConditionNotRunning)
 		defer func() {
 			<-waitChan // Ignore returned exit code.
 		}()

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/api/types/volume"
-	containerpkg "github.com/docker/docker/container"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
 	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/image"
@@ -45,7 +44,7 @@ type Backend interface {
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
 	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (*container.InspectResponse, error)
-	ContainerWait(ctx context.Context, name string, condition containerpkg.WaitCondition) (<-chan containerpkg.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error)
 	ContainerRm(name string, config *backend.ContainerRmConfig) error
 	ContainerKill(name string, sig string) error
 	SetContainerDependencyStore(name string, store exec.DependencyGetter) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
@@ -416,8 +415,8 @@ func (c *containerAdapter) events(ctx context.Context) <-chan events.Message {
 	return eventsq
 }
 
-func (c *containerAdapter) wait(ctx context.Context) (<-chan container.StateStatus, error) {
-	return c.backend.ContainerWait(ctx, c.container.nameOrID(), container.WaitConditionNotRunning)
+func (c *containerAdapter) wait(ctx context.Context) (<-chan containertypes.StateStatus, error) {
+	return c.backend.ContainerWait(ctx, c.container.nameOrID(), containertypes.WaitConditionNotRunning)
 }
 
 func (c *containerAdapter) shutdown(ctx context.Context) error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1224,7 +1224,7 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 
 	// Wait without timeout for the container to exit.
 	// Ignore the result.
-	<-c.Wait(ctx, container.WaitConditionNotRunning)
+	<-c.Wait(ctx, containertypes.WaitConditionNotRunning)
 	return nil
 }
 

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	containerpkg "github.com/docker/docker/container"
 	"github.com/docker/docker/errdefs"
@@ -122,7 +123,7 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 				// But this prevents race conditions in processing the container.
 				ctx, cancel := context.WithTimeout(context.TODO(), time.Duration(container.StopTimeout())*time.Second)
 				defer cancel()
-				s := <-container.Wait(ctx, containerpkg.WaitConditionNotRunning)
+				s := <-container.Wait(ctx, containertypes.WaitConditionNotRunning)
 				if s.Err() != nil {
 					if err := daemon.handleContainerExit(container, nil); err != nil {
 						log.G(context.TODO()).WithFields(log.Fields{
@@ -177,7 +178,7 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
 	defer cancel()
 
-	status := <-container.Wait(ctx, containerpkg.WaitConditionNotRunning)
+	status := <-container.Wait(ctx, containertypes.WaitConditionNotRunning)
 	if status.Err() == nil {
 		return nil
 	}
@@ -195,7 +196,7 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel2()
 
-	if status := <-container.Wait(ctx2, containerpkg.WaitConditionNotRunning); status.Err() != nil {
+	if status := <-container.Wait(ctx2, containertypes.WaitConditionNotRunning); status.Err() != nil {
 		return errors.New("tried to kill container, but did not receive an exit event")
 	}
 	return nil

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -92,7 +92,7 @@ func (daemon *Daemon) containerStop(ctx context.Context, ctr *container.Containe
 	}
 	defer cancel()
 
-	if status := <-ctr.Wait(subCtx, container.WaitConditionNotRunning); status.Err() == nil {
+	if status := <-ctr.Wait(subCtx, containertypes.WaitConditionNotRunning); status.Err() == nil {
 		// container did exit, so ignore any previous errors and return
 		return nil
 	}
@@ -114,7 +114,7 @@ func (daemon *Daemon) containerStop(ctx context.Context, ctr *container.Containe
 		// got a kill error, but give container 2 more seconds to exit just in case
 		subCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		status := <-ctr.Wait(subCtx, container.WaitConditionNotRunning)
+		status := <-ctr.Wait(subCtx, containertypes.WaitConditionNotRunning)
 		if status.Err() != nil {
 			log.G(ctx).WithError(err).WithField("container", ctr.ID).Errorf("error killing container: %v", status.Err())
 			return err

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -3,7 +3,7 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 
-	"github.com/docker/docker/container"
+	containertypes "github.com/docker/docker/api/types/container"
 )
 
 // ContainerWait waits until the given container is in a certain state
@@ -13,7 +13,7 @@ import (
 // condition is met or if an error occurs waiting for the container (such as a
 // context timeout or cancellation). On a successful wait, the exit code of the
 // container is returned in the status with a non-nil Err() value.
-func (daemon *Daemon) ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error) {
+func (daemon *Daemon) ContainerWait(ctx context.Context, name string, condition containertypes.WaitCondition) (<-chan containertypes.StateStatus, error) {
 	cntr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Alias and deprecate the status types and constants from the root container package. The root container package is intended for use within the daemon and no the api package.

This is a part of separating the dependency of api to non-api packages.

- Related to https://github.com/moby/moby/issues/49873

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: container: deprecate `StateStatus`, `WaitCondition`, and the related  `WaitConditionNotRunning`, `WaitConditionNextExit`, and `WaitConditionRemoved` consts in favor of their equivalents in `api/types/container`.
```
