### PR TITLE
client: Use gotest.tools style assertions

### DIFF
--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -75,7 +75,5 @@ func TestCheckpointCreate(t *testing.T) {
 		CheckpointID: expectedCheckpointID,
 		Exit:         true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -56,7 +56,5 @@ func TestCheckpointDelete(t *testing.T) {
 	err := client.CheckpointDelete(context.Background(), "container_id", checkpoint.DeleteOptions{
 		CheckpointID: "checkpoint_id",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -49,12 +49,8 @@ func TestCheckpointList(t *testing.T) {
 	}
 
 	checkpoints, err := client.CheckpointList(context.Background(), "container_id", checkpoint.ListOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(checkpoints) != 1 {
-		t.Fatalf("expected 1 checkpoint, got %v", checkpoints)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(checkpoints, 1))
 }
 
 func TestCheckpointListContainerNotFound(t *testing.T) {

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -60,10 +60,6 @@ func TestConfigCreate(t *testing.T) {
 	}
 
 	r, err := client.ConfigCreate(context.Background(), swarm.ConfigSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "test_config" {
-		t.Fatalf("expected `test_config`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "test_config"))
 }

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -92,10 +92,6 @@ func TestConfigInspect(t *testing.T) {
 	}
 
 	configInspect, _, err := client.ConfigInspectWithRaw(context.Background(), "config_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if configInspect.ID != "config_id" {
-		t.Fatalf("expected `config_id`, got %s", configInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(configInspect.ID, "config_id"))
 }

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -95,11 +95,7 @@ func TestConfigList(t *testing.T) {
 		}
 
 		configs, err := client.ConfigList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(configs) != 2 {
-			t.Fatalf("expected 2 configs, got %v", configs)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(configs, 2))
 	}
 }

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -61,7 +61,5 @@ func TestConfigRemove(t *testing.T) {
 	}
 
 	err := client.ConfigRemove(context.Background(), "config_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -62,7 +62,5 @@ func TestConfigUpdate(t *testing.T) {
 	}
 
 	err := client.ConfigUpdate(context.Background(), "config_id", swarm.Version{}, swarm.ConfigSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -98,10 +98,6 @@ func TestContainerCommit(t *testing.T) {
 		Changes:   expectedChanges,
 		Pause:     false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "new_container_id" {
-		t.Fatalf("expected `new_container_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "new_container_id"))
 }

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -51,9 +52,7 @@ func TestContainerStatPathNoHeaderError(t *testing.T) {
 		}),
 	}
 	_, err := client.ContainerStatPath(context.Background(), "container_id", "path/to/file")
-	if err == nil {
-		t.Fatalf("expected an error, got nothing")
-	}
+	assert.Check(t, err != nil, "expected an error, got nothing")
 }
 
 func TestContainerStatPath(t *testing.T) {
@@ -90,15 +89,9 @@ func TestContainerStatPath(t *testing.T) {
 		}),
 	}
 	stat, err := client.ContainerStatPath(context.Background(), "container_id", expectedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stat.Name != "name" {
-		t.Fatalf("expected container path stat name to be 'name', got '%s'", stat.Name)
-	}
-	if stat.Mode != 0o700 {
-		t.Fatalf("expected container path stat mode to be 0700, got '%v'", stat.Mode)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(stat.Name, "name"))
+	assert.Check(t, is.Equal(stat.Mode, os.FileMode(0o700)))
 }
 
 func TestCopyToContainerError(t *testing.T) {
@@ -132,9 +125,7 @@ func TestCopyToContainerEmptyResponse(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNoContent, "No content")),
 	}
 	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), container.CopyToContainerOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestCopyToContainer(t *testing.T) {
@@ -178,9 +169,7 @@ func TestCopyToContainer(t *testing.T) {
 	err := client.CopyToContainer(context.Background(), "container_id", expectedPath, bytes.NewReader([]byte("content")), container.CopyToContainerOptions{
 		AllowOverwriteDirWithFile: false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestCopyFromContainerError(t *testing.T) {
@@ -229,9 +218,7 @@ func TestCopyFromContainerEmptyResponse(t *testing.T) {
 		}),
 	}
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestCopyFromContainerNoHeaderError(t *testing.T) {
@@ -244,9 +231,7 @@ func TestCopyFromContainerNoHeaderError(t *testing.T) {
 		}),
 	}
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
-	if err == nil {
-		t.Fatalf("expected an error, got nothing")
-	}
+	assert.Check(t, err != nil, "expected an error, got nothing")
 }
 
 func TestCopyFromContainer(t *testing.T) {
@@ -285,23 +270,12 @@ func TestCopyFromContainer(t *testing.T) {
 		}),
 	}
 	r, stat, err := client.CopyFromContainer(context.Background(), "container_id", expectedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stat.Name != "name" {
-		t.Fatalf("expected container path stat name to be 'name', got '%s'", stat.Name)
-	}
-	if stat.Mode != 0o700 {
-		t.Fatalf("expected container path stat mode to be 0700, got '%v'", stat.Mode)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(stat.Name, "name"))
+	assert.Check(t, is.Equal(stat.Mode, os.FileMode(0o700)))
+
 	content, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := r.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != "content" {
-		t.Fatalf("expected content to be 'content', got %s", string(content))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(content), "content"))
+	assert.NilError(t, r.Close())
 }

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -64,12 +64,8 @@ func TestContainerCreateWithName(t *testing.T) {
 	}
 
 	r, err := client.ContainerCreate(context.Background(), nil, nil, nil, nil, "container_name")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "container_id" {
-		t.Fatalf("expected `container_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "container_id"))
 }
 
 // TestContainerCreateAutoRemove validates that a client using API 1.24 always disables AutoRemove. When using API 1.25
@@ -97,20 +93,22 @@ func TestContainerCreateAutoRemove(t *testing.T) {
 			}, nil
 		}
 	}
