### PR TITLE
validation: re-enable check for changes in integration-cli"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,9 +104,8 @@ jobs:
       -
         name: Create matrix
         id: scripts
-        # FIXME(thaJeztah): re-enable deprecate-integration-cli once https://github.com/moby/moby/pull/42300 is merged
         run: |
-          scripts=$(cd ./hack/validate && jq -nc '$ARGS.positional - ["all", "default", "dco", "deprecate-integration-cli"] | map(select(test("[.]")|not)) + ["generate-files"]' --args *)
+          scripts=$(cd ./hack/validate && jq -nc '$ARGS.positional - ["all", "default", "dco"] | map(select(test("[.]")|not)) + ["generate-files"]' --args *)
           echo "matrix=$scripts" >> $GITHUB_OUTPUT
       -
         name: Show matrix


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/42300

This reverts commit a891e4e3e15ddfc5bbf19089ff31ec840c76ed4a.


**- A picture of a cute animal (not mandatory but encouraged)**

