### PR TITLE
api/types: move swarm-related types to api/types/swarm

### DIFF
--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -3,7 +3,6 @@ package swarm // import "github.com/docker/docker/api/server/router/swarm"
 import (
 	"context"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
@@ -21,7 +20,7 @@ type Backend interface {
 	GetServices(swarm.ServiceListOptions) ([]swarm.Service, error)
 	GetService(idOrName string, insertDefaults bool) (swarm.Service, error)
 	CreateService(swarm.ServiceSpec, string, bool) (*swarm.ServiceCreateResponse, error)
-	UpdateService(string, uint64, swarm.ServiceSpec, types.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)
+	UpdateService(string, uint64, swarm.ServiceSpec, swarm.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)
 	RemoveService(string) error
 	ServiceLogs(context.Context, *backend.LogSelector, *container.LogsOptions) (<-chan *backend.LogMessage, error)
 	GetNodes(swarm.NodeListOptions) ([]swarm.Node, error)

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -28,7 +28,7 @@ type Backend interface {
 	GetNode(string) (swarm.Node, error)
 	UpdateNode(string, uint64, swarm.NodeSpec) error
 	RemoveNode(string, bool) error
-	GetTasks(types.TaskListOptions) ([]swarm.Task, error)
+	GetTasks(swarm.TaskListOptions) ([]swarm.Task, error)
 	GetTask(string) (swarm.Task, error)
 	GetSecrets(opts swarm.SecretListOptions) ([]swarm.Secret, error)
 	CreateSecret(s swarm.SecretSpec) (string, error)

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -24,7 +24,7 @@ type Backend interface {
 	UpdateService(string, uint64, swarm.ServiceSpec, types.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)
 	RemoveService(string) error
 	ServiceLogs(context.Context, *backend.LogSelector, *container.LogsOptions) (<-chan *backend.LogMessage, error)
-	GetNodes(types.NodeListOptions) ([]swarm.Node, error)
+	GetNodes(swarm.NodeListOptions) ([]swarm.Node, error)
 	GetNode(string) (swarm.Node, error)
 	UpdateNode(string, uint64, swarm.NodeSpec) error
 	RemoveNode(string, bool) error

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -18,7 +18,7 @@ type Backend interface {
 	Update(uint64, swarm.Spec, swarm.UpdateFlags) error
 	GetUnlockKey() (string, error)
 	UnlockSwarm(req swarm.UnlockRequest) error
-	GetServices(types.ServiceListOptions) ([]swarm.Service, error)
+	GetServices(swarm.ServiceListOptions) ([]swarm.Service, error)
 	GetService(idOrName string, insertDefaults bool) (swarm.Service, error)
 	CreateService(swarm.ServiceSpec, string, bool) (*swarm.ServiceCreateResponse, error)
 	UpdateService(string, uint64, swarm.ServiceSpec, types.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -166,7 +166,7 @@ func (sr *swarmRouter) getServices(ctx context.Context, w http.ResponseWriter, r
 		}
 	}
 
-	services, err := sr.backend.GetServices(basictypes.ServiceListOptions{Filters: filter, Status: status})
+	services, err := sr.backend.GetServices(types.ServiceListOptions{Filters: filter, Status: status})
 	if err != nil {
 		log.G(ctx).WithContext(ctx).WithError(err).Debug("Error getting services")
 		return err

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -385,7 +385,7 @@ func (sr *swarmRouter) getTasks(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	tasks, err := sr.backend.GetTasks(basictypes.TaskListOptions{Filters: filter})
+	tasks, err := sr.backend.GetTasks(types.TaskListOptions{Filters: filter})
 	if err != nil {
 		log.G(ctx).WithContext(ctx).WithError(err).Debug("Error getting tasks")
 		return err

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -314,7 +314,7 @@ func (sr *swarmRouter) getNodes(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	nodes, err := sr.backend.GetNodes(basictypes.NodeListOptions{Filters: filter})
+	nodes, err := sr.backend.GetNodes(types.NodeListOptions{Filters: filter})
 	if err != nil {
 		log.G(ctx).WithContext(ctx).WithError(err).Debug("Error getting nodes")
 		return err

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/httputils"
-	basictypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
@@ -245,7 +244,7 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 		return errdefs.InvalidParameter(err)
 	}
 
-	var flags basictypes.ServiceUpdateOptions
+	var flags types.ServiceUpdateOptions
 
 	// Get returns "" if the header does not exist
 	flags.EncodedRegistryAuth = r.Header.Get(registry.AuthHeader)

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -140,7 +140,7 @@ func (sr *swarmRouter) getUnlockKey(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	return httputils.WriteJSON(w, http.StatusOK, &basictypes.SwarmUnlockKeyResponse{
+	return httputils.WriteJSON(w, http.StatusOK, &types.UnlockKeyResponse{
 		UnlockKey: unlockKey,
 	})
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -109,21 +109,6 @@ type ServiceUpdateOptions struct {
 	QueryRegistry bool
 }
 
-// ServiceListOptions holds parameters to list services with.
-type ServiceListOptions struct {
-	Filters filters.Args
-
-	// Status indicates whether the server should include the service task
-	// count of running and desired tasks.
-	Status bool
-}
-
-// ServiceInspectOptions holds parameters related to the "service inspect"
-// operation.
-type ServiceInspectOptions struct {
-	InsertDefaults bool
-}
-
 // TaskListOptions holds parameters to list tasks with.
 type TaskListOptions struct {
 	Filters filters.Args

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -48,16 +48,6 @@ func (h *HijackedResponse) CloseWrite() error {
 	return nil
 }
 
-// NodeListOptions holds parameters to list nodes with.
-type NodeListOptions struct {
-	Filters filters.Args
-}
-
-// NodeRemoveOptions holds parameters to remove nodes with.
-type NodeRemoveOptions struct {
-	Force bool
-}
-
 // ServiceCreateOptions contains the options to use when creating a service.
 type ServiceCreateOptions struct {
 	// EncodedRegistryAuth is the encoded registry authorization credentials to

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -46,42 +46,6 @@ func (h *HijackedResponse) CloseWrite() error {
 	return nil
 }
 
-// Values for RegistryAuthFrom in ServiceUpdateOptions
-const (
-	RegistryAuthFromSpec         = "spec"
-	RegistryAuthFromPreviousSpec = "previous-spec"
-)
-
-// ServiceUpdateOptions contains the options to be used for updating services.
-type ServiceUpdateOptions struct {
-	// EncodedRegistryAuth is the encoded registry authorization credentials to
-	// use when updating the service.
-	//
-	// This field follows the format of the X-Registry-Auth header.
-	EncodedRegistryAuth string
-
-	// TODO(stevvooe): Consider moving the version parameter of ServiceUpdate
-	// into this field. While it does open API users up to racy writes, most
-	// users may not need that level of consistency in practice.
-
-	// RegistryAuthFrom specifies where to find the registry authorization
-	// credentials if they are not given in EncodedRegistryAuth. Valid
-	// values are "spec" and "previous-spec".
-	RegistryAuthFrom string
-
-	// Rollback indicates whether a server-side rollback should be
-	// performed. When this is set, the provided spec will be ignored.
-	// The valid values are "previous" and "none". An empty value is the
-	// same as "none".
-	Rollback string
-
-	// QueryRegistry indicates whether the service update requires
-	// contacting a registry. A registry may be contacted to retrieve
-	// the image digest and manifest, which in turn can be used to update
-	// platform or other information about the service.
-	QueryRegistry bool
-}
-
 // PluginRemoveOptions holds parameters to remove plugins.
 type PluginRemoveOptions struct {
 	Force bool

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"context"
 	"net"
-
-	"github.com/docker/docker/api/types/filters"
 )
 
 // NewHijackedResponse initializes a [HijackedResponse] type.
@@ -97,11 +95,6 @@ type ServiceUpdateOptions struct {
 	// the image digest and manifest, which in turn can be used to update
 	// platform or other information about the service.
 	QueryRegistry bool
-}
-
-// TaskListOptions holds parameters to list tasks with.
-type TaskListOptions struct {
-	Filters filters.Args
 }
 
 // PluginRemoveOptions holds parameters to remove plugins.

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -46,21 +46,6 @@ func (h *HijackedResponse) CloseWrite() error {
 	return nil
 }
 
-// ServiceCreateOptions contains the options to use when creating a service.
-type ServiceCreateOptions struct {
-	// EncodedRegistryAuth is the encoded registry authorization credentials to
-	// use when updating the service.
-	//
-	// This field follows the format of the X-Registry-Auth header.
-	EncodedRegistryAuth string
-
-	// QueryRegistry indicates whether the service update requires
-	// contacting a registry. A registry may be contacted to retrieve
-	// the image digest and manifest, which in turn can be used to update
-	// platform or other information about the service.
-	QueryRegistry bool
-}
-
 // Values for RegistryAuthFrom in ServiceUpdateOptions
 const (
 	RegistryAuthFromSpec         = "spec"

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -137,13 +137,6 @@ type PluginInstallOptions struct {
 	Args                  []string
 }
 
-// SwarmUnlockKeyResponse contains the response for Engine API:
-// GET /swarm/unlockkey
-type SwarmUnlockKeyResponse struct {
-	// UnlockKey is the unlock key in ASCII-armored format.
-	UnlockKey string
-}
-
 // PluginCreateOptions hold all options to plugin create.
 type PluginCreateOptions struct {
 	RepoName string

--- a/api/types/swarm/node.go
+++ b/api/types/swarm/node.go
@@ -1,4 +1,5 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
+import "github.com/docker/docker/api/types/filters"
 
 // Node represents a node.
 type Node struct {
@@ -136,4 +137,14 @@ const (
 // duplicate it here. See that type for full documentation
 type Topology struct {
 	Segments map[string]string `json:",omitempty"`
+}
+
+// NodeListOptions holds parameters to list nodes with.
+type NodeListOptions struct {
+	Filters filters.Args
+}
+
+// NodeRemoveOptions holds parameters to remove nodes with.
+type NodeRemoveOptions struct {
+	Force bool
 }

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -205,6 +205,21 @@ type JobStatus struct {
 	LastExecution time.Time `json:",omitempty"`
 }
 
+// ServiceCreateOptions contains the options to use when creating a service.
+type ServiceCreateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
+}
+
 // ServiceListOptions holds parameters to list services with.
 type ServiceListOptions struct {
 	Filters filters.Args

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -220,6 +220,42 @@ type ServiceCreateOptions struct {
 	QueryRegistry bool
 }
 
+// Values for RegistryAuthFrom in ServiceUpdateOptions
+const (
+	RegistryAuthFromSpec         = "spec"
+	RegistryAuthFromPreviousSpec = "previous-spec"
+)
+
+// ServiceUpdateOptions contains the options to be used for updating services.
+type ServiceUpdateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+
+	// TODO(stevvooe): Consider moving the version parameter of ServiceUpdate
+	// into this field. While it does open API users up to racy writes, most
+	// users may not need that level of consistency in practice.
+
+	// RegistryAuthFrom specifies where to find the registry authorization
+	// credentials if they are not given in EncodedRegistryAuth. Valid
+	// values are "spec" and "previous-spec".
+	RegistryAuthFrom string
+
+	// Rollback indicates whether a server-side rollback should be
+	// performed. When this is set, the provided spec will be ignored.
+	// The valid values are "previous" and "none". An empty value is the
+	// same as "none".
+	Rollback string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
+}
+
 // ServiceListOptions holds parameters to list services with.
 type ServiceListOptions struct {
 	Filters filters.Args

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -1,6 +1,10 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
 
-import "time"
+import (
+	"time"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // Service represents a service.
 type Service struct {
@@ -199,4 +203,19 @@ type JobStatus struct {
 	// LastExecution is the time that the job was last executed, as observed by
 	// Swarm manager.
 	LastExecution time.Time `json:",omitempty"`
+}
+
+// ServiceListOptions holds parameters to list services with.
+type ServiceListOptions struct {
+	Filters filters.Args
+
+	// Status indicates whether the server should include the service task
+	// count of running and desired tasks.
+	Status bool
+}
+
+// ServiceInspectOptions holds parameters related to the "service inspect"
+// operation.
+type ServiceInspectOptions struct {
+	InsertDefaults bool
 }

--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -235,3 +235,10 @@ type UpdateFlags struct {
 	RotateManagerToken     bool
 	RotateManagerUnlockKey bool
 }
+
+// UnlockKeyResponse contains the response for Engine API:
+// GET /swarm/unlockkey
+type UnlockKeyResponse struct {
+	// UnlockKey is the unlock key in ASCII-armored format.
+	UnlockKey string
+}

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -3,6 +3,7 @@ package swarm // import "github.com/docker/docker/api/types/swarm"
 import (
 	"time"
 
+	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm/runtime"
 )
 
@@ -222,4 +223,9 @@ type VolumeAttachment struct {
 	// Target, together with Source, indicates the Mount, as specified
 	// in the ContainerSpec, that this volume fulfills.
 	Target string `json:",omitempty"`
+}
+
+// TaskListOptions holds parameters to list tasks with.
+type TaskListOptions struct {
+	Filters filters.Args
 }

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -159,6 +159,12 @@ type ServiceListOptions = swarm.ServiceListOptions
 // Deprecated: use [swarm.ServiceInspectOptions].
 type ServiceInspectOptions = swarm.ServiceInspectOptions
 
+// SwarmUnlockKeyResponse contains the response for Engine API:
+// GET /swarm/unlockkey
+//
+// Deprecated: use [swarm.UnlockKeyResponse].
+type SwarmUnlockKeyResponse = swarm.UnlockKeyResponse
+
 // BuildCache contains information about a build cache record.
 //
 // Deprecated: deprecated in API 1.49. Use [build.CacheRecord] instead.

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -138,6 +138,16 @@ type ConfigCreateResponse = swarm.ConfigCreateResponse
 // Deprecated: use [swarm.ConfigListOptions].
 type ConfigListOptions = swarm.ConfigListOptions
 
+// NodeListOptions holds parameters to list nodes with.
+//
+// Deprecated: use [swarm.NodeListOptions].
+type NodeListOptions = swarm.NodeListOptions
+
+// NodeRemoveOptions holds parameters to remove nodes with.
+//
+// Deprecated: use [swarm.NodeRemoveOptions].
+type NodeRemoveOptions = swarm.NodeRemoveOptions
+
 // ServiceListOptions holds parameters to list services with.
 //
 // Deprecated: use [swarm.ServiceListOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -148,6 +148,11 @@ type NodeListOptions = swarm.NodeListOptions
 // Deprecated: use [swarm.NodeRemoveOptions].
 type NodeRemoveOptions = swarm.NodeRemoveOptions
 
+// TaskListOptions holds parameters to list tasks with.
+//
+// Deprecated: use [swarm.TaskListOptions].
+type TaskListOptions = swarm.TaskListOptions
+
 // ServiceListOptions holds parameters to list services with.
 //
 // Deprecated: use [swarm.ServiceListOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -158,6 +158,16 @@ type TaskListOptions = swarm.TaskListOptions
 // Deprecated: use [swarm.ServiceCreateOptions].
 type ServiceCreateOptions = swarm.ServiceCreateOptions
 
+// ServiceUpdateOptions contains the options to be used for updating services.
+//
+// Deprecated: use [swarm.ServiceCreateOptions].
+type ServiceUpdateOptions = swarm.ServiceUpdateOptions
+
+const (
+	RegistryAuthFromSpec         = swarm.RegistryAuthFromSpec         // Deprecated: use [swarm.RegistryAuthFromSpec].
+	RegistryAuthFromPreviousSpec = swarm.RegistryAuthFromPreviousSpec // Deprecated: use [swarm.RegistryAuthFromPreviousSpec].
+)
+
 // ServiceListOptions holds parameters to list services with.
 //
 // Deprecated: use [swarm.ServiceListOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -153,6 +153,11 @@ type NodeRemoveOptions = swarm.NodeRemoveOptions
 // Deprecated: use [swarm.TaskListOptions].
 type TaskListOptions = swarm.TaskListOptions
 
+// ServiceCreateOptions contains the options to use when creating a service.
+//
+// Deprecated: use [swarm.ServiceCreateOptions].
+type ServiceCreateOptions = swarm.ServiceCreateOptions
+
 // ServiceListOptions holds parameters to list services with.
 //
 // Deprecated: use [swarm.ServiceListOptions].

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -138,6 +138,17 @@ type ConfigCreateResponse = swarm.ConfigCreateResponse
 // Deprecated: use [swarm.ConfigListOptions].
 type ConfigListOptions = swarm.ConfigListOptions
 
+// ServiceListOptions holds parameters to list services with.
+//
+// Deprecated: use [swarm.ServiceListOptions].
+type ServiceListOptions = swarm.ServiceListOptions
+
+// ServiceInspectOptions holds parameters related to the "service inspect"
+// operation.
+//
+// Deprecated: use [swarm.ServiceInspectOptions].
+type ServiceInspectOptions = swarm.ServiceInspectOptions
+
 // BuildCache contains information about a build cache record.
 //
 // Deprecated: deprecated in API 1.49. Use [build.CacheRecord] instead.

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -176,7 +176,7 @@ type PluginAPIClient interface {
 
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
-	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options swarm.ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -177,8 +177,8 @@ type PluginAPIClient interface {
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
 	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
-	ServiceInspectWithRaw(ctx context.Context, serviceID string, options types.ServiceInspectOptions) (swarm.Service, []byte, error)
-	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
+	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
+	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
 	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -191,7 +191,7 @@ type ServiceAPIClient interface {
 type SwarmAPIClient interface {
 	SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error)
 	SwarmJoin(ctx context.Context, req swarm.JoinRequest) error
-	SwarmGetUnlockKey(ctx context.Context) (types.SwarmUnlockKeyResponse, error)
+	SwarmGetUnlockKey(ctx context.Context) (swarm.UnlockKeyResponse, error)
 	SwarmUnlock(ctx context.Context, req swarm.UnlockRequest) error
 	SwarmLeave(ctx context.Context, force bool) error
 	SwarmInspect(ctx context.Context) (swarm.Swarm, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -155,8 +155,8 @@ type NetworkAPIClient interface {
 // NodeAPIClient defines API client methods for the nodes
 type NodeAPIClient interface {
 	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
-	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
-	NodeRemove(ctx context.Context, nodeID string, options types.NodeRemoveOptions) error
+	NodeList(ctx context.Context, options swarm.NodeListOptions) ([]swarm.Node, error)
+	NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error
 	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
 }
 

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -180,7 +180,7 @@ type ServiceAPIClient interface {
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
-	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options swarm.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskLogs(ctx context.Context, taskID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -184,7 +184,7 @@ type ServiceAPIClient interface {
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskLogs(ctx context.Context, taskID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
-	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
+	TaskList(ctx context.Context, options swarm.TaskListOptions) ([]swarm.Task, error)
 }
 
 // SwarmAPIClient defines API client methods for the swarm

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // NodeList returns the list of nodes.
-func (cli *Client) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
+func (cli *Client) NodeList(ctx context.Context, options swarm.NodeListOptions) ([]swarm.Node, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -23,7 +22,7 @@ func TestNodeListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NodeList(context.Background(), types.NodeListOptions{})
+	_, err := client.NodeList(context.Background(), swarm.NodeListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -31,17 +30,17 @@ func TestNodeList(t *testing.T) {
 	const expectedURL = "/nodes"
 
 	listCases := []struct {
-		options             types.NodeListOptions
+		options             swarm.NodeListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.NodeListOptions{},
+			options: swarm.NodeListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: types.NodeListOptions{
+			options: swarm.NodeListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/node_remove.go
+++ b/client/node_remove.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 // NodeRemove removes a Node.
-func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options types.NodeRemoveOptions) error {
+func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error {
 	nodeID, err := trimID("node", nodeID)
 	if err != nil {
 		return err

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -20,14 +20,14 @@ func TestNodeRemoveError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.NodeRemove(context.Background(), "node_id", types.NodeRemoveOptions{Force: false})
+	err := client.NodeRemove(context.Background(), "node_id", swarm.NodeRemoveOptions{Force: false})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 
-	err = client.NodeRemove(context.Background(), "", types.NodeRemoveOptions{Force: false})
+	err = client.NodeRemove(context.Background(), "", swarm.NodeRemoveOptions{Force: false})
 	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.NodeRemove(context.Background(), "    ", types.NodeRemoveOptions{Force: false})
+	err = client.NodeRemove(context.Background(), "    ", swarm.NodeRemoveOptions{Force: false})
 	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -69,7 +69,7 @@ func TestNodeRemove(t *testing.T) {
 			}),
 		}
 
-		err := client.NodeRemove(context.Background(), "node_id", types.NodeRemoveOptions{Force: removeCase.force})
+		err := client.NodeRemove(context.Background(), "node_id", swarm.NodeRemoveOptions{Force: removeCase.force})
 		assert.NilError(t, err)
 	}
 }

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
@@ -17,7 +16,7 @@ import (
 )
 
 // ServiceCreate creates a new service.
-func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options types.ServiceCreateOptions) (swarm.ServiceCreateResponse, error) {
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options swarm.ServiceCreateOptions) (swarm.ServiceCreateResponse, error) {
 	var response swarm.ServiceCreateResponse
 
 	// Make sure we negotiated (if the client is configured to do so),

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -24,7 +23,7 @@ func TestServiceCreateError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
+	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, swarm.ServiceCreateOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -36,7 +35,7 @@ func TestServiceCreateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
+	_, err = client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, swarm.ServiceCreateOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
@@ -63,7 +62,7 @@ func TestServiceCreate(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
+	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, swarm.ServiceCreateOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(r.ID, "service_id"))
 }
@@ -122,7 +121,7 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 
 	spec := swarm.ServiceSpec{TaskTemplate: swarm.TaskSpec{ContainerSpec: &swarm.ContainerSpec{Image: "foobar:1.0"}}}
 
-	r, err := client.ServiceCreate(context.Background(), spec, types.ServiceCreateOptions{QueryRegistry: true})
+	r, err := client.ServiceCreate(context.Background(), spec, swarm.ServiceCreateOptions{QueryRegistry: true})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal("service_linux_amd64", r.ID))
 }
@@ -201,7 +200,7 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 					Image: p.img,
 				},
 			},
-		}, types.ServiceCreateOptions{QueryRegistry: true})
+		}, swarm.ServiceCreateOptions{QueryRegistry: true})
 		assert.NilError(t, err)
 
 		assert.Check(t, is.Equal(r.ID, "service_id"))

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -8,12 +8,11 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // ServiceInspectWithRaw returns the service information and the raw data.
-func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error) {
+func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts swarm.ServiceInspectOptions) (swarm.Service, []byte, error) {
 	serviceID, err := trimID("service", serviceID)
 	if err != nil {
 		return swarm.Service{}, nil, err

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -23,7 +22,7 @@ func TestServiceInspectError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", types.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", swarm.ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -32,7 +31,7 @@ func TestServiceInspectServiceNotFound(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", types.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", swarm.ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
@@ -42,11 +41,11 @@ func TestServiceInspectWithEmptyID(t *testing.T) {
 			return nil, errors.New("should not make request")
 		}),
 	}
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "", types.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "", swarm.ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	_, _, err = client.ServiceInspectWithRaw(context.Background(), "    ", types.ServiceInspectOptions{})
+	_, _, err = client.ServiceInspectWithRaw(context.Background(), "    ", swarm.ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -71,7 +70,7 @@ func TestServiceInspect(t *testing.T) {
 		}),
 	}
 
-	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id", types.ServiceInspectOptions{})
+	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id", swarm.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(serviceInspect.ID, "service_id"))
 }

--- a/client/service_list.go
+++ b/client/service_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // ServiceList returns the list of services.
-func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+func (cli *Client) ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -23,7 +22,7 @@ func TestServiceListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ServiceList(context.Background(), types.ServiceListOptions{})
+	_, err := client.ServiceList(context.Background(), swarm.ServiceListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -31,17 +30,17 @@ func TestServiceList(t *testing.T) {
 	const expectedURL = "/services"
 
 	listCases := []struct {
-		options             types.ServiceListOptions
+		options             swarm.ServiceListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.ServiceListOptions{},
+			options: swarm.ServiceListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: types.ServiceListOptions{
+			options: swarm.ServiceListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
@@ -15,7 +14,7 @@ import (
 // ServiceUpdate updates a Service. The version number is required to avoid conflicting writes.
 // It should be the value as set *before* the update. You can find this value in the Meta field
 // of swarm.Service, which can be found using ServiceInspectWithRaw.
-func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options swarm.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
 	serviceID, err := trimID("service", serviceID)
 	if err != nil {
 		return swarm.ServiceUpdateResponse{}, err

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -21,14 +20,14 @@ func TestServiceUpdateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
+	_, err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 
-	_, err = client.ServiceUpdate(context.Background(), "", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
+	_, err = client.ServiceUpdate(context.Background(), "", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	_, err = client.ServiceUpdate(context.Background(), "    ", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
+	_, err = client.ServiceUpdate(context.Background(), "    ", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -41,7 +40,7 @@ func TestServiceUpdateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
+	_, err = client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
@@ -89,7 +88,7 @@ func TestServiceUpdate(t *testing.T) {
 			}),
 		}
 
-		_, err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
+		_, err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
 		assert.NilError(t, err)
 	}
 }

--- a/client/swarm_get_unlock_key.go
+++ b/client/swarm_get_unlock_key.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 // SwarmGetUnlockKey retrieves the swarm's unlock key.
-func (cli *Client) SwarmGetUnlockKey(ctx context.Context) (types.SwarmUnlockKeyResponse, error) {
+func (cli *Client) SwarmGetUnlockKey(ctx context.Context) (swarm.UnlockKeyResponse, error) {
 	resp, err := cli.get(ctx, "/swarm/unlockkey", nil, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return types.SwarmUnlockKeyResponse{}, err
+		return swarm.UnlockKeyResponse{}, err
 	}
 
-	var response types.SwarmUnlockKeyResponse
+	var response swarm.UnlockKeyResponse
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/swarm_get_unlock_key_test.go
+++ b/client/swarm_get_unlock_key_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -38,7 +38,7 @@ func TestSwarmGetUnlockKey(t *testing.T) {
 				return nil, fmt.Errorf("expected GET method, got %s", req.Method)
 			}
 
-			key := types.SwarmUnlockKeyResponse{
+			key := swarm.UnlockKeyResponse{
 				UnlockKey: unlockKey,
 			}
 

--- a/client/task_list.go
+++ b/client/task_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // TaskList returns the list of tasks.
-func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+func (cli *Client) TaskList(ctx context.Context, options swarm.TaskListOptions) ([]swarm.Task, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -23,7 +22,7 @@ func TestTaskListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.TaskList(context.Background(), types.TaskListOptions{})
+	_, err := client.TaskList(context.Background(), swarm.TaskListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -31,17 +30,17 @@ func TestTaskList(t *testing.T) {
 	const expectedURL = "/tasks"
 
 	listCases := []struct {
-		options             types.TaskListOptions
+		options             swarm.TaskListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.TaskListOptions{},
+			options: swarm.TaskListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: types.TaskListOptions{
+			options: swarm.TaskListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/daemon/cluster/nodes.go
+++ b/daemon/cluster/nodes.go
@@ -3,7 +3,6 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 
-	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	"github.com/docker/docker/errdefs"
@@ -12,7 +11,7 @@ import (
 )
 
 // GetNodes returns a list of all nodes known to a cluster.
-func (c *Cluster) GetNodes(options apitypes.NodeListOptions) ([]types.Node, error) {
+func (c *Cluster) GetNodes(options types.NodeListOptions) ([]types.Node, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetServices returns all services of a managed swarm cluster.
-func (c *Cluster) GetServices(options types.ServiceListOptions) ([]swarm.Service, error) {
+func (c *Cluster) GetServices(options swarm.ServiceListOptions) ([]swarm.Service, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
@@ -283,7 +282,7 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 }
 
 // UpdateService updates existing service to match new properties.
-func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swarm.ServiceSpec, flags types.ServiceUpdateOptions, queryRegistry bool) (*swarm.ServiceUpdateResponse, error) {
+func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swarm.ServiceSpec, flags swarm.ServiceUpdateOptions, queryRegistry bool) (*swarm.ServiceUpdateResponse, error) {
 	var resp *swarm.ServiceUpdateResponse
 
 	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
@@ -328,9 +327,9 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swa
 				// shouldn't lose it, and continue to use the one that was already present
 				var ctnr *swarmapi.ContainerSpec
 				switch flags.RegistryAuthFrom {
-				case types.RegistryAuthFromSpec, "":
+				case swarm.RegistryAuthFromSpec, "":
 					ctnr = currentService.Spec.Task.GetContainer()
-				case types.RegistryAuthFromPreviousSpec:
+				case swarm.RegistryAuthFromPreviousSpec:
 					if currentService.PreviousSpec == nil {
 						return errors.New("service does not have a previous spec")
 					}

--- a/daemon/cluster/tasks.go
+++ b/daemon/cluster/tasks.go
@@ -3,7 +3,6 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 
-	apitypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
@@ -12,7 +11,7 @@ import (
 )
 
 // GetTasks returns a list of tasks matching the filter options.
-func (c *Cluster) GetTasks(options apitypes.TaskListOptions) ([]types.Task, error) {
+func (c *Cluster) GetTasks(options types.TaskListOptions) ([]types.Task, error) {
 	var r *swarmapi.ListTasksResponse
 
 	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -103,7 +102,7 @@ func (d *Daemon) CheckRunningTaskNetworks(ctx context.Context) func(t *testing.T
 		cli := d.NewClientT(t)
 		defer cli.Close()
 
-		tasks, err := cli.TaskList(ctx, types.TaskListOptions{
+		tasks, err := cli.TaskList(ctx, swarm.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("desired-state", "running")),
 		})
 		assert.NilError(t, err)
@@ -124,7 +123,7 @@ func (d *Daemon) CheckRunningTaskImages(ctx context.Context) func(t *testing.T) 
 		cli := d.NewClientT(t)
 		defer cli.Close()
 
-		tasks, err := cli.TaskList(ctx, types.TaskListOptions{
+		tasks, err := cli.TaskList(ctx, swarm.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("desired-state", "running")),
 		})
 		assert.NilError(t, err)

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -178,7 +178,7 @@ func (d *Daemon) CheckLeader(ctx context.Context) func(t *testing.T) (interface{
 
 		errList := "could not get node list"
 
-		ls, err := cli.NodeList(ctx, types.NodeListOptions{})
+		ls, err := cli.NodeList(ctx, swarm.NodeListOptions{})
 		if err != nil {
 			return err, errList
 		}

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/cli"
@@ -75,7 +74,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *testing.T) {
 	client := d.NewClientT(c)
 	defer client.Close()
 
-	options := types.ServiceInspectOptions{InsertDefaults: true}
+	options := swarm.ServiceInspectOptions{InsertDefaults: true}
 
 	// insertDefaults inserts UpdateConfig when service is fetched by ID
 	resp, _, err := client.ServiceInspectWithRaw(ctx, id, options)

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/initca"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
@@ -890,7 +889,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateWithName(c *testing.T) {
 	setInstances(instances)(service)
 	cli := d.NewClientT(c)
 	defer cli.Close()
-	_, err := cli.ServiceUpdate(ctx, service.Spec.Name, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err := cli.ServiceUpdate(ctx, service.Spec.Name, service.Version, service.Spec, swarm.ServiceUpdateOptions{})
 	assert.NilError(c, err)
 	poll.WaitOn(c, pollCheck(c, d.CheckActiveContainerCount(ctx), checker.Equals(instances)), poll.WithTimeout(defaultReconciliationTimeout))
 }

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -414,7 +414,7 @@ func (s *DockerSwarmSuite) TestAPISwarmRaftQuorum(c *testing.T) {
 
 	// d1 will eventually step down from leader because there is no longer an active quorum, wait for that to happen
 	poll.WaitOn(c, pollCheck(c, func(c *testing.T) (interface{}, string) {
-		_, err := cli.ServiceCreate(testutil.GetContext(c), service.Spec, types.ServiceCreateOptions{})
+		_, err := cli.ServiceCreate(testutil.GetContext(c), service.Spec, swarm.ServiceCreateOptions{})
 		return err.Error(), ""
 	}, checker.Contains("Make sure more than half of the managers are online.")), poll.WithTimeout(defaultReconciliationTimeout*2))
 

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -200,7 +200,7 @@ func ServiceWithPidsLimit(limit int64) ServiceSpecOpt {
 func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClient, serviceID string) []swarmtypes.Task {
 	t.Helper()
 
-	tasks, err := c.TaskList(ctx, types.TaskListOptions{
+	tasks, err := c.TaskList(ctx, swarmtypes.TaskListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("service", serviceID),
 			filters.Arg("desired-state", "running"),

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -64,7 +64,7 @@ func CreateService(ctx context.Context, t *testing.T, d *daemon.Daemon, opts ...
 	defer apiClient.Close()
 
 	spec := CreateServiceSpec(t, opts...)
-	resp, err := apiClient.ServiceCreate(ctx, spec, types.ServiceCreateOptions{})
+	resp, err := apiClient.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{})
 	assert.NilError(t, err, "error creating service")
 	return resp.ID
 }

--- a/integration/internal/swarm/states.go
+++ b/integration/internal/swarm/states.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -14,7 +13,7 @@ import (
 // NoTasksForService verifies that there are no more tasks for the given service
 func NoTasksForService(ctx context.Context, client client.ServiceAPIClient, serviceID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{
+		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
 			Filters: filters.NewArgs(
 				filters.Arg("service", serviceID),
 			),
@@ -36,7 +35,7 @@ func NoTasksForService(ctx context.Context, client client.ServiceAPIClient, serv
 // NoTasks verifies that all tasks are gone
 func NoTasks(ctx context.Context, client client.ServiceAPIClient) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{})
+		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)
@@ -53,7 +52,7 @@ func RunningTasksCount(ctx context.Context, client client.ServiceAPIClient, serv
 	return func(log poll.LogT) poll.Result {
 		filter := filters.NewArgs()
 		filter.Add("service", serviceID)
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{
+		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
 			Filters: filter,
 		})
 		var running int
@@ -102,7 +101,7 @@ func JobComplete(ctx context.Context, client client.ServiceAPIClient, service sw
 	previousResult := ""
 
 	return func(log poll.LogT) poll.Result {
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{
+		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
 			Filters: filter,
 		})
 		if err != nil {

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
@@ -246,7 +245,7 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	err = c.ServiceRemove(ctx, serviceID)
@@ -287,7 +286,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	err = c.ServiceRemove(ctx, serviceID)
@@ -334,7 +333,7 @@ func swarmIngressReady(ctx context.Context, client client.NetworkAPIClient) func
 
 func noServices(ctx context.Context, client client.ServiceAPIClient) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		services, err := client.ServiceList(ctx, types.ServiceListOptions{})
+		services, err := client.ServiceList(ctx, swarmtypes.ServiceListOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)
@@ -441,7 +440,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, cli, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+	_, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	out, err := cli.NetworkInspect(ctx, overlayID, networktypes.InspectOptions{Verbose: true})

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
@@ -165,7 +164,7 @@ func TestCreateServiceConflict(t *testing.T) {
 	swarm.CreateService(ctx, t, d, serviceSpec...)
 
 	spec := swarm.CreateServiceSpec(t, serviceSpec...)
-	_, err := c.ServiceCreate(ctx, spec, types.ServiceCreateOptions{})
+	_, err := c.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{})
 	assert.Check(t, errdefs.IsConflict(err))
 	assert.ErrorContains(t, err, "service "+serviceName+" already exists")
 }

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -368,7 +368,7 @@ func TestCreateServiceSysctls(t *testing.T) {
 		// more complex)
 
 		// get all tasks of the service, so we can get the container
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{
+		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("service", serviceID)),
 		})
 		assert.NilError(t, err)
@@ -438,7 +438,7 @@ func TestCreateServiceCapabilities(t *testing.T) {
 	// level has been tested elsewhere.
 
 	// get all tasks of the service, so we can get the container
-	tasks, err := client.TaskList(ctx, types.TaskListOptions{
+	tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
 		Filters: filters.NewArgs(filters.Arg("service", serviceID)),
 	})
 	assert.NilError(t, err)

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -102,7 +102,7 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 	serviceID := swarm.CreateService(ctx, t, d, serviceSpec...)
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, client, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := client.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	err = client.ServiceRemove(ctx, serviceID)
@@ -187,7 +187,7 @@ func TestCreateServiceMaxReplicas(t *testing.T) {
 	serviceID := swarm.CreateService(ctx, t, d, serviceSpec...)
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, client, serviceID, maxReplicas), swarm.ServicePoll)
 
-	_, _, err := client.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 }
 
@@ -383,7 +383,7 @@ func TestCreateServiceSysctls(t *testing.T) {
 		assert.DeepEqual(t, tasks[0].Spec.ContainerSpec.Sysctls, expectedSysctls)
 
 		// verify that the service also has the sysctl set in the spec.
-		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 		assert.NilError(t, err)
 		assert.DeepEqual(t,
 			service.Spec.TaskTemplate.ContainerSpec.Sysctls, expectedSysctls,
@@ -455,7 +455,7 @@ func TestCreateServiceCapabilities(t *testing.T) {
 	assert.DeepEqual(t, tasks[0].Spec.ContainerSpec.CapabilityDrop, capDrop)
 
 	// verify that the service also has the capabilities set in the spec.
-	service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+	service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd, capAdd)
 	assert.DeepEqual(t, service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop, capDrop)

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -36,7 +36,7 @@ func TestInspect(t *testing.T) {
 	id := resp.ID
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, client, id, instances))
 
-	service, _, err := client.ServiceInspectWithRaw(ctx, id, types.ServiceInspectOptions{})
+	service, _, err := client.ServiceInspectWithRaw(ctx, id, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	expected := swarmtypes.Service{

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration/internal/swarm"
@@ -28,7 +27,7 @@ func TestInspect(t *testing.T) {
 	var instances uint64 = 2
 	serviceSpec := fullSwarmServiceSpec("test-service-inspect"+t.Name(), instances)
 
-	resp, err := client.ServiceCreate(ctx, serviceSpec, types.ServiceCreateOptions{
+	resp, err := client.ServiceCreate(ctx, serviceSpec, swarmtypes.ServiceCreateOptions{
 		QueryRegistry: false,
 	})
 	assert.NilError(t, err)

--- a/integration/service/jobs_test.go
+++ b/integration/service/jobs_test.go
@@ -75,7 +75,7 @@ func TestReplicatedJob(t *testing.T) {
 	)
 
 	service, _, err := client.ServiceInspectWithRaw(
-		ctx, id, types.ServiceInspectOptions{},
+		ctx, id, swarmtypes.ServiceInspectOptions{},
 	)
 	assert.NilError(t, err)
 
@@ -108,7 +108,7 @@ func TestUpdateReplicatedJob(t *testing.T) {
 	)
 
 	service, _, err := client.ServiceInspectWithRaw(
-		ctx, id, types.ServiceInspectOptions{},
+		ctx, id, swarmtypes.ServiceInspectOptions{},
 	)
 	assert.NilError(t, err)
 
@@ -125,7 +125,7 @@ func TestUpdateReplicatedJob(t *testing.T) {
 	assert.NilError(t, err)
 
 	service2, _, err := client.ServiceInspectWithRaw(
-		ctx, id, types.ServiceInspectOptions{},
+		ctx, id, swarmtypes.ServiceInspectOptions{},
 	)
 	assert.NilError(t, err)
 

--- a/integration/service/jobs_test.go
+++ b/integration/service/jobs_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration/internal/swarm"
 	"gotest.tools/v3/assert"
@@ -120,7 +119,7 @@ func TestUpdateReplicatedJob(t *testing.T) {
 	spec.TaskTemplate.ForceUpdate++
 
 	_, err = client.ServiceUpdate(
-		ctx, id, service.Version, spec, types.ServiceUpdateOptions{},
+		ctx, id, service.Version, spec, swarmtypes.ServiceUpdateOptions{},
 	)
 	assert.NilError(t, err)
 

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -53,7 +53,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 		// serviceContainerCount function does not do. instead, we'll use a
 		// bespoke closure right here.
 		poll.WaitOn(t, func(log poll.LogT) poll.Result {
-			tasks, err := client.TaskList(ctx, types.TaskListOptions{
+			tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
 				Filters: filters.NewArgs(filters.Arg("service", id)),
 			})
 

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/integration/internal/swarm"
@@ -44,7 +43,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 		// tasks to fail and exit. instead, we'll just pass no args, which
 		// works.
 		spec.TaskTemplate.ContainerSpec.Args = []string{}
-		resp, err := client.ServiceCreate(ctx, spec, types.ServiceCreateOptions{
+		resp, err := client.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{
 			QueryRegistry: false,
 		})
 		assert.NilError(t, err)

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -79,7 +79,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 	}
 
 	// now, let's do the list operation with no status arg set.
-	resp, err := client.ServiceList(ctx, types.ServiceListOptions{})
+	resp, err := client.ServiceList(ctx, swarmtypes.ServiceListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(resp, serviceCount))
 	for _, service := range resp {
@@ -87,7 +87,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 	}
 
 	// now try again, but with Status: true. This time, we should have statuses
-	resp, err = client.ServiceList(ctx, types.ServiceListOptions{Status: true})
+	resp, err = client.ServiceList(ctx, swarmtypes.ServiceListOptions{Status: true})
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(resp, serviceCount))
 	for _, service := range resp {

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	networktypes "github.com/docker/docker/api/types/network"
@@ -35,7 +34,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 
 	// add label to empty set
 	service.Spec.Labels["foo"] = "bar"
-	_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -43,21 +42,21 @@ func TestServiceUpdateLabel(t *testing.T) {
 
 	// add label to non-empty set
 	service.Spec.Labels["foo2"] = "bar"
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar", "foo2": "bar"}))
 
 	delete(service.Spec.Labels, "foo2")
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
 	delete(service.Spec.Labels, "foo")
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -65,7 +64,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 
 	// now make sure we can add again
 	service.Spec.Labels["foo"] = "bar"
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -112,7 +111,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 			SecretName: secretName,
 		},
 	)
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
@@ -127,7 +126,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 	// remove
 	service.Spec.TaskTemplate.ContainerSpec.Secrets = []*swarmtypes.SecretReference{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -174,7 +173,7 @@ func TestServiceUpdateConfigs(t *testing.T) {
 			ConfigName: configName,
 		},
 	)
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
@@ -189,7 +188,7 @@ func TestServiceUpdateConfigs(t *testing.T) {
 
 	// remove
 	service.Spec.TaskTemplate.ContainerSpec.Configs = []*swarmtypes.ConfigReference{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -232,7 +231,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 	// Remove network from service
 	service.Spec.TaskTemplate.Networks = []swarmtypes.NetworkAttachmentConfig{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
@@ -300,7 +299,7 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 					service.Spec.TaskTemplate.Resources.Limits = &swarmtypes.Limit{}
 				}
 				service.Spec.TaskTemplate.Resources.Limits.Pids = tc.pidsLimit
-				_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+				_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
 				assert.NilError(t, err)
 				poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 			}

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -343,14 +343,14 @@ func getServiceTaskContainer(ctx context.Context, t *testing.T, cli client.APICl
 
 func getService(ctx context.Context, t *testing.T, cli client.ServiceAPIClient, serviceID string) swarmtypes.Service {
 	t.Helper()
-	service, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+	service, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	return service
 }
 
 func serviceIsUpdated(ctx context.Context, client client.ServiceAPIClient, serviceID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)
@@ -367,7 +367,7 @@ func serviceIsUpdated(ctx context.Context, client client.ServiceAPIClient, servi
 
 func serviceSpecIsUpdated(ctx context.Context, client client.ServiceAPIClient, serviceID string, serviceOldVersion uint64) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -326,7 +326,7 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 
 func getServiceTaskContainer(ctx context.Context, t *testing.T, cli client.APIClient, serviceID string) container.InspectResponse {
 	t.Helper()
-	tasks, err := cli.TaskList(ctx, types.TaskListOptions{
+	tasks, err := cli.TaskList(ctx, swarmtypes.TaskListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("service", serviceID),
 			filters.Arg("desired-state", "running"),

--- a/testutil/daemon/node.go
+++ b/testutil/daemon/node.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 )
@@ -39,7 +38,7 @@ func (d *Daemon) RemoveNode(ctx context.Context, t testing.TB, id string, force 
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	options := types.NodeRemoveOptions{
+	options := swarm.NodeRemoveOptions{
 		Force: force,
 	}
 	err := cli.NodeRemove(ctx, id, options)
@@ -74,7 +73,7 @@ func (d *Daemon) ListNodes(ctx context.Context, t testing.TB) []swarm.Node {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	nodes, err := cli.NodeList(ctx, types.NodeListOptions{})
+	nodes, err := cli.NodeList(ctx, swarm.NodeListOptions{})
 	assert.NilError(t, err)
 
 	return nodes

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -44,7 +44,7 @@ func (d *Daemon) GetService(ctx context.Context, t testing.TB, id string) *swarm
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	service, _, err := cli.ServiceInspectWithRaw(ctx, id, types.ServiceInspectOptions{})
+	service, _, err := cli.ServiceInspectWithRaw(ctx, id, swarm.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	return &service
 }
@@ -102,7 +102,7 @@ func (d *Daemon) ListServices(ctx context.Context, t testing.TB) []swarm.Service
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	services, err := cli.ServiceList(ctx, types.ServiceListOptions{})
+	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
 	assert.NilError(t, err)
 	return services
 }

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -63,7 +63,7 @@ func (d *Daemon) GetServiceTasks(ctx context.Context, t testing.TB, service stri
 		filterArgs.Add(filter.Key, filter.Value)
 	}
 
-	options := types.TaskListOptions{
+	options := swarm.TaskListOptions{
 		Filters: filterArgs,
 	}
 

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
@@ -82,7 +81,7 @@ func (d *Daemon) UpdateService(ctx context.Context, t testing.TB, service *swarm
 		fn(service)
 	}
 
-	_, err := cli.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, types.ServiceUpdateOptions{})
+	_, err := cli.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, swarm.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 }
 

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -14,7 +14,7 @@ import (
 // ServiceConstructor defines a swarm service constructor function
 type ServiceConstructor func(*swarm.Service)
 
-func (d *Daemon) createServiceWithOptions(ctx context.Context, t testing.TB, opts types.ServiceCreateOptions, f ...ServiceConstructor) string {
+func (d *Daemon) createServiceWithOptions(ctx context.Context, t testing.TB, opts swarm.ServiceCreateOptions, f ...ServiceConstructor) string {
 	t.Helper()
 	var service swarm.Service
 	for _, fn := range f {
@@ -35,7 +35,7 @@ func (d *Daemon) createServiceWithOptions(ctx context.Context, t testing.TB, opt
 // CreateService creates a swarm service given the specified service constructor
 func (d *Daemon) CreateService(ctx context.Context, t testing.TB, f ...ServiceConstructor) string {
 	t.Helper()
-	return d.createServiceWithOptions(ctx, t, types.ServiceCreateOptions{}, f...)
+	return d.createServiceWithOptions(ctx, t, swarm.ServiceCreateOptions{}, f...)
 }
 
 // GetService returns the swarm service corresponding to the specified id


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/50024

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types: deprecate `NodeListOptions`, `NodeRemoveOptions`, `ServiceCreateOptions`, `ServiceUpdateOptions`, `RegistryAuthFromSpec`, `RegistryAuthFromPreviousSpec`, `ServiceListOptions`, `ServiceInspectOptions`, and `SwarmUnlockKeyResponse` which were moved to `api/types/swarm`
```

**- A picture of a cute animal (not mandatory but encouraged)**