-
-	client := &Client{
-		client:  newMockClient(autoRemoveValidator(false)),
-		version: "1.24",
+	testCases := []struct {
+		version            string
+		expectedAutoRemove bool
+	}{
+		{version: "1.24", expectedAutoRemove: false},
+		{version: "1.25", expectedAutoRemove: true},
 	}
-	if _, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, ""); err != nil {
-		t.Fatal(err)
-	}
-	client = &Client{
-		client:  newMockClient(autoRemoveValidator(true)),
-		version: "1.25",
-	}
-	if _, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, ""); err != nil {
-		t.Fatal(err)
+	for _, tc := range testCases {
+		t.Run(tc.version, func(t *testing.T) {
+			client := &Client{
+				client:  newMockClient(autoRemoveValidator(tc.expectedAutoRemove)),
+				version: tc.version,
+			}
+			_, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, "")
+			assert.NilError(t, err)
+		})
 	}
 }
 

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -67,6 +67,6 @@ func TestContainerDiff(t *testing.T) {
 	}
 
 	changes, err := client.ContainerDiff(context.Background(), "container_id")
-	assert.Check(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(changes, expected))
 }

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -82,12 +82,8 @@ func TestContainerExecCreate(t *testing.T) {
 	r, err := client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{
 		User: "user",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "exec_id" {
-		t.Fatalf("expected `exec_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "exec_id"))
 }
 
 func TestContainerExecStartError(t *testing.T) {
@@ -127,9 +123,7 @@ func TestContainerExecStart(t *testing.T) {
 		Detach: true,
 		Tty:    false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestContainerExecInspectError(t *testing.T) {
@@ -162,13 +156,7 @@ func TestContainerExecInspect(t *testing.T) {
 	}
 
 	inspect, err := client.ContainerExecInspect(context.Background(), "exec_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if inspect.ExecID != "exec_id" {
-		t.Fatalf("expected ExecID to be `exec_id`, got %s", inspect.ExecID)
-	}
-	if inspect.ContainerID != "container_id" {
-		t.Fatalf("expected ContainerID `container_id`, got %s", inspect.ContainerID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(inspect.ExecID, "exec_id"))
+	assert.Check(t, is.Equal(inspect.ContainerID, "container_id"))
 }

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -45,15 +45,9 @@ func TestContainerExport(t *testing.T) {
 		}),
 	}
 	body, err := client.ContainerExport(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	defer body.Close()
 	content, err := io.ReadAll(body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != "response" {
-		t.Fatalf("expected response to contain 'response', got %s", string(content))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(content), "response"))
 }

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -83,16 +83,8 @@ func TestContainerInspect(t *testing.T) {
 	}
 
 	r, err := client.ContainerInspect(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "container_id" {
-		t.Fatalf("expected `container_id`, got %s", r.ID)
-	}
-	if r.Image != "image" {
-		t.Fatalf("expected `image`, got %s", r.Image)
-	}
-	if r.Name != "name" {
-		t.Fatalf("expected `name`, got %s", r.Name)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "container_id"))
+	assert.Check(t, is.Equal(r.Image, "image"))
+	assert.Check(t, is.Equal(r.Name, "name"))
 }

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -49,7 +49,5 @@ func TestContainerKill(t *testing.T) {
 	}
 
 	err := client.ContainerKill(context.Background(), "container_id", "SIGKILL")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -88,10 +88,6 @@ func TestContainerList(t *testing.T) {
 			filters.Arg("before", "container"),
 		),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(containers) != 2 {
-		t.Fatalf("expected 2 containers, got %v", containers)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(containers, 2))
 }

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -36,7 +36,5 @@ func TestContainerPause(t *testing.T) {
 		}),
 	}
 	err := client.ContainerPause(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -109,7 +109,7 @@ func TestContainersPrune(t *testing.T) {
 		}
 
 		report, err := client.ContainersPrune(context.Background(), listCase.filters)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		assert.Check(t, is.Len(report.ContainersDeleted, 2))
 		assert.Check(t, is.Equal(uint64(9999), report.SpaceReclaimed))
 	}

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -71,5 +71,5 @@ func TestContainerRemove(t *testing.T) {
 		RemoveVolumes: true,
 		Force:         true,
 	})
