### PR TITLE
libnetwork: don't reinvent mutexes

### DIFF
--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -484,8 +484,8 @@ func (ep *Endpoint) Join(ctx context.Context, sb *Sandbox, options ...EndpointOp
 		return types.InvalidParameterErrorf("invalid Sandbox passed to endpoint join: %v", sb)
 	}
 
-	sb.joinLeaveStart()
-	defer sb.joinLeaveEnd()
+	sb.joinLeaveMu.Lock()
+	defer sb.joinLeaveMu.Unlock()
 
 	return ep.sbJoin(ctx, sb, options...)
 }
@@ -820,8 +820,8 @@ func (ep *Endpoint) Leave(ctx context.Context, sb *Sandbox) error {
 		return types.InvalidParameterErrorf("invalid Sandbox passed to endpoint leave: %v", sb)
 	}
 
-	sb.joinLeaveStart()
-	defer sb.joinLeaveEnd()
+	sb.joinLeaveMu.Lock()
+	defer sb.joinLeaveMu.Unlock()
 
 	return ep.sbLeave(ctx, sb, false)
 }


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
**- How I did it**
The (*Sandbox).joinLeaveStart() and .joinLeaveEnd() methods implement an exclusive lock which is almost functionally identical to (*sync.Mutex).Lock() and .Unlock(), respectively. The only notable differences are that joinLeaveStart allocates, and calling joinLeaveEnd() more times than joinLeaveStart() is a silent no-op instead of a fatal error.

The construction of the joinLeaveStart/End methods is shaped like a condition variable which uses channels for waiting and broadcasting. The condition being waited for is that the joinLeaveDone struct field is nil, i.e. that the lock has not been acquired by another goroutine. As the condition is being checked and set while in a critical section, it is a mutex implemented in terms of mutexes and channels. Replace the home-grown mutex with a plain sync.Mutex.

**- How to verify it**
By inspection & CI

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

