### PR TITLE
container: Snapshot.Health: change type to container.HealthStatus

### DIFF
--- a/container/view.go
+++ b/container/view.go
@@ -45,7 +45,7 @@ type Snapshot struct {
 	Managed      bool
 	ExposedPorts nat.PortSet
 	PortBindings nat.PortSet
-	Health       string
+	Health       container.HealthStatus
 	HostConfig   struct {
 		Isolation string
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49876

container.HealthStatus is a pseudo-type (alias for string) that was introduced in 1e4bb14bcde14f5e133bc5b493bd332c1802cefb.

Changing this field to use that type as a potential stepping-stone towards making that type a distinct type.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

