### PR TITLE
libnetwork/networkdb: use correct index in GetTableByNetwork

### DIFF
--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -430,7 +430,7 @@ type TableElem struct {
 // returns a map of keys and values
 func (nDB *NetworkDB) GetTableByNetwork(tname, nid string) map[string]*TableElem {
 	nDB.RLock()
-	root := nDB.indexes[byNetwork].Root()
+	root := nDB.indexes[byTable].Root()
 	nDB.RUnlock()
 	entries := make(map[string]*TableElem)
 	root.WalkPrefix([]byte(fmt.Sprintf("/%s/%s", tname, nid)), func(k []byte, v *entry) bool {


### PR DESCRIPTION
Commit ec65f2d21b83a2ccb7b216357d4d979e6157966d has a typo: it switches `indexes[byTable]` with `indexes[byNetwork]`. The indexes are not equivalent. Switch it back.

- Updates #49937 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

