### PR TITLE
refactor: replace uses of errdefs package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -251,11 +251,6 @@ linters:
         linters:
           - forbidigo
 
-        # FIXME(dmcgowan): ignoring while transitioning to containerd/errdefs
-      - text: "SA1019: errdefs\\.(.*) is deprecated"
-        linters:
-          - staticcheck
-
     # Log a warning if an exclusion rule is unused.
     # Default: false
     warn-unused: true

--- a/api/server/httputils/form_test.go
+++ b/api/server/httputils/form_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -225,7 +225,7 @@ func TestDecodePlatform(t *testing.T) {
 			p, err := DecodePlatform(tc.platformJSON)
 			assert.Check(t, is.DeepEqual(p, tc.expected))
 			if tc.expectedErr != "" {
-				assert.Check(t, errdefs.IsInvalidParameter(err))
+				assert.Check(t, cerrdefs.IsInvalidArgument(err))
 				assert.Check(t, is.Error(err, tc.expectedErr))
 			} else {
 				assert.Check(t, err)

--- a/api/server/router/volume/volume_routes.go
+++ b/api/server/router/volume/volume_routes.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/filters"
@@ -69,7 +70,7 @@ func (v *volumeRouter) getVolumeByName(ctx context.Context, w http.ResponseWrite
 	// if the volume is not found in the regular volume backend, and the client
 	// is using an API version greater than 1.42 (when cluster volumes were
 	// introduced), then check if Swarm has the volume.
-	if errdefs.IsNotFound(err) && versions.GreaterThanOrEqualTo(version, clusterVolumesVersion) && v.cluster.IsManager() {
+	if cerrdefs.IsNotFound(err) && versions.GreaterThanOrEqualTo(version, clusterVolumesVersion) && v.cluster.IsManager() {
 		swarmVol, err := v.cluster.GetVolume(vars["name"])
 		// if swarm returns an error and that error indicates that swarm is not
 		// initialized, return original NotFound error. Otherwise, we'd return
@@ -164,7 +165,7 @@ func (v *volumeRouter) deleteVolumes(ctx context.Context, w http.ResponseWriter,
 	// errors at this stage. Note that no "not found" error is produced if
 	// "force" is enabled.
 	err := v.backend.Remove(ctx, vars["name"], opts.WithPurgeOnError(force))
-	if err != nil && !errdefs.IsNotFound(err) {
+	if err != nil && !cerrdefs.IsNotFound(err) {
 		return err
 	}
 
@@ -172,7 +173,7 @@ func (v *volumeRouter) deleteVolumes(ctx context.Context, w http.ResponseWriter,
 	// is enabled, the volume backend won't return an error for non-existing
 	// volumes, so we don't know if removal succeeded (or not volume existed).
 	// In that case we always try to delete cluster volumes as well.
-	if errdefs.IsNotFound(err) || force {
+	if cerrdefs.IsNotFound(err) || force {
 		version := httputils.VersionFromContext(ctx)
 		if versions.GreaterThanOrEqualTo(version, clusterVolumesVersion) && v.cluster.IsManager() {
 			err = v.cluster.RemoveVolume(vars["name"], force)

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
@@ -47,7 +48,7 @@ func TestGetVolumeByNameNotFoundNoSwarm(t *testing.T) {
 	_, err := callGetVolume(v, "notReal")
 
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsNotFound(err))
+	assert.Assert(t, cerrdefs.IsNotFound(err))
 }
 
 func TestGetVolumeByNameNotFoundNotManager(t *testing.T) {
@@ -59,7 +60,7 @@ func TestGetVolumeByNameNotFoundNotManager(t *testing.T) {
 	_, err := callGetVolume(v, "notReal")
 
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsNotFound(err))
+	assert.Assert(t, cerrdefs.IsNotFound(err))
 }
 
 func TestGetVolumeByNameNotFound(t *testing.T) {
@@ -71,7 +72,7 @@ func TestGetVolumeByNameNotFound(t *testing.T) {
 	_, err := callGetVolume(v, "notReal")
 
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsNotFound(err))
+	assert.Assert(t, cerrdefs.IsNotFound(err))
 }
 
 func TestGetVolumeByNameFoundRegular(t *testing.T) {
@@ -238,7 +239,7 @@ func TestCreateSwarmVolumeNoSwarm(t *testing.T) {
 	resp := httptest.NewRecorder()
 	err = v.postVolumesCreate(ctx, resp, req, nil)
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsUnavailable(err))
+	assert.Assert(t, cerrdefs.IsUnavailable(err))
 }
 
 func TestCreateSwarmVolumeNotManager(t *testing.T) {
@@ -267,7 +268,7 @@ func TestCreateSwarmVolumeNotManager(t *testing.T) {
 	resp := httptest.NewRecorder()
 	err = v.postVolumesCreate(ctx, resp, req, nil)
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsUnavailable(err))
+	assert.Assert(t, cerrdefs.IsUnavailable(err))
 }
 
 func TestCreateVolumeCluster(t *testing.T) {
@@ -376,7 +377,7 @@ func TestUpdateVolumeNoSwarm(t *testing.T) {
 
 	err = v.putVolumesUpdate(ctx, resp, req, map[string]string{"name": "vol1"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsUnavailable(err))
+	assert.Assert(t, cerrdefs.IsUnavailable(err))
 }
 
 func TestUpdateVolumeNotFound(t *testing.T) {
@@ -408,7 +409,7 @@ func TestUpdateVolumeNotFound(t *testing.T) {
 
 	err = v.putVolumesUpdate(ctx, resp, req, map[string]string{"name": "vol1"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsNotFound(err))
+	assert.Assert(t, cerrdefs.IsNotFound(err))
 }
 
 func TestVolumeRemove(t *testing.T) {
@@ -476,7 +477,7 @@ func TestVolumeRemoveNotFoundNoSwarm(t *testing.T) {
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsNotFound(err), err.Error())
+	assert.Assert(t, cerrdefs.IsNotFound(err), err.Error())
 }
 
 func TestVolumeRemoveNotFoundNoManager(t *testing.T) {
@@ -493,7 +494,7 @@ func TestVolumeRemoveNotFoundNoManager(t *testing.T) {
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsNotFound(err))
+	assert.Assert(t, cerrdefs.IsNotFound(err))
 }
 
 func TestVolumeRemoveFoundNoSwarm(t *testing.T) {
@@ -540,7 +541,7 @@ func TestVolumeRemoveNoSwarmInUse(t *testing.T) {
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "inuse"})
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsConflict(err))
+	assert.Assert(t, cerrdefs.IsConflict(err))
 }
 
 func TestVolumeRemoveSwarmForce(t *testing.T) {
@@ -569,7 +570,7 @@ func TestVolumeRemoveSwarmForce(t *testing.T) {
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
 
 	assert.Assert(t, err != nil)
-	assert.Assert(t, errdefs.IsConflict(err))
+	assert.Assert(t, cerrdefs.IsConflict(err))
 
 	ctx = context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
 	req = httptest.NewRequest(http.MethodDelete, "/volumes/vol1?force=1", nil)

--- a/api/types/container/hostconfig_test.go
+++ b/api/types/container/hostconfig_test.go
@@ -102,7 +102,7 @@ func TestValidateRestartPolicy(t *testing.T) {
 	}
 }
 
-// isInvalidParameter is a minimal implementation of [github.com/docker/docker/errdefs.IsInvalidParameter],
+// isInvalidParameter is a minimal implementation of [github.com/containerd/errdefs.IsInvalidArgument],
 // because this was the only import of that package in api/types, which is the
 // package imported by external users.
 func isInvalidParameter(err error) bool {

--- a/builder/dockerfile/containerbackend.go
+++ b/builder/dockerfile/containerbackend.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/builder"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 )
@@ -126,7 +126,7 @@ func (e *statusCodeError) StatusCode() int {
 // RemoveAll containers managed by this container manager
 func (c *containerManager) RemoveAll(stdout io.Writer) {
 	for containerID := range c.tmpContainers {
-		if err := c.backend.ContainerRm(containerID, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil && !errdefs.IsNotFound(err) {
+		if err := c.backend.ContainerRm(containerID, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil && !cerrdefs.IsNotFound(err) {
 			_, _ = fmt.Fprintf(stdout, "Removing intermediate container %s: %v\n", stringid.TruncateID(containerID), err)
 			continue
 		}

--- a/container/container.go
+++ b/container/container.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/pkg/cio"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -814,7 +815,7 @@ func (container *Container) RestoreTask(ctx context.Context, client libcontainer
 		return err
 	}
 	container.task, err = container.ctr.AttachTask(ctx, container.InitializeStdio)
-	if err != nil && !errdefs.IsNotFound(err) {
+	if err != nil && !cerrdefs.IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/container/view_test.go
+++ b/container/view_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/google/uuid"
 	"gotest.tools/v3/assert"
@@ -87,7 +87,7 @@ func TestNames(t *testing.T) {
 	assert.Check(t, db.ReserveName("name2", "containerid2"))
 
 	err = db.ReserveName("name2", "containerid3")
-	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 	assert.Check(t, is.Error(err, "name is reserved"))
 
 	// Releasing a name allows the name to point to something else later.
@@ -105,7 +105,7 @@ func TestNames(t *testing.T) {
 	assert.Check(t, is.Equal("containerid3", id))
 
 	_, err = view.GetID("notreserved")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.Error(err, "name is not reserved"))
 
 	// Releasing and re-reserving a name doesn't affect the snapshot.
@@ -163,7 +163,7 @@ func TestTruncIndex(t *testing.T) {
 
 	// Get on an empty index
 	_, err = db.GetByPrefix("foobar")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 
 	// Add an id
 	const id = "99b36c2c326ccc11e726eee6ee78a0baf166ef96"

--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
 )
@@ -22,7 +23,7 @@ func (daemon *Daemon) ContainerStatPath(name string, path string) (*container.Pa
 			return nil, containerFileNotFound{path, name}
 		}
 		// TODO(thaJeztah): check if daemon.containerStatPath returns any errors that are not typed; if not, then return as-is
-		if errdefs.IsInvalidParameter(err) {
+		if cerrdefs.IsInvalidArgument(err) {
 			return nil, err
 		}
 		return nil, errdefs.System(err)
@@ -45,7 +46,7 @@ func (daemon *Daemon) ContainerArchivePath(name string, path string) (content io
 			return nil, nil, containerFileNotFound{path, name}
 		}
 		// TODO(thaJeztah): check if daemon.containerArchivePath returns any errors that are not typed; if not, then return as-is
-		if errdefs.IsInvalidParameter(err) {
+		if cerrdefs.IsInvalidArgument(err) {
 			return nil, nil, err
 		}
 		return nil, nil, errdefs.System(err)
@@ -71,7 +72,7 @@ func (daemon *Daemon) ContainerExtractToDir(name, path string, copyUIDGID, noOve
 			return containerFileNotFound{path, name}
 		}
 		// TODO(thaJeztah): check if daemon.containerExtractToDir returns any errors that are not typed; if not, then return as-is
-		if errdefs.IsInvalidParameter(err) {
+		if cerrdefs.IsInvalidArgument(err) {
 			return err
 		}
 		return errdefs.System(err)

--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -5,13 +5,13 @@ import (
 	"io"
 	"net/http"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm/runtime"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/plugin"
 	v2 "github.com/docker/docker/plugin/v2"
 	"github.com/gogo/protobuf/proto"
@@ -200,7 +200,7 @@ func (p *Controller) Wait(ctx context.Context) error {
 }
 
 func isNotFound(err error) bool {
-	return errdefs.IsNotFound(err)
+	return cerrdefs.IsNotFound(err)
 }
 
 // Shutdown is the shutdown phase from swarmkit

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/go-connections/nat"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -66,7 +66,7 @@ func (r *controller) Task() (*api.Task, error) {
 func (r *controller) ContainerStatus(ctx context.Context) (*api.ContainerStatus, error) {
 	ctnr, err := r.adapter.inspect(ctx)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -77,7 +77,7 @@ func (r *controller) ContainerStatus(ctx context.Context) (*api.ContainerStatus,
 func (r *controller) PortStatus(ctx context.Context) (*api.PortStatus, error) {
 	ctnr, err := r.adapter.inspect(ctx)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil, nil
 		}
 
@@ -179,7 +179,7 @@ func (r *controller) Prepare(ctx context.Context) error {
 		}
 	}
 	if err := r.adapter.create(ctx); err != nil {
-		if errdefs.IsConflict(err) {
+		if cerrdefs.IsConflict(err) {
 			if _, err := r.adapter.inspect(ctx); err != nil {
 				return err
 			}
@@ -382,7 +382,7 @@ func (r *controller) Shutdown(ctx context.Context) error {
 	}
 
 	if err := r.adapter.shutdown(ctx); err != nil {
-		if !errdefs.IsNotFound(err) && !errdefs.IsNotModified(err) {
+		if !cerrdefs.IsNotFound(err) && !cerrdefs.IsNotModified(err) {
 			return err
 		}
 	}
@@ -390,7 +390,7 @@ func (r *controller) Shutdown(ctx context.Context) error {
 	// Try removing networks referenced in this task in case this
 	// task is the last one referencing it
 	if err := r.adapter.removeNetworks(ctx); err != nil {
-		if !errdefs.IsNotFound(err) {
+		if !cerrdefs.IsNotFound(err) {
 			return err
 		}
 	}
@@ -409,7 +409,7 @@ func (r *controller) Terminate(ctx context.Context) error {
 	}
 
 	if err := r.adapter.terminate(ctx); err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil
 		}
 
@@ -431,7 +431,7 @@ func (r *controller) Remove(ctx context.Context) error {
 
 	// It may be necessary to shut down the task before removing it.
 	if err := r.Shutdown(ctx); err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil
 		}
 		// This may fail if the task was already shut down.
@@ -439,7 +439,7 @@ func (r *controller) Remove(ctx context.Context) error {
 	}
 
 	if err := r.adapter.remove(ctx); err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil
 		}
 
@@ -462,7 +462,7 @@ func (r *controller) waitReady(pctx context.Context) error {
 
 	ctnr, err := r.adapter.inspect(ctx)
 	if err != nil {
-		if !errdefs.IsNotFound(err) {
+		if !cerrdefs.IsNotFound(err) {
 			return errors.Wrap(err, "inspect container failed")
 		}
 	} else {

--- a/daemon/cluster/volumes.go
+++ b/daemon/cluster/volumes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	cerrdefs "github.com/containerd/errdefs"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/daemon/cluster/convert"
 	"github.com/docker/docker/errdefs"
@@ -90,7 +91,7 @@ func (c *Cluster) RemoveVolume(nameOrID string, force bool) error {
 	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
 		volume, err := getVolume(ctx, state.controlClient, nameOrID)
 		if err != nil {
-			if force && errdefs.IsNotFound(err) {
+			if force && cerrdefs.IsNotFound(err) {
 				return nil
 			}
 			return err

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -899,7 +900,7 @@ func (daemon *Daemon) getNetworkedContainer(containerID, connectedContainerPrefi
 	nc, err := daemon.GetContainer(connectedContainerPrefixOrName)
 	if err != nil {
 		err = fmt.Errorf("joining network namespace of container: %w", err)
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			// Deliberately masking "not found" errors, because failing to find
 			// the network container is a system error. We return a system error,
 			// not an "invalid parameter" because getNetworkedContainer is called

--- a/daemon/containerd/cache.go
+++ b/daemon/containerd/cache.go
@@ -85,7 +85,7 @@ func (c cacheAdaptor) Get(id image.ID) (*image.Image, error) {
 
 			var config container.Config
 			if err := readJSON(ctx, c.is.content, configDesc, &config); err != nil {
-				if !errdefs.IsNotFound(err) {
+				if !cerrdefs.IsNotFound(err) {
 					log.G(ctx).WithFields(log.Fields{
 						"configDigest": dgst,
 						"error":        err,

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -87,7 +87,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 			return nil, nil, err
 		}
 		imgDesc, err := i.resolveDescriptor(ctx, refOrID)
-		if err != nil && !errdefs.IsNotFound(err) {
+		if err != nil && !cerrdefs.IsNotFound(err) {
 			return nil, nil, err
 		}
 		if img != nil {
@@ -152,7 +152,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 
 	img, err := i.GetImage(ctx, name, backend.GetImageOpts{Platform: platform})
 	if err != nil {
-		if errdefs.IsNotFound(err) && img != nil && platform != nil {
+		if cerrdefs.IsNotFound(err) && img != nil && platform != nil {
 			imgPlat := ocispec.Platform{
 				OS:           img.OS,
 				Architecture: img.BaseImgArch(),

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -259,7 +259,7 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, platf
 				if err := i.ensureDanglingImage(ctx, img); err != nil {
 					log.G(ctx).WithError(err).Warnf("failed to keep the previous image for %s as dangling", img.Name)
 				}
-			} else if !errdefs.IsNotFound(err) {
+			} else if !cerrdefs.IsNotFound(err) {
 				log.G(ctx).WithError(err).Warn("failed to retrieve image: %w", err)
 			}
 			return true

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -241,7 +241,7 @@ func (i *ImageService) multiPlatformSummary(ctx context.Context, img c8dimages.I
 		})
 
 		available, err := img.CheckContentAvailable(ctx)
-		if err != nil && !errdefs.IsNotFound(err) {
+		if err != nil && !cerrdefs.IsNotFound(err) {
 			logger.WithError(err).Warn("checking availability of platform specific manifest failed")
 			return nil
 		}
@@ -276,7 +276,7 @@ func (i *ImageService) multiPlatformSummary(ctx context.Context, img c8dimages.I
 		// so we don't error out the whole list in case the error is related to
 		// the content itself (e.g. corrupted data) or just manifest kind that
 		// we don't know about (yet).
-		if err != nil && !errdefs.IsNotFound(err) {
+		if err != nil && !cerrdefs.IsNotFound(err) {
 			logger.WithError(err).Debug("pseudo image check failed")
 			return nil
 		}
@@ -660,7 +660,7 @@ func setupLabelFilter(ctx context.Context, store content.Store, fltrs filters.Ar
 			}
 			var cfg configLabels
 			if err := readJSON(ctx, store, desc, &cfg); err != nil {
-				if errdefs.IsNotFound(err) {
+				if cerrdefs.IsNotFound(err) {
 					return nil, nil
 				}
 				return nil, err

--- a/daemon/containerd/image_load_test.go
+++ b/daemon/containerd/image_load_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/plugins/content/local"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/testutils/labelstore"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"github.com/moby/go-archive"
@@ -62,7 +62,7 @@ func TestImageLoadMissing(t *testing.T) {
 
 		err = tryLoad(ctx, t, imgDataDir, linuxAmd64)
 		assert.Check(t, is.Error(err, "image emptyindex:latest was loaded, but doesn't provide the requested platform (linux/amd64)"))
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 	clearStore(ctx, t)
 
@@ -74,7 +74,7 @@ func TestImageLoadMissing(t *testing.T) {
 
 		err = tryLoad(ctx, t, imgDataDir, linuxArm64)
 		assert.Check(t, is.ErrorContains(err, "doesn't provide the requested platform (linux/arm64)"))
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 
 	clearStore(ctx, t)
@@ -87,7 +87,7 @@ func TestImageLoadMissing(t *testing.T) {
 		t.Run("platform not included in index", func(t *testing.T) {
 			err = tryLoad(ctx, t, imgDataDir, linuxArmv5)
 			assert.Check(t, is.Error(err, "image multiplatform:latest was loaded, but doesn't provide the requested platform (linux/arm/v5)"))
-			assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 		})
 
 		clearStore(ctx, t)
@@ -106,7 +106,7 @@ func TestImageLoadMissing(t *testing.T) {
 
 			err = tryLoad(ctx, t, imgDataDir, linuxArm64)
 			assert.Check(t, is.ErrorContains(err, "requested platform (linux/arm64) found, but some content is missing"))
-			assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 		})
 	})
 }

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -85,7 +85,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	opts = append(opts, containerd.WithResolver(resolver))
 
 	oldImage, err := i.resolveImage(ctx, ref.String())
-	if err != nil && !errdefs.IsNotFound(err) {
+	if err != nil && !cerrdefs.IsNotFound(err) {
 		return err
 	}
 

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -331,7 +331,7 @@ func findMissingMountable(ctx context.Context, store content.Store, queue *jobs,
 
 	sources, err := getDigestSources(ctx, store, target.Digest)
 	if err != nil {
-		if !errdefs.IsNotFound(err) {
+		if !cerrdefs.IsNotFound(err) {
 			return nil, err
 		}
 		log.G(ctx).WithField("target", target).Debug("distribution source label not found")

--- a/daemon/containerd/image_push_test.go
+++ b/daemon/containerd/image_push_test.go
@@ -12,8 +12,8 @@ import (
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -279,10 +279,10 @@ func singleManifestSelected(platform ocispec.Platform) func(t *testing.T, img c8
 
 // candidateNotFound asserts that the no matching candidate was found.
 func candidateNotFound(t *testing.T, _ c8dimages.Image, desc ocispec.Descriptor, err error) {
-	assert.Check(t, errdefs.IsNotFound(err), "expected NotFound error, got %v, candidate: %v", err, desc.Platform)
+	assert.Check(t, cerrdefs.IsNotFound(err), "expected NotFound error, got %v, candidate: %v", err, desc.Platform)
 }
 
 // multipleCandidates asserts that multiple matching candidates were found and no decision could be made.
 func multipleCandidates(t *testing.T, _ c8dimages.Image, desc ocispec.Descriptor, err error) {
-	assert.Check(t, errdefs.IsConflict(err), "expected Conflict error, got %v, candidate: %v", err, desc.Platform)
+	assert.Check(t, cerrdefs.IsConflict(err), "expected Conflict error, got %v, candidate: %v", err, desc.Platform)
 }

--- a/daemon/containerd/image_save_test.go
+++ b/daemon/containerd/image_save_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -54,7 +54,7 @@ func TestImageMultiplatformSaveShallowWithNative(t *testing.T) {
 	})
 	t.Run("export missing", func(t *testing.T) {
 		err = imgSvc.ExportImage(ctx, []string{img.Name}, &arm64, io.Discard)
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 }
 
@@ -94,7 +94,7 @@ func TestImageMultiplatformSaveShallowWithoutNative(t *testing.T) {
 	})
 	t.Run("export native", func(t *testing.T) {
 		err = imgSvc.ExportImage(ctx, []string{img.Name}, &native, io.Discard)
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 	t.Run("export arm64", func(t *testing.T) {
 		err = imgSvc.ExportImage(ctx, []string{img.Name}, &arm64, io.Discard)

--- a/daemon/containerd/progress.go
+++ b/daemon/containerd/progress.go
@@ -182,7 +182,7 @@ func (p *pullProgress) UpdateProgress(ctx context.Context, ongoing *jobs, out pr
 	for idx, desc := range p.layers {
 		sn, err := findMatchingSnapshot(ctx, p.snapshotter, desc)
 		if err != nil {
-			if errdefs.IsNotFound(err) {
+			if cerrdefs.IsNotFound(err) {
 				continue
 			}
 			return err

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -8,11 +8,11 @@ import (
 	"os"
 	"path/filepath"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/oci"
 	"github.com/docker/docker/pkg/idtools"
 	volumemounts "github.com/docker/docker/volume/mounts"
@@ -110,7 +110,7 @@ func (daemon *Daemon) populateVolume(ctx context.Context, c *container.Container
 	uid, gid := daemon.idMapping.RootPair()
 	volumePath, cleanup, err := mnt.Setup(ctx, c.MountLabel, idtools.Identity{UID: uid, GID: gid}, nil)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil
 		}
 		log.G(ctx).WithError(err).Debugf("can't copy data from %s:%s, to %s", c.ID, mnt.Destination, volumePath)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -27,6 +27,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/dialer"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	dist "github.com/docker/distribution"
@@ -52,7 +53,6 @@ import (
 	"github.com/docker/docker/distribution"
 	dmetadata "github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/dockerversion"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/internal/metrics"
 	"github.com/docker/docker/layer"
@@ -361,7 +361,7 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 
 			var es *containerd.ExitStatus
 
-			if err := c.RestoreTask(context.Background(), daemon.containerd); err != nil && !errdefs.IsNotFound(err) {
+			if err := c.RestoreTask(context.Background(), daemon.containerd); err != nil && !cerrdefs.IsNotFound(err) {
 				logger(c).WithError(err).Error("failed to restore container with containerd")
 				return
 			}
@@ -378,13 +378,13 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 					if !alive {
 						logger(c).Debug("cleaning up dead container process")
 						es, err = tsk.Delete(context.Background())
-						if err != nil && !errdefs.IsNotFound(err) {
+						if err != nil && !cerrdefs.IsNotFound(err) {
 							logger(c).WithError(err).Error("failed to delete task from containerd")
 							return
 						}
 					} else if !cfg.LiveRestoreEnabled {
 						logger(c).Debug("shutting down container considered alive by containerd")
-						if err := daemon.shutdownContainer(c); err != nil && !errdefs.IsNotFound(err) {
+						if err := daemon.shutdownContainer(c); err != nil && !cerrdefs.IsNotFound(err) {
 							baseLogger.WithError(err).Error("error shutting down container")
 							return
 						}
@@ -699,7 +699,7 @@ func (daemon *Daemon) restartSwarmContainers(ctx context.Context, cfg *configSto
 func (daemon *Daemon) registerLink(parent, child *container.Container, alias string) error {
 	fullName := path.Join(parent.Name, alias)
 	if err := daemon.containersReplica.ReserveName(fullName, child.ID); err != nil {
-		if errdefs.IsConflict(err) {
+		if cerrdefs.IsConflict(err) {
 			log.G(context.TODO()).Warnf("error registering link for %s, to %s, as alias %s, ignoring: %v", parent.ID, child.ID, alias, err)
 			return nil
 		}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -7,9 +7,9 @@ import (
 	"runtime"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork"
 	"github.com/docker/docker/pkg/idtools"
 	volumesservice "github.com/docker/docker/volume/service"
@@ -310,7 +310,7 @@ func TestFindNetworkErrorType(t *testing.T) {
 	_, err := d.FindNetwork("fakeNet")
 	var nsn libnetwork.ErrNoSuchNetwork
 	ok := errors.As(err, &nsn)
-	if !errdefs.IsNotFound(err) || !ok {
+	if !cerrdefs.IsNotFound(err) || !ok {
 		t.Error("The FindNetwork method MUST always return an error that implements the NotFound interface and is ErrNoSuchNetwork")
 	}
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups/v3"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/blkiodev"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -1535,7 +1536,7 @@ func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *
 		}
 		child, err := daemon.GetContainer(name)
 		if err != nil {
-			if errdefs.IsNotFound(err) {
+			if cerrdefs.IsNotFound(err) {
 				// Trying to link to a non-existing container is not valid, and
 				// should return an "invalid parameter" error. Returning a "not
 				// found" error here would make the client report the container's
@@ -1548,7 +1549,7 @@ func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *
 			cid := child.HostConfig.NetworkMode.ConnectedContainer()
 			child, err = daemon.GetContainer(cid)
 			if err != nil {
-				if errdefs.IsNotFound(err) {
+				if cerrdefs.IsNotFound(err) {
 					// Trying to link to a non-existing container is not valid, and
 					// should return an "invalid parameter" error. Returning a "not
 					// found" error here would make the client report the container's

--- a/daemon/delete_test.go
+++ b/daemon/delete_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -75,7 +75,7 @@ func TestContainerDelete(t *testing.T) {
 			d.containers.Add(c.ID, c)
 
 			err := d.ContainerRm(c.ID, &backend.ContainerRmConfig{ForceRemove: false})
-			assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 			assert.Check(t, is.ErrorContains(err, tc.errMsg))
 		})
 	}

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"runtime"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/builder"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"
@@ -166,7 +166,7 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 	}
 
 	img, err := i.GetImage(ctx, name, backend.GetImageOpts{Platform: platform})
-	if errdefs.IsNotFound(err) && img != nil && platform != nil {
+	if cerrdefs.IsNotFound(err) && img != nil && platform != nil {
 		imgPlat := ocispec.Platform{
 			OS:           img.OS,
 			Architecture: img.BaseImgArch(),
@@ -211,7 +211,7 @@ func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID s
 		if err != nil && opts.PullOption == backend.PullOptionNoPull {
 			return nil, nil, err
 		}
-		if err != nil && !errdefs.IsNotFound(err) {
+		if err != nil && !cerrdefs.IsNotFound(err) {
 			return nil, nil, err
 		}
 		if img != nil {

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
@@ -162,7 +163,7 @@ func imageDeleteFailed(ref string, err error) bool {
 	switch {
 	case err == nil:
 		return false
-	case errdefs.IsConflict(err), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+	case cerrdefs.IsConflict(err), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return true
 	default:
 		log.G(context.TODO()).Warnf("failed to prune image %s: %v", ref, err)

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/distribution"
 	progressutils "github.com/docker/docker/distribution/utils"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/metrics"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -43,7 +43,7 @@ func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platf
 
 		// Note that this is a special case where GetImage returns both an image
 		// and an error: https://github.com/docker/docker/blob/v20.10.7/daemon/images/image.go#L175-L183
-		if errdefs.IsNotFound(err) && img != nil {
+		if cerrdefs.IsNotFound(err) && img != nil {
 			po := streamformatter.NewJSONProgressOutput(outStream, false)
 			progress.Messagef(po, "", `WARNING: %s`, err.Error())
 			log.G(ctx).WithError(err).WithField("image", reference.FamiliarName(ref)).Warn("ignoring platform mismatch on single-arch image")

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -17,7 +17,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/rootless"
 	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/pkg/errors"
@@ -180,7 +179,7 @@ func (daemon *Daemon) fillPlatformVersion(ctx context.Context, v *types.Version,
 	}
 
 	if err := daemon.fillRootlessVersion(ctx, v); err != nil {
-		if errdefs.IsContext(err) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 		log.G(ctx).WithError(err).Warn("Failed to fill rootless version")
@@ -207,7 +206,7 @@ func (daemon *Daemon) populateInitCommit(ctx context.Context, v *system.Info, cf
 
 	rv, err := exec.CommandContext(ctx, initBinary, "--version").Output()
 	if err != nil {
-		if errdefs.IsContext(err) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 		log.G(ctx).WithError(err).Warnf("Failed to retrieve %s version", initBinary)
@@ -262,7 +261,7 @@ func (daemon *Daemon) fillRootlessVersion(ctx context.Context, v *types.Version)
 		err = func() error {
 			rv, err := exec.CommandContext(ctx, "slirp4netns", "--version").Output()
 			if err != nil {
-				if errdefs.IsContext(err) {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return err
 				}
 				log.G(ctx).WithError(err).Warn("Failed to retrieve slirp4netns version")
@@ -290,7 +289,7 @@ func (daemon *Daemon) fillRootlessVersion(ctx context.Context, v *types.Version)
 		err = func() error {
 			out, err := exec.CommandContext(ctx, "vpnkit", "--version").Output()
 			if err != nil {
-				if errdefs.IsContext(err) {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return err
 				}
 				log.G(ctx).WithError(err).Warn("Failed to retrieve vpnkit version")
@@ -426,7 +425,7 @@ func noNewPrivileges(cfg *config.Config) bool {
 func (daemon *Daemon) populateContainerdCommit(ctx context.Context, v *system.Commit) error {
 	rv, err := daemon.containerd.Version(ctx)
 	if err != nil {
-		if errdefs.IsContext(err) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 		log.G(ctx).WithError(err).Warnf("Failed to retrieve containerd version")
@@ -439,7 +438,7 @@ func (daemon *Daemon) populateContainerdCommit(ctx context.Context, v *system.Co
 func (daemon *Daemon) populateContainerdVersion(ctx context.Context, v *types.Version) error {
 	rv, err := daemon.containerd.Version(ctx)
 	if err != nil {
-		if errdefs.IsContext(err) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 		log.G(ctx).WithError(err).Warn("Failed to retrieve containerd version")
@@ -480,7 +479,7 @@ func populateInitVersion(ctx context.Context, cfg *configStore, v *types.Version
 
 	rv, err := exec.CommandContext(ctx, initBinary, "--version").Output()
 	if err != nil {
-		if errdefs.IsContext(err) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 		log.G(ctx).WithError(err).Warnf("Failed to retrieve %s version", initBinary)

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
@@ -108,7 +109,7 @@ func (daemon *Daemon) killWithSignal(container *containerpkg.Container, stopSign
 	}
 
 	if err := task.Kill(context.Background(), stopSignal); err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			unpause = false
 			log.G(context.TODO()).WithFields(log.Fields{
 				"error":     err,
@@ -205,7 +206,7 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 // killPossiblyDeadProcess is a wrapper around killSig() suppressing "no such process" error.
 func (daemon *Daemon) killPossiblyDeadProcess(container *containerpkg.Container, sig syscall.Signal) error {
 	err := daemon.killWithSignal(container, sig)
-	if errdefs.IsNotFound(err) {
+	if cerrdefs.IsNotFound(err) {
 		err = errNoSuchProcess{container.GetPID(), sig}
 		log.G(context.TODO()).Debug(err)
 		return err

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/backend"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -244,7 +245,7 @@ func (daemon *Daemon) filterByNameIDMatches(view *container.View, filter *listCo
 	for id := range matches {
 		c, err := view.Get(id)
 		if err != nil {
-			if errdefs.IsNotFound(err) {
+			if cerrdefs.IsNotFound(err) {
 				// ignore error
 				continue
 			}
@@ -375,7 +376,7 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view *container.View, conf
 
 func idOrNameFilter(view *container.View, value string) (*container.Snapshot, error) {
 	filter, err := view.Get(value)
-	if err != nil && errdefs.IsNotFound(err) {
+	if err != nil && cerrdefs.IsNotFound(err) {
 		// Try name search instead
 		found := ""
 		searchName := strings.TrimPrefix(value, "/")
@@ -634,7 +635,7 @@ func (daemon *Daemon) refreshImage(ctx context.Context, s *container.Snapshot) *
 	// reason. Update the Image to the specific ID of the original image it
 	// resolved to when the container was created.
 	if err != nil {
-		if !errdefs.IsNotFound(err) {
+		if !cerrdefs.IsNotFound(err) {
 			log.G(ctx).WithFields(log.Fields{
 				"error":       err,
 				"containerID": c.ID,

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -6,12 +6,12 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/metrics"
 	libcontainerdtypes "github.com/docker/docker/libcontainerd/types"
 	"github.com/docker/docker/restartmanager"
@@ -250,7 +250,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 		if !c.Running {
 			ctr, err := daemon.containerd.LoadContainer(context.Background(), c.ID)
 			if err != nil {
-				if errdefs.IsNotFound(err) {
+				if cerrdefs.IsNotFound(err) {
 					// The container was started by not-docker and so could have been deleted by
 					// not-docker before we got around to loading it from containerd.
 					log.G(context.TODO()).WithFields(log.Fields{
@@ -263,7 +263,7 @@ func (daemon *Daemon) ProcessEvent(id string, e libcontainerdtypes.EventType, ei
 			}
 			tsk, err := ctr.Task(context.Background())
 			if err != nil {
-				if errdefs.IsNotFound(err) {
+				if cerrdefs.IsNotFound(err) {
 					log.G(context.TODO()).WithFields(log.Fields{
 						"error":     err,
 						"container": c.ID,

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/names"
@@ -68,7 +69,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 	}
 
 	if err := daemon.containersReplica.ReserveName(name, id); err != nil {
-		if errdefs.IsConflict(err) {
+		if cerrdefs.IsConflict(err) {
 			id, err := daemon.containersReplica.Snapshot().GetID(name)
 			if err != nil {
 				log.G(context.TODO()).Errorf("got unexpected error while looking up reserved name: %v", err)
@@ -94,7 +95,7 @@ func (daemon *Daemon) generateAndReserveName(id string) (string, error) {
 		}
 
 		if err := daemon.containersReplica.ReserveName(name, id); err != nil {
-			if errdefs.IsConflict(err) {
+			if cerrdefs.IsConflict(err) {
 				continue
 			}
 			return "", err

--- a/daemon/runtime_unix_test.go
+++ b/daemon/runtime_unix_test.go
@@ -12,9 +12,9 @@ import (
 	runcoptions "github.com/containerd/containerd/api/types/runc/options"
 	runtimeoptions "github.com/containerd/containerd/api/types/runtimeoptions/v1"
 	"github.com/containerd/containerd/v2/plugins"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/errdefs"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/proto"
 	"gotest.tools/v3/assert"
@@ -341,7 +341,7 @@ func TestGetRuntime(t *testing.T) {
 			} else {
 				assert.Check(t, is.Equal(shim, ""))
 				assert.Check(t, is.Nil(opts))
-				assert.Check(t, errdefs.IsInvalidParameter(err), "[%T] %[1]v", err)
+				assert.Check(t, cerrdefs.IsInvalidArgument(err), "[%T] %[1]v", err)
 			}
 		})
 	}

--- a/daemon/stats_windows.go
+++ b/daemon/stats_windows.go
@@ -3,9 +3,9 @@ package daemon // import "github.com/docker/docker/daemon"
 import (
 	"context"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/platform"
 )
 
@@ -20,7 +20,7 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 	// Obtain the stats from HCS via libcontainerd
 	stats, err := task.Stats(context.Background())
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return nil, containerNotFound(c.ID)
 		}
 		return nil, err

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/errdefs"
@@ -86,7 +87,7 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 	isRestarting := ctr.Restarting
 	tsk, err := ctr.GetRunningTask()
 	ctr.Unlock()
-	if errdefs.IsConflict(err) || isRestarting {
+	if cerrdefs.IsConflict(err) || isRestarting {
 		return nil
 	}
 	if err != nil {

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -91,7 +91,7 @@ func (e unsupportedMediaTypeError) Error() string {
 // log at info level.
 func translatePullError(err error, ref reference.Named) error {
 	// FIXME(thaJeztah): cleanup error and context handling in this package, as it's really messy.
-	if errdefs.IsContext(err) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 	switch v := err.(type) {
@@ -135,7 +135,7 @@ func isNotFound(err error) bool {
 // as a result of this error.
 func continueOnError(err error, mirrorEndpoint bool) bool {
 	// FIXME(thaJeztah): cleanup error and context handling in this package, as it's really messy.
-	if errdefs.IsContext(err) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
 	}
 	switch v := err.(type) {

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -8,7 +8,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/errdefs"
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
@@ -134,7 +133,7 @@ func pullEndpoints(ctx context.Context, registryService RegistryResolver, ref re
 				continue
 			}
 			// FIXME(thaJeztah): cleanup error and context handling in this package, as it's really messy.
-			if errdefs.IsContext(err) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				log.G(ctx).WithError(err).Info("Not continuing with pull after error")
 			} else {
 				log.G(ctx).WithError(err).Error("Not continuing with pull after error")

--- a/distribution/push.go
+++ b/distribution/push.go
@@ -4,13 +4,13 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/progress"
 )
 
@@ -72,7 +72,7 @@ func Push(ctx context.Context, ref reference.Named, config *ImagePushConfig) err
 			}
 
 			// FIXME(thaJeztah): cleanup error and context handling in this package, as it's really messy.
-			if errdefs.IsContext(err) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				log.G(ctx).WithError(err).Info("Not continuing with push after error")
 			} else {
 				log.G(ctx).WithError(err).Error("Not continuing with push after error")

--- a/errdefs/helpers.go
+++ b/errdefs/helpers.go
@@ -1,6 +1,10 @@
 package errdefs
 
-import "context"
+import (
+	"context"
+
+	cerrdefs "github.com/containerd/errdefs"
+)
 
 type errNotFound struct{ error }
 
@@ -18,7 +22,7 @@ func (e errNotFound) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrNotFound],
 func NotFound(err error) error {
-	if err == nil || IsNotFound(err) {
+	if err == nil || cerrdefs.IsNotFound(err) {
 		return err
 	}
 	return errNotFound{err}
@@ -40,7 +44,7 @@ func (e errInvalidParameter) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrInvalidParameter],
 func InvalidParameter(err error) error {
-	if err == nil || IsInvalidParameter(err) {
+	if err == nil || cerrdefs.IsInvalidArgument(err) {
 		return err
 	}
 	return errInvalidParameter{err}
@@ -62,7 +66,7 @@ func (e errConflict) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrConflict],
 func Conflict(err error) error {
-	if err == nil || IsConflict(err) {
+	if err == nil || cerrdefs.IsConflict(err) {
 		return err
 	}
 	return errConflict{err}
@@ -84,7 +88,7 @@ func (e errUnauthorized) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrUnauthorized],
 func Unauthorized(err error) error {
-	if err == nil || IsUnauthorized(err) {
+	if err == nil || cerrdefs.IsUnauthorized(err) {
 		return err
 	}
 	return errUnauthorized{err}
@@ -106,7 +110,7 @@ func (e errUnavailable) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrUnavailable],
 func Unavailable(err error) error {
-	if err == nil || IsUnavailable(err) {
+	if err == nil || cerrdefs.IsUnavailable(err) {
 		return err
 	}
 	return errUnavailable{err}
@@ -128,7 +132,7 @@ func (e errForbidden) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrForbidden],
 func Forbidden(err error) error {
-	if err == nil || IsForbidden(err) {
+	if err == nil || cerrdefs.IsPermissionDenied(err) {
 		return err
 	}
 	return errForbidden{err}
@@ -150,7 +154,7 @@ func (e errSystem) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrSystem],
 func System(err error) error {
-	if err == nil || IsSystem(err) {
+	if err == nil || cerrdefs.IsInternal(err) {
 		return err
 	}
 	return errSystem{err}
@@ -172,7 +176,7 @@ func (e errNotModified) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [NotModified],
 func NotModified(err error) error {
-	if err == nil || IsNotModified(err) {
+	if err == nil || cerrdefs.IsNotModified(err) {
 		return err
 	}
 	return errNotModified{err}
@@ -194,7 +198,7 @@ func (e errNotImplemented) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrNotImplemented],
 func NotImplemented(err error) error {
-	if err == nil || IsNotImplemented(err) {
+	if err == nil || cerrdefs.IsNotImplemented(err) {
 		return err
 	}
 	return errNotImplemented{err}
@@ -216,7 +220,7 @@ func (e errUnknown) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrUnknown],
 func Unknown(err error) error {
-	if err == nil || IsUnknown(err) {
+	if err == nil || cerrdefs.IsUnknown(err) {
 		return err
 	}
 	return errUnknown{err}
@@ -238,7 +242,7 @@ func (e errCancelled) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrCancelled],
 func Cancelled(err error) error {
-	if err == nil || IsCancelled(err) {
+	if err == nil || cerrdefs.IsCanceled(err) {
 		return err
 	}
 	return errCancelled{err}
@@ -260,7 +264,7 @@ func (e errDeadline) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrDeadline],
 func Deadline(err error) error {
-	if err == nil || IsDeadline(err) {
+	if err == nil || cerrdefs.IsDeadlineExceeded(err) {
 		return err
 	}
 	return errDeadline{err}
@@ -282,7 +286,7 @@ func (e errDataLoss) Unwrap() error {
 // It returns the error as-is if it is either nil (no error) or already implements
 // [ErrDataLoss],
 func DataLoss(err error) error {
-	if err == nil || IsDataLoss(err) {
+	if err == nil || cerrdefs.IsDataLoss(err) {
 		return err
 	}
 	return errDataLoss{err}

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
 )
 
 var errTest = errors.New("this is a test")
@@ -13,11 +15,11 @@ type wrapped interface {
 }
 
 func TestNotFound(t *testing.T) {
-	if IsNotFound(errTest) {
+	if cerrdefs.IsNotFound(errTest) {
 		t.Fatalf("did not expect not found error, got %T", errTest)
 	}
 	e := NotFound(errTest)
-	if !IsNotFound(e) {
+	if !cerrdefs.IsNotFound(e) {
 		t.Fatalf("expected not found error, got: %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -28,17 +30,17 @@ func TestNotFound(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsNotFound(wrapped) {
+	if !cerrdefs.IsNotFound(wrapped) {
 		t.Fatalf("expected not found error, got: %T", wrapped)
 	}
 }
 
 func TestConflict(t *testing.T) {
-	if IsConflict(errTest) {
+	if cerrdefs.IsConflict(errTest) {
 		t.Fatalf("did not expect conflict error, got %T", errTest)
 	}
 	e := Conflict(errTest)
-	if !IsConflict(e) {
+	if !cerrdefs.IsConflict(e) {
 		t.Fatalf("expected conflict error, got: %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -49,17 +51,17 @@ func TestConflict(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsConflict(wrapped) {
+	if !cerrdefs.IsConflict(wrapped) {
 		t.Fatalf("expected conflict error, got: %T", wrapped)
 	}
 }
 
 func TestForbidden(t *testing.T) {
-	if IsForbidden(errTest) {
+	if cerrdefs.IsPermissionDenied(errTest) {
 		t.Fatalf("did not expect forbidden error, got %T", errTest)
 	}
 	e := Forbidden(errTest)
-	if !IsForbidden(e) {
+	if !cerrdefs.IsPermissionDenied(e) {
 		t.Fatalf("expected forbidden error, got: %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -70,17 +72,17 @@ func TestForbidden(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsForbidden(wrapped) {
+	if !cerrdefs.IsPermissionDenied(wrapped) {
 		t.Fatalf("expected forbidden error, got: %T", wrapped)
 	}
 }
 
 func TestInvalidParameter(t *testing.T) {
-	if IsInvalidParameter(errTest) {
+	if cerrdefs.IsInvalidArgument(errTest) {
 		t.Fatalf("did not expect invalid argument error, got %T", errTest)
 	}
 	e := InvalidParameter(errTest)
-	if !IsInvalidParameter(e) {
+	if !cerrdefs.IsInvalidArgument(e) {
 		t.Fatalf("expected invalid argument error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -91,17 +93,17 @@ func TestInvalidParameter(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsInvalidParameter(wrapped) {
+	if !cerrdefs.IsInvalidArgument(wrapped) {
 		t.Fatalf("expected invalid argument error, got: %T", wrapped)
 	}
 }
 
 func TestNotImplemented(t *testing.T) {
-	if IsNotImplemented(errTest) {
+	if cerrdefs.IsNotImplemented(errTest) {
 		t.Fatalf("did not expect not implemented error, got %T", errTest)
 	}
 	e := NotImplemented(errTest)
-	if !IsNotImplemented(e) {
+	if !cerrdefs.IsNotImplemented(e) {
 		t.Fatalf("expected not implemented error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -112,17 +114,17 @@ func TestNotImplemented(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsNotImplemented(wrapped) {
+	if !cerrdefs.IsNotImplemented(wrapped) {
 		t.Fatalf("expected not implemented error, got: %T", wrapped)
 	}
 }
 
 func TestNotModified(t *testing.T) {
-	if IsNotModified(errTest) {
+	if cerrdefs.IsNotModified(errTest) {
 		t.Fatalf("did not expect not modified error, got %T", errTest)
 	}
 	e := NotModified(errTest)
-	if !IsNotModified(e) {
+	if !cerrdefs.IsNotModified(e) {
 		t.Fatalf("expected not modified error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -133,17 +135,17 @@ func TestNotModified(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsNotModified(wrapped) {
+	if !cerrdefs.IsNotModified(wrapped) {
 		t.Fatalf("expected not modified error, got: %T", wrapped)
 	}
 }
 
 func TestUnauthorized(t *testing.T) {
-	if IsUnauthorized(errTest) {
+	if cerrdefs.IsUnauthorized(errTest) {
 		t.Fatalf("did not expect unauthorized error, got %T", errTest)
 	}
 	e := Unauthorized(errTest)
-	if !IsUnauthorized(e) {
+	if !cerrdefs.IsUnauthorized(e) {
 		t.Fatalf("expected unauthorized error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -154,17 +156,17 @@ func TestUnauthorized(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsUnauthorized(wrapped) {
+	if !cerrdefs.IsUnauthorized(wrapped) {
 		t.Fatalf("expected unauthorized error, got: %T", wrapped)
 	}
 }
 
 func TestUnknown(t *testing.T) {
-	if IsUnknown(errTest) {
+	if cerrdefs.IsUnknown(errTest) {
 		t.Fatalf("did not expect unknown error, got %T", errTest)
 	}
 	e := Unknown(errTest)
-	if !IsUnknown(e) {
+	if !cerrdefs.IsUnknown(e) {
 		t.Fatalf("expected unknown error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -175,17 +177,17 @@ func TestUnknown(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsUnknown(wrapped) {
+	if !cerrdefs.IsUnknown(wrapped) {
 		t.Fatalf("expected unknown error, got: %T", wrapped)
 	}
 }
 
 func TestCancelled(t *testing.T) {
-	if IsCancelled(errTest) {
+	if cerrdefs.IsCanceled(errTest) {
 		t.Fatalf("did not expect cancelled error, got %T", errTest)
 	}
 	e := Cancelled(errTest)
-	if !IsCancelled(e) {
+	if !cerrdefs.IsCanceled(e) {
 		t.Fatalf("expected cancelled error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -196,17 +198,17 @@ func TestCancelled(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsCancelled(wrapped) {
+	if !cerrdefs.IsCanceled(wrapped) {
 		t.Fatalf("expected cancelled error, got: %T", wrapped)
 	}
 }
 
 func TestDeadline(t *testing.T) {
-	if IsDeadline(errTest) {
+	if cerrdefs.IsDeadlineExceeded(errTest) {
 		t.Fatalf("did not expect deadline error, got %T", errTest)
 	}
 	e := Deadline(errTest)
-	if !IsDeadline(e) {
+	if !cerrdefs.IsDeadlineExceeded(e) {
 		t.Fatalf("expected deadline error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -217,17 +219,17 @@ func TestDeadline(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsDeadline(wrapped) {
+	if !cerrdefs.IsDeadlineExceeded(wrapped) {
 		t.Fatalf("expected deadline error, got: %T", wrapped)
 	}
 }
 
 func TestDataLoss(t *testing.T) {
-	if IsDataLoss(errTest) {
+	if cerrdefs.IsDataLoss(errTest) {
 		t.Fatalf("did not expect data loss error, got %T", errTest)
 	}
 	e := DataLoss(errTest)
-	if !IsDataLoss(e) {
+	if !cerrdefs.IsDataLoss(e) {
 		t.Fatalf("expected data loss error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -238,17 +240,17 @@ func TestDataLoss(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsDataLoss(wrapped) {
+	if !cerrdefs.IsDataLoss(wrapped) {
 		t.Fatalf("expected data loss error, got: %T", wrapped)
 	}
 }
 
 func TestUnavailable(t *testing.T) {
-	if IsUnavailable(errTest) {
+	if cerrdefs.IsUnavailable(errTest) {
 		t.Fatalf("did not expect unavaillable error, got %T", errTest)
 	}
 	e := Unavailable(errTest)
-	if !IsUnavailable(e) {
+	if !cerrdefs.IsUnavailable(e) {
 		t.Fatalf("expected unavaillable error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -259,17 +261,17 @@ func TestUnavailable(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsUnavailable(wrapped) {
+	if !cerrdefs.IsUnavailable(wrapped) {
 		t.Fatalf("expected unavaillable error, got: %T", wrapped)
 	}
 }
 
 func TestSystem(t *testing.T) {
-	if IsSystem(errTest) {
+	if cerrdefs.IsInternal(errTest) {
 		t.Fatalf("did not expect system error, got %T", errTest)
 	}
 	e := System(errTest)
-	if !IsSystem(e) {
+	if !cerrdefs.IsInternal(e) {
 		t.Fatalf("expected system error, got %T", e)
 	}
 	if cause := e.(wrapped).Unwrap(); cause != errTest {
@@ -280,7 +282,7 @@ func TestSystem(t *testing.T) {
 	}
 
 	wrapped := fmt.Errorf("foo: %w", e)
-	if !IsSystem(wrapped) {
+	if !cerrdefs.IsInternal(wrapped) {
 		t.Fatalf("expected system error, got: %T", wrapped)
 	}
 }

--- a/image/store_test.go
+++ b/image/store_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/layer"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -47,7 +47,7 @@ func TestRestore(t *testing.T) {
 	assert.Check(t, is.Equal("def", img2.Comment))
 
 	_, err = imgStore.GetParent(ID(id1))
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.ErrorContains(t, err, "failed to read metadata")
 
 	p, err := imgStore.GetParent(ID(id2))
@@ -69,7 +69,7 @@ func TestRestore(t *testing.T) {
 
 	invalidPattern := id1.Encoded()[1:6]
 	_, err = imgStore.Search(invalidPattern)
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, invalidPattern))
 }
 
@@ -98,14 +98,14 @@ func TestAddDelete(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = imgStore.Get(id1)
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.ErrorContains(t, err, "failed to get digest")
 
 	_, err = imgStore.Get(id2)
 	assert.NilError(t, err)
 
 	_, err = imgStore.GetParent(id2)
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.ErrorContains(t, err, "failed to read metadata")
 }
 
@@ -123,14 +123,14 @@ func TestSearchAfterDelete(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = imgStore.Search(string(id)[:15])
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.ErrorContains(t, err, "No such image")
 }
 
 func TestDeleteNotExisting(t *testing.T) {
 	imgStore := defaultImageStore(t)
 	_, err := imgStore.Delete(ID("i_dont_exists"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }
 
 func TestParentReset(t *testing.T) {

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 )
 
@@ -67,7 +67,7 @@ func (d *Daemon) CheckPluginRunning(ctx context.Context, plugin string) func(c *
 	return func(c *testing.T) (interface{}, string) {
 		apiclient := d.NewClientT(c)
 		resp, _, err := apiclient.PluginInspectWithRaw(ctx, plugin)
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return false, fmt.Sprintf("%v", err)
 		}
 		assert.NilError(c, err)
@@ -80,7 +80,7 @@ func (d *Daemon) CheckPluginImage(ctx context.Context, plugin string) func(c *te
 	return func(c *testing.T) (interface{}, string) {
 		apiclient := d.NewClientT(c)
 		resp, _, err := apiclient.PluginInspectWithRaw(ctx, plugin)
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return false, fmt.Sprintf("%v", err)
 		}
 		assert.NilError(c, err)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -16,12 +16,12 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	dconfig "github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/pkg/stringid"
@@ -1391,7 +1391,7 @@ func (s *DockerAPISuite) TestContainerAPIDeleteWithEmptyName(c *testing.T) {
 	defer apiClient.Close()
 
 	err = apiClient.ContainerRemove(testutil.GetContext(c), "", container.RemoveOptions{})
-	assert.Check(c, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(c, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(c, is.ErrorContains(err, "value is empty"))
 }
 
@@ -1968,7 +1968,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 			// anonymous volumes are removed
 			default:
 				_, err := apiclient.VolumeInspect(ctx, mountPoint.Name)
-				assert.Check(c, is.ErrorType(err, errdefs.IsNotFound))
+				assert.Check(c, is.ErrorType(err, cerrdefs.IsNotFound))
 			}
 		})
 	}

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -18,10 +18,10 @@ import (
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/initca"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration-cli/checker"
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/testutil"
@@ -1031,5 +1031,5 @@ func (s *DockerSwarmSuite) TestAPINetworkInspectWithScope(c *testing.T) {
 	assert.Check(c, is.Equal(resp.ID, nw.ID))
 
 	_, err = apiclient.NetworkInspect(ctx, name, network.InspectOptions{Scope: "local"})
-	assert.Check(c, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(c, is.ErrorType(err, cerrdefs.IsNotFound))
 }

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/fakecontext"
@@ -690,7 +690,7 @@ func TestBuildPlatformInvalid(t *testing.T) {
 	})
 
 	assert.Check(t, is.ErrorContains(err, "unknown operating system or architecture"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 }
 
 // TestBuildWorkdirNoCacheMiss is a regression test for https://github.com/moby/moby/issues/47627

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/testutil"
@@ -147,11 +147,11 @@ func TestConfigsCreateAndDelete(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, _, err = c.ConfigInspectWithRaw(ctx, configID)
-	assert.Check(t, errdefs.IsNotFound(err))
+	assert.Check(t, cerrdefs.IsNotFound(err))
 	assert.Check(t, is.ErrorContains(err, configID))
 
 	err = c.ConfigRemove(ctx, "non-existing")
-	assert.Check(t, errdefs.IsNotFound(err))
+	assert.Check(t, cerrdefs.IsNotFound(err))
 	assert.Check(t, is.ErrorContains(err, "non-existing"))
 
 	testName = "test_secret_with_labels_" + t.Name()
@@ -216,7 +216,7 @@ func TestConfigsUpdate(t *testing.T) {
 	// this test will produce an error in func UpdateConfig
 	insp.Spec.Data = []byte("TESTINGDATA2")
 	err = c.ConfigUpdate(ctx, configID, insp.Version, insp.Spec)
-	assert.Check(t, errdefs.IsInvalidParameter(err))
+	assert.Check(t, cerrdefs.IsInvalidArgument(err))
 	assert.Check(t, is.ErrorContains(err, "only updates to Labels are allowed"))
 }
 

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/build"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil/fakecontext"
@@ -30,7 +30,7 @@ func TestCopyFromContainerPathDoesNotExist(t *testing.T) {
 	cid := container.Create(ctx, t, apiClient)
 
 	_, _, err := apiClient.CopyFromContainer(ctx, cid, "/dne")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "Could not find the file /dne in container "+cid))
 }
 
@@ -58,7 +58,7 @@ func TestCopyToContainerPathDoesNotExist(t *testing.T) {
 	cid := container.Create(ctx, t, apiClient)
 
 	err := apiClient.CopyToContainer(ctx, cid, "/dne", nil, containertypes.CopyToContainerOptions{})
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "Could not find the file /dne in container "+cid))
 }
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	testContainer "github.com/docker/docker/integration/internal/container"
 	net "github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/oci"
@@ -66,7 +66,7 @@ func TestCreateFailsWhenIdentifierDoesNotExist(t *testing.T) {
 				"",
 			)
 			assert.Check(t, is.ErrorContains(err, tc.expectedError))
-			assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 		})
 	}
 }
@@ -104,13 +104,13 @@ func TestCreateByImageID(t *testing.T) {
 		{
 			doc:             "image with ID and algorithm as tag",
 			image:           "busybox:" + imgIDWithAlgorithm,
-			expectedErrType: errdefs.IsInvalidParameter,
+			expectedErrType: cerrdefs.IsInvalidArgument,
 			expectedErr:     "Error response from daemon: invalid reference format",
 		},
 		{
 			doc:             "image with ID as tag",
 			image:           "busybox:" + imgID,
-			expectedErrType: errdefs.IsNotFound,
+			expectedErrType: cerrdefs.IsNotFound,
 			expectedErr:     "Error response from daemon: No such image: busybox:" + imgID,
 		},
 	}
@@ -160,7 +160,7 @@ func TestCreateLinkToNonExistingContainer(t *testing.T) {
 		"",
 	)
 	assert.Check(t, is.ErrorContains(err, "could not get container for no-such-container"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 }
 
 func TestCreateWithInvalidEnv(t *testing.T) {
@@ -200,7 +200,7 @@ func TestCreateWithInvalidEnv(t *testing.T) {
 				"",
 			)
 			assert.Check(t, is.ErrorContains(err, tc.expectedError))
-			assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 		})
 	}
 }
@@ -247,7 +247,7 @@ func TestCreateTmpfsMountsTarget(t *testing.T) {
 			"",
 		)
 		assert.Check(t, is.ErrorContains(err, tc.expectedError))
-		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	}
 }
 
@@ -502,7 +502,7 @@ func TestCreateWithInvalidHealthcheckParams(t *testing.T) {
 
 			resp, err := apiClient.ContainerCreate(ctx, &cfg, &container.HostConfig{}, nil, nil, "")
 			assert.Check(t, is.Equal(len(resp.Warnings), 0))
-			assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 			assert.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
@@ -572,7 +572,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 			Variant:      img.Variant,
 		}
 		_, err := apiClient.ContainerCreate(ctx, &container.Config{Image: "busybox:latest"}, &container.HostConfig{}, nil, &p, "")
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 	t.Run("different cpu arch", func(t *testing.T) {
 		ctx := testutil.StartSpan(ctx, t)
@@ -582,7 +582,7 @@ func TestCreateDifferentPlatform(t *testing.T) {
 			Variant:      img.Variant,
 		}
 		_, err := apiClient.ContainerCreate(ctx, &container.Config{Image: "busybox:latest"}, &container.HostConfig{}, nil, &p, "")
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 }
 
@@ -598,7 +598,7 @@ func TestCreateVolumesFromNonExistingContainer(t *testing.T) {
 		nil,
 		"",
 	)
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 }
 
 // Test that we can create a container from an image that is for a different platform even if a platform was not specified
@@ -673,7 +673,7 @@ func TestCreateInvalidHostConfig(t *testing.T) {
 			}
 			resp, err := apiClient.ContainerCreate(ctx, &cfg, &tc.hc, nil, nil, "")
 			assert.Check(t, is.Equal(len(resp.Warnings), 0))
-			assert.Check(t, errdefs.IsInvalidParameter(err), "got: %T", err)
+			assert.Check(t, cerrdefs.IsInvalidArgument(err), "got: %T", err)
 			assert.Error(t, err, tc.expectedErr)
 		})
 	}

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil/fakecontext"
@@ -244,7 +244,7 @@ func TestExecResize(t *testing.T) {
 			Height: 40,
 			Width:  40,
 		})
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 		assert.Check(t, is.ErrorContains(err, "No such exec instance: no-such-exec-id"))
 	})
 
@@ -272,7 +272,7 @@ func TestExecResize(t *testing.T) {
 			Height: 40,
 			Width:  40,
 		})
-		assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 		assert.Check(t, is.ErrorContains(err, "is not running"))
 	})
 }
@@ -394,7 +394,7 @@ func TestExecUser(t *testing.T) {
 			result, err := container.Exec(ctx, apiClient, cID, []string{"id"}, withUser(tc.user))
 			if tc.expectedErr != "" {
 				assert.Check(t, is.Error(err, tc.expectedErr))
-				assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+				assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 				assert.Check(t, is.Equal(result.Stdout(), "<nil>"))
 				assert.Check(t, is.Equal(result.Stderr(), "<nil>"))
 			} else {

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -7,13 +7,13 @@ import (
 	"syscall"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api"
 	containertypes "github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/testutil"
@@ -435,7 +435,7 @@ func TestContainerVolumeAnonymous(t *testing.T) {
 		// when used, which we use as indicator that the driver was passed
 		// through. We should have a cleaner way for this, but that would
 		// require a custom volume plugin to be installed.
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 		assert.Check(t, is.ErrorContains(err, fmt.Sprintf(`plugin %q not found`, testNonExistingPlugin)))
 	})
 }

--- a/integration/container/pidmode_linux_test.go
+++ b/integration/container/pidmode_linux_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -39,7 +39,7 @@ func TestPIDModeContainer(t *testing.T) {
 
 	t.Run("non-existing container", func(t *testing.T) {
 		_, err := container.CreateFromConfig(ctx, apiClient, container.NewTestConfig(container.WithPIDMode("container:nosuchcontainer")))
-		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 		assert.Check(t, is.ErrorContains(err, "No such container: nosuchcontainer"))
 	})
 
@@ -51,7 +51,7 @@ func TestPIDModeContainer(t *testing.T) {
 		assert.NilError(t, err, "should not produce an error when creating, only when starting")
 
 		err = apiClient.ContainerStart(ctx, ctr.ID, containertypes.StartOptions{})
-		assert.Check(t, is.ErrorType(err, errdefs.IsSystem), "should produce a System error when starting an existing container from an invalid state")
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal), "should produce a System error when starting an existing container from an invalid state")
 		assert.Check(t, is.ErrorContains(err, "failed to join PID namespace"))
 		assert.Check(t, is.ErrorContains(err, cPIDContainerID+" is not running"))
 	})

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -46,7 +46,7 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, _, err = apiClient.ContainerInspectWithRaw(ctx, cID, true)
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "No such container"))
 }
 
@@ -84,7 +84,7 @@ func TestRemoveContainerRunning(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient)
 
 	err := apiClient.ContainerRemove(ctx, cID, containertypes.RemoveOptions{})
-	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 	assert.Check(t, is.ErrorContains(err, "container is running"))
 }
 
@@ -105,6 +105,6 @@ func TestRemoveInvalidContainer(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	err := apiClient.ContainerRemove(ctx, "unknown", containertypes.RemoveOptions{})
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "No such container"))
 }

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	req "github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
@@ -133,7 +133,7 @@ func TestResize(t *testing.T) {
 			Height: 40,
 			Width:  40,
 		})
-		assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 		assert.Check(t, is.ErrorContains(err, "is not running"))
 	})
 }

--- a/integration/container/stop_linux_test.go
+++ b/integration/container/stop_linux_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/pkg/stdcopy"
 	"gotest.tools/v3/assert"
@@ -50,7 +50,7 @@ func TestStopContainerWithTimeoutCancel(t *testing.T) {
 
 	select {
 	case stoppedErr := <-stoppedCh:
-		assert.Check(t, is.ErrorType(stoppedErr, errdefs.IsCancelled))
+		assert.Check(t, is.ErrorType(stoppedErr, cerrdefs.IsCanceled))
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout waiting for stop request to be cancelled")
 	}

--- a/integration/container/update_test.go
+++ b/integration/container/update_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -56,5 +56,5 @@ func TestUpdateRestartWithAutoRemove(t *testing.T) {
 		},
 	})
 	assert.Check(t, is.ErrorContains(err, "Restart policy cannot be updated because AutoRemove is enabled for the container"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 }

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -14,12 +14,12 @@ import (
 	"syscall"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/process"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -609,7 +609,7 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 		poll.WaitOn(t, func(t poll.LogT) poll.Result {
 			stat, err := c.ContainerStatPath(ctx, cID, "/foo/test.txt")
 			if err != nil {
-				if errdefs.IsNotFound(err) {
+				if cerrdefs.IsNotFound(err) {
 					return poll.Continue("file doesn't yet exist")
 				}
 				return poll.Error(err)
@@ -682,7 +682,7 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 		waitFn := func(t poll.LogT) poll.Result {
 			_, err := c.ContainerStatPath(ctx, cID, "/image/hello")
 			if err != nil {
-				if errdefs.IsNotFound(err) {
+				if cerrdefs.IsNotFound(err) {
 					return poll.Continue("file doesn't yet exist")
 				}
 				return poll.Error(err)

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	imagetypes "github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
@@ -178,7 +178,7 @@ func TestImportWithCustomPlatformReject(t *testing.T) {
 				reference,
 				imagetypes.ImportOptions{Platform: tc.platform})
 
-			assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 			assert.Check(t, is.ErrorContains(err, tc.expectedErr))
 		})
 	}

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/plugins/content/local"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/registry"
 	"github.com/opencontainers/go-digest"
@@ -36,7 +36,7 @@ func TestImagePullPlatformInvalid(t *testing.T) {
 	_, err := client.ImagePull(ctx, "docker.io/library/hello-world:latest", image.PullOptions{Platform: "foobar"})
 	assert.Assert(t, err != nil)
 	assert.Check(t, is.ErrorContains(err, "unknown operating system or architecture"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 }
 
 func createTestImage(ctx context.Context, t testing.TB, store content.Store) ocispec.Descriptor {
@@ -157,8 +157,8 @@ func TestImagePullStoredDigestForOtherRepo(t *testing.T) {
 		assert.Check(t, rdr.Close())
 	}
 	assert.Assert(t, err != nil, "Expected error, got none: %v", err)
-	assert.Assert(t, errdefs.IsNotFound(err), err)
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Assert(t, cerrdefs.IsNotFound(err), err)
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }
 
 // TestImagePullNonExisting pulls non-existing images from the central registry, with different
@@ -188,7 +188,7 @@ func TestImagePullNonExisting(t *testing.T) {
 
 			expectedMsg := fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", "asdfasdf")
 			assert.Check(t, is.ErrorContains(err, expectedMsg))
-			assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 			if all {
 				// pull -a on a nonexistent registry should fall back as well
 				assert.Check(t, !strings.Contains(err.Error(), "unauthorized"), `message should not contain "unauthorized"`)

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -92,7 +92,7 @@ func TestRemoveByDigest(t *testing.T) {
 	assert.NilError(t, err, "busybox image got deleted")
 
 	inspect, err = client.ImageInspect(ctx, "test-remove-by-digest")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.DeepEqual(inspect, image.InspectResponse{}))
 }
 

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -13,11 +13,11 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/cpuguy83/tar2go"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/testutils"
@@ -227,7 +227,7 @@ func TestSavePlatform(t *testing.T) {
 		ocispec.Platform{Architecture: "amd64", OS: "linux"},
 		ocispec.Platform{Architecture: "arm64", OS: "linux", Variant: "v8"},
 	))
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.Error(err, "Error response from daemon: multiple platform parameters not supported"))
 }
 

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"strings"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/poll"
 )
@@ -74,7 +74,7 @@ func IsRemoved(ctx context.Context, apiClient client.APIClient, containerID stri
 	return func(log poll.LogT) poll.Result {
 		inspect, err := apiClient.ContainerInspect(ctx, containerID)
 		if err != nil {
-			if errdefs.IsNotFound(err) {
+			if cerrdefs.IsNotFound(err) {
 				return poll.Success()
 			}
 			return poll.Error(err)

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/testutil"
@@ -142,18 +142,18 @@ func TestSecretsCreateAndDelete(t *testing.T) {
 		},
 		Data: []byte("TESTINGDATA"),
 	})
-	assert.Check(t, errdefs.IsConflict(err))
+	assert.Check(t, cerrdefs.IsConflict(err))
 	assert.Check(t, is.ErrorContains(err, testName))
 
 	err = c.SecretRemove(ctx, secretID)
 	assert.NilError(t, err)
 
 	_, _, err = c.SecretInspectWithRaw(ctx, secretID)
-	assert.Check(t, errdefs.IsNotFound(err))
+	assert.Check(t, cerrdefs.IsNotFound(err))
 	assert.Check(t, is.ErrorContains(err, secretID))
 
 	err = c.SecretRemove(ctx, "non-existing")
-	assert.Check(t, errdefs.IsNotFound(err))
+	assert.Check(t, cerrdefs.IsNotFound(err))
 	assert.Check(t, is.ErrorContains(err, "non-existing"))
 
 	testName = "test_secret_with_labels_" + t.Name()
@@ -217,7 +217,7 @@ func TestSecretsUpdate(t *testing.T) {
 	// this test will produce an error in func UpdateSecret
 	insp.Spec.Data = []byte("TESTINGDATA2")
 	err = c.SecretUpdate(ctx, secretID, insp.Version, insp.Spec)
-	assert.Check(t, errdefs.IsInvalidParameter(err))
+	assert.Check(t, cerrdefs.IsInvalidArgument(err))
 	assert.Check(t, is.ErrorContains(err, "only updates to Labels are allowed"))
 }
 

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/integration/internal/swarm"
 	"github.com/docker/docker/testutil"
@@ -165,7 +165,7 @@ func TestCreateServiceConflict(t *testing.T) {
 
 	spec := swarm.CreateServiceSpec(t, serviceSpec...)
 	_, err := c.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{})
-	assert.Check(t, errdefs.IsConflict(err))
+	assert.Check(t, cerrdefs.IsConflict(err))
 	assert.ErrorContains(t, err, "service "+serviceName+" already exists")
 }
 

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	clientpkg "github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
@@ -79,7 +79,7 @@ func TestVolumesRemove(t *testing.T) {
 
 	t.Run("volume in use", func(t *testing.T) {
 		err = client.VolumeRemove(ctx, vname, false)
-		assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 		assert.Check(t, is.ErrorContains(err, "volume is in use"))
 	})
 
@@ -95,7 +95,7 @@ func TestVolumesRemove(t *testing.T) {
 
 	t.Run("non-existing volume", func(t *testing.T) {
 		err = client.VolumeRemove(ctx, "no_such_volume", false)
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 
 	t.Run("non-existing volume force", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestVolumesRemoveSwarmEnabled(t *testing.T) {
 
 	t.Run("volume in use", func(t *testing.T) {
 		err = client.VolumeRemove(ctx, vname, false)
-		assert.Check(t, is.ErrorType(err, errdefs.IsConflict))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict))
 		assert.Check(t, is.ErrorContains(err, "volume is in use"))
 	})
 
@@ -147,7 +147,7 @@ func TestVolumesRemoveSwarmEnabled(t *testing.T) {
 
 	t.Run("non-existing volume", func(t *testing.T) {
 		err = client.VolumeRemove(ctx, "no_such_volume", false)
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 
 	t.Run("non-existing volume force", func(t *testing.T) {

--- a/libcontainerd/replace.go
+++ b/libcontainerd/replace.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd/types"
 )
 
@@ -19,14 +19,14 @@ func ReplaceContainer(ctx context.Context, client types.Client, id string, spec 
 		return client.NewContainer(ctx, id, spec, shim, runtimeOptions, opts...)
 	}
 	ctr, err := newContainer()
-	if err == nil || !errdefs.IsConflict(err) {
+	if err == nil || !cerrdefs.IsConflict(err) {
 		return ctr, err
 	}
 
 	log.G(ctx).WithContext(ctx).WithField("container", id).Debug("A container already exists with the same ID. Attempting to clean up the old container.")
 	ctr, err = client.LoadContainer(ctx, id)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			// Task failed successfully: the container no longer exists,
 			// despite us not doing anything. May as well try to create
 			// the container again. It might succeed.
@@ -36,7 +36,7 @@ func ReplaceContainer(ctx context.Context, client types.Client, id string, spec 
 	}
 	tsk, err := ctr.Task(ctx)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			goto deleteContainer
 		}
 		// There is no point in trying to delete the container if we
@@ -46,14 +46,14 @@ func ReplaceContainer(ctx context.Context, client types.Client, id string, spec 
 		return nil, errors.Wrap(err, "could not load stale containerd task object")
 	}
 	if err := tsk.ForceDelete(ctx); err != nil {
-		if !errdefs.IsNotFound(err) {
+		if !cerrdefs.IsNotFound(err) {
 			return nil, errors.Wrap(err, "could not delete stale containerd task object")
 		}
 		// The task might have exited on its own. Proceed with
 		// attempting to delete the container.
 	}
 deleteContainer:
-	if err := ctr.Delete(ctx); err != nil && !errdefs.IsNotFound(err) {
+	if err := ctr.Delete(ctx); err != nil && !cerrdefs.IsNotFound(err) {
 		return nil, errors.Wrap(err, "could not delete stale containerd container object")
 	}
 

--- a/libnetwork/default_gateway.go
+++ b/libnetwork/default_gateway.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/types"
 )
@@ -170,7 +170,7 @@ func (c *Controller) defaultGwNetwork() (*Network, error) {
 	defer func() { <-procGwNetwork }()
 
 	n, err := c.NetworkByName(libnGWNetwork)
-	if errdefs.IsNotFound(err) {
+	if cerrdefs.IsNotFound(err) {
 		n, err = c.createGWNetwork()
 	}
 	return n, err

--- a/libnetwork/drivers/bridge/internal/iptabler/network.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/network.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"net/netip"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
 	"github.com/docker/docker/libnetwork/iptables"
 )
@@ -106,7 +106,7 @@ func (n *network) setupIPTables(ctx context.Context, ipVersion iptables.IPVersio
 			return err
 		}
 		n.registerCleanFunc(func() error {
-			if err := iptables.DelInterfaceFirewalld(n.config.IfName); err != nil && !errdefs.IsNotFound(err) {
+			if err := iptables.DelInterfaceFirewalld(n.config.IfName); err != nil && !cerrdefs.IsNotFound(err) {
 				return err
 			}
 			return nil
@@ -534,7 +534,7 @@ func setupInternalNetworkRules(ctx context.Context, bridgeIface string, prefix n
 			return err
 		}
 	} else {
-		if err := iptables.DelInterfaceFirewalld(bridgeIface); err != nil && !errdefs.IsNotFound(err) {
+		if err := iptables.DelInterfaceFirewalld(bridgeIface); err != nil && !cerrdefs.IsNotFound(err) {
 			return err
 		}
 	}

--- a/libnetwork/drivers/bridge/network_linux_test.go
+++ b/libnetwork/drivers/bridge/network_linux_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/internal/nlwrap"
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/internal/testutils/storeutils"
@@ -36,7 +36,7 @@ func TestLinkCreate(t *testing.T) {
 
 	te := newTestEndpoint46(ipdList[0].Pool, ipd6List[0].Pool, 10)
 	err = d.CreateEndpoint(context.Background(), "dummy", "", te.Interface(), nil)
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.Error(err, "invalid endpoint id: "))
 
 	// Good endpoint creation
@@ -57,7 +57,7 @@ func TestLinkCreate(t *testing.T) {
 
 	te1 := newTestEndpoint(ipdList[0].Pool, 11)
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te1.Interface(), nil)
-	assert.Check(t, is.ErrorType(err, errdefs.IsForbidden))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsPermissionDenied))
 	assert.Assert(t, is.Error(err, "Endpoint (ep) already exists (Only one endpoint allowed)"), "Failed to detect duplicate endpoint id on same network")
 
 	_, err = nlwrap.LinkByName(te.iface.srcName)
@@ -100,7 +100,7 @@ func TestLinkCreateTwo(t *testing.T) {
 
 	te2 := newTestEndpoint(ipdList[0].Pool, 12)
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep", te2.Interface(), nil)
-	assert.Check(t, is.ErrorType(err, errdefs.IsForbidden))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsPermissionDenied))
 	assert.Assert(t, is.Error(err, "Endpoint (ep) already exists (Only one endpoint allowed)"), "Failed to detect duplicate endpoint id on same network")
 }
 
@@ -152,7 +152,7 @@ func TestLinkDelete(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = d.DeleteEndpoint("dummy", "")
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Assert(t, is.Error(err, "invalid endpoint id: "))
 
 	err = d.DeleteEndpoint("dummy", "ep1")

--- a/libnetwork/drivers/bridge/setup_device_linux_test.go
+++ b/libnetwork/drivers/bridge/setup_device_linux_test.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/internal/nlwrap"
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/netutils"
@@ -52,7 +52,7 @@ func TestSetupNewNonDefaultBridge(t *testing.T) {
 
 	err = setupDevice(config, br)
 	assert.Check(t, is.Error(err, "bridge device with non default name test0 must be created manually"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsForbidden))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsPermissionDenied))
 }
 
 func TestSetupDeviceUp(t *testing.T) {

--- a/libnetwork/errors_test.go
+++ b/libnetwork/errors_test.go
@@ -3,7 +3,7 @@ package libnetwork
 import (
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/libnetwork/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -21,11 +21,11 @@ func TestErrorInterfaces(t *testing.T) {
 
 	notFoundErrorList := []error{ErrNoSuchNetwork("")}
 	for _, err := range notFoundErrorList {
-		assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	}
 
 	forbiddenErrorList := []error{&ActiveContainerError{}}
 	for _, err := range forbiddenErrorList {
-		assert.Check(t, is.ErrorType(err, errdefs.IsForbidden))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsPermissionDenied))
 	}
 }

--- a/libnetwork/sandbox_unix_test.go
+++ b/libnetwork/sandbox_unix_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/internal/testutils/netnsutils"
 	"github.com/docker/docker/libnetwork/config"
 	"github.com/docker/docker/libnetwork/drivers/bridge"
@@ -65,14 +65,14 @@ func TestControllerGetSandbox(t *testing.T) {
 	t.Run("invalid id", func(t *testing.T) {
 		const cID = ""
 		sb, err := ctrlr.GetSandbox(cID)
-		assert.Check(t, errdefs.IsInvalidParameter(err), "expected a ErrInvalidParameter, got %[1]v (%[1]T)", err)
+		assert.Check(t, cerrdefs.IsInvalidArgument(err), "expected a ErrInvalidParameter, got %[1]v (%[1]T)", err)
 		assert.Check(t, is.Error(err, "invalid id: id is empty"))
 		assert.Check(t, is.Nil(sb))
 	})
 	t.Run("not found", func(t *testing.T) {
 		const cID = "container-id-with-no-sandbox"
 		sb, err := ctrlr.GetSandbox(cID)
-		assert.Check(t, errdefs.IsNotFound(err), "expected a ErrNotFound, got %[1]v (%[1]T)", err)
+		assert.Check(t, cerrdefs.IsNotFound(err), "expected a ErrNotFound, got %[1]v (%[1]T)", err)
 		assert.Check(t, is.Error(err, "network sandbox for container container-id-with-no-sandbox not found"))
 		assert.Check(t, is.Nil(sb))
 	})
@@ -92,7 +92,7 @@ func TestControllerGetSandbox(t *testing.T) {
 		assert.Check(t, err)
 
 		sb, err = ctrlr.GetSandbox(cID)
-		assert.Check(t, errdefs.IsNotFound(err), "expected a ErrNotFound, got %[1]v (%[1]T)", err)
+		assert.Check(t, cerrdefs.IsNotFound(err), "expected a ErrNotFound, got %[1]v (%[1]T)", err)
 		assert.Check(t, is.Error(err, "network sandbox for container test-container-id not found"))
 		assert.Check(t, is.Nil(sb))
 	})

--- a/libnetwork/types/types_test.go
+++ b/libnetwork/types/types_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -16,31 +16,31 @@ func TestErrorConstructors(t *testing.T) {
 
 	err = InvalidParameterErrorf("Io ho %d uccello", 1)
 	assert.Check(t, is.Error(err, "Io ho 1 uccello"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	_, ok = err.(MaskableError)
 	assert.Check(t, !ok, "error should not be maskable: %[1]v (%[1]T)", err)
 
 	err = NotFoundErrorf("Can't find the %s", "keys")
 	assert.Check(t, is.Error(err, "Can't find the keys"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	_, ok = err.(MaskableError)
 	assert.Check(t, !ok, "error should not be maskable: %[1]v (%[1]T)", err)
 
 	err = ForbiddenErrorf("Can't open door %d", 2)
 	assert.Check(t, is.Error(err, "Can't open door 2"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsForbidden))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsPermissionDenied))
 	_, ok = err.(MaskableError)
 	assert.Check(t, !ok, "error should not be maskable: %[1]v (%[1]T)", err)
 
 	err = NotImplementedErrorf("Functionality %s is not implemented", "x")
 	assert.Check(t, is.Error(err, "Functionality x is not implemented"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotImplemented))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotImplemented))
 	_, ok = err.(MaskableError)
 	assert.Check(t, !ok, "error should not be maskable: %[1]v (%[1]T)", err)
 
 	err = UnavailableErrorf("Driver %s is not available", "mh")
 	assert.Check(t, is.Error(err, "Driver mh is not available"))
-	assert.Check(t, is.ErrorType(err, errdefs.IsUnavailable))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnavailable))
 	_, ok = err.(MaskableError)
 	assert.Check(t, !ok, "error should not be maskable: %[1]v (%[1]T)", err)
 

--- a/plugin/executor/containerd/containerd.go
+++ b/plugin/executor/containerd/containerd.go
@@ -9,6 +9,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/libcontainerd"
@@ -61,12 +62,12 @@ type c8dPlugin struct {
 // deleteTaskAndContainer deletes plugin task and then plugin container from containerd
 func (p c8dPlugin) deleteTaskAndContainer(ctx context.Context) {
 	if p.tsk != nil {
-		if err := p.tsk.ForceDelete(ctx); err != nil && !errdefs.IsNotFound(err) {
+		if err := p.tsk.ForceDelete(ctx); err != nil && !cerrdefs.IsNotFound(err) {
 			p.log.WithError(err).Error("failed to delete plugin task from containerd")
 		}
 	}
 	if p.ctr != nil {
-		if err := p.ctr.Delete(ctx); err != nil && !errdefs.IsNotFound(err) {
+		if err := p.ctr.Delete(ctx); err != nil && !cerrdefs.IsNotFound(err) {
 			p.log.WithError(err).Error("failed to delete plugin container from containerd")
 		}
 	}
@@ -102,14 +103,14 @@ func (e *Executor) Restore(id string, stdout, stderr io.WriteCloser) (bool, erro
 	p := c8dPlugin{log: log.G(ctx).WithField("plugin", id)}
 	ctr, err := e.client.LoadContainer(ctx, id)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return false, nil
 		}
 		return false, err
 	}
 	p.tsk, err = ctr.AttachTask(ctx, attachStreamsFunc(stdout, stderr))
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			p.deleteTaskAndContainer(ctx)
 			return false, nil
 		}
@@ -117,7 +118,7 @@ func (e *Executor) Restore(id string, stdout, stderr io.WriteCloser) (bool, erro
 	}
 	s, err := p.tsk.Status(ctx)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			// Task vanished after attaching?
 			p.tsk = nil
 			p.deleteTaskAndContainer(ctx)

--- a/reference/store_test.go
+++ b/reference/store_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -162,13 +162,13 @@ func TestAddDeleteGet(t *testing.T) {
 		t.Fatalf("error redundantly adding to store: %v", err)
 	}
 	err = store.AddDigest(ref5.(reference.Canonical), testImageID3, false)
-	assert.Check(t, is.ErrorType(err, errdefs.IsConflict), "overwriting a digest with a different digest should fail")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict), "overwriting a digest with a different digest should fail")
 	err = store.AddDigest(ref5.(reference.Canonical), testImageID3, true)
-	assert.Check(t, is.ErrorType(err, errdefs.IsConflict), "overwriting a digest cannot be forced")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict), "overwriting a digest cannot be forced")
 
 	// Attempt to overwrite with force == false
 	err = store.AddTag(ref4, testImageID3, false)
-	assert.Check(t, is.ErrorType(err, errdefs.IsConflict), "did not get expected error on overwrite attempt")
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsConflict), "did not get expected error on overwrite attempt")
 	// Repeat to overwrite with force == true
 	if err = store.AddTag(ref4, testImageID3, true); err != nil {
 		t.Fatalf("failed to force tag overwrite: %v", err)
@@ -328,12 +328,12 @@ func TestInvalidTags(t *testing.T) {
 	ref, err := reference.ParseNormalizedNamed("sha256:abc")
 	assert.NilError(t, err)
 	err = store.AddTag(ref, id, true)
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 
 	// setting digest as a tag
 	ref, err = reference.ParseNormalizedNamed("registry@sha256:367eb40fd0330a7e464777121e39d2f5b3e8e23a1e159342e53ab05c9e4d94e6")
 	assert.NilError(t, err)
 
 	err = store.AddTag(ref, id, true)
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 }

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/sysinfo"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -99,7 +99,7 @@ func TestDecodeContainerConfigIsolation(t *testing.T) {
 			cfg, hostConfig, nwConfig, err := decodeContainerConfig(bytes.NewReader(b), sysinfo.New())
 			if tc.invalid {
 				assert.Check(t, is.ErrorContains(err, tc.expectedErr))
-				assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+				assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 				assert.Check(t, is.Nil(cfg))
 				assert.Check(t, is.Nil(hostConfig))
 				assert.Check(t, is.Nil(nwConfig))
@@ -118,7 +118,7 @@ func TestDecodeContainerConfigPrivileged(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		const expected = "invalid option: privileged mode is not supported for Windows containers"
 		assert.Check(t, is.Error(err, expected))
-		assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 		assert.Check(t, is.Nil(cfg))
 		assert.Check(t, is.Nil(hostConfig))
 		assert.Check(t, is.Nil(nwConfig))

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -5,8 +5,8 @@ package runconfig // import "github.com/docker/docker/runconfig"
 import (
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/sysinfo"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -77,7 +77,7 @@ func TestValidateResources(t *testing.T) {
 
 			err := validateResources(&hc, &si)
 			if tc.expectedError != "" {
-				assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+				assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 				assert.Check(t, is.Error(err, tc.expectedError))
 			} else {
 				assert.NilError(t, err)

--- a/testutil/daemon/plugin.go
+++ b/testutil/daemon/plugin.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/poll"
 )
 
@@ -34,7 +34,7 @@ func (d *Daemon) PluginIsNotRunning(t testing.TB, name string) func(poll.LogT) p
 func (d *Daemon) PluginIsNotPresent(t testing.TB, name string) func(poll.LogT) poll.Result {
 	return withClient(t, d, func(c client.APIClient, t poll.LogT) poll.Result {
 		_, _, err := c.PluginInspectWithRaw(context.Background(), name)
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return poll.Success()
 		}
 		if err != nil {
@@ -57,7 +57,7 @@ func (d *Daemon) PluginReferenceIs(t testing.TB, name, expectedRef string) func(
 func withPluginInspect(name string, f func(*types.Plugin, poll.LogT) poll.Result) func(client.APIClient, poll.LogT) poll.Result {
 	return func(c client.APIClient, t poll.LogT) poll.Result {
 		plugin, _, err := c.PluginInspectWithRaw(context.Background(), name)
-		if errdefs.IsNotFound(err) {
+		if cerrdefs.IsNotFound(err) {
 			return poll.Continue("plugin %q not found", name)
 		}
 		if err != nil {

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/internal/lazyregexp"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
@@ -82,7 +82,7 @@ func deleteAllContainers(ctx context.Context, t testing.TB, apiclient client.Con
 			Force:         true,
 			RemoveVolumes: true,
 		})
-		if err == nil || errdefs.IsNotFound(err) || alreadyExists.MatchString(err.Error()) {
+		if err == nil || cerrdefs.IsNotFound(err) || alreadyExists.MatchString(err.Error()) {
 			continue
 		}
 		assert.Check(t, err, "failed to remove %s", ctr.ID)
@@ -125,7 +125,7 @@ func removeImage(ctx context.Context, t testing.TB, apiclient client.ImageAPICli
 	_, err := apiclient.ImageRemove(ctx, ref, image.RemoveOptions{
 		Force: true,
 	})
-	if errdefs.IsNotFound(err) {
+	if cerrdefs.IsNotFound(err) {
 		return
 	}
 	assert.Check(t, err, "failed to remove image %s", ref)
@@ -170,7 +170,7 @@ func deleteAllPlugins(ctx context.Context, t testing.TB, c client.PluginAPIClien
 	t.Helper()
 	plugins, err := c.PluginList(ctx, filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
-	if errdefs.IsNotImplemented(err) {
+	if cerrdefs.IsNotImplemented(err) {
 		return
 	}
 	assert.Check(t, err, "failed to list plugins")

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/testutil"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
@@ -200,7 +200,7 @@ func getExistingPlugins(ctx context.Context, t testing.TB, testEnv *Execution) [
 	client := testEnv.APIClient()
 	pluginList, err := client.PluginList(ctx, filters.Args{})
 	// Docker EE does not allow cluster-wide plugin management.
-	if errdefs.IsNotImplemented(err) {
+	if cerrdefs.IsNotImplemented(err) {
 		return []string{}
 	}
 	assert.NilError(t, err, "failed to list plugins")

--- a/volume/local/local_linux_test.go
+++ b/volume/local/local_linux_test.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/quota"
 	"gotest.tools/v3/assert"
@@ -240,7 +240,7 @@ func TestVolCreateValidation(t *testing.T) {
 			if tc.expectedErr == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Check(t, errdefs.IsInvalidParameter(err), "got: %T", err)
+				assert.Check(t, cerrdefs.IsInvalidArgument(err), "got: %T", err)
 				assert.ErrorContains(t, err, tc.expectedErr)
 			}
 		})

--- a/volume/service/service_test.go
+++ b/volume/service/service_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/volume"
 	volumedrivers "github.com/docker/docker/volume/drivers"
 	"github.com/docker/docker/volume/service/opts"
@@ -27,7 +27,7 @@ func TestServiceCreate(t *testing.T) {
 	defer cleanup()
 
 	_, err := service.Create(ctx, "v1", "notexist")
-	assert.Assert(t, errdefs.IsNotFound(err), err)
+	assert.Assert(t, cerrdefs.IsNotFound(err), err)
 
 	v, err := service.Create(ctx, "v1", "d1")
 	assert.NilError(t, err)
@@ -38,7 +38,7 @@ func TestServiceCreate(t *testing.T) {
 
 	_, err = service.Create(ctx, "v1", "d2")
 	assert.Check(t, IsNameConflict(err), err)
-	assert.Check(t, errdefs.IsConflict(err), err)
+	assert.Check(t, cerrdefs.IsConflict(err), err)
 
 	assert.Assert(t, service.Remove(ctx, "v1"))
 	_, err = service.Create(ctx, "v1", "d2")
@@ -146,14 +146,14 @@ func TestServiceGet(t *testing.T) {
 	assert.Assert(t, is.Len(v.Status, 1), v.Status)
 
 	_, err = service.Get(ctx, "test", opts.WithGetDriver("notarealdriver"))
-	assert.Assert(t, errdefs.IsConflict(err), err)
+	assert.Assert(t, cerrdefs.IsConflict(err), err)
 	v, err = service.Get(ctx, "test", opts.WithGetDriver("d1"))
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(created, v))
 
 	assert.Assert(t, ds.Register(testutils.NewFakeDriver("d2"), "d2"))
 	_, err = service.Get(ctx, "test", opts.WithGetDriver("d2"))
-	assert.Assert(t, errdefs.IsConflict(err), err)
+	assert.Assert(t, cerrdefs.IsConflict(err), err)
 }
 
 func TestServicePrune(t *testing.T) {


### PR DESCRIPTION
**- What I did**

Use `github.com/containerd/errdefs` instead of deprecated methods from `errdefs/is.go`

**- How I did it**

Remove errdefs/is.go and replace every used methods with it's github.com/containerd/errdefs equivalent

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

