### PR TITLE
fix: basic revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -224,6 +224,7 @@ linters:
         - name: superfluous-else
           arguments:
             - preserve-scope
+        - name: time-equal
         - name: use-any
         - name: use-errors-new
         - name: useless-break

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -213,6 +213,9 @@ linters:
         - name: early-return
           arguments:
             - preserve-scope
+        - name: indent-error-flow
+          arguments:
+            - preserve-scope
           # FIXME make sure all packages have a description. Currently, there's many packages without.
         - name: package-comments
           disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -213,6 +213,7 @@ linters:
         - name: early-return
           arguments:
             - preserve-scope
+        - name: if-return
         - name: indent-error-flow
           arguments:
             - preserve-scope

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -226,6 +226,7 @@ linters:
             - preserve-scope
         - name: use-any
         - name: use-errors-new
+        - name: useless-break
         - name: var-declaration
 
     staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -210,6 +210,9 @@ linters:
       # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
       rules:
         - name: increment-decrement
+        - name: early-return
+          arguments:
+            - preserve-scope
           # FIXME make sure all packages have a description. Currently, there's many packages without.
         - name: package-comments
           disabled: true

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -114,9 +114,8 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewReader(b)),
 				}, nil
-			} else {
-				return nil, fmt.Errorf("unexpected URL '%s'", req.URL.Path)
 			}
