### PR TITLE
remove fallback for non-OCI-compliant docker.pkg.github.com registry

### DIFF
--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -114,23 +114,6 @@ func translatePullError(err error, ref reference.Named) error {
 	return errdefs.Unknown(err)
 }
 
-func isNotFound(err error) bool {
-	switch v := err.(type) {
-	case errcode.Errors:
-		for _, e := range v {
-			if isNotFound(e) {
-				return true
-			}
-		}
-	case errcode.Error:
-		switch v.Code {
-		case errcode.ErrorCodeDenied, v2.ErrorCodeManifestUnknown, v2.ErrorCodeNameUnknown:
-			return true
-		}
-	}
-	return false
-}
-
 // continueOnError returns true if we should fallback to the next endpoint
 // as a result of this error.
 func continueOnError(err error, mirrorEndpoint bool) bool {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/41749
- relates to https://github.com/moby/moby/issues/41687
- relates to https://github.com/docker/cli/pull/2872


The legacy `docker.pkg.github.com` registry provided by GitHub was not OCI compliant, and did not suport pull by digest (among others). Commit 495d623ae5b1b601667d82682c5c265be189a29b added fallback code to detect "not found" errors when pulling by digest, in which case we would fall back to pulling by `name:tag`.

GitHub deprecated the legacy registry, and it was [sunset on Feb 24th, 2025][1] in favor of GitHub Container Registry (GHCR) (ghcr.io).

This reverts commit 495d623ae5b1b601667d82682c5c265be189a29b, removing the fallback logic.

[1]: https://github.blog/changelog/2025-01-23-legacy-docker-registry-closing-down/

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Remove fallback for pulling images from non-OCI-compliant `docker.pkg.github.com` registry
```

**- A picture of a cute animal (not mandatory but encouraged)**

