### PR TITLE
daemon/create: Simplify `GetImage` args

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -78,7 +78,7 @@ func (daemon *Daemon) containerCreate(ctx context.Context, daemonCfg *configStor
 	}
 
 	if opts.params.Platform == nil && opts.params.Config.Image != "" {
-		img, err := daemon.imageService.GetImage(ctx, opts.params.Config.Image, backend.GetImageOpts{Platform: opts.params.Platform})
+		img, err := daemon.imageService.GetImage(ctx, opts.params.Config.Image, backend.GetImageOpts{})
 		if err != nil {
 			return containertypes.CreateResponse{}, err
 		}


### PR DESCRIPTION
`opts.params.Platform` is always nil inside this branch so we can omit it from the `GetImage` call to make it less confusing.
