### PR TITLE
libnetwork/networkdb: fix logical race conditions

### DIFF
--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -777,23 +777,6 @@ func (n *Network) addDriverWatches() {
 		agent.driverCancelFuncs[n.ID()] = append(agent.driverCancelFuncs[n.ID()], cancel)
 		agent.mu.Unlock()
 		go c.handleTableEvents(ch, n.handleDriverTableEvent)
-		d, err := n.driver(false)
-		if err != nil {
-			log.G(context.TODO()).Errorf("Could not resolve driver %s while walking driver table: %v", n.networkType, err)
-			return
-		}
-
-		err = agent.networkDB.WalkTable(table.name, func(nid, key string, value []byte, deleted bool) bool {
-			// skip the entries that are mark for deletion, this is safe because this function is
-			// called at initialization time so there is no state to delete
-			if nid == n.ID() && !deleted {
-				d.EventNotify(driverapi.Create, nid, table.name, key, value)
-			}
-			return false
-		})
-		if err != nil {
-			log.G(context.TODO()).WithError(err).Warn("Error while walking networkdb")
-		}
 	}
 }
 

--- a/libnetwork/networkdb/delegate.go
+++ b/libnetwork/networkdb/delegate.go
@@ -179,14 +179,6 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent, isBulkSync bool) bool
 			nDB.Unlock()
 			return false
 		}
