### PR TITLE
libn/networkdb: fix data race in GetTableByNetwork

### DIFF
--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -428,6 +428,22 @@ func TestNetworkDBCRUDMediumCluster(t *testing.T) {
 
 	dbs := createNetworkDBInstances(t, n, "node", DefaultConfig())
 
+	// Shake out any data races.
+	done := make(chan struct{})
+	defer close(done)
+	for _, db := range dbs {
+		go func(db *NetworkDB) {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				_ = db.GetTableByNetwork("test_table", "network1")
+			}
+		}(db)
+	}
+
 	for i := 0; i < n; i++ {
 		for j := 0; j < n; j++ {
 			if i == j {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Fixes #49402 

**- What I did**
**- How I did it**

The function was accessing the index map without holding the mutex, so it would race any mutation to the database indexes. Fetch the reference to the tree's root while holding a read lock. Since the radix tree is immutable, taking a reference to the root is equivalent to starting a read-only database transaction, providing a consistent view of the data at a snapshot in time, even as the live state is mutated concurrently.

Also optimize the WalkTable function by leveraging the immutability of the radix tree.

**- How to verify it**

`go test -race`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix an issue where `docker network inspect --verbose` could sometimes crash the daemon
```

**- A picture of a cute animal (not mandatory but encouraged)**

