### PR TITLE
nftables: rules for the internal DNS resolver

### DIFF
--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -180,8 +180,8 @@ func (r *Resolver) Start() error {
 		return r.err
 	}
 
-	if err := r.setupIPTable(); err != nil {
-		return fmt.Errorf("setting up IP table rules failed: %v", err)
+	if err := r.setupNAT(context.TODO()); err != nil {
+		return fmt.Errorf("setting up DNAT/SNAT rules failed: %v", err)
 	}
 
 	s := &dns.Server{Handler: dns.HandlerFunc(r.serveDNS), PacketConn: r.conn}

--- a/libnetwork/resolver_windows.go
+++ b/libnetwork/resolver_windows.go
@@ -2,6 +2,8 @@
 
 package libnetwork
 
-func (r *Resolver) setupIPTable() error {
+import "context"
+
+func (r *Resolver) setupNAT(context.Context) error {
 	return nil
 }


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49637

When nftables is enabled, use nftables instead of iptables to redirect DNS requests from containers to the internal DNS resolver.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

