### PR TITLE
Force LF line feeds for certain files under Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,20 @@
-Dockerfile* linguist-language=Dockerfile
+# Source: https://stackoverflow.com/a/10855862/14731
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Exceptional cases that do not use the standard extensions. Must be listed before the generic rules that follow.
+/hack/** text eol=lf
+/integration-cli/fixtures/auth/docker-credential-shell-test
+
+Dockerfile* linguist-language=Dockerfile eol=lf
 vendor.mod linguist-language=Go-Module
 vendor.sum linguist-language=Go-Checksums
+
+*.go -text diff=golang
+
+*.sh text eol=lf
+*.bash text eol=lf
+*.ps1 text eol=crlf
+
+# init scripts
+/contrib/init/** eol=lf


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added LF line feed configuration for `*.sh` and `Dockerfile*` files.

**- How I did it**
Updated .gitattributes

**- How to verify it**
Clone the repository on Windows and try running `make` within WSL

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

