### PR TITLE
api/types/container: Summary.State change type to ContainerState

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -132,7 +132,7 @@ type Summary struct {
 	SizeRw                  int64 `json:",omitempty"`
 	SizeRootFs              int64 `json:",omitempty"`
 	Labels                  map[string]string
-	State                   string
+	State                   ContainerState
 	Status                  string
 	HostConfig              struct {
 		NetworkMode string            `json:",omitempty"`


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49965

ContainerState is currently an alias for string, so this should not be a disruptive change, but is a stepping-stone to make it a distinct type in future.

Relates to b81182959592e2a06a56d3c5ec7fbc229cb90840

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: `api/types/container`: change `Summary.State` to a `ContainerState`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

