### PR TITLE
run/pull: Warn/reject AI model images

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -3,6 +3,7 @@ package containerd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/leases"
@@ -102,6 +103,15 @@ func (i *ImageService) getImageSnapshot(ctx context.Context, descriptor *ocispec
 	platformImg, err := i.NewImageManifest(ctx, c8dImg, c8dImg.Target)
 	if err != nil {
 		return "", err
+	}
+
+	cfgDesc, err := platformImg.Config(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.HasPrefix(strings.ToLower(cfgDesc.MediaType), "application/vnd.docker.ai.") {
+		return "", errors.New("Running AI models directly by the Engine is not supported yet, please use 'docker model run' instead")
 	}
 
 	unpacked, err := platformImg.IsUnpacked(ctx, i.snapshotter)

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -203,6 +203,14 @@ func retryOnError(err error) error {
 	return err
 }
 
+type AIModelNotSupportedError struct{}
+
+func (e AIModelNotSupportedError) Error() string {
+	return `AI models are not yet supported by the Engine, please use "docker model pull/run" instead`
+}
+
+func (e AIModelNotSupportedError) InvalidParameter() {}
+
 type invalidManifestClassError struct {
 	mediaType string
 	class     string

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -498,6 +498,9 @@ func (p *puller) validateMediaType(mediaType string) error {
 
 func checkSupportedMediaType(mediaType string) error {
 	lowerMt := strings.ToLower(mediaType)
+	if strings.HasPrefix(lowerMt, "application/vnd.docker.ai.") {
+		return AIModelNotSupportedError{}
+	}
 	for _, mt := range supportedMediaTypes {
 		// The should either be an exact match, or have a valid prefix
 		// we append a "." when matching prefixes to exclude "false positives";


### PR DESCRIPTION
Add checks in both containerd-based and distribution-based image pull
code paths to detect and AI model images early in the pull process.

These are not yet supported directly by the Engine and need to be
handled by the `docker model` CLI plugin.

For distribution-based pull, reject the AI models pulls.

For containerd image service only emit a warning.
    

```bash
$ docker run ai/gemma3
Unable to find image 'ai/gemma3:latest' locally
latest: Pulling from ai/gemma3
WARNING: AI models are not supported by the Engine yet, did you mean to use docker model pull/run instead?
09b370de51ad: Downloading [>                                                  ]  26.21MB/2.49GB
a4b03d96571f: Already exists 
22273fd2f4e6: Already exists 
```
    