### PR TITLE
daemon: startIngressWorker: fix S1000: should use for range (staticcheck)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -152,7 +152,6 @@ linters:
       checks:
         - all
         - -QF1008 # Omit embedded fields from selector expression; https://staticcheck.dev/docs/checks/#QF1008
-        - -S1000  # Use plain channel send or receive instead of single-case select; https://staticcheck.dev/docs/checks/#S1000
         - -ST1000 # Incorrect or missing package comment; https://staticcheck.dev/docs/checks/#ST1000
         - -ST1003 # Poorly chosen identifier; https://staticcheck.dev/docs/checks/#ST1003
         - -ST1005 # Incorrectly formatted error string; https://staticcheck.dev/docs/checks/#ST1005
@@ -167,7 +166,7 @@ linters:
   exclusions:
     paths:
       - volume/drivers/proxy.go # TODO: this is a generated file but with an invalid header, see https://github.com/moby/moby/pull/46274
-    
+
     rules:
         # We prefer to use an "linters.exclusions.rules" so that new "default" exclusions are not
         # automatically inherited. We can decide whether or not to follow upstream

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -153,18 +153,15 @@ var (
 func (daemon *Daemon) startIngressWorker() {
 	ingressJobsChannel = make(chan *ingressJob, 100)
 	go func() {
-		for {
-			select {
-			case r := <-ingressJobsChannel:
-				if r.create != nil {
-					daemon.setupIngress(&daemon.config().Config, r.create, r.ip, ingressID)
-					ingressID = r.create.ID
-				} else {
-					daemon.releaseIngress(ingressID)
-					ingressID = ""
-				}
-				close(r.jobDone)
+		for r := range ingressJobsChannel {
+			if r.create != nil {
+				daemon.setupIngress(&daemon.config().Config, r.create, r.ip, ingressID)
+				ingressID = r.create.ID
+			} else {
+				daemon.releaseIngress(ingressID)
+				ingressID = ""
 			}
+			close(r.jobDone)
 		}
 	}()
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49870#discussion_r2088345478

    daemon/network.go:156:3: S1000: should use for range instead of for { select {} } (staticcheck)
            for {
            ^


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