-	} else if tEvent.Type == TableEventTypeDelete && !isBulkSync {
-		nDB.Unlock()
-		// We don't know the entry, the entry is being deleted and the message is an async message
-		// In this case the safest approach is to ignore it, it is possible that the queue grew so much to
-		// exceed the garbage collection time (the residual reap time that is in the message is not being
-		// updated, to avoid inserting too many messages in the queue).
-		// Instead the messages coming from TCP bulk sync are safe with the latest value for the garbage collection time
-		return false
 	}
 
 	e := &entry{
@@ -208,18 +200,24 @@ func (nDB *NetworkDB) handleTableEvent(tEvent *TableEvent, isBulkSync bool) bool
 	nDB.createOrUpdateEntry(tEvent.NetworkID, tEvent.TableName, tEvent.Key, e)
 	nDB.Unlock()
 
-	if err != nil && tEvent.Type == TableEventTypeDelete {
-		// Again we don't know the entry but this is coming from a TCP sync so the message body is up to date.
-		// We had saved the state so to speed up convergence and be able to avoid accepting create events.
-		// Now we will rebroadcast the message if 2 conditions are met:
-		// 1) we had already synced this network (during the network join)
-		// 2) the residual reapTime is higher than 1/6 of the total reapTime.
-		// If the residual reapTime is lower or equal to 1/6 of the total reapTime don't bother broadcasting it around
-		// most likely the cluster is already aware of it
-		// This also reduce the possibility that deletion of entries close to their garbage collection ends up circling around
-		// forever
+	if !entryPresent && tEvent.Type == TableEventTypeDelete {
+		// We will rebroadcast the message for an unknown entry if all the conditions are met:
+		// 1) the message was received from a bulk sync
+		// 2) we had already synced this network (during the network join)
+		// 3) the residual reapTime is higher than 1/6 of the total reapTime.
+		//
+		// If the residual reapTime is lower or equal to 1/6 of the total reapTime
+		// don't bother broadcasting it around as most likely the cluster is already aware of it.
+		// This also reduces the possibility that deletion of entries close to their garbage collection
+		// ends up circling around forever.
+		//
+		// The safest approach is to not rebroadcast async messages for unknown entries.
+		// It is possible that the queue grew so much to exceed the garbage collection time
+		// (the residual reap time that is in the message is not being updated, to avoid
+		// inserting too many messages in the queue).
+
 		// log.G(ctx).Infof("exiting on delete not knowing the obj with rebroadcast:%t", network.inSync)
-		return network.inSync && e.reapTime > nDB.config.reapEntryInterval/6
+		return isBulkSync && network.inSync && e.reapTime > nDB.config.reapEntryInterval/6
 	}
 
 	var op opType

--- a/libnetwork/networkdb/watch.go
+++ b/libnetwork/networkdb/watch.go
@@ -2,6 +2,7 @@ package networkdb
 
 import (
 	"net"
+	"strings"
 
 	"github.com/docker/go-events"
 )
@@ -42,7 +43,8 @@ type DeleteEvent event
 // network or any combination of the tuple. If any of the
 // filter is an empty string it acts as a wildcard for that
 // field. Watch returns a channel of events, where the events will be
-// sent.
+// sent. The watch channel is initialized with synthetic create events for all
+// the existing table entries not owned by this node which match the filters.
 func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 	var matcher events.Matcher
 
@@ -75,6 +77,45 @@ func (nDB *NetworkDB) Watch(tname, nid string) (*events.Channel, func()) {
 
 	if matcher != nil {
 		sink = events.NewFilter(sink, matcher)
+	}
+
+	// Synthesize events for all the existing table entries not owned by
+	// this node so that the watcher receives all state without racing with
+	// any concurrent mutations to the table.
+	nDB.RLock()
+	defer nDB.RUnlock()
+	if tname == "" {
+		var prefix []byte
+		if nid != "" {
+			prefix = []byte("/" + nid + "/")
+		} else {
+			prefix = []byte("/")
+		}
+		nDB.indexes[byNetwork].Root().WalkPrefix(prefix, func(path []byte, v *entry) bool {
+			if !v.deleting && v.node != nDB.config.NodeID {
+				tuple := strings.SplitN(string(path[1:]), "/", 3)
+				if len(tuple) == 3 {
+					entryNid, entryTname, key := tuple[0], tuple[1], tuple[2]
+					sink.Write(makeEvent(opCreate, entryTname, entryNid, key, v.value))
+				}
+			}
+			return false
+		})
+	} else {
+		prefix := []byte("/" + tname + "/")
+		if nid != "" {
+			prefix = append(prefix, []byte(nid+"/")...)
+		}
+		nDB.indexes[byTable].Root().WalkPrefix(prefix, func(path []byte, v *entry) bool {
+			if !v.deleting && v.node != nDB.config.NodeID {
+				tuple := strings.SplitN(string(path[1:]), "/", 3)
+				if len(tuple) == 3 {
+					entryTname, entryNid, key := tuple[0], tuple[1], tuple[2]
+					sink.Write(makeEvent(opCreate, entryTname, entryNid, key, v.value))
+				}
+			}
+			return false
+		})
 	}
 
 	nDB.broadcaster.Add(sink)

--- a/libnetwork/networkdb/watch_test.go
+++ b/libnetwork/networkdb/watch_test.go
@@ -60,6 +60,12 @@ func TestWatch_out_of_order(t *testing.T) {
 	appendTableEvent(13, TableEventTypeUpdate, "key4", []byte("b"))
 	appendTableEvent(14, TableEventTypeUpdate, "key4", []byte("c"))
 
+	// Delete, create
+	appendTableEvent(16, TableEventTypeDelete, "key5", []byte("a"))
+	appendTableEvent(15, TableEventTypeCreate, "key5", []byte("a"))
+	// (Hidden recreate), delete
+	appendTableEvent(18, TableEventTypeDelete, "key5", []byte("b"))
+
 	d.NotifyMsg(msgs.Compound())
 	msgs.Reset()
 
@@ -76,6 +82,8 @@ func TestWatch_out_of_order(t *testing.T) {
 		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "key3", Value: []byte("b")}),
 		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "key4", Value: []byte("b")}),
 		UpdateEvent(event{Table: "table1", NetworkID: "network1", Key: "key4", Value: []byte("c")}),
+
+		// key5 should not appear in the events.
 	}))
 }
 

