### PR TITLE
nftables: don't create DOCKER-USER iptables chains

### DIFF
--- a/libnetwork/firewall_linux.go
+++ b/libnetwork/firewall_linux.go
@@ -24,6 +24,11 @@ func (c *Controller) selectFirewallBackend() {
 // Sets up the DOCKER-USER chain for each iptables version (IPv4, IPv6) that's
 // enabled in the controller's configuration.
 func (c *Controller) setupUserChains() {
+	// There's no equivalent to DOCKER-USER in the nftables implementation.
+	if nftables.Enabled() {
+		return
+	}
+
 	setup := func() error {
 		var errs []error
 		for _, ipVersion := range c.enabledIptablesVersions() {

--- a/libnetwork/firewall_linux_test.go
+++ b/libnetwork/firewall_linux_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/libnetwork/drivers/bridge"
-
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
+	"github.com/docker/docker/libnetwork/drivers/bridge"
+	"github.com/docker/docker/libnetwork/internal/nftables"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/options"
@@ -17,6 +17,7 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/skip"
 )
 
 const (
@@ -71,6 +72,7 @@ func TestUserChain(t *testing.T) {
 				}))
 			assert.NilError(t, err)
 			defer c.Stop()
+			skip.If(t, nftables.Enabled(), "nftables is enabled, skipping iptables test")
 
 			// init. condition
 			golden.Assert(t, getRules(t, iptable4, fwdChainName),


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49643

We might be able to preserve the jumps to the `DOCKER-USER` iptables chains, as described in https://github.com/moby/moby/issues/49643. But, for now just don't create the chains.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

