### PR TITLE
dockerd-rootless-setuptool.sh: Fix silent stop on error due to using output redirection together wit…

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -238,12 +238,13 @@ init() {
 	fi
 
 	# instructions: validate subuid for current user
+	error_subid=
 	if command -v "getsubids" > /dev/null 2>&1; then
-		getsubids "$USERNAME" > /dev/null 2>&1 || getsubids "$(id -u)" > /dev/null 2>&1
+		getsubids "$USERNAME" > /dev/null 2>&1 || getsubids "$(id -u)" > /dev/null 2>&1 || error_subid=1
 	else
-		grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subuid 2> /dev/null
+		grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subuid 2> /dev/null || error_subid=1
 	fi
-	if [ $? -ne 0 ]; then
+	if [ "$error_subid" = "1" ]; then
 		instructions=$(
 			cat <<- EOI
 				${instructions}
@@ -254,12 +255,13 @@ init() {
 	fi
 
 	# instructions: validate subgid for current user
+	error_subid=
 	if command -v "getsubids" > /dev/null 2>&1; then
-		getsubids -g "$USERNAME" > /dev/null 2>&1 || getsubids -g "$(id -u)" > /dev/null 2>&1
+		getsubids -g "$USERNAME" > /dev/null 2>&1 || getsubids -g "$(id -u)" > /dev/null 2>&1 || error_subid=1
 	else
-		grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subgid 2> /dev/null
+		grep -q "^$USERNAME_ESCAPED:\|^$(id -u):" /etc/subgid 2> /dev/null || error_subid=1
 	fi
-	if [ $? -ne 0 ]; then
+	if [ "$error_subid" = "1" ]; then
 		instructions=$(
 			cat <<- EOI
 				${instructions}


### PR DESCRIPTION
dockerd-rootless-setuptool.sh: Fix silent stop on error when subuid/subgid system requirements are not satisfied.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Use an account without relevant entries in /etc/subuid or /etc/subgid and run `dockerd-rootless-setuptool.sh check` or `dockerd-rootless-setuptool.sh install`. It should print '[ERROR] ...' instead of silently returns.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`dockerd-rootless-setuptool.sh`: Fix the script from silently returning with no error message when subuid/subgid system requirements are not satisfied.
```

**- A picture of a cute animal (not mandatory but encouraged)**

