### PR TITLE
Add Image Pull Metrics

### DIFF
--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -23,9 +23,18 @@ import (
 
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) (rerr error) {
 	start := time.Now()
 
+	defer func() {
+		if rerr != nil {
+			metrics.ImagePulls.WithValues("failure").Inc()
+		} else {
+			metrics.ImagePulls.WithValues("success").Inc()
+		}
+	}()
+
+	metrics.ImagePullsStarted.Inc()
 	err := i.pullImageWithReference(ctx, ref, platform, metaHeaders, authConfig, outStream)
 	metrics.ImageActions.WithValues("pull").UpdateSince(start)
 	if err != nil {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+type fakeCounter struct {
+	count int
+}
+
+func (f *fakeCounter) Inc(vs ...float64) {
+	if len(vs) == 0 {
+		f.count++
+		return
+	}
+
+	for _, v := range vs {
+		f.count += int(v)
+	}
+}
+
+func TestMetricsReader(t *testing.T) {
+	// create a byte array of a known size, just filled with whatever
+	testBytes := []byte{}
+	for i := 0; i < 1234; i++ {
+		testBytes = append(testBytes, 123)
+	}
+	testReader := bytes.NewBuffer(testBytes)
+	f := &fakeCounter{}
+
+	met := MetricsReader{
+		ReadCloser: io.NopCloser(testReader),
+		Counter:    f,
+	}
+	p := make([]byte, 11)
+	read, err := met.Read(p)
+	if err != nil {
+		t.Errorf("error in read: %v", err)
+	}
+
+	count := f.count
+	if read != count {
+		t.Errorf("count read is not count recorded: %v != %v", read, count)
+	}
+
+	read, err = met.Read(p)
+	if err != nil {
+		t.Errorf("error in read: %v", err)
+	}
+
+	// get the count as the difference between the previous and current counts
+	count = f.count - count
+	if read != count {
+		t.Errorf("count read is not count recorded: %v != %v", read, count)
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added some Prometheus metrics for image pulling:

* `image_pulls_started` is a counter that increments each time an image pull operation starts
* `image_pulls` is a counter of image pulls completed, grouped by `success` or `failure`.
* `image_pull_bytes` counts the number of bytes downloaded in image pulls.

These 3 metrics allow one to derive other statistics:

* Count of pulls in progress, by taking the difference of `image_pulls_started` and `image_pulls`.
* Pull throughput, by taking the first derivative of `image_pull_bytes`.

These metrics were created to provide the same information as is available for containerd image pulling (introduced in containerd/containerd#7313)

**- How I did it**

* Updated `internal/metrics` package to include new metrics
* Added wrapper reader for pull throughput counting. Bytes are recorded live, so fidelity of this metric is defined by sample rate.
  * Added test for this object.

**- How to verify it**

`image_pulls_started` and `image_pulls` are trivial (and also painful to test).

`image_pull_bytes` includes a test for its behavior.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Add metric `image_pulls`, which shows count of image pulls completed, grouped by `success` or `failure`.
- Add metric `image_pulls_started`, which shows count of image pulls started. Subtract `image_pulls` to obtain count of image pulls in progress.
- Add metric `image_pull_bytes` to count total bytes downloaded as part of image pulls.
```