### PR TITLE
Update image backend api to not use non-api types

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -12,8 +12,9 @@ import (
 	"github.com/docker/docker/builder"
 	buildkit "github.com/docker/docker/builder/builder-next"
 	daemonevents "github.com/docker/docker/daemon/events"
-	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -21,7 +22,7 @@ import (
 // ImageComponent provides an interface for working with images
 type ImageComponent interface {
 	SquashImage(from string, to string) (string, error)
-	TagImage(context.Context, image.ID, reference.Named) error
+	TagImage(context.Context, ocispec.Descriptor, reference.Named) error
 }
 
 // Builder defines interface for running a build
@@ -91,7 +92,11 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 	if imageID != "" && !useBuildKit {
 		stdout := config.ProgressWriter.StdoutFormatter
 		_, _ = fmt.Fprintf(stdout, "Successfully built %s\n", stringid.TruncateID(imageID))
-		err = tagImages(ctx, b.imageComponent, config.ProgressWriter.StdoutFormatter, image.ID(imageID), tags)
+		desc := ocispec.Descriptor{
+			Digest: digest.FromString(imageID),
+			//
+		}
+		err = tagImages(ctx, b.imageComponent, config.ProgressWriter.StdoutFormatter, desc, tags)
 	}
 	return imageID, err
 }

--- a/api/server/backend/build/tag.go
+++ b/api/server/backend/build/tag.go
@@ -6,14 +6,14 @@ import (
 	"io"
 
 	"github.com/distribution/reference"
-	"github.com/docker/docker/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
 // tagImages creates image tags for the imageID.
-func tagImages(ctx context.Context, ic ImageComponent, stdout io.Writer, imageID image.ID, repoAndTags []reference.Named) error {
+func tagImages(ctx context.Context, ic ImageComponent, stdout io.Writer, img ocispec.Descriptor, repoAndTags []reference.Named) error {
 	for _, rt := range repoAndTags {
-		if err := ic.TagImage(ctx, imageID, rt); err != nil {
+		if err := ic.TagImage(ctx, img, rt); err != nil {
 			return err
 		}
 		_, _ = fmt.Fprintln(stdout, "Successfully tagged", reference.FamiliarString(rt))

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/registry"
-	dockerimage "github.com/docker/docker/image"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -25,15 +24,15 @@ type imageBackend interface {
 	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]image.DeleteResponse, error)
 	ImageHistory(ctx context.Context, imageName string, platform *ocispec.Platform) ([]*image.HistoryResponseItem, error)
 	Images(ctx context.Context, opts image.ListOptions) ([]*image.Summary, error)
-	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*dockerimage.Image, error)
+	ResolveDescriptor(ctx context.Context, refOrID string, options backend.GetImageOpts) (ocispec.Descriptor, error)
 	ImageInspect(ctx context.Context, refOrID string, options backend.ImageInspectOpts) (*image.InspectResponse, error)
-	TagImage(ctx context.Context, id dockerimage.ID, newRef reference.Named) error
+	TagImage(ctx context.Context, desc ocispec.Descriptor, newRef reference.Named) error
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*image.PruneReport, error)
 }
 
 type importExportBackend interface {
 	LoadImage(ctx context.Context, inTar io.ReadCloser, platform *ocispec.Platform, outStream io.Writer, quiet bool) error
-	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (dockerimage.ID, error)
+	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (ocispec.Descriptor, error)
 	ExportImage(ctx context.Context, names []string, platform *ocispec.Platform, outStream io.Writer) error
 }
 

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/builder/dockerfile"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/metrics"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -173,10 +174,13 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 	if err != nil {
 		return "", err
 	}
+	img := ocispec.Descriptor{
+		Digest: id.Digest(),
+	}
 
 	imageRef := ""
 	if c.Tag != nil {
-		err = daemon.imageService.TagImage(ctx, id, c.Tag)
+		err = daemon.imageService.TagImage(ctx, img, c.Tag)
 		if err != nil {
 			return "", err
 		}

--- a/daemon/containerd/cache.go
+++ b/daemon/containerd/cache.go
@@ -137,7 +137,7 @@ func (c cacheAdaptor) SetParent(target, parent image.ID) error {
 
 func (c cacheAdaptor) GetParent(target image.ID) (image.ID, error) {
 	ctx := context.TODO()
-	value, err := c.is.getImageLabelByDigest(ctx, target.Digest(), imageLabelClassicBuilderParent)
+	value, err := c.is.getImageLabelByDigest(ctx, digest.Digest(target), imageLabelClassicBuilderParent)
 	if err != nil {
 		return "", fmt.Errorf("failed to read parent image: %w", err)
 	}
@@ -180,7 +180,7 @@ func (c cacheAdaptor) Create(parent *image.Image, target image.Image, extraLayer
 
 func (c cacheAdaptor) IsBuiltLocally(target image.ID) (bool, error) {
 	ctx := context.TODO()
-	value, err := c.is.getImageLabelByDigest(ctx, target.Digest(), imageLabelClassicBuilderContainerConfig)
+	value, err := c.is.getImageLabelByDigest(ctx, digest.Digest(target), imageLabelClassicBuilderContainerConfig)
 	if err != nil {
 		return false, fmt.Errorf("failed to read container config label: %w", err)
 	}

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -112,6 +112,10 @@ func (i *ImageService) getBestPresentImageManifest(ctx context.Context, img c8di
 	return best, nil
 }
 
+func (i *ImageService) ResolveDescriptor(ctx context.Context, refOrID string, options backend.GetImageOpts) (ocispec.Descriptor, error) {
+	return i.resolveDescriptor(ctx, refOrID)
+}
+
 // resolveDescriptor searches for a descriptor based on the given
 // reference or identifier. Returns the descriptor of
 // the image, which could be a manifest list, manifest, or config.

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -166,7 +166,7 @@ func filterImagesUsedByContainers(ctx context.Context,
 	// Exclude images used by existing containers
 	for _, ctr := range allContainers {
 		// If the original image was force deleted, make sure we don't delete the dangling image
-		delete(imagesToPrune, danglingImageName(ctr.ImageID.Digest()))
+		delete(imagesToPrune, danglingImageName(digest.Digest(ctr.ImageID)))
 
 		// Config.Image is the image reference passed by user.
 		// Config.ImageID is the resolved content digest based on the user's Config.Image.

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -36,9 +36,12 @@ type ImageService interface {
 	LogImageEvent(ctx context.Context, imageID, refName string, action events.Action)
 	CountImages(ctx context.Context) int
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*imagetype.PruneReport, error)
-	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
-	TagImage(ctx context.Context, imageID image.ID, newTag reference.Named) error
+	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (ocispec.Descriptor, error)
+	TagImage(ctx context.Context, img ocispec.Descriptor, newTag reference.Named) error
+	// TODO: Change this to resolve an image?
+	// TODO: Separate interface for loading details?
 	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*image.Image, error)
+	ResolveDescriptor(ctx context.Context, refOrID string, options backend.GetImageOpts) (ocispec.Descriptor, error)
 	ImageHistory(ctx context.Context, name string, platform *ocispec.Platform) ([]*imagetype.HistoryResponseItem, error)
 	CommitImage(ctx context.Context, c backend.CommitConfig) (image.ID, error)
 	SquashImage(id, parent string) (string, error)

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -232,6 +232,18 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 	return nil, ErrImageDoesNotExist{Ref: ref}
 }
 
+func (i *ImageService) ResolveDescriptor(ctx context.Context, refOrID string, options backend.GetImageOpts) (ocispec.Descriptor, error) {
+	img, err := i.GetImage(ctx, refOrID, options)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return ocispec.Descriptor{
+		MediaType: c8dimages.MediaTypeDockerSchema2Config,
+		Digest:    img.ID().Digest(),
+		Size:      int64(len(img.RawJSON())),
+	}, nil
+}
+
 // OnlyPlatformWithFallback uses `platforms.Only` with a fallback to handle the case where the platform
 // being matched does not have a CPU variant.
 //

--- a/daemon/images/image_tag.go
+++ b/daemon/images/image_tag.go
@@ -6,17 +6,18 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/image"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // TagImage adds the given reference to the image ID provided.
-func (i *ImageService) TagImage(ctx context.Context, imageID image.ID, newTag reference.Named) error {
-	if err := i.referenceStore.AddTag(newTag, imageID.Digest(), true); err != nil {
+func (i *ImageService) TagImage(ctx context.Context, img ocispec.Descriptor, newTag reference.Named) error {
+	if err := i.referenceStore.AddTag(newTag, img.Digest, true); err != nil {
 		return err
 	}
 
-	if err := i.imageStore.SetLastUpdated(imageID); err != nil {
+	if err := i.imageStore.SetLastUpdated(image.ID(img.Digest)); err != nil {
 		return err
 	}
-	i.LogImageEvent(ctx, imageID.String(), reference.FamiliarString(newTag), events.ActionTag)
+	i.LogImageEvent(ctx, img.Digest.String(), reference.FamiliarString(newTag), events.ActionTag)
 	return nil
 }


### PR DESCRIPTION
Replace use of non-api image ID with oci descriptor. This more closely aligns with the containerd backend. Additionally, this is necessary to isolate the api package from non-api packages.

Related to #49873 