### PR TITLE
issue #49934 Relax some checks tight to CGROUP V1 when running CGROUP V2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -251,6 +251,11 @@ linters:
         linters:
           - forbidigo
 
+        # FIXME(dmcgowan): ignoring while transitioning to containerd/errdefs
+      - text: "SA1019: errdefs\\.(.*) is deprecated"
+        linters:
+          - staticcheck
+
     # Log a warning if an exclusion rule is unused.
     # Default: false
     warn-unused: true

--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of the current REST API.
-	DefaultVersion = "1.49"
+	DefaultVersion = "1.50"
 
 	// MinSupportedAPIVersion is the minimum API version that can be supported
 	// by the API server, specified as "major.minor". Note that the daemon

--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/builder"
 	buildkit "github.com/docker/docker/builder/builder-next"
@@ -97,7 +98,7 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 }
 
 // PruneCache removes all cached build sources
-func (b *Backend) PruneCache(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {
+func (b *Backend) PruneCache(ctx context.Context, opts build.CachePruneOptions) (*build.CachePruneReport, error) {
 	buildCacheSize, cacheIDs, err := b.buildkit.Prune(ctx, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prune build cache")
@@ -107,7 +108,7 @@ func (b *Backend) PruneCache(ctx context.Context, opts types.BuildCachePruneOpti
 			"reclaimed": strconv.FormatInt(buildCacheSize, 10),
 		},
 	})
-	return &types.BuildCachePruneReport{SpaceReclaimed: uint64(buildCacheSize), CachesDeleted: cacheIDs}, nil
+	return &build.CachePruneReport{SpaceReclaimed: uint64(buildCacheSize), CachesDeleted: cacheIDs}, nil
 }
 
 // Cancel cancels the build by ID

--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -60,30 +60,30 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		return "", err
 	}
 
