### PR TITLE
Skip tests that recently started failing in rootless/firewalld

### DIFF
--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -458,7 +458,12 @@ func TestIsolated(t *testing.T) {
 		defer apiClient.ContainerRemove(ctx, res.ContainerID, containertypes.RemoveOptions{Force: true})
 		if ipv == "-6" && networking.FirewalldRunning() {
 			// FIXME(robmry) - this fails due to https://github.com/moby/moby/issues/49680
-			assert.Check(t, is.Equal(res.ExitCode, 1))
+			if res.ExitCode != 1 {
+				t.Log("Unexpected pass!")
+				t.Log(icmd.RunCommand("nft", "list ruleset").Stdout())
+				t.Log(icmd.RunCommand("ip", "a").Stdout())
+				t.Log(icmd.RunCommand("route", "-6").Stdout())
+			}
 			t.Skip("XFAIL - IPv6, firewalld, isolated - see https://github.com/moby/moby/issues/49680")
 		}
 		assert.Check(t, is.Equal(res.ExitCode, 0))

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -522,6 +522,7 @@ func TestPublishedPortAlreadyInUse(t *testing.T) {
 //
 // Regression test for https://github.com/moby/moby/issues/49654.
 func TestAllPortMappingsAreReturned(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "cannot disable userland proxy in rootless netns unless br-netfilter loaded by host")
 	ctx := setupTest(t)
 
 	d := daemon.New(t)
@@ -617,6 +618,7 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 // TestLegacyLink checks that a legacy link ("--link" in the default bridge network)
 // sets up a hostname and opens ports when the daemon is running with icc=false.
 func TestLegacyLink(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "cannot set icc=false in rootless netns unless br-netfilter loaded by host")
 	ctx := setupTest(t)
 
 	// Tidy up after the test by starting a new daemon, which will remove the icc=false
@@ -693,6 +695,7 @@ func TestLegacyLink(t *testing.T) {
 //
 // Replacement for DockerDaemonSuite/TestDaemonLinksIpTablesRulesWhenLinkAndUnlink
 func TestRemoveLegacyLink(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "cannot set icc=false in rootless netns unless br-netfilter loaded by host")
 	ctx := setupTest(t)
 
 	// Tidy up after the test by starting a new daemon, which will remove the icc=false


### PR DESCRIPTION
**- What I did**

These tests seem to have started failing reliably, which isn't helpful. For example:
- https://github.com/moby/moby/pull/49932
- https://github.com/moby/moby/pull/49937
- https://github.com/moby/moby/pull/49939

So, park them for now.


#### rootless: skip tests that need br-netfilter loaded

Skip tests that have recently started failing in rootless
mode with error:

```
failed to start daemon: Error initializing network controller:
  error creating default "bridge" network:
    cannot restrict inter-container communication or run
    without the userland proxy:
      stat /proc/sys/net/bridge/bridge-nf-call-iptables:
        no such file or directory:
          set environment variable DOCKER_IGNORE_BR_NETFILTER_ERROR=1 to ignore
```

Perhaps we can ensure the module is loaded before starting the rootless env - or work out why the failures have only recently started, and put-back whatever changed. But, for now, I think we need to skip.

#### Allow TestIsolated/ipv6 to unexpectedly pass

This test normally fails due to a known issue (https://github.com/moby/moby/issues/49680), but it has recently started passing in CI ... not sure why, it still fails locally - so, allow it to unexpectedly pass, but collect some debug info to try to undertand why.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

