### PR TITLE
daemon: Discover devices and include in system info 

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of the current REST API.
-	DefaultVersion = "1.49"
+	DefaultVersion = "1.50"
 
 	// MinSupportedAPIVersion is the minimum API version that can be supported
 	// by the API server, specified as "major.minor". Note that the daemon

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -127,6 +127,9 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false
 		}
+		if versions.LessThan(version, "1.50") {
+			info.DiscoveredDevices = nil
+		}
 		return info, nil
 	})
 	return httputils.WriteJSON(w, http.StatusOK, info)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.49"
+basePath: "/v1.50"
 info:
   title: "Docker Engine API"
-  version: "1.49"
+  version: "1.50"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.49) is used.
-    For example, calling `/info` is the same as calling `/v1.49/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.50) is used.
+    For example, calling `/info` is the same as calling `/v1.50/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2956,6 +2956,23 @@ definitions:
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 
+  DeviceInfo:
+    type: "object"
+    description: |
+      DeviceInfo represents a device that can be used by a container.
+    properties:
+      Source:
+        type: "string"
+        example: "cdi"
+        description: |
+          The origin device driver.
+      ID:
+        type: "string"
+        example: "vendor.com/gpu=0"
+        description: |
+          The unique identifier for the device within its source driver.
+          For CDI devices, this would be an FQDN like "vendor.com/gpu=0".
+
   ErrorDetail:
     type: "object"
     properties:
@@ -6858,6 +6875,15 @@ definitions:
               example: "24"
       FirewallBackend:
         $ref: "#/definitions/FirewallInfo"
+      DiscoveredDevices:
+        description: |
+          List of devices discovered by device drivers.
+
+          Each device includes information about its source driver, kind, name,
+          and additional driver-specific attributes.
+        type: "array"
+        items:
+          $ref: "#/definitions/DeviceInfo"
       Warnings:
         description: |
           List of warnings / informational messages about missing features, or

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -75,6 +75,7 @@ type Info struct {
 	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
 	FirewallBackend     *FirewallInfo        `json:"FirewallBackend,omitempty"`
 	CDISpecDirs         []string
+	DiscoveredDevices   []DeviceInfo `json:",omitempty"`
 
 	Containerd *ContainerdInfo `json:",omitempty"`
 
@@ -159,4 +160,13 @@ type FirewallInfo struct {
 	Driver string `json:"Driver"`
 	// Info is a list of label/value pairs, containing information related to the firewall.
 	Info [][2]string `json:"Info,omitempty"`
+}
+
+// DeviceInfo represents a discoverable device from a device driver.
+type DeviceInfo struct {
+	// Source indicates the origin device driver.
+	Source string `json:"Source"`
+	// ID is the unique identifier for the device.
+	// Example: CDI FQDN like "vendor.com/gpu=0", or other driver-specific device ID
+	ID string `json:"ID"`
 }

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -34,9 +34,7 @@ func TestInfoInvalidResponseJSONError(t *testing.T) {
 		}),
 	}
 	_, err := client.Info(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "invalid character") {
-		t.Fatalf("expected a 'invalid character' error, got %v", err)
-	}
+	assert.Check(t, is.ErrorContains(err, "invalid character"))
 }
 
 func TestInfo(t *testing.T) {
@@ -63,17 +61,10 @@ func TestInfo(t *testing.T) {
 	}
 
 	info, err := client.Info(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
-	if info.ID != "daemonID" {
-		t.Fatalf("expected daemonID, got %s", info.ID)
-	}
-
-	if info.Containers != 3 {
-		t.Fatalf("expected 3 containers, got %d", info.Containers)
-	}
+	assert.Check(t, is.Equal(info.ID, "daemonID"))
+	assert.Check(t, is.Equal(info.Containers, 3))
 }
 
 func TestInfoWithDiscoveredDevices(t *testing.T) {

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -75,3 +75,53 @@ func TestInfo(t *testing.T) {
 		t.Fatalf("expected 3 containers, got %d", info.Containers)
 	}
 }
+
+func TestInfoWithDiscoveredDevices(t *testing.T) {
+	expectedURL := "/info"
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			info := &system.Info{
+				ID:         "daemonID",
+				Containers: 3,
+				DiscoveredDevices: []system.DeviceInfo{
+					{
+						Source: "cdi",
+						ID:     "vendor.com/gpu=0",
+					},
+					{
+						Source: "cdi",
+						ID:     "vendor.com/gpu=1",
+					},
+				},
+			}
+			b, err := json.Marshal(info)
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	info, err := client.Info(context.Background())
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Equal(info.ID, "daemonID"))
+	assert.Check(t, is.Equal(info.Containers, 3))
+
+	assert.Check(t, is.Len(info.DiscoveredDevices, 2))
+
+	device0 := info.DiscoveredDevices[0]
+	assert.Check(t, is.Equal(device0.Source, "cdi"))
+	assert.Check(t, is.Equal(device0.ID, "vendor.com/gpu=0"))
+
+	device1 := info.DiscoveredDevices[1]
+	assert.Check(t, is.Equal(device1.Source, "cdi"))
+	assert.Check(t, is.Equal(device1.ID, "vendor.com/gpu=1"))
+}