--- a/libnetwork/networkdb/watch_test.go
+++ b/libnetwork/networkdb/watch_test.go
@@ -1,0 +1,129 @@
+package networkdb
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/docker/go-events"
+	"github.com/hashicorp/memberlist"
+	"github.com/hashicorp/serf/serf"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestWatch_out_of_order(t *testing.T) {
+	nDB := new(DefaultConfig())
+	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{}
+	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{}
+	assert.Assert(t, nDB.JoinNetwork("network1"))
+
+	(&eventDelegate{nDB}).NotifyJoin(&memberlist.Node{
+		Name: "node1",
+		Addr: net.IPv4(1, 2, 3, 4),
+	})
+
+	d := &delegate{nDB}
+
+	msgs := messageBuffer{t: t}
+	appendTableEvent := tableEventHelper(&msgs, "node1", "network1", "table1")
+	msgs.Append(MessageTypeNetworkEvent, &NetworkEvent{
+		Type:      NetworkEventTypeJoin,
+		LTime:     1,
+		NodeName:  "node1",
+		NetworkID: "network1",
+	})
+	appendTableEvent(1, TableEventTypeCreate, "tombstone1", []byte("a"))
+	appendTableEvent(2, TableEventTypeDelete, "tombstone1", []byte("b"))
+	appendTableEvent(3, TableEventTypeCreate, "key1", []byte("value1"))
+	d.NotifyMsg(msgs.Compound())
+	msgs.Reset()
+
+	nDB.CreateEntry("table1", "network1", "local1", []byte("should not see me in watch events"))
+	watch, cancel := nDB.Watch("table1", "network1")
+	defer cancel()
+
+	// Receive events from node1, with events not received or received out of order
+	// Create, (hidden update), delete
+	appendTableEvent(4, TableEventTypeCreate, "key2", []byte("a"))
+	appendTableEvent(6, TableEventTypeDelete, "key2", []byte("b"))
+	// (Hidden recreate), delete
+	appendTableEvent(8, TableEventTypeDelete, "key2", []byte("c"))
+	// (Hidden recreate), update
+	appendTableEvent(10, TableEventTypeUpdate, "key2", []byte("d"))
+
+	// Update, create
+	appendTableEvent(11, TableEventTypeUpdate, "key3", []byte("b"))
+	appendTableEvent(10, TableEventTypeCreate, "key3", []byte("a"))
+
+	// (Hidden create), update, update
+	appendTableEvent(13, TableEventTypeUpdate, "key4", []byte("b"))
+	appendTableEvent(14, TableEventTypeUpdate, "key4", []byte("c"))
+
+	d.NotifyMsg(msgs.Compound())
+	msgs.Reset()
+
+	got := drainChannel(watch.C)
+	assert.Check(t, is.DeepEqual(got, []events.Event{
+		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "key2", Value: []byte("a")}),
+		// Delete value should match last observed value,
+		// irrespective of the content of the delete event over the wire.
+		DeleteEvent(event{Table: "table1", NetworkID: "network1", Key: "key2", Value: []byte("a")}),
+		// Updates to previously-deleted keys should be observed as creates.
+		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "key2", Value: []byte("d")}),
+
+		// Out-of-order update events should be observed as creates.
+		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "key3", Value: []byte("b")}),
+		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "key4", Value: []byte("b")}),
+		UpdateEvent(event{Table: "table1", NetworkID: "network1", Key: "key4", Value: []byte("c")}),
+	}))
+}
+
+func drainChannel(ch <-chan events.Event) []events.Event {
+	var events []events.Event
+	for {
+		select {
+		case ev := <-ch:
+			events = append(events, ev)
+		case <-time.After(time.Second):
+			return events
+		}
+	}
+}
+
+type messageBuffer struct {
+	t    *testing.T
+	msgs [][]byte
+}
+
+func (mb *messageBuffer) Append(typ MessageType, msg any) {
+	mb.t.Helper()
+	buf, err := encodeMessage(typ, msg)
+	if err != nil {
+		mb.t.Fatalf("failed to encode message: %v", err)
+	}
+	mb.msgs = append(mb.msgs, buf)
+}
+
+func (mb *messageBuffer) Compound() []byte {
+	return makeCompoundMessage(mb.msgs)
+}
+
+func (mb *messageBuffer) Reset() {
+	mb.msgs = nil
+}
+
+func tableEventHelper(mb *messageBuffer, nodeName, networkID, tableName string) func(ltime serf.LamportTime, typ TableEvent_Type, key string, value []byte) {
+	return func(ltime serf.LamportTime, typ TableEvent_Type, key string, value []byte) {
+		mb.t.Helper()
+		mb.Append(MessageTypeTableEvent, &TableEvent{
+			Type:      typ,
+			LTime:     ltime,
+			NodeName:  nodeName,
+			NetworkID: networkID,
+			TableName: tableName,
+			Key:       key,
+			Value:     value,
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed #41896 and probably others

**- How I did it**
I fixed bugs in NetworkDB and the libnetwork cluster agent which manifest in imperfect conditions, when table events are received unreliably or out-of-order. And I changed the semantics of `(*NetworkDB).Watch()` so it can be used without racing table mutations from remote nodes.

See individual commit messages for more detail.

**- How to verify it**
New unit test

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Improve the reliability of NetworkDB in busy clusters and lossy networks
```

**- A picture of a cute animal (not mandatory but encouraged)**

