### PR TITLE
d/cluster/convert: expose Addr() on plugins

### DIFF
--- a/daemon/cluster/convert/pluginadapter.go
+++ b/daemon/cluster/convert/pluginadapter.go
@@ -24,19 +24,37 @@ func (p swarmPlugin) Client() plugin.Client {
 	return p.CompatPlugin.Client()
 }
 
+type addrPlugin struct {
+	plugingetter.CompatPlugin
+	plugingetter.PluginAddr
+}
+
+var _ plugin.AddrPlugin = (*addrPlugin)(nil)
+
+func (p addrPlugin) Client() plugin.Client {
+	return p.CompatPlugin.Client()
+}
+
+func adaptPluginForSwarm(p plugingetter.CompatPlugin) plugin.Plugin {
+	if pa, ok := p.(plugingetter.PluginAddr); ok {
+		return addrPlugin{p, pa}
+	}
+	return swarmPlugin{p}
+}
+
 func (g pluginGetter) Get(name string, capability string) (plugin.Plugin, error) {
 	p, err := g.pg.Get(name, capability, plugingetter.Lookup)
 	if err != nil {
 		return nil, err
 	}
-	return swarmPlugin{p}, nil
+	return adaptPluginForSwarm(p), nil
 }
 
 func (g pluginGetter) GetAllManagedPluginsByCap(capability string) []plugin.Plugin {
 	pp := g.pg.GetAllManagedPluginsByCap(capability)
 	ret := make([]plugin.Plugin, len(pp))
 	for i, p := range pp {
-		ret[i] = swarmPlugin{p}
+		ret[i] = adaptPluginForSwarm(p)
 	}
 	return ret
 }


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed #48133

**- How I did it**
The swarmPlugin type does not implement the Swarm plugin.AddrPlugin interface because it embeds an interface value which does not include that method in its method set. (You can type-assert an interface value to another interface which the concrete type implements, but a struct embedding an interface value is not itself an interface value.) Wrap the plugin with a different adapter type which exposes the Addr() method if the concrete plugin implements it.

**- How to verify it**
Hopes and prayers. Perhaps @dperny could lend me a hand in testing it?

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix the `plugin does not implement PluginAddr interface` error for Swarm CSI drivers.
```

**- A picture of a cute animal (not mandatory but encouraged)**

