### PR TITLE
daemon: Enable CDI by default

### DIFF
--- a/cmd/dockerd/daemon_test.go
+++ b/cmd/dockerd/daemon_test.go
@@ -220,7 +220,12 @@ func TestCDISpecDirs(t *testing.T) {
 		expectedCDISpecDirs []string
 	}{
 		{
-			description:         "CDI enabled and no spec dirs specified returns default",
+			description:         "CDI enabled by default",
+			specDirs:            nil,
+			expectedCDISpecDirs: []string{"/etc/cdi", "/var/run/cdi"},
+		},
+		{
+			description:         "CDI explicitly enabled and no spec dirs specified returns default",
 			specDirs:            nil,
 			configContent:       `{"features": {"cdi": true}}`,
 			expectedCDISpecDirs: []string{"/etc/cdi", "/var/run/cdi"},
@@ -245,11 +250,13 @@ func TestCDISpecDirs(t *testing.T) {
 		{
 			description:         "CDI disabled and no spec dirs specified returns no cdi spec dirs",
 			specDirs:            nil,
+			configContent:       `{"features": {"cdi": false}}`,
 			expectedCDISpecDirs: nil,
 		},
 		{
 			description:         "CDI disabled and specified spec dirs returns no cdi spec dirs",
 			specDirs:            []string{"/foo/bar", "/baz/qux"},
+			configContent:       `{"features": {"cdi": false}}`,
 			expectedCDISpecDirs: nil,
 		},
 	}


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/45134
- addresses: https://github.com/moby/moby/issues/45192

CDI support has been available as opt-in starting from v25.0.0. Considering that there are no known blockers I believe it's about time to make it enabled by default to encourage wider usage.

```markdown changelog
CDI is now enabled by default
```

**- A picture of a cute animal (not mandatory but encouraged)**

