### PR TITLE
Remove unused reference store in image api

### DIFF
--- a/api/server/router/image/image.go
+++ b/api/server/router/image/image.go
@@ -2,23 +2,20 @@ package image // import "github.com/docker/docker/api/server/router/image"
 
 import (
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/reference"
 )
 
 // imageRouter is a router to talk with the image controller
 type imageRouter struct {
-	backend          Backend
-	searcher         Searcher
-	referenceBackend reference.Store
-	routes           []router.Route
+	backend  Backend
+	searcher Searcher
+	routes   []router.Route
 }
 
 // NewRouter initializes a new image router
-func NewRouter(backend Backend, searcher Searcher, referenceBackend reference.Store) router.Router {
+func NewRouter(backend Backend, searcher Searcher) router.Router {
 	ir := &imageRouter{
-		backend:          backend,
-		searcher:         searcher,
-		referenceBackend: referenceBackend,
+		backend:  backend,
+		searcher: searcher,
 	}
 	ir.initRoutes()
 	return ir

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -713,7 +713,6 @@ func buildRouters(opts routerOptions) []router.Router {
 		image.NewRouter(
 			opts.daemon.ImageService(),
 			opts.daemon.RegistryService(),
-			opts.daemon.ReferenceStore,
 		),
 		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.builder.buildkit, opts.daemon.Features),
 		volume.NewRouter(opts.daemon.VolumesService(), opts.cluster),


### PR DESCRIPTION
The image api already defines the backend used and does not directly use the reference store backend. It also should not directly use the reference store backend.

Related to #49873