### PR TITLE
[25.0] Backport: Add image pull metrics

### DIFF
--- a/daemon/images/locals.go
+++ b/daemon/images/locals.go
@@ -4,10 +4,21 @@ import (
 	metrics "github.com/docker/go-metrics"
 )
 
-var imageActions metrics.LabeledTimer
+var (
+	imageActions      metrics.LabeledTimer
+	imagePullsStarted metrics.Counter
+	imagePulls        metrics.LabeledCounter
+)
 
 func init() {
 	ns := metrics.NewNamespace("engine", "daemon", nil)
+
+	// imagePullsStarted increments when a pull starts.
+	imagePullsStarted = ns.NewCounter("image_pulls_started", "The number of total image pulls started")
+	// imagePulls increments when a pull finishes. By subtracting this from
+	// ImagePullsStarted, the user can determine how many pulls are in progress.
+	imagePulls = ns.NewLabeledCounter("image_pulls", "The number of total image pulls", "status")
+
 	imageActions = ns.NewLabeledTimer("image_actions", "The number of seconds it takes to process each image action", "action")
 	// TODO: is it OK to register a namespace with the same name? Or does this
 	// need to be exported from somewhere?

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/distribution/metadata"
+	"github.com/docker/docker/distribution/utils"
 	"github.com/docker/docker/distribution/xfer"
 	"github.com/docker/docker/image"
 	v1 "github.com/docker/docker/image/v1"
@@ -239,7 +240,12 @@ func (ld *layerDescriptor) Download(ctx context.Context, progressOutput progress
 		}
 	}
 
-	reader := progress.NewProgressReader(ioutils.NewCancelReadCloser(ctx, layerDownload), progressOutput, size-offset, ld.ID(), "Downloading")
+	reader := progress.NewProgressReader(
+		&utils.MetricsReader{
+			ReadCloser: ioutils.NewCancelReadCloser(ctx, layerDownload),
+			Counter:    utils.ImagePullBytes,
+		}, progressOutput, size-offset, ld.ID(), "Downloading",
+	)
 	defer reader.Close()
 
 	if ld.verifier == nil {

--- a/distribution/utils/metrics.go
+++ b/distribution/utils/metrics.go
@@ -1,0 +1,32 @@
+package utils // import "github.com/docker/docker/distribution/utils"
+
+import (
+	"io"
+
+	gometrics "github.com/docker/go-metrics"
+)
+
+var (
+	metricsNS = gometrics.NewNamespace("engine", "daemon", nil)
+
+	// ImagePullBytes is a running tally of the bytes downloaded and extracted
+	// by image pull operations. By taking the derrivative of this metric over
+	// time, image pull throughput can be measured.
+	ImagePullBytes = metricsNS.NewCounter("image_pull_bytes", "The number of bytes processed as part of image pulls")
+)
+
+// MetricsReader is a reader which keeps track of the number of bytes read in
+// the provided Counter.
+type MetricsReader struct {
+	io.ReadCloser
+	Counter gometrics.Counter
+}
+
+// Read increments the Counter by the number of bytes read
+func (m *MetricsReader) Read(p []byte) (int, error) {
+	read, err := m.ReadCloser.Read(p)
+	// we are counting bytes here. This is OK; the number of bytes may be very
+	// large, but the counter is uint64, which is enough for exabytes of data.
+	m.Counter.Inc(float64(read))
+	return read, err
+}

--- a/distribution/utils/metrics_test.go
+++ b/distribution/utils/metrics_test.go
@@ -1,0 +1,58 @@
+package utils // import "github.com/docker/docker/distribution/utils"
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+type fakeCounter struct {
+	count int
+}
+
+func (f *fakeCounter) Inc(vs ...float64) {
+	if len(vs) == 0 {
+		f.count++
+		return
+	}
+
+	for _, v := range vs {
+		f.count += int(v)
+	}
+}
+
+func TestMetricsReader(t *testing.T) {
+	// create a byte array of a known size, just filled with whatever
+	testBytes := []byte{}
+	for i := 0; i < 1234; i++ {
+		testBytes = append(testBytes, 123)
+	}
+	testReader := bytes.NewBuffer(testBytes)
+	f := &fakeCounter{}
+
+	met := MetricsReader{
+		ReadCloser: io.NopCloser(testReader),
+		Counter:    f,
+	}
+	p := make([]byte, 11)
+	read, err := met.Read(p)
+	if err != nil {
+		t.Errorf("error in read: %v", err)
+	}
+
+	count := f.count
+	if read != count {
+		t.Errorf("count read is not count recorded: %v != %v", read, count)
+	}
+
+	read, err = met.Read(p)
+	if err != nil {
+		t.Errorf("error in read: %v", err)
+	}
+
+	// get the count as the difference between the previous and current counts
+	count = f.count - count
+	if read != count {
+		t.Errorf("count read is not count recorded: %v != %v", read, count)
+	}
+}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Backport of #49926 to the 25.0 branch.

**- How I did it**

Done manually, because between 25.0 and main, there was substantial refactoring of metrics code to pile it all into an internal package. The code has been laid out as sensibly as possible under the old paradigm.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Added new metric `image_pulls`, which shows count of image pulls completed, grouped by `success` or `failure`.
- Added new metric `image_pulls_started`, which shows count of image pulls started. Subtract `image_pulls` to obtain count of image pulls in progress.
- Added new metric `image_pull_bytes` to count total bytes downloaded as part of image pulls.
```