### PR TITLE
integration/networking: mark TestPortMappedHairpinWindows as flaky

### DIFF
--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -75,7 +75,9 @@ func TestNatNetworkICC(t *testing.T) {
 
 // Check that a container on one network can reach a service in a container on
 // another network, via a mapped port on the host.
-func TestPortMappedHairpinWindows(t *testing.T) {
+//
+// FIXME: flaky test; see https://github.com/moby/moby/issues/48881
+func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	ctx := setupTest(t)
 	c := testEnv.APIClient()
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/issues/48881
- https://github.com/moby/moby/pull/47553


---

This test is failing frequently on Windows;

    === FAIL: github.com/docker/docker/integration/networking TestPortMappedHairpinWindows (12.37s)
        nat_windows_test.go:108: assertion failed: error is not nil: Post "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.49/containers/1181d6510a2f55c742b7b183aa7324eddbc213cd15797428c4062dcb031fb825/start": context deadline exceeded
        panic.go:636: assertion failed: error is not nil: Error response from daemon: error while removing network: network clientnet has active endpoints (name:"laughing_lederberg" id:"8605ebbc2c7c")

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

