### PR TITLE
c8d: ImageService.ReleaseLayer: slight cleanup in error-handling

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -249,9 +249,10 @@ func (i *ImageService) ReleaseLayer(rwlayer container.RWLayer) error {
 
 	ls := i.client.LeasesService()
 	if err := ls.Delete(context.Background(), c8dLayer.lease, leases.SynchronousDelete); err != nil {
-		if !cerrdefs.IsNotFound(err) {
-			return err
+		if cerrdefs.IsNotFound(err) {
+			return nil
 		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/45282#issuecomment-2875660411

Make it slightly more explicit that we only want to return on an error, but fall-through on "not-found" errors (which currently is just return at the end of the function).


**- A picture of a cute animal (not mandatory but encouraged)**

