### PR TITLE
container: use defer for locks

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -225,17 +225,15 @@ func (s *State) conditionAlreadyMet(condition container.WaitCondition) bool {
 // IsRunning returns whether the running flag is set. Used by Container to check whether a container is running.
 func (s *State) IsRunning() bool {
 	s.Lock()
-	res := s.Running
-	s.Unlock()
-	return res
+	defer s.Unlock()
+	return s.Running
 }
 
 // GetPID holds the process id of a container.
 func (s *State) GetPID() int {
 	s.Lock()
-	res := s.Pid
-	s.Unlock()
-	return res
+	defer s.Unlock()
+	return s.Pid
 }
 
 // ExitCode returns current exitcode for the state. Take lock before if state
@@ -327,17 +325,15 @@ func (s *State) SetError(err error) {
 // IsPaused returns whether the container is paused or not.
 func (s *State) IsPaused() bool {
 	s.Lock()
-	res := s.Paused
-	s.Unlock()
-	return res
+	defer s.Unlock()
+	return s.Paused
 }
 
 // IsRestarting returns whether the container is restarting or not.
 func (s *State) IsRestarting() bool {
 	s.Lock()
-	res := s.Restarting
-	s.Unlock()
-	return res
+	defer s.Unlock()
+	return s.Restarting
 }
 
 // SetRemovalInProgress sets the container state as being removed.
@@ -363,17 +359,15 @@ func (s *State) ResetRemovalInProgress() {
 // Used by Container to check whether a container is being removed.
 func (s *State) IsRemovalInProgress() bool {
 	s.Lock()
-	res := s.RemovalInProgress
-	s.Unlock()
-	return res
+	defer s.Unlock()
+	return s.RemovalInProgress
 }
 
 // IsDead returns whether the Dead flag is set. Used by Container to check whether a container is dead.
 func (s *State) IsDead() bool {
 	s.Lock()
-	res := s.Dead
-	s.Unlock()
-	return res
+	defer s.Unlock()
+	return s.Dead
 }
 
 // SetRemoved assumes this container is already in the "dead" state and notifies all waiters.


### PR DESCRIPTION
Makes the code slightly more idiomatic. These paths avoided uses of defer because they came with an overhead in older versions of Go, but this overhead should now be neglectible.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