--- a/daemon/cdi.go
+++ b/daemon/cdi.go
@@ -3,8 +3,11 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/api/types/system"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/errdefs"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -40,6 +43,11 @@ func newCDIDeviceDriver(cdiSpecDirs ...string) *deviceDriver {
 		}
 		return &deviceDriver{
 			updateSpec: errorOnUpdateSpec,
+			ListDevices: func(ctx context.Context, cfg *config.Config) (deviceListing, error) {
+				return deviceListing{
+					Warnings: []string{fmt.Sprintf("CDI cache initialization failed: %v", err)},
+				}, nil
+			},
 		}
 	}
 
@@ -49,7 +57,8 @@ func newCDIDeviceDriver(cdiSpecDirs ...string) *deviceDriver {
 	}
 
 	return &deviceDriver{
-		updateSpec: c.injectCDIDevices,
+		updateSpec:  c.injectCDIDevices,
+		ListDevices: c.listDevices,
 	}
 }
 
@@ -104,4 +113,40 @@ func (c *cdiHandler) getErrors() error {
 		err = multierror.Append(err, errs...)
 	}
 	return err.ErrorOrNil()
+}
+
+// listDevices uses the CDI cache to list all discovered CDI devices.
+// It conforms to the deviceDriver.ListDevices function signature.
+func (c *cdiHandler) listDevices(ctx context.Context, cfg *config.Config) (deviceListing, error) {
+	var out deviceListing
+
+	// Collect global errors from the CDI cache (e.g., issues with spec files themselves).
+	for specPath, specErrs := range c.registry.GetErrors() {
+		for _, err := range specErrs {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			out.Warnings = append(out.Warnings, fmt.Sprintf("CDI: Error associated with spec file %s: %v", specPath, err))
+		}
+	}
+
+	qualifiedDeviceNames := c.registry.ListDevices()
+	if len(qualifiedDeviceNames) == 0 {
+		return out, nil
+	}
+
+	for _, qdn := range qualifiedDeviceNames {
+		device := c.registry.GetDevice(qdn)
+		if device == nil {
+			log.G(ctx).WithField("device", qdn).Warn("CDI: Cache.GetDevice() returned nil for a listed device, skipping.")
+			out.Warnings = append(out.Warnings, fmt.Sprintf("CDI: Device %s listed but not found by GetDevice()", qdn))
+			continue
+		}
+
+		out.Devices = append(out.Devices, system.DeviceInfo{
+			ID: qdn,
+		})
+	}
+
+	return out, nil
 }

--- a/daemon/cdi.go
+++ b/daemon/cdi.go
@@ -30,7 +30,7 @@ func RegisterCDIDriver(cdiSpecDirs ...string) {
 func newCDIDeviceDriver(cdiSpecDirs ...string) *deviceDriver {
 	cache, err := createCDICache(cdiSpecDirs...)
 	if err != nil {
-		log.G(context.TODO()).WithError(err)
+		log.G(context.TODO()).WithError(err).Error("Failed to create CDI cache")
 		// We create a spec updater that always returns an error.
 		// This error will be returned only when a CDI device is requested.
 		// This ensures that daemon startup is not blocked by a CDI registry initialization failure or being disabled

--- a/daemon/devices.go
+++ b/daemon/devices.go
@@ -1,16 +1,31 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/system"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/internal/capabilities"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var deviceDrivers = map[string]*deviceDriver{}
 
+type deviceListing struct {
+	Devices  []system.DeviceInfo
+	Warnings []string
+}
+
 type deviceDriver struct {
 	capset     capabilities.Set
 	updateSpec func(*specs.Spec, *deviceInstance) error
+
+	// ListDevices returns a list of discoverable devices provided by this
+	// driver, any warnings encountered during the discovery, and an error if
+	// the overall listing operation failed.
+	// Can be nil if the driver does not provide a device listing.
+	ListDevices func(ctx context.Context, cfg *config.Config) (deviceListing, error)
 }
 
 type deviceInstance struct {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,15 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.50 API changes
+
+[Docker Engine API v1.50](https://docs.docker.com/reference/api/engine/version/v1.50/) documentation
+
+* `GET /info` now includes a `DiscoveredDevices` field. This is an array of
+  `DeviceInfo` objects, each providing details about a device discovered by a
+  device driver.
+  Currently only the CDI device driver is supported.
+
 ## v1.49 API changes
 
 [Docker Engine API v1.49](https://docs.docker.com/reference/api/engine/version/v1.49/) documentation

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -478,6 +478,8 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	}
 
 	d.args = append(d.args,
+		// Make sure we don't use the environment-provided global config file.
+		"--config-file", "/dev/null",
 		"--data-root", d.Root,
 		"--exec-root", d.execRoot,
 		"--pidfile", d.pidFile,


### PR DESCRIPTION
Add ability for the device driver to implement a device discovery mechanism and expose discovered devices in the `docker info` output.

Currently it's only implemented for CDI devices.

**- How to verify it**
New tests

Example `/info` output:

```json
...
  "DiscoveredDevices": [
    {
      "Source": "cdi",
      "Name": "test.com/device=mygpu0",
    }
  ],
...
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`GET /info` now includes a `DiscoveredDevices` field. This is an array of `DeviceInfo` objects, each providing details about a device discovered by a device driver.
```

TODO: Make CLI print it (`docker info` now returns `DiscoveredDevices` providing a result of CDI device discovery.)