+			return nil, fmt.Errorf("unexpected URL '%s'", req.URL.Path)
 		}),
 	}
 

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -28,22 +28,21 @@ func (c *Cluster) Init(req types.InitRequest) (string, error) {
 	c.controlMutex.Lock()
 	defer c.controlMutex.Unlock()
 	if c.nr != nil {
-		if req.ForceNewCluster {
-
-			// Take c.mu temporarily to wait for presently running
-			// API handlers to finish before shutting down the node.
-			c.mu.Lock()
-			if !c.nr.nodeState.IsManager() {
-				c.mu.Unlock()
-				return "", errSwarmNotManager
-			}
-			c.mu.Unlock()
-
-			if err := c.nr.Stop(); err != nil {
-				return "", err
-			}
-		} else {
+		if !req.ForceNewCluster {
 			return "", errSwarmExists
+		}
+
+		// Take c.mu temporarily to wait for presently running
+		// API handlers to finish before shutting down the node.
+		c.mu.Lock()
+		if !c.nr.nodeState.IsManager() {
+			c.mu.Unlock()
+			return "", errSwarmNotManager
+		}
+		c.mu.Unlock()
+
+		if err := c.nr.Stop(); err != nil {
+			return "", err
 		}
 	}
 
@@ -311,17 +310,16 @@ func (c *Cluster) UnlockSwarm(req types.UnlockRequest) error {
 	c.mu.RLock()
 	state := c.currentNodeState()
 
-	if !state.IsActiveManager() {
-		// when manager is not active,
-		// unless it is locked, otherwise return error.
-		if err := c.errNoManager(state); !errors.Is(err, errSwarmLocked) {
-			c.mu.RUnlock()
-			return err
-		}
-	} else {
+	if state.IsActiveManager() {
 		// when manager is active, return an error of "not locked"
 		c.mu.RUnlock()
 		return notLockedError{}
+	}
+	// when manager is not active,
+	// unless it is locked, otherwise return error.
+	if err := c.errNoManager(state); !errors.Is(err, errSwarmLocked) {
+		c.mu.RUnlock()
+		return err
 	}
 
 	// only when swarm is locked, code running reaches here

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -1055,11 +1055,7 @@ func (daemon *Daemon) DisconnectFromNetwork(ctx context.Context, ctr *container.
 		return err
 	}
 
-	if err := ctr.CheckpointTo(ctx, daemon.containersReplica); err != nil {
-		return err
-	}
-
-	return nil
+	return ctr.CheckpointTo(ctx, daemon.containersReplica)
 }
 
 // ActivateContainerServiceBinding puts this container into load balancer active rotation and DNS response

--- a/daemon/containerd/image_delete.go
+++ b/daemon/containerd/image_delete.go
@@ -354,19 +354,19 @@ func (i *ImageService) getSameReferences(ctx context.Context, named reference.Na
 				} else if named.Name() != repoRef.Name() {
 					continue
 				} else if !allTags {
-					if tagged, ok := repoRef.(reference.Tagged); ok {
-						if tag == "" {
-							tag = tagged.Tag()
-						} else if tag != tagged.Tag() {
-							// Same repo, different tag, do not include digest refs
-							digestRefs = nil
-							continue
-						}
-					} else {
+					tagged, ok := repoRef.(reference.Tagged)
+					if !ok {
 						if digestRefs != nil {
 							digestRefs = append(digestRefs, ref)
 						}
 						// Add digest refs at end if no other tags in the same name
+						continue
+					}
+					if tag == "" {
+						tag = tagged.Tag()
+					} else if tag != tagged.Tag() {
+						// Same repo, different tag, do not include digest refs
+						digestRefs = nil
 						continue
 					}
 				}

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -358,14 +358,13 @@ func (i *ImageService) multiPlatformSummary(ctx context.Context, img c8dimages.I
 		return nil
 	})
 	if err != nil {
-		if errors.Is(err, errNotManifestOrIndex) {
-			log.G(ctx).WithFields(log.Fields{
-				"error": err,
-				"image": img.Name,
-			}).Warn("unexpected image target (neither a manifest nor index)")
-		} else {
+		if !errors.Is(err, errNotManifestOrIndex) {
 			return nil, err
 		}
+		log.G(ctx).WithFields(log.Fields{
+			"error": err,
+			"image": img.Name,
+		}).Warn("unexpected image target (neither a manifest nor index)")
 	}
 
 	return &summary, nil

--- a/daemon/containerd/registry_errors.go
+++ b/daemon/containerd/registry_errors.go
@@ -40,11 +40,10 @@ func translateRegistryError(ctx context.Context, err error) error {
 			}
 		} else {
 			var derr docker.Error
-			if errors.As(err, &derr) {
-				derrs = append(derrs, derr)
-			} else {
+			if !errors.As(err, &derr) {
 				return err
 			}
+			derrs = append(derrs, derr)
 		}
 	}
 	var errs []error

--- a/daemon/containerfs_linux.go
+++ b/daemon/containerfs_linux.go
@@ -143,9 +143,8 @@ func (daemon *Daemon) openContainerFS(ctr *container.Container) (_ *containerFSV
 					if err := makeMountRRO(dest); err != nil {
 						if m.ReadOnlyForceRecursive {
 							return err
-						} else {
-							log.G(context.TODO()).WithError(err).Debugf("Failed to make %q recursively read-only", dest)
 						}
+						log.G(context.TODO()).WithError(err).Debugf("Failed to make %q recursively read-only", dest)
 					}
 				}
 			}

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -123,9 +123,5 @@ func (daemon *Daemon) populateVolume(ctx context.Context, c *container.Container
 	}()
 
 	log.G(ctx).Debugf("copying image data from %s:%s, to %s", c.ID, mnt.Destination, volumePath)
-	if err := c.CopyImagePathContent(volumePath, ctrDestPath); err != nil {
-		return err
-	}
-
-	return nil
+	return c.CopyImagePathContent(volumePath, ctrDestPath)
 }

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -92,9 +92,8 @@ func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.
 		if !config.ForceRemove {
 			if ctr.Paused {
 				return errdefs.Conflict(errors.New("container is paused and must be unpaused first"))
-			} else {
-				return errdefs.Conflict(fmt.Errorf("container is %s: stop the container before removing or force remove", ctr.StateString()))
 			}
+			return errdefs.Conflict(fmt.Errorf("container is %s: stop the container before removing or force remove", ctr.StateString()))
 		}
 		if err := daemon.Kill(ctr); err != nil && !isNotRunning(err) {
 			return fmt.Errorf("could not kill container: %w", err)

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -164,11 +164,7 @@ func (d *Driver) GetMetadata(id string) (map[string]string, error) {
 
 // Cleanup unmounts the home directory.
 func (d *Driver) Cleanup() error {
-	if err := mount.Unmount(d.home); err != nil {
-		return err
-	}
-
-	return nil
+	return mount.Unmount(d.home)
 }
 
 func free(p *C.char) {

--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -57,11 +57,10 @@ func copyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRang
 		err = doCopyWithFileRange(srcFile, dstFile, fileinfo)
 		// Trying the file_clone may not have caught the exdev case
 		// as the ioctl may not have been available (therefore EINVAL)
-		if errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOSYS) {
-			*copyWithFileRange = false
-		} else {
+		if !errors.Is(err, unix.EXDEV) && !errors.Is(err, unix.ENOSYS) {
 			return err
 		}
+		*copyWithFileRange = false
 	}
 	return legacyCopy(srcFile, dstFile)
 }

--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -32,11 +32,10 @@ func doesSupportNativeDiff(d string) error {
 		if err != nil {
 			return err
 		}
-		if needed {
-			userxattr = true
-		} else {
+		if !needed {
 			return errors.New("native diff is not supported in user namespace, consider updating to kernel 5.11 or later to fix")
 		}
+		userxattr = true
 	}
 
 	td, err := os.MkdirTemp(d, "opaque-bug-check")

--- a/daemon/hosts.go
+++ b/daemon/hosts.go
@@ -145,11 +145,10 @@ func loadTLSConfig(d string) (*tls.Config, error) {
 	if len(rootCAs) > 0 {
 		systemPool, err := x509.SystemCertPool()
 		if err != nil {
-			if runtime.GOOS == "windows" {
-				systemPool = x509.NewCertPool()
-			} else {
+			if runtime.GOOS != "windows" {
 				return nil, errors.Wrapf(err, "unable to get system cert pool")
 			}
+			systemPool = x509.NewCertPool()
 		}
 		tc.RootCAs = systemPool
 	}

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -183,15 +183,14 @@ func (i *ImageService) Images(ctx context.Context, opts imagetypes.ListOptions) 
 			}
 		}
 		if summary.RepoDigests == nil && summary.RepoTags == nil {
-			if opts.All || len(i.imageStore.Children(id)) == 0 {
-				if opts.Filters.Contains("dangling") && !danglingOnly {
-					// dangling=false case, so dangling image is not needed
-					continue
-				}
-				if opts.Filters.Contains("reference") { // skip images with no references if filtering by reference
-					continue
-				}
-			} else {
+			if !opts.All && len(i.imageStore.Children(id)) != 0 {
+				continue
+			}
+			if opts.Filters.Contains("dangling") && !danglingOnly {
+				// dangling=false case, so dangling image is not needed
+				continue
+			}
+			if opts.Filters.Contains("reference") { // skip images with no references if filtering by reference
 				continue
 			}
 		} else if danglingOnly && len(summary.RepoTags) > 0 {

--- a/daemon/initlayer/setup_unix.go
+++ b/daemon/initlayer/setup_unix.go
@@ -40,29 +40,28 @@ func Setup(initLayerFs string, uid int, gid int) error {
 		}
 
 		if _, err := os.Stat(filepath.Join(initLayer, pth)); err != nil {
-			if os.IsNotExist(err) {
-				if err := user.MkdirAllAndChown(filepath.Join(initLayer, filepath.Dir(pth)), 0o755, uid, gid, user.WithOnlyNew); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			if err := user.MkdirAllAndChown(filepath.Join(initLayer, filepath.Dir(pth)), 0o755, uid, gid, user.WithOnlyNew); err != nil {
+				return err
+			}
+			switch typ {
+			case "dir":
+				if err := user.MkdirAllAndChown(filepath.Join(initLayer, pth), 0o755, uid, gid, user.WithOnlyNew); err != nil {
 					return err
 				}
-				switch typ {
-				case "dir":
-					if err := user.MkdirAllAndChown(filepath.Join(initLayer, pth), 0o755, uid, gid, user.WithOnlyNew); err != nil {
-						return err
-					}
-				case "file":
-					f, err := os.OpenFile(filepath.Join(initLayer, pth), os.O_CREATE, 0o755)
-					if err != nil {
-						return err
-					}
-					f.Chown(uid, gid)
-					f.Close()
-				default:
-					if err := os.Symlink(typ, filepath.Join(initLayer, pth)); err != nil {
-						return err
-					}
+			case "file":
+				f, err := os.OpenFile(filepath.Join(initLayer, pth), os.O_CREATE, 0o755)
+				if err != nil {
+					return err
 				}
-			} else {
-				return err
+				f.Chown(uid, gid)
+				f.Close()
+			default:
+				if err := os.Symlink(typ, filepath.Join(initLayer, pth)); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/daemon/internal/distribution/xfer/download.go
+++ b/daemon/internal/distribution/xfer/download.go
@@ -200,7 +200,6 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, layers []Download
 		topDownload.transfer.release(xferWatcher)
 		return rootFS, func() {}, ctx.Err()
 	case <-topDownload.done():
-		break
 	}
 
 	l, err := topDownload.result()

--- a/daemon/internal/runconfig/config.go
+++ b/daemon/internal/runconfig/config.go
@@ -74,10 +74,8 @@ func validateCreateRequest(w container.CreateRequest, si *sysinfo.SysInfo) error
 	if err := validatePrivileged(w.HostConfig); err != nil {
 		return err
 	}
-	if err := validateReadonlyRootfs(w.HostConfig); err != nil {
-		return err
-	}
-	return nil
+	err := validateReadonlyRootfs(w.HostConfig)
+	return err
 }
 
 // loadJSON is similar to api/server/httputils.ReadJSON()

--- a/daemon/internal/system/chtimes_linux_test.go
+++ b/daemon/internal/system/chtimes_linux_test.go
@@ -31,7 +31,7 @@ func TestChtimesATime(t *testing.T) {
 
 		stat := f.Sys().(*syscall.Stat_t)
 		aTime := time.Unix(stat.Atim.Unix())
-		if aTime != unixEpochTime {
+		if !aTime.Equal(unixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
 		}
 	})
@@ -49,7 +49,7 @@ func TestChtimesATime(t *testing.T) {
 
 		stat := f.Sys().(*syscall.Stat_t)
 		aTime := time.Unix(stat.Atim.Unix())
-		if aTime != unixEpochTime {
+		if !aTime.Equal(unixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
 		}
 	})
@@ -67,7 +67,7 @@ func TestChtimesATime(t *testing.T) {
 
 		stat := f.Sys().(*syscall.Stat_t)
 		aTime := time.Unix(stat.Atim.Unix())
-		if aTime != unixEpochTime {
+		if !aTime.Equal(unixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", unixEpochTime, aTime)
 		}
 	})
@@ -85,7 +85,7 @@ func TestChtimesATime(t *testing.T) {
 
 		stat := f.Sys().(*syscall.Stat_t)
 		aTime := time.Unix(stat.Atim.Unix())
-		if aTime != afterUnixEpochTime {
+		if !aTime.Equal(afterUnixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", afterUnixEpochTime, aTime)
 		}
 	})
@@ -103,7 +103,7 @@ func TestChtimesATime(t *testing.T) {
 
 		stat := f.Sys().(*syscall.Stat_t)
 		aTime := time.Unix(stat.Atim.Unix())
-		if aTime.Truncate(time.Second) != unixMaxTime.Truncate(time.Second) {
+		if !aTime.Truncate(time.Second).Equal(unixMaxTime.Truncate(time.Second)) {
 			t.Fatalf("Expected: %s, got: %s", unixMaxTime.Truncate(time.Second), aTime.Truncate(time.Second))
 		}
 	})

--- a/daemon/internal/system/chtimes_test.go
+++ b/daemon/internal/system/chtimes_test.go
@@ -29,7 +29,7 @@ func TestChtimesModTime(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if f.ModTime() != unixEpochTime {
+		if !f.ModTime().Equal(unixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", unixEpochTime, f.ModTime())
 		}
 	})
@@ -45,7 +45,7 @@ func TestChtimesModTime(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if f.ModTime() != unixEpochTime {
+		if !f.ModTime().Equal(unixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", unixEpochTime, f.ModTime())
 		}
 	})
@@ -61,7 +61,7 @@ func TestChtimesModTime(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if f.ModTime() != unixEpochTime {
+		if !f.ModTime().Equal(unixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", unixEpochTime, f.ModTime())
 		}
 	})
@@ -77,7 +77,7 @@ func TestChtimesModTime(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if f.ModTime() != afterUnixEpochTime {
+		if !f.ModTime().Equal(afterUnixEpochTime) {
 			t.Fatalf("Expected: %s, got: %s", afterUnixEpochTime, f.ModTime())
 		}
 	})
@@ -93,7 +93,7 @@ func TestChtimesModTime(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if f.ModTime().Truncate(time.Second) != unixMaxTime.Truncate(time.Second) {
+		if !f.ModTime().Truncate(time.Second).Equal(unixMaxTime.Truncate(time.Second)) {
 			t.Fatalf("Expected: %s, got: %s", unixMaxTime.Truncate(time.Second), f.ModTime().Truncate(time.Second))
 		}
 	})

--- a/daemon/libnetwork/cnmallocator/drivers_ipam.go
+++ b/daemon/libnetwork/cnmallocator/drivers_ipam.go
@@ -43,9 +43,5 @@ func initIPAMDrivers(r ipamapi.Registerer, netConfig *networkallocator.Config) e
 		log.G(context.TODO()).Info("Swarm initialized global default address pool to: " + str.String())
 	}
 
-	if err := ipams.Register(r, nil, nil, addressPool); err != nil {
-		return err
-	}
-
-	return nil
+	return ipams.Register(r, nil, nil, addressPool)
 }

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1887,23 +1887,23 @@ func parseConnectivityOptions(cOptions map[string]any) (*connectivityConfigurati
 	cc := &connectivityConfiguration{}
 
 	if opt, ok := cOptions[netlabel.PortMap]; ok {
-		if pbs, ok := opt.([]types.PortBinding); ok {
-			cc.PortBindings = sliceutil.Map(pbs, func(pb types.PortBinding) portmapperapi.PortBindingReq {
-				return portmapperapi.PortBindingReq{
-					PortBinding: pb.Copy(),
-				}
-			})
-		} else {
+		pbs, ok := opt.([]types.PortBinding)
+		if !ok {
 			return nil, types.InvalidParameterErrorf("invalid port mapping data in connectivity configuration: %v", opt)
 		}
+		cc.PortBindings = sliceutil.Map(pbs, func(pb types.PortBinding) portmapperapi.PortBindingReq {
+			return portmapperapi.PortBindingReq{
+				PortBinding: pb.Copy(),
+			}
+		})
 	}
 
 	if opt, ok := cOptions[netlabel.ExposedPorts]; ok {
-		if ports, ok := opt.([]types.TransportPort); ok {
-			cc.ExposedPorts = ports
-		} else {
+		ports, ok := opt.([]types.TransportPort)
+		if !ok {
 			return nil, types.InvalidParameterErrorf("invalid exposed ports data in connectivity configuration: %v", opt)
 		}
+		cc.ExposedPorts = ports
 	}
 
 	return cc, nil

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
@@ -113,11 +113,7 @@ func (n *network) setPerPortNAT(ipv iptables.IPVersion, b types.PortBinding, ena
 		"--dport", strconv.Itoa(int(b.Port)),
 		"-j", "MASQUERADE",
 	}}
-	if err := appendOrDelChainRule(rule, "MASQUERADE", n.ipt.config.Hairpin && enable); err != nil {
-		return err
-	}
-
-	return nil
+	return appendOrDelChainRule(rule, "MASQUERADE", n.ipt.config.Hairpin && enable)
 }
 
 // setPerPortForwarding opens access to a container's published port, as described by binding b.
@@ -136,11 +132,8 @@ func setPerPortForwarding(b types.PortBinding, ipv iptables.IPVersion, bridgeNam
 		"--dport", strconv.Itoa(int(b.Port)),
 		"-j", "ACCEPT",
 	}}
-	if err := programChainRule(rule, "OPEN PORT", enable); err != nil {
-		return err
-	}
-
-	return nil
+	err := programChainRule(rule, "OPEN PORT", enable)
+	return err
 }
 
 // filterPortMappedOnLoopback adds an iptables rule that drops remote
@@ -176,11 +169,7 @@ func filterPortMappedOnLoopback(ctx context.Context, b types.PortBinding, hostIP
 		"!", "-i", "lo",
 		"-j", "DROP",
 	}}
-	if err := appendOrDelChainRule(drop, "LOOPBACK FILTERING - DROP", enable); err != nil {
-		return err
-	}
-
-	return nil
+	return appendOrDelChainRule(drop, "LOOPBACK FILTERING - DROP", enable)
 }
 
 // dropLegacyFilterDirectAccess deletes a rule that was introduced in 28.0.0 to
@@ -228,11 +217,7 @@ func (n *network) dropLegacyFilterDirectAccess(ctx context.Context, b types.Port
 		"!", "-i", n.config.IfName,
 		"-j", "DROP",
 	}}
-	if err := appendOrDelChainRule(drop, "LEGACY DIRECT ACCESS FILTERING - DROP", false); err != nil {
-		return err
-	}
-
-	return nil
+	return appendOrDelChainRule(drop, "LEGACY DIRECT ACCESS FILTERING - DROP", false)
 }
 
 func rawRulesDisabled(ctx context.Context) bool {

--- a/daemon/libnetwork/drivers/bridge/setup_ipv6_linux.go
+++ b/daemon/libnetwork/drivers/bridge/setup_ipv6_linux.go
@@ -37,10 +37,7 @@ func setupBridgeIPv6(config *networkConfiguration, i *bridgeInterface) error {
 
 	// Remove unwanted addresses from the bridge, add required addresses, and assign
 	// values to "i.bridgeIPv6", "i.gatewayIPv6".
-	if err := i.programIPv6Addresses(config); err != nil {
-		return err
-	}
-	return nil
+	return i.programIPv6Addresses(config)
 }
 
 func setupGatewayIPv6(config *networkConfiguration, i *bridgeInterface) error {

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -694,11 +694,7 @@ func (ep *Endpoint) rename(name string) error {
 	ep.mu.Unlock()
 
 	// Update the store with the updated name
-	if err := ep.getNetwork().getController().storeEndpoint(context.TODO(), ep); err != nil {
-		return err
-	}
-
-	return nil
+	return ep.getNetwork().getController().storeEndpoint(context.TODO(), ep)
 }
 
 func (ep *Endpoint) UpdateDNSNames(dnsNames []string) error {
@@ -730,11 +726,7 @@ func (ep *Endpoint) UpdateDNSNames(dnsNames []string) error {
 	}
 
 	// Update the store with the updated name
-	if err := c.storeEndpoint(context.TODO(), ep); err != nil {
-		return err
-	}
-
-	return nil
+	return c.storeEndpoint(context.TODO(), ep)
 }
 
 func (ep *Endpoint) hasInterface(iName string) bool {

--- a/daemon/libnetwork/ipams/defaultipam/structures.go
+++ b/daemon/libnetwork/ipams/defaultipam/structures.go
@@ -63,9 +63,8 @@ func PoolIDFromString(str string) (pID PoolID, err error) {
 func (s *PoolID) String() string {
 	if s.ChildSubnet == (netip.Prefix{}) {
 		return s.AddressSpace + "/" + s.Subnet.String()
-	} else {
-		return s.AddressSpace + "/" + s.Subnet.String() + "/" + s.ChildSubnet.String()
 	}
+	return s.AddressSpace + "/" + s.Subnet.String() + "/" + s.ChildSubnet.String()
 }
 
 // String returns the string form of the PoolData object

--- a/daemon/libnetwork/ipams/remote/remote.go
+++ b/daemon/libnetwork/ipams/remote/remote.go
@@ -231,11 +231,10 @@ func (a *allocator) RequestAddress(poolID string, address net.IP, options map[st
 	if err := a.call("RequestAddress", req, res); err != nil {
 		return nil, nil, err
 	}
-	if res.Address != "" {
-		retAddress, err = types.ParseCIDR(res.Address)
-	} else {
+	if res.Address == "" {
 		return nil, nil, ipamapi.ErrNoIPReturned
 	}
+	retAddress, err = types.ParseCIDR(res.Address)
 	return retAddress, res.Data, err
 }
 

--- a/daemon/libnetwork/ipbits/ipbits.go
+++ b/daemon/libnetwork/ipbits/ipbits.go
@@ -15,13 +15,12 @@ func Add(ip netip.Addr, x uint64, shift uint) netip.Addr {
 		addr += uint32(x) << shift
 		binary.BigEndian.PutUint32(a[:], addr)
 		return netip.AddrFrom4(a)
-	} else {
-		a := ip.As16()
-		addr := uint128From16(a)
-		addr = addr.add(uint128From(x).lsh(shift))
-		addr.fill16(&a)
-		return netip.AddrFrom16(a)
 	}
+	a := ip.As16()
+	addr := uint128From16(a)
+	addr = addr.add(uint128From(x).lsh(shift))
+	addr.fill16(&a)
+	return netip.AddrFrom16(a)
 }
 
 // SubnetsBetween computes the number of subnets of size 'sz' available between 'a1'
@@ -55,8 +54,7 @@ func Field(ip netip.Addr, u, v uint) uint64 {
 		mask := ^uint32(0) >> u
 		a := ip.As4()
 		return uint64((binary.BigEndian.Uint32(a[:]) & mask) >> (32 - v))
-	} else {
-		mask := uint128From(0).not().rsh(u)
-		return uint128From16(ip.As16()).and(mask).rsh(128 - v).uint64()
 	}
+	mask := uint128From(0).not().rsh(u)
+	return uint128From16(ip.As16()).and(mask).rsh(128 - v).uint64()
 }

--- a/daemon/libnetwork/iptables/firewalld.go
+++ b/daemon/libnetwork/iptables/firewalld.go
@@ -321,10 +321,7 @@ func AddInterfaceFirewalld(intf string) error {
 
 	log.G(context.TODO()).Debugf("Firewalld: adding %s interface to %s zone", intf, dockerZone)
 	// Runtime
-	if err := connection.sysObj.Call(dbusInterface+".zone.addInterface", 0, dockerZone, intf).Err; err != nil {
-		return err
-	}
-	return nil
+	return connection.sysObj.Call(dbusInterface+".zone.addInterface", 0, dockerZone, intf).Err
 }
 
 // DelInterfaceFirewalld removes the interface from the trusted zone It is a
@@ -346,10 +343,7 @@ func DelInterfaceFirewalld(intf string) error {
 
 	log.G(context.TODO()).Debugf("Firewalld: removing %s interface from %s zone", intf, dockerZone)
 	// Runtime
-	if err := connection.sysObj.Call(dbusInterface+".zone.removeInterface", 0, dockerZone, intf).Err; err != nil {
-		return err
-	}
-	return nil
+	return connection.sysObj.Call(dbusInterface+".zone.removeInterface", 0, dockerZone, intf).Err
 }
 
 type interfaceNotFound struct{ error }

--- a/daemon/libnetwork/iptables/iptables_test.go
+++ b/daemon/libnetwork/iptables/iptables_test.go
@@ -184,11 +184,7 @@ func addSomeRules(c *ChainInfo, ip net.IP, port int, proto, destAddr string, des
 		"--dport", strconv.Itoa(destPort),
 		"-j", "MASQUERADE",
 	}
-	if err := iptable.ProgramRule(Nat, "POSTROUTING", Append, args); err != nil {
-		return err
-	}
-
-	return nil
+	return iptable.ProgramRule(Nat, "POSTROUTING", Append, args)
 }
 
 func TestCleanup(t *testing.T) {

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -935,19 +935,18 @@ func (n *Network) resolveDriver(name string, load bool) (driverapi.Driver, drive
 	// Check if a driver for the specified network type is available
 	d, capabilities := c.drvRegistry.Driver(name)
 	if d == nil {
-		if load {
-			err := c.loadDriver(name)
-			if err != nil {
-				return nil, driverapi.Capability{}, err
-			}
-
-			d, capabilities = c.drvRegistry.Driver(name)
-			if d == nil {
-				return nil, driverapi.Capability{}, fmt.Errorf("could not resolve driver %s in registry", name)
-			}
-		} else {
+		if !load {
 			// don't fail if driver loading is not required
 			return nil, driverapi.Capability{}, nil
+		}
+		err := c.loadDriver(name)
+		if err != nil {
+			return nil, driverapi.Capability{}, err
+		}
+
+		d, capabilities = c.drvRegistry.Driver(name)
+		if d == nil {
+			return nil, driverapi.Capability{}, fmt.Errorf("could not resolve driver %s in registry", name)
 		}
 	}
 

--- a/daemon/libnetwork/osl/interface_linux.go
+++ b/daemon/libnetwork/osl/interface_linux.go
@@ -870,11 +870,7 @@ func (n *Namespace) configureInterface(ctx context.Context, nlh nlwrap.Handle, i
 		}
 	}
 
-	if err := n.setSysctls(ctx, i.dstName, i.sysctls); err != nil {
-		return err
-	}
-
-	return nil
+	return n.setSysctls(ctx, i.dstName, i.sysctls)
 }
 
 func setInterfaceMaster(ctx context.Context, nlh nlwrap.Handle, iface netlink.Link, i *Interface) error {

--- a/daemon/libnetwork/osl/neigh_linux.go
+++ b/daemon/libnetwork/osl/neigh_linux.go
@@ -100,9 +100,8 @@ func (n *Namespace) AddNeighbor(dstIP net.IP, dstMac net.HardwareAddr, options .
 				"neigh": fmt.Sprintf("%+v", nlnh),
 			}).Warn("Neighbor entry already present")
 			return NeighborSearchError{dstIP, dstMac, linkName, true}
-		} else {
-			return fmt.Errorf("could not add neighbor entry %+v: %w", nlnh, err)
 		}
+		return fmt.Errorf("could not add neighbor entry %+v: %w", nlnh, err)
 	}
 
 	log.G(context.TODO()).WithFields(log.Fields{

--- a/daemon/libnetwork/osl/route_linux.go
+++ b/daemon/libnetwork/osl/route_linux.go
@@ -255,14 +255,11 @@ func (n *Namespace) setDefaultRoute(srcName string, routeMatcher func(*net.IPNet
 		return fmt.Errorf("no link src:%s dst:%s", srcName, iface.dstName)
 	}
 
-	if err := n.nlHandle.RouteAdd(&netlink.Route{
+	return n.nlHandle.RouteAdd(&netlink.Route{
 		Scope:     netlink.SCOPE_LINK,
 		LinkIndex: link.Attrs().Index,
 		Dst:       iface.routes[ridx],
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 // UnsetDefaultRouteIPv4 unsets the previously set default IPv4 default route

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -251,13 +251,14 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 
 	writeTimeout := time.Duration(0)
 	if cfg[writeTimeoutKey] != "" {
-		if d, err := time.ParseDuration(cfg[writeTimeoutKey]); err != nil {
+		d, err := time.ParseDuration(cfg[writeTimeoutKey])
+		if err != nil {
 			return config, errors.Wrapf(err, "invalid value for %s: value must be a duration", writeTimeoutKey)
-		} else if d < 0 {
-			return config, errors.Errorf("invalid value for %s: value must be a duration that is non-negative", writeTimeoutKey)
-		} else {
-			writeTimeout = d
 		}
+		if d < 0 {
+			return config, errors.Errorf("invalid value for %s: value must be a duration that is non-negative", writeTimeoutKey)
+		}
+		writeTimeout = d
 	}
 
 	config = fluent.Config{

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -355,27 +355,26 @@ func (daemon *Daemon) createNetwork(ctx context.Context, cfg *config.Config, cre
 	}
 
 	if err := networktypes.ValidateIPAM(create.IPAM, enableIPv6); err != nil {
-		if agent {
-			// This function is called with agent=false for all networks. For swarm-scoped
-			// networks, the configuration is validated but ManagerRedirectError is returned
-			// and the network is not created. Then, each time a swarm-scoped network is
-			// needed, this function is called again with agent=true.
-			//
-			// Non-swarm networks created before ValidateIPAM was introduced continue to work
-			// as they did before-upgrade, even if they would fail the new checks on creation
-			// (for example, by having host-bits set in their subnet). Those networks are not
-			// seen again here.
-			//
-			// By dropping errors for agent networks, existing swarm-scoped networks also
-			// continue to behave as they did before upgrade - but new networks are still
-			// validated.
-			log.G(ctx).WithFields(log.Fields{
-				"error":   err,
-				"network": create.Name,
-			}).Warn("Continuing with validation errors in agent IPAM")
-		} else {
+		if !agent {
 			return nil, errdefs.InvalidParameter(err)
 		}
+		// This function is called with agent=false for all networks. For swarm-scoped
+		// networks, the configuration is validated but ManagerRedirectError is returned
+		// and the network is not created. Then, each time a swarm-scoped network is
+		// needed, this function is called again with agent=true.
+		//
+		// Non-swarm networks created before ValidateIPAM was introduced continue to work
+		// as they did before-upgrade, even if they would fail the new checks on creation
+		// (for example, by having host-bits set in their subnet). Those networks are not
+		// seen again here.
+		//
+		// By dropping errors for agent networks, existing swarm-scoped networks also
+		// continue to behave as they did before upgrade - but new networks are still
+		// validated.
+		log.G(ctx).WithFields(log.Fields{
+			"error":   err,
+			"network": create.Name,
+		}).Warn("Continuing with validation errors in agent IPAM")
 	}
 
 	if create.IPAM != nil {

--- a/daemon/server/router/build/build_routes.go
+++ b/daemon/server/router/build/build_routes.go
@@ -216,18 +216,18 @@ func (br *buildRouter) postPrune(ctx context.Context, w http.ResponseWriter, r *
 			opts.MaxUsedSpace = bs
 		}
 
-		if bs, err := parseBytesFromFormValue("min-free-space"); err != nil {
+		bs, err := parseBytesFromFormValue("min-free-space")
+		if err != nil {
 			return err
-		} else {
-			opts.MinFreeSpace = bs
 		}
+		opts.MinFreeSpace = bs
 	} else {
 		// Only keep-storage was valid in pre-1.48 versions.
-		if bs, err := parseBytesFromFormValue("keep-storage"); err != nil {
+		bs, err := parseBytesFromFormValue("keep-storage")
+		if err != nil {
 			return err
-		} else {
-			opts.ReservedSpace = bs
 		}
+		opts.ReservedSpace = bs
 	}
 
 	report, err := br.backend.PruneCache(ctx, opts)

--- a/daemon/volume/local/local.go
+++ b/daemon/volume/local/local.go
@@ -340,14 +340,13 @@ func (v *localVolume) Unmount(id string) error {
 	// this volume can never be removed until a daemon restart occurs.
 	if v.needsMount() {
 		// TODO: Remove once the real bug is fixed: https://github.com/moby/moby/issues/46508
-		if v.active.count > 0 {
-			v.active.count--
-			logger.WithField("active mounts", v.active).Debug("Decremented active mount count")
-		} else {
+		if v.active.count <= 0 {
 			logger.Error("An attempt to decrement a zero mount count")
 			logger.Error(string(debug.Stack()))
 			return nil
 		}
+		v.active.count--
+		logger.WithField("active mounts", v.active).Debug("Decremented active mount count")
 	}
 
 	if v.active.count > 0 {

--- a/daemon/volume/local/local_unix.go
+++ b/daemon/volume/local/local_unix.go
@@ -182,11 +182,10 @@ func (v *localVolume) postMount() error {
 		return nil
 	}
 	if v.opts.Quota.Size > 0 {
-		if v.quotaCtl != nil {
-			return v.quotaCtl.SetQuota(v.path, v.opts.Quota)
-		} else {
+		if v.quotaCtl == nil {
 			return errors.New("size quota requested for volume but no quota support")
 		}
+		return v.quotaCtl.SetQuota(v.path, v.opts.Quota)
 	}
 	return nil
 }

--- a/integration/container/overlayfs_linux_test.go
+++ b/integration/container/overlayfs_linux_test.go
@@ -103,10 +103,9 @@ func diffDmesg(prev, next []string) []string {
 			nextIdx := idx + 1
 			if nextIdx < len(next) {
 				return next[nextIdx:]
-			} else {
-				// Found at the last position, log is the same.
-				return nil
 			}
+			// Found at the last position, log is the same.
+			return nil
 		}
 	}
 

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -144,7 +144,6 @@ func demultiplexStreams(ctx context.Context, resp client.HijackedResponse) (stre
 	select {
 	case copyErr := <-outputDone:
 		err = copyErr
-		break
 	case <-ctx.Done():
 		err = ctx.Err()
 	}

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -46,9 +46,8 @@ func IsInState(ctx context.Context, apiClient client.APIClient, containerID stri
 		}
 		if len(state) == 1 {
 			return poll.Continue("waiting for container State.Status to be '%s', currently '%s'", state[0], inspect.State.Status)
-		} else {
-			return poll.Continue("waiting for container State.Status to be one of (%s), currently '%s'", strings.Join(state, ", "), inspect.State.Status)
 		}
+		return poll.Continue("waiting for container State.Status to be one of (%s), currently '%s'", strings.Join(state, ", "), inspect.State.Status)
 	}
 }
 

--- a/internal/testutils/specialimage/random.go
+++ b/internal/testutils/specialimage/random.go
@@ -101,9 +101,5 @@ func LegacyManifest(dir string, imageRef string, mfstDesc ocispec.Descriptor) er
 		Layers:   blobPaths(mfst.Layers),
 	})
 
-	if err := writeJson(legacyManifests, filepath.Join(dir, "manifest.json")); err != nil {
-		return err
-	}
-
-	return nil
+	return writeJson(legacyManifests, filepath.Join(dir, "manifest.json"))
 }


### PR DESCRIPTION
**- What I did**

Revive rules configuration use a default list when no rules are listed but in the current state no rules are applied as only one rule is listed and deactivated. This PR enables and fixes the following revive rules:

* [early-return](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#early-return)
* [if-return](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#if-return)
* [indent-error-flow](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#indent-error-flow)
* [time-equal](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#time-equal)
* [useless-break](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#useless-break)

**- How I did it**

Edit golangci-lint and fix one rule per commit

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