-	assert.Check(t, err)
+	assert.NilError(t, err)
 }

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -49,7 +49,5 @@ func TestContainerRename(t *testing.T) {
 	}
 
 	err := client.ContainerRename(context.Background(), "container_id", "newName")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -77,7 +77,7 @@ func TestContainerResize(t *testing.T) {
 				client: newMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)),
 			}
 			err := client.ContainerResize(context.Background(), "container_id", tc.opts)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 		})
 	}
 }
@@ -120,7 +120,7 @@ func TestContainerExecResize(t *testing.T) {
 				client: newMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)),
 			}
 			err := client.ContainerExecResize(context.Background(), "exec_id", tc.opts)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 		})
 	}
 }

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -70,7 +70,5 @@ func TestContainerRestart(t *testing.T) {
 		Signal:  "SIGKILL",
 		Timeout: &timeout,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -60,7 +60,5 @@ func TestContainerStart(t *testing.T) {
 	}
 
 	err := client.ContainerStart(context.Background(), "container_id", container.StartOptions{CheckpointID: "checkpoint_id"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -64,16 +64,10 @@ func TestContainerStats(t *testing.T) {
 			}),
 		}
 		resp, err := client.ContainerStats(context.Background(), "container_id", c.stream)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		defer resp.Body.Close()
 		content, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(content) != "response" {
-			t.Fatalf("expected response to contain 'response', got %s", string(content))
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(string(content), "response"))
 	}
 }

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -70,7 +70,5 @@ func TestContainerStop(t *testing.T) {
 		Signal:  "SIGKILL",
 		Timeout: &timeout,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -71,13 +70,7 @@ func TestContainerTop(t *testing.T) {
 	}
 
 	processList, err := client.ContainerTop(context.Background(), "container_id", []string{"arg1", "arg2"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(expectedProcesses, processList.Processes) {
-		t.Fatalf("Processes: expected %v, got %v", expectedProcesses, processList.Processes)
-	}
-	if !reflect.DeepEqual(expectedTitles, processList.Titles) {
-		t.Fatalf("Titles: expected %v, got %v", expectedTitles, processList.Titles)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expectedProcesses, processList.Processes))
+	assert.Check(t, is.DeepEqual(expectedTitles, processList.Titles))
 }

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -44,7 +44,5 @@ func TestContainerUnpause(t *testing.T) {
 		}),
 	}
 	err := client.ContainerUnpause(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -61,7 +61,5 @@ func TestContainerUpdate(t *testing.T) {
 			Name: "always",
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -74,11 +74,9 @@ func TestContainerWait(t *testing.T) {
 	resultC, errC := client.ContainerWait(context.Background(), "container_id", "")
 	select {
 	case err := <-errC:
-		t.Fatal(err)
+		assert.NilError(t, err)
 	case result := <-resultC:
-		if result.StatusCode != 15 {
-			t.Fatalf("expected a status code equal to '15', got %d", result.StatusCode)
-		}
+		assert.Check(t, is.Equal(result.StatusCode, int64(15)))
 	}
 }
 
@@ -101,9 +99,7 @@ func TestContainerWaitProxyInterrupt(t *testing.T) {
 	resultC, errC := client.ContainerWait(context.Background(), "container_id", "")
 	select {
 	case err := <-errC:
-		if !strings.Contains(err.Error(), msg) {
-			t.Fatalf("Expected: %s, Actual: %s", msg, err.Error())
-		}
+		assert.Check(t, is.ErrorContains(err, msg))
 	case result := <-resultC:
 		t.Fatalf("Unexpected result: %v", result)
 	}
@@ -129,9 +125,7 @@ func TestContainerWaitProxyInterruptLong(t *testing.T) {
 	select {
 	case err := <-errC:
 		// LimitReader limiting isn't exact, because of how the Readers do chunking.
-		if len(err.Error()) > containerWaitErrorMsgLimit*2 {
-			t.Fatalf("Expected error to be limited around %d, actual length: %d", containerWaitErrorMsgLimit, len(err.Error()))
-		}
+		assert.Check(t, len(err.Error()) <= containerWaitErrorMsgLimit*2, "Expected error to be limited around %d, actual length: %d", containerWaitErrorMsgLimit, len(err.Error()))
 	case result := <-resultC:
 		t.Fatalf("Unexpected result: %v", result)
 	}
@@ -164,9 +158,7 @@ func TestContainerWaitErrorHandling(t *testing.T) {
 			resultC, errC := client.ContainerWait(ctx, "container_id", "")
 			select {
 			case err := <-errC:
-				if err.Error() != test.exp.Error() {
-					t.Fatalf("ContainerWait() errC = %v; want %v", err, test.exp)
-				}
+				assert.Check(t, is.Equal(err.Error(), test.exp.Error()))
 				return
 			case result := <-resultC:
 				t.Fatalf("expected to not get a wait result, got %d", result.StatusCode)

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -50,7 +50,6 @@ func TestDiskUsage(t *testing.T) {
 			}, nil
 		}),
 	}
-	if _, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{}); err != nil {
-		t.Fatal(err)
-	}
+	_, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{})
+	assert.NilError(t, err)
 }

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -35,15 +35,13 @@ func TestEventsErrorInOptions(t *testing.T) {
 			expectedError: `parsing time "2006-01-02TZ"`,
 		},
 	}
