### PR TITLE
daemon: rmLink, cleanupContainer: cleanup errors

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -215,7 +215,10 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 				RemoveVolume: true,
 			})
 			if err != nil {
-				log.G(ctx).WithError(err).Error("failed to cleanup container on create error")
+				log.G(ctx).WithFields(log.Fields{
+					"error":     err,
+					"container": ctr.ID,
+				}).Errorf("failed to cleanup container on create error")
 			}
 		}
 	}()

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -88,10 +88,10 @@ func (daemon *Daemon) rmLink(cfg *config.Config, ctr *container.Container, name 
 func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.ContainerRmConfig) error {
 	if ctr.IsRunning() {
 		if !config.ForceRemove {
-			if state := ctr.StateString(); state == "paused" {
-				return errdefs.Conflict(fmt.Errorf("cannot remove container %q: container is %s and must be unpaused first", ctr.Name, state))
+			if ctr.Paused {
+				return errdefs.Conflict(fmt.Errorf("cannot remove container %q: container is paused and must be unpaused first", ctr.Name))
 			} else {
-				return errdefs.Conflict(fmt.Errorf("cannot remove container %q: container is %s: stop the container before removing or force remove", ctr.Name, state))
+				return errdefs.Conflict(fmt.Errorf("cannot remove container %q: container is %s: stop the container before removing or force remove", ctr.Name, ctr.StateString()))
 			}
 		}
 		if err := daemon.Kill(ctr); err != nil && !isNotRunning(err) {


### PR DESCRIPTION
### daemon: rmLink, cleanupContainer: rename args that shadowed import

### daemon: cleanupContainer: use state-fields instead of string form

This code only needed to know whether the container was running (but paused),
or running. Use the `Paused` field to detect which one.


### daemon: cleanupContainer: leave decorating container-id/name to caller

This function was decorating errors with the container name, but within its
own context wouldn't be aware how the delete was referenced. This could
result in a container deleted by "ID" to produce an error with the container
Name. Some errors were also decorated before storing as "removalError" on
the container object itself.

The removalError was originally added in f963500c544daa3c158c0ca3d2985295c875cb6b,
before which the error was returned. Now that it's part of the container's
state itself, adding the container's ID is probably not very useful.

This patch reduces the scope of decorating the errors to the error-condition
itself, leaving it to the caller to decorate them further with the container
ID or Name (if any).

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

