### PR TITLE
Dockerfile: install nano as alternative to vim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -512,6 +512,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             libnl-3-200 \
             libprotobuf-c1 \
             libyajl2 \
+            nano \
             net-tools \
             netcat-openbsd \
             patch \


### PR DESCRIPTION
I'm horrible at vim, and use nano as my go-to editor for quick changes. Let's install nano in the dev-container as alternative to vim for those like me, who are not so vim-savvy ^O^C^C:wq:


**- A picture of a cute animal (not mandatory but encouraged)**

![youngafricangrayparrotposing-77197](https://github.com/user-attachments/assets/3754be19-b382-47cc-9b0b-88d2850147fa)


[Image via Shutterstock/Jelena Stankoviv](https://paradepets.com/pet-news/african-grey-parrot-has-cute-british-mannerism)