### PR TITLE
Fix possible overlapping IPs when ingressNA == nil

### DIFF
--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -213,36 +213,35 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 
 	if ingressNA == nil {
 		e.backend.ReleaseIngress()
-		return e.backend.GetAttachmentStore().ResetAttachments(attachments)
-	}
-
-	options := network.CreateOptions{
-		Driver: ingressNA.Network.DriverState.Name,
-		IPAM: &network.IPAM{
-			Driver: ingressNA.Network.IPAM.Driver.Name,
-		},
-		Options: ingressNA.Network.DriverState.Options,
-		Ingress: true,
-	}
-
-	for _, ic := range ingressNA.Network.IPAM.Configs {
-		c := network.IPAMConfig{
-			Subnet:  ic.Subnet,
-			IPRange: ic.Range,
-			Gateway: ic.Gateway,
+	} else {
+		options := network.CreateOptions{
+			Driver: ingressNA.Network.DriverState.Name,
+			IPAM: &network.IPAM{
+				Driver: ingressNA.Network.IPAM.Driver.Name,
+			},
+			Options: ingressNA.Network.DriverState.Options,
+			Ingress: true,
 		}
-		options.IPAM.Config = append(options.IPAM.Config, c)
-	}
 
-	_, err := e.backend.SetupIngress(clustertypes.NetworkCreateRequest{
-		ID: ingressNA.Network.ID,
-		CreateRequest: network.CreateRequest{
-			Name:          ingressNA.Network.Spec.Annotations.Name,
-			CreateOptions: options,
-		},
-	}, ingressNA.Addresses[0])
-	if err != nil {
-		return err
+		for _, ic := range ingressNA.Network.IPAM.Configs {
+			c := network.IPAMConfig{
+				Subnet:  ic.Subnet,
+				IPRange: ic.Range,
+				Gateway: ic.Gateway,
+			}
+			options.IPAM.Config = append(options.IPAM.Config, c)
+		}
+
+		_, err := e.backend.SetupIngress(clustertypes.NetworkCreateRequest{
+			ID: ingressNA.Network.ID,
+			CreateRequest: network.CreateRequest{
+				Name:          ingressNA.Network.Spec.Annotations.Name,
+				CreateOptions: options,
+			},
+		}, ingressNA.Addresses[0])
+		if err != nil {
+			return err
+		}
 	}
 
 	var (


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Fixes #40989 (again)

**- What I did**
Logic was added to the Swarm executor in #42432 to clean up managed networks whenever the node's load-balancer IP address is removed or changed in order to free up the address in the case where the container fails to start entirely. Unfortunately, due to an oversight the function returns early if the Swarm is lacking an ingress network. Fix the implementation so that load-balancer IP addresses for all the other networks are freed as appropriate, irrespective of whether an ingress network exists in the Swarm.

**- How I did it**
Change the early return to a conditional.

**- How to verify it**
By inspection 🤷 

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix an issue where the load-balancer IP address for an overlay network would not be released in certain cases if the Swarm was lacking an ingress network
```

**- A picture of a cute animal (not mandatory but encouraged)**

