### PR TITLE
libn/networkdb: don't exceed broadcast size limit

### DIFF
--- a/libnetwork/networkdb/delegate.go
+++ b/libnetwork/networkdb/delegate.go
@@ -408,7 +408,12 @@ func (d *delegate) NotifyMsg(buf []byte) {
 
 func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
 	msgs := d.nDB.networkBroadcasts.GetBroadcasts(overhead, limit)
-	msgs = append(msgs, d.nDB.nodeBroadcasts.GetBroadcasts(overhead, limit)...)
+	for _, m := range msgs {
+		limit -= overhead + len(m)
+	}
+	if limit > 0 {
+		msgs = append(msgs, d.nDB.nodeBroadcasts.GetBroadcasts(overhead, limit)...)
+	}
 	return msgs
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
NetworkDB uses a hierarchy of queues to prioritize messages for broadcast. Unfortunately the logic to pull from multiple queues is flawed. The length of the messages pulled from the first queue is not taken into account when pulling messages from the second queue. A list of messages up to tiwce as long as the limit could be returned! Messages beyond the limit will be truncated unceremoniously by memberlist.

Memberlist broadcast queues assume that all messages returned from a GetBroadcasts call will be broadcasted to other nodes in the cluster. Messages are popped from the queue once they have hit their retransmit limit. On a busy system messages may be broadcast fewer times than intended, possibly even being dropped without ever being broadcast!

I fixed this oversight so that the delegate never returns more data than the specified length limit.

**- How I did it**
Subtract the length of messages pulled from the first queue from the broadcast size limit so the limit is not exceeded when pulling from the second queue.

**- How to verify it**
[By inspection 🤷](https://github.com/grafana/dskit/blob/1ca3f08a7c994cac2e2809dae1e5b9125a72cb6e/kv/memberlist/memberlist_client.go#L1408-L1415)

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Improvements to the reliability and convergence speed of NetworkDB
```

**- A picture of a cute animal (not mandatory but encouraged)**

