### PR TITLE
daemon: restore: fix fluentd-async-connect migration for downgrades

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -335,10 +335,11 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 				// deprecated in v20.10 in favor of 'fluentd-async', and
 				// removed in v28.0.
 				// TODO(aker): remove this migration once the next LTS version of MCR is released.
-				if _, ok := c.HostConfig.LogConfig.Config["fluentd-async-connect"]; ok {
+				if v, ok := c.HostConfig.LogConfig.Config["fluentd-async-connect"]; ok {
 					if _, ok := c.HostConfig.LogConfig.Config["fluentd-async"]; !ok {
-						c.HostConfig.LogConfig.Config["fluentd-async"] = c.HostConfig.LogConfig.Config["fluentd-async-connect"]
+						c.HostConfig.LogConfig.Config["fluentd-async"] = v
 					}
+					delete(c.HostConfig.LogConfig.Config, "fluentd-async-connect")
 				}
 			}
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/46114
- https://github.com/moby/moby/pull/39086


The "fluentd-async-connect" option was deprecated in 20.10 through cc1f3c750e1da19c02be13ffd71d882af3e23c4a, and removed in 28.0 trough 49ec488036d9702df8432ec0e6f33c170a4a2bbe, which added migration code on daemon startup.

However, the migration code _copied_ the deprecated option to the new ("fluentd-async") option, preserving the old field. Doing so could cause an issue if a user would downgrade the daemon to a previous release, as the changes in cc1f3c750e1da19c02be13ffd71d882af3e23c4a invalidate a config that has both fields set (see [daemon/logger/fluentd/fluentd.go#L198-L200]);

```go
if cfg[asyncKey] != "" && cfg[asyncConnectKey] != "" {
    return config, errors.Errorf("conflicting options: cannot specify both '%s' and '%s", asyncKey, asyncConnectKey)
}
```

This patch updates the migration code to remove the deprecated option.

[daemon/logger/fluentd/fluentd.go#L198-L200]: https://github.com/moby/moby/blob/cc1f3c750e1da19c02be13ffd71d882af3e23c4a/daemon/logger/fluentd/fluentd.go#L198-L200

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

