### PR TITLE
api/types: move build-related types to api/types/build

### DIFF
--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -60,30 +60,30 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		return "", err
 	}
 
-	var build *builder.Result
+	var buildResult *builder.Result
 	if useBuildKit {
-		build, err = b.buildkit.Build(ctx, config)
+		buildResult, err = b.buildkit.Build(ctx, config)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		build, err = b.builder.Build(ctx, config)
+		buildResult, err = b.builder.Build(ctx, config)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	if build == nil {
+	if buildResult == nil {
 		return "", nil
 	}
 
-	imageID := build.ImageID
+	imageID := buildResult.ImageID
 	if options.Squash {
-		if imageID, err = squashBuild(build, b.imageComponent); err != nil {
+		if imageID, err = squashBuild(buildResult, b.imageComponent); err != nil {
 			return "", err
 		}
 		if config.ProgressWriter.AuxFormatter != nil {
-			if err = config.ProgressWriter.AuxFormatter.Emit("moby.image.id", types.BuildResult{ID: imageID}); err != nil {
+			if err = config.ProgressWriter.AuxFormatter.Emit("moby.image.id", build.Result{ID: imageID}); err != nil {
 				return "", err
 			}
 		}

--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/events"
@@ -53,7 +52,7 @@ func (b *Backend) RegisterGRPC(s *grpc.Server) {
 // Build builds an image from a Source
 func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string, error) {
 	options := config.Options
-	useBuildKit := options.Version == types.BuilderBuildKit
+	useBuildKit := options.Version == build.BuilderBuildKit
 
 	tags, err := sanitizeRepoAndTags(options.Tags)
 	if err != nil {

--- a/api/server/router/build/build.go
+++ b/api/server/router/build/build.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/api/types"
+	build2 "github.com/docker/docker/api/types/build"
 )
 
 // buildRouter is a router to talk with the build controller
@@ -46,15 +46,15 @@ func (br *buildRouter) initRoutes() {
 //
 // This value is only a recommendation as advertised by the daemon, and it is
 // up to the client to choose which builder to use.
-func BuilderVersion(features map[string]bool) types.BuilderVersion {
+func BuilderVersion(features map[string]bool) build2.BuilderVersion {
 	// TODO(thaJeztah) move the default to daemon/config
 	if runtime.GOOS == "windows" {
-		return types.BuilderV1
+		return build2.BuilderV1
 	}
 
-	bv := types.BuilderBuildKit
+	bv := build2.BuilderBuildKit
 	if v, ok := features["buildkit"]; ok && !v {
-		bv = types.BuilderV1
+		bv = build2.BuilderV1
 	}
 	return bv
 }

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/httputils"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -36,9 +35,9 @@ type invalidParam struct {
 
 func (e invalidParam) InvalidParameter() {}
 
-func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBuildOptions, error) {
-	options := &types.ImageBuildOptions{
-		Version:        types.BuilderV1, // Builder V1 is the default, but can be overridden
+func newImageBuildOptions(ctx context.Context, r *http.Request) (*build.ImageBuildOptions, error) {
+	options := &build.ImageBuildOptions{
+		Version:        build.BuilderV1, // Builder V1 is the default, but can be overridden
 		Dockerfile:     r.FormValue("dockerfile"),
 		SuppressOutput: httputils.BoolValue(r, "q"),
 		NoCache:        httputils.BoolValue(r, "nocache"),
@@ -82,7 +81,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	if versions.GreaterThanOrEqualTo(version, "1.40") {
 		outputsJSON := r.FormValue("outputs")
 		if outputsJSON != "" {
-			var outputs []types.ImageBuildOutput
+			var outputs []build.ImageBuildOutput
 			if err := json.Unmarshal([]byte(outputsJSON), &outputs); err != nil {
 				return nil, invalidParam{errors.Wrap(err, "invalid outputs specified")}
 			}
@@ -160,12 +159,12 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	return options, nil
 }
 
-func parseVersion(s string) (types.BuilderVersion, error) {
-	switch types.BuilderVersion(s) {
-	case types.BuilderV1:
-		return types.BuilderV1, nil
-	case types.BuilderBuildKit:
-		return types.BuilderBuildKit, nil
+func parseVersion(s string) (build.BuilderVersion, error) {
+	switch build.BuilderVersion(s) {
+	case build.BuilderV1:
+		return build.BuilderV1, nil
+	case build.BuilderBuildKit:
+		return build.BuilderBuildKit, nil
 	default:
 		return "", invalidParam{errors.Errorf("invalid version %q", s)}
 	}

--- a/api/types/backend/build.go
+++ b/api/types/backend/build.go
@@ -3,7 +3,7 @@ package backend // import "github.com/docker/docker/api/types/backend"
 import (
 	"io"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/streamformatter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -34,7 +34,7 @@ type ProgressWriter struct {
 type BuildConfig struct {
 	Source         io.ReadCloser
 	ProgressWriter ProgressWriter
-	Options        *types.ImageBuildOptions
+	Options        *build.ImageBuildOptions
 }
 
 // GetImageAndLayerOptions are the options supported by GetImageAndReleasableLayer

--- a/api/types/build/build.go
+++ b/api/types/build/build.go
@@ -1,6 +1,91 @@
 package build
 
+import (
+	"io"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/registry"
+)
+
+// BuilderVersion sets the version of underlying builder to use
+type BuilderVersion string
+
+const (
+	// BuilderV1 is the first generation builder in docker daemon
+	BuilderV1 BuilderVersion = "1"
+	// BuilderBuildKit is builder based on moby/buildkit project
+	BuilderBuildKit BuilderVersion = "2"
+)
+
 // Result contains the image id of a successful build.
 type Result struct {
 	ID string
+}
+
+// ImageBuildOptions holds the information
+// necessary to build images.
+type ImageBuildOptions struct {
+	Tags           []string
+	SuppressOutput bool
+	RemoteContext  string
+	NoCache        bool
+	Remove         bool
+	ForceRemove    bool
+	PullParent     bool
+	Isolation      container.Isolation
+	CPUSetCPUs     string
+	CPUSetMems     string
+	CPUShares      int64
+	CPUQuota       int64
+	CPUPeriod      int64
+	Memory         int64
+	MemorySwap     int64
+	CgroupParent   string
+	NetworkMode    string
+	ShmSize        int64
+	Dockerfile     string
+	Ulimits        []*container.Ulimit
+	// BuildArgs needs to be a *string instead of just a string so that
+	// we can tell the difference between "" (empty string) and no value
+	// at all (nil). See the parsing of buildArgs in
+	// api/server/router/build/build_routes.go for even more info.
+	BuildArgs   map[string]*string
+	AuthConfigs map[string]registry.AuthConfig
+	Context     io.Reader
+	Labels      map[string]string
+	// squash the resulting image's layers to the parent
+	// preserves the original image and creates a new one from the parent with all
+	// the changes applied to a single layer
+	Squash bool
+	// CacheFrom specifies images that are used for matching cache. Images
+	// specified here do not need to have a valid parent chain to match cache.
+	CacheFrom   []string
+	SecurityOpt []string
+	ExtraHosts  []string // List of extra hosts
+	Target      string
+	SessionID   string
+	Platform    string
+	// Version specifies the version of the underlying builder to use
+	Version BuilderVersion
+	// BuildID is an optional identifier that can be passed together with the
+	// build request. The same identifier can be used to gracefully cancel the
+	// build with the cancel request.
+	BuildID string
+	// Outputs defines configurations for exporting build results. Only supported
+	// in BuildKit mode
+	Outputs []ImageBuildOutput
+}
+
+// ImageBuildOutput defines configuration for exporting a build result
+type ImageBuildOutput struct {
+	Type  string
+	Attrs map[string]string
+}
+
+// ImageBuildResponse holds information
+// returned by a server after building
+// an image.
+type ImageBuildResponse struct {
+	Body   io.ReadCloser
+	OSType string
 }

--- a/api/types/build/build.go
+++ b/api/types/build/build.go
@@ -1,0 +1,6 @@
+package build
+
+// Result contains the image id of a successful build.
+type Result struct {
+	ID string
+}

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -3,12 +3,9 @@ package types // import "github.com/docker/docker/api/types"
 import (
 	"bufio"
 	"context"
-	"io"
 	"net"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/registry"
 )
 
 // NewHijackedResponse initializes a [HijackedResponse] type.
@@ -49,84 +46,6 @@ func (h *HijackedResponse) CloseWrite() error {
 		return conn.CloseWrite()
 	}
 	return nil
-}
-
-// ImageBuildOptions holds the information
-// necessary to build images.
-type ImageBuildOptions struct {
-	Tags           []string
-	SuppressOutput bool
-	RemoteContext  string
-	NoCache        bool
-	Remove         bool
-	ForceRemove    bool
-	PullParent     bool
-	Isolation      container.Isolation
-	CPUSetCPUs     string
-	CPUSetMems     string
-	CPUShares      int64
-	CPUQuota       int64
-	CPUPeriod      int64
-	Memory         int64
-	MemorySwap     int64
-	CgroupParent   string
-	NetworkMode    string
-	ShmSize        int64
-	Dockerfile     string
-	Ulimits        []*container.Ulimit
-	// BuildArgs needs to be a *string instead of just a string so that
-	// we can tell the difference between "" (empty string) and no value
-	// at all (nil). See the parsing of buildArgs in
-	// api/server/router/build/build_routes.go for even more info.
-	BuildArgs   map[string]*string
-	AuthConfigs map[string]registry.AuthConfig
-	Context     io.Reader
-	Labels      map[string]string
-	// squash the resulting image's layers to the parent
-	// preserves the original image and creates a new one from the parent with all
-	// the changes applied to a single layer
-	Squash bool
-	// CacheFrom specifies images that are used for matching cache. Images
-	// specified here do not need to have a valid parent chain to match cache.
-	CacheFrom   []string
-	SecurityOpt []string
-	ExtraHosts  []string // List of extra hosts
-	Target      string
-	SessionID   string
-	Platform    string
-	// Version specifies the version of the underlying builder to use
-	Version BuilderVersion
-	// BuildID is an optional identifier that can be passed together with the
-	// build request. The same identifier can be used to gracefully cancel the
-	// build with the cancel request.
-	BuildID string
-	// Outputs defines configurations for exporting build results. Only supported
-	// in BuildKit mode
-	Outputs []ImageBuildOutput
-}
-
-// ImageBuildOutput defines configuration for exporting a build result
-type ImageBuildOutput struct {
-	Type  string
-	Attrs map[string]string
-}
-
-// BuilderVersion sets the version of underlying builder to use
-type BuilderVersion string
-
-const (
-	// BuilderV1 is the first generation builder in docker daemon
-	BuilderV1 BuilderVersion = "1"
-	// BuilderBuildKit is builder based on moby/buildkit project
-	BuilderBuildKit BuilderVersion = "2"
-)
-
-// ImageBuildResponse holds information
-// returned by a server after building
-// an image.
-type ImageBuildResponse struct {
-	Body   io.ReadCloser
-	OSType string
 }
 
 // NodeListOptions holds parameters to list nodes with.

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -126,8 +126,3 @@ type PushResult struct {
 	Digest string
 	Size   int
 }
-
-// BuildResult contains the image id of a successful build
-type BuildResult struct {
-	ID string
-}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -23,7 +23,7 @@ type Ping struct {
 	APIVersion     string
 	OSType         string
 	Experimental   bool
-	BuilderVersion BuilderVersion
+	BuilderVersion build.BuilderVersion
 
 	// SwarmStatus provides information about the current swarm status of the
 	// engine, obtained from the "Swarm" header in the API response.

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -130,3 +130,8 @@ type BuildCachePruneOptions = build.CachePruneOptions
 //
 // Deprecated: use [build.CachePruneReport].
 type BuildCachePruneReport = build.CachePruneReport
+
+// BuildResult contains the image id of a successful build/
+//
+// Deprecated: use [build.Result].
+type BuildResult = build.Result

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -135,3 +135,37 @@ type BuildCachePruneReport = build.CachePruneReport
 //
 // Deprecated: use [build.Result].
 type BuildResult = build.Result
+
+// ImageBuildOptions holds the information
+// necessary to build images.
+//
+// Deprecated: use [build.ImageBuildOptions].
+type ImageBuildOptions = build.ImageBuildOptions
+
+// ImageBuildOutput defines configuration for exporting a build result
+//
+// Deprecated: use [build.ImageBuildOutput].
+type ImageBuildOutput = build.ImageBuildOutput
+
+// ImageBuildResponse holds information
+// returned by a server after building
+// an image.
+//
+// Deprecated: use [build.ImageBuildResponse].
+type ImageBuildResponse = build.ImageBuildResponse
+
+// BuilderVersion sets the version of underlying builder to use
+//
+// Deprecated: use [build.BuilderVersion].
+type BuilderVersion = build.BuilderVersion
+
+const (
+	// BuilderV1 is the first generation builder in docker daemon
+	//
+	// Deprecated: use [build.BuilderV1].
+	BuilderV1 = build.BuilderV1
+	// BuilderBuildKit is builder based on moby/buildkit project
+	//
+	// Deprecated: use [build.BuilderBuildKit].
+	BuilderBuildKit = build.BuilderBuildKit
+)

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -438,7 +437,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 			return errors.Errorf("missing image id")
 		}
 		out.ImageID = imgID
-		return aux.Emit("moby.image.id", types.BuildResult{ID: imgID})
+		return aux.Emit("moby.image.id", build.Result{ID: imgID})
 	})
 
 	ch := make(chan *controlapi.StatusResponse)

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -100,7 +99,7 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 
 // builderOptions are the dependencies required by the builder
 type builderOptions struct {
-	Options        *types.ImageBuildOptions
+	Options        *build.ImageBuildOptions
 	Backend        builder.Backend
 	ProgressWriter backend.ProgressWriter
 	PathCache      pathCache
@@ -110,7 +109,7 @@ type builderOptions struct {
 // Builder is a Dockerfile builder
 // It implements the builder.Backend interface.
 type Builder struct {
-	options *types.ImageBuildOptions
+	options *build.ImageBuildOptions
 
 	Stdout io.Writer
 	Stderr io.Writer
@@ -132,7 +131,7 @@ type Builder struct {
 func newBuilder(ctx context.Context, options builderOptions) (*Builder, error) {
 	config := options.Options
 	if config == nil {
-		config = new(types.ImageBuildOptions)
+		config = new(build.ImageBuildOptions)
 	}
 
 	imgProber, err := newImageProber(ctx, options.Backend, config.CacheFrom, config.NoCache)
@@ -332,7 +331,7 @@ func BuildFromConfig(ctx context.Context, config *container.Config, changes []st
 	}
 
 	b, err := newBuilder(ctx, builderOptions{
-		Options: &types.ImageBuildOptions{NoCache: true},
+		Options: &build.ImageBuildOptions{NoCache: true},
 	})
 	if err != nil {
 		return nil, err

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
@@ -222,7 +223,7 @@ func emitImageID(aux *streamformatter.AuxFormatter, state *dispatchState) error 
 	if aux == nil || state.imageID == "" {
 		return nil
 	}
-	return aux.Emit("", types.BuildResult{ID: state.imageID})
+	return aux.Emit("", build.Result{ID: state.imageID})
 }
 
 func processMetaArg(meta instructions.ArgCommand, shlex *shell.Lex, args *BuildArgs) error {

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image"
@@ -25,7 +25,7 @@ import (
 func newBuilderWithMockBackend(t *testing.T) *Builder {
 	t.Helper()
 	mockBackend := &MockBackend{}
-	opts := &types.ImageBuildOptions{}
+	opts := &build.ImageBuildOptions{}
 	ctx := context.Background()
 
 	imageProber, err := newImageProber(ctx, mockBackend, nil, false)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/builder"
@@ -364,7 +364,7 @@ func (b *Builder) create(ctx context.Context, runConfig *container.Config) (stri
 	return ctr.ID, nil
 }
 
-func hostConfigFromOptions(options *types.ImageBuildOptions) *container.HostConfig {
+func hostConfigFromOptions(options *build.ImageBuildOptions) *container.HostConfig {
 	resources := container.Resources{
 		CgroupParent: options.CgroupParent,
 		CPUShares:    options.CPUShares,

--- a/builder/dockerfile/internals_linux_test.go
+++ b/builder/dockerfile/internals_linux_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/moby/sys/user"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -58,7 +58,7 @@ othergrp:x:6666:
 		expected  identity
 	}{
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDNoMap",
 			chownStr:  "1",
 			idMapping: unmapped,
@@ -66,7 +66,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 1, GID: 1},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDGIDNoMap",
 			chownStr:  "0:1",
 			idMapping: unmapped,
@@ -74,7 +74,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 0, GID: 1},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDWithMap",
 			chownStr:  "0",
 			idMapping: remapped,
@@ -82,7 +82,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 100000, GID: 100000},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDGIDWithMap",
 			chownStr:  "1:33",
 			idMapping: remapped,
@@ -90,7 +90,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 100001, GID: 100033},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UserNoMap",
 			chownStr:  "bin:5555",
 			idMapping: unmapped,
@@ -98,7 +98,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 1, GID: 5555},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "GroupWithMap",
 			chownStr:  "0:unicorn",
 			idMapping: remapped,
@@ -106,7 +106,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 100000, GID: 101002},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UserOnlyWithMap",
 			chownStr:  "unicorn",
 			idMapping: remapped,
@@ -131,7 +131,7 @@ othergrp:x:6666:
 		descr     string
 	}{
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "BadChownFlagFormat",
 			chownStr:  "bob:1:555",
 			idMapping: unmapped,
@@ -139,7 +139,7 @@ othergrp:x:6666:
 			descr:     "invalid chown string format: bob:1:555",
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UserNoExist",
 			chownStr:  "bob",
 			idMapping: unmapped,
@@ -147,7 +147,7 @@ othergrp:x:6666:
 			descr:     "can't find uid for user bob: no such user: bob",
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "GroupNoExist",
 			chownStr:  "root:bob",
 			idMapping: unmapped,

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
@@ -77,7 +77,7 @@ func readAndCheckDockerfile(t *testing.T, testName, contextDir, dockerfilePath, 
 	}
 
 	config := backend.BuildConfig{
-		Options: &types.ImageBuildOptions{Dockerfile: dockerfilePath},
+		Options: &build.ImageBuildOptions{Dockerfile: dockerfilePath},
 		Source:  tarStream,
 	}
 	_, _, err = remotecontext.Detect(config)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -110,7 +110,7 @@ type DistributionAPIClient interface {
 
 // ImageAPIClient defines API client methods for the images
 type ImageAPIClient interface {
-	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
+	ImageBuild(ctx context.Context, context io.Reader, options build.ImageBuildOptions) (build.ImageBuildResponse, error)
 	BuildCachePrune(ctx context.Context, opts build.CachePruneOptions) (*build.CachePruneReport, error)
 	BuildCancel(ctx context.Context, id string) error
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 )
@@ -18,15 +18,15 @@ import (
 // ImageBuild sends a request to the daemon to build images.
 // The Body in the response implements an io.ReadCloser and it's up to the caller to
 // close it.
-func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
+func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, options build.ImageBuildOptions) (build.ImageBuildResponse, error) {
 	query, err := cli.imageBuildOptionsToQuery(ctx, options)
 	if err != nil {
-		return types.ImageBuildResponse{}, err
+		return build.ImageBuildResponse{}, err
 	}
 
 	buf, err := json.Marshal(options.AuthConfigs)
 	if err != nil {
-		return types.ImageBuildResponse{}, err
+		return build.ImageBuildResponse{}, err
 	}
 
 	headers := http.Header{}
@@ -35,16 +35,16 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 
 	resp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
 	if err != nil {
-		return types.ImageBuildResponse{}, err
+		return build.ImageBuildResponse{}, err
 	}
 
-	return types.ImageBuildResponse{
+	return build.ImageBuildResponse{
 		Body:   resp.Body,
 		OSType: getDockerOS(resp.Header.Get("Server")),
 	}, nil
 }
 
-func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.ImageBuildOptions) (url.Values, error) {
+func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options build.ImageBuildOptions) (url.Values, error) {
 	query := url.Values{}
 	if len(options.Tags) > 0 {
 		query["t"] = options.Tags

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
@@ -22,7 +22,7 @@ func TestImageBuildError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageBuild(context.Background(), nil, types.ImageBuildOptions{})
+	_, err := client.ImageBuild(context.Background(), nil, build.ImageBuildOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -31,13 +31,13 @@ func TestImageBuild(t *testing.T) {
 	v2 := "value2"
 	emptyRegistryConfig := "bnVsbA=="
 	buildCases := []struct {
-		buildOptions           types.ImageBuildOptions
+		buildOptions           build.ImageBuildOptions
 		expectedQueryParams    map[string]string
 		expectedTags           []string
 		expectedRegistryConfig string
 	}{
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				SuppressOutput: true,
 				NoCache:        true,
 				Remove:         true,
@@ -54,7 +54,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				SuppressOutput: false,
 				NoCache:        false,
 				Remove:         false,
@@ -72,7 +72,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				RemoteContext: "remoteContext",
 				Isolation:     container.Isolation("isolation"),
 				CPUSetCPUs:    "2",
@@ -105,7 +105,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				BuildArgs: map[string]*string{
 					"ARG1": &v1,
 					"ARG2": &v2,
@@ -120,7 +120,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				Ulimits: []*container.Ulimit{
 					{
 						Name: "nproc",
@@ -142,7 +142,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				AuthConfigs: map[string]registry.AuthConfig{
 					"https://index.docker.io/v1/": {
 						Auth: "dG90bwo=",

--- a/client/ping.go
+++ b/client/ping.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/swarm"
 )
 
@@ -67,7 +68,7 @@ func parsePingResponse(cli *Client, resp *http.Response) (types.Ping, error) {
 		ping.Experimental = true
 	}
 	if bv := resp.Header.Get("Builder-Version"); bv != "" {
-		ping.BuilderVersion = types.BuilderVersion(bv)
+		ping.BuilderVersion = build.BuilderVersion(bv)
 	}
 	if si := resp.Header.Get("Swarm"); si != "" {
 		state, role, _ := strings.Cut(si, "/")

--- a/integration/build/build_cgroupns_linux_test.go
+++ b/integration/build/build_cgroupns_linux_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/integration/internal/requirement"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil"
@@ -54,7 +54,7 @@ func testBuildWithCgroupNs(ctx context.Context, t *testing.T, daemonNsMode strin
 	client := d.NewClientT(t)
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{"buildcgroupns"},

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
@@ -54,7 +54,7 @@ func TestBuildSquashParent(t *testing.T) {
 	name := strings.ToLower(t.Name())
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{name},
@@ -71,7 +71,7 @@ func TestBuildSquashParent(t *testing.T) {
 	// build with squash
 	resp, err = client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Squash:      true,

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -109,7 +109,7 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 			_, err := tw.Write(dockerfile)
 			assert.NilError(t, err)
 			assert.NilError(t, tw.Close())
-			resp, err := client.ImageBuild(ctx, buff, types.ImageBuildOptions{Remove: tc.rm, ForceRemove: tc.forceRm, NoCache: true})
+			resp, err := client.ImageBuild(ctx, buff, build.ImageBuildOptions{Remove: tc.rm, ForceRemove: tc.forceRm, NoCache: true})
 			assert.NilError(t, err)
 			defer resp.Body.Close()
 			filter, err := buildContainerIdsFilter(resp.Body)
@@ -165,7 +165,7 @@ func TestBuildMultiStageCopy(t *testing.T) {
 			resp, err := apiclient.ImageBuild(
 				ctx,
 				source.AsTarReader(t),
-				types.ImageBuildOptions{
+				build.ImageBuildOptions{
 					Remove:      true,
 					ForceRemove: true,
 					Target:      target,
@@ -214,7 +214,7 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 	imgName := strings.ToLower(t.Name())
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
@@ -261,7 +261,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	// For `target-a` build
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
@@ -288,7 +288,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	delete(testLabels, "label-a")
 	resp, err = apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
@@ -329,7 +329,7 @@ COPY    3/ /target/
 	apiclient := testEnv.APIClient()
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -365,7 +365,7 @@ RUN cat somefile`
 	apiclient := testEnv.APIClient()
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -411,7 +411,7 @@ COPY bar /
 	apiclient := testEnv.APIClient()
 	resp, err := apiclient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -434,7 +434,7 @@ COPY bar /
 
 	resp, err = apiclient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -473,7 +473,7 @@ RUN [ ! -f foo ]
 	apiClient := testEnv.APIClient()
 	resp, err := apiClient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -519,7 +519,7 @@ RUN for g in $(seq 0 8); do dd if=/dev/urandom of=rnd bs=1K count=1 seek=$((1024
 	apiClient := testEnv.APIClient()
 	resp, err := apiClient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -560,7 +560,7 @@ COPY --from=intermediate C:\\stuff C:\\stuff
 	apiClient := testEnv.APIClient()
 	resp, err := apiClient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -625,7 +625,7 @@ func TestBuildWithEmptyDockerfile(t *testing.T) {
 
 			_, err = apiClient.ImageBuild(ctx,
 				buf,
-				types.ImageBuildOptions{
+				build.ImageBuildOptions{
 					Remove:      true,
 					ForceRemove: true,
 				})
@@ -655,7 +655,7 @@ func TestBuildPreserveOwnership(t *testing.T) {
 			resp, err := apiClient.ImageBuild(
 				ctx,
 				source.AsTarReader(t),
-				types.ImageBuildOptions{
+				build.ImageBuildOptions{
 					Remove:      true,
 					ForceRemove: true,
 					Target:      target,
@@ -683,7 +683,7 @@ func TestBuildPlatformInvalid(t *testing.T) {
 	err := w.Close()
 	assert.NilError(t, err)
 
-	_, err = testEnv.APIClient().ImageBuild(ctx, buf, types.ImageBuildOptions{
+	_, err = testEnv.APIClient().ImageBuild(ctx, buf, build.ImageBuildOptions{
 		Remove:      true,
 		ForceRemove: true,
 		Platform:    "foobar",
@@ -712,8 +712,8 @@ func TestBuildWorkdirNoCacheMiss(t *testing.T) {
 			apiClient := testEnv.APIClient()
 
 			buildAndGetID := func() string {
-				resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), types.ImageBuildOptions{
-					Version: types.BuilderV1,
+				resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), build.ImageBuildOptions{
+					Version: build.BuilderV1,
 				})
 				assert.NilError(t, err)
 				defer resp.Body.Close()
@@ -740,9 +740,9 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 
 	apiClient := testEnv.APIClient()
 
-	for _, builderVersion := range []types.BuilderVersion{types.BuilderV1, types.BuilderBuildKit} {
+	for _, builderVersion := range []build.BuilderVersion{build.BuilderV1, build.BuilderBuildKit} {
 		t.Run("v"+string(builderVersion), func(t *testing.T) {
-			if builderVersion == types.BuilderBuildKit {
+			if builderVersion == build.BuilderBuildKit {
 				skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Buildkit is not supported on Windows")
 			}
 
@@ -751,7 +751,7 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 
 			since := time.Now()
 
-			resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), types.ImageBuildOptions{
+			resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), build.ImageBuildOptions{
 				Version: builderVersion,
 				NoCache: true,
 			})
@@ -806,11 +806,11 @@ func TestBuildHistoryDoesNotPreventRemoval(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	buildImage := func(imgName string) error {
-		resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), types.ImageBuildOptions{
+		resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
-			Version:     types.BuilderBuildKit,
+			Version:     build.BuilderBuildKit,
 		})
 		if err != nil {
 			return err

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -66,7 +66,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 
 	resp, err := clientUserRemap.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Tags: []string{imageTag},
 		})
 	assert.NilError(t, err)

--- a/integration/capabilities/capabilities_linux_test.go
+++ b/integration/capabilities/capabilities_linux_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -37,7 +37,7 @@ func TestNoNewPrivileges(t *testing.T) {
 	// Build image
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Tags: []string{imageTag},
 		})
 	assert.NilError(t, err)

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
@@ -196,7 +195,7 @@ func makeTestImage(ctx context.Context, t *testing.T) (imageID string) {
 	`))
 	defer buildCtx.Close()
 
-	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), types.ImageBuildOptions{})
+	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), build.ImageBuildOptions{})
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
@@ -270,7 +269,7 @@ func TestCopyFromContainer(t *testing.T) {
 	`))
 	defer buildCtx.Close()
 
-	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), types.ImageBuildOptions{})
+	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), build.ImageBuildOptions{})
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
@@ -200,7 +201,7 @@ func makeTestImage(ctx context.Context, t *testing.T) (imageID string) {
 	defer resp.Body.Close()
 
 	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
-		var r types.BuildResult
+		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID
 	})
@@ -275,7 +276,7 @@ func TestCopyFromContainer(t *testing.T) {
 
 	var imageID string
 	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
-		var r types.BuildResult
+		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID
 	})

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/image"
 	_ "github.com/docker/docker/daemon/graphdriver/register" // register graph drivers
 	"github.com/docker/docker/daemon/images"
@@ -62,7 +62,7 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	defer source.Close()
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -32,7 +33,7 @@ func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fa
 func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 	var (
 		jm  jsonmessage.JSONMessage
-		br  types.BuildResult
+		br  build.Result
 		dec = json.NewDecoder(body)
 	)
 	for {

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
@@ -17,7 +16,7 @@ import (
 
 // Do builds an image from the given context and returns the image ID.
 func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fakecontext.Fake) string {
-	resp, err := client.ImageBuild(ctx, buildCtx.AsTarReader(t), types.ImageBuildOptions{})
+	resp, err := client.ImageBuild(ctx, buildCtx.AsTarReader(t), build.ImageBuildOptions{})
 	if resp.Body != nil {
 		defer resp.Body.Close()
 	}

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
@@ -110,9 +110,9 @@ func TestPingBuilderHeader(t *testing.T) {
 		d.Start(t)
 		defer d.Stop(t)
 
-		expected := types.BuilderBuildKit
+		expected := build.BuilderBuildKit
 		if runtime.GOOS == "windows" {
-			expected = types.BuilderV1
+			expected = build.BuilderV1
 		}
 
 		p, err := apiClient.Ping(ctx)
@@ -128,7 +128,7 @@ func TestPingBuilderHeader(t *testing.T) {
 		d.Start(t, "--config-file", cfg)
 		defer d.Stop(t)
 
-		expected := types.BuilderV1
+		expected := build.BuilderV1
 		p, err := apiClient.Ping(ctx)
 		assert.NilError(t, err)
 		assert.Equal(t, p.BuilderVersion, expected)

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
@@ -330,7 +330,7 @@ func setupTestImage(t *testing.T, ctx context.Context, apiClient client.APIClien
 
 	resp, err := apiClient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      false,
 			ForceRemove: false,
 			Tags:        []string{imgName},

--- a/testutil/fakestorage/fixtures.go
+++ b/testutil/fakestorage/fixtures.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/moby/go-archive"
 	"gotest.tools/v3/assert"
 )
@@ -74,7 +74,7 @@ func ensureHTTPServerImage(t testing.TB) {
 	c := testEnv.APIClient()
 	reader, err := archive.TarWithOptions(tmp, &archive.TarOptions{})
 	assert.NilError(t, err)
-	resp, err := c.ImageBuild(context.Background(), reader, types.ImageBuildOptions{
+	resp, err := c.ImageBuild(context.Background(), reader, build.ImageBuildOptions{
 		Remove:      true,
 		ForceRemove: true,
 		Tags:        []string{"httpserver"},

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
@@ -145,7 +145,7 @@ func newRemoteFileServer(t testing.TB, ctx *fakecontext.Fake, c client.APIClient
 COPY . /static`); err != nil {
 		t.Fatal(err)
 	}
-	resp, err := c.ImageBuild(context.Background(), ctx.AsTarReader(t), types.ImageBuildOptions{
+	resp, err := c.ImageBuild(context.Background(), ctx.AsTarReader(t), build.ImageBuildOptions{
 		NoCache: true,
 		Tags:    []string{imgName},
 	})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: `api/types`: deprecate `BuildResult`, `ImageBuildOptions`, `ImageBuildOutput`, `ImageBuildResponse`, `BuilderVersion`, `BuilderV1`, and `BuilderBuildKi` which were moved to `api/types/build`
```

**- A picture of a cute animal (not mandatory but encouraged)**