-	for _, e := range errorCases {
+	for _, tc := range errorCases {
 		client := &Client{
 			client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 		}
-		_, errs := client.Events(context.Background(), e.options)
+		_, errs := client.Events(context.Background(), tc.options)
 		err := <-errs
-		if err == nil || !strings.Contains(err.Error(), e.expectedError) {
-			t.Fatalf("expected an error %q, got %v", e.expectedError, err)
-		}
+		assert.Check(t, is.ErrorContains(err, tc.expectedError))
 	}
 }
 
@@ -152,9 +150,7 @@ func TestEvents(t *testing.T) {
 				break loop
 			case e := <-messages:
 				_, ok := eventsCase.expectedEvents[e.Actor.ID]
-				if !ok {
-					t.Fatalf("event received not expected with action %s & id %s", e.Action, e.Actor.ID)
-				}
+				assert.Check(t, ok, "event received not expected with action %s & id %s", e.Action, e.Actor.ID)
 			}
 		}
 	}

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -200,20 +200,12 @@ func TestImageBuild(t *testing.T) {
 			}),
 		}
 		buildResponse, err := client.ImageBuild(context.Background(), nil, buildCase.buildOptions)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if buildResponse.OSType != "MyOS" {
-			t.Fatalf("expected OSType to be 'MyOS', got %s", buildResponse.OSType)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(buildResponse.OSType, "MyOS"))
 		response, err := io.ReadAll(buildResponse.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		buildResponse.Body.Close()
-		if string(response) != "body" {
-			t.Fatalf("expected Body to contain 'body' string, got %s", response)
-		}
+		assert.Check(t, is.Equal(string(response), "body"))
 	}
 }
 
@@ -225,8 +217,6 @@ func TestGetDockerOS(t *testing.T) {
 	}
 	for header, os := range cases {
 		g := getDockerOS(header)
-		if g != os {
-			t.Fatalf("Expected %s, got %s", os, g)
-		}
+		assert.Check(t, is.Equal(g, os))
 	}
 }

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -64,17 +64,10 @@ func TestImageCreate(t *testing.T) {
 	createResponse, err := client.ImageCreate(context.Background(), specifiedReference, image.CreateOptions{
 		RegistryAuth: expectedRegistryAuth,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	response, err := io.ReadAll(createResponse)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = createResponse.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if string(response) != "body" {
-		t.Fatalf("expected Body to contain 'body' string, got %s", response)
-	}
+	assert.NilError(t, err)
+	err = createResponse.Close()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(response), "body"))
 }

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -89,7 +89,7 @@ func TestImageImport(t *testing.T) {
 
 			body, err := io.ReadAll(resp)
 			assert.NilError(t, err)
-			assert.Equal(t, string(body), expectedOutput)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -70,15 +69,9 @@ func TestImageInspect(t *testing.T) {
 	}
 
 	imageInspect, err := client.ImageInspect(context.Background(), "image_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if imageInspect.ID != "image_id" {
-		t.Fatalf("expected `image_id`, got %s", imageInspect.ID)
-	}
-	if !reflect.DeepEqual(imageInspect.RepoTags, expectedTags) {
-		t.Fatalf("expected `%v`, got %v", expectedTags, imageInspect.RepoTags)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(imageInspect.ID, "image_id"))
+	assert.Check(t, is.DeepEqual(imageInspect.RepoTags, expectedTags))
 }
 
 func TestImageInspectWithPlatform(t *testing.T) {
@@ -120,7 +113,7 @@ func TestImageInspectWithPlatform(t *testing.T) {
 
 	imageInspect, err := client.ImageInspect(context.Background(), "image_id", ImageInspectWithPlatform(requestedPlatform))
 	assert.NilError(t, err)
-	assert.Equal(t, imageInspect.ID, "image_id")
-	assert.Equal(t, imageInspect.Architecture, "arm64")
-	assert.Equal(t, imageInspect.Os, "linux")
+	assert.Check(t, is.Equal(imageInspect.ID, "image_id"))
+	assert.Check(t, is.Equal(imageInspect.Architecture, "arm64"))
+	assert.Check(t, is.Equal(imageInspect.Os, "linux"))
 }

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -111,12 +111,8 @@ func TestImageList(t *testing.T) {
 		}
 
 		images, err := client.ImageList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(images) != 2 {
-			t.Fatalf("expected 2 images, got %v", images)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(images, 2))
 	}
 }
 
@@ -157,12 +153,8 @@ func TestImageListApiBefore125(t *testing.T) {
 	}
 
 	images, err := client.ImageList(context.Background(), options)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(images) != 2 {
-		t.Fatalf("expected 2 images, got %v", images)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(images, 2))
 }
 
 // Checks if shared-size query parameter is set/not being set correctly
