### PR TITLE
Create api interface to define build usage backend

### DIFF
--- a/api/server/router/system/backend.go
+++ b/api/server/router/system/backend.go
@@ -41,6 +41,11 @@ type ClusterBackend interface {
 	Info(context.Context) swarm.Info
 }
 
+// BuildBackend provides build specific system information.
+type BuildBackend interface {
+	DiskUsage(context.Context) ([]*types.BuildCache, error)
+}
+
 // StatusProvider provides methods to get the swarm status of the current node.
 type StatusProvider interface {
 	Status() string

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -6,7 +6,6 @@ package system // import "github.com/docker/docker/api/server/router/system"
 import (
 	"github.com/docker/docker/api/server/router"
 	"github.com/docker/docker/api/types/system"
-	buildkit "github.com/docker/docker/builder/builder-next"
 	"resenje.org/singleflight"
 )
 
@@ -16,7 +15,7 @@ type systemRouter struct {
 	backend  Backend
 	cluster  ClusterBackend
 	routes   []router.Route
-	builder  *buildkit.Builder
+	builder  BuildBackend
 	features func() map[string]bool
 
 	// collectSystemInfo is a single-flight for the /info endpoint,
@@ -26,7 +25,7 @@ type systemRouter struct {
 }
 
 // NewRouter initializes a new system router
-func NewRouter(b Backend, c ClusterBackend, builder *buildkit.Builder, features func() map[string]bool) router.Router {
+func NewRouter(b Backend, c ClusterBackend, builder BuildBackend, features func() map[string]bool) router.Router {
 	r := &systemRouter{
 		backend:  b,
 		cluster:  c,


### PR DESCRIPTION
Avoid importing buildkit builder into api package when only a single backend function is needed.

Related to #49873
