### PR TITLE
Optimization methods in internal\metrics\metrics.go

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -91,29 +91,33 @@ func (ctr *StateCounter) Get() (running int, paused int, stopped int) {
 	ctr.mu.RLock()
 	defer ctr.mu.RUnlock()
 
-	states := map[string]int{
-		"running": 0,
-		"paused":  0,
-		"stopped": 0,
-	}
 	for _, state := range ctr.states {
-		states[state]++
+		switch state {
+		case "running":
+			running++
+		case "paused":
+			paused++
+		case "stopped":
+			stopped++
+		}
 	}
-	return states["running"], states["paused"], states["stopped"]
+	return running, paused, stopped
 }
 
 // Set updates the state for a container
 func (ctr *StateCounter) Set(id, label string) {
 	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
+
 	ctr.states[id] = label
-	ctr.mu.Unlock()
 }
 
 // Delete removes a container's state
 func (ctr *StateCounter) Delete(id string) {
 	ctr.mu.Lock()
+	defer ctr.mu.Unlock()
+
 	delete(ctr.states, id)
-	ctr.mu.Unlock()
 }
 
 // Describe implements prometheus.Collector


### PR DESCRIPTION
**- What I did**

Optimized getting statistics on containers in the "internal\metrics\metrics.go"

**- How I did it**

Instead of creating a map each time, I used variable counters and incremented them.

**- How to verify it**

I tested both implementations on the same examples and got identical outputs.

Also, I benchmarked and got result:

```
BenchmarkGetWithSeparated-12    	   99218	     12068 ns/op
BenchmarkOptimized-12           	 1456731	       823.2 ns/op
```

**- Human readable description for the release notes**

Optimized the collection of statistics on containers


**- Cute animal**

![image](https://github.com/user-attachments/assets/8e2c584a-4d52-48d3-851d-ef7041ff1551)

