### PR TITLE
api/types: move config and secret options to api/types/swarm

### DIFF
--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -30,7 +30,7 @@ type Backend interface {
 	RemoveNode(string, bool) error
 	GetTasks(types.TaskListOptions) ([]swarm.Task, error)
 	GetTask(string) (swarm.Task, error)
-	GetSecrets(opts types.SecretListOptions) ([]swarm.Secret, error)
+	GetSecrets(opts swarm.SecretListOptions) ([]swarm.Secret, error)
 	CreateSecret(s swarm.SecretSpec) (string, error)
 	RemoveSecret(idOrName string) error
 	GetSecret(id string) (swarm.Secret, error)

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -35,7 +35,7 @@ type Backend interface {
 	RemoveSecret(idOrName string) error
 	GetSecret(id string) (swarm.Secret, error)
 	UpdateSecret(idOrName string, version uint64, spec swarm.SecretSpec) error
-	GetConfigs(opts types.ConfigListOptions) ([]swarm.Config, error)
+	GetConfigs(opts swarm.ConfigListOptions) ([]swarm.Config, error)
 	CreateConfig(s swarm.ConfigSpec) (string, error)
 	RemoveConfig(id string) error
 	GetConfig(id string) (swarm.Config, error)

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -487,7 +487,7 @@ func (sr *swarmRouter) getConfigs(ctx context.Context, w http.ResponseWriter, r 
 		return err
 	}
 
-	configs, err := sr.backend.GetConfigs(basictypes.ConfigListOptions{Filters: filters})
+	configs, err := sr.backend.GetConfigs(types.ConfigListOptions{Filters: filters})
 	if err != nil {
 		return err
 	}
@@ -511,7 +511,7 @@ func (sr *swarmRouter) createConfig(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	return httputils.WriteJSON(w, http.StatusCreated, &basictypes.ConfigCreateResponse{
+	return httputils.WriteJSON(w, http.StatusCreated, &types.ConfigCreateResponse{
 		ID: id,
 	})
 }

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -416,7 +416,7 @@ func (sr *swarmRouter) getSecrets(ctx context.Context, w http.ResponseWriter, r 
 		return err
 	}
 
-	secrets, err := sr.backend.GetSecrets(basictypes.SecretListOptions{Filters: filters})
+	secrets, err := sr.backend.GetSecrets(types.SecretListOptions{Filters: filters})
 	if err != nil {
 		return err
 	}
@@ -439,7 +439,7 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	return httputils.WriteJSON(w, http.StatusCreated, &basictypes.SecretCreateResponse{
+	return httputils.WriteJSON(w, http.StatusCreated, &types.SecretCreateResponse{
 		ID: id,
 	})
 }

--- a/api/types/swarm/config.go
+++ b/api/types/swarm/config.go
@@ -1,6 +1,10 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
 
-import "os"
+import (
+	"os"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // Config represents a config.
 type Config struct {
@@ -43,4 +47,16 @@ type ConfigReference struct {
 	Runtime    *ConfigReferenceRuntimeTarget `json:",omitempty"`
 	ConfigID   string
 	ConfigName string
+}
+
+// ConfigCreateResponse contains the information returned to a client
+// on the creation of a new config.
+type ConfigCreateResponse struct {
+	// ID is the id of the created config.
+	ID string
+}
+
+// ConfigListOptions holds parameters to list configs
+type ConfigListOptions struct {
+	Filters filters.Args
 }

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -1,6 +1,10 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
 
-import "os"
+import (
+	"os"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // Secret represents a secret.
 type Secret struct {
@@ -47,4 +51,16 @@ type SecretReference struct {
 	File       *SecretReferenceFileTarget
 	SecretID   string
 	SecretName string
+}
+
+// SecretCreateResponse contains the information returned to a client
+// on the creation of a new secret.
+type SecretCreateResponse struct {
+	// ID is the id of the created secret.
+	ID string
+}
+
+// SecretListOptions holds parameters to list secrets
+type SecretListOptions struct {
+	Filters filters.Args
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -3,7 +3,6 @@ package types // import "github.com/docker/docker/api/types"
 import (
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
@@ -92,18 +91,6 @@ type DiskUsage struct {
 	Volumes     []*volume.Volume
 	BuildCache  []*build.CacheRecord
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
-}
-
-// ConfigCreateResponse contains the information returned to a client
-// on the creation of a new config.
-type ConfigCreateResponse struct {
-	// ID is the id of the created config.
-	ID string
-}
-
-// ConfigListOptions holds parameters to list configs
-type ConfigListOptions struct {
-	Filters filters.Args
 }
 
 // PushResult contains the tag, manifest digest, and manifest size from the

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -94,18 +94,6 @@ type DiskUsage struct {
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
 }
 
-// SecretCreateResponse contains the information returned to a client
-// on the creation of a new secret.
-type SecretCreateResponse struct {
-	// ID is the id of the created secret.
-	ID string
-}
-
-// SecretListOptions holds parameters to list secrets
-type SecretListOptions struct {
-	Filters filters.Args
-}
-
 // ConfigCreateResponse contains the information returned to a client
 // on the creation of a new config.
 type ConfigCreateResponse struct {

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/storage"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 // IDResponse Response to an API call that returns just an Id.
@@ -114,6 +115,17 @@ type ImageInspect = image.InspectResponse
 //
 // Deprecated: moved to [github.com/docker/docker/api/types/registry.RequestAuthConfig].
 type RequestPrivilegeFunc func(context.Context) (string, error)
+
+// SecretCreateResponse contains the information returned to a client
+// on the creation of a new secret.
+//
+// Deprecated: use [swarm.SecretCreateResponse].
+type SecretCreateResponse = swarm.SecretCreateResponse
+
+// SecretListOptions holds parameters to list secrets
+//
+// Deprecated: use [swarm.SecretListOptions].
+type SecretListOptions = swarm.SecretListOptions
 
 // BuildCache contains information about a build cache record.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -127,6 +127,17 @@ type SecretCreateResponse = swarm.SecretCreateResponse
 // Deprecated: use [swarm.SecretListOptions].
 type SecretListOptions = swarm.SecretListOptions
 
+// ConfigCreateResponse contains the information returned to a client
+// on the creation of a new config.
+//
+// Deprecated: use [swarm.ConfigCreateResponse].
+type ConfigCreateResponse = swarm.ConfigCreateResponse
+
+// ConfigListOptions holds parameters to list configs
+//
+// Deprecated: use [swarm.ConfigListOptions].
+type ConfigListOptions = swarm.ConfigListOptions
+
 // BuildCache contains information about a build cache record.
 //
 // Deprecated: deprecated in API 1.49. Use [build.CacheRecord] instead.

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -220,8 +220,8 @@ type VolumeAPIClient interface {
 
 // SecretAPIClient defines API client methods for secrets
 type SecretAPIClient interface {
-	SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error)
-	SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error)
+	SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error)
+	SecretCreate(ctx context.Context, secret swarm.SecretSpec) (swarm.SecretCreateResponse, error)
 	SecretRemove(ctx context.Context, id string) error
 	SecretInspectWithRaw(ctx context.Context, name string) (swarm.Secret, []byte, error)
 	SecretUpdate(ctx context.Context, id string, version swarm.Version, secret swarm.SecretSpec) error

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -229,8 +229,8 @@ type SecretAPIClient interface {
 
 // ConfigAPIClient defines API client methods for configs
 type ConfigAPIClient interface {
-	ConfigList(ctx context.Context, options types.ConfigListOptions) ([]swarm.Config, error)
-	ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (types.ConfigCreateResponse, error)
+	ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error)
+	ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (swarm.ConfigCreateResponse, error)
 	ConfigRemove(ctx context.Context, id string) error
 	ConfigInspectWithRaw(ctx context.Context, name string) (swarm.Config, []byte, error)
 	ConfigUpdate(ctx context.Context, id string, version swarm.Version, config swarm.ConfigSpec) error

--- a/client/config_create.go
+++ b/client/config_create.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // ConfigCreate creates a new config.
-func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
-	var response types.ConfigCreateResponse
+func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (swarm.ConfigCreateResponse, error) {
+	var response swarm.ConfigCreateResponse
 	if err := cli.NewVersionError(ctx, "1.30", "config create"); err != nil {
 		return response, err
 	}

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -46,7 +45,7 @@ func TestConfigCreate(t *testing.T) {
 			if req.Method != http.MethodPost {
 				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
 			}
-			b, err := json.Marshal(types.ConfigCreateResponse{
+			b, err := json.Marshal(swarm.ConfigCreateResponse{
 				ID: "test_config",
 			})
 			if err != nil {

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // ConfigList returns the list of configs.
-func (cli *Client) ConfigList(ctx context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
+func (cli *Client) ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error) {
 	if err := cli.NewVersionError(ctx, "1.30", "config list"); err != nil {
 		return nil, err
 	}

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -23,7 +22,7 @@ func TestConfigListUnsupported(t *testing.T) {
 		version: "1.29",
 		client:  &http.Client{},
 	}
-	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
+	_, err := client.ConfigList(context.Background(), swarm.ConfigListOptions{})
 	assert.Check(t, is.Error(err, `"config list" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
@@ -33,7 +32,7 @@ func TestConfigListError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
+	_, err := client.ConfigList(context.Background(), swarm.ConfigListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -41,17 +40,17 @@ func TestConfigList(t *testing.T) {
 	expectedURL := "/v1.30/configs"
 
 	listCases := []struct {
-		options             types.ConfigListOptions
+		options             swarm.ConfigListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.ConfigListOptions{},
+			options: swarm.ConfigListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: types.ConfigListOptions{
+			options: swarm.ConfigListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -4,22 +4,21 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // SecretCreate creates a new secret.
-func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error) {
+func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (swarm.SecretCreateResponse, error) {
 	if err := cli.NewVersionError(ctx, "1.25", "secret create"); err != nil {
-		return types.SecretCreateResponse{}, err
+		return swarm.SecretCreateResponse{}, err
 	}
 	resp, err := cli.post(ctx, "/secrets/create", nil, secret, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return types.SecretCreateResponse{}, err
+		return swarm.SecretCreateResponse{}, err
 	}
 
-	var response types.SecretCreateResponse
+	var response swarm.SecretCreateResponse
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -46,7 +45,7 @@ func TestSecretCreate(t *testing.T) {
 			if req.Method != http.MethodPost {
 				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
 			}
-			b, err := json.Marshal(types.SecretCreateResponse{
+			b, err := json.Marshal(swarm.SecretCreateResponse{
 				ID: "test_secret",
 			})
 			if err != nil {

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // SecretList returns the list of secrets.
-func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
+func (cli *Client) SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error) {
 	if err := cli.NewVersionError(ctx, "1.25", "secret list"); err != nil {
 		return nil, err
 	}

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -23,7 +22,7 @@ func TestSecretListUnsupported(t *testing.T) {
 		version: "1.24",
 		client:  &http.Client{},
 	}
-	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
+	_, err := client.SecretList(context.Background(), swarm.SecretListOptions{})
 	assert.Check(t, is.Error(err, `"secret list" requires API version 1.25, but the Docker daemon API version is 1.24`))
 }
 
@@ -33,7 +32,7 @@ func TestSecretListError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
+	_, err := client.SecretList(context.Background(), swarm.SecretListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -41,17 +40,17 @@ func TestSecretList(t *testing.T) {
 	const expectedURL = "/v1.25/secrets"
 
 	listCases := []struct {
-		options             types.SecretListOptions
+		options             swarm.SecretListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.SecretListOptions{},
+			options: swarm.SecretListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: types.SecretListOptions{
+			options: swarm.SecretListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -3,7 +3,6 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 
-	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/moby/swarmkit/v2/api"
@@ -28,7 +27,7 @@ func (c *Cluster) GetConfig(input string) (types.Config, error) {
 }
 
 // GetConfigs returns all configs of a managed swarm cluster.
-func (c *Cluster) GetConfigs(options apitypes.ConfigListOptions) ([]types.Config, error) {
+func (c *Cluster) GetConfigs(options types.ConfigListOptions) ([]types.Config, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -3,7 +3,6 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 
-	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/moby/swarmkit/v2/api"
@@ -28,7 +27,7 @@ func (c *Cluster) GetSecret(input string) (types.Secret, error) {
 }
 
 // GetSecrets returns all secrets of a managed swarm cluster.
-func (c *Cluster) GetSecrets(options apitypes.SecretListOptions) ([]types.Secret, error) {
+func (c *Cluster) GetSecrets(options types.SecretListOptions) ([]types.Secret, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
@@ -57,7 +56,7 @@ func TestConfigList(t *testing.T) {
 	defer c.Close()
 
 	// This test case is ported from the original TestConfigsEmptyList
-	configs, err := c.ConfigList(ctx, types.ConfigListOptions{})
+	configs, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(configs), 0))
 
@@ -72,7 +71,7 @@ func TestConfigList(t *testing.T) {
 	config1ID := createConfig(ctx, t, c, testName1, []byte("TESTINGDATA1"), map[string]string{"type": "production"})
 
 	// test by `config ls`
-	entries, err := c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(configNamesFromList(entries), testNames))
 
@@ -110,7 +109,7 @@ func TestConfigList(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
-			entries, err = c.ConfigList(ctx, types.ConfigListOptions{
+			entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{
 				Filters: tc.filters,
 			})
 			assert.NilError(t, err)
@@ -357,7 +356,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	fakeName := configID
 	fakeID := createConfig(ctx, t, c, fakeName, []byte("fake foo"), nil)
 
-	entries, err := c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Contains(configNamesFromList(entries), configName))
 	assert.Assert(t, is.Contains(configNamesFromList(entries), fakeName))
@@ -366,7 +365,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Fake one will remain
-	entries, err = c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(configNamesFromList(entries), []string{fakeName}))
 
@@ -378,14 +377,14 @@ func TestConfigCreateResolve(t *testing.T) {
 	// - Partial ID (prefix)
 	err = c.ConfigRemove(ctx, configID[:5])
 	assert.Assert(t, nil != err)
-	entries, err = c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(configNamesFromList(entries), []string{fakeName}))
 
 	// Remove based on ID prefix of the fake one should succeed
 	err = c.ConfigRemove(ctx, fakeID[:5])
 	assert.NilError(t, err)
-	entries, err = c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(0, len(entries)))
 }

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
@@ -54,7 +53,7 @@ func TestSecretList(t *testing.T) {
 	c := d.NewClientT(t)
 	defer c.Close()
 
-	configs, err := c.SecretList(ctx, types.SecretListOptions{})
+	configs, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(configs), 0))
 
@@ -70,7 +69,7 @@ func TestSecretList(t *testing.T) {
 	secret1ID := createSecret(ctx, t, c, testName1, []byte("TESTINGDATA1"), map[string]string{"type": "production"})
 
 	// test by `secret ls`
-	entries, err := c.SecretList(ctx, types.SecretListOptions{})
+	entries, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(secretNamesFromList(entries), testNames))
 
@@ -103,7 +102,7 @@ func TestSecretList(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		entries, err = c.SecretList(ctx, types.SecretListOptions{
+		entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{
 			Filters: tc.filters,
 		})
 		assert.NilError(t, err)
@@ -357,7 +356,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	fakeName := secretID
 	fakeID := createSecret(ctx, t, c, fakeName, []byte("fake foo"), nil)
 
-	entries, err := c.SecretList(ctx, types.SecretListOptions{})
+	entries, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(secretNamesFromList(entries), testName))
 	assert.Check(t, is.Contains(secretNamesFromList(entries), fakeName))
@@ -366,7 +365,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Fake one will remain
-	entries, err = c.SecretList(ctx, types.SecretListOptions{})
+	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(secretNamesFromList(entries), []string{fakeName}))
 
@@ -377,14 +376,14 @@ func TestSecretCreateResolve(t *testing.T) {
 	// - Partial ID (prefix)
 	err = c.SecretRemove(ctx, fakeName[:5])
 	assert.Assert(t, nil != err)
-	entries, err = c.SecretList(ctx, types.SecretListOptions{})
+	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(secretNamesFromList(entries), []string{fakeName}))
 
 	// Remove based on ID prefix of the fake one should succeed
 	err = c.SecretRemove(ctx, fakeID[:5])
 	assert.NilError(t, err)
-	entries, err = c.SecretList(ctx, types.SecretListOptions{})
+	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(0, len(entries)))
 }

--- a/testutil/daemon/config.go
+++ b/testutil/daemon/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 )
@@ -29,7 +28,7 @@ func (d *Daemon) ListConfigs(t testing.TB) []swarm.Config {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	configs, err := cli.ConfigList(context.Background(), types.ConfigListOptions{})
+	configs, err := cli.ConfigList(context.Background(), swarm.ConfigListOptions{})
 	assert.NilError(t, err)
 	return configs
 }

--- a/testutil/daemon/secret.go
+++ b/testutil/daemon/secret.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 )
@@ -30,7 +29,7 @@ func (d *Daemon) ListSecrets(t testing.TB) []swarm.Secret {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	secrets, err := cli.SecretList(context.Background(), types.SecretListOptions{})
+	secrets, err := cli.SecretList(context.Background(), swarm.SecretListOptions{})
 	assert.NilError(t, err)
 	return secrets
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types: deprecate `SecretCreateResponse`, `SecretListOptions`, `ConfigCreateResponse`, `ConfigListOptions` which were moved to api/types/swarm
```

**- A picture of a cute animal (not mandatory but encouraged)**

