### PR TITLE
container: don't persist State.RemovalInProgress on disk

### DIFF
--- a/container/state.go
+++ b/container/state.go
@@ -36,7 +36,7 @@ type State struct {
 	Paused            bool
 	Restarting        bool
 	OOMKilled         bool
-	RemovalInProgress bool // Not need for this to be persistent on disk.
+	RemovalInProgress bool `json:"-"` // No need for this to be persistent on disk.
 	Dead              bool
 	Pid               int
 	ExitCodeValue     int    `json:"ExitCode"`

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -495,6 +495,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 			}
 
 			c.Lock()
+			// TODO(thaJeztah): we no longer persist RemovalInProgress on disk, so this code is likely redundant; see https://github.com/moby/moby/pull/49968
 			if c.RemovalInProgress {
 				// We probably crashed in the middle of a removal, reset
 				// the flag.


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/issues/45282
- https://github.com/moby/moby/pull/11137
- https://github.com/moby/moby/pull/18347
- https://github.com/moby/moby/pull/22423


State.RemovalInProgress was originally non-exported when it was added in [40945fc186067e5b7edd1f6cd7645ff2ae7cea6c][1], adding a comment that the field should not be persisted to disk.

But when moved to a separate package in [6bb0d1816acd8d4f7a542a6aac047da2b874f476][2], it was was exported, without adding `json:"-"`. As a result, it's now persisted to disk;

    cat /var/lib/docker/containers/e493924a99cad918cda8048f967032729105ee072d563d734125cec46e1b5885/config.v2.json | jq .State
    {
      "Running": true,
      "Paused": false,
      "Restarting": false,
      "OOMKilled": false,
      "RemovalInProgress": false,
      "Dead": false,
      "Pid": 5053,
      "ExitCode": 0,
      "Error": "",
      "StartedAt": "2025-05-13T12:12:15.115512564Z",
      "FinishedAt": "0001-01-01T00:00:00Z",
      "Health": null
    }

Note that this type is used internally, and (while similar) is not used for API responses;

    docker inspect e493924a99cad918cda8048f967032729105ee072d563d734125cec46e1b5885 | jq .[].State
    {
      "Status": "running",
      "Running": true,
      "Paused": false,
      "Restarting": false,
      "OOMKilled": false,
      "Dead": false,
      "Pid": 5053,
      "ExitCode": 0,
      "Error": "",
      "StartedAt": "2025-05-13T12:12:15.115512564Z",
      "FinishedAt": "0001-01-01T00:00:00Z"
    }

However, interestingly, [`daemon.restore`][3] does take this field into account while restoring containers, which seems that it depends on the field being persisted to disk. That logic was added in [ce724731973159a4fcedf16d0996571684cc3843][4]. That logic may be redundant if we no longer persist to disk, as the `State.Dead` is already set when cleaning up a container in [`daemon.cleanupContainer`][5].

[1]: https://github.com/moby/moby/commit/40945fc186067e5b7edd1f6cd7645ff2ae7cea6c
[2]: https://github.com/moby/moby/commit/6bb0d1816acd8d4f7a542a6aac047da2b874f476#diff-60173e67d15f3085dd09956b3ffa83566ae25fec61cfe08ddd2e1c37223e3be7R24
[3]: https://github.com/moby/moby/blob/d42d79dceb68349795f9a0b6397fa955681fcc88/daemon/daemon.go#L498-L514
[4]: https://github.com/moby/moby/commit/ce724731973159a4fcedf16d0996571684cc3843
[5]: https://github.com/moby/moby/blob/294f0c36e468dc097d56dcf88d4418b7dc3d2856/daemon/delete.go#L124-L126


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

