### PR TITLE
Move Cory from Reviewers to Committers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,6 +7,7 @@
 "akerouanton","Albin Kerouanton","albinker@gmail.com"
 "AkihiroSuda","Akihiro Suda","akihiro.suda.cz@hco.ntt.co.jp"
 "austinvazquez","Austin Vazquez","macedonv@amazon.com"
+"corhere","Cory Snider","csnider@mirantis.com"
 "cpuguy83","Brian Goff","cpuguy83@gmail.com"
 "robmry","Rob Murray","rob.murray@docker.com"
 "thaJeztah","Sebastiaan van Stijn","github@gone.nl"
@@ -17,7 +18,6 @@
 # REVIEWERS
 # GitHub ID, Name, Email address, GPG fingerprint
 "coolljt0725","Lei Jitang","leijitang@huawei.com"
-"corhere","Cory Snider","csnider@mirantis.com"
 "crazy-max","Kevin Alvarez","contact@crazymax.dev"
 "dmcgowan","Derek McGowan","derek@mcgstyle.net"
 "estesp","Phil Estes","estesp@linux.vnet.ibm.com"


### PR DESCRIPTION
**- What I did**

Move @corhere from REVIEWERS to COMMITTERS in the MAINTAINERS file. 

From [project/GOVERNANCE.md](https://github.com/moby/moby/blob/master/project/GOVERNANCE.md#adding-maintainers):
> Candidates must be approved by 2/3 of the current committers by adding their approval or LGTM to the pull request.

- [ ] @akerouanton
- [x] @AkihiroSuda
- [x] @austinvazquez
- [x] @cpuguy83
- [x] @robmry
- [x] @thaJeztah
- [x] @tianon
- [ ] @tonistiigi
- [x] @vvoland

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

