### PR TITLE
[25.0] daemon: restore: migrate deprecated fluentd-async-connect

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -373,6 +373,16 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 						Type: local.Name,
 					}
 				}
+
+				// The logger option 'fluentd-async-connect' has been
+				// deprecated in v20.10 in favor of 'fluentd-async', and
+				// removed in v28.0.
+				if v, ok := c.HostConfig.LogConfig.Config["fluentd-async-connect"]; ok {
+					if _, ok := c.HostConfig.LogConfig.Config["fluentd-async"]; !ok {
+						c.HostConfig.LogConfig.Config["fluentd-async"] = v
+					}
+					delete(c.HostConfig.LogConfig.Config, "fluentd-async-connect")
+				}
 			}
 
 			if err := daemon.checkpointAndSave(c); err != nil {


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/46114
- https://github.com/moby/moby/pull/39086
- https://github.com/moby/moby/pull/50055


The "fluentd-async-connect" option was deprecated in 20.10 through cc1f3c750e1da19c02be13ffd71d882af3e23c4a, and removed in 28.0 trough 49ec488036d9702df8432ec0e6f33c170a4a2bbe, which added migration code on daemon startup.

This patch ports the migration code to the 25.0 branch to prevent future disruption when upgrading existing containers to a new version of the daemon.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

