### PR TITLE
Fix multiarch image push tag for containerd snapshotter

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -144,7 +144,16 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 	wrapped := wrapWithFakeMountableBlobs(store, mountableBlobs)
 	store = wrapped
 
-	pusher, err := resolver.Pusher(ctx, targetRef.String())
+	// Annotate ref with digest to push only push tag for single digest
+	ref := targetRef
+	if _, digested := ref.(reference.Digested); !digested {
+		ref, err = reference.WithDigest(ref, target.Digest)
+		if err != nil {
+			return err
+		}
+	}
+
+	pusher, err := resolver.Pusher(ctx, ref.String())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When the "containerd-snapshotter" feature is enabled and pushing multiarch images, I would expect all platform specific image manifest to be pushed by digest, but only the top level manifest index being pushed by tag. But in the current implementation in moby, all of them are pushed by tag.

**- How I did it**
Replicate the similar logic in containerd here: https://github.com/containerd/containerd/blob/main/client/client.go#L485-L488

**- How to verify it**
Turn on debug level and verify the logs.

Steps:
```
$ docker images
REPOSITORY                      TAG       IMAGE ID       CREATED         SIZE
localhost:5000/multi-platform   latest    e3456080ddef   5 hours ago     15.9MB

$ docker push localhost:5000/multi-platform:latest
```

Logs before fix:
```
    May 09 20:51:06 ip-172-31-53-148.us-west-2.compute.internal dockerd[350657]: time="2025-05-09T20:51:06.466443875Z" level=debug msg="checking and pushing to" digest="sha256:bee6572fc9601b636b4c9ca47f3242394c9acc16a2cafbe2b9d70863fa8bf68a" mediatype=application/vnd.oci.image.manifest.v1+json size=668 url="https://localhost:5000/v2/multi-platform/manifests/latest"
    May 09 20:51:06 ip-172-31-53-148.us-west-2.compute.internal dockerd[350657]: time="2025-05-09T20:51:06.466682422Z" level=debug msg="checking and pushing to" digest="sha256:26de95632909aec43e64b57756169187e4c9ad5b839dedde93d3ad1b38e40179" mediatype=application/vnd.oci.image.manifest.v1+json size=566 url="https://localhost:5000/v2/multi-platform/manifests/latest"
    May 09 20:51:06 ip-172-31-53-148.us-west-2.compute.internal dockerd[350657]: time="2025-05-09T20:51:06.466849174Z" level=debug msg="checking and pushing to" digest="sha256:4276f635f76d8ce2a58e74895718839ad845ee7c0616a7411253cfcc2b482e1b" mediatype=application/vnd.oci.image.manifest.v1+json size=668 url="https://localhost:5000/v2/multi-platform/manifests/latest"
    May 09 20:51:06 ip-172-31-53-148.us-west-2.compute.internal dockerd[350657]: time="2025-05-09T20:51:06.467165117Z" level=debug msg="checking and pushing to" digest="sha256:61a91a053385e6639c7d6c5619a9955574df7ba788bdcbe130778380b9c5649e" mediatype=application/vnd.oci.image.manifest.v1+json size=566 url="https://localhost:5000/v2/multi-platform/manifests/latest"
    May 09 20:51:06 ip-172-31-53-148.us-west-2.compute.internal dockerd[350657]: time="2025-05-09T20:51:06.487842936Z" level=debug msg="checking and pushing to" digest="sha256:e3456080ddefc6caf948b68daa8ee8ea0dda5ec46f272dcb55e0d6b9f1ed2e64" mediatype=application/vnd.oci.image.index.v1+json size=1607 url="https://localhost:5000/v2/multi-platform/manifests/latest"
```

Logs after fix:
```
May 09 20:48:38 ip-172-31-53-148.us-west-2.compute.internal dockerd[350106]: time="2025-05-09T20:48:38.810289068Z" level=debug msg="checking and pushing to" digest="sha256:bee6572fc9601b636b4c9ca47f3242394c9acc16a2cafbe2b9d70863fa8bf68a" mediatype=application/vnd.oci.image.manifest.v1+json size=668 url="https://localhost:5000/v2/multi-platform/manifests/sha256:bee6572fc9601b636b4c9ca47f3242394c9acc16a2cafbe2b9d70863fa8bf68a"
May 09 20:48:38 ip-172-31-53-148.us-west-2.compute.internal dockerd[350106]: time="2025-05-09T20:48:38.810358707Z" level=debug msg="checking and pushing to" digest="sha256:61a91a053385e6639c7d6c5619a9955574df7ba788bdcbe130778380b9c5649e" mediatype=application/vnd.oci.image.manifest.v1+json size=566 url="https://localhost:5000/v2/multi-platform/manifests/sha256:61a91a053385e6639c7d6c5619a9955574df7ba788bdcbe130778380b9c5649e"
May 09 20:48:38 ip-172-31-53-148.us-west-2.compute.internal dockerd[350106]: time="2025-05-09T20:48:38.810367373Z" level=debug msg="checking and pushing to" digest="sha256:26de95632909aec43e64b57756169187e4c9ad5b839dedde93d3ad1b38e40179" mediatype=application/vnd.oci.image.manifest.v1+json size=566 url="https://localhost:5000/v2/multi-platform/manifests/sha256:26de95632909aec43e64b57756169187e4c9ad5b839dedde93d3ad1b38e40179"
May 09 20:48:38 ip-172-31-53-148.us-west-2.compute.internal dockerd[350106]: time="2025-05-09T20:48:38.810552604Z" level=debug msg="checking and pushing to" digest="sha256:4276f635f76d8ce2a58e74895718839ad845ee7c0616a7411253cfcc2b482e1b" mediatype=application/vnd.oci.image.manifest.v1+json size=668 url="https://localhost:5000/v2/multi-platform/manifests/sha256:4276f635f76d8ce2a58e74895718839ad845ee7c0616a7411253cfcc2b482e1b"
May 09 20:48:38 ip-172-31-53-148.us-west-2.compute.internal dockerd[350106]: time="2025-05-09T20:48:38.815839022Z" level=debug msg="checking and pushing to" digest="sha256:e3456080ddefc6caf948b68daa8ee8ea0dda5ec46f272dcb55e0d6b9f1ed2e64" mediatype=application/vnd.oci.image.index.v1+json size=1607 url="https://localhost:5000/v2/multi-platform/manifests/latest"
```


```markdown changelog
containerd image store: Fix duplicate `PUT` requests when pushing a multi-platform image
```