### PR TITLE
config: set buildkit gc enabled to default to true

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -444,7 +444,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 func getGCPolicy(conf config.BuilderConfig, root string) ([]client.PruneInfo, error) {
 	var gcPolicy []client.PruneInfo
-	if conf.GC.Enabled {
+	if conf.GC.IsEnabled() {
 		if conf.GC.Policy == nil {
 			reservedSpace, maxUsedSpace, minFreeSpace, err := parseGCPolicy(config.BuilderGCRule{
 				ReservedSpace: conf.GC.DefaultReservedSpace,

--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -84,11 +84,15 @@ func (x *BuilderGCFilter) UnmarshalJSON(data []byte) error {
 
 // BuilderGCConfig contains GC config for a buildkit builder
 type BuilderGCConfig struct {
-	Enabled              bool            `json:",omitempty"`
+	Enabled              *bool           `json:",omitempty"`
 	Policy               []BuilderGCRule `json:",omitempty"`
 	DefaultReservedSpace string          `json:",omitempty"`
 	DefaultMaxUsedSpace  string          `json:",omitempty"`
 	DefaultMinFreeSpace  string          `json:",omitempty"`
+}
+
+func (x *BuilderGCConfig) IsEnabled() bool {
+	return x.Enabled == nil || *x.Enabled
 }
 
 func (x *BuilderGCConfig) UnmarshalJSON(data []byte) error {
@@ -103,11 +107,14 @@ func (x *BuilderGCConfig) UnmarshalJSON(data []byte) error {
 		DefaultKeepStorage string `json:",omitempty"`
 	}
 
+	// Set defaults.
+	xx.Enabled = true
+
 	if err := json.Unmarshal(data, &xx); err != nil {
 		return err
 	}
 
-	x.Enabled = xx.Enabled
+	x.Enabled = &xx.Enabled
 	x.Policy = xx.Policy
 	x.DefaultReservedSpace = xx.DefaultReservedSpace
 	x.DefaultMaxUsedSpace = xx.DefaultMaxUsedSpace


### PR DESCRIPTION
This will use the default settings for buildkit gc unless explicitly
disabled by setting `enabled: false` in the gc configuration.

Fixes #49826.

```markdown changelog
containerd image store: Enable BuildKit garbage collector by default.
```
