### PR TITLE
c8d/delete: Add support for deleting specific platforms

### DIFF
--- a/api/server/httputils/form.go
+++ b/api/server/httputils/form.go
@@ -162,3 +162,22 @@ func DecodePlatform(platformJSON string) (*ocispec.Platform, error) {
 
 	return &p, nil
 }
+
+// DecodePlatforms decodes the OCI platform JSON string into a Platform struct.
+//
+// Typically, the argument is a value of: r.Form["platform"]
+func DecodePlatforms(platformJSONs []string) ([]ocispec.Platform, error) {
+	if len(platformJSONs) == 0 {
+		return nil, nil
+	}
+
+	var output []ocispec.Platform
+	for _, platform := range platformJSONs {
+		p, err := DecodePlatform(platform)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, *p)
+	}
+	return output, nil
+}

--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -22,7 +22,7 @@ type Backend interface {
 }
 
 type imageBackend interface {
-	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]image.DeleteResponse, error)
+	ImageDelete(ctx context.Context, imageRef string, options image.RemoveOptions) ([]image.DeleteResponse, error)
 	ImageHistory(ctx context.Context, imageName string, platform *ocispec.Platform) ([]*image.HistoryResponseItem, error)
 	Images(ctx context.Context, opts image.ListOptions) ([]*image.Summary, error)
 	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*dockerimage.Image, error)

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -323,9 +323,19 @@ func (ir *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, 
 	force := httputils.BoolValue(r, "force")
 	prune := !httputils.BoolValue(r, "noprune")
 
+	var platforms []ocispec.Platform
+	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.50") {
+		p, err := httputils.DecodePlatforms(r.Form["platforms"])
+		if err != nil {
+			return err
+		}
+		platforms = p
+	}
+
 	list, err := ir.backend.ImageDelete(ctx, name, imagetypes.RemoveOptions{
 		Force:         force,
 		PruneChildren: prune,
+		Platforms:     platforms,
 	})
 	if err != nil {
 		return err

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -323,7 +323,10 @@ func (ir *imageRouter) deleteImages(ctx context.Context, w http.ResponseWriter, 
 	force := httputils.BoolValue(r, "force")
 	prune := !httputils.BoolValue(r, "noprune")
 
-	list, err := ir.backend.ImageDelete(ctx, name, force, prune)
+	list, err := ir.backend.ImageDelete(ctx, name, imagetypes.RemoveOptions{
+		Force:         force,
+		PruneChildren: prune,
+	})
 	if err != nil {
 		return err
 	}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9960,6 +9960,18 @@ paths:
           description: "Do not delete untagged parent images"
           type: "boolean"
           default: false
+        - name: "platforms"
+          in: "query"
+          description: |
+            Select platform-specific content to delete.
+            Multiple values are accepted.
+            Each platform is a OCI platform encoded as a JSON string.
+          type: "array"
+          items:
+            # This should be OCIPlatform
+            # but $ref is not supported for array in query in Swagger 2.0
+            # $ref: "#/definitions/OCIPlatform"
+            type: "string"
       tags: ["Image"]
   /images/search:
     get:

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -83,6 +83,7 @@ type ListOptions struct {
 
 // RemoveOptions holds parameters to remove images.
 type RemoveOptions struct {
+	Platforms     []ocispec.Platform
 	Force         bool
 	PruneChildren bool
 }

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -19,6 +19,14 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options imag
 		query.Set("noprune", "1")
 	}
 
+	if len(options.Platforms) > 0 {
+		p, err := encodePlatforms(options.Platforms...)
+		if err != nil {
+			return nil, err
+		}
+		query["platforms"] = p
+	}
+
 	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/daemon/containerd/fake_service_test.go
+++ b/daemon/containerd/fake_service_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
@@ -243,49 +242,4 @@ func (s *delayedStore) Info(ctx context.Context, dgst digest.Digest) (content.In
 func (s *delayedStore) Update(ctx context.Context, info content.Info, fieldpaths ...string) (content.Info, error) {
 	s.delay()
 	return s.store.Update(ctx, info, fieldpaths...)
-}
-
-type memoryLabelStore struct {
-	mu     sync.Mutex
-	labels map[digest.Digest]map[string]string
-}
-
-// Get returns all the labels for the given digest
-func (s *memoryLabelStore) Get(dgst digest.Digest) (map[string]string, error) {
-	s.mu.Lock()
-	labels := s.labels[dgst]
-	s.mu.Unlock()
-	return labels, nil
-}
-
-// Set sets all the labels for a given digest
-func (s *memoryLabelStore) Set(dgst digest.Digest, labels map[string]string) error {
-	s.mu.Lock()
-	if s.labels == nil {
-		s.labels = make(map[digest.Digest]map[string]string)
-	}
-	s.labels[dgst] = labels
-	s.mu.Unlock()
-	return nil
-}
-
-// Update replaces the given labels for a digest,
-// a key with an empty value removes a label.
-func (s *memoryLabelStore) Update(dgst digest.Digest, update map[string]string) (map[string]string, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	labels, ok := s.labels[dgst]
-	if !ok {
-		labels = map[string]string{}
-	}
-	for k, v := range update {
-		labels[k] = v
-	}
-	if s.labels == nil {
-		s.labels = map[digest.Digest]map[string]string{}
-	}
-	s.labels[dgst] = labels
-
-	return labels, nil
 }

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -52,13 +52,16 @@ import (
 // conflict will not be reported.
 //
 // TODO(thaJeztah): image delete should send prometheus counters; see https://github.com/moby/moby/issues/45268
-func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, prune bool) (response []imagetypes.DeleteResponse, retErr error) {
+func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, options imagetypes.RemoveOptions) (response []imagetypes.DeleteResponse, retErr error) {
 	start := time.Now()
 	defer func() {
 		if retErr == nil {
 			metrics.ImageActions.WithValues("delete").UpdateSince(start)
 		}
 	}()
+
+	force := options.Force
+	prune := options.PruneChildren
 
 	var c conflictType
 	if !force {

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -65,6 +65,10 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, options
 		}
 	}()
 
+	if len(options.Platforms) > 0 && !options.Force {
+		return nil, cerrdefs.ErrInvalidArgument.WithMessage("Content will be removed from all images referencing this variant. Use —-force to force delete.")
+	}
+
 	force := options.Force
 	prune := options.PruneChildren
 

--- a/daemon/containerd/image_delete_test.go
+++ b/daemon/containerd/image_delete_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/containerd/v2/core/metadata"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log/logtest"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/container"
 	daemonevents "github.com/docker/docker/daemon/events"
 	dimages "github.com/docker/docker/daemon/images"
@@ -234,7 +235,7 @@ func TestImageDelete(t *testing.T) {
 				}
 			}
 
-			_, err := service.ImageDelete(ctx, tc.ref, false, false)
+			_, err := service.ImageDelete(ctx, tc.ref, image.RemoveOptions{})
 			if tc.err == nil {
 				assert.NilError(t, err)
 			} else {

--- a/daemon/containerd/image_load_test.go
+++ b/daemon/containerd/image_load_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins/content/local"
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/internal/testutils/labelstore"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"github.com/moby/go-archive"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -27,7 +28,7 @@ func TestImageLoadMissing(t *testing.T) {
 
 	ctx := namespaces.WithNamespace(context.TODO(), "testing-"+t.Name())
 
-	store, err := local.NewLabeledStore(t.TempDir(), &memoryLabelStore{})
+	store, err := local.NewLabeledStore(t.TempDir(), &labelstore.InMemory{})
 	assert.NilError(t, err)
 
 	imgSvc := fakeImageService(t, ctx, store)

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -29,7 +29,7 @@ type ImageService interface {
 	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	CreateImage(ctx context.Context, config []byte, parent string, contentStoreDigest digest.Digest) (builder.Image, error)
-	ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]imagetype.DeleteResponse, error)
+	ImageDelete(ctx context.Context, imageRef string, options imagetype.RemoveOptions) ([]imagetype.DeleteResponse, error)
 	ExportImage(ctx context.Context, names []string, platform *ocispec.Platform, outStream io.Writer) error
 	LoadImage(ctx context.Context, inTar io.ReadCloser, platform *ocispec.Platform, outStream io.Writer, quiet bool) error
 	Images(ctx context.Context, opts imagetype.ListOptions) ([]*imagetype.Summary, error)

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/internal/metrics"
 	"github.com/docker/docker/pkg/stringid"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -39,7 +40,7 @@ const (
 // reference will be removed. However, if there exists any containers which
 // were created using the same image reference then the repository reference
 // cannot be removed unless either there are other repository references to the
-// same image or force is true. Following removal of the repository reference,
+// same image or options.Force is true. Following removal of the repository reference,
 // the referenced image itself will attempt to be deleted as described below
 // but quietly, meaning any image delete conflicts will cause the image to not
 // be deleted and the conflict will not be reported.
@@ -57,16 +58,25 @@ const (
 //   - any repository tag or digest references to the image.
 //
 // The image cannot be removed if there are any hard conflicts and can be
-// removed if there are soft conflicts only if force is true.
+// removed if there are soft conflicts only if options.Force is true.
 //
-// If prune is true, ancestor images will each attempt to be deleted quietly,
+// If options.PruneChildren is true, ancestor images are attempted to be deleted quietly,
 // meaning any delete conflicts will cause the image to not be deleted and the
 // conflict will not be reported.
 func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, options imagetypes.RemoveOptions) ([]imagetypes.DeleteResponse, error) {
 	start := time.Now()
 	records := []imagetypes.DeleteResponse{}
 
-	img, err := i.GetImage(ctx, imageRef, backend.GetImageOpts{})
+	var platform *ocispec.Platform
+	switch len(options.Platforms) {
+	case 0:
+	case 1:
+		platform = &options.Platforms[0]
+	default:
+		return nil, errdefs.InvalidParameter(errors.New("multiple platforms are not supported"))
+	}
+
+	img, err := i.GetImage(ctx, imageRef, backend.GetImageOpts{Platform: platform})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -62,7 +62,7 @@ const (
 // If prune is true, ancestor images will each attempt to be deleted quietly,
 // meaning any delete conflicts will cause the image to not be deleted and the
 // conflict will not be reported.
-func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]imagetypes.DeleteResponse, error) {
+func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, options imagetypes.RemoveOptions) ([]imagetypes.DeleteResponse, error) {
 	start := time.Now()
 	records := []imagetypes.DeleteResponse{}
 
@@ -90,6 +90,8 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, force, 
 		return false
 	}
 
+	force := options.Force
+	prune := options.PruneChildren
 	var removedRepositoryRef bool
 	if !isImageIDPrefix(imgID.String(), imageRef) {
 		// A repository reference was given and should be removed

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -115,7 +115,6 @@ deleteImagesLoop:
 			if shouldDelete {
 				for _, ref := range refs {
 					imgDel, err := i.ImageDelete(ctx, ref.String(), imagetypes.RemoveOptions{
-						Force:         false,
 						PruneChildren: true,
 					})
 					if imageDeleteFailed(ref.String(), err) {
@@ -127,7 +126,6 @@ deleteImagesLoop:
 		} else {
 			hex := id.Digest().Encoded()
 			imgDel, err := i.ImageDelete(ctx, hex, imagetypes.RemoveOptions{
-				Force:         false,
 				PruneChildren: true,
 			})
 			if imageDeleteFailed(hex, err) {

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -114,7 +114,10 @@ deleteImagesLoop:
 
 			if shouldDelete {
 				for _, ref := range refs {
-					imgDel, err := i.ImageDelete(ctx, ref.String(), false, true)
+					imgDel, err := i.ImageDelete(ctx, ref.String(), imagetypes.RemoveOptions{
+						Force:         false,
+						PruneChildren: true,
+					})
 					if imageDeleteFailed(ref.String(), err) {
 						continue
 					}
@@ -123,7 +126,10 @@ deleteImagesLoop:
 			}
 		} else {
 			hex := id.Digest().Encoded()
-			imgDel, err := i.ImageDelete(ctx, hex, false, true)
+			imgDel, err := i.ImageDelete(ctx, hex, imagetypes.RemoveOptions{
+				Force:         false,
+				PruneChildren: true,
+			})
 			if imageDeleteFailed(hex, err) {
 				continue
 			}

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -21,6 +21,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   `DeviceInfo` objects, each providing details about a device discovered by a
   device driver.
   Currently only the CDI device driver is supported.
+* `DELETE /images/{name}` now supports a `platforms` query parameter. It accepts
+  an array of JSON-encoded OCI Platform objects, allowing for selecting specific
+  platforms to delete content for.
 * Deprecated: The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the
   `GET /info` response were deprecated in API v1.48, and are now omitted
   in API v1.50.

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -143,6 +143,7 @@ func TestRemoveWithPlatform(t *testing.T) {
 	} {
 		resp, err := apiClient.ImageRemove(ctx, imgName, image.RemoveOptions{
 			Platforms: []ocispec.Platform{*tc.platform},
+			Force:     true,
 		})
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(resp, 1))

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -4,10 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/platforms"
+
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
+	"github.com/docker/docker/internal/testutils/specialimage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -90,4 +94,83 @@ func TestRemoveByDigest(t *testing.T) {
 	inspect, err = client.ImageInspect(ctx, "test-remove-by-digest")
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	assert.Check(t, is.DeepEqual(inspect, image.InspectResponse{}))
+}
+
+func TestRemoveWithPlatform(t *testing.T) {
+	skip.If(t, !testEnv.UsingSnapshotter())
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	imgName := strings.ToLower(t.Name()) + ":latest"
+
+	platformHost := platforms.Normalize(ocispec.Platform{
+		Architecture: testEnv.DaemonInfo.Architecture,
+		OS:           testEnv.DaemonInfo.OSType,
+	})
+	someOtherPlatform := platforms.Platform{
+		OS:           "other",
+		Architecture: "some",
+	}
+
+	var imageIdx *ocispec.Index
+	var descs []ocispec.Descriptor
+	specialimage.Load(ctx, t, apiClient, func(dir string) (*ocispec.Index, error) {
+		idx, d, err := specialimage.MultiPlatform(dir, imgName, []ocispec.Platform{
+			platformHost,
+			{
+				OS:           "linux",
+				Architecture: "test", Variant: "1",
+			},
+			{
+				OS:           "linux",
+				Architecture: "test", Variant: "2",
+			},
+			someOtherPlatform,
+		})
+		descs = d
+		imageIdx = idx
+		return idx, err
+	})
+	_ = imageIdx
+
+	for _, tc := range []struct {
+		platform *ocispec.Platform
+		deleted  ocispec.Descriptor
+	}{
+		{&platformHost, descs[0]},
+		{&someOtherPlatform, descs[3]},
+	} {
+		resp, err := apiClient.ImageRemove(ctx, imgName, image.RemoveOptions{
+			Platforms: []ocispec.Platform{*tc.platform},
+		})
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(resp, 1))
+		for _, r := range resp {
+			assert.Check(t, is.Equal(r.Untagged, ""), "No image should be untagged")
+		}
+		checkPlatformDeleted(t, imageIdx, resp, tc.deleted)
+	}
+
+	// Delete the rest
+	resp, err := apiClient.ImageRemove(ctx, imgName, image.RemoveOptions{})
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Len(resp, 2))
+	assert.Check(t, is.Equal(resp[0].Untagged, imgName))
+	assert.Check(t, is.Equal(resp[1].Deleted, imageIdx.Manifests[0].Digest.String()))
+	// TODO: Should it also include platform-specific manifests?
+}
+
+func checkPlatformDeleted(t *testing.T, imageIdx *ocispec.Index, resp []image.DeleteResponse, mfstDesc ocispec.Descriptor) {
+	for _, r := range resp {
+		if r.Deleted != "" {
+			if assert.Check(t, is.Equal(r.Deleted, mfstDesc.Digest.String())) {
+				continue
+			}
+			if r.Deleted == imageIdx.Manifests[0].Digest.String() {
+				t.Log("Root image was deleted, expected only platform:", platforms.FormatAll(*mfstDesc.Platform))
+			}
+		}
+	}
 }

--- a/internal/testutils/labelstore/memory_label_store.go
+++ b/internal/testutils/labelstore/memory_label_store.go
@@ -1,0 +1,52 @@
+package labelstore
+
+import (
+	"sync"
+
+	"github.com/opencontainers/go-digest"
+)
+
+type InMemory struct {
+	mu     sync.Mutex
+	labels map[digest.Digest]map[string]string
+}
+
+// Get returns all the labels for the given digest
+func (s *InMemory) Get(dgst digest.Digest) (map[string]string, error) {
+	s.mu.Lock()
+	labels := s.labels[dgst]
+	s.mu.Unlock()
+	return labels, nil
+}
+
+// Set sets all the labels for a given digest
+func (s *InMemory) Set(dgst digest.Digest, labels map[string]string) error {
+	s.mu.Lock()
+	if s.labels == nil {
+		s.labels = make(map[digest.Digest]map[string]string)
+	}
+	s.labels[dgst] = labels
+	s.mu.Unlock()
+	return nil
+}
+
+// Update replaces the given labels for a digest,
+// a key with an empty value removes a label.
+func (s *InMemory) Update(dgst digest.Digest, update map[string]string) (map[string]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	labels, ok := s.labels[dgst]
+	if !ok {
+		labels = map[string]string{}
+	}
+	for k, v := range update {
+		labels[k] = v
+	}
+	if s.labels == nil {
+		s.labels = map[digest.Digest]map[string]string{}
+	}
+	s.labels[dgst] = labels
+
+	return labels, nil
+}


### PR DESCRIPTION
- addresses: https://github.com/moby/moby/issues/47680

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`DELETE /images/{name}` now supports a `platforms` query parameter. It accepts an array of JSON-encoded OCI Platform objects, allowing for selecting a specific platforms to delete content for.
```

**- A picture of a cute animal (not mandatory but encouraged)**

