### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -410,7 +410,7 @@ func (b *limitedBuffer) Write(data []byte) (int, error) {
 
 	bufLen := b.buf.Len()
 	dataLen := len(data)
-	keep := minInt(maxOutputLen-bufLen, dataLen)
+	keep := min(maxOutputLen-bufLen, dataLen)
 	if keep > 0 {
 		b.buf.Write(data[:keep])
 	}
@@ -438,13 +438,6 @@ func timeoutWithDefault(configuredValue time.Duration, defaultValue time.Duratio
 		return defaultValue
 	}
 	return configuredValue
-}
-
-func minInt(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
 }
 
 func getShell(cntr *container.Container) []string {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

use the built-in max/min to simplify the code


**- A picture of a cute animal (not mandatory but encouraged)**

![947bbc698980a9a13dff93606efc94de](https://github.com/user-attachments/assets/7a1c2752-4363-4f8f-b5a3-6fdeb334d356)

