### PR TITLE
libn/networkdb: SetPrimaryKey() under a write lock

### DIFF
--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -71,8 +71,8 @@ func (nDB *NetworkDB) SetKey(key []byte) {
 // been added apriori through SetKey
 func (nDB *NetworkDB) SetPrimaryKey(key []byte) {
 	log.G(context.TODO()).Debugf("Primary Key %.5s", hex.EncodeToString(key))
-	nDB.RLock()
-	defer nDB.RUnlock()
+	nDB.Lock()
+	defer nDB.Unlock()
 	for _, dbKey := range nDB.config.Keys {
 		if bytes.Equal(key, dbKey) {
 			if nDB.keyring != nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
**- How I did it**
(*NetworkDB).SetPrimaryKey() acquires a read lock on the NetworkDB instance. That seems sound on the surface as it is only reading from the NetworkDB struct, not mutating it. However, concurrent calls to (*memberlist.Keyring).UseKey() would get flagged by Go's race detector due to some questionable locking in its implementation. Acquire an exclusive lock in SetPrimaryKey so concurrent calls don't race each other.

**- How to verify it**
By inspection.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

