### PR TITLE
libnetwork/d/overlay: simplify the encryption logic

### DIFF
--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -132,7 +132,7 @@ func (d *driver) checkEncryption(nid string, rIP netip.Addr, isLocal, add bool) 
 	switch {
 	case isLocal:
 		if err := d.peerDbNetworkWalk(nid, func(_ netip.Addr, _ net.HardwareAddr, pEntry *peerEntry) bool {
-			if !pEntry.isLocal {
+			if !pEntry.isLocal() {
 				nodes[pEntry.vtep] = struct{}{}
 			}
 			return false

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -132,7 +132,7 @@ func (d *driver) checkEncryption(nid string, rIP netip.Addr, isLocal, add bool) 
 	switch {
 	case isLocal:
 		if err := d.peerDbNetworkWalk(nid, func(_ netip.Addr, _ net.HardwareAddr, pEntry *peerEntry) bool {
-			if aIP != pEntry.vtep {
+			if !pEntry.isLocal {
 				nodes[pEntry.vtep] = struct{}{}
 			}
 			return false

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -121,10 +121,6 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 
 	d.peerAdd(nid, eid, ep.addr, ep.mac, netip.Addr{})
 
-	if err = d.initEncryption(nid); err != nil {
-		log.G(ctx).Warn(err)
-	}
-
 	buf, err := proto.Marshal(&PeerRecord{
 		EndpointIP:       ep.addr.String(),
 		EndpointMAC:      ep.mac.String(),

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -121,7 +121,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 
 	d.peerAdd(nid, eid, ep.addr, ep.mac, netip.Addr{})
 
-	if err = d.checkEncryption(nid, netip.Addr{}, true, true); err != nil {
+	if err = d.checkEncryption(nid, netip.Addr{}, true); err != nil {
 		log.G(ctx).Warn(err)
 	}
 

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -119,7 +119,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		}
 	}
 
-	d.peerAdd(nid, eid, ep.addr, ep.mac, d.advertiseAddress, true)
+	d.peerAdd(nid, eid, ep.addr, ep.mac, netip.Addr{})
 
 	if err = d.checkEncryption(nid, netip.Addr{}, true, true); err != nil {
 		log.G(ctx).Warn(err)
@@ -197,11 +197,11 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 	}
 
 	if etype == driverapi.Delete {
-		d.peerDelete(nid, eid, addr, mac, vtep, false)
+		d.peerDelete(nid, eid, addr, mac, vtep)
 		return
 	}
 
-	d.peerAdd(nid, eid, addr, mac, vtep, false)
+	d.peerAdd(nid, eid, addr, mac, vtep)
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
@@ -221,7 +221,7 @@ func (d *driver) Leave(nid, eid string) error {
 		return types.InternalMaskableErrorf("could not find endpoint with id %s", eid)
 	}
 
-	d.peerDelete(nid, eid, ep.addr, ep.mac, d.advertiseAddress, true)
+	d.peerDelete(nid, eid, ep.addr, ep.mac, netip.Addr{})
 
 	n.leaveSandbox()
 

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -121,7 +121,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 
 	d.peerAdd(nid, eid, ep.addr, ep.mac, netip.Addr{})
 
-	if err = d.checkEncryption(nid, netip.Addr{}, true); err != nil {
+	if err = d.initEncryption(nid); err != nil {
 		log.G(ctx).Warn(err)
 	}
 

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -30,14 +30,13 @@ var _ discoverapi.Discover = (*driver)(nil)
 type driver struct {
 	bindAddress, advertiseAddress netip.Addr
 
-	config        map[string]interface{}
-	peerDb        peerNetworkMap
-	secMap        *encrMap
-	networks      networkTable
-	initOS        sync.Once
-	localJoinOnce sync.Once
-	keys          []*key
-	peerOpMu      sync.Mutex
+	config   map[string]interface{}
+	peerDb   peerNetworkMap
+	secMap   *encrMap
+	networks networkTable
+	initOS   sync.Once
+	keys     []*key
+	peerOpMu sync.Mutex
 	sync.Mutex
 }
 
@@ -95,12 +94,6 @@ func (d *driver) nodeJoin(data discoverapi.NodeDiscoveryData) error {
 		d.advertiseAddress = advAddr
 		d.bindAddress = bindAddr
 		d.Unlock()
-
-		// If containers are already running on this network update the
-		// advertise address in the peerDB
-		d.localJoinOnce.Do(func() {
-			d.peerDBUpdateSelf()
-		})
 	}
 	return nil
 }

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -235,8 +235,10 @@ func (d *driver) peerAddOp(nid, eid string, peerIP netip.Prefix, peerMac net.Har
 		return fmt.Errorf("subnet sandbox join failed for %q: %v", s.subnetIP.String(), err)
 	}
 
-	if err := d.checkEncryption(nid, vtep, true); err != nil {
-		log.G(context.TODO()).Warn(err)
+	if n.secure && len(n.endpoints) > 0 {
+		if err := d.setupEncryption(vtep); err != nil {
+			log.G(context.TODO()).Warn(err)
+		}
 	}
 
 	// Add neighbor entry for the peer IP
@@ -291,8 +293,10 @@ func (d *driver) peerDeleteOp(nid, eid string, peerIP netip.Prefix, peerMac net.
 		return nil
 	}
 
-	if err := d.checkEncryption(nid, vtep, false); err != nil {
-		log.G(context.TODO()).Warn(err)
+	if n.secure && len(n.endpoints) == 0 {
+		if err := d.removeEncryption(vtep); err != nil {
+			log.G(context.TODO()).Warn(err)
+		}
 	}
 
 	// Local peers do not have any local configuration to delete

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -37,22 +37,6 @@ type peerNetworkMap struct {
 	sync.Mutex
 }
 
-func (d *driver) peerDbWalk(f func(string, netip.Addr, net.HardwareAddr, *peerEntry) bool) error {
-	d.peerDb.Lock()
-	nids := []string{}
-	for nid := range d.peerDb.mp {
-		nids = append(nids, nid)
-	}
-	d.peerDb.Unlock()
-
-	for _, nid := range nids {
-		d.peerDbNetworkWalk(nid, func(peerIP netip.Addr, peerMac net.HardwareAddr, pEntry *peerEntry) bool {
-			return f(nid, peerIP, peerMac, pEntry)
-		})
-	}
-	return nil
-}
-
 func (d *driver) peerDbNetworkWalk(nid string, f func(netip.Addr, net.HardwareAddr, *peerEntry) bool) error {
 	d.peerDb.Lock()
 	pMap, ok := d.peerDb.mp[nid]
@@ -358,13 +342,4 @@ func (d *driver) peerFlushOp(nid string) error {
 	}
 	delete(d.peerDb.mp, nid)
 	return nil
-}
-
-func (d *driver) peerDBUpdateSelf() {
-	d.peerDbWalk(func(nid string, _ netip.Addr, _ net.HardwareAddr, pEntry *peerEntry) bool {
-		if pEntry.isLocal {
-			pEntry.vtep = d.advertiseAddress
-		}
-		return false
-	})
 }

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -235,7 +235,7 @@ func (d *driver) peerAddOp(nid, eid string, peerIP netip.Prefix, peerMac net.Har
 		return fmt.Errorf("subnet sandbox join failed for %q: %v", s.subnetIP.String(), err)
 	}
 
-	if err := d.checkEncryption(nid, vtep, false, true); err != nil {
+	if err := d.checkEncryption(nid, vtep, true); err != nil {
 		log.G(context.TODO()).Warn(err)
 	}
 
@@ -291,7 +291,7 @@ func (d *driver) peerDeleteOp(nid, eid string, peerIP netip.Prefix, peerMac net.
 		return nil
 	}
 
-	if err := d.checkEncryption(nid, vtep, !vtep.IsValid(), false); err != nil {
+	if err := d.checkEncryption(nid, vtep, false); err != nil {
 		log.G(context.TODO()).Warn(err)
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Split from #50081 

**- What I did**
I refactored the encryption related code in the overlay driver to simplify the implementation, making it easier to understand and work on further.

**- How I did it**
Iteratively -- see individual commits for details.

**- How to verify it**
1. Create a multi-node Swarm cluster.
2. Create a user-defined encrypted overlay network.
3. `docker service create --mode global --network my-overlay nginxdemos/hello:plain-text`
4. Exec into one of the service containers and verify that the other containers can be curl'ed by the IP address of its user-defined overlay network endpoint. Repeat with the other replicas.
5. curl port 8080 on each Swarm node. Verify that the service is reachable. Repeat to verify that the requests are load-balanced among the replicas.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

