### PR TITLE
volume/*: use Go's native t.TempDir() in tests

### DIFF
--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -49,11 +49,7 @@ func TestGetPassword(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "FIXME: investigate why this test fails on CI")
-	rootDir, err := os.MkdirTemp("", "local-volume-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	r, err := New(rootDir, idtools.Identity{UID: os.Geteuid(), GID: os.Getegid()})
 	if err != nil {
@@ -91,11 +87,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestInitializeWithVolumes(t *testing.T) {
-	rootDir, err := os.MkdirTemp("", "local-volume-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	r, err := New(rootDir, idtools.Identity{UID: os.Geteuid(), GID: os.Getegid()})
 	if err != nil {
@@ -123,11 +115,7 @@ func TestInitializeWithVolumes(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	rootDir, err := os.MkdirTemp("", "local-volume-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	r, err := New(rootDir, idtools.Identity{UID: os.Geteuid(), GID: os.Getegid()})
 	if err != nil {
@@ -197,11 +185,7 @@ func TestValidateName(t *testing.T) {
 func TestCreateWithOpts(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows")
 	skip.If(t, os.Getuid() != 0, "requires mounts")
-	rootDir, err := os.MkdirTemp("", "local-volume-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	r, err := New(rootDir, idtools.Identity{UID: os.Geteuid(), GID: os.Getegid()})
 	if err != nil {
@@ -294,11 +278,7 @@ func TestCreateWithOpts(t *testing.T) {
 }
 
 func TestReloadNoOpts(t *testing.T) {
-	rootDir, err := os.MkdirTemp("", "volume-test-reload-no-opts")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	r, err := New(rootDir, idtools.Identity{UID: os.Geteuid(), GID: os.Getegid()})
 	if err != nil {

--- a/volume/mounts/parser_test.go
+++ b/volume/mounts/parser_test.go
@@ -43,11 +43,7 @@ func (m mockFiProviderWithError) fileInfo(path string) (bool, bool, error) {
 }
 
 func TestParseMountSpec(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "test-mount-config")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 	parser := NewParser()
 	tests := []struct {
 		input    mount.Mount

--- a/volume/service/db_test.go
+++ b/volume/service/db_test.go
@@ -1,7 +1,6 @@
 package service // import "github.com/docker/docker/volume/service"
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,11 +12,8 @@ import (
 func TestSetGetMeta(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "test-set-get")
-	assert.NilError(t, err)
-	defer os.RemoveAll(dir)
-
-	db, err := bolt.Open(filepath.Join(dir, "db"), 0o600, &bolt.Options{Timeout: 1 * time.Second})
+	tmpDir := t.TempDir()
+	db, err := bolt.Open(filepath.Join(tmpDir, "db"), 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	assert.NilError(t, err)
 
 	store := &VolumeStore{db: db}

--- a/volume/service/restore_test.go
+++ b/volume/service/restore_test.go
@@ -2,7 +2,6 @@ package service // import "github.com/docker/docker/volume/service"
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/docker/docker/volume"
@@ -15,9 +14,7 @@ import (
 func TestRestore(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", "test-restore")
-	assert.NilError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	drivers := volumedrivers.NewStore(nil)
 	driverName := "test-restore"

--- a/volume/service/service.go
+++ b/volume/service/service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type ds interface {
+type driverLister interface {
 	GetDriverList() []string
 }
 
@@ -34,7 +34,7 @@ type VolumeEventLogger interface {
 // This is used as the main access point for volumes to higher level services and the API.
 type VolumesService struct {
 	vs           *VolumeStore
-	ds           ds
+	ds           driverLister
 	pruneRunning atomic.Bool
 	eventLogger  VolumeEventLogger
 }

--- a/volume/service/service_linux_test.go
+++ b/volume/service/service_linux_test.go
@@ -19,13 +19,11 @@ import (
 func TestLocalVolumeSize(t *testing.T) {
 	t.Parallel()
 
-	ds := volumedrivers.NewStore(nil)
-	dir, err := os.MkdirTemp("", t.Name())
+	tmpDir := t.TempDir()
+	l, err := local.New(tmpDir, idtools.Identity{UID: os.Getuid(), GID: os.Getegid()})
 	assert.NilError(t, err)
-	defer os.RemoveAll(dir)
 
-	l, err := local.New(dir, idtools.Identity{UID: os.Getuid(), GID: os.Getegid()})
-	assert.NilError(t, err)
+	ds := volumedrivers.NewStore(nil)
 	assert.Assert(t, ds.Register(l, volume.DefaultDriverName))
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("fake"), "fake"))
 

--- a/volume/service/service_test.go
+++ b/volume/service/service_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/docker/docker/api/types/events"
@@ -235,15 +234,13 @@ func TestServicePrune(t *testing.T) {
 func newTestService(t *testing.T, ds *volumedrivers.Store) (*VolumesService, func()) {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", t.Name())
-	assert.NilError(t, err)
+	dir := t.TempDir()
 
 	store, err := NewStore(dir, ds)
 	assert.NilError(t, err)
 	s := &VolumesService{vs: store, eventLogger: dummyEventLogger{}}
 	return s, func() {
 		assert.Check(t, s.Shutdown())
-		assert.Check(t, os.RemoveAll(dir))
 	}
 }
 


### PR DESCRIPTION
- part of https://github.com/moby/moby/pull/43346