### PR TITLE
fix go-critic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,8 +146,6 @@ linters:
         - regexpSimplify
         - singleCaseSwitch
         - sloppyReassign
-        - stringsCompare
-        - stringConcatSimplify
         - stringXbytes
         - typeAssertChain
         - typeDefFirst

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,7 +110,6 @@ linters:
         - appendCombine
         - assignOp
         - badCall
-        - badLock
         - builtinShadow
         - builtinShadowDecl
         - captLocal

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,7 +131,6 @@ linters:
         - importShadow
         - indexAlloc
         - initClause
-        - mapKey
         - methodExprCall
         - nestingReduce
         - nilValReturn

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -162,8 +162,8 @@ linters:
         - unslice
         - valSwap
         - whyNoLint
-        - yodaStyleExpr
       enable-all: true
+
     gosec:
       excludes:
         - G104 # G104: Errors unhandled; (TODO: reduce unhandled errors, or explicitly ignore)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,7 +116,6 @@ linters:
         - captLocal
         - commentedOutCode
         - deferInLoop
-        - deprecatedComment
         - dupImport
         - dupSubExpr
         - elseif

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - fatcontext                # Detects nested contexts in loops and function literals.
     - forbidigo
     - gocheckcompilerdirectives # Detects invalid go compiler directive comments (//go:).
+    - gocritic                  # Detects for bugs, performance and style issues.
     - gosec                     # Detects security problems.
     - govet
     - iface                     # Detects incorrect use of interfaces. Currently only used for "identical" interfaces in the same package.
@@ -103,6 +104,66 @@ linters:
           msg: Add a wrapper to nlwrap.Handle for EINTR handling and update the list in .golangci.yml.
       analyze-types: true
 
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - appendCombine
+        - assignOp
+        - badCall
+        - badLock
+        - boolExprSimplify
+        - builtinShadow
+        - builtinShadowDecl
+        - captLocal
+        - commentedOutCode
+        - deferInLoop
+        - deprecatedComment
+        - dupImport
+        - elseif
+        - emptyFallthrough
+        - emptyStringTest
+        - equalFold
+        - evalOrder
+        - exitAfterDefer
+        - exposedSyncMutex
+        - filepathJoin
+        - hexLiteral
+        - httpNoBody
+        - hugeParam
+        - ifElseChain
+        - importShadow
+        - indexAlloc
+        - initClause
+        - mapKey
+        - methodExprCall
+        - nestingReduce
+        - nilValReturn
+        - octalLiteral
+        - paramTypeCombine
+        - preferStringWriter
+        - ptrToRefParam
+        - rangeValCopy
+        - redundantSprint
+        - regexpMust
+        - regexpSimplify
+        - singleCaseSwitch
+        - sloppyReassign
+        - sprintfQuotedString
+        - stringsCompare
+        - stringConcatSimplify
+        - stringXbytes
+        - typeAssertChain
+        - typeDefFirst
+        - typeUnparen
+        - uncheckedInlineErr
+        - unlambda
+        - unnamedResult
+        - unnecessaryDefer
+        - unslice
+        - valSwap
+        - whyNoLint
+        - yodaStyleExpr
+      enable-all: true
     gosec:
       excludes:
         - G104 # G104: Errors unhandled; (TODO: reduce unhandled errors, or explicitly ignore)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,7 +109,6 @@ linters:
         - appendAssign
         - appendCombine
         - assignOp
-        - badCall
         - builtinShadow
         - builtinShadowDecl
         - captLocal

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,7 +130,6 @@ linters:
         - ifElseChain
         - importShadow
         - indexAlloc
-        - initClause
         - methodExprCall
         - nestingReduce
         - nilValReturn

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,9 +118,9 @@ linters:
         - deferInLoop
         - deprecatedComment
         - dupImport
+        - dupSubExpr
         - elseif
         - emptyFallthrough
-        - emptyStringTest
         - equalFold
         - evalOrder
         - exitAfterDefer

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,7 +111,6 @@ linters:
         - assignOp
         - badCall
         - badLock
-        - boolExprSimplify
         - builtinShadow
         - builtinShadowDecl
         - captLocal

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,7 +127,6 @@ linters:
         - exposedSyncMutex
         - filepathJoin
         - hexLiteral
-        - httpNoBody
         - hugeParam
         - ifElseChain
         - importShadow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,7 +146,6 @@ linters:
         - regexpSimplify
         - singleCaseSwitch
         - sloppyReassign
-        - sprintfQuotedString
         - stringsCompare
         - stringConcatSimplify
         - stringXbytes

