### PR TITLE
Active endpoints error error

### DIFF
--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1048,9 +1048,11 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 	eps := c.findEndpoints(filterEndpointByNetworkId(n.id))
 	if !force && len(eps) > emptyCount {
 		return &ActiveEndpointsError{
-			name:      n.name,
-			id:        n.id,
-			endpoints: sliceutil.Map(eps, func(ep *Endpoint) string { return ep.name }),
+			name: n.name,
+			id:   n.id,
+			endpoints: sliceutil.Map(eps, func(ep *Endpoint) string {
+				return fmt.Sprintf(`name:"%s" id:"%s"`, ep.name, stringid.TruncateID(ep.id))
+			}),
 		}
 	}
 


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/49887
  - introduced by https://github.com/moby/moby/pull/49736
  - related to https://github.com/moby/moby/commit/c8a66f5e72d085d0f3550f70adde82ad3e9121b0
- fix https://github.com/moby/moby/issues/49888
  - introduced by https://github.com/moby/moby/pull/49773

When a `Sandbox` is restored on startup (either to be used, because live-restore is enabled, or to clean up a container that was left running on shutdown) ... if the `Network` or `Endpoint` objects can't be loaded from store, stub objects are created.

If the `Sandbox` is being live-restored, the stub `Endpoint` is then just discarded. Otherwise, the `Endpoint` is added to the `Sandbox` then `sb.delete` is called to do the cleanup.

`sb.delete` calls `Endpoint.Delete` on each `Endpoint` - and `Endpoint.Delete` does nothing if it can't load both `Network` and `Endpoint` from the disk store.

So, either way, the stub `Network`/`Endpoint` objects end up having no effect.

https://github.com/moby/moby/issues/49887 added in-memory caches of `Network` and `Endpoint` objects. The caches are populated whenever those objects are read from or written to the on-disk store - but most readers don't use the cached objects (yet), they just load a new copy of the object from the disk store and use that.

That change added the stub objects to the in-memory cache - but they were never deleted from cache... if live-restore, they'd just be orphaned (the Endpoint wasn't added to the Sandbox). It not-live-restore, `Endpoint.Delete` returned early, before removing the cached `Endpoint` object so, again, the stub objects were orphaned.

That caused a problem for the one of the only uses (so far) of the in-memory caches, replacing the stored Endpoint Count  for a network with a search of the cache. The orphaned stub Endpoints referred to the network, so network deletion would fail with `ActiveEndpointsError`. I've not been able to reproduce the problem reported in https://github.com/moby/moby/issues/49887, so don't have logs to prove it and none have been provided on the issue yet... but the error message has an empty Endpoint name, so it looks very much like the endpoints are stub objects.

If all that theorising is correct ...
- it's a regression, it's no longer possible to delete a network after restore on startup has failed to read load an Endpoint from the store - and that's fixable.
- but, the root cause, a stored Sandbox having a reference to an Endpoint that isn't stored is a separate issue.
  - I guess it'll have been caused by the issue the in-memory caches should eventually resolve... multiple copies of the same object in memory, racing/trampling each other to the store. Although a race like that is detected, it's handled by just [forcing a write to store anyway](https://github.com/moby/moby/blob/d377cd3810bf6e7a328371402a23ab76043a37a5/libnetwork/sandbox_store.go#L134).

**- How I did it**


#### Report endpoint id as well as name in ActiveEndpointsError

When a network genuinely has active endpoints, the new error looks like this ...
```
# docker network rm nnn
Error response from daemon: error while removing network: network nnn has active endpoints (name:"romantic_cerf" id:"6e6ce97cc986", name:"charming_rubin" id:"2f704afa034c")
```

#### Improve logging and readability of Controller.sandboxRestore

- Use structured logging.
  - Which means ids are logged consistently.
- Use variable 'isRestore' instead of extra map lookups.

#### Don't add stub Endpoint/Network object to cache on Sandbox restore

The stub objects were introduced by https://github.com/moby/moby/commit/c8a66f5e72d085d0f3550f70adde82ad3e9121b0 - I don't think that logic applies any more, and ...
- a stub `Network` that doesn't know which network driver it should have isn't going to be able to get involved in much cleanup, I think it was just a way to load an `Endpoint` object.
- a stub `Endpoint` can't clean up anything like addresses/dns-entries etc, because it doesn't know what they are. But, that's ok because those things couldn't have been restored to internal structures anyway.
- worst-case, an Endpoint object that couldn't be loaded because of a missing `Network` gets leaked in the disk-store (but, quite likely, it's not there anyway!).

So, removed them.

**- How to verify it**

Tricky - no repro, and I can't add a unit test for deleted code.

**- Human readable description for the release notes**
```markdown changelog
Fix an issue that could cause network deletion to fail after a daemon restart, with error "has active endpoints" listing empty endpoint names.
```