-	var build *builder.Result
+	var buildResult *builder.Result
 	if useBuildKit {
-		build, err = b.buildkit.Build(ctx, config)
+		buildResult, err = b.buildkit.Build(ctx, config)
 		if err != nil {
 			return "", err
 		}
 	} else {
-		build, err = b.builder.Build(ctx, config)
+		buildResult, err = b.builder.Build(ctx, config)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	if build == nil {
+	if buildResult == nil {
 		return "", nil
 	}
 
-	imageID := build.ImageID
+	imageID := buildResult.ImageID
 	if options.Squash {
-		if imageID, err = squashBuild(build, b.imageComponent); err != nil {
+		if imageID, err = squashBuild(buildResult, b.imageComponent); err != nil {
 			return "", err
 		}
 		if config.ProgressWriter.AuxFormatter != nil {
-			if err = config.ProgressWriter.AuxFormatter.Emit("moby.image.id", types.BuildResult{ID: imageID}); err != nil {
+			if err = config.ProgressWriter.AuxFormatter.Emit("moby.image.id", build.Result{ID: imageID}); err != nil {
 				return "", err
 			}
 		}

--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/events"
@@ -53,7 +52,7 @@ func (b *Backend) RegisterGRPC(s *grpc.Server) {
 // Build builds an image from a Source
 func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string, error) {
 	options := config.Options
-	useBuildKit := options.Version == types.BuilderBuildKit
+	useBuildKit := options.Version == build.BuilderBuildKit
 
 	tags, err := sanitizeRepoAndTags(options.Tags)
 	if err != nil {

--- a/api/server/httpstatus/status.go
+++ b/api/server/httpstatus/status.go
@@ -8,7 +8,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/distribution/registry/api/errcode"
-	"github.com/docker/docker/errdefs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -25,23 +24,23 @@ func FromError(err error) int {
 
 	// Note that the below functions are already checking the error causal chain for matches.
 	switch {
-	case errdefs.IsNotFound(err):
+	case cerrdefs.IsNotFound(err):
 		return http.StatusNotFound
-	case errdefs.IsInvalidParameter(err):
+	case cerrdefs.IsInvalidArgument(err):
 		return http.StatusBadRequest
-	case errdefs.IsConflict(err):
+	case cerrdefs.IsConflict(err):
 		return http.StatusConflict
-	case errdefs.IsUnauthorized(err):
+	case cerrdefs.IsUnauthorized(err):
 		return http.StatusUnauthorized
-	case errdefs.IsUnavailable(err):
+	case cerrdefs.IsUnavailable(err):
 		return http.StatusServiceUnavailable
-	case errdefs.IsForbidden(err):
+	case cerrdefs.IsPermissionDenied(err):
 		return http.StatusForbidden
-	case errdefs.IsNotModified(err):
+	case cerrdefs.IsNotModified(err):
 		return http.StatusNotModified
-	case errdefs.IsNotImplemented(err):
+	case cerrdefs.IsNotImplemented(err):
 		return http.StatusNotImplemented
-	case errdefs.IsSystem(err) || errdefs.IsUnknown(err) || errdefs.IsDataLoss(err) || errdefs.IsDeadline(err) || errdefs.IsCancelled(err):
+	case cerrdefs.IsInternal(err) || cerrdefs.IsUnknown(err) || cerrdefs.IsDataLoss(err) || cerrdefs.IsDeadlineExceeded(err) || cerrdefs.IsCanceled(err):
 		return http.StatusInternalServerError
 	default:
 		if statusCode := statusCodeFromGRPCError(err); statusCode != http.StatusInternalServerError {

--- a/api/server/router/build/backend.go
+++ b/api/server/router/build/backend.go
@@ -3,8 +3,8 @@ package build // import "github.com/docker/docker/api/server/router/build"
 import (
 	"context"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 )
 
 // Backend abstracts an image builder whose only purpose is to build an image referenced by an imageID.
@@ -13,8 +13,8 @@ type Backend interface {
 	// TODO: make this return a reference instead of string
 	Build(context.Context, backend.BuildConfig) (string, error)
 
-	// Prune build cache
-	PruneCache(context.Context, types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
+	// PruneCache prunes the build cache.
+	PruneCache(context.Context, build.CachePruneOptions) (*build.CachePruneReport, error)
 	Cancel(context.Context, string) error
 }
 

--- a/api/server/router/build/build.go
+++ b/api/server/router/build/build.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/api/types"
+	build2 "github.com/docker/docker/api/types/build"
 )
 
 // buildRouter is a router to talk with the build controller
@@ -46,15 +46,15 @@ func (br *buildRouter) initRoutes() {
 //
 // This value is only a recommendation as advertised by the daemon, and it is
 // up to the client to choose which builder to use.
-func BuilderVersion(features map[string]bool) types.BuilderVersion {
+func BuilderVersion(features map[string]bool) build2.BuilderVersion {
 	// TODO(thaJeztah) move the default to daemon/config
 	if runtime.GOOS == "windows" {
-		return types.BuilderV1
+		return build2.BuilderV1
 	}
 
-	bv := types.BuilderBuildKit
+	bv := build2.BuilderBuildKit
 	if v, ok := features["buildkit"]; ok && !v {
-		bv = types.BuilderV1
+		bv = build2.BuilderV1
 	}
 	return bv
 }

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/httputils"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -36,9 +35,9 @@ type invalidParam struct {
 
 func (e invalidParam) InvalidParameter() {}
 
-func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBuildOptions, error) {
-	options := &types.ImageBuildOptions{
-		Version:        types.BuilderV1, // Builder V1 is the default, but can be overridden
+func newImageBuildOptions(ctx context.Context, r *http.Request) (*build.ImageBuildOptions, error) {
+	options := &build.ImageBuildOptions{
+		Version:        build.BuilderV1, // Builder V1 is the default, but can be overridden
 		Dockerfile:     r.FormValue("dockerfile"),
 		SuppressOutput: httputils.BoolValue(r, "q"),
 		NoCache:        httputils.BoolValue(r, "nocache"),
@@ -82,7 +81,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	if versions.GreaterThanOrEqualTo(version, "1.40") {
 		outputsJSON := r.FormValue("outputs")
 		if outputsJSON != "" {
-			var outputs []types.ImageBuildOutput
+			var outputs []build.ImageBuildOutput
 			if err := json.Unmarshal([]byte(outputsJSON), &outputs); err != nil {
 				return nil, invalidParam{errors.Wrap(err, "invalid outputs specified")}
 			}
@@ -160,12 +159,12 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	return options, nil
 }
 
-func parseVersion(s string) (types.BuilderVersion, error) {
-	switch types.BuilderVersion(s) {
-	case types.BuilderV1:
-		return types.BuilderV1, nil
-	case types.BuilderBuildKit:
-		return types.BuilderBuildKit, nil
+func parseVersion(s string) (build.BuilderVersion, error) {
+	switch build.BuilderVersion(s) {
+	case build.BuilderV1:
+		return build.BuilderV1, nil
+	case build.BuilderBuildKit:
+		return build.BuilderBuildKit, nil
 	default:
 		return "", invalidParam{errors.Errorf("invalid version %q", s)}
 	}

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"
@@ -179,7 +180,7 @@ func (br *buildRouter) postPrune(ctx context.Context, w http.ResponseWriter, r *
 		return err
 	}
 
-	opts := types.BuildCachePruneOptions{
+	opts := build.CachePruneOptions{
 		All:     httputils.BoolValue(r, "all"),
 		Filters: fltrs,
 	}

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -30,7 +30,7 @@ type Backend interface {
 	RemoveNode(string, bool) error
 	GetTasks(types.TaskListOptions) ([]swarm.Task, error)
 	GetTask(string) (swarm.Task, error)
-	GetSecrets(opts types.SecretListOptions) ([]swarm.Secret, error)
+	GetSecrets(opts swarm.SecretListOptions) ([]swarm.Secret, error)
 	CreateSecret(s swarm.SecretSpec) (string, error)
 	RemoveSecret(idOrName string) error
 	GetSecret(id string) (swarm.Secret, error)

--- a/api/server/router/swarm/backend.go
+++ b/api/server/router/swarm/backend.go
@@ -35,7 +35,7 @@ type Backend interface {
 	RemoveSecret(idOrName string) error
 	GetSecret(id string) (swarm.Secret, error)
 	UpdateSecret(idOrName string, version uint64, spec swarm.SecretSpec) error
-	GetConfigs(opts types.ConfigListOptions) ([]swarm.Config, error)
+	GetConfigs(opts swarm.ConfigListOptions) ([]swarm.Config, error)
 	CreateConfig(s swarm.ConfigSpec) (string, error)
 	RemoveConfig(id string) error
 	GetConfig(id string) (swarm.Config, error)

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -487,7 +487,7 @@ func (sr *swarmRouter) getConfigs(ctx context.Context, w http.ResponseWriter, r 
 		return err
 	}
 
-	configs, err := sr.backend.GetConfigs(basictypes.ConfigListOptions{Filters: filters})
+	configs, err := sr.backend.GetConfigs(types.ConfigListOptions{Filters: filters})
 	if err != nil {
 		return err
 	}
@@ -511,7 +511,7 @@ func (sr *swarmRouter) createConfig(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	return httputils.WriteJSON(w, http.StatusCreated, &basictypes.ConfigCreateResponse{
+	return httputils.WriteJSON(w, http.StatusCreated, &types.ConfigCreateResponse{
 		ID: id,
 	})
 }

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -416,7 +416,7 @@ func (sr *swarmRouter) getSecrets(ctx context.Context, w http.ResponseWriter, r 
 		return err
 	}
 
-	secrets, err := sr.backend.GetSecrets(basictypes.SecretListOptions{Filters: filters})
+	secrets, err := sr.backend.GetSecrets(types.SecretListOptions{Filters: filters})
 	if err != nil {
 		return err
 	}
@@ -439,7 +439,7 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 		return err
 	}
 
-	return httputils.WriteJSON(w, http.StatusCreated, &basictypes.SecretCreateResponse{
+	return httputils.WriteJSON(w, http.StatusCreated, &types.SecretCreateResponse{
 		ID: id,
 	})
 }

--- a/api/server/router/system/info_response.go
+++ b/api/server/router/system/info_response.go
@@ -1,0 +1,39 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.23
+
+package system
+
+import (
+	"encoding/json"
+
+	"github.com/docker/docker/api/types/system"
+)
+
+// infoResponse is a wrapper around [system.Info] with a custom
+// marshal function for legacy fields.
+type infoResponse struct {
+	*system.Info
+
+	// extraFields is for internal use to include deprecated fields on older API versions.
+	extraFields map[string]any
+}
+
+// MarshalJSON implements a custom marshaler to include legacy fields
+// in API responses.
+func (sc *infoResponse) MarshalJSON() ([]byte, error) {
+	type tmp *system.Info
+	base, err := json.Marshal((tmp)(sc.Info))
+	if err != nil {
+		return nil, err
+	}
+	if len(sc.extraFields) == 0 {
+		return base, nil
+	}
+	var merged map[string]any
+	_ = json.Unmarshal(base, &merged)
+
+	for k, v := range sc.extraFields {
+		merged[k] = v
+	}
+	return json.Marshal(merged)
+}

--- a/api/server/router/system/info_response_test.go
+++ b/api/server/router/system/info_response_test.go
@@ -1,0 +1,33 @@
+package system
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/system"
+)
+
+func TestLegacyFields(t *testing.T) {
+	infoResp := &infoResponse{
+		Info: &system.Info{
+			Containers: 10,
+		},
+		extraFields: map[string]any{
+			"LegacyFoo": false,
+			"LegacyBar": true,
+		},
+	}
+
+	data, err := json.MarshalIndent(infoResp, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := `"LegacyFoo": false`; !strings.Contains(string(data), expected) {
+		t.Errorf("legacy fields should contain %s: %s", expected, string(data))
+	}
+	if expected := `"LegacyBar": true`; !strings.Contains(string(data), expected) {
+		t.Errorf("legacy fields should contain %s: %s", expected, string(data))
+	}
+}

--- a/api/server/router/system/system.go
+++ b/api/server/router/system/system.go
@@ -5,7 +5,6 @@ package system // import "github.com/docker/docker/api/server/router/system"
 
 import (
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/api/types/system"
 	"resenje.org/singleflight"
 )
 
@@ -21,7 +20,7 @@ type systemRouter struct {
 	// collectSystemInfo is a single-flight for the /info endpoint,
 	// unique per API version (as different API versions may return
 	// a different API response).
-	collectSystemInfo singleflight.Group[string, *system.Info]
+	collectSystemInfo singleflight.Group[string, *infoResponse]
 }
 
 // NewRouter initializes a new system router

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -127,6 +127,9 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false
 		}
+		if versions.LessThan(version, "1.50") {
+			info.DiscoveredDevices = nil
+		}
 		return info, nil
 	})
 	return httputils.WriteJSON(w, http.StatusOK, info)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.49"
+basePath: "/v1.50"
 info:
   title: "Docker Engine API"
-  version: "1.49"
+  version: "1.50"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -55,8 +55,8 @@ info:
     the URL is not supported by the daemon, a HTTP `400 Bad Request` error message
     is returned.
 
-    If you omit the version-prefix, the current version of the API (v1.49) is used.
-    For example, calling `/info` is the same as calling `/v1.49/info`. Using the
+    If you omit the version-prefix, the current version of the API (v1.50) is used.
+    For example, calling `/info` is the same as calling `/v1.50/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2956,6 +2956,23 @@ definitions:
       progressDetail:
         $ref: "#/definitions/ProgressDetail"
 
+  DeviceInfo:
+    type: "object"
+    description: |
+      DeviceInfo represents a device that can be used by a container.
+    properties:
+      Source:
+        type: "string"
+        example: "cdi"
+        description: |
+          The origin device driver.
+      ID:
+        type: "string"
+        example: "vendor.com/gpu=0"
+        description: |
+          The unique identifier for the device within its source driver.
+          For CDI devices, this would be an FQDN like "vendor.com/gpu=0".
+
   ErrorDetail:
     type: "object"
     properties:
@@ -6858,6 +6875,15 @@ definitions:
               example: "24"
       FirewallBackend:
         $ref: "#/definitions/FirewallInfo"
+      DiscoveredDevices:
+        description: |
+          List of devices discovered by device drivers.
+
+          Each device includes information about its source driver, kind, name,
+          and additional driver-specific attributes.
+        type: "array"
+        items:
+          $ref: "#/definitions/DeviceInfo"
       Warnings:
         description: |
           List of warnings / informational messages about missing features, or

--- a/api/types/backend/build.go
+++ b/api/types/backend/build.go
@@ -3,7 +3,7 @@ package backend // import "github.com/docker/docker/api/types/backend"
 import (
 	"io"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/streamformatter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -34,7 +34,7 @@ type ProgressWriter struct {
 type BuildConfig struct {
 	Source         io.ReadCloser
 	ProgressWriter ProgressWriter
-	Options        *types.ImageBuildOptions
+	Options        *build.ImageBuildOptions
 }
 
 // GetImageAndLayerOptions are the options supported by GetImageAndReleasableLayer

--- a/api/types/build/build.go
+++ b/api/types/build/build.go
@@ -1,6 +1,91 @@
 package build
 
+import (
+	"io"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/registry"
+)
+
+// BuilderVersion sets the version of underlying builder to use
+type BuilderVersion string
+
+const (
+	// BuilderV1 is the first generation builder in docker daemon
+	BuilderV1 BuilderVersion = "1"
+	// BuilderBuildKit is builder based on moby/buildkit project
+	BuilderBuildKit BuilderVersion = "2"
+)
+
 // Result contains the image id of a successful build.
 type Result struct {
 	ID string
+}
+
+// ImageBuildOptions holds the information
+// necessary to build images.
+type ImageBuildOptions struct {
+	Tags           []string
+	SuppressOutput bool
+	RemoteContext  string
+	NoCache        bool
+	Remove         bool
+	ForceRemove    bool
+	PullParent     bool
+	Isolation      container.Isolation
+	CPUSetCPUs     string
+	CPUSetMems     string
+	CPUShares      int64
+	CPUQuota       int64
+	CPUPeriod      int64
+	Memory         int64
+	MemorySwap     int64
+	CgroupParent   string
+	NetworkMode    string
+	ShmSize        int64
+	Dockerfile     string
+	Ulimits        []*container.Ulimit
+	// BuildArgs needs to be a *string instead of just a string so that
+	// we can tell the difference between "" (empty string) and no value
+	// at all (nil). See the parsing of buildArgs in
+	// api/server/router/build/build_routes.go for even more info.
+	BuildArgs   map[string]*string
+	AuthConfigs map[string]registry.AuthConfig
+	Context     io.Reader
+	Labels      map[string]string
+	// squash the resulting image's layers to the parent
+	// preserves the original image and creates a new one from the parent with all
+	// the changes applied to a single layer
+	Squash bool
+	// CacheFrom specifies images that are used for matching cache. Images
+	// specified here do not need to have a valid parent chain to match cache.
+	CacheFrom   []string
+	SecurityOpt []string
+	ExtraHosts  []string // List of extra hosts
+	Target      string
+	SessionID   string
+	Platform    string
+	// Version specifies the version of the underlying builder to use
+	Version BuilderVersion
+	// BuildID is an optional identifier that can be passed together with the
+	// build request. The same identifier can be used to gracefully cancel the
+	// build with the cancel request.
+	BuildID string
+	// Outputs defines configurations for exporting build results. Only supported
+	// in BuildKit mode
+	Outputs []ImageBuildOutput
+}
+
+// ImageBuildOutput defines configuration for exporting a build result
+type ImageBuildOutput struct {
+	Type  string
+	Attrs map[string]string
+}
+
+// ImageBuildResponse holds information
+// returned by a server after building
+// an image.
+type ImageBuildResponse struct {
+	Body   io.ReadCloser
+	OSType string
 }

--- a/api/types/build/build.go
+++ b/api/types/build/build.go
@@ -1,0 +1,6 @@
+package build
+
+// Result contains the image id of a successful build.
+type Result struct {
+	ID string
+}

--- a/api/types/build/cache.go
+++ b/api/types/build/cache.go
@@ -1,6 +1,10 @@
 package build
 
-import "time"
+import (
+	"time"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // CacheRecord contains information about a build cache record.
 type CacheRecord struct {
@@ -27,4 +31,22 @@ type CacheRecord struct {
 	// LastUsedAt is the date and time at which the build cache was last used.
 	LastUsedAt *time.Time
 	UsageCount int
+}
+
+// CachePruneOptions hold parameters to prune the build cache.
+type CachePruneOptions struct {
+	All           bool
+	ReservedSpace int64
+	MaxUsedSpace  int64
+	MinFreeSpace  int64
+	Filters       filters.Args
+
+	KeepStorage int64 // Deprecated: deprecated in API 1.48.
+}
+
+// CachePruneReport contains the response for Engine API:
+// POST "/build/prune"
+type CachePruneReport struct {
+	CachesDeleted  []string
+	SpaceReclaimed uint64
 }

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -3,12 +3,9 @@ package types // import "github.com/docker/docker/api/types"
 import (
 	"bufio"
 	"context"
-	"io"
 	"net"
 
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/registry"
 )
 
 // NewHijackedResponse initializes a [HijackedResponse] type.
@@ -49,84 +46,6 @@ func (h *HijackedResponse) CloseWrite() error {
 		return conn.CloseWrite()
 	}
 	return nil
-}
-
-// ImageBuildOptions holds the information
-// necessary to build images.
-type ImageBuildOptions struct {
-	Tags           []string
-	SuppressOutput bool
-	RemoteContext  string
-	NoCache        bool
-	Remove         bool
-	ForceRemove    bool
-	PullParent     bool
-	Isolation      container.Isolation
-	CPUSetCPUs     string
-	CPUSetMems     string
-	CPUShares      int64
-	CPUQuota       int64
-	CPUPeriod      int64
-	Memory         int64
-	MemorySwap     int64
-	CgroupParent   string
-	NetworkMode    string
-	ShmSize        int64
-	Dockerfile     string
-	Ulimits        []*container.Ulimit
-	// BuildArgs needs to be a *string instead of just a string so that
-	// we can tell the difference between "" (empty string) and no value
-	// at all (nil). See the parsing of buildArgs in
-	// api/server/router/build/build_routes.go for even more info.
-	BuildArgs   map[string]*string
-	AuthConfigs map[string]registry.AuthConfig
-	Context     io.Reader
-	Labels      map[string]string
-	// squash the resulting image's layers to the parent
-	// preserves the original image and creates a new one from the parent with all
-	// the changes applied to a single layer
-	Squash bool
-	// CacheFrom specifies images that are used for matching cache. Images
-	// specified here do not need to have a valid parent chain to match cache.
-	CacheFrom   []string
-	SecurityOpt []string
-	ExtraHosts  []string // List of extra hosts
-	Target      string
-	SessionID   string
-	Platform    string
-	// Version specifies the version of the underlying builder to use
-	Version BuilderVersion
-	// BuildID is an optional identifier that can be passed together with the
-	// build request. The same identifier can be used to gracefully cancel the
-	// build with the cancel request.
-	BuildID string
-	// Outputs defines configurations for exporting build results. Only supported
-	// in BuildKit mode
-	Outputs []ImageBuildOutput
-}
-
-// ImageBuildOutput defines configuration for exporting a build result
-type ImageBuildOutput struct {
-	Type  string
-	Attrs map[string]string
-}
-
-// BuilderVersion sets the version of underlying builder to use
-type BuilderVersion string
-
-const (
-	// BuilderV1 is the first generation builder in docker daemon
-	BuilderV1 BuilderVersion = "1"
-	// BuilderBuildKit is builder based on moby/buildkit project
-	BuilderBuildKit BuilderVersion = "2"
-)
-
-// ImageBuildResponse holds information
-// returned by a server after building
-// an image.
-type ImageBuildResponse struct {
-	Body   io.ReadCloser
-	OSType string
 }
 
 // NodeListOptions holds parameters to list nodes with.

--- a/api/types/swarm/config.go
+++ b/api/types/swarm/config.go
@@ -1,6 +1,10 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
 
-import "os"
+import (
+	"os"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // Config represents a config.
 type Config struct {
@@ -43,4 +47,16 @@ type ConfigReference struct {
 	Runtime    *ConfigReferenceRuntimeTarget `json:",omitempty"`
 	ConfigID   string
 	ConfigName string
+}
+
+// ConfigCreateResponse contains the information returned to a client
+// on the creation of a new config.
+type ConfigCreateResponse struct {
+	// ID is the id of the created config.
+	ID string
+}
+
+// ConfigListOptions holds parameters to list configs
+type ConfigListOptions struct {
+	Filters filters.Args
 }

--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -1,6 +1,10 @@
 package swarm // import "github.com/docker/docker/api/types/swarm"
 
-import "os"
+import (
+	"os"
+
+	"github.com/docker/docker/api/types/filters"
+)
 
 // Secret represents a secret.
 type Secret struct {
@@ -47,4 +51,16 @@ type SecretReference struct {
 	File       *SecretReferenceFileTarget
 	SecretID   string
 	SecretName string
+}
+
+// SecretCreateResponse contains the information returned to a client
+// on the creation of a new secret.
+type SecretCreateResponse struct {
+	// ID is the id of the created secret.
+	ID string
+}
+
+// SecretListOptions holds parameters to list secrets
+type SecretListOptions struct {
+	Filters filters.Args
 }

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -29,8 +29,6 @@ type Info struct {
 	CPUSet             bool
 	PidsLimit          bool
 	IPv4Forwarding     bool
-	BridgeNfIptables   bool `json:"BridgeNfIptables"`  // Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
-	BridgeNfIP6tables  bool `json:"BridgeNfIp6tables"` // Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
 	Debug              bool
 	NFd                int
 	OomKillDisable     bool

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -75,6 +75,7 @@ type Info struct {
 	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
 	FirewallBackend     *FirewallInfo        `json:"FirewallBackend,omitempty"`
 	CDISpecDirs         []string
+	DiscoveredDevices   []DeviceInfo `json:",omitempty"`
 
 	Containerd *ContainerdInfo `json:",omitempty"`
 
@@ -159,4 +160,13 @@ type FirewallInfo struct {
 	Driver string `json:"Driver"`
 	// Info is a list of label/value pairs, containing information related to the firewall.
 	Info [][2]string `json:"Info,omitempty"`
+}
+
+// DeviceInfo represents a discoverable device from a device driver.
+type DeviceInfo struct {
+	// Source indicates the origin device driver.
+	Source string `json:"Source"`
+	// ID is the unique identifier for the device.
+	// Example: CDI FQDN like "vendor.com/gpu=0", or other driver-specific device ID
+	ID string `json:"ID"`
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -3,7 +3,6 @@ package types // import "github.com/docker/docker/api/types"
 import (
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
@@ -92,18 +91,6 @@ type DiskUsage struct {
 	Volumes     []*volume.Volume
 	BuildCache  []*build.CacheRecord
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
-}
-
-// ConfigCreateResponse contains the information returned to a client
-// on the creation of a new config.
-type ConfigCreateResponse struct {
-	// ID is the id of the created config.
-	ID string
-}
-
-// ConfigListOptions holds parameters to list configs
-type ConfigListOptions struct {
-	Filters filters.Args
 }
 
 // PushResult contains the tag, manifest digest, and manifest size from the

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -94,18 +94,6 @@ type DiskUsage struct {
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
 }
 
-// SecretCreateResponse contains the information returned to a client
-// on the creation of a new secret.
-type SecretCreateResponse struct {
-	// ID is the id of the created secret.
-	ID string
-}
-
-// SecretListOptions holds parameters to list secrets
-type SecretListOptions struct {
-	Filters filters.Args
-}
-
 // ConfigCreateResponse contains the information returned to a client
 // on the creation of a new config.
 type ConfigCreateResponse struct {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -90,15 +90,8 @@ type DiskUsage struct {
 	Images      []*image.Summary
 	Containers  []*container.Summary
 	Volumes     []*volume.Volume
-	BuildCache  []*BuildCache
+	BuildCache  []*build.CacheRecord
 	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
-}
-
-// BuildCachePruneReport contains the response for Engine API:
-// POST "/build/prune"
-type BuildCachePruneReport struct {
-	CachesDeleted  []string
-	SpaceReclaimed uint64
 }
 
 // SecretCreateResponse contains the information returned to a client
@@ -137,20 +130,4 @@ type PushResult struct {
 // BuildResult contains the image id of a successful build
 type BuildResult struct {
 	ID string
-}
-
-// BuildCache contains information about a build cache record.
-//
-// Deprecated: deprecated in API 1.49. Use [build.CacheRecord] instead.
-type BuildCache = build.CacheRecord
-
-// BuildCachePruneOptions hold parameters to prune the build cache
-type BuildCachePruneOptions struct {
-	All           bool
-	ReservedSpace int64
-	MaxUsedSpace  int64
-	MinFreeSpace  int64
-	Filters       filters.Args
-
-	KeepStorage int64 // Deprecated: deprecated in API 1.48.
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -22,7 +22,7 @@ type Ping struct {
 	APIVersion     string
 	OSType         string
 	Experimental   bool
-	BuilderVersion BuilderVersion
+	BuilderVersion build.BuilderVersion
 
 	// SwarmStatus provides information about the current swarm status of the
 	// engine, obtained from the "Swarm" header in the API response.

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -101,8 +101,3 @@ type PushResult struct {
 	Digest string
 	Size   int
 }
-
-// BuildResult contains the image id of a successful build
-type BuildResult struct {
-	ID string
-}

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/common"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
@@ -113,3 +114,19 @@ type ImageInspect = image.InspectResponse
 //
 // Deprecated: moved to [github.com/docker/docker/api/types/registry.RequestAuthConfig].
 type RequestPrivilegeFunc func(context.Context) (string, error)
+
+// BuildCache contains information about a build cache record.
+//
+// Deprecated: deprecated in API 1.49. Use [build.CacheRecord] instead.
+type BuildCache = build.CacheRecord
+
+// BuildCachePruneOptions hold parameters to prune the build cache
+//
+// Deprecated: use [build.CachePruneOptions].
+type BuildCachePruneOptions = build.CachePruneOptions
+
+// BuildCachePruneReport contains the response for Engine API:
+// POST "/build/prune"
+//
+// Deprecated: use [build.CachePruneReport].
+type BuildCachePruneReport = build.CachePruneReport

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -158,3 +158,37 @@ type BuildCachePruneReport = build.CachePruneReport
 //
 // Deprecated: use [build.Result].
 type BuildResult = build.Result
+
+// ImageBuildOptions holds the information
+// necessary to build images.
+//
+// Deprecated: use [build.ImageBuildOptions].
+type ImageBuildOptions = build.ImageBuildOptions
+
+// ImageBuildOutput defines configuration for exporting a build result
+//
+// Deprecated: use [build.ImageBuildOutput].
+type ImageBuildOutput = build.ImageBuildOutput
+
+// ImageBuildResponse holds information
+// returned by a server after building
+// an image.
+//
+// Deprecated: use [build.ImageBuildResponse].
+type ImageBuildResponse = build.ImageBuildResponse
+
+// BuilderVersion sets the version of underlying builder to use
+//
+// Deprecated: use [build.BuilderVersion].
+type BuilderVersion = build.BuilderVersion
+
+const (
+	// BuilderV1 is the first generation builder in docker daemon
+	//
+	// Deprecated: use [build.BuilderV1].
+	BuilderV1 = build.BuilderV1
+	// BuilderBuildKit is builder based on moby/buildkit project
+	//
+	// Deprecated: use [build.BuilderBuildKit].
+	BuilderBuildKit = build.BuilderBuildKit
+)

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/storage"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 // IDResponse Response to an API call that returns just an Id.
@@ -114,6 +115,17 @@ type ImageInspect = image.InspectResponse
 //
 // Deprecated: moved to [github.com/docker/docker/api/types/registry.RequestAuthConfig].
 type RequestPrivilegeFunc func(context.Context) (string, error)
+
+// SecretCreateResponse contains the information returned to a client
+// on the creation of a new secret.
+//
+// Deprecated: use [swarm.SecretCreateResponse].
+type SecretCreateResponse = swarm.SecretCreateResponse
+
+// SecretListOptions holds parameters to list secrets
+//
+// Deprecated: use [swarm.SecretListOptions].
+type SecretListOptions = swarm.SecretListOptions
 
 // BuildCache contains information about a build cache record.
 //

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -153,3 +153,8 @@ type BuildCachePruneOptions = build.CachePruneOptions
 //
 // Deprecated: use [build.CachePruneReport].
 type BuildCachePruneReport = build.CachePruneReport
+
+// BuildResult contains the image id of a successful build/
+//
+// Deprecated: use [build.Result].
+type BuildResult = build.Result

--- a/api/types/types_deprecated.go
+++ b/api/types/types_deprecated.go
@@ -127,6 +127,17 @@ type SecretCreateResponse = swarm.SecretCreateResponse
 // Deprecated: use [swarm.SecretListOptions].
 type SecretListOptions = swarm.SecretListOptions
 
+// ConfigCreateResponse contains the information returned to a client
+// on the creation of a new config.
+//
+// Deprecated: use [swarm.ConfigCreateResponse].
+type ConfigCreateResponse = swarm.ConfigCreateResponse
+
+// ConfigListOptions holds parameters to list configs
+//
+// Deprecated: use [swarm.ConfigListOptions].
+type ConfigListOptions = swarm.ConfigListOptions
+
 // BuildCache contains information about a build cache record.
 //
 // Deprecated: deprecated in API 1.49. Use [build.CacheRecord] instead.

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -438,7 +437,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 			return errors.Errorf("missing image id")
 		}
 		out.ImageID = imgID
-		return aux.Emit("moby.image.id", types.BuildResult{ID: imgID})
+		return aux.Emit("moby.image.id", build.Result{ID: imgID})
 	})
 
 	ch := make(chan *controlapi.StatusResponse)

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -187,7 +187,7 @@ func (b *Builder) DiskUsage(ctx context.Context) ([]*build.CacheRecord, error) {
 }
 
 // Prune clears all reclaimable build cache.
-func (b *Builder) Prune(ctx context.Context, opts types.BuildCachePruneOptions) (int64, []string, error) {
+func (b *Builder) Prune(ctx context.Context, opts build.CachePruneOptions) (int64, []string, error) {
 	ch := make(chan *controlapi.UsageRecord)
 
 	eg, ctx := errgroup.WithContext(ctx)
@@ -641,7 +641,7 @@ func toBuildkitUlimits(inp []*container.Ulimit) (string, error) {
 	return strings.Join(ulimits, ","), nil
 }
 
-func toBuildkitPruneInfo(opts types.BuildCachePruneOptions) (client.PruneInfo, error) {
+func toBuildkitPruneInfo(opts build.CachePruneOptions) (client.PruneInfo, error) {
 	var until time.Duration
 	untilValues := opts.Filters.Get("until")          // canonical
 	unusedForValues := opts.Filters.Get("unused-for") // deprecated synonym for "until" filter

--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins/content/local"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/builder/builder-next/adapters/containerimage"
 	"github.com/docker/docker/builder/builder-next/adapters/localinlinecache"
@@ -467,7 +467,7 @@ func getGCPolicy(conf config.BuilderConfig, root string) ([]client.PruneInfo, er
 					return nil, err
 				}
 
-				gcPolicy[i], err = toBuildkitPruneInfo(types.BuildCachePruneOptions{
+				gcPolicy[i], err = toBuildkitPruneInfo(build.CachePruneOptions{
 					All:           p.All,
 					ReservedSpace: reservedSpace,
 					MaxUsedSpace:  maxUsedSpace,

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
@@ -100,7 +99,7 @@ func (bm *BuildManager) Build(ctx context.Context, config backend.BuildConfig) (
 
 // builderOptions are the dependencies required by the builder
 type builderOptions struct {
-	Options        *types.ImageBuildOptions
+	Options        *build.ImageBuildOptions
 	Backend        builder.Backend
 	ProgressWriter backend.ProgressWriter
 	PathCache      pathCache
@@ -110,7 +109,7 @@ type builderOptions struct {
 // Builder is a Dockerfile builder
 // It implements the builder.Backend interface.
 type Builder struct {
-	options *types.ImageBuildOptions
+	options *build.ImageBuildOptions
 
 	Stdout io.Writer
 	Stderr io.Writer
@@ -132,7 +131,7 @@ type Builder struct {
 func newBuilder(ctx context.Context, options builderOptions) (*Builder, error) {
 	config := options.Options
 	if config == nil {
-		config = new(types.ImageBuildOptions)
+		config = new(build.ImageBuildOptions)
 	}
 
 	imgProber, err := newImageProber(ctx, options.Backend, config.CacheFrom, config.NoCache)
@@ -332,7 +331,7 @@ func BuildFromConfig(ctx context.Context, config *container.Config, changes []st
 	}
 
 	b, err := newBuilder(ctx, builderOptions{
-		Options: &types.ImageBuildOptions{NoCache: true},
+		Options: &build.ImageBuildOptions{NoCache: true},
 	})
 	if err != nil {
 		return nil, err

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
@@ -222,7 +223,7 @@ func emitImageID(aux *streamformatter.AuxFormatter, state *dispatchState) error 
 	if aux == nil || state.imageID == "" {
 		return nil
 	}
-	return aux.Emit("", types.BuildResult{ID: state.imageID})
+	return aux.Emit("", build.Result{ID: state.imageID})
 }
 
 func processMetaArg(meta instructions.ArgCommand, shlex *shell.Lex, args *BuildArgs) error {

--- a/builder/dockerfile/dispatchers_test.go
+++ b/builder/dockerfile/dispatchers_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/image"
@@ -25,7 +25,7 @@ import (
 func newBuilderWithMockBackend(t *testing.T) *Builder {
 	t.Helper()
 	mockBackend := &MockBackend{}
-	opts := &types.ImageBuildOptions{}
+	opts := &build.ImageBuildOptions{}
 	ctx := context.Background()
 
 	imageProber, err := newImageProber(ctx, mockBackend, nil, false)

--- a/builder/dockerfile/internals.go
+++ b/builder/dockerfile/internals.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/builder"
@@ -364,7 +364,7 @@ func (b *Builder) create(ctx context.Context, runConfig *container.Config) (stri
 	return ctr.ID, nil
 }
 
-func hostConfigFromOptions(options *types.ImageBuildOptions) *container.HostConfig {
+func hostConfigFromOptions(options *build.ImageBuildOptions) *container.HostConfig {
 	resources := container.Resources{
 		CgroupParent: options.CgroupParent,
 		CPUShares:    options.CPUShares,

--- a/builder/dockerfile/internals_linux_test.go
+++ b/builder/dockerfile/internals_linux_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/moby/sys/user"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -58,7 +58,7 @@ othergrp:x:6666:
 		expected  identity
 	}{
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDNoMap",
 			chownStr:  "1",
 			idMapping: unmapped,
@@ -66,7 +66,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 1, GID: 1},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDGIDNoMap",
 			chownStr:  "0:1",
 			idMapping: unmapped,
@@ -74,7 +74,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 0, GID: 1},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDWithMap",
 			chownStr:  "0",
 			idMapping: remapped,
@@ -82,7 +82,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 100000, GID: 100000},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UIDGIDWithMap",
 			chownStr:  "1:33",
 			idMapping: remapped,
@@ -90,7 +90,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 100001, GID: 100033},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UserNoMap",
 			chownStr:  "bin:5555",
 			idMapping: unmapped,
@@ -98,7 +98,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 1, GID: 5555},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "GroupWithMap",
 			chownStr:  "0:unicorn",
 			idMapping: remapped,
@@ -106,7 +106,7 @@ othergrp:x:6666:
 			expected:  identity{UID: 100000, GID: 101002},
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UserOnlyWithMap",
 			chownStr:  "unicorn",
 			idMapping: remapped,
@@ -131,7 +131,7 @@ othergrp:x:6666:
 		descr     string
 	}{
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "BadChownFlagFormat",
 			chownStr:  "bob:1:555",
 			idMapping: unmapped,
@@ -139,7 +139,7 @@ othergrp:x:6666:
 			descr:     "invalid chown string format: bob:1:555",
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "UserNoExist",
 			chownStr:  "bob",
 			idMapping: unmapped,
@@ -147,7 +147,7 @@ othergrp:x:6666:
 			descr:     "can't find uid for user bob: no such user: bob",
 		},
 		{
-			builder:   &Builder{options: &types.ImageBuildOptions{Platform: "linux"}},
+			builder:   &Builder{options: &build.ImageBuildOptions{Platform: "linux"}},
 			name:      "GroupNoExist",
 			chownStr:  "root:bob",
 			idMapping: unmapped,

--- a/builder/dockerfile/internals_test.go
+++ b/builder/dockerfile/internals_test.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
@@ -77,7 +77,7 @@ func readAndCheckDockerfile(t *testing.T, testName, contextDir, dockerfilePath, 
 	}
 
 	config := backend.BuildConfig{
-		Options: &types.ImageBuildOptions{Dockerfile: dockerfilePath},
+		Options: &build.ImageBuildOptions{Dockerfile: dockerfilePath},
 		Source:  tarStream,
 	}
 	_, _, err = remotecontext.Detect(config)

--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -6,13 +6,13 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/pkg/errors"
 )
 
 // BuildCachePrune requests the daemon to delete unused cache data
-func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {
+func (cli *Client) BuildCachePrune(ctx context.Context, opts build.CachePruneOptions) (*build.CachePruneReport, error) {
 	if err := cli.NewVersionError(ctx, "1.31", "build prune"); err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePru
 		return nil, err
 	}
 
-	report := types.BuildCachePruneReport{}
+	report := build.CachePruneReport{}
 	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
 		return nil, errors.Wrap(err, "error retrieving disk usage")
 	}

--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -75,7 +75,5 @@ func TestCheckpointCreate(t *testing.T) {
 		CheckpointID: expectedCheckpointID,
 		Exit:         true,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -56,7 +56,5 @@ func TestCheckpointDelete(t *testing.T) {
 	err := client.CheckpointDelete(context.Background(), "container_id", checkpoint.DeleteOptions{
 		CheckpointID: "checkpoint_id",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -49,12 +49,8 @@ func TestCheckpointList(t *testing.T) {
 	}
 
 	checkpoints, err := client.CheckpointList(context.Background(), "container_id", checkpoint.ListOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(checkpoints) != 1 {
-		t.Fatalf("expected 1 checkpoint, got %v", checkpoints)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(checkpoints, 1))
 }
 
 func TestCheckpointListContainerNotFound(t *testing.T) {

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -110,7 +111,7 @@ type DistributionAPIClient interface {
 // ImageAPIClient defines API client methods for the images
 type ImageAPIClient interface {
 	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
-	BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
+	BuildCachePrune(ctx context.Context, opts build.CachePruneOptions) (*build.CachePruneReport, error)
 	BuildCancel(ctx context.Context, id string) error
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)
 	ImageImport(ctx context.Context, source image.ImportSource, ref string, options image.ImportOptions) (io.ReadCloser, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -220,8 +220,8 @@ type VolumeAPIClient interface {
 
 // SecretAPIClient defines API client methods for secrets
 type SecretAPIClient interface {
-	SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error)
-	SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error)
+	SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error)
+	SecretCreate(ctx context.Context, secret swarm.SecretSpec) (swarm.SecretCreateResponse, error)
 	SecretRemove(ctx context.Context, id string) error
 	SecretInspectWithRaw(ctx context.Context, name string) (swarm.Secret, []byte, error)
 	SecretUpdate(ctx context.Context, id string, version swarm.Version, secret swarm.SecretSpec) error

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -229,8 +229,8 @@ type SecretAPIClient interface {
 
 // ConfigAPIClient defines API client methods for configs
 type ConfigAPIClient interface {
-	ConfigList(ctx context.Context, options types.ConfigListOptions) ([]swarm.Config, error)
-	ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (types.ConfigCreateResponse, error)
+	ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error)
+	ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (swarm.ConfigCreateResponse, error)
 	ConfigRemove(ctx context.Context, id string) error
 	ConfigInspectWithRaw(ctx context.Context, name string) (swarm.Config, []byte, error)
 	ConfigUpdate(ctx context.Context, id string, version swarm.Version, config swarm.ConfigSpec) error

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -110,7 +110,7 @@ type DistributionAPIClient interface {
 
 // ImageAPIClient defines API client methods for the images
 type ImageAPIClient interface {
-	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
+	ImageBuild(ctx context.Context, context io.Reader, options build.ImageBuildOptions) (build.ImageBuildResponse, error)
 	BuildCachePrune(ctx context.Context, opts build.CachePruneOptions) (*build.CachePruneReport, error)
 	BuildCancel(ctx context.Context, id string) error
 	ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)

--- a/client/config_create.go
+++ b/client/config_create.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // ConfigCreate creates a new config.
-func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
-	var response types.ConfigCreateResponse
+func (cli *Client) ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (swarm.ConfigCreateResponse, error) {
+	var response swarm.ConfigCreateResponse
 	if err := cli.NewVersionError(ctx, "1.30", "config create"); err != nil {
 		return response, err
 	}

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -46,7 +45,7 @@ func TestConfigCreate(t *testing.T) {
 			if req.Method != http.MethodPost {
 				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
 			}
-			b, err := json.Marshal(types.ConfigCreateResponse{
+			b, err := json.Marshal(swarm.ConfigCreateResponse{
 				ID: "test_config",
 			})
 			if err != nil {

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -60,10 +60,6 @@ func TestConfigCreate(t *testing.T) {
 	}
 
 	r, err := client.ConfigCreate(context.Background(), swarm.ConfigSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "test_config" {
-		t.Fatalf("expected `test_config`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "test_config"))
 }

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -92,10 +92,6 @@ func TestConfigInspect(t *testing.T) {
 	}
 
 	configInspect, _, err := client.ConfigInspectWithRaw(context.Background(), "config_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if configInspect.ID != "config_id" {
-		t.Fatalf("expected `config_id`, got %s", configInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(configInspect.ID, "config_id"))
 }

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // ConfigList returns the list of configs.
-func (cli *Client) ConfigList(ctx context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
+func (cli *Client) ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error) {
 	if err := cli.NewVersionError(ctx, "1.30", "config list"); err != nil {
 		return nil, err
 	}

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -95,11 +95,7 @@ func TestConfigList(t *testing.T) {
 		}
 
 		configs, err := client.ConfigList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(configs) != 2 {
-			t.Fatalf("expected 2 configs, got %v", configs)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(configs, 2))
 	}
 }

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -23,7 +22,7 @@ func TestConfigListUnsupported(t *testing.T) {
 		version: "1.29",
 		client:  &http.Client{},
 	}
-	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
+	_, err := client.ConfigList(context.Background(), swarm.ConfigListOptions{})
 	assert.Check(t, is.Error(err, `"config list" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
@@ -33,7 +32,7 @@ func TestConfigListError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ConfigList(context.Background(), types.ConfigListOptions{})
+	_, err := client.ConfigList(context.Background(), swarm.ConfigListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -41,17 +40,17 @@ func TestConfigList(t *testing.T) {
 	expectedURL := "/v1.30/configs"
 
 	listCases := []struct {
-		options             types.ConfigListOptions
+		options             swarm.ConfigListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.ConfigListOptions{},
+			options: swarm.ConfigListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: types.ConfigListOptions{
+			options: swarm.ConfigListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -61,7 +61,5 @@ func TestConfigRemove(t *testing.T) {
 	}
 
 	err := client.ConfigRemove(context.Background(), "config_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -62,7 +62,5 @@ func TestConfigUpdate(t *testing.T) {
 	}
 
 	err := client.ConfigUpdate(context.Background(), "config_id", swarm.Version{}, swarm.ConfigSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -98,10 +98,6 @@ func TestContainerCommit(t *testing.T) {
 		Changes:   expectedChanges,
 		Pause:     false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "new_container_id" {
-		t.Fatalf("expected `new_container_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "new_container_id"))
 }

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -51,9 +52,7 @@ func TestContainerStatPathNoHeaderError(t *testing.T) {
 		}),
 	}
 	_, err := client.ContainerStatPath(context.Background(), "container_id", "path/to/file")
-	if err == nil {
-		t.Fatalf("expected an error, got nothing")
-	}
+	assert.Check(t, err != nil, "expected an error, got nothing")
 }
 
 func TestContainerStatPath(t *testing.T) {
@@ -90,15 +89,9 @@ func TestContainerStatPath(t *testing.T) {
 		}),
 	}
 	stat, err := client.ContainerStatPath(context.Background(), "container_id", expectedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stat.Name != "name" {
-		t.Fatalf("expected container path stat name to be 'name', got '%s'", stat.Name)
-	}
-	if stat.Mode != 0o700 {
-		t.Fatalf("expected container path stat mode to be 0700, got '%v'", stat.Mode)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(stat.Name, "name"))
+	assert.Check(t, is.Equal(stat.Mode, os.FileMode(0o700)))
 }
 
 func TestCopyToContainerError(t *testing.T) {
@@ -132,9 +125,7 @@ func TestCopyToContainerEmptyResponse(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNoContent, "No content")),
 	}
 	err := client.CopyToContainer(context.Background(), "container_id", "path/to/file", bytes.NewReader([]byte("")), container.CopyToContainerOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestCopyToContainer(t *testing.T) {
@@ -178,9 +169,7 @@ func TestCopyToContainer(t *testing.T) {
 	err := client.CopyToContainer(context.Background(), "container_id", expectedPath, bytes.NewReader([]byte("content")), container.CopyToContainerOptions{
 		AllowOverwriteDirWithFile: false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestCopyFromContainerError(t *testing.T) {
@@ -229,9 +218,7 @@ func TestCopyFromContainerEmptyResponse(t *testing.T) {
 		}),
 	}
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestCopyFromContainerNoHeaderError(t *testing.T) {
@@ -244,9 +231,7 @@ func TestCopyFromContainerNoHeaderError(t *testing.T) {
 		}),
 	}
 	_, _, err := client.CopyFromContainer(context.Background(), "container_id", "path/to/file")
-	if err == nil {
-		t.Fatalf("expected an error, got nothing")
-	}
+	assert.Check(t, err != nil, "expected an error, got nothing")
 }
 
 func TestCopyFromContainer(t *testing.T) {
@@ -285,23 +270,12 @@ func TestCopyFromContainer(t *testing.T) {
 		}),
 	}
 	r, stat, err := client.CopyFromContainer(context.Background(), "container_id", expectedPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if stat.Name != "name" {
-		t.Fatalf("expected container path stat name to be 'name', got '%s'", stat.Name)
-	}
-	if stat.Mode != 0o700 {
-		t.Fatalf("expected container path stat mode to be 0700, got '%v'", stat.Mode)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(stat.Name, "name"))
+	assert.Check(t, is.Equal(stat.Mode, os.FileMode(0o700)))
+
 	content, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := r.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != "content" {
-		t.Fatalf("expected content to be 'content', got %s", string(content))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(content), "content"))
+	assert.NilError(t, r.Close())
 }

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -64,12 +64,8 @@ func TestContainerCreateWithName(t *testing.T) {
 	}
 
 	r, err := client.ContainerCreate(context.Background(), nil, nil, nil, nil, "container_name")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "container_id" {
-		t.Fatalf("expected `container_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "container_id"))
 }
 
 // TestContainerCreateAutoRemove validates that a client using API 1.24 always disables AutoRemove. When using API 1.25
@@ -97,20 +93,22 @@ func TestContainerCreateAutoRemove(t *testing.T) {
 			}, nil
 		}
 	}
-
-	client := &Client{
-		client:  newMockClient(autoRemoveValidator(false)),
-		version: "1.24",
+	testCases := []struct {
+		version            string
+		expectedAutoRemove bool
+	}{
+		{version: "1.24", expectedAutoRemove: false},
+		{version: "1.25", expectedAutoRemove: true},
 	}
-	if _, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, ""); err != nil {
-		t.Fatal(err)
-	}
-	client = &Client{
-		client:  newMockClient(autoRemoveValidator(true)),
-		version: "1.25",
-	}
-	if _, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, ""); err != nil {
-		t.Fatal(err)
+	for _, tc := range testCases {
+		t.Run(tc.version, func(t *testing.T) {
+			client := &Client{
+				client:  newMockClient(autoRemoveValidator(tc.expectedAutoRemove)),
+				version: tc.version,
+			}
+			_, err := client.ContainerCreate(context.Background(), nil, &container.HostConfig{AutoRemove: true}, nil, nil, "")
+			assert.NilError(t, err)
+		})
 	}
 }
 

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -67,6 +67,6 @@ func TestContainerDiff(t *testing.T) {
 	}
 
 	changes, err := client.ContainerDiff(context.Background(), "container_id")
-	assert.Check(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(changes, expected))
 }

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -82,12 +82,8 @@ func TestContainerExecCreate(t *testing.T) {
 	r, err := client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{
 		User: "user",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "exec_id" {
-		t.Fatalf("expected `exec_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "exec_id"))
 }
 
 func TestContainerExecStartError(t *testing.T) {
@@ -127,9 +123,7 @@ func TestContainerExecStart(t *testing.T) {
 		Detach: true,
 		Tty:    false,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestContainerExecInspectError(t *testing.T) {
@@ -162,13 +156,7 @@ func TestContainerExecInspect(t *testing.T) {
 	}
 
 	inspect, err := client.ContainerExecInspect(context.Background(), "exec_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if inspect.ExecID != "exec_id" {
-		t.Fatalf("expected ExecID to be `exec_id`, got %s", inspect.ExecID)
-	}
-	if inspect.ContainerID != "container_id" {
-		t.Fatalf("expected ContainerID `container_id`, got %s", inspect.ContainerID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(inspect.ExecID, "exec_id"))
+	assert.Check(t, is.Equal(inspect.ContainerID, "container_id"))
 }

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -45,15 +45,9 @@ func TestContainerExport(t *testing.T) {
 		}),
 	}
 	body, err := client.ContainerExport(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	defer body.Close()
 	content, err := io.ReadAll(body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != "response" {
-		t.Fatalf("expected response to contain 'response', got %s", string(content))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(content), "response"))
 }

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -83,16 +83,8 @@ func TestContainerInspect(t *testing.T) {
 	}
 
 	r, err := client.ContainerInspect(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "container_id" {
-		t.Fatalf("expected `container_id`, got %s", r.ID)
-	}
-	if r.Image != "image" {
-		t.Fatalf("expected `image`, got %s", r.Image)
-	}
-	if r.Name != "name" {
-		t.Fatalf("expected `name`, got %s", r.Name)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "container_id"))
+	assert.Check(t, is.Equal(r.Image, "image"))
+	assert.Check(t, is.Equal(r.Name, "name"))
 }

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -49,7 +49,5 @@ func TestContainerKill(t *testing.T) {
 	}
 
 	err := client.ContainerKill(context.Background(), "container_id", "SIGKILL")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -88,10 +88,6 @@ func TestContainerList(t *testing.T) {
 			filters.Arg("before", "container"),
 		),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(containers) != 2 {
-		t.Fatalf("expected 2 containers, got %v", containers)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(containers, 2))
 }

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -36,7 +36,5 @@ func TestContainerPause(t *testing.T) {
 		}),
 	}
 	err := client.ContainerPause(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -109,7 +109,7 @@ func TestContainersPrune(t *testing.T) {
 		}
 
 		report, err := client.ContainersPrune(context.Background(), listCase.filters)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		assert.Check(t, is.Len(report.ContainersDeleted, 2))
 		assert.Check(t, is.Equal(uint64(9999), report.SpaceReclaimed))
 	}

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -71,5 +71,5 @@ func TestContainerRemove(t *testing.T) {
 		RemoveVolumes: true,
 		Force:         true,
 	})
-	assert.Check(t, err)
+	assert.NilError(t, err)
 }

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -49,7 +49,5 @@ func TestContainerRename(t *testing.T) {
 	}
 
 	err := client.ContainerRename(context.Background(), "container_id", "newName")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -77,7 +77,7 @@ func TestContainerResize(t *testing.T) {
 				client: newMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)),
 			}
 			err := client.ContainerResize(context.Background(), "container_id", tc.opts)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 		})
 	}
 }
@@ -120,7 +120,7 @@ func TestContainerExecResize(t *testing.T) {
 				client: newMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)),
 			}
 			err := client.ContainerExecResize(context.Background(), "exec_id", tc.opts)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 		})
 	}
 }

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -70,7 +70,5 @@ func TestContainerRestart(t *testing.T) {
 		Signal:  "SIGKILL",
 		Timeout: &timeout,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -60,7 +60,5 @@ func TestContainerStart(t *testing.T) {
 	}
 
 	err := client.ContainerStart(context.Background(), "container_id", container.StartOptions{CheckpointID: "checkpoint_id"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -64,16 +64,10 @@ func TestContainerStats(t *testing.T) {
 			}),
 		}
 		resp, err := client.ContainerStats(context.Background(), "container_id", c.stream)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		defer resp.Body.Close()
 		content, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(content) != "response" {
-			t.Fatalf("expected response to contain 'response', got %s", string(content))
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(string(content), "response"))
 	}
 }

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -70,7 +70,5 @@ func TestContainerStop(t *testing.T) {
 		Signal:  "SIGKILL",
 		Timeout: &timeout,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -71,13 +70,7 @@ func TestContainerTop(t *testing.T) {
 	}
 
 	processList, err := client.ContainerTop(context.Background(), "container_id", []string{"arg1", "arg2"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(expectedProcesses, processList.Processes) {
-		t.Fatalf("Processes: expected %v, got %v", expectedProcesses, processList.Processes)
-	}
-	if !reflect.DeepEqual(expectedTitles, processList.Titles) {
-		t.Fatalf("Titles: expected %v, got %v", expectedTitles, processList.Titles)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expectedProcesses, processList.Processes))
+	assert.Check(t, is.DeepEqual(expectedTitles, processList.Titles))
 }

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -44,7 +44,5 @@ func TestContainerUnpause(t *testing.T) {
 		}),
 	}
 	err := client.ContainerUnpause(context.Background(), "container_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -61,7 +61,5 @@ func TestContainerUpdate(t *testing.T) {
 			Name: "always",
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -74,11 +74,9 @@ func TestContainerWait(t *testing.T) {
 	resultC, errC := client.ContainerWait(context.Background(), "container_id", "")
 	select {
 	case err := <-errC:
-		t.Fatal(err)
+		assert.NilError(t, err)
 	case result := <-resultC:
-		if result.StatusCode != 15 {
-			t.Fatalf("expected a status code equal to '15', got %d", result.StatusCode)
-		}
+		assert.Check(t, is.Equal(result.StatusCode, int64(15)))
 	}
 }
 
@@ -101,9 +99,7 @@ func TestContainerWaitProxyInterrupt(t *testing.T) {
 	resultC, errC := client.ContainerWait(context.Background(), "container_id", "")
 	select {
 	case err := <-errC:
-		if !strings.Contains(err.Error(), msg) {
-			t.Fatalf("Expected: %s, Actual: %s", msg, err.Error())
-		}
+		assert.Check(t, is.ErrorContains(err, msg))
 	case result := <-resultC:
 		t.Fatalf("Unexpected result: %v", result)
 	}
@@ -129,9 +125,7 @@ func TestContainerWaitProxyInterruptLong(t *testing.T) {
 	select {
 	case err := <-errC:
 		// LimitReader limiting isn't exact, because of how the Readers do chunking.
-		if len(err.Error()) > containerWaitErrorMsgLimit*2 {
-			t.Fatalf("Expected error to be limited around %d, actual length: %d", containerWaitErrorMsgLimit, len(err.Error()))
-		}
+		assert.Check(t, len(err.Error()) <= containerWaitErrorMsgLimit*2, "Expected error to be limited around %d, actual length: %d", containerWaitErrorMsgLimit, len(err.Error()))
 	case result := <-resultC:
 		t.Fatalf("Unexpected result: %v", result)
 	}
@@ -164,9 +158,7 @@ func TestContainerWaitErrorHandling(t *testing.T) {
 			resultC, errC := client.ContainerWait(ctx, "container_id", "")
 			select {
 			case err := <-errC:
-				if err.Error() != test.exp.Error() {
-					t.Fatalf("ContainerWait() errC = %v; want %v", err, test.exp)
-				}
+				assert.Check(t, is.Equal(err.Error(), test.exp.Error()))
 				return
 			case result := <-resultC:
 				t.Fatalf("expected to not get a wait result, got %d", result.StatusCode)

--- a/client/disk_usage_test.go
+++ b/client/disk_usage_test.go
@@ -50,7 +50,6 @@ func TestDiskUsage(t *testing.T) {
 			}, nil
 		}),
 	}
-	if _, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{}); err != nil {
-		t.Fatal(err)
-	}
+	_, err := client.DiskUsage(context.Background(), types.DiskUsageOptions{})
+	assert.NilError(t, err)
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/docker/docker/errdefs"
 )
 
 // errConnectionFailed implements an error returned when connection failed.
@@ -48,9 +48,11 @@ func connectionFailed(host string) error {
 }
 
 // IsErrNotFound returns true if the error is a NotFound error, which is returned
-// by the API when some object is not found. It is an alias for [errdefs.IsNotFound].
+// by the API when some object is not found. It is an alias for [cerrdefs.IsNotFound].
+//
+// Deprecated: use [cerrdefs.IsNotFound] instead.
 func IsErrNotFound(err error) bool {
-	return errdefs.IsNotFound(err)
+	return cerrdefs.IsNotFound(err)
 }
 
 type objectNotFoundError struct {

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -35,15 +35,13 @@ func TestEventsErrorInOptions(t *testing.T) {
 			expectedError: `parsing time "2006-01-02TZ"`,
 		},
 	}
-	for _, e := range errorCases {
+	for _, tc := range errorCases {
 		client := &Client{
 			client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 		}
-		_, errs := client.Events(context.Background(), e.options)
+		_, errs := client.Events(context.Background(), tc.options)
 		err := <-errs
-		if err == nil || !strings.Contains(err.Error(), e.expectedError) {
-			t.Fatalf("expected an error %q, got %v", e.expectedError, err)
-		}
+		assert.Check(t, is.ErrorContains(err, tc.expectedError))
 	}
 }
 
@@ -152,9 +150,7 @@ func TestEvents(t *testing.T) {
 				break loop
 			case e := <-messages:
 				_, ok := eventsCase.expectedEvents[e.Actor.ID]
-				if !ok {
-					t.Fatalf("event received not expected with action %s & id %s", e.Action, e.Actor.ID)
-				}
+				assert.Check(t, ok, "event received not expected with action %s & id %s", e.Action, e.Actor.ID)
 			}
 		}
 	}

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 )
@@ -18,15 +18,15 @@ import (
 // ImageBuild sends a request to the daemon to build images.
 // The Body in the response implements an io.ReadCloser and it's up to the caller to
 // close it.
-func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
+func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, options build.ImageBuildOptions) (build.ImageBuildResponse, error) {
 	query, err := cli.imageBuildOptionsToQuery(ctx, options)
 	if err != nil {
-		return types.ImageBuildResponse{}, err
+		return build.ImageBuildResponse{}, err
 	}
 
 	buf, err := json.Marshal(options.AuthConfigs)
 	if err != nil {
-		return types.ImageBuildResponse{}, err
+		return build.ImageBuildResponse{}, err
 	}
 
 	headers := http.Header{}
@@ -35,16 +35,16 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 
 	resp, err := cli.postRaw(ctx, "/build", query, buildContext, headers)
 	if err != nil {
-		return types.ImageBuildResponse{}, err
+		return build.ImageBuildResponse{}, err
 	}
 
-	return types.ImageBuildResponse{
+	return build.ImageBuildResponse{
 		Body:   resp.Body,
 		OSType: getDockerOS(resp.Header.Get("Server")),
 	}, nil
 }
 
-func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.ImageBuildOptions) (url.Values, error) {
+func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options build.ImageBuildOptions) (url.Values, error) {
 	query := url.Values{}
 	if len(options.Tags) > 0 {
 		query["t"] = options.Tags

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
@@ -22,7 +22,7 @@ func TestImageBuildError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageBuild(context.Background(), nil, types.ImageBuildOptions{})
+	_, err := client.ImageBuild(context.Background(), nil, build.ImageBuildOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -31,13 +31,13 @@ func TestImageBuild(t *testing.T) {
 	v2 := "value2"
 	emptyRegistryConfig := "bnVsbA=="
 	buildCases := []struct {
-		buildOptions           types.ImageBuildOptions
+		buildOptions           build.ImageBuildOptions
 		expectedQueryParams    map[string]string
 		expectedTags           []string
 		expectedRegistryConfig string
 	}{
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				SuppressOutput: true,
 				NoCache:        true,
 				Remove:         true,
@@ -54,7 +54,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				SuppressOutput: false,
 				NoCache:        false,
 				Remove:         false,
@@ -72,7 +72,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				RemoteContext: "remoteContext",
 				Isolation:     container.Isolation("isolation"),
 				CPUSetCPUs:    "2",
@@ -105,7 +105,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				BuildArgs: map[string]*string{
 					"ARG1": &v1,
 					"ARG2": &v2,
@@ -120,7 +120,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				Ulimits: []*container.Ulimit{
 					{
 						Name: "nproc",
@@ -142,7 +142,7 @@ func TestImageBuild(t *testing.T) {
 			expectedRegistryConfig: emptyRegistryConfig,
 		},
 		{
-			buildOptions: types.ImageBuildOptions{
+			buildOptions: build.ImageBuildOptions{
 				AuthConfigs: map[string]registry.AuthConfig{
 					"https://index.docker.io/v1/": {
 						Auth: "dG90bwo=",

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -200,20 +200,12 @@ func TestImageBuild(t *testing.T) {
 			}),
 		}
 		buildResponse, err := client.ImageBuild(context.Background(), nil, buildCase.buildOptions)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if buildResponse.OSType != "MyOS" {
-			t.Fatalf("expected OSType to be 'MyOS', got %s", buildResponse.OSType)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Equal(buildResponse.OSType, "MyOS"))
 		response, err := io.ReadAll(buildResponse.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 		buildResponse.Body.Close()
-		if string(response) != "body" {
-			t.Fatalf("expected Body to contain 'body' string, got %s", response)
-		}
+		assert.Check(t, is.Equal(string(response), "body"))
 	}
 }
 
@@ -225,8 +217,6 @@ func TestGetDockerOS(t *testing.T) {
 	}
 	for header, os := range cases {
 		g := getDockerOS(header)
-		if g != os {
-			t.Fatalf("Expected %s, got %s", os, g)
-		}
+		assert.Check(t, is.Equal(g, os))
 	}
 }

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -64,17 +64,10 @@ func TestImageCreate(t *testing.T) {
 	createResponse, err := client.ImageCreate(context.Background(), specifiedReference, image.CreateOptions{
 		RegistryAuth: expectedRegistryAuth,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	response, err := io.ReadAll(createResponse)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = createResponse.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if string(response) != "body" {
-		t.Fatalf("expected Body to contain 'body' string, got %s", response)
-	}
+	assert.NilError(t, err)
+	err = createResponse.Close()
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(response), "body"))
 }

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -89,7 +89,7 @@ func TestImageImport(t *testing.T) {
 
 			body, err := io.ReadAll(resp)
 			assert.NilError(t, err)
-			assert.Equal(t, string(body), expectedOutput)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -70,15 +69,9 @@ func TestImageInspect(t *testing.T) {
 	}
 
 	imageInspect, err := client.ImageInspect(context.Background(), "image_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if imageInspect.ID != "image_id" {
-		t.Fatalf("expected `image_id`, got %s", imageInspect.ID)
-	}
-	if !reflect.DeepEqual(imageInspect.RepoTags, expectedTags) {
-		t.Fatalf("expected `%v`, got %v", expectedTags, imageInspect.RepoTags)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(imageInspect.ID, "image_id"))
+	assert.Check(t, is.DeepEqual(imageInspect.RepoTags, expectedTags))
 }
 
 func TestImageInspectWithPlatform(t *testing.T) {
@@ -120,7 +113,7 @@ func TestImageInspectWithPlatform(t *testing.T) {
 
 	imageInspect, err := client.ImageInspect(context.Background(), "image_id", ImageInspectWithPlatform(requestedPlatform))
 	assert.NilError(t, err)
-	assert.Equal(t, imageInspect.ID, "image_id")
-	assert.Equal(t, imageInspect.Architecture, "arm64")
-	assert.Equal(t, imageInspect.Os, "linux")
+	assert.Check(t, is.Equal(imageInspect.ID, "image_id"))
+	assert.Check(t, is.Equal(imageInspect.Architecture, "arm64"))
+	assert.Check(t, is.Equal(imageInspect.Os, "linux"))
 }

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -111,12 +111,8 @@ func TestImageList(t *testing.T) {
 		}
 
 		images, err := client.ImageList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(images) != 2 {
-			t.Fatalf("expected 2 images, got %v", images)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(images, 2))
 	}
 }
 
@@ -157,12 +153,8 @@ func TestImageListApiBefore125(t *testing.T) {
 	}
 
 	images, err := client.ImageList(context.Background(), options)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(images) != 2 {
-		t.Fatalf("expected 2 images, got %v", images)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(images, 2))
 }
 
 // Checks if shared-size query parameter is set/not being set correctly
@@ -194,7 +186,7 @@ func TestImageListWithSharedSize(t *testing.T) {
 				version: tc.version,
 			}
 			_, err := client.ImageList(context.Background(), tc.options)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 			expectedSet := tc.sharedSize != ""
 			assert.Check(t, is.Equal(query.Has(sharedSize), expectedSet))
 			assert.Check(t, is.Equal(query.Get(sharedSize), tc.sharedSize))

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -106,7 +106,7 @@ func TestImagesPrune(t *testing.T) {
 		}
 
 		report, err := client.ImagesPrune(context.Background(), listCase.filters)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		assert.Check(t, is.Len(report.ImagesDeleted, 2))
 		assert.Check(t, is.Equal(uint64(9999), report.SpaceReclaimed))
 	}

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -24,9 +24,7 @@ func TestImagePullReferenceParseError(t *testing.T) {
 	}
 	// An empty reference is an invalid reference
 	_, err := client.ImagePull(context.Background(), "", image.PullOptions{})
-	if err == nil || !strings.Contains(err.Error(), "invalid reference format") {
-		t.Fatalf("expected an error, got %v", err)
-	}
+	assert.Check(t, is.ErrorContains(err, "invalid reference format"))
 }
 
 func TestImagePullAnyError(t *testing.T) {
@@ -55,9 +53,7 @@ func TestImagePullWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	_, err := client.ImagePull(context.Background(), "myimage", image.PullOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err == nil || err.Error() != "Error requesting privilege" {
-		t.Fatalf("expected an error requesting privilege, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "Error requesting privilege"))
 }
 
 func TestImagePullWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
@@ -112,16 +108,10 @@ func TestImagePullWithPrivilegedFuncNoError(t *testing.T) {
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	body, err := io.ReadAll(resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(body) != "hello world" {
-		t.Fatalf("expected 'hello world', got %s", string(body))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(body), "hello world"))
 }
 
 func TestImagePullWithoutErrors(t *testing.T) {
@@ -210,16 +200,10 @@ func TestImagePullWithoutErrors(t *testing.T) {
 			resp, err := client.ImagePull(context.Background(), pullCase.reference, image.PullOptions{
 				All: pullCase.all,
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
+			assert.NilError(t, err)
 			body, err := io.ReadAll(resp)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(body) != expectedOutput {
-				t.Fatalf("expected '%s', got %s", expectedOutput, string(body))
-			}
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -24,14 +24,10 @@ func TestImagePushReferenceError(t *testing.T) {
 	}
 	// An empty reference is an invalid reference
 	_, err := client.ImagePush(context.Background(), "", image.PushOptions{})
-	if err == nil || !strings.Contains(err.Error(), "invalid reference format") {
-		t.Fatalf("expected an error, got %v", err)
-	}
+	assert.Check(t, is.ErrorContains(err, "invalid reference format"))
 	// An canonical reference cannot be pushed
 	_, err = client.ImagePush(context.Background(), "repo@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", image.PushOptions{})
-	if err == nil || err.Error() != "cannot push a digest reference" {
-		t.Fatalf("expected an error, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "cannot push a digest reference"))
 }
 
 func TestImagePushAnyError(t *testing.T) {
@@ -60,9 +56,7 @@ func TestImagePushWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	_, err := client.ImagePush(context.Background(), "myimage", image.PushOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err == nil || err.Error() != "Error requesting privilege" {
-		t.Fatalf("expected an error requesting privilege, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "Error requesting privilege"))
 }
 
 func TestImagePushWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
@@ -113,16 +107,10 @@ func TestImagePushWithPrivilegedFuncNoError(t *testing.T) {
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 	body, err := io.ReadAll(resp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(body) != "hello world" {
-		t.Fatalf("expected 'hello world', got %s", string(body))
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(body), "hello world"))
 }
 
 func TestImagePushWithoutErrors(t *testing.T) {
@@ -208,16 +196,10 @@ func TestImagePushWithoutErrors(t *testing.T) {
 			resp, err := client.ImagePush(context.Background(), tc.reference, image.PushOptions{
 				All: tc.all,
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
+			assert.NilError(t, err)
 			body, err := io.ReadAll(resp)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(body) != expectedOutput {
-				t.Fatalf("expected '%s', got %s", expectedOutput, string(body))
-			}
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -96,11 +96,7 @@ func TestImageRemove(t *testing.T) {
 			Force:         removeCase.force,
 			PruneChildren: removeCase.pruneChildren,
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(imageDeletes) != 2 {
-			t.Fatalf("expected 2 deleted images, got %v", imageDeletes)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(imageDeletes, 2))
 	}
 }

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -81,7 +81,7 @@ func TestImageSave(t *testing.T) {
 
 			body, err := io.ReadAll(resp)
 			assert.NilError(t, err)
-			assert.Equal(t, string(body), expectedOutput)
+			assert.Check(t, is.Equal(string(body), expectedOutput))
 		})
 	}
 }

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -43,9 +43,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err == nil || err.Error() != "Error requesting privilege" {
-		t.Fatalf("expected an error requesting privilege, got %v", err)
-	}
+	assert.Check(t, is.Error(err, "Error requesting privilege"))
 }
 
 func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
@@ -104,12 +102,8 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %v", results)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(results, 1))
 }
 
 func TestImageSearchWithoutErrors(t *testing.T) {
@@ -150,10 +144,6 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 			filters.Arg("stars", "3"),
 		),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(results) != 1 {
-		t.Fatalf("expected a result, got %v", results)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(results, 1))
 }

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -32,9 +32,7 @@ func TestImageTagInvalidReference(t *testing.T) {
 	}
 
 	err := client.ImageTag(context.Background(), "image_id", "aa/asdf$$^/aa")
-	if err == nil || err.Error() != `Error parsing reference: "aa/asdf$$^/aa" is not a valid repository/tag: invalid reference format` {
-		t.Fatalf("expected ErrReferenceInvalidFormat, got %v", err)
-	}
+	assert.Check(t, is.Error(err, `Error parsing reference: "aa/asdf$$^/aa" is not a valid repository/tag: invalid reference format`))
 }
 
 // Ensure we don't allow the use of invalid repository names or tags; these tag operations should fail.
@@ -89,9 +87,7 @@ func TestImageTagHexSource(t *testing.T) {
 	}
 
 	err := client.ImageTag(context.Background(), "0d409d33b27e47423b049f7f863faa08655a8c901749c2b25b93ca67d01a470d", "repo:tag")
-	if err != nil {
-		t.Fatalf("got error: %v", err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestImageTag(t *testing.T) {
@@ -173,8 +169,6 @@ func TestImageTag(t *testing.T) {
 			}),
 		}
 		err := client.ImageTag(context.Background(), "image_id", tagCase.reference)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -34,9 +34,7 @@ func TestInfoInvalidResponseJSONError(t *testing.T) {
 		}),
 	}
 	_, err := client.Info(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "invalid character") {
-		t.Fatalf("expected a 'invalid character' error, got %v", err)
-	}
+	assert.Check(t, is.ErrorContains(err, "invalid character"))
 }
 
 func TestInfo(t *testing.T) {
@@ -63,17 +61,10 @@ func TestInfo(t *testing.T) {
 	}
 
 	info, err := client.Info(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 
-	if info.ID != "daemonID" {
-		t.Fatalf("expected daemonID, got %s", info.ID)
-	}
-
-	if info.Containers != 3 {
-		t.Fatalf("expected 3 containers, got %d", info.Containers)
-	}
+	assert.Check(t, is.Equal(info.ID, "daemonID"))
+	assert.Check(t, is.Equal(info.Containers, 3))
 }
 
 func TestInfoWithDiscoveredDevices(t *testing.T) {

--- a/client/info_test.go
+++ b/client/info_test.go
@@ -75,3 +75,53 @@ func TestInfo(t *testing.T) {
 		t.Fatalf("expected 3 containers, got %d", info.Containers)
 	}
 }
+
+func TestInfoWithDiscoveredDevices(t *testing.T) {
+	expectedURL := "/info"
+	client := &Client{
+		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			info := &system.Info{
+				ID:         "daemonID",
+				Containers: 3,
+				DiscoveredDevices: []system.DeviceInfo{
+					{
+						Source: "cdi",
+						ID:     "vendor.com/gpu=0",
+					},
+					{
+						Source: "cdi",
+						ID:     "vendor.com/gpu=1",
+					},
+				},
+			}
+			b, err := json.Marshal(info)
+			if err != nil {
+				return nil, err
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}),
+	}
+
+	info, err := client.Info(context.Background())
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Equal(info.ID, "daemonID"))
+	assert.Check(t, is.Equal(info.Containers, 3))
+
+	assert.Check(t, is.Len(info.DiscoveredDevices, 2))
+
+	device0 := info.DiscoveredDevices[0]
+	assert.Check(t, is.Equal(device0.Source, "cdi"))
+	assert.Check(t, is.Equal(device0.ID, "vendor.com/gpu=0"))
+
+	device1 := info.DiscoveredDevices[1]
+	assert.Check(t, is.Equal(device1.Source, "cdi"))
+	assert.Check(t, is.Equal(device1.ID, "vendor.com/gpu=1"))
+}

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -68,9 +68,7 @@ func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
 	}
 
 	err := client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }
 
 func TestNetworkConnect(t *testing.T) {
@@ -113,7 +111,5 @@ func TestNetworkConnect(t *testing.T) {
 	err := client.NetworkConnect(context.Background(), "network_id", "container_id", &network.EndpointSettings{
 		NetworkID: "NetworkID",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -73,13 +73,7 @@ func TestNetworkCreate(t *testing.T) {
 			"opt-key": "opt-value",
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if networkResponse.ID != "network_id" {
-		t.Fatalf("expected networkResponse.ID to be 'network_id', got %s", networkResponse.ID)
-	}
-	if networkResponse.Warning != "warning" {
-		t.Fatalf("expected networkResponse.Warning to be 'warning', got %s", networkResponse.Warning)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(networkResponse.ID, "network_id"))
+	assert.Check(t, is.Equal(networkResponse.Warning, "warning"))
 }

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -68,7 +68,5 @@ func TestNetworkDisconnect(t *testing.T) {
 	}
 
 	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -79,16 +79,14 @@ func TestNetworkInspect(t *testing.T) {
 	t.Run("no options", func(t *testing.T) {
 		r, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{})
 		assert.NilError(t, err)
-		assert.Equal(t, r.Name, "mynetwork")
+		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 	})
 	t.Run("verbose", func(t *testing.T) {
 		r, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{Verbose: true})
 		assert.NilError(t, err)
-		assert.Equal(t, r.Name, "mynetwork")
+		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 		_, ok := r.Services["web"]
-		if !ok {
-			t.Fatalf("expected service `web` missing in the verbose output")
-		}
+		assert.Check(t, ok, "expected service `web` missing in the verbose output")
 	})
 	t.Run("global scope", func(t *testing.T) {
 		_, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{Scope: "global"})

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -91,11 +91,7 @@ func TestNetworkList(t *testing.T) {
 		}
 
 		networkResources, err := client.NetworkList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(networkResources) != 1 {
-			t.Fatalf("expected 1 network resource, got %v", networkResources)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(networkResources, 1))
 	}
 }

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -97,7 +97,7 @@ func TestNetworksPrune(t *testing.T) {
 		}
 
 		report, err := client.NetworksPrune(context.Background(), listCase.filters)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		assert.Check(t, is.Len(report.NetworksDeleted, 2))
 	}
 }

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -50,7 +50,5 @@ func TestNetworkRemove(t *testing.T) {
 	}
 
 	err := client.NetworkRemove(context.Background(), "network_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -71,10 +71,6 @@ func TestNodeInspect(t *testing.T) {
 	}
 
 	nodeInspect, _, err := client.NodeInspectWithRaw(context.Background(), "node_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if nodeInspect.ID != "node_id" {
-		t.Fatalf("expected `node_id`, got %s", nodeInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(nodeInspect.ID, "node_id"))
 }

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -84,11 +84,7 @@ func TestNodeList(t *testing.T) {
 		}
 
 		nodes, err := client.NodeList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(nodes) != 2 {
-			t.Fatalf("expected 2 nodes, got %v", nodes)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(nodes, 2))
 	}
 }

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -70,8 +70,6 @@ func TestNodeRemove(t *testing.T) {
 		}
 
 		err := client.NodeRemove(context.Background(), "node_id", types.NodeRemoveOptions{Force: removeCase.force})
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -51,7 +51,5 @@ func TestNodeUpdate(t *testing.T) {
 	}
 
 	err := client.NodeUpdate(context.Background(), "node_id", swarm.Version{}, swarm.NodeSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -43,23 +43,23 @@ func TestOptionWithTimeout(t *testing.T) {
 	c, err := NewClientWithOpts(WithTimeout(timeout))
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.client.Timeout, timeout)
+	assert.Check(t, is.Equal(c.client.Timeout, timeout))
 }
 
 func TestOptionWithVersionFromEnv(t *testing.T) {
 	c, err := NewClientWithOpts(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.version, api.DefaultVersion)
-	assert.Equal(t, c.manualOverride, false)
+	assert.Check(t, is.Equal(c.version, api.DefaultVersion))
+	assert.Check(t, is.Equal(c.manualOverride, false))
 
 	t.Setenv("DOCKER_API_VERSION", "2.9999")
 
 	c, err = NewClientWithOpts(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
-	assert.Equal(t, c.version, "2.9999")
-	assert.Equal(t, c.manualOverride, true)
+	assert.Check(t, is.Equal(c.version, "2.9999"))
+	assert.Check(t, is.Equal(c.manualOverride, true))
 }
 
 func TestWithUserAgent(t *testing.T) {
@@ -72,10 +72,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("user-agent and custom headers", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -87,10 +87,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("custom headers", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -101,10 +101,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("no user-agent set", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -115,10 +115,10 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 	t.Run("reset custom user-agent", func(t *testing.T) {
 		c, err := NewClientWithOpts(
@@ -130,9 +130,9 @@ func TestWithUserAgent(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			})),
 		)
-		assert.Check(t, err)
+		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
-		assert.Check(t, err)
-		assert.Check(t, c.Close())
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
 	})
 }

--- a/client/ping.go
+++ b/client/ping.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/swarm"
 )
 
@@ -67,7 +68,7 @@ func parsePingResponse(cli *Client, resp *http.Response) (types.Ping, error) {
 		ping.Experimental = true
 	}
 	if bv := resp.Header.Get("Builder-Version"); bv != "" {
-		ping.BuilderVersion = types.BuilderVersion(bv)
+		ping.BuilderVersion = build.BuilderVersion(bv)
 	}
 	if si := resp.Header.Get("Swarm"); si != "" {
 		state, role, _ := strings.Cut(si, "/")

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -51,7 +51,5 @@ func TestPluginDisable(t *testing.T) {
 	}
 
 	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -51,7 +51,5 @@ func TestPluginEnable(t *testing.T) {
 	}
 
 	err := client.PluginEnable(context.Background(), "plugin_name", types.PluginEnableOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -62,10 +62,6 @@ func TestPluginInspect(t *testing.T) {
 	}
 
 	pluginInspect, _, err := client.PluginInspectWithRaw(context.Background(), "plugin_name")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if pluginInspect.ID != "plugin_id" {
-		t.Fatalf("expected `plugin_id`, got %s", pluginInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(pluginInspect.ID, "plugin_id"))
 }

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -94,11 +94,7 @@ func TestPluginList(t *testing.T) {
 		}
 
 		plugins, err := client.PluginList(context.Background(), listCase.filters)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(plugins) != 2 {
-			t.Fatalf("expected 2 plugins, got %v", plugins)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(plugins, 2))
 	}
 }

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -55,7 +55,5 @@ func TestPluginPush(t *testing.T) {
 	}
 
 	_, err := client.PluginPush(context.Background(), "plugin_name", "authtoken")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -51,7 +51,5 @@ func TestPluginRemove(t *testing.T) {
 	}
 
 	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -50,7 +50,5 @@ func TestPluginSet(t *testing.T) {
 	}
 
 	err := client.PluginSet(context.Background(), "plugin_name", []string{"arg1"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -53,7 +53,7 @@ func TestSetHostHeader(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.host, func(t *testing.T) {
 			hostURL, err := ParseHostURL(tc.host)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 
 			client := &Client{
 				client: newMockClient(func(req *http.Request) (*http.Response, error) {
@@ -78,7 +78,7 @@ func TestSetHostHeader(t *testing.T) {
 			}
 
 			_, err = client.sendRequest(context.Background(), http.MethodGet, testEndpoint, nil, nil, nil)
-			assert.Check(t, err)
+			assert.NilError(t, err)
 		})
 	}
 }

--- a/client/secret_create.go
+++ b/client/secret_create.go
@@ -4,22 +4,21 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // SecretCreate creates a new secret.
-func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (types.SecretCreateResponse, error) {
+func (cli *Client) SecretCreate(ctx context.Context, secret swarm.SecretSpec) (swarm.SecretCreateResponse, error) {
 	if err := cli.NewVersionError(ctx, "1.25", "secret create"); err != nil {
-		return types.SecretCreateResponse{}, err
+		return swarm.SecretCreateResponse{}, err
 	}
 	resp, err := cli.post(ctx, "/secrets/create", nil, secret, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return types.SecretCreateResponse{}, err
+		return swarm.SecretCreateResponse{}, err
 	}
 
-	var response types.SecretCreateResponse
+	var response swarm.SecretCreateResponse
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	return response, err
 }

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -60,10 +60,6 @@ func TestSecretCreate(t *testing.T) {
 	}
 
 	r, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "test_secret" {
-		t.Fatalf("expected `test_secret`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "test_secret"))
 }

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
@@ -46,7 +45,7 @@ func TestSecretCreate(t *testing.T) {
 			if req.Method != http.MethodPost {
 				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
 			}
-			b, err := json.Marshal(types.SecretCreateResponse{
+			b, err := json.Marshal(swarm.SecretCreateResponse{
 				ID: "test_secret",
 			})
 			if err != nil {

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -83,10 +83,6 @@ func TestSecretInspect(t *testing.T) {
 	}
 
 	secretInspect, _, err := client.SecretInspectWithRaw(context.Background(), "secret_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if secretInspect.ID != "secret_id" {
-		t.Fatalf("expected `secret_id`, got %s", secretInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(secretInspect.ID, "secret_id"))
 }

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 )
 
 // SecretList returns the list of secrets.
-func (cli *Client) SecretList(ctx context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
+func (cli *Client) SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error) {
 	if err := cli.NewVersionError(ctx, "1.25", "secret list"); err != nil {
 		return nil, err
 	}

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -95,11 +95,7 @@ func TestSecretList(t *testing.T) {
 		}
 
 		secrets, err := client.SecretList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(secrets) != 2 {
-			t.Fatalf("expected 2 secrets, got %v", secrets)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(secrets, 2))
 	}
 }

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/errdefs"
@@ -23,7 +22,7 @@ func TestSecretListUnsupported(t *testing.T) {
 		version: "1.24",
 		client:  &http.Client{},
 	}
-	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
+	_, err := client.SecretList(context.Background(), swarm.SecretListOptions{})
 	assert.Check(t, is.Error(err, `"secret list" requires API version 1.25, but the Docker daemon API version is 1.24`))
 }
 
@@ -33,7 +32,7 @@ func TestSecretListError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.SecretList(context.Background(), types.SecretListOptions{})
+	_, err := client.SecretList(context.Background(), swarm.SecretListOptions{})
 	assert.Check(t, is.ErrorType(err, errdefs.IsSystem))
 }
 
@@ -41,17 +40,17 @@ func TestSecretList(t *testing.T) {
 	const expectedURL = "/v1.25/secrets"
 
 	listCases := []struct {
-		options             types.SecretListOptions
+		options             swarm.SecretListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: types.SecretListOptions{},
+			options: swarm.SecretListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: types.SecretListOptions{
+			options: swarm.SecretListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -61,7 +61,5 @@ func TestSecretRemove(t *testing.T) {
 	}
 
 	err := client.SecretRemove(context.Background(), "secret_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/secret_update_test.go
+++ b/client/secret_update_test.go
@@ -62,7 +62,5 @@ func TestSecretUpdate(t *testing.T) {
 	}
 
 	err := client.SecretUpdate(context.Background(), "secret_id", swarm.Version{}, swarm.SecretSpec{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -64,12 +64,8 @@ func TestServiceCreate(t *testing.T) {
 	}
 
 	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, types.ServiceCreateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.ID != "service_id" {
-		t.Fatalf("expected `service_id`, got %s", r.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "service_id"))
 }
 
 func TestServiceCreateCompatiblePlatforms(t *testing.T) {
@@ -127,7 +123,7 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 	spec := swarm.ServiceSpec{TaskTemplate: swarm.TaskSpec{ContainerSpec: &swarm.ContainerSpec{Image: "foobar:1.0"}}}
 
 	r, err := client.ServiceCreate(context.Background(), spec, types.ServiceCreateOptions{QueryRegistry: true})
-	assert.Check(t, err)
+	assert.NilError(t, err)
 	assert.Check(t, is.Equal("service_linux_amd64", r.ID))
 }
 
@@ -206,16 +202,10 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 				},
 			},
 		}, types.ServiceCreateOptions{QueryRegistry: true})
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 
-		if r.ID != "service_id" {
-			t.Fatalf("expected `service_id`, got %s", r.ID)
-		}
+		assert.Check(t, is.Equal(r.ID, "service_id"))
 
-		if p.expected != serviceCreateImage {
-			t.Fatalf("expected image %s, got %s", p.expected, serviceCreateImage)
-		}
+		assert.Check(t, is.Equal(p.expected, serviceCreateImage))
 	}
 }

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -72,10 +72,6 @@ func TestServiceInspect(t *testing.T) {
 	}
 
 	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id", types.ServiceInspectOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if serviceInspect.ID != "service_id" {
-		t.Fatalf("expected `service_id`, got %s", serviceInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(serviceInspect.ID, "service_id"))
 }

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -84,11 +84,7 @@ func TestServiceList(t *testing.T) {
 		}
 
 		services, err := client.ServiceList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(services) != 2 {
-			t.Fatalf("expected 2 services, got %v", services)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(services, 2))
 	}
 }

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -60,7 +60,5 @@ func TestServiceRemove(t *testing.T) {
 	}
 
 	err := client.ServiceRemove(context.Background(), "service_id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -90,8 +90,6 @@ func TestServiceUpdate(t *testing.T) {
 		}
 
 		_, err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, types.ServiceUpdateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -45,10 +45,6 @@ func TestSwarmInit(t *testing.T) {
 	resp, err := client.SwarmInit(context.Background(), swarm.InitRequest{
 		ListenAddr: "0.0.0.0:2377",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp != "body" {
-		t.Fatalf("Expected 'body', got %s", resp)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(resp, "body"))
 }

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -48,10 +48,6 @@ func TestSwarmInspect(t *testing.T) {
 	}
 
 	swarmInspect, err := client.SwarmInspect(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if swarmInspect.ID != "swarm_id" {
-		t.Fatalf("expected `swarm_id`, got %s", swarmInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(swarmInspect.ID, "swarm_id"))
 }

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -45,7 +45,5 @@ func TestSwarmJoin(t *testing.T) {
 	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{
 		ListenAddr: "0.0.0.0:2377",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -60,8 +60,6 @@ func TestSwarmLeave(t *testing.T) {
 		}
 
 		err := client.SwarmLeave(context.Background(), leaveCase.force)
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.NilError(t, err)
 	}
 }

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -43,7 +43,5 @@ func TestSwarmUnlock(t *testing.T) {
 	}
 
 	err := client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -43,7 +43,5 @@ func TestSwarmUpdate(t *testing.T) {
 	}
 
 	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -62,10 +62,6 @@ func TestTaskInspect(t *testing.T) {
 	}
 
 	taskInspect, _, err := client.TaskInspectWithRaw(context.Background(), "task_id")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if taskInspect.ID != "task_id" {
-		t.Fatalf("expected `task_id`, got %s", taskInspect.ID)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(taskInspect.ID, "task_id"))
 }

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -84,11 +84,7 @@ func TestTaskList(t *testing.T) {
 		}
 
 		tasks, err := client.TaskList(context.Background(), listCase.options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(tasks) != 2 {
-			t.Fatalf("expected 2 tasks, got %v", tasks)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(tasks, 2))
 	}
 }

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -5,6 +5,7 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestEncodePlatforms(t *testing.T) {
@@ -50,7 +51,7 @@ func TestEncodePlatforms(t *testing.T) {
 		t.Run(tc.doc, func(t *testing.T) {
 			out, err := encodePlatforms(tc.platforms...)
 			assert.NilError(t, err)
-			assert.DeepEqual(t, out, tc.expected)
+			assert.Check(t, is.DeepEqual(out, tc.expected))
 		})
 	}
 }

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -60,16 +60,8 @@ func TestVolumeCreate(t *testing.T) {
 			"opt-key": "opt-value",
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if vol.Name != "volume" {
-		t.Fatalf("expected volume.Name to be 'volume', got %s", vol.Name)
-	}
-	if vol.Driver != "local" {
-		t.Fatalf("expected volume.Driver to be 'local', got %s", vol.Driver)
-	}
-	if vol.Mountpoint != "mountpoint" {
-		t.Fatalf("expected volume.Mountpoint to be 'mountpoint', got %s", vol.Mountpoint)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(vol.Name, "volume"))
+	assert.Check(t, is.Equal(vol.Driver, "local"))
+	assert.Check(t, is.Equal(vol.Mountpoint, "mountpoint"))
 }

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -81,11 +81,7 @@ func TestVolumeList(t *testing.T) {
 		}
 
 		volumeResponse, err := client.VolumeList(context.Background(), volume.ListOptions{Filters: listCase.filters})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(volumeResponse.Volumes) != 1 {
-			t.Fatalf("expected 1 volume, got %v", volumeResponse.Volumes)
-		}
+		assert.NilError(t, err)
+		assert.Check(t, is.Len(volumeResponse.Volumes, 1))
 	}
 }

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -62,7 +62,5 @@ func TestVolumeRemove(t *testing.T) {
 	}
 
 	err := client.VolumeRemove(context.Background(), "volume_id", false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/client/volume_update_test.go
+++ b/client/volume_update_test.go
@@ -56,7 +56,5 @@ func TestVolumeUpdate(t *testing.T) {
 	}
 
 	err := client.VolumeUpdate(context.Background(), "test1", swarm.Version{Index: uint64(10)}, volumetypes.UpdateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NilError(t, err)
 }

--- a/container/state.go
+++ b/container/state.go
@@ -36,7 +36,7 @@ type State struct {
 	Paused            bool
 	Restarting        bool
 	OOMKilled         bool
-	RemovalInProgress bool // Not need for this to be persistent on disk.
+	RemovalInProgress bool `json:"-"` // No need for this to be persistent on disk.
 	Dead              bool
 	Pid               int
 	ExitCodeValue     int    `json:"ExitCode"`

--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -35,7 +35,7 @@ kernelMinor="${kernelVersion#$kernelMajor.}"
 kernelMinor="${kernelMinor%%.*}"
 
 check_cgroup() {
-    local sys_fs_cgroup="$(grep -E '\s+/sys/fs/cgroup\s+' /proc/mounts | head -n 1 | cut -d ' ' -f1)"
+    sys_fs_cgroup="$(grep -E '\s+/sys/fs/cgroup\s+' /proc/mounts | head -n 1 | awk '{ print $1 }')"
 
     if [ "$sys_fs_cgroup" != "cgroup2" ]; then
         echo 1
@@ -213,7 +213,7 @@ fi
 
 check_flags \
 	NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
-	CGROUPS CGROUP_SCHED \
+	CGROUPS CGROUP_SCHED CPUSETS MEMCG \
 	KEYS \
 	VETH BRIDGE BRIDGE_NETFILTER \
 	IP_NF_FILTER IP_NF_MANGLE IP_NF_TARGET_MASQUERADE \
@@ -228,7 +228,7 @@ check_flags \
 # (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
 
 if [ "$cgroupVersion" -eq 1 ]; then
-	check_flags CGROUP_FREEZER CGROUP_DEVICE CPUSETS CGROUP_CPUACCT MEMCG
+	check_flags CGROUP_FREEZER CGROUP_DEVICE CGROUP_CPUACCT
 fi
 
 if [ "$kernelMajor" -lt 4 ] || ([ "$kernelMajor" -eq 4 ] && [ "$kernelMinor" -lt 8 ]); then
@@ -258,9 +258,7 @@ echo 'Optional Features:'
 	check_flags SECCOMP_FILTER
 }
 {
-	if [ "$cgroupVersion" -eq 1 ]; then
-		check_flags CGROUP_PIDS CGROUP_HUGETLB
-	fi
+	check_flags CGROUP_PIDS
 }
 {
 	check_flags MEMCG_SWAP
@@ -323,6 +321,7 @@ fi
 check_flags \
 	BLK_CGROUP BLK_DEV_THROTTLING \
 	CGROUP_PERF \
+	CGROUP_HUGETLB \
 	NET_CLS_CGROUP $netprio \
 	CFS_BANDWIDTH FAIR_GROUP_SCHED \
 	IP_NF_TARGET_REDIRECT \

--- a/daemon/cdi.go
+++ b/daemon/cdi.go
@@ -3,8 +3,11 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/api/types/system"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/errdefs"
 	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -40,6 +43,11 @@ func newCDIDeviceDriver(cdiSpecDirs ...string) *deviceDriver {
 		}
 		return &deviceDriver{
 			updateSpec: errorOnUpdateSpec,
+			ListDevices: func(ctx context.Context, cfg *config.Config) (deviceListing, error) {
+				return deviceListing{
+					Warnings: []string{fmt.Sprintf("CDI cache initialization failed: %v", err)},
+				}, nil
+			},
 		}
 	}
 
@@ -49,7 +57,8 @@ func newCDIDeviceDriver(cdiSpecDirs ...string) *deviceDriver {
 	}
 
 	return &deviceDriver{
-		updateSpec: c.injectCDIDevices,
+		updateSpec:  c.injectCDIDevices,
+		ListDevices: c.listDevices,
 	}
 }
 
@@ -104,4 +113,40 @@ func (c *cdiHandler) getErrors() error {
 		err = multierror.Append(err, errs...)
 	}
 	return err.ErrorOrNil()
+}
+
+// listDevices uses the CDI cache to list all discovered CDI devices.
+// It conforms to the deviceDriver.ListDevices function signature.
+func (c *cdiHandler) listDevices(ctx context.Context, cfg *config.Config) (deviceListing, error) {
+	var out deviceListing
+
+	// Collect global errors from the CDI cache (e.g., issues with spec files themselves).
+	for specPath, specErrs := range c.registry.GetErrors() {
+		for _, err := range specErrs {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			out.Warnings = append(out.Warnings, fmt.Sprintf("CDI: Error associated with spec file %s: %v", specPath, err))
+		}
+	}
+
+	qualifiedDeviceNames := c.registry.ListDevices()
+	if len(qualifiedDeviceNames) == 0 {
+		return out, nil
+	}
+
+	for _, qdn := range qualifiedDeviceNames {
+		device := c.registry.GetDevice(qdn)
+		if device == nil {
+			log.G(ctx).WithField("device", qdn).Warn("CDI: Cache.GetDevice() returned nil for a listed device, skipping.")
+			out.Warnings = append(out.Warnings, fmt.Sprintf("CDI: Device %s listed but not found by GetDevice()", qdn))
+			continue
+		}
+
+		out.Devices = append(out.Devices, system.DeviceInfo{
+			ID: qdn,
+		})
+	}
+
+	return out, nil
 }

--- a/daemon/cdi.go
+++ b/daemon/cdi.go
@@ -30,7 +30,7 @@ func RegisterCDIDriver(cdiSpecDirs ...string) {
 func newCDIDeviceDriver(cdiSpecDirs ...string) *deviceDriver {
 	cache, err := createCDICache(cdiSpecDirs...)
 	if err != nil {
-		log.G(context.TODO()).WithError(err)
+		log.G(context.TODO()).WithError(err).Error("Failed to create CDI cache")
 		// We create a spec updater that always returns an error.
 		// This error will be returned only when a CDI device is requested.
 		// This ensures that daemon startup is not blocked by a CDI registry initialization failure or being disabled

--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -3,7 +3,6 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 
-	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/moby/swarmkit/v2/api"
@@ -28,7 +27,7 @@ func (c *Cluster) GetConfig(input string) (types.Config, error) {
 }
 
 // GetConfigs returns all configs of a managed swarm cluster.
-func (c *Cluster) GetConfigs(options apitypes.ConfigListOptions) ([]types.Config, error) {
+func (c *Cluster) GetConfigs(options types.ConfigListOptions) ([]types.Config, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -3,7 +3,6 @@ package cluster // import "github.com/docker/docker/daemon/cluster"
 import (
 	"context"
 
-	apitypes "github.com/docker/docker/api/types"
 	types "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/daemon/cluster/convert"
 	swarmapi "github.com/moby/swarmkit/v2/api"
@@ -28,7 +27,7 @@ func (c *Cluster) GetSecret(input string) (types.Secret, error) {
 }
 
 // GetSecrets returns all secrets of a managed swarm cluster.
-func (c *Cluster) GetSecrets(options apitypes.SecretListOptions) ([]types.Secret, error) {
+func (c *Cluster) GetSecrets(options types.SecretListOptions) ([]types.Secret, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -144,7 +144,16 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 	wrapped := wrapWithFakeMountableBlobs(store, mountableBlobs)
 	store = wrapped
 
-	pusher, err := resolver.Pusher(ctx, targetRef.String())
+	// Annotate ref with digest to push only push tag for single digest
+	ref := targetRef
+	if _, digested := ref.(reference.Digested); !digested {
+		ref, err = reference.WithDigest(ref, target.Digest)
+		if err != nil {
+			return err
+		}
+	}
+
+	pusher, err := resolver.Pusher(ctx, ref.String())
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -495,6 +495,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 			}
 
 			c.Lock()
+			// TODO(thaJeztah): we no longer persist RemovalInProgress on disk, so this code is likely redundant; see https://github.com/moby/moby/pull/49968
 			if c.RemovalInProgress {
 				// We probably crashed in the middle of a removal, reset
 				// the flag.

--- a/daemon/devices.go
+++ b/daemon/devices.go
@@ -1,16 +1,31 @@
 package daemon // import "github.com/docker/docker/daemon"
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/system"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/internal/capabilities"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var deviceDrivers = map[string]*deviceDriver{}
 
+type deviceListing struct {
+	Devices  []system.DeviceInfo
+	Warnings []string
+}
+
 type deviceDriver struct {
 	capset     capabilities.Set
 	updateSpec func(*specs.Spec, *deviceInstance) error
+
+	// ListDevices returns a list of discoverable devices provided by this
+	// driver, any warnings encountered during the discovery, and an error if
+	// the overall listing operation failed.
+	// Can be nil if the driver does not provide a device listing.
+	ListDevices func(ctx context.Context, cfg *config.Config) (deviceListing, error)
 }
 
 type deviceInstance struct {

--- a/daemon/stats_unix_test.go
+++ b/daemon/stats_unix_test.go
@@ -3,28 +3,20 @@
 package daemon
 
 import (
-	"os"
-	"path/filepath"
+	_ "embed"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
+//go:embed testdata/stat
+var statData string
+
 func TestGetSystemCPUUsageParsing(t *testing.T) {
-	dummyFilePath := filepath.Join("testdata", "stat")
-	expectedCpuUsage := uint64(65647090000000)
-	expectedCpuNum := uint32(128)
-
-	origStatPath := procStatPath
-	procStatPath = dummyFilePath
-	defer func() { procStatPath = origStatPath }()
-
-	_, err := os.Stat(dummyFilePath)
-	assert.NilError(t, err)
-
-	cpuUsage, cpuNum, err := getSystemCPUUsage()
-
-	assert.Equal(t, cpuUsage, expectedCpuUsage)
-	assert.Equal(t, cpuNum, expectedCpuNum)
-	assert.NilError(t, err)
+	input := strings.NewReader(statData)
+	cpuUsage, cpuNum, _ := readSystemCPUUsage(input)
+	assert.Check(t, is.Equal(cpuUsage, uint64(65647090000000)))
+	assert.Check(t, is.Equal(cpuNum, uint32(128)))
 }

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,15 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.50 API changes
+
+[Docker Engine API v1.50](https://docs.docker.com/reference/api/engine/version/v1.50/) documentation
+
+* `GET /info` now includes a `DiscoveredDevices` field. This is an array of
+  `DeviceInfo` objects, each providing details about a device discovered by a
+  device driver.
+  Currently only the CDI device driver is supported.
+
 ## v1.49 API changes
 
 [Docker Engine API v1.49](https://docs.docker.com/reference/api/engine/version/v1.49/) documentation

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -21,6 +21,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   `DeviceInfo` objects, each providing details about a device discovered by a
   device driver.
   Currently only the CDI device driver is supported.
+* Deprecated: The `BridgeNfIptables` and `BridgeNfIp6tables` fields in the
+  `GET /info` response were deprecated in API v1.48, and are now omitted
+  in API v1.50.
 
 ## v1.49 API changes
 

--- a/errdefs/doc.go
+++ b/errdefs/doc.go
@@ -4,5 +4,5 @@
 // Packages should not reference these interfaces directly, only implement them.
 // To check if a particular error implements one of these interfaces, there are helper
 // functions provided (e.g. `Is<SomeError>`) which can be used rather than asserting the interfaces directly.
-// If you must assert on these interfaces, be sure to check the causal chain (`err.Cause()`).
+// If you must assert on these interfaces, be sure to check the causal chain (`err.Unwrap()`).
 package errdefs // import "github.com/docker/docker/errdefs"

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -8,6 +8,10 @@ import (
 
 var errTest = errors.New("this is a test")
 
+type wrapped interface {
+	Unwrap() error
+}
+
 func TestNotFound(t *testing.T) {
 	if IsNotFound(errTest) {
 		t.Fatalf("did not expect not found error, got %T", errTest)
@@ -16,7 +20,7 @@ func TestNotFound(t *testing.T) {
 	if !IsNotFound(e) {
 		t.Fatalf("expected not found error, got: %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -37,7 +41,7 @@ func TestConflict(t *testing.T) {
 	if !IsConflict(e) {
 		t.Fatalf("expected conflict error, got: %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -58,7 +62,7 @@ func TestForbidden(t *testing.T) {
 	if !IsForbidden(e) {
 		t.Fatalf("expected forbidden error, got: %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -79,7 +83,7 @@ func TestInvalidParameter(t *testing.T) {
 	if !IsInvalidParameter(e) {
 		t.Fatalf("expected invalid argument error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -100,7 +104,7 @@ func TestNotImplemented(t *testing.T) {
 	if !IsNotImplemented(e) {
 		t.Fatalf("expected not implemented error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -121,7 +125,7 @@ func TestNotModified(t *testing.T) {
 	if !IsNotModified(e) {
 		t.Fatalf("expected not modified error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -142,7 +146,7 @@ func TestUnauthorized(t *testing.T) {
 	if !IsUnauthorized(e) {
 		t.Fatalf("expected unauthorized error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -163,7 +167,7 @@ func TestUnknown(t *testing.T) {
 	if !IsUnknown(e) {
 		t.Fatalf("expected unknown error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -184,7 +188,7 @@ func TestCancelled(t *testing.T) {
 	if !IsCancelled(e) {
 		t.Fatalf("expected cancelled error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -205,7 +209,7 @@ func TestDeadline(t *testing.T) {
 	if !IsDeadline(e) {
 		t.Fatalf("expected deadline error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -226,7 +230,7 @@ func TestDataLoss(t *testing.T) {
 	if !IsDataLoss(e) {
 		t.Fatalf("expected data loss error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -247,7 +251,7 @@ func TestUnavailable(t *testing.T) {
 	if !IsUnavailable(e) {
 		t.Fatalf("expected unavaillable error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -268,7 +272,7 @@ func TestSystem(t *testing.T) {
 	if !IsSystem(e) {
 		t.Fatalf("expected system error, got %T", e)
 	}
-	if cause := e.(causer).Cause(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest {
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {

--- a/errdefs/is.go
+++ b/errdefs/is.go
@@ -3,119 +3,74 @@ package errdefs
 import (
 	"context"
 	"errors"
+
+	cerrdefs "github.com/containerd/errdefs"
 )
 
-type causer interface {
-	Cause() error
-}
-
-type wrapErr interface {
-	Unwrap() error
-}
-
-func getImplementer(err error) error {
-	switch e := err.(type) {
-	case
-		ErrNotFound,
-		ErrInvalidParameter,
-		ErrConflict,
-		ErrUnauthorized,
-		ErrUnavailable,
-		ErrForbidden,
-		ErrSystem,
-		ErrNotModified,
-		ErrNotImplemented,
-		ErrCancelled,
-		ErrDeadline,
-		ErrDataLoss,
-		ErrUnknown:
-		return err
-	case causer:
-		return getImplementer(e.Cause())
-	case wrapErr:
-		return getImplementer(e.Unwrap())
-	default:
-		return err
-	}
-}
-
 // IsNotFound returns if the passed in error is an [ErrNotFound],
-func IsNotFound(err error) bool {
-	_, ok := getImplementer(err).(ErrNotFound)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsNotFound]
+var IsNotFound = cerrdefs.IsNotFound
 
 // IsInvalidParameter returns if the passed in error is an [ErrInvalidParameter].
-func IsInvalidParameter(err error) bool {
-	_, ok := getImplementer(err).(ErrInvalidParameter)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsInvalidArgument]
+var IsInvalidParameter = cerrdefs.IsInvalidArgument
 
 // IsConflict returns if the passed in error is an [ErrConflict].
-func IsConflict(err error) bool {
-	_, ok := getImplementer(err).(ErrConflict)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsConflict]
+var IsConflict = cerrdefs.IsConflict
 
 // IsUnauthorized returns if the passed in error is an [ErrUnauthorized].
-func IsUnauthorized(err error) bool {
-	_, ok := getImplementer(err).(ErrUnauthorized)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsUnauthorized]
+var IsUnauthorized = cerrdefs.IsUnauthorized
 
 // IsUnavailable returns if the passed in error is an [ErrUnavailable].
-func IsUnavailable(err error) bool {
-	_, ok := getImplementer(err).(ErrUnavailable)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsUnavailable]
+var IsUnavailable = cerrdefs.IsUnavailable
 
 // IsForbidden returns if the passed in error is an [ErrForbidden].
-func IsForbidden(err error) bool {
-	_, ok := getImplementer(err).(ErrForbidden)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsPermissionDenied]
+var IsForbidden = cerrdefs.IsPermissionDenied
 
 // IsSystem returns if the passed in error is an [ErrSystem].
-func IsSystem(err error) bool {
-	_, ok := getImplementer(err).(ErrSystem)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsInternal]
+var IsSystem = cerrdefs.IsInternal
 
 // IsNotModified returns if the passed in error is an [ErrNotModified].
-func IsNotModified(err error) bool {
-	_, ok := getImplementer(err).(ErrNotModified)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsNotModified]
+var IsNotModified = cerrdefs.IsNotModified
 
 // IsNotImplemented returns if the passed in error is an [ErrNotImplemented].
-func IsNotImplemented(err error) bool {
-	_, ok := getImplementer(err).(ErrNotImplemented)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsNotImplemented]
+var IsNotImplemented = cerrdefs.IsNotImplemented
 
 // IsUnknown returns if the passed in error is an [ErrUnknown].
-func IsUnknown(err error) bool {
-	_, ok := getImplementer(err).(ErrUnknown)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsUnknown]
+var IsUnknown = cerrdefs.IsUnknown
 
 // IsCancelled returns if the passed in error is an [ErrCancelled].
-func IsCancelled(err error) bool {
-	_, ok := getImplementer(err).(ErrCancelled)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsCanceled]
+var IsCancelled = cerrdefs.IsCanceled
 
 // IsDeadline returns if the passed in error is an [ErrDeadline].
-func IsDeadline(err error) bool {
-	_, ok := getImplementer(err).(ErrDeadline)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsDeadlineExceeded]
+var IsDeadline = cerrdefs.IsDeadlineExceeded
 
 // IsDataLoss returns if the passed in error is an [ErrDataLoss].
-func IsDataLoss(err error) bool {
-	_, ok := getImplementer(err).(ErrDataLoss)
-	return ok
-}
+//
+// Deprecated: use containerd [cerrdefs.IsDataLoss]
+var IsDataLoss = cerrdefs.IsDataLoss
 
 // IsContext returns if the passed in error is due to context cancellation or deadline exceeded.
 func IsContext(err error) bool {

--- a/integration/build/build_cgroupns_linux_test.go
+++ b/integration/build/build_cgroupns_linux_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/integration/internal/requirement"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil"
@@ -54,7 +54,7 @@ func testBuildWithCgroupNs(ctx context.Context, t *testing.T, daemonNsMode strin
 	client := d.NewClientT(t)
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{"buildcgroupns"},

--- a/integration/build/build_squash_test.go
+++ b/integration/build/build_squash_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	dclient "github.com/docker/docker/client"
 	"github.com/docker/docker/integration/internal/container"
@@ -54,7 +54,7 @@ func TestBuildSquashParent(t *testing.T) {
 	name := strings.ToLower(t.Name())
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{name},
@@ -71,7 +71,7 @@ func TestBuildSquashParent(t *testing.T) {
 	// build with squash
 	resp, err = client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Squash:      true,

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
@@ -109,7 +109,7 @@ func TestBuildWithRemoveAndForceRemove(t *testing.T) {
 			_, err := tw.Write(dockerfile)
 			assert.NilError(t, err)
 			assert.NilError(t, tw.Close())
-			resp, err := client.ImageBuild(ctx, buff, types.ImageBuildOptions{Remove: tc.rm, ForceRemove: tc.forceRm, NoCache: true})
+			resp, err := client.ImageBuild(ctx, buff, build.ImageBuildOptions{Remove: tc.rm, ForceRemove: tc.forceRm, NoCache: true})
 			assert.NilError(t, err)
 			defer resp.Body.Close()
 			filter, err := buildContainerIdsFilter(resp.Body)
@@ -165,7 +165,7 @@ func TestBuildMultiStageCopy(t *testing.T) {
 			resp, err := apiclient.ImageBuild(
 				ctx,
 				source.AsTarReader(t),
-				types.ImageBuildOptions{
+				build.ImageBuildOptions{
 					Remove:      true,
 					ForceRemove: true,
 					Target:      target,
@@ -214,7 +214,7 @@ func TestBuildMultiStageParentConfig(t *testing.T) {
 	imgName := strings.ToLower(t.Name())
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
@@ -261,7 +261,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	// For `target-a` build
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
@@ -288,7 +288,7 @@ func TestBuildLabelWithTargets(t *testing.T) {
 	delete(testLabels, "label-a")
 	resp, err = apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
@@ -329,7 +329,7 @@ COPY    3/ /target/
 	apiclient := testEnv.APIClient()
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -365,7 +365,7 @@ RUN cat somefile`
 	apiclient := testEnv.APIClient()
 	resp, err := apiclient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -411,7 +411,7 @@ COPY bar /
 	apiclient := testEnv.APIClient()
 	resp, err := apiclient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -434,7 +434,7 @@ COPY bar /
 
 	resp, err = apiclient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -473,7 +473,7 @@ RUN [ ! -f foo ]
 	apiClient := testEnv.APIClient()
 	resp, err := apiClient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -519,7 +519,7 @@ RUN for g in $(seq 0 8); do dd if=/dev/urandom of=rnd bs=1K count=1 seek=$((1024
 	apiClient := testEnv.APIClient()
 	resp, err := apiClient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -560,7 +560,7 @@ COPY --from=intermediate C:\\stuff C:\\stuff
 	apiClient := testEnv.APIClient()
 	resp, err := apiClient.ImageBuild(ctx,
 		buf,
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 		})
@@ -625,7 +625,7 @@ func TestBuildWithEmptyDockerfile(t *testing.T) {
 
 			_, err = apiClient.ImageBuild(ctx,
 				buf,
-				types.ImageBuildOptions{
+				build.ImageBuildOptions{
 					Remove:      true,
 					ForceRemove: true,
 				})
@@ -655,7 +655,7 @@ func TestBuildPreserveOwnership(t *testing.T) {
 			resp, err := apiClient.ImageBuild(
 				ctx,
 				source.AsTarReader(t),
-				types.ImageBuildOptions{
+				build.ImageBuildOptions{
 					Remove:      true,
 					ForceRemove: true,
 					Target:      target,
@@ -683,7 +683,7 @@ func TestBuildPlatformInvalid(t *testing.T) {
 	err := w.Close()
 	assert.NilError(t, err)
 
-	_, err = testEnv.APIClient().ImageBuild(ctx, buf, types.ImageBuildOptions{
+	_, err = testEnv.APIClient().ImageBuild(ctx, buf, build.ImageBuildOptions{
 		Remove:      true,
 		ForceRemove: true,
 		Platform:    "foobar",
@@ -712,8 +712,8 @@ func TestBuildWorkdirNoCacheMiss(t *testing.T) {
 			apiClient := testEnv.APIClient()
 
 			buildAndGetID := func() string {
-				resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), types.ImageBuildOptions{
-					Version: types.BuilderV1,
+				resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), build.ImageBuildOptions{
+					Version: build.BuilderV1,
 				})
 				assert.NilError(t, err)
 				defer resp.Body.Close()
@@ -740,9 +740,9 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 
 	apiClient := testEnv.APIClient()
 
-	for _, builderVersion := range []types.BuilderVersion{types.BuilderV1, types.BuilderBuildKit} {
+	for _, builderVersion := range []build.BuilderVersion{build.BuilderV1, build.BuilderBuildKit} {
 		t.Run("v"+string(builderVersion), func(t *testing.T) {
-			if builderVersion == types.BuilderBuildKit {
+			if builderVersion == build.BuilderBuildKit {
 				skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Buildkit is not supported on Windows")
 			}
 
@@ -751,7 +751,7 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 
 			since := time.Now()
 
-			resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), types.ImageBuildOptions{
+			resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), build.ImageBuildOptions{
 				Version: builderVersion,
 				NoCache: true,
 			})
@@ -806,11 +806,11 @@ func TestBuildHistoryDoesNotPreventRemoval(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	buildImage := func(imgName string) error {
-		resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), types.ImageBuildOptions{
+		resp, err := apiClient.ImageBuild(ctx, source.AsTarReader(t), build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},
-			Version:     types.BuilderBuildKit,
+			Version:     build.BuilderBuildKit,
 		})
 		if err != nil {
 			return err

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -66,7 +66,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 
 	resp, err := clientUserRemap.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Tags: []string{imageTag},
 		})
 	assert.NilError(t, err)

--- a/integration/capabilities/capabilities_linux_test.go
+++ b/integration/capabilities/capabilities_linux_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -37,7 +37,7 @@ func TestNoNewPrivileges(t *testing.T) {
 	// Build image
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Tags: []string{imageTag},
 		})
 	assert.NilError(t, err)

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
@@ -57,7 +56,7 @@ func TestConfigList(t *testing.T) {
 	defer c.Close()
 
 	// This test case is ported from the original TestConfigsEmptyList
-	configs, err := c.ConfigList(ctx, types.ConfigListOptions{})
+	configs, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(configs), 0))
 
@@ -72,7 +71,7 @@ func TestConfigList(t *testing.T) {
 	config1ID := createConfig(ctx, t, c, testName1, []byte("TESTINGDATA1"), map[string]string{"type": "production"})
 
 	// test by `config ls`
-	entries, err := c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(configNamesFromList(entries), testNames))
 
@@ -110,7 +109,7 @@ func TestConfigList(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
-			entries, err = c.ConfigList(ctx, types.ConfigListOptions{
+			entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{
 				Filters: tc.filters,
 			})
 			assert.NilError(t, err)
@@ -357,7 +356,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	fakeName := configID
 	fakeID := createConfig(ctx, t, c, fakeName, []byte("fake foo"), nil)
 
-	entries, err := c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Contains(configNamesFromList(entries), configName))
 	assert.Assert(t, is.Contains(configNamesFromList(entries), fakeName))
@@ -366,7 +365,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Fake one will remain
-	entries, err = c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(configNamesFromList(entries), []string{fakeName}))
 
@@ -378,14 +377,14 @@ func TestConfigCreateResolve(t *testing.T) {
 	// - Partial ID (prefix)
 	err = c.ConfigRemove(ctx, configID[:5])
 	assert.Assert(t, nil != err)
-	entries, err = c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(configNamesFromList(entries), []string{fakeName}))
 
 	// Remove based on ID prefix of the fake one should succeed
 	err = c.ConfigRemove(ctx, fakeID[:5])
 	assert.NilError(t, err)
-	entries, err = c.ConfigList(ctx, types.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(0, len(entries)))
 }

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
@@ -196,7 +195,7 @@ func makeTestImage(ctx context.Context, t *testing.T) (imageID string) {
 	`))
 	defer buildCtx.Close()
 
-	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), types.ImageBuildOptions{})
+	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), build.ImageBuildOptions{})
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
@@ -270,7 +269,7 @@ func TestCopyFromContainer(t *testing.T) {
 	`))
 	defer buildCtx.Close()
 
-	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), types.ImageBuildOptions{})
+	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), build.ImageBuildOptions{})
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
@@ -200,7 +201,7 @@ func makeTestImage(ctx context.Context, t *testing.T) (imageID string) {
 	defer resp.Body.Close()
 
 	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
-		var r types.BuildResult
+		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID
 	})
@@ -275,7 +276,7 @@ func TestCopyFromContainer(t *testing.T) {
 
 	var imageID string
 	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
-		var r types.BuildResult
+		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID
 	})

--- a/integration/image/remove_unix_test.go
+++ b/integration/image/remove_unix_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/image"
 	_ "github.com/docker/docker/daemon/graphdriver/register" // register graph drivers
 	"github.com/docker/docker/daemon/images"
@@ -62,7 +62,7 @@ func TestRemoveImageGarbageCollector(t *testing.T) {
 	defer source.Close()
 	resp, err := client.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      true,
 			ForceRemove: true,
 			Tags:        []string{imgName},

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -32,7 +33,7 @@ func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fa
 func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 	var (
 		jm  jsonmessage.JSONMessage
-		br  types.BuildResult
+		br  build.Result
 		dec = json.NewDecoder(body)
 	)
 	for {

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
@@ -17,7 +16,7 @@ import (
 
 // Do builds an image from the given context and returns the image ID.
 func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fakecontext.Fake) string {
-	resp, err := client.ImageBuild(ctx, buildCtx.AsTarReader(t), types.ImageBuildOptions{})
+	resp, err := client.ImageBuild(ctx, buildCtx.AsTarReader(t), build.ImageBuildOptions{})
 	if resp.Body != nil {
 		defer resp.Body.Close()
 	}

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
@@ -54,7 +53,7 @@ func TestSecretList(t *testing.T) {
 	c := d.NewClientT(t)
 	defer c.Close()
 
-	configs, err := c.SecretList(ctx, types.SecretListOptions{})
+	configs, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(configs), 0))
 
@@ -70,7 +69,7 @@ func TestSecretList(t *testing.T) {
 	secret1ID := createSecret(ctx, t, c, testName1, []byte("TESTINGDATA1"), map[string]string{"type": "production"})
 
 	// test by `secret ls`
-	entries, err := c.SecretList(ctx, types.SecretListOptions{})
+	entries, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(secretNamesFromList(entries), testNames))
 
@@ -103,7 +102,7 @@ func TestSecretList(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		entries, err = c.SecretList(ctx, types.SecretListOptions{
+		entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{
 			Filters: tc.filters,
 		})
 		assert.NilError(t, err)
@@ -357,7 +356,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	fakeName := secretID
 	fakeID := createSecret(ctx, t, c, fakeName, []byte("fake foo"), nil)
 
-	entries, err := c.SecretList(ctx, types.SecretListOptions{})
+	entries, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(secretNamesFromList(entries), testName))
 	assert.Check(t, is.Contains(secretNamesFromList(entries), fakeName))
@@ -366,7 +365,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Fake one will remain
-	entries, err = c.SecretList(ctx, types.SecretListOptions{})
+	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(secretNamesFromList(entries), []string{fakeName}))
 
@@ -377,14 +376,14 @@ func TestSecretCreateResolve(t *testing.T) {
 	// - Partial ID (prefix)
 	err = c.SecretRemove(ctx, fakeName[:5])
 	assert.Assert(t, nil != err)
-	entries, err = c.SecretList(ctx, types.SecretListOptions{})
+	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(secretNamesFromList(entries), []string{fakeName}))
 
 	// Remove based on ID prefix of the fake one should succeed
 	err = c.SecretRemove(ctx, fakeID[:5])
 	assert.NilError(t, err)
-	entries, err = c.SecretList(ctx, types.SecretListOptions{})
+	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(0, len(entries)))
 }

--- a/integration/system/info_linux_test.go
+++ b/integration/system/info_linux_test.go
@@ -3,9 +3,13 @@
 package system // import "github.com/docker/docker/integration/system"
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -46,4 +50,57 @@ func TestInfoBinaryCommits(t *testing.T) {
 		assert.Check(t, info.RuncCommit.ID != "N/A")
 		assert.Check(t, is.Equal(info.RuncCommit.Expected, info.RuncCommit.ID)) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.49.
 	})
+}
+
+func TestInfoLegacyFields(t *testing.T) {
+	ctx := setupTest(t)
+
+	const notPresent = "expected field to not be present"
+
+	tests := []struct {
+		name           string
+		url            string
+		expectedFields map[string]any
+	}{
+		{
+			name: "api v1.49 legacy bridge-nftables",
+			url:  "/v1.49/info",
+			expectedFields: map[string]any{
+				"BridgeNfIp6tables": false,
+				"BridgeNfIptables":  false,
+			},
+		},
+		{
+			name: "api v1.50 legacy bridge-nftables",
+			url:  "/v1.50/info",
+			expectedFields: map[string]any{
+				"BridgeNfIp6tables": notPresent,
+				"BridgeNfIptables":  notPresent,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			res, _, err := request.Get(ctx, tc.url)
+			assert.NilError(t, err)
+			assert.Equal(t, res.StatusCode, http.StatusOK)
+			body, err := io.ReadAll(res.Body)
+			assert.NilError(t, err)
+
+			actual := map[string]any{}
+			err = json.Unmarshal(body, &actual)
+			assert.NilError(t, err, string(body))
+
+			for field, expectedValue := range tc.expectedFields {
+				if expectedValue == notPresent {
+					_, found := actual[field]
+					assert.Assert(t, !found, "field %s should not be present", field)
+				} else {
+					_, found := actual[field]
+					assert.Assert(t, found, "field %s should be present", field)
+					assert.Check(t, is.DeepEqual(actual[field], expectedValue))
+				}
+			}
+		})
+	}
 }

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
@@ -110,9 +110,9 @@ func TestPingBuilderHeader(t *testing.T) {
 		d.Start(t)
 		defer d.Stop(t)
 
-		expected := types.BuilderBuildKit
+		expected := build.BuilderBuildKit
 		if runtime.GOOS == "windows" {
-			expected = types.BuilderV1
+			expected = build.BuilderV1
 		}
 
 		p, err := apiClient.Ping(ctx)
@@ -128,7 +128,7 @@ func TestPingBuilderHeader(t *testing.T) {
 		d.Start(t, "--config-file", cfg)
 		defer d.Stop(t)
 
-		expected := types.BuilderV1
+		expected := build.BuilderV1
 		p, err := apiClient.Ping(ctx)
 		assert.NilError(t, err)
 		assert.Equal(t, p.BuilderVersion, expected)

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
@@ -330,7 +330,7 @@ func setupTestImage(t *testing.T, ctx context.Context, apiClient client.APIClien
 
 	resp, err := apiClient.ImageBuild(ctx,
 		source.AsTarReader(t),
-		types.ImageBuildOptions{
+		build.ImageBuildOptions{
 			Remove:      false,
 			ForceRemove: false,
 			Tags:        []string{imgName},

--- a/libnetwork/drivers/bridge/internal/firewaller/stub.go
+++ b/libnetwork/drivers/bridge/internal/firewaller/stub.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22 && linux
+//go:build go1.23 && linux
 
 package firewaller
 

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -24,16 +24,6 @@ type SysInfo struct {
 	// Whether IPv4 forwarding is supported or not, if this was disabled, networking will not work
 	IPv4ForwardingDisabled bool
 
-	// Whether bridge-nf-call-iptables is supported or not
-	//
-	// Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
-	BridgeNFCallIPTablesDisabled bool
-
-	// Whether bridge-nf-call-ip6tables is supported or not
-	//
-	// Deprecated: netfilter module is now loaded on-demand and no longer during daemon startup, making this field obsolete. This field is always false and will be removed in the next release.
-	BridgeNFCallIP6TablesDisabled bool
-
 	// Whether the cgroup has the mountpoint of "devices" or not
 	CgroupDevicesEnabled bool
 

--- a/testutil/daemon/config.go
+++ b/testutil/daemon/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 )
@@ -29,7 +28,7 @@ func (d *Daemon) ListConfigs(t testing.TB) []swarm.Config {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	configs, err := cli.ConfigList(context.Background(), types.ConfigListOptions{})
+	configs, err := cli.ConfigList(context.Background(), swarm.ConfigListOptions{})
 	assert.NilError(t, err)
 	return configs
 }

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -478,6 +478,8 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	}
 
 	d.args = append(d.args,
+		// Make sure we don't use the environment-provided global config file.
+		"--config-file", "/dev/null",
 		"--data-root", d.Root,
 		"--exec-root", d.execRoot,
 		"--pidfile", d.pidFile,

--- a/testutil/daemon/secret.go
+++ b/testutil/daemon/secret.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 )
@@ -30,7 +29,7 @@ func (d *Daemon) ListSecrets(t testing.TB) []swarm.Secret {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	secrets, err := cli.SecretList(context.Background(), types.SecretListOptions{})
+	secrets, err := cli.SecretList(context.Background(), swarm.SecretListOptions{})
 	assert.NilError(t, err)
 	return secrets
 }

--- a/testutil/environment/protect_linux.go
+++ b/testutil/environment/protect_linux.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.22
+//go:build go1.23
 
 package environment
 

--- a/testutil/fakestorage/fixtures.go
+++ b/testutil/fakestorage/fixtures.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	"github.com/moby/go-archive"
 	"gotest.tools/v3/assert"
 )
@@ -74,7 +74,7 @@ func ensureHTTPServerImage(t testing.TB) {
 	c := testEnv.APIClient()
 	reader, err := archive.TarWithOptions(tmp, &archive.TarOptions{})
 	assert.NilError(t, err)
-	resp, err := c.ImageBuild(context.Background(), reader, types.ImageBuildOptions{
+	resp, err := c.ImageBuild(context.Background(), reader, build.ImageBuildOptions{
 		Remove:      true,
 		ForceRemove: true,
 		Tags:        []string{"httpserver"},

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
@@ -145,7 +145,7 @@ func newRemoteFileServer(t testing.TB, ctx *fakecontext.Fake, c client.APIClient
 COPY . /static`); err != nil {
 		t.Fatal(err)
 	}
-	resp, err := c.ImageBuild(context.Background(), ctx.AsTarReader(t), types.ImageBuildOptions{
+	resp, err := c.ImageBuild(context.Background(), ctx.AsTarReader(t), build.ImageBuildOptions{
 		NoCache: true,
 		Tags:    []string{imgName},
 	})

--- a/volume/service/errors.go
+++ b/volume/service/errors.go
@@ -85,22 +85,21 @@ func IsNameConflict(err error) bool {
 	return isErr(err, errNameConflict)
 }
 
-type causal interface {
-	Cause() error
-}
-
-type wrapErr interface {
-	Unwrap() error
-}
-
 func isErr(err error, expected error) bool {
 	switch pe := err.(type) {
 	case nil:
 		return false
-	case wrapErr:
-		return isErr(pe.Unwrap(), expected)
-	case causal:
+	case interface{ Cause() error }:
 		return isErr(pe.Cause(), expected)
+	case interface{ Unwrap() error }:
+		return isErr(pe.Unwrap(), expected)
+	case interface{ Unwrap() []error }:
+		for _, ue := range pe.Unwrap() {
+			if isErr(ue, expected) {
+				return true
+			}
+		}
+		return false
 	}
 	return err == expected
 }


### PR DESCRIPTION
This PR implements : https://github.com/moby/moby/issues/49934

This change is inspired by this commit : https://github.com/kubernetes/system-validators/pull/41/files
as well as : https://github.com/k0sproject/k0s/pull/5735/files

**- What I did**
* Verify which cgroup is currently mounted
* Adapt checks depending if running cgroup or cgroup2
* This script is POSIX compliant

**- How to verify it**
* execute the updated script  `contrib/check-config.sh` on RHEL8 / RHEL9 / openSuse MicroOS / openSUSE Tumbleweed

**- Human readable description for the release notes**

```markdown changelog
Relax kernel configuration checks for cgroup v2
```