### PR TITLE
[28.x] fluentd: add write timeout log option

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -58,6 +58,11 @@ const (
 	requestAckKey             = "fluentd-request-ack"
 	retryWaitKey              = "fluentd-retry-wait"
 	subSecondPrecisionKey     = "fluentd-sub-second-precision"
+	// writeTimeoutKey can be used to specify the WriteTimeout config for fluentd.
+	// Ref: https://github.com/fluent/fluent-logger-golang/blob/5538e904aeb515c10a624da620581bdf420d4b8a/fluent/fluent.go#L55
+	// This allows fluentd to give up unhealthy connections and not be blocked forever
+	// when downstream connections get unhealthy.
+	writeTimeoutKey = "fluentd-write-timeout"
 )
 
 func init() {
@@ -156,6 +161,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case requestAckKey:
 		case retryWaitKey:
 		case subSecondPrecisionKey:
+		case writeTimeoutKey:
 			// Accepted
 		default:
 			return errors.Errorf("unknown log opt '%s' for fluentd log driver", key)
@@ -237,6 +243,17 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		}
 	}
 
+	writeTimeout := time.Duration(0)
+	if cfg[writeTimeoutKey] != "" {
+		if d, err := time.ParseDuration(cfg[writeTimeoutKey]); err != nil {
+			return config, errors.Wrapf(err, "invalid value for %s: value must be a duration", writeTimeoutKey)
+		} else if d < 0 {
+			return config, errors.Errorf("invalid value for %s: value must be a duration that is non-negative", writeTimeoutKey)
+		} else {
+			writeTimeout = d
+		}
+	}
+
 	config = fluent.Config{
 		FluentPort:             loc.port,
 		FluentHost:             loc.host,
@@ -250,6 +267,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		SubSecondPrecision:     subSecondPrecision,
 		RequestAck:             requestAck,
 		ForceStopAsyncSend:     async,
+		WriteTimeout:           writeTimeout,
 	}
 
 	return config, nil

--- a/daemon/logger/fluentd/fluentd_test.go
+++ b/daemon/logger/fluentd/fluentd_test.go
@@ -1,7 +1,14 @@
 package fluentd // import "github.com/docker/docker/daemon/logger/fluentd"
 import (
+	"context"
+	"net"
+	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/docker/docker/daemon/logger"
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 )
@@ -198,4 +205,128 @@ func TestValidateLogOptAddress(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestValidateWriteTimeoutDuration(t *testing.T) {
+	invalidDurations := []string{"-1", "1", "-1s"}
+	for _, d := range invalidDurations {
+		t.Run("invalid "+d, func(t *testing.T) {
+			err := ValidateLogOpt(map[string]string{writeTimeoutKey: d})
+			assert.ErrorContains(t, err, "invalid value for fluentd-write-timeout:")
+		})
+	}
+
+	validDurations := map[string]time.Duration{
+		"100ms": 100 * time.Millisecond,
+		"10s":   10 * time.Second,
+		"":      0,
+	}
+	for k, v := range validDurations {
+		t.Run("valid "+k, func(t *testing.T) {
+			err := ValidateLogOpt(map[string]string{writeTimeoutKey: k})
+			assert.NilError(t, err)
+			cfg, err := parseConfig(map[string]string{writeTimeoutKey: k})
+			// This check is mostly redundant since it's checked in ValidateLogOpt as well.
+			// This is here to guard against potential regressions in the future.
+			assert.NilError(t, err)
+			assert.Equal(t, cfg.WriteTimeout, v)
+		})
+	}
+}
+
+// TestWriteTimeoutIsEffective tests that writes timeout when the server is unresponsive.
+// The test ensures that instead of hanging forever, the fluentd write operation returns
+// an error when writes cannot be completed within the specified duration.
+func TestWriteTimeoutIsEffective(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows not supported")
+	}
+
+	// Create a temporary directory for the socket file
+	tmpDir := t.TempDir()
+	socketFile := filepath.Join(tmpDir, "fluent-logger-golang.sock")
+	l, err := net.Listen("unix", socketFile)
+	assert.NilError(t, err, "unable to create listener for socket %s", socketFile)
+	defer l.Close()
+
+	// This is to guard against potential run-away test scenario so that a future change
+	// doesn't cause the tests suite to timeout. It "fluentd-write-timeout" is not set, this
+	// test will be blocked on the socket write operation. The timeout guards against that.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var connectedWG sync.WaitGroup
+	connectedWG.Add(1)
+
+	// Start accepting connections.
+	go func(ctx context.Context, wg *sync.WaitGroup) {
+		wg.Done()
+
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				// Unable to process the connection. This can happen if the connection is closed.
+				select {
+				case <-ctx.Done():
+					// If the context is canceled, there's nothing for us to do here.
+					return
+				default:
+					t.Logf("Unable to accept connection: %v", err)
+					continue
+				}
+			}
+
+			// Handle an incoming connection. We're essentially blackholing this by not reading from
+			// or writing to the connection.
+			go func(ctx context.Context, conn net.Conn) {
+				// Simulate unresponsive server: do nothing with the connection
+				<-ctx.Done()
+				_ = conn.Close()
+			}(ctx, conn)
+		}
+	}(ctx, &connectedWG)
+
+	f, err := New(logger.Info{
+		ContainerName: "/test-container",
+		ContainerID:   "container-abcdefghijklmnopqrstuvwxyz01234567890",
+		Config: map[string]string{
+			"fluentd-address": "unix://" + socketFile,
+			"tag":             "{{.Name}}/{{.FullID}}",
+			// Disabling async behavior with limited retries and buffer size lets
+			// us test this in a more preditable manner for failures. Otherwise,
+			// write errors could be silently consumed. The "fluentd-write-timeout"
+			// flag should be equally effective regardless of async being enabled/disabled.
+			"fluentd-async":         "false",
+			"fluentd-max-retries":   "1",
+			"fluentd-retry-wait":    "10ms",
+			"fluentd-buffer-limit":  "1",
+			"fluentd-write-timeout": "1ms",
+		},
+	})
+	assert.NilError(t, err)
+	defer f.Close()
+
+	// Ensure that the server is ready to accept connections since we have disabled async mode
+	// in fluentd options.
+	connectedWG.Wait()
+
+	// Attempt writing 1MiB worth of log data (all 0's) repeatedly. We should see a failure
+	// after the 1st or the 2nd attempt depending on when the connection's write buffer gets
+	// filled up.
+	// If we don't set a write timeout on the connection, this will hang forever. But, because
+	// we have a write timeout, we expect the `Log` method to return an error.
+	data := make([]byte, 1024*1024)
+	for range 10 {
+		err = f.Log(&logger.Message{
+			Line:      data,
+			Timestamp: time.Now(),
+		})
+		if err != nil {
+			break
+		}
+	}
+
+	// Checks if the error contains the expected message. The full message is of the format:
+	// "fluent#write: failed to write after %d attempts".
+	assert.ErrorContains(t, err, "fluent#write: failed to write after")
 }


### PR DESCRIPTION
**- What I did**

Cherry-pick https://github.com/moby/moby/pull/49911 to 28.x branch

Currently, there's no mechanism to specify a write timeout value for fluentd connections. This means that writes can forever be blocked if the downstream connections is unhealthy. This commit makes this value configurable via a new fluentd log option called "fluentd-write-timeout".


(cherry picked from commit 7dae7c54dde81951330170c7678deea350b1d2b8)

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
Added a new log option for fluentd log driver ("fluentd-write-timeout"), which lets users specify write timeouts for fluentd connections.
```

**- A picture of a cute animal (not mandatory but encouraged)**