--- a/api/server/httputils/form_test.go
+++ b/api/server/httputils/form_test.go
@@ -30,7 +30,7 @@ func TestBoolValue(t *testing.T) {
 	for c, e := range cases {
 		v := url.Values{}
 		v.Set("test", c)
-		r, _ := http.NewRequest(http.MethodPost, "", nil)
+		r, _ := http.NewRequest(http.MethodPost, "", http.NoBody)
 		r.Form = v
 
 		a := BoolValue(r, "test")
@@ -41,14 +41,14 @@ func TestBoolValue(t *testing.T) {
 }
 
 func TestBoolValueOrDefault(t *testing.T) {
-	r, _ := http.NewRequest(http.MethodGet, "", nil)
+	r, _ := http.NewRequest(http.MethodGet, "", http.NoBody)
 	if !BoolValueOrDefault(r, "queryparam", true) {
 		t.Fatal("Expected to get true default value, got false")
 	}
 
 	v := url.Values{}
 	v.Set("param", "")
-	r, _ = http.NewRequest(http.MethodGet, "", nil)
+	r, _ = http.NewRequest(http.MethodGet, "", http.NoBody)
 	r.Form = v
 	if BoolValueOrDefault(r, "param", true) {
 		t.Fatal("Expected not to get true")
@@ -66,7 +66,7 @@ func TestInt64ValueOrZero(t *testing.T) {
 	for c, e := range cases {
 		v := url.Values{}
 		v.Set("test", c)
-		r, _ := http.NewRequest(http.MethodPost, "", nil)
+		r, _ := http.NewRequest(http.MethodPost, "", http.NoBody)
 		r.Form = v
 
 		a := Int64ValueOrZero(r, "test")
@@ -86,7 +86,7 @@ func TestInt64ValueOrDefault(t *testing.T) {
 	for c, e := range cases {
 		v := url.Values{}
 		v.Set("test", c)
-		r, _ := http.NewRequest(http.MethodPost, "", nil)
+		r, _ := http.NewRequest(http.MethodPost, "", http.NoBody)
 		r.Form = v
 
 		a, err := Int64ValueOrDefault(r, "test", -1)
@@ -102,7 +102,7 @@ func TestInt64ValueOrDefault(t *testing.T) {
 func TestInt64ValueOrDefaultWithError(t *testing.T) {
 	v := url.Values{}
 	v.Set("test", "invalid")
-	r, _ := http.NewRequest(http.MethodPost, "", nil)
+	r, _ := http.NewRequest(http.MethodPost, "", http.NoBody)
 	r.Form = v
 
 	_, err := Int64ValueOrDefault(r, "test", -1)
@@ -150,7 +150,7 @@ func TestUint32Value(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.value, func(t *testing.T) {
-			r, _ := http.NewRequest(http.MethodPost, "", nil)
+			r, _ := http.NewRequest(http.MethodPost, "", http.NoBody)
 			r.Form = url.Values{}
 			if tc.value != valueNotSet {
 				r.Form.Set("field", tc.value)

--- a/api/server/httputils/httputils_test.go
+++ b/api/server/httputils/httputils_test.go
@@ -33,7 +33,7 @@ func TestJsonContentType(t *testing.T) {
 
 func TestReadJSON(t *testing.T) {
 	t.Run("nil body", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodPost, "https://example.com/some/path", nil)
+		req, err := http.NewRequest(http.MethodPost, "https://example.com/some/path", http.NoBody)
 		if err != nil {
 			t.Error(err)
 		}

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -79,7 +79,7 @@ func TestVersionMiddlewareVersion(t *testing.T) {
 	assert.NilError(t, err)
 	h := m.WrapHandler(handler)
 
-	req, _ := http.NewRequest(http.MethodGet, "/containers/json", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/containers/json", http.NoBody)
 	resp := httptest.NewRecorder()
 	ctx := context.Background()
 
@@ -129,7 +129,7 @@ func TestVersionMiddlewareWithErrorsReturnsHeaders(t *testing.T) {
 	assert.NilError(t, err)
 	h := m.WrapHandler(handler)
 
-	req, _ := http.NewRequest(http.MethodGet, "/containers/json", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/containers/json", http.NoBody)
 	resp := httptest.NewRecorder()
 	ctx := context.Background()
 

--- a/api/server/middleware/version_test.go
+++ b/api/server/middleware/version_test.go
@@ -121,7 +121,7 @@ func TestVersionMiddlewareVersion(t *testing.T) {
 func TestVersionMiddlewareWithErrorsReturnsHeaders(t *testing.T) {
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		v := httputils.VersionFromContext(ctx)
-		assert.Check(t, len(v) != 0)
+		assert.Check(t, v != "")
 		return nil
 	}
 

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -113,7 +113,7 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 			return errdefs.InvalidParameter(err)
 		}
 
-		if len(comment) == 0 {
+		if comment == "" {
 			comment = "Imported from " + src
 		}
 

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -22,7 +22,7 @@ import (
 func callGetVolume(v *volumeRouter, name string) (*httptest.ResponseRecorder, error) {
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
 	vars := map[string]string{"name": name}
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/volumes/%s", name), nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/volumes/%s", name), http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.getVolumeByName(ctx, resp, req, vars)
@@ -32,7 +32,7 @@ func callGetVolume(v *volumeRouter, name string) (*httptest.ResponseRecorder, er
 func callListVolumes(v *volumeRouter) (*httptest.ResponseRecorder, error) {
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
 	vars := map[string]string{}
-	req := httptest.NewRequest(http.MethodGet, "/volumes", nil)
+	req := httptest.NewRequest(http.MethodGet, "/volumes", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.getVolumesList(ctx, resp, req, vars)
@@ -428,7 +428,7 @@ func TestVolumeRemove(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
@@ -455,7 +455,7 @@ func TestVolumeRemoveSwarm(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
@@ -472,7 +472,7 @@ func TestVolumeRemoveNotFoundNoSwarm(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
@@ -489,7 +489,7 @@ func TestVolumeRemoveNotFoundNoManager(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
@@ -513,7 +513,7 @@ func TestVolumeRemoveFoundNoSwarm(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
@@ -536,7 +536,7 @@ func TestVolumeRemoveNoSwarmInUse(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req := httptest.NewRequest(http.MethodDelete, "/volumes/inuse", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/volumes/inuse", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "inuse"})
@@ -564,7 +564,7 @@ func TestVolumeRemoveSwarmForce(t *testing.T) {
 	}
 
 	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/volumes/vol1", http.NoBody)
 	resp := httptest.NewRecorder()
 
 	err := v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})
@@ -573,7 +573,7 @@ func TestVolumeRemoveSwarmForce(t *testing.T) {
 	assert.Assert(t, cerrdefs.IsConflict(err))
 
 	ctx = context.WithValue(context.Background(), httputils.APIVersionKey{}, clusterVolumesVersion)
-	req = httptest.NewRequest(http.MethodDelete, "/volumes/vol1?force=1", nil)
+	req = httptest.NewRequest(http.MethodDelete, "/volumes/vol1?force=1", http.NoBody)
 	resp = httptest.NewRecorder()
 
 	err = v.deleteVolumes(ctx, resp, req, map[string]string{"name": "vol1"})

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -21,7 +21,7 @@ func TestMiddlewares(t *testing.T) {
 	}
 	srv.UseMiddleware(*m)
 
-	req, _ := http.NewRequest(http.MethodGet, "/containers/json", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/containers/json", http.NoBody)
 	resp := httptest.NewRecorder()
 	ctx := context.Background()
 

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -112,11 +112,14 @@ type Actor struct {
 
 // Message represents the information an event contains
 type Message struct {
-	// Deprecated information from JSONMessage.
+	// Deprecated: use Action instead.
+	// Information from JSONMessage.
 	// With data only in container events.
-	Status string `json:"status,omitempty"` // Deprecated: use Action instead.
-	ID     string `json:"id,omitempty"`     // Deprecated: use Actor.ID instead.
-	From   string `json:"from,omitempty"`   // Deprecated: use Actor.Attributes["image"] instead.
+	Status string `json:"status,omitempty"`
+	// Deprecated: use Actor.ID instead.
+	ID string `json:"id,omitempty"`
+	// Deprecated: use Actor.Attributes["image"] instead.
+	From string `json:"from,omitempty"`
 
 	Type   Type
 	Action Action

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -368,7 +368,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 	ulimits, err := toBuildkitUlimits(opt.Options.Ulimits)
 	if err != nil {
 		return nil, err
-	} else if len(ulimits) > 0 {
+	} else if ulimits != "" {
 		frontendAttrs["ulimit"] = ulimits
 	}
 

--- a/builder/dockerfile/imageprobe.go
+++ b/builder/dockerfile/imageprobe.go
@@ -60,7 +60,7 @@ func (c *imageProber) Probe(parentID string, runConfig *container.Config, platfo
 	if err != nil {
 		return "", err
 	}
-	if len(cacheID) == 0 {
+	if cacheID == "" {
 		log.G(context.TODO()).Debugf("[BUILDER] Cache miss: %s", runConfig.Cmd)
 		c.cacheBusted = true
 		return "", nil

--- a/builder/remotecontext/remote.go
+++ b/builder/remotecontext/remote.go
@@ -106,7 +106,7 @@ func inspectResponse(ct string, r io.Reader, clen int64) (string, io.Reader, err
 	// content type for files without an extension (e.g. 'Dockerfile')
 	// so if we receive this value we better check for text content
 	contentType := ct
-	if len(ct) == 0 || ct == mimeTypeOctetStream {
+	if ct == "" || ct == mimeTypeOctetStream {
 		contentType, err = detectContentType(preamble)
 		if err != nil {
 			return contentType, bodyReader, err
@@ -115,7 +115,7 @@ func inspectResponse(ct string, r io.Reader, clen int64) (string, io.Reader, err
 
 	contentType = selectAcceptableMIME(contentType)
 	var cterr error
-	if len(contentType) == 0 {
+	if contentType == "" {
 		cterr = fmt.Errorf("unsupported Content-Type %q", ct)
 		contentType = ct
 	}

--- a/builder/remotecontext/remote_test.go
+++ b/builder/remotecontext/remote_test.go
@@ -36,7 +36,7 @@ func TestSelectAcceptableMIME(t *testing.T) {
 	}
 
 	for _, m := range invalidMimeStrings {
-		if len(selectAcceptableMIME(m)) > 0 {
+		if selectAcceptableMIME(m) != "" {
 			t.Fatalf("Should not have accepted %q", m)
 		}
 	}

--- a/builder/remotecontext/tarsum_test.go
+++ b/builder/remotecontext/tarsum_test.go
@@ -49,7 +49,7 @@ func TestHashFile(t *testing.T) {
 		t.Fatalf("Error when executing Stat: %s", err)
 	}
 
-	if len(sum) == 0 {
+	if sum == "" {
 		t.Fatalf("Hash returned empty sum")
 	}
 
@@ -83,7 +83,7 @@ func TestHashSubdir(t *testing.T) {
 		t.Fatalf("Error when executing Stat: %s", err)
 	}
 
-	if len(sum) == 0 {
+	if sum == "" {
 		t.Fatalf("Hash returned empty sum")
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -525,7 +525,7 @@ func TestClientRedirect(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.httpMethod, func(t *testing.T) {
-			req, err := http.NewRequest(tc.httpMethod, "/redirectme", nil)
+			req, err := http.NewRequest(tc.httpMethod, "/redirectme", http.NoBody)
 			assert.NilError(t, err)
 			resp, err := client.Do(req)
 			assert.Check(t, is.Equal(resp.StatusCode, tc.statusCode))

--- a/client/container_start.go
+++ b/client/container_start.go
@@ -15,10 +15,10 @@ func (cli *Client) ContainerStart(ctx context.Context, containerID string, optio
 	}
 
 	query := url.Values{}
-	if len(options.CheckpointID) != 0 {
+	if options.CheckpointID != "" {
 		query.Set("checkpoint", options.CheckpointID)
 	}
-	if len(options.CheckpointDir) != 0 {
+	if options.CheckpointDir != "" {
 		query.Set("checkpoint-dir", options.CheckpointDir)
 	}
 

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -58,7 +58,7 @@ func TestEvents(t *testing.T) {
 	const expectedURL = "/events"
 
 	fltrs := filters.NewArgs(filters.Arg("type", string(events.ContainerEventType)))
-	expectedFiltersJSON := fmt.Sprintf(`{"type":{"%s":true}}`, events.ContainerEventType)
+	expectedFiltersJSON := fmt.Sprintf(`{"type":{%q:true}}`, events.ContainerEventType)
 
 	eventsCases := []struct {
 		options             events.ListOptions

--- a/client/hijack.go
+++ b/client/hijack.go
@@ -40,7 +40,7 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 
 // DialHijack returns a hijacked connection with negotiated protocol proto.
 func (cli *Client) DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/client/utils.go
+++ b/client/utils.go
@@ -25,7 +25,7 @@ func (e emptyIDError) Error() string {
 // trimID trims the given object-ID / name, returning an error if it's empty.
 func trimID(objType, id string) (string, error) {
 	id = strings.TrimSpace(id)
-	if len(id) == 0 {
+	if id == "" {
 		return "", emptyIDError(objType)
 	}
 	return id, nil

--- a/cmd/dockerd/options.go
+++ b/cmd/dockerd/options.go
@@ -108,7 +108,7 @@ func (o *daemonOptions) installFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
 	flags.BoolVar(&o.Validate, "validate", false, "Validate daemon configuration and exit")
 	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
-	flags.StringVar(&o.LogFormat, "log-format", string(log.TextFormat), fmt.Sprintf(`Set the logging format ("%s"|"%s")`, log.TextFormat, log.JSONFormat))
+	flags.StringVar(&o.LogFormat, "log-format", string(log.TextFormat), fmt.Sprintf(`Set the logging format (%q|%q)`, log.TextFormat, log.JSONFormat))
 	flags.BoolVar(&o.TLS, FlagTLS, DefaultTLSValue, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&o.TLSVerify, FlagTLSVerify, dockerTLSVerify || DefaultTLSValue, "Use TLS and verify the remote")
 

--- a/container/container.go
+++ b/container/container.go
@@ -380,7 +380,7 @@ func (container *Container) GetResourcePath(path string) (string, error) {
 // The returned path is always prefixed with a [filepath.Separator].
 func cleanScopedPath(path string) string {
 	if len(path) >= 2 {
-		if v := filepath.VolumeName(path); len(v) > 0 {
+		if v := filepath.VolumeName(path); v != "" {
 			path = path[len(v):]
 		}
 	}

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -254,7 +254,7 @@ func (c *containerConfig) labels() map[string]string {
 
 	// finally, we apply the system labels, which override all labels.
 	for k, v := range system {
-		labels[strings.Join([]string{systemLabelPrefix, k}, ".")] = v
+		labels[systemLabelPrefix+"."+k] = v
 	}
 
 	return labels

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -36,7 +36,7 @@ import (
 //     unique enough to only return a single container object
 //     If none of these searches succeed, an error is returned
 func (daemon *Daemon) GetContainer(prefixOrName string) (*container.Container, error) {
-	if len(prefixOrName) == 0 {
+	if prefixOrName == "" {
 		return nil, errors.WithStack(invalidIdentifier(prefixOrName))
 	}
 
@@ -178,7 +178,7 @@ func getEntrypointAndArgs(configEntrypoint, configCmd []string) (string, []strin
 
 // GetByName returns a container given a name.
 func (daemon *Daemon) GetByName(name string) (*container.Container, error) {
-	if len(name) == 0 {
+	if name == "" {
 		return nil, fmt.Errorf("No container name supplied")
 	}
 	fullName := name
@@ -252,7 +252,7 @@ func validateContainerConfig(config *containertypes.Config) error {
 	if err := translateWorkingDir(config); err != nil {
 		return err
 	}
-	if len(config.StopSignal) > 0 {
+	if config.StopSignal != "" {
 		if _, err := signal.ParseSignal(config.StopSignal); err != nil {
 			return err
 		}

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -94,12 +94,12 @@ func (e *Events) Log(action eventtypes.Action, eventType eventtypes.Type, actor 
 	// fill deprecated fields for container and images
 	switch eventType {
 	case eventtypes.ContainerEventType:
-		jm.ID = actor.ID
-		jm.Status = string(action)
-		jm.From = actor.Attributes["image"]
+		jm.ID = actor.ID                    //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
+		jm.Status = string(action)          //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
+		jm.From = actor.Attributes["image"] //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
 	case eventtypes.ImageEventType:
-		jm.ID = actor.ID
-		jm.Status = string(action)
+		jm.ID = actor.ID           //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
+		jm.Status = string(action) //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
 	default:
 		// TODO(thaJeztah): make switch exhaustive
 	}

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -20,9 +20,9 @@ import (
 // TODO remove this once we removed the deprecated `ID`, `Status`, and `From` fields.
 func validateLegacyFields(t *testing.T, msg events.Message) {
 	t.Helper()
-	assert.Check(t, is.Equal(msg.Status, string(msg.Action)), "Legacy Status field does not match Action")
-	assert.Check(t, is.Equal(msg.ID, msg.Actor.ID), "Legacy ID field does not match Actor.ID")
-	assert.Check(t, is.Equal(msg.From, msg.Actor.Attributes["image"]), "Legacy From field does not match Actor.Attributes.image")
+	assert.Check(t, is.Equal(msg.Status, string(msg.Action)), "Legacy Status field does not match Action")                        //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
+	assert.Check(t, is.Equal(msg.ID, msg.Actor.ID), "Legacy ID field does not match Actor.ID")                                    //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
+	assert.Check(t, is.Equal(msg.From, msg.Actor.Attributes["image"]), "Legacy From field does not match Actor.Attributes.image") //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
 }
 
 func TestEventsLog(t *testing.T) {

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -141,10 +141,10 @@ func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.E
 		return "", err
 	}
 	execConfig.Env = container.ReplaceOrAppendEnvValues(cntr.CreateDaemonEnvironment(options.Tty, linkedEnv), options.Env)
-	if len(execConfig.User) == 0 {
+	if execConfig.User == "" {
 		execConfig.User = cntr.Config.User
 	}
-	if len(execConfig.WorkingDir) == 0 {
+	if execConfig.WorkingDir == "" {
 		execConfig.WorkingDir = cntr.Config.WorkingDir
 	}
 

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -43,7 +43,7 @@ func getUserFromContainerd(ctx context.Context, containerdCli *containerd.Client
 }
 
 func (daemon *Daemon) execSetPlatformOpt(ctx context.Context, daemonCfg *config.Config, ec *container.ExecConfig, p *specs.Process) error {
-	if len(ec.User) > 0 {
+	if ec.User != "" {
 		var err error
 		if daemon.UsesSnapshotter() {
 			p.User, err = getUserFromContainerd(ctx, daemon.containerdClient, ec)

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -137,7 +137,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 		<-execErr
 
 		var msg string
-		if out := output.String(); len(out) > 0 {
+		if out := output.String(); out != "" {
 			msg = fmt.Sprintf("Health check exceeded timeout (%v): %s", probeTimeout, out)
 		} else {
 			msg = fmt.Sprintf("Health check exceeded timeout (%v)", probeTimeout)

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -39,7 +39,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 	}
 
 	comment := img.Comment
-	if len(comment) == 0 && len(img.History) > 0 {
+	if comment == "" && len(img.History) > 0 {
 		comment = img.History[len(img.History)-1].Comment
 	}
 

--- a/daemon/images/image_squash.go
+++ b/daemon/images/image_squash.go
@@ -25,7 +25,7 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 
 	var parentImg *image.Image
 	var parentChainID layer.ChainID
-	if len(parent) != 0 {
+	if parent != "" {
 		parentImg, err = i.imageStore.Get(image.ID(parent))
 		if err != nil {
 			return "", errors.Wrap(err, "error getting specified parent layer")
@@ -69,7 +69,7 @@ func (i *ImageService) SquashImage(id, parent string) (string, error) {
 
 	now := time.Now()
 	var historyComment string
-	if len(parent) > 0 {
+	if parent != "" {
 		historyComment = fmt.Sprintf("merge %s to %s", id, parent)
 	} else {
 		historyComment = fmt.Sprintf("create new from %s", id)

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -857,7 +857,7 @@ func (b *eventBatch) add(event wrappedEvent, size int) bool {
 
 	// verify we are still within service limits
 	switch {
-	case len(b.batch)+1 > maximumLogEventsPerPut:
+	case len(b.batch) >= maximumLogEventsPerPut:
 		return false
 	case b.bytes+addBytes > maximumBytesPerPut:
 		return false

--- a/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
+++ b/daemon/logger/jsonfilelog/jsonlog/jsonlogbytes.go
@@ -28,7 +28,7 @@ func (mj *JSONLogs) MarshalJSONBuf(buf *bytes.Buffer) error {
 		buf.WriteString(`"log":`)
 		ffjsonWriteJSONBytesAsString(buf, mj.Log)
 	}
-	if len(mj.Stream) != 0 {
+	if mj.Stream != "" {
 		if first {
 			first = false
 		} else {

--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -371,7 +371,7 @@ func (w *LogFile) Close() error {
 	close(w.closed)
 	// Wait until any in-progress rotation is complete.
 	w.rotateMu.Lock()
-	w.rotateMu.Unlock() //nolint:staticcheck
+	w.rotateMu.Unlock() //nolint:staticcheck,gocritic
 	return nil
 }
 

--- a/daemon/logger/loginfo.go
+++ b/daemon/logger/loginfo.go
@@ -30,7 +30,7 @@ type Info struct {
 func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string, error) {
 	extra := make(map[string]string)
 
-	if labels, ok := info.Config["labels"]; ok && len(labels) > 0 {
+	if labels, ok := info.Config["labels"]; ok && labels != "" {
 		for _, l := range strings.Split(labels, ",") {
 			if v, ok := info.ContainerLabels[l]; ok {
 				if keyMod != nil {
@@ -41,7 +41,7 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 		}
 	}
 
-	if labelsRegex, ok := info.Config["labels-regex"]; ok && len(labelsRegex) > 0 {
+	if labelsRegex, ok := info.Config["labels-regex"]; ok && labelsRegex != "" {
 		re, err := regexp.Compile(labelsRegex)
 		if err != nil {
 			return nil, err
@@ -68,7 +68,7 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 		return extra, nil
 	}
 
-	if env, ok := info.Config["env"]; ok && len(env) > 0 {
+	if env, ok := info.Config["env"]; ok && env != "" {
 		for _, l := range strings.Split(env, ",") {
 			if v, ok := envMapping[l]; ok {
 				if keyMod != nil {
@@ -79,7 +79,7 @@ func (info *Info) ExtraAttributes(keyMod func(string) string) (map[string]string
 		}
 	}
 
-	if envRegex, ok := info.Config["env-regex"]; ok && len(envRegex) > 0 {
+	if envRegex, ok := info.Config["env-regex"]; ok && envRegex != "" {
 		re, err := regexp.Compile(envRegex)
 		if err != nil {
 			return nil, err

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -603,7 +603,7 @@ func parseURL(info logger.Info) (*url.URL, error) {
 }
 
 func verifySplunkConnection(l *splunkLogger) error {
-	req, err := http.NewRequest(http.MethodOptions, l.url, nil)
+	req, err := http.NewRequest(http.MethodOptions, l.url, http.NoBody)
 	if err != nil {
 		return err
 	}

--- a/daemon/logger/splunk/splunk_test.go
+++ b/daemon/logger/splunk/splunk_test.go
@@ -103,7 +103,7 @@ func TestNewWithProxy(t *testing.T) {
 	proxyFunc := splunkLogger.transport.Proxy
 	assert.Assert(t, proxyFunc != nil)
 
-	req, err := http.NewRequest(http.MethodGet, splunkURL, nil)
+	req, err := http.NewRequest(http.MethodGet, splunkURL, http.NoBody)
 	assert.NilError(t, err)
 
 	proxyURL, err := proxyFunc(req)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -715,7 +715,7 @@ func withCommonOptions(daemon *Daemon, daemonCfg *dconfig.Config, c *container.C
 			return err
 		}
 		cwd := c.Config.WorkingDir
-		if len(cwd) == 0 {
+		if cwd == "" {
 			cwd = "/"
 		}
 		if s.Process == nil {

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -87,7 +87,7 @@ func parsePSOutput(output []byte, procs []uint32) (*container.TopResponse, error
 	// in "docker top" client command
 	preContainedPidFlag := false
 	for _, line := range lines[1:] {
-		if len(line) == 0 {
+		if line == "" {
 			continue
 		}
 		fields := fieldsASCII(line)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -124,7 +124,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 				CopyData:    false,
 			}
 
-			if len(cp.Source) == 0 {
+			if cp.Source == "" {
 				v, err := daemon.volumes.Get(ctx, cp.Name, volumeopts.WithGetDriver(cp.Driver), volumeopts.WithGetReference(container.ID))
 				if err != nil {
 					return err
@@ -308,7 +308,7 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 // lazyInitializeVolume initializes a mountpoint's volume if needed.
 // This happens after a daemon restart.
 func (daemon *Daemon) lazyInitializeVolume(containerID string, m *volumemounts.MountPoint) error {
-	if len(m.Driver) > 0 && m.Volume == nil {
+	if m.Driver != "" && m.Volume == nil {
 		v, err := daemon.volumes.Get(context.TODO(), m.Name, volumeopts.WithGetDriver(m.Driver), volumeopts.WithGetReference(containerID))
 		if err != nil {
 			return err

--- a/distribution/metadata/v2_metadata_service.go
+++ b/distribution/metadata/v2_metadata_service.go
@@ -40,8 +40,8 @@ type V2Metadata struct {
 
 // CheckV2MetadataHMAC returns true if the given "meta" is tagged with a hmac hashed by the given "key".
 func CheckV2MetadataHMAC(meta *V2Metadata, key []byte) bool {
-	if len(meta.HMAC) == 0 || len(key) == 0 {
-		return len(meta.HMAC) == 0 && len(key) == 0
+	if meta.HMAC == "" || len(key) == 0 {
+		return meta.HMAC == "" && len(key) == 0
 	}
 	mac := hmac.New(sha256.New, key)
 	mac.Write([]byte(meta.Digest))

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -294,7 +294,7 @@ func (pd *pushDescriptor) Upload(ctx context.Context, progressOutput progress.Ou
 		log.G(ctx).Debugf("attempting to mount layer %s (%s) from %s", diffID, mountCandidate.Digest, mountCandidate.SourceRepository)
 		createOpts := []distribution.BlobCreateOption{}
 
-		if len(mountCandidate.SourceRepository) > 0 {
+		if mountCandidate.SourceRepository != "" {
 			namedRef, err := reference.ParseNormalizedNamed(mountCandidate.SourceRepository)
 			if err != nil {
 				log.G(ctx).WithError(err).Errorf("failed to parse source repository reference %v", reference.FamiliarString(namedRef))
@@ -359,10 +359,10 @@ func (pd *pushDescriptor) Upload(ctx context.Context, progressOutput progress.Ou
 
 		// when error is unauthorizedError and user don't hasAuthInfo that's the case user don't has right to push layer to register
 		// and he hasn't login either, in this case candidate cache should be removed
-		if len(mountCandidate.SourceRepository) > 0 &&
+		if mountCandidate.SourceRepository != "" &&
 			(!isUnauthorizedError || pd.pushState.hasAuthInfo) &&
 			(metadata.CheckV2MetadataHMAC(&mountCandidate, pd.hmacKey) ||
-				len(mountCandidate.HMAC) == 0) {
+				mountCandidate.HMAC == "") {
 			cause := "blob mount failure"
 			if err != nil {
 				cause = fmt.Sprintf("an error: %v", err.Error())
@@ -488,7 +488,7 @@ func (pd *pushDescriptor) layerAlreadyExists(
 	// filter the metadata
 	candidates := []metadata.V2Metadata{}
 	for _, meta := range v2Metadata {
-		if len(meta.SourceRepository) > 0 && !checkOtherRepositories && meta.SourceRepository != pd.repoName.Name() {
+		if meta.SourceRepository != "" && !checkOtherRepositories && meta.SourceRepository != pd.repoName.Name() {
 			continue
 		}
 		candidates = append(candidates, meta)

--- a/image/fs.go
+++ b/image/fs.go
@@ -144,11 +144,11 @@ func (s *fs) SetMetadata(dgst digest.Digest, key string, data []byte) error {
 		return err
 	}
 
-	baseDir := filepath.Join(s.metadataDir(dgst))
+	baseDir := s.metadataDir(dgst)
 	if err := os.MkdirAll(baseDir, 0o700); err != nil {
 		return err
 	}
-	return atomicwriter.WriteFile(filepath.Join(s.metadataDir(dgst), key), data, 0o600)
+	return atomicwriter.WriteFile(filepath.Join(baseDir, key), data, 0o600)
 }
 
 // GetMetadata returns metadata for a given digest.

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -85,7 +85,7 @@ func (d *Daemon) CheckActiveContainerCount(ctx context.Context) func(t *testing.
 		t.Helper()
 		out, err := d.Cmd("ps", "-q")
 		assert.NilError(t, err)
-		if len(strings.TrimSpace(out)) == 0 {
+		if strings.TrimSpace(out) == "" {
 			return 0, ""
 		}
 		return len(strings.Split(strings.TrimSpace(out), "\n")), fmt.Sprintf("output: %q", out)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1748,7 +1748,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsValidation(c *testing.T) {
 	for i, tc := range tests {
 		c.Run(fmt.Sprintf("case %d", i), func(c *testing.T) {
 			_, err = apiClient.ContainerCreate(testutil.GetContext(c), &tc.config, &tc.hostConfig, &network.NetworkingConfig{}, nil, "")
-			if len(tc.msg) > 0 {
+			if tc.msg != "" {
 				assert.ErrorContains(c, err, tc.msg, "%v", tests[i].config)
 			} else {
 				assert.NilError(c, err)
@@ -1958,7 +1958,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 
 			switch {
 			// Named volumes still exist after the container is removed
-			case tc.spec.Type == "volume" && len(tc.spec.Source) > 0:
+			case tc.spec.Type == "volume" && tc.spec.Source != "":
 				_, err := apiclient.VolumeInspect(ctx, mountPoint.Name)
 				assert.NilError(c, err)
 

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -105,7 +105,7 @@ func (s *DockerAPISuite) TestAPIImagesImportBadSrc(c *testing.T) {
 
 	ctx := testutil.GetContext(c)
 	for _, te := range tt {
-		res, _, err := request.Post(ctx, strings.Join([]string{"/images/create?fromSrc=", te.fromSrc}, ""), request.JSON)
+		res, _, err := request.Post(ctx, "/images/create?fromSrc="+te.fromSrc, request.JSON)
 		assert.NilError(c, err)
 		assert.Equal(c, res.StatusCode, te.statusExp)
 		assert.Equal(c, res.Header.Get("Content-Type"), "application/json")

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -103,7 +103,7 @@ func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings121(c *testing.T) {
 	assert.NilError(c, err)
 
 	settings := inspectJSON.NetworkSettings
-	assert.Assert(c, len(settings.IPAddress) != 0)
+	assert.Assert(c, settings.IPAddress != "")
 	assert.Assert(c, settings.Networks["bridge"] != nil)
 	assert.Equal(c, settings.IPAddress, settings.Networks["bridge"].IPAddress)
 }

--- a/integration-cli/docker_cli_logout_test.go
+++ b/integration-cli/docker_cli_logout_test.go
@@ -77,7 +77,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithWrongHostnamesStored(c *
 	c.Setenv("PATH", testPath)
 
 	cmd := exec.Command("docker-credential-shell-test", "store")
-	stdin := bytes.NewReader([]byte(fmt.Sprintf(`{"ServerURL": "https://%s", "Username": "%s", "Secret": "%s"}`, privateRegistryURL, s.reg.Username(), s.reg.Password())))
+	stdin := bytes.NewReader([]byte(fmt.Sprintf(`{"ServerURL": "https://%s", "Username": %q, "Secret": %q}`, privateRegistryURL, s.reg.Username(), s.reg.Password())))
 	cmd.Stdin = stdin
 	assert.NilError(c, cmd.Run())
 
@@ -95,12 +95,12 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestLogoutWithWrongHostnamesStored(c *
 	b, err := os.ReadFile(configPath)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Contains(string(b), fmt.Sprintf(`"https://%s": {}`, privateRegistryURL)))
-	assert.Assert(c, is.Contains(string(b), fmt.Sprintf(`"%s": {}`, privateRegistryURL)))
+	assert.Assert(c, is.Contains(string(b), fmt.Sprintf(`%q: {}`, privateRegistryURL)))
 
 	cli.DockerCmd(c, "--config", tmp, "logout", privateRegistryURL)
 
 	b, err = os.ReadFile(configPath)
 	assert.NilError(c, err)
 	assert.Assert(c, !strings.Contains(string(b), fmt.Sprintf(`"https://%s": {}`, privateRegistryURL)))
-	assert.Assert(c, !strings.Contains(string(b), fmt.Sprintf(`"%s": {}`, privateRegistryURL)))
+	assert.Assert(c, !strings.Contains(string(b), fmt.Sprintf(`%q: {}`, privateRegistryURL)))
 }

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -216,7 +216,7 @@ func (s *DockerCLILogsSuite) TestLogsSinceFutureFollow(c *testing.T) {
 
 	since := t.Unix() + 2
 	out := cli.DockerCmd(c, "logs", "-t", "-f", fmt.Sprintf("--since=%v", since), name).Combined()
-	assert.Assert(c, len(out) != 0, "cannot read from empty log")
+	assert.Assert(c, out != "", "cannot read from empty log")
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	for _, v := range lines {
 		ts, err := time.Parse(time.RFC3339Nano, strings.Split(v, " ")[0])

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1679,7 +1679,7 @@ func (s *DockerDaemonSuite) TestDaemonRestartRestoreBridgeNetwork(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Compare(strings.TrimSpace(oldContainerIP), strings.TrimSpace(newContainerIP)) == 0 {
+	if strings.TrimSpace(oldContainerIP) == strings.TrimSpace(newContainerIP) {
 		t.Fatalf("new container ip should not equal to old running container  ip")
 	}
 

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -184,7 +184,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	assert.Assert(c, !strings.Contains(out1, "Mounted from"))
 
 	digest1 := reference.DigestRegexp.FindString(out1)
-	assert.Assert(c, len(digest1) > 0, "no digest found for pushed manifest")
+	assert.Assert(c, digest1 != "", "no digest found for pushed manifest")
 
 	const destRepoName = privateRegistryURL + "/crossrepopush/img"
 
@@ -198,7 +198,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	assert.Assert(c, is.Contains(out2, "Mounted from crossrepopush/busybox"))
 
 	digest2 := reference.DigestRegexp.FindString(out2)
-	assert.Assert(c, len(digest2) > 0, "no digest found for pushed manifest")
+	assert.Assert(c, digest2 != "", "no digest found for pushed manifest")
 	assert.Equal(c, digest1, digest2)
 
 	// ensure that pushing again produces the same digest
@@ -206,7 +206,7 @@ func (s *DockerRegistrySuite) TestCrossRepositoryLayerPush(c *testing.T) {
 	assert.NilError(c, err, "pushing the image to the private registry has failed: %s", out3)
 
 	digest3 := reference.DigestRegexp.FindString(out3)
-	assert.Assert(c, len(digest3) > 0, "no digest found for pushed manifest")
+	assert.Assert(c, digest3 != "", "no digest found for pushed manifest")
 	assert.Equal(c, digest3, digest2)
 
 	// ensure that we can pull and run the cross-repo-pushed repository

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1820,7 +1820,7 @@ func testRunWriteSpecialFilesAndNotCommit(t *testing.T, name, path string) {
 	}
 
 	out = cli.DockerCmd(t, "diff", name).Combined()
-	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, t) {
+	if strings.Trim(out, "\r\n") != "" && !eqToBaseDiff(out, t) {
 		t.Fatal("diff should be empty")
 	}
 }
@@ -2258,7 +2258,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughExpose(c *testing.T) {
 		if portnum < 3000 || portnum > 3003 {
 			c.Fatalf("Port %d is out of range ", portnum)
 		}
-		if len(binding) == 0 || len(binding[0].HostPort) == 0 {
+		if len(binding) == 0 || binding[0].HostPort == "" {
 			c.Fatalf("Port is not mapped for the port %s", port)
 		}
 	}
@@ -2591,7 +2591,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughPublish(c *testing.T) {
 		if portnum < 3000 || portnum > 3003 {
 			c.Fatalf("Port %d is out of range ", portnum)
 		}
-		if len(binding) == 0 || len(binding[0].HostPort) == 0 {
+		if len(binding) == 0 || binding[0].HostPort == "" {
 			c.Fatal("Port is not mapped for the port "+port, id)
 		}
 	}

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -1810,7 +1810,7 @@ func waitForEvent(t *testing.T, d *daemon.Daemon, since string, filter string, e
 	for i := 0; i < retry; i++ {
 		until := daemonUnixTime(t)
 		var err error
-		if len(filter) > 0 {
+		if filter != "" {
 			out, err = d.Cmd("events", "--since", since, "--until", until, filter)
 		} else {
 			out, err = d.Cmd("events", "--since", since, "--until", until)

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -446,7 +446,7 @@ func reducedCheck(r reducer, funcs ...checkF) checkF {
 		for _, f := range funcs {
 			v, comment := f(t)
 			values = append(values, v)
-			if len(comment) > 0 {
+			if comment != "" {
 				comments = append(comments, comment)
 			}
 		}

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -851,7 +851,8 @@ func readBuildImageIDs(t *testing.T, rd io.Reader) string {
 			ID string `json:"ID"`
 		}
 
-		if json.Unmarshal(*jm.Aux, &auxId); auxId.ID != "" {
+		json.Unmarshal(*jm.Aux, &auxId)
+		if auxId.ID != "" {
 			return auxId.ID
 		}
 	}

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -376,7 +376,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	// - Full Name
 	// - Partial ID (prefix)
 	err = c.ConfigRemove(ctx, configID[:5])
-	assert.Assert(t, nil != err)
+	assert.Assert(t, err != nil)
 	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(configNamesFromList(entries), []string{fakeName}))

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -190,7 +190,7 @@ func TestAuthZPluginAPIDenyResponse(t *testing.T) {
 	socketClient, err := socketHTTPClient(daemonURL)
 	assert.NilError(t, err)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/version", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/version", http.NoBody)
 	assert.NilError(t, err)
 	req.URL.Scheme = "http"
 	req.URL.Host = client.DummyHost
@@ -486,7 +486,7 @@ func TestAuthZPluginHeader(t *testing.T) {
 	socketClient, err := socketHTTPClient(daemonURL)
 	assert.NilError(t, err)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/version", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/version", http.NoBody)
 	assert.NilError(t, err)
 	req.URL.Scheme = "http"
 	req.URL.Host = client.DummyHost

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -375,7 +375,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	// - Full Name
 	// - Partial ID (prefix)
 	err = c.SecretRemove(ctx, fakeName[:5])
-	assert.Assert(t, nil != err)
+	assert.Assert(t, err != nil)
 	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(secretNamesFromList(entries), []string{fakeName}))

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -121,7 +121,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 	secret := *secrets[0]
 	assert.Check(t, is.Equal(secretName, secret.SecretName))
-	assert.Check(t, nil != secret.File)
+	assert.Check(t, secret.File != nil)
 	assert.Check(t, is.Equal(secretTarget, secret.File.Name))
 
 	// remove
@@ -183,7 +183,7 @@ func TestServiceUpdateConfigs(t *testing.T) {
 
 	config := *configs[0]
 	assert.Check(t, is.Equal(configName, config.ConfigName))
-	assert.Check(t, nil != config.File)
+	assert.Check(t, config.File != nil)
 	assert.Check(t, is.Equal(configTarget, config.File.Name))
 
 	// remove

--- a/libnetwork/cmd/diagnostic/main.go
+++ b/libnetwork/cmd/diagnostic/main.go
@@ -193,7 +193,7 @@ func fetchTable(ip string, port int, network, tableName string, clusterPeers, ne
 		reader := bufio.NewReader(os.Stdin)
 		text, _ := reader.ReadString('\n')
 		text = strings.ReplaceAll(text, "\n", "")
-		if strings.Compare(text, "Yes") == 0 {
+		if text == "Yes" {
 			for _, k := range orphanKeys {
 				r, err := http.Get(fmt.Sprintf(deleteEntry, ip, port, network, tableName, k))
 				if err != nil {

--- a/libnetwork/driverapi/ipamdata.go
+++ b/libnetwork/driverapi/ipamdata.go
@@ -95,7 +95,7 @@ func (i *IPAMData) Validate() error {
 
 // IsV6 returns whether this is an IPv6 IPAMData structure
 func (i *IPAMData) IsV6() bool {
-	return nil == i.Pool.IP.To4()
+	return i.Pool.IP.To4() == nil
 }
 
 func (i *IPAMData) String() string {

--- a/libnetwork/drivers/bridge/internal/iptabler/iptabler_test.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/iptabler_test.go
@@ -159,7 +159,7 @@ func testIptabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 
 	stripComments := func(text string) string {
 		lines := strings.Split(text, "\n")
-		lines = slices.DeleteFunc(lines, func(l string) bool { return len(l) > 0 && l[0] == '#' })
+		lines = slices.DeleteFunc(lines, func(l string) bool { return l != "" && l[0] == '#' })
 		return strings.Join(lines, "\n")
 	}
 

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -150,9 +150,9 @@ func dbusConnectionChanged(args []interface{}) {
 		return
 	}
 
-	if len(newOwner) > 0 {
+	if newOwner != "" {
 		connectionEstablished()
-	} else if len(oldOwner) > 0 {
+	} else if oldOwner != "" {
 		connectionLost()
 	}
 }

--- a/libnetwork/netutils/utils.go
+++ b/libnetwork/netutils/utils.go
@@ -80,7 +80,7 @@ func ReverseIP(IP string) string {
 		// Reversed IPv6 is represented in dotted decimal instead of the typical
 		// colon hex notation
 		for key := range reverseIP {
-			if len(reverseIP[key]) == 0 { // expand the compressed 0s
+			if reverseIP[key] == "" { // expand the compressed 0s
 				reverseIP[key] = strings.Repeat("0000", 8-strings.Count(IP, ":"))
 			} else if len(reverseIP[key]) < 4 { // 0-padding needed
 				reverseIP[key] = strings.Repeat("0", 4-len(reverseIP[key])) + reverseIP[key]

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -99,7 +99,7 @@ type IpamConf struct {
 
 // Validate checks whether the configuration is valid
 func (c *IpamConf) Validate() error {
-	if c.Gateway != "" && nil == net.ParseIP(c.Gateway) {
+	if c.Gateway != "" && net.ParseIP(c.Gateway) == nil {
 		return types.InvalidParameterErrorf("invalid gateway address %s in Ipam configuration", c.Gateway)
 	}
 	return nil

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1051,7 +1051,7 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 			name: n.name,
 			id:   n.id,
 			endpoints: sliceutil.Map(eps, func(ep *Endpoint) string {
-				return fmt.Sprintf(`name:"%s" id:"%s"`, ep.name, stringid.TruncateID(ep.id))
+				return fmt.Sprintf(`name:%q id:%q`, ep.name, stringid.TruncateID(ep.id))
 			}),
 		}
 	}

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -421,7 +421,7 @@ func (n *Network) applyConfigurationTo(to *Network) error {
 			}
 		}
 	}
-	if len(n.ipamType) != 0 {
+	if n.ipamType != "" {
 		to.ipamType = n.ipamType
 	}
 	if len(n.ipamOptions) > 0 {

--- a/libnetwork/sandbox.go
+++ b/libnetwork/sandbox.go
@@ -367,7 +367,7 @@ func (sb *Sandbox) ResolveIP(ctx context.Context, ip string) string {
 	for _, ep := range sb.Endpoints() {
 		n := ep.getNetwork()
 		svc = n.ResolveIP(ctx, ip)
-		if len(svc) != 0 {
+		if svc != "" {
 			return svc
 		}
 	}

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -77,7 +77,7 @@ func TestParseDockerDaemonHost(t *testing.T) {
 		"udp://127.0.0.1":               "invalid bind address (udp://127.0.0.1): unsupported proto 'udp'",
 		"udp://127.0.0.1:5555":          "invalid bind address (udp://127.0.0.1:5555): unsupported proto 'udp'",
 		"tcp://unix:///run/docker.sock": "invalid bind address (tcp://unix:///run/docker.sock): should not contain a path element",
-		" tcp://:5555/path ":            "invalid bind address ( tcp://:5555/path ): unsupported proto ' tcp'",
+		" tcp://:5555/path ":            "invalid bind address ( tcp://:5555/path ): unsupported proto ' tcp'", //nolint:gocritic // This is a valid test case.
 		"":                              "invalid bind address (): unsupported proto ''",
 		":5555/path":                    "invalid bind address (:5555/path): should not contain a path element",
 		"0.0.0.1:5555/path":             "invalid bind address (0.0.0.1:5555/path): should not contain a path element",

--- a/pkg/authorization/api_test.go
+++ b/pkg/authorization/api_test.go
@@ -46,7 +46,7 @@ func TestPeerCertificateMarshalJSON(t *testing.T) {
 
 	certs := []*x509.Certificate{cert}
 	addr := "www.authz.com/auth"
-	req, err := http.NewRequest(http.MethodGet, addr, nil)
+	req, err := http.NewRequest(http.MethodGet, addr, http.NoBody)
 	assert.NilError(t, err)
 
 	req.RequestURI = addr

--- a/pkg/authorization/middleware_unix_test.go
+++ b/pkg/authorization/middleware_unix_test.go
@@ -33,7 +33,7 @@ func TestMiddlewareWrapHandler(t *testing.T) {
 	assert.Assert(t, mdHandler != nil)
 
 	addr := "www.example.com/auth"
-	req, _ := http.NewRequest(http.MethodGet, addr, nil)
+	req, _ := http.NewRequest(http.MethodGet, addr, http.NoBody)
 	req.RequestURI = addr
 	req.Header.Add("header", "value")
 

--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -151,7 +151,7 @@ func readPluginInfo(name, path string) (*Plugin, error) {
 		return nil, err
 	}
 
-	if len(u.Scheme) == 0 {
+	if u.Scheme == "" {
 		return nil, fmt.Errorf("Unknown protocol")
 	}
 
@@ -170,7 +170,7 @@ func readPluginJSONInfo(name, path string) (*Plugin, error) {
 		return nil, err
 	}
 	p.name = name
-	if p.TLSConfig != nil && len(p.TLSConfig.CAFile) == 0 {
+	if p.TLSConfig != nil && p.TLSConfig.CAFile == "" {
 		p.TLSConfig.InsecureSkipVerify = true
 	}
 	p.activateWait = sync.NewCond(&sync.Mutex{})

--- a/pkg/plugins/pluginrpc-gen/parser.go
+++ b/pkg/plugins/pluginrpc-gen/parser.go
@@ -54,7 +54,7 @@ type importSpec struct {
 
 func (s *importSpec) String() string {
 	var ss string
-	if len(s.Name) != 0 {
+	if s.Name != "" {
 		ss += s.Name
 	}
 	ss += s.Path
@@ -96,7 +96,7 @@ func Parse(filePath string, objName string) (*ParsedPkg, error) {
 	for _, f := range p.Functions {
 		args := append(f.Args, f.Returns...)
 		for _, arg := range args {
-			if len(arg.PackageSelector) == 0 {
+			if arg.PackageSelector == "" {
 				continue
 			}
 

--- a/pkg/tarsum/tarsum_test.go
+++ b/pkg/tarsum/tarsum_test.go
@@ -330,7 +330,7 @@ func TestTarSums(t *testing.T) {
 			fh  io.Reader
 			err error
 		)
-		if len(layer.filename) > 0 {
+		if layer.filename != "" {
 			fh, err = os.Open(layer.filename)
 			if err != nil {
 				t.Errorf("failed to open %s: %s", layer.filename, err)
@@ -380,7 +380,7 @@ func TestTarSums(t *testing.T) {
 			continue
 		}
 		var gotSum string
-		if len(layer.jsonfile) > 0 {
+		if layer.jsonfile != "" {
 			jfh, err := os.Open(layer.jsonfile)
 			if err != nil {
 				t.Errorf("failed to open %s: %s", layer.jsonfile, err)

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -16,10 +16,10 @@ func (vi *VersionInfo) isValid() bool {
 	const stopChars = " \t\r\n/"
 	name := vi.Name
 	vers := vi.Version
-	if len(name) == 0 || strings.ContainsAny(name, stopChars) {
+	if name == "" || strings.ContainsAny(name, stopChars) {
 		return false
 	}
-	if len(vers) == 0 || strings.ContainsAny(vers, stopChars) {
+	if vers == "" || strings.ContainsAny(vers, stopChars) {
 		return false
 	}
 	return true
@@ -41,7 +41,7 @@ func AppendVersions(base string, versions ...VersionInfo) string {
 	}
 
 	verstrs := make([]string, 0, 1+len(versions))
-	if len(base) > 0 {
+	if base != "" {
 		verstrs = append(verstrs, base)
 	}
 

--- a/plugin/v2/plugin_linux.go
+++ b/plugin/v2/plugin_linux.go
@@ -124,7 +124,7 @@ func (p *Plugin) InitSpec(execRoot string) (*specs.Spec, error) {
 
 	args := append(p.PluginObj.Config.Entrypoint, p.PluginObj.Settings.Args...)
 	cwd := p.PluginObj.Config.WorkDir
-	if len(cwd) == 0 {
+	if cwd == "" {
 		cwd = "/"
 	}
 	s.Process.Terminal = false

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -70,7 +70,7 @@ func loginV2(ctx context.Context, authConfig *registry.AuthConfig, endpoint APIE
 	endpointStr := strings.TrimRight(endpoint.URL.String(), "/") + "/v2/"
 	log.G(ctx).WithField("endpoint", endpointStr).Debug("attempting v2 login to registry endpoint")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpointStr, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpointStr, http.NoBody)
 	if err != nil {
 		return "", err
 	}
@@ -181,7 +181,7 @@ func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.M
 		Timeout:   15 * time.Second,
 	}
 	endpointStr := strings.TrimRight(endpoint.String(), "/") + "/v2/"
-	req, err := http.NewRequest(http.MethodGet, endpointStr, nil)
+	req, err := http.NewRequest(http.MethodGet, endpointStr, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/resumable/resumablerequestreader_test.go
+++ b/registry/resumable/resumablerequestreader_test.go
@@ -22,7 +22,7 @@ func TestResumableRequestHeaderSimpleErrors(t *testing.T) {
 	client := &http.Client{}
 
 	var req *http.Request
-	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
 	assert.NilError(t, err)
 
 	resreq := &requestReader{}
@@ -43,7 +43,7 @@ func TestResumableRequestHeaderNotTooMuchFailures(t *testing.T) {
 	client := &http.Client{}
 
 	var badReq *http.Request
-	badReq, err := http.NewRequest(http.MethodGet, "I'm not an url", nil)
+	badReq, err := http.NewRequest(http.MethodGet, "I'm not an url", http.NoBody)
 	assert.NilError(t, err)
 
 	resreq := &requestReader{
@@ -63,7 +63,7 @@ func TestResumableRequestHeaderTooMuchFailures(t *testing.T) {
 	client := &http.Client{}
 
 	var badReq *http.Request
-	badReq, err := http.NewRequest(http.MethodGet, "I'm not an url", nil)
+	badReq, err := http.NewRequest(http.MethodGet, "I'm not an url", http.NoBody)
 	assert.NilError(t, err)
 
 	resreq := &requestReader{
@@ -92,7 +92,7 @@ func (errorReaderCloser) Read(p []byte) (int, error) {
 // If an unknown error is encountered, return 0, nil and log it
 func TestResumableRequestReaderWithReadError(t *testing.T) {
 	var req *http.Request
-	req, err := http.NewRequest(http.MethodGet, "", nil)
+	req, err := http.NewRequest(http.MethodGet, "", http.NoBody)
 	assert.NilError(t, err)
 
 	client := &http.Client{}
@@ -123,7 +123,7 @@ func TestResumableRequestReaderWithReadError(t *testing.T) {
 
 func TestResumableRequestReaderWithEOFWith416Response(t *testing.T) {
 	var req *http.Request
-	req, err := http.NewRequest(http.MethodGet, "", nil)
+	req, err := http.NewRequest(http.MethodGet, "", http.NoBody)
 	assert.NilError(t, err)
 
 	client := &http.Client{}
@@ -159,7 +159,7 @@ func TestResumableRequestReaderWithServerDoesntSupportByteRanges(t *testing.T) {
 	defer ts.Close()
 
 	var req *http.Request
-	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
 	assert.NilError(t, err)
 
 	client := &http.Client{}
@@ -185,7 +185,7 @@ func TestResumableRequestReaderWithZeroTotalSize(t *testing.T) {
 	defer ts.Close()
 
 	var req *http.Request
-	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
 	assert.NilError(t, err)
 
 	client := &http.Client{}
@@ -210,7 +210,7 @@ func TestResumableRequestReader(t *testing.T) {
 	defer ts.Close()
 
 	var req *http.Request
-	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
 	assert.NilError(t, err)
 
 	client := &http.Client{}
@@ -236,7 +236,7 @@ func TestResumableRequestReaderWithInitialResponse(t *testing.T) {
 	defer ts.Close()
 
 	var req *http.Request
-	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
 	assert.NilError(t, err)
 
 	client := &http.Client{}

--- a/registry/search_endpoint_v1.go
+++ b/registry/search_endpoint_v1.go
@@ -122,7 +122,7 @@ func (e *v1Endpoint) ping(ctx context.Context) (v1PingResult, error) {
 
 	pingURL := e.String() + "_ping"
 	log.G(ctx).WithField("url", pingURL).Debug("attempting v1 ping for registry endpoint")
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pingURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pingURL, http.NoBody)
 	if err != nil {
 		return v1PingResult{}, invalidParam(err)
 	}

--- a/registry/search_endpoint_v1_test.go
+++ b/registry/search_endpoint_v1_test.go
@@ -175,12 +175,12 @@ func TestV1EndpointValidate(t *testing.T) {
 
 func TestTrustedLocation(t *testing.T) {
 	for _, u := range []string{"http://example.com", "https://example.com:7777", "http://docker.io", "http://test.docker.com", "https://fakedocker.com"} {
-		req, _ := http.NewRequest(http.MethodGet, u, nil)
+		req, _ := http.NewRequest(http.MethodGet, u, http.NoBody)
 		assert.Check(t, !trustedLocation(req))
 	}
 
 	for _, u := range []string{"https://docker.io", "https://test.docker.com:80"} {
-		req, _ := http.NewRequest(http.MethodGet, u, nil)
+		req, _ := http.NewRequest(http.MethodGet, u, http.NoBody)
 		assert.Check(t, trustedLocation(req))
 	}
 }
@@ -191,10 +191,10 @@ func TestAddRequiredHeadersToRedirectedRequests(t *testing.T) {
 		{"https://foo.docker.io:7777", "http://bar.docker.com"},
 		{"https://foo.docker.io", "https://example.com"},
 	} {
-		reqFrom, _ := http.NewRequest(http.MethodGet, urls[0], nil)
+		reqFrom, _ := http.NewRequest(http.MethodGet, urls[0], http.NoBody)
 		reqFrom.Header.Add("Content-Type", "application/json")
 		reqFrom.Header.Add("Authorization", "super_secret")
-		reqTo, _ := http.NewRequest(http.MethodGet, urls[1], nil)
+		reqTo, _ := http.NewRequest(http.MethodGet, urls[1], http.NoBody)
 
 		_ = addRequiredHeadersToRedirectedRequests(reqTo, []*http.Request{reqFrom})
 
@@ -215,10 +215,10 @@ func TestAddRequiredHeadersToRedirectedRequests(t *testing.T) {
 		{"https://docker.io", "https://docker.com"},
 		{"https://foo.docker.io:7777", "https://bar.docker.com"},
 	} {
-		reqFrom, _ := http.NewRequest(http.MethodGet, urls[0], nil)
+		reqFrom, _ := http.NewRequest(http.MethodGet, urls[0], http.NoBody)
 		reqFrom.Header.Add("Content-Type", "application/json")
 		reqFrom.Header.Add("Authorization", "super_secret")
-		reqTo, _ := http.NewRequest(http.MethodGet, urls[1], nil)
+		reqTo, _ := http.NewRequest(http.MethodGet, urls[1], http.NoBody)
 
 		_ = addRequiredHeadersToRedirectedRequests(reqTo, []*http.Request{reqFrom})
 

--- a/registry/search_session.go
+++ b/registry/search_session.go
@@ -222,7 +222,7 @@ func (r *session) searchRepositories(ctx context.Context, term string, limit int
 	u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(fmt.Sprintf("%d", limit))
 	log.G(ctx).WithField("url", u).Debug("searchRepositories")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
 	if err != nil {
 		return nil, invalidParamWrapf(err, "error building request")
 	}

--- a/registry/search_session.go
+++ b/registry/search_session.go
@@ -131,7 +131,7 @@ func (tr *authTransport) RoundTrip(orig *http.Request) (*http.Response, error) {
 
 	// Don't override
 	if req.Header.Get("Authorization") == "" {
-		if req.Header.Get("X-Docker-Token") == "true" && tr.authConfig != nil && len(tr.authConfig.Username) > 0 {
+		if req.Header.Get("X-Docker-Token") == "true" && tr.authConfig != nil && tr.authConfig.Username != "" {
 			req.SetBasicAuth(tr.authConfig.Username, tr.authConfig.Password)
 		} else if len(tr.token) > 0 {
 			req.Header.Set("Authorization", "Token "+strings.Join(tr.token, ","))

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -153,7 +153,7 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 		op(d)
 	}
 
-	if len(d.resolvConfContent) > 0 {
+	if d.resolvConfContent != "" {
 		path := filepath.Join(d.Folder, "resolv.conf")
 		if err := os.WriteFile(path, []byte(d.resolvConfContent), 0644); err != nil {
 			return nil, fmt.Errorf("failed to write docker resolv.conf to %q: %v", path, err)

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -572,7 +572,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		Transport: clientConfig.transport,
 	}
 
-	req, err := http.NewRequest(http.MethodGet, "/_ping", nil)
+	req, err := http.NewRequest(http.MethodGet, "/_ping", http.NoBody)
 	if err != nil {
 		return errors.Wrapf(err, "[%s] could not create new request", d.id)
 	}
@@ -947,7 +947,7 @@ func (d *Daemon) queryRootDir() (string, error) {
 		Transport: clientConfig.transport,
 	}
 
-	req, err := http.NewRequest(http.MethodGet, "/info", nil)
+	req, err := http.NewRequest(http.MethodGet, "/info", http.NoBody)
 	if err != nil {
 		return "", err
 	}

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -117,7 +117,7 @@ func newRequest(endpoint string, opts *Options) (*http.Request, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed parsing url %q", opts.host)
 	}
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request")
 	}

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -98,7 +98,7 @@ func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 	}
 
 	// don't spam the warn log below just because the plugin didn't provide a scope
-	if len(cap.Scope) == 0 {
+	if cap.Scope == "" {
 		cap.Scope = volume.LocalScope
 	}
 
@@ -138,7 +138,7 @@ func (a *volumeAdapter) DriverName() string {
 }
 
 func (a *volumeAdapter) Path() string {
-	if len(a.eMount) == 0 {
+	if a.eMount == "" {
 		mountpoint, _ := a.proxy.Path(a.name)
 		a.eMount = a.scopePath(mountpoint)
 	}

--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -46,7 +46,7 @@ func (p *linuxParser) ValidateMountConfig(mnt *mount.Mount) error {
 }
 
 func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSourceExists bool) error {
-	if len(mnt.Target) == 0 {
+	if mnt.Target == "" {
 		return &errMountConfig{mnt, errMissingField("Target")}
 	}
 
@@ -60,7 +60,7 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 
 	switch mnt.Type {
 	case mount.TypeBind:
-		if len(mnt.Source) == 0 {
+		if mnt.Source == "" {
 			return &errMountConfig{mnt, errMissingField("Source")}
 		}
 		// Don't error out just because the propagation mode is not supported on the platform
@@ -101,7 +101,7 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 		if mnt.ImageOptions != nil {
 			return &errMountConfig{mnt, errExtraField("ImageOptions")}
 		}
-		anonymousVolume := len(mnt.Source) == 0
+		anonymousVolume := mnt.Source == ""
 
 		if mnt.VolumeOptions != nil && mnt.VolumeOptions.Subpath != "" {
 			if anonymousVolume {
@@ -122,7 +122,7 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 		if mnt.ImageOptions != nil {
 			return &errMountConfig{mnt, errExtraField("ImageOptions")}
 		}
-		if len(mnt.Source) != 0 {
+		if mnt.Source != "" {
 			return &errMountConfig{mnt, errExtraField("Source")}
 		}
 		if _, err := p.ConvertTmpfsOptions(mnt.TmpfsOptions, mnt.ReadOnly); err != nil {
@@ -135,7 +135,7 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 		if mnt.VolumeOptions != nil {
 			return &errMountConfig{mnt, errExtraField("VolumeOptions")}
 		}
-		if len(mnt.Source) == 0 {
+		if mnt.Source == "" {
 			return &errMountConfig{mnt, errMissingField("Source")}
 		}
 		if mnt.ImageOptions != nil && mnt.ImageOptions.Subpath != "" {
@@ -393,7 +393,7 @@ func (p *linuxParser) parseMountSpec(cfg mount.Mount, validateBindSourceExists b
 }
 
 func (p *linuxParser) ParseVolumesFrom(spec string) (string, string, error) {
-	if len(spec) == 0 {
+	if spec == "" {
 		return "", "", fmt.Errorf("volumes-from specification cannot be an empty string")
 	}
 
@@ -484,7 +484,7 @@ func (p *linuxParser) ValidateVolumeName(name string) error {
 }
 
 func (p *linuxParser) IsBackwardCompatible(m *MountPoint) bool {
-	return len(m.Source) > 0 || m.Driver == volume.DefaultDriverName
+	return m.Source != "" || m.Driver == volume.DefaultDriverName
 }
 
 func (p *linuxParser) ValidateTmpfsMountDestination(dest string) error {

--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -233,7 +233,7 @@ func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtoo
 		}
 	}
 
-	if len(m.Source) == 0 {
+	if m.Source == "" {
 		return "", noCleanup, fmt.Errorf("Unable to setup mount point, neither source nor volume defined")
 	}
 

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -213,7 +213,7 @@ func (defaultFileInfoProvider) fileInfo(path string) (exist, isDir bool, _ error
 }
 
 func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValidators ...mountValidator) error {
-	if len(mnt.Target) == 0 {
+	if mnt.Target == "" {
 		return &errMountConfig{mnt, errMissingField("Target")}
 	}
 	for _, v := range additionalValidators {
@@ -224,7 +224,7 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 
 	switch mnt.Type {
 	case mount.TypeBind:
-		if len(mnt.Source) == 0 {
+		if mnt.Source == "" {
 			return &errMountConfig{mnt, errMissingField("Source")}
 		}
 		// Don't error out just because the propagation mode is not supported on the platform
@@ -257,7 +257,7 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 			return &errMountConfig{mnt, errExtraField("BindOptions")}
 		}
 
-		anonymousVolume := len(mnt.Source) == 0
+		anonymousVolume := mnt.Source == ""
 		if mnt.VolumeOptions != nil && mnt.VolumeOptions.Subpath != "" {
 			if anonymousVolume {
 				return errAnonymousVolumeWithSubpath
@@ -273,13 +273,13 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 			return &errMountConfig{mnt, fmt.Errorf("must not set ReadOnly mode when using anonymous volumes")}
 		}
 
-		if len(mnt.Source) != 0 {
+		if mnt.Source != "" {
 			if err := p.ValidateVolumeName(mnt.Source); err != nil {
 				return &errMountConfig{mnt, err}
 			}
 		}
 	case mount.TypeNamedPipe:
-		if len(mnt.Source) == 0 {
+		if mnt.Source == "" {
 			return &errMountConfig{mnt, errMissingField("Source")}
 		}
 
@@ -423,7 +423,7 @@ func (p *windowsParser) parseMountSpec(cfg mount.Mount, convertTargetToBackslash
 }
 
 func (p *windowsParser) ParseVolumesFrom(spec string) (string, string, error) {
-	if len(spec) == 0 {
+	if spec == "" {
 		return "", "", fmt.Errorf("volumes-from specification cannot be an empty string")
 	}
 

--- a/volume/service/store.go
+++ b/volume/service/store.go
@@ -147,7 +147,7 @@ func (s *VolumeStore) setNamed(v volume.Volume, ref string) {
 
 	s.globalLock.Lock()
 	s.names[name] = v
-	if len(ref) > 0 {
+	if ref != "" {
 		if s.refs[name] == nil {
 			s.refs[name] = make(map[string]struct{})
 		}


### PR DESCRIPTION
**- What I did**

Enable all rules from [go-critic](https://golangci-lint.run/usage/linters/#gocritic) and disable rules which the code do not comply with. This enables and fixes the following rules:

* [badCall](https://go-critic.com/overview.html#badcall)
* [badLock](https://go-critic.com/overview.html#badlock)
* [boolExprSimplify](https://go-critic.com/overview.html#boolexprsimplify)
* [deprecatedComment](https://go-critic.com/overview.html#deprecatedcomment)
* [emptyStringTest](https://go-critic.com/overview.html#emptystringtest)
* [httpNoBody](https://go-critic.com/overview.html#httpnobody)
* [initClause](https://go-critic.com/overview.html#initclause)
* [mapKey](https://go-critic.com/overview.html#mapkey)
* [stringConcatSimplify](https://go-critic.com/overview.html#stringconcatsimplify)
* [stringsCompare](https://go-critic.com/overview.html#stringscompare)
* [yodaStyleExpr](https://go-critic.com/overview.html#yodastyleexpr)

**- How I did it**

Edit golangci-lint and fix one rule per commit

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

