### PR TITLE
Try to load br_netfilter on the test host for rootless test-integration

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -84,6 +84,9 @@ if [ -n "$DOCKER_ROOTLESS" ]; then
 	mkdir -p -m 700 "/tmp/docker-${uid}"
 	chown "$user" "/tmp/docker-${uid}"
 	chmod -R o+w "$DEST"
+	# The rootless daemon won't be able to load modules for tests that need them, so do it here.
+	# There's no modprobe in the dev container, so https://x.com/lucabruno/status/902934379835662336
+	ip link show br_netfilter || true
 	dockerd="sudo -u $user -E -E XDG_RUNTIME_DIR=/tmp/docker-${uid} -E HOME=/home/${user} -E PATH=$PATH -- dockerd-rootless.sh"
 fi
 

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -527,7 +527,6 @@ func TestPublishedPortAlreadyInUse(t *testing.T) {
 //
 // Regression test for https://github.com/moby/moby/issues/49654.
 func TestAllPortMappingsAreReturned(t *testing.T) {
-	skip.If(t, testEnv.IsRootless, "cannot disable userland proxy in rootless netns unless br-netfilter loaded by host")
 	ctx := setupTest(t)
 
 	d := daemon.New(t)
@@ -623,7 +622,6 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 // TestLegacyLink checks that a legacy link ("--link" in the default bridge network)
 // sets up a hostname and opens ports when the daemon is running with icc=false.
 func TestLegacyLink(t *testing.T) {
-	skip.If(t, testEnv.IsRootless, "cannot set icc=false in rootless netns unless br-netfilter loaded by host")
 	ctx := setupTest(t)
 
 	// Tidy up after the test by starting a new daemon, which will remove the icc=false
@@ -700,7 +698,6 @@ func TestLegacyLink(t *testing.T) {
 //
 // Replacement for DockerDaemonSuite/TestDaemonLinksIpTablesRulesWhenLinkAndUnlink
 func TestRemoveLegacyLink(t *testing.T) {
-	skip.If(t, testEnv.IsRootless, "cannot set icc=false in rootless netns unless br-netfilter loaded by host")
 	ctx := setupTest(t)
 
 	// Tidy up after the test by starting a new daemon, which will remove the icc=false


### PR DESCRIPTION
**- What I did**

- Try to load br_netfilter before running rootless test-integration.
- Remove skip-if-rootless from integration tests that depend on br_netfilter.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