@@ -194,7 +186,7 @@ func TestImageListWithSharedSize(t *testing.T) {
 				version: tc.version,
 			}
 			_, err := client.ImageList(context.Background(), tc.options)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 			expectedSet := tc.sharedSize != ""
 			assert.Check(t, is.Equal(query.Has(sharedSize), expectedSet))
 			assert.Check(t, is.Equal(query.Get(sharedSize), tc.sharedSize))

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -106,7 +106,7 @@ func TestImagesPrune(t *testing.T) {
 		}
 
 		report, err := client.ImagesPrune(context.Background(), listCase.filters)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		assert.Check(t, is.Len(report.ImagesDeleted, 2))
 		assert.Check(t, is.Equal(uint64(9999), report.SpaceReclaimed))
 	}

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -24,9 +24,7 @@ func TestImagePullReferenceParseError(t *testing.T) {
 	}
 	// An empty reference is an invalid reference
 	_, err := client.ImagePull(context.Background(), "", image.PullOptions{})
-	if err == nil || !strings.Contains(err.Error(), "invalid reference format") {
-		t.Fatalf("expected an error, got %v", err)
-	}
+	assert.Check(t, is.ErrorContains(err, "invalid reference format"))
 }
 
 func TestImagePullAnyError(t *testing.T) {
@@ -55,9 +53,7 @@ func TestImagePullWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	_, err := client.ImagePull(context.Background(), "myimage", image.PullOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err == nil || err.Error() != "Error requesting privilege" {
-		t.Fatalf("expected an error requesting privilege, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "Error requesting privilege"))
 }
 
 func TestImagePullWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
@@ -112,16 +108,10 @@ func TestImagePullWithPrivilegedFuncNoError(t *testing.T) {
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	body, err := io.ReadAll(resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(body) != "hello world" {
-		t.Fatalf("expected 'hello world', got %s", string(body))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(body), "hello world"))
 }
 
 func TestImagePullWithoutErrors(t *testing.T) {
@@ -210,16 +200,10 @@ func TestImagePullWithoutErrors(t *testing.T) {
 			resp, err := client.ImagePull(context.Background(), pullCase.reference, image.PullOptions{
 				All: pullCase.all,
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
+			assert.NilError(t, err)
 			body, err := io.ReadAll(resp)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(body) != expectedOutput {
-				t.Fatalf("expected '%s', got %s", expectedOutput, string(body))
-			}
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -24,14 +24,10 @@ func TestImagePushReferenceError(t *testing.T) {
 	}
 	// An empty reference is an invalid reference
 	_, err := client.ImagePush(context.Background(), "", image.PushOptions{})
-	if err == nil || !strings.Contains(err.Error(), "invalid reference format") {
-		t.Fatalf("expected an error, got %v", err)
-	}
+	assert.Check(t, is.ErrorContains(err, "invalid reference format"))
 	// An canonical reference cannot be pushed
 	_, err = client.ImagePush(context.Background(), "repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", image.PushOptions{})
-	if err == nil || err.Error() != "cannot push a digest reference" {
-		t.Fatalf("expected an error, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "cannot push a digest reference"))
 }
 
 func TestImagePushAnyError(t *testing.T) {
@@ -60,9 +56,7 @@ func TestImagePushWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	_, err := client.ImagePush(context.Background(), "myimage", image.PushOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err == nil || err.Error() != "Error requesting privilege" {
-		t.Fatalf("expected an error requesting privilege, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "Error requesting privilege"))
 }
 
 func TestImagePushWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
@@ -113,16 +107,10 @@ func TestImagePushWithPrivilegedFuncNoError(t *testing.T) {
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	body, err := io.ReadAll(resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(body) != "hello world" {
-		t.Fatalf("expected 'hello world', got %s", string(body))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(body), "hello world"))
 }
 
 func TestImagePushWithoutErrors(t *testing.T) {
@@ -208,16 +196,10 @@ func TestImagePushWithoutErrors(t *testing.T) {
 			resp, err := client.ImagePush(context.Background(), tc.reference, image.PushOptions{
 				All: tc.all,
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
+			assert.NilError(t, err)
 			body, err := io.ReadAll(resp)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(body) != expectedOutput {
-				t.Fatalf("expected '%s', got %s", expectedOutput, string(body))
-			}
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -96,11 +96,7 @@ func TestImageRemove(t *testing.T) {
 			Force:         removeCase.force,
 			PruneChildren: removeCase.pruneChildren,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(imageDeletes) != 2 {
-			t.Fatalf("expected 2 deleted images, got %v", imageDeletes)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(imageDeletes, 2))
 	}
 }

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -81,7 +81,7 @@ func TestImageSave(t *testing.T) {
 
 			body, err := io.ReadAll(resp)
 			assert.NilError(t, err)
-			assert.Equal(t, string(body), expectedOutput)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -43,9 +43,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err == nil || err.Error() != "Error requesting privilege" {
-		t.Fatalf("expected an error requesting privilege, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "Error requesting privilege"))
 }
 
 func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
@@ -104,12 +102,8 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %v", results)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(results, 1))
 }
 
 func TestImageSearchWithoutErrors(t *testing.T) {
@@ -150,10 +144,6 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 			filters.Arg("stars", "3"),
 		),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected a result, got %v", results)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(results, 1))
 }

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -32,9 +32,7 @@ func TestImageTagInvalidReference(t *testing.T) {
 	}
 
 	err := client.ImageTag(context.Background(), "image_id", "aa/asdf$$^/aa")
-	if err == nil || err.Error() != `Error parsing reference: "aa/asdf$$^/aa" is not a valid repository/tag: invalid reference format` {
-		t.Fatalf("expected ErrReferenceInvalidFormat, got %v", err)
-	}
+	assert.Check(t, is.Error(err, `Error parsing reference: "aa/asdf$$^/aa" is not a valid repository/tag: invalid reference format`))
 }
 
 // Ensure we don't allow the use of invalid repository names or tags; these tag operations should fail.
@@ -89,9 +87,7 @@ func TestImageTagHexSource(t *testing.T) {
 	}
 
 	err := client.ImageTag(context.Background(), "0d409d33b27e47423b049f7f863faa08655a8c901749c2b25b93ca67d01a470d", "repo:tag")
-	if err != nil {
-		t.Fatalf("got error: %v", err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestImageTag(t *testing.T) {
@@ -173,8 +169,6 @@ func TestImageTag(t *testing.T) {
 			}),
 		}
 		err := client.ImageTag(context.Background(), "image_id", tagCase.reference)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -68,9 +68,7 @@ func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
 	}
 
 	err := client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestNetworkConnect(t *testing.T) {
@@ -113,7 +111,5 @@ func TestNetworkConnect(t *testing.T) {
 	err := client.NetworkConnect(context.Background(), "network_id", "container_id", &network.EndpointSettings{
 		NetworkID: "NetworkID",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -73,13 +73,7 @@ func TestNetworkCreate(t *testing.T) {
 			"opt-key": "opt-value",
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if networkResponse.ID != "network_id" {
-		t.Fatalf("expected networkResponse.ID to be 'network_id', got %s", networkResponse.ID)
-	}
-	if networkResponse.Warning != "warning" {
-		t.Fatalf("expected networkResponse.Warning to be 'warning', got %s", networkResponse.Warning)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(networkResponse.ID, "network_id"))
+	assert.Check(t, is.Equal(networkResponse.Warning, "warning"))
 }

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -68,7 +68,5 @@ func TestNetworkDisconnect(t *testing.T) {
 	}
 
 	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -79,16 +79,14 @@ func TestNetworkInspect(t *testing.T) {
 	t.Run("no options", func(t *testing.T) {
 		r, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{})
 		assert.NilError(t, err)
-		assert.Equal(t, r.Name, "mynetwork")
+		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 	})
 	t.Run("verbose", func(t *testing.T) {
 		r, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{Verbose: true})
 		assert.NilError(t, err)
-		assert.Equal(t, r.Name, "mynetwork")
+		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 		_, ok := r.Services["web"]
-		if !ok {
-			t.Fatalf("expected service `web` missing in the verbose output")
-		}
+		assert.Check(t, ok, "expected service `web` missing in the verbose output")
 	})
 	t.Run("global scope", func(t *testing.T) {
 		_, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{Scope: "global"})

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -91,11 +91,7 @@ func TestNetworkList(t *testing.T) {
 		}
 
 		networkResources, err := client.NetworkList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(networkResources) != 1 {
-			t.Fatalf("expected 1 network resource, got %v", networkResources)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(networkResources, 1))
 	}
 }

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -97,7 +97,7 @@ func TestNetworksPrune(t *testing.T) {
 		}
 
 		report, err := client.NetworksPrune(context.Background(), listCase.filters)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		assert.Check(t, is.Len(report.NetworksDeleted, 2))
 	}
 }

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -50,7 +50,5 @@ func TestNetworkRemove(t *testing.T) {
 	}
 
 	err := client.NetworkRemove(context.Background(), "network_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -71,10 +71,6 @@ func TestNodeInspect(t *testing.T) {
 	}
 
 	nodeInspect, _, err := client.NodeInspectWithRaw(context.Background(), "node_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if nodeInspect.ID != "node_id" {
-		t.Fatalf("expected `node_id`, got %s", nodeInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nodeInspect.ID, "node_id"))
 }

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -84,11 +84,7 @@ func TestNodeList(t *testing.T) {
 		}
 
 		nodes, err := client.NodeList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(nodes) != 2 {
-			t.Fatalf("expected 2 nodes, got %v", nodes)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(nodes, 2))
 	}
 }

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -70,8 +70,6 @@ func TestNodeRemove(t *testing.T) {
 		}
 
 		err := client.NodeRemove(context.Background(), "node_id", types.NodeRemoveOptions{Force: removeCase.force})
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -51,7 +51,5 @@ func TestNodeUpdate(t *testing.T) {
 	}
 
 	err := client.NodeUpdate(context.Background(), "node_id", swarm.Version{}, swarm.NodeSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -43,23 +43,23 @@ func TestOptionWithTimeout(t *testing.T) {
 	c, err := NewClientWithOpts(WithTimeout(timeout))
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.client.Timeout, timeout)
+	assert.Check(t, is.Equal(c.client.Timeout, timeout))
 }
 
 func TestOptionWithVersionFromEnv(t *testing.T) {
 	c, err := NewClientWithOpts(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.version, api.DefaultVersion)
-	assert.Equal(t, c.manualOverride, false)
+	assert.Check(t, is.Equal(c.version, api.DefaultVersion))
+	assert.Check(t, is.Equal(c.manualOverride, false))
 
 	t.Setenv("DOCKER_API_VERSION", "2.9999")
 
 	c, err = NewClientWithOpts(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.version, "2.9999")
-	assert.Equal(t, c.manualOverride, true)
+	assert.Check(t, is.Equal(c.version, "2.9999"))
+	assert.Check(t, is.Equal(c.manualOverride, true))
 }
 
 func TestWithUserAgent(t *testing.T) {
@@ -72,10 +72,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("user-agent and custom headers", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -87,10 +87,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("custom headers", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -101,10 +101,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("no user-agent set", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -115,10 +115,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("reset custom user-agent", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -130,9 +130,9 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 }

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -51,7 +51,5 @@ func TestPluginDisable(t *testing.T) {
 	}
 
 	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -51,7 +51,5 @@ func TestPluginEnable(t *testing.T) {
 	}
 
 	err := client.PluginEnable(context.Background(), "plugin_name", types.PluginEnableOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -62,10 +62,6 @@ func TestPluginInspect(t *testing.T) {
 	}
 
 	pluginInspect, _, err := client.PluginInspectWithRaw(context.Background(), "plugin_name")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if pluginInspect.ID != "plugin_id" {
-		t.Fatalf("expected `plugin_id`, got %s", pluginInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(pluginInspect.ID, "plugin_id"))
 }

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -94,11 +94,7 @@ func TestPluginList(t *testing.T) {
 		}
 
 		plugins, err := client.PluginList(context.Background(), listCase.filters)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(plugins) != 2 {
-			t.Fatalf("expected 2 plugins, got %v", plugins)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(plugins, 2))
 	}
 }

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -55,7 +55,5 @@ func TestPluginPush(t *testing.T) {
 	}
 
 	_, err := client.PluginPush(context.Background(), "plugin_name", "authtoken")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -51,7 +51,5 @@ func TestPluginRemove(t *testing.T) {
 	}
 
 	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -50,7 +50,5 @@ func TestPluginSet(t *testing.T) {
 	}
 
 	err := client.PluginSet(context.Background(), "plugin_name", []string{"arg1"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -53,7 +53,7 @@ func TestSetHostHeader(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.host, func(t *testing.T) {
 			hostURL, err := ParseHostURL(tc.host)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 
 			client := &Client{
 				client: newMockClient(func(req *http.Request) (*http.Response, error) {
@@ -78,7 +78,7 @@ func TestSetHostHeader(t *testing.T) {
 			}
 
 			_, err = client.sendRequest(context.Background(), http.MethodGet, testEndpoint, nil, nil, nil)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 		})
 	}
 }

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -60,10 +60,6 @@ func TestSecretCreate(t *testing.T) {
 	}
 
 	r, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "test_secret" {
-		t.Fatalf("expected `test_secret`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "test_secret"))
 }

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -83,10 +83,6 @@ func TestSecretInspect(t *testing.T) {
 	}
 
 	secretInspect, _, err := client.SecretInspectWithRaw(context.Background(), "secret_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if secretInspect.ID != "secret_id" {
-		t.Fatalf("expected `secret_id`, got %s", secretInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(secretInspect.ID, "secret_id"))
 }

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -95,11 +95,7 @@ func TestSecretList(t *testing.T) {
 		}
 
 		secrets, err := client.SecretList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(secrets) != 2 {
-			t.Fatalf("expected 2 secrets, got %v", secrets)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(secrets, 2))
 	}
 }

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -61,7 +61,5 @@ func TestSecretRemove(t *testing.T) {
 	}
 
 	err := client.SecretRemove(context.Background(), "secret_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/secret_update_test.go
+++ b/client/secret_update_test.go
@@ -62,7 +62,5 @@ func TestSecretUpdate(t *testing.T) {
 	}
 
 	err := client.SecretUpdate(context.Background(), "secret_id", swarm.Version{}, swarm.SecretSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -64,12 +64,8 @@ func TestServiceCreate(t *testing.T) {
 	}
 
 	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "service_id" {
-		t.Fatalf("expected `service_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "service_id"))
 }
 
 func TestServiceCreateCompatiblePlatforms(t *testing.T) {
@@ -127,7 +123,7 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 	spec := swarm.ServiceSpec{TaskTemplate: swarm.TaskSpec{ContainerSpec: &swarm.ContainerSpec{Image: "foobar:1.0"}}}
 
 	r, err := client.ServiceCreate(context.Background(), spec, types.ServiceCreateOptions{QueryRegistry: true})
-	assert.Check(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, is.Equal("service_linux_amd64", r.ID))
 }
 
@@ -206,16 +202,10 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 				},
 			},
 		}, types.ServiceCreateOptions{QueryRegistry: true})
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 
-		if r.ID != "service_id" {
-			t.Fatalf("expected `service_id`, got %s", r.ID)
-		}
+		assert.Check(t, is.Equal(r.ID, "service_id"))
 
-		if p.expected != serviceCreateImage {
-			t.Fatalf("expected image %s, got %s", p.expected, serviceCreateImage)
-		}
+		assert.Check(t, is.Equal(p.expected, serviceCreateImage))
 	}
 }

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -72,10 +72,6 @@ func TestServiceInspect(t *testing.T) {
 	}
 
 	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id", types.ServiceInspectOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if serviceInspect.ID != "service_id" {
-		t.Fatalf("expected `service_id`, got %s", serviceInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(serviceInspect.ID, "service_id"))
 }

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -84,11 +84,7 @@ func TestServiceList(t *testing.T) {
 		}
 
 		services, err := client.ServiceList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(services) != 2 {
-			t.Fatalf("expected 2 services, got %v", services)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(services, 2))
 	}
 }

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -60,7 +60,5 @@ func TestServiceRemove(t *testing.T) {
 	}
 
 	err := client.ServiceRemove(context.Background(), "service_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -90,8 +90,6 @@ func TestServiceUpdate(t *testing.T) {
 		}
 
 		_, err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -45,10 +45,6 @@ func TestSwarmInit(t *testing.T) {
 	resp, err := client.SwarmInit(context.Background(), swarm.InitRequest{
 		ListenAddr: "0.0.0.0:2377",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp != "body" {
-		t.Fatalf("Expected 'body', got %s", resp)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(resp, "body"))
 }

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -48,10 +48,6 @@ func TestSwarmInspect(t *testing.T) {
 	}
 
 	swarmInspect, err := client.SwarmInspect(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if swarmInspect.ID != "swarm_id" {
-		t.Fatalf("expected `swarm_id`, got %s", swarmInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(swarmInspect.ID, "swarm_id"))
 }

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -45,7 +45,5 @@ func TestSwarmJoin(t *testing.T) {
 	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{
 		ListenAddr: "0.0.0.0:2377",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -60,8 +60,6 @@ func TestSwarmLeave(t *testing.T) {
 		}
 
 		err := client.SwarmLeave(context.Background(), leaveCase.force)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -43,7 +43,5 @@ func TestSwarmUnlock(t *testing.T) {
 	}
 
 	err := client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -43,7 +43,5 @@ func TestSwarmUpdate(t *testing.T) {
 	}
 
 	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -62,10 +62,6 @@ func TestTaskInspect(t *testing.T) {
 	}
 
 	taskInspect, _, err := client.TaskInspectWithRaw(context.Background(), "task_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if taskInspect.ID != "task_id" {
-		t.Fatalf("expected `task_id`, got %s", taskInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(taskInspect.ID, "task_id"))
 }

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -84,11 +84,7 @@ func TestTaskList(t *testing.T) {
 		}
 
 		tasks, err := client.TaskList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(tasks) != 2 {
-			t.Fatalf("expected 2 tasks, got %v", tasks)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(tasks, 2))
 	}
 }

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -5,6 +5,7 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestEncodePlatforms(t *testing.T) {
@@ -50,7 +51,7 @@ func TestEncodePlatforms(t *testing.T) {
 		t.Run(tc.doc, func(t *testing.T) {
 			out, err := encodePlatforms(tc.platforms...)
 			assert.NilError(t, err)
-			assert.DeepEqual(t, out, tc.expected)
+			assert.Check(t, is.DeepEqual(out, tc.expected))
 		})
 	}
 }

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -60,16 +60,8 @@ func TestVolumeCreate(t *testing.T) {
 			"opt-key": "opt-value",
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if vol.Name != "volume" {
-		t.Fatalf("expected volume.Name to be 'volume', got %s", vol.Name)
-	}
-	if vol.Driver != "local" {
-		t.Fatalf("expected volume.Driver to be 'local', got %s", vol.Driver)
-	}
-	if vol.Mountpoint != "mountpoint" {
-		t.Fatalf("expected volume.Mountpoint to be 'mountpoint', got %s", vol.Mountpoint)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(vol.Name, "volume"))
+	assert.Check(t, is.Equal(vol.Driver, "local"))
+	assert.Check(t, is.Equal(vol.Mountpoint, "mountpoint"))
 }

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -81,11 +81,7 @@ func TestVolumeList(t *testing.T) {
 		}
 
 		volumeResponse, err := client.VolumeList(context.Background(), volume.ListOptions{Filters: listCase.filters})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(volumeResponse.Volumes) != 1 {
-			t.Fatalf("expected 1 volume, got %v", volumeResponse.Volumes)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(volumeResponse.Volumes, 1))
 	}
 }

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -62,7 +62,5 @@ func TestVolumeRemove(t *testing.T) {
 	}
 
 	err := client.VolumeRemove(context.Background(), "volume_id", false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/volume_update_test.go
+++ b/client/volume_update_test.go
@@ -56,7 +56,5 @@ func TestVolumeUpdate(t *testing.T) {
 	}
 
 	err := client.VolumeUpdate(context.Background(), "test1", swarm.Version{Index: uint64(10)}, volumetypes.UpdateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
The usage of assertions was inconsistent. This PR makes all assertions use the gotest.tools style.