### PR TITLE
nftables: add initial/outline nftabler

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -19,8 +19,10 @@ import (
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
 	"github.com/docker/docker/libnetwork/drivers/bridge/internal/iptabler"
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/nftabler"
 	"github.com/docker/docker/libnetwork/drivers/bridge/internal/rlkclient"
 	"github.com/docker/docker/libnetwork/internal/netiputil"
+	"github.com/docker/docker/libnetwork/internal/nftables"
 	"github.com/docker/docker/libnetwork/iptables"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/netutils"
@@ -544,6 +546,9 @@ func (d *driver) configure(option map[string]interface{}) error {
 }
 
 var newFirewaller = func(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
+	if nftables.Enabled() {
+		return nftabler.NewNftabler(ctx, config)
+	}
 	return iptabler.NewIptabler(ctx, config)
 }
 

--- a/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package nftabler
+
+import (
+	"context"
+	"net/netip"
+)
+
+func (n *network) AddEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
+	return nil
+}
+
+func (n *network) DelEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
+	return nil
+}

--- a/libnetwork/drivers/bridge/internal/nftabler/link.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/link.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package nftabler
+
+import (
+	"context"
+	"net/netip"
+
+	"github.com/docker/docker/libnetwork/types"
+)
+
+func (n *network) AddLink(ctx context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort) error {
+	return nil
+}
+
+func (n *network) DelLink(ctx context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort) {
+}

--- a/libnetwork/drivers/bridge/internal/nftabler/network.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/network.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package nftabler
+
+import (
+	"context"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
+)
+
+type network struct {
+	config firewaller.NetworkConfig
+	fw     *nftabler
+}
+
+func (nft *nftabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig) (_ firewaller.Network, retErr error) {
+	n := &network{
+		fw:     nft,
+		config: nc,
+	}
+	return n, nil
+}
+
+func (n *network) ReapplyNetworkLevelRules(ctx context.Context) error {
+	log.G(ctx).Warn("ReapplyNetworkLevelRules is not implemented for nftables")
+	return nil
+}
+
+func (n *network) DelNetworkLevelRules(ctx context.Context) error {
+	return nil
+}

--- a/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -184,6 +184,12 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 		return nftables.TableRef{}, err
 	}
 
+	if !nft.config.Hairpin && nft.config.WSL2Mirrored {
+		if err := mirroredWSL2Workaround(ctx, table); err != nil {
+			return nftables.TableRef{}, err
+		}
+	}
+
 	return table, nil
 }
 

--- a/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -1,0 +1,197 @@
+//go:build linux
+
+package nftabler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
+	"github.com/docker/docker/libnetwork/internal/nftables"
+	"go.opentelemetry.io/otel"
+)
+
+// Prefix for OTEL span names.
+const spanPrefix = "libnetwork.drivers.bridge.nftabler"
+
+const (
+	dockerTable           = "docker-bridges"
+	forwardChain          = "filter-FORWARD"
+	postroutingChain      = "nat-POSTROUTING"
+	preroutingChain       = "nat-PREROUTING"
+	outputChain           = "nat-OUTPUT"
+	natChain              = "nat-prerouting-and-output"
+	rawPreroutingChain    = "raw-PREROUTING"
+	filtFwdInVMap         = "filter-forward-in-jumps"
+	filtFwdOutVMap        = "filter-forward-out-jumps"
+	natPostroutingOutVMap = "nat-postrouting-out-jumps"
+	natPostroutingInVMap  = "nat-postrouting-in-jumps"
+)
+
+const (
+	initialRuleGroup nftables.RuleGroup = iota
+)
+
+type nftabler struct {
+	config firewaller.Config
+	table4 nftables.TableRef
+	table6 nftables.TableRef
+}
+
+func NewNftabler(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
+	nft := &nftabler{config: config}
+
+	if nft.config.IPv4 {
+		var err error
+		nft.table4, err = nft.init(ctx, nftables.IPv4)
+		if err != nil {
+			return nil, err
+		}
+		if err := nftApply(ctx, nft.table4); err != nil {
+			return nil, fmt.Errorf("IPv4 initialisation: %w", err)
+		}
+	}
+
+	if nft.config.IPv6 {
+		var err error
+		nft.table6, err = nft.init(ctx, nftables.IPv6)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := nftApply(ctx, nft.table6); err != nil {
+			// Perhaps the kernel has no IPv6 support. It won't be possible to create IPv6
+			// networks without enabling ip6_tables in the kernel, or disabling ip6tables in
+			// the daemon config. But, allow the daemon to start because IPv4 will work. So,
+			// log the problem, and continue.
+			log.G(ctx).WithError(err).Warn("ip6tables is enabled, but cannot set up IPv6 nftables table")
+		}
+	}
+
+	return nft, nil
+}
+
+func (nft *nftabler) getTable(ipv firewaller.IPVersion) nftables.TableRef {
+	if ipv == firewaller.IPv4 {
+		return nft.table4
+	}
+	return nft.table6
+}
+
+func (nft *nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
+	table := nft.getTable(ipv)
+	if err := table.Chain(forwardChain).SetPolicy("drop"); err != nil {
+		return err
+	}
+	return nftApply(ctx, table)
+}
+
+// init creates the bridge driver's nftables table for IPv4 or IPv6.
+func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables.TableRef, error) {
+	// Instantiate the table.
+	table, err := nftables.NewTable(family, dockerTable)
+	if err != nil {
+		return table, err
+	}
+
+	// Set up the filter forward chain.
+	//
+	// This base chain only contains two rules that use verdict maps:
+	// - if a packet is entering a bridge network, jump to that network's filter-forward ingress chain.
+	// - if a packet is leaving a bridge network, jump to that network's filter-forward egress chain.
+	//
+	// So, packets that aren't related to docker don't need to traverse any per-network filter forward
+	// rules - and packets that are entering or leaving docker networks only need to traverse rules
+	// related to those networks.
+	fwdChain, err := table.BaseChain(forwardChain,
+		nftables.BaseChainTypeFilter,
+		nftables.BaseChainHookForward,
+		nftables.BaseChainPriorityFilter)
+	if err != nil {
+		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
+	}
+	// Instantiate the verdict maps and add the jumps.
+	_ = table.InterfaceVMap(filtFwdInVMap)
+	if err := fwdChain.AppendRule(initialRuleGroup, "oifname vmap @"+filtFwdInVMap); err != nil {
+		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
+	}
+	_ = table.InterfaceVMap(filtFwdOutVMap)
+	if err := fwdChain.AppendRule(initialRuleGroup, "iifname vmap @"+filtFwdOutVMap); err != nil {
+		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
+	}
+
+	// Set up the NAT postrouting base chain.
+	//
+	// Like the filter-forward chain, its only rules are jumps to network-specific ingress and egress chains.
+	natPostRtChain, err := table.BaseChain(postroutingChain,
+		nftables.BaseChainTypeNAT,
+		nftables.BaseChainHookPostrouting,
+		nftables.BaseChainPrioritySrcNAT)
+	if err != nil {
+		return nftables.TableRef{}, err
+	}
+	_ = table.InterfaceVMap(natPostroutingOutVMap)
+	if err := natPostRtChain.AppendRule(initialRuleGroup, "iifname vmap @"+natPostroutingOutVMap); err != nil {
+		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
+	}
+	_ = table.InterfaceVMap(natPostroutingInVMap)
+	if err := natPostRtChain.AppendRule(initialRuleGroup, "oifname vmap @"+natPostroutingInVMap); err != nil {
+		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
+	}
+
+	// Instantiate natChain, for the NAT prerouting and output base chains to jump to.
+	_ = table.Chain(natChain)
+
+	// Set up the NAT prerouting base chain.
+	natPreRtChain, err := table.BaseChain(preroutingChain,
+		nftables.BaseChainTypeNAT,
+		nftables.BaseChainHookPrerouting,
+		nftables.BaseChainPriorityDstNAT)
+	if err != nil {
+		return nftables.TableRef{}, err
+	}
+	if err := natPreRtChain.AppendRule(initialRuleGroup, "fib daddr type local counter jump "+natChain); err != nil {
+		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
+	}
+
+	// Set up the NAT output base chain
+	natOutputChain, err := table.BaseChain(outputChain,
+		nftables.BaseChainTypeNAT,
+		nftables.BaseChainHookOutput,
+		nftables.BaseChainPriorityDstNAT)
+	if err != nil {
+		return nftables.TableRef{}, err
+	}
+	// For output, don't jump to the NAT chain if hairpin is enabled (no userland proxy).
+	var skipLoopback string
+	if !nft.config.Hairpin {
+		if family == nftables.IPv4 {
+			skipLoopback = "ip daddr != 127.0.0.1/8 "
+		} else {
+			skipLoopback = "ip6 daddr != ::1 "
+		}
+	}
+	if err := natOutputChain.AppendRule(initialRuleGroup, skipLoopback+"fib daddr type local counter jump "+natChain); err != nil {
+		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
+	}
+
+	// Set up the raw prerouting base chain
+	if _, err := table.BaseChain(rawPreroutingChain,
+		nftables.BaseChainTypeFilter,
+		nftables.BaseChainHookPrerouting,
+		nftables.BaseChainPriorityRaw); err != nil {
+		return nftables.TableRef{}, err
+	}
+
+	return table, nil
+}
+
+func nftApply(ctx context.Context, table nftables.TableRef) error {
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply."+string(table.Family()))
+	defer span.End()
+	if err := table.Apply(ctx); err != nil {
+		return fmt.Errorf("applying nftables rules: %w", err)
+	}
+	return nil
+}

--- a/libnetwork/drivers/bridge/internal/nftabler/port.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/port.go
@@ -1,0 +1,22 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22 && linux
+
+package nftabler
+
+import (
+	"context"
+
+	"github.com/docker/docker/libnetwork/types"
+)
+
+func (n *network) AddPorts(ctx context.Context, pbs []types.PortBinding) error {
+	return n.modPorts(ctx, pbs, true)
+}
+
+func (n *network) DelPorts(ctx context.Context, pbs []types.PortBinding) error {
+	return n.modPorts(ctx, pbs, false)
+}
+
+func (n *network) modPorts(ctx context.Context, pbs []types.PortBinding, enable bool) error {
+	return nil
+}

--- a/libnetwork/drivers/bridge/internal/nftabler/wsl2.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/wsl2.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package nftabler
+
+import (
+	"context"
+
+	"github.com/docker/docker/libnetwork/internal/nftables"
+)
+
+// mirroredWSL2Workaround adds  IPv4 NAT rule if docker's host Linux appears to
+// be a guest running under WSL2 in with mirrored mode networking.
+// https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking
+//
+// Without mirrored mode networking, or for a packet sent from Linux, packets
+// sent to 127.0.0.1 are processed as outgoing - they hit the nat-OUTPUT chain,
+// which does not jump to the nat-DOCKER chain because the rule has an exception
+// for "-d 127.0.0.0/8". The default action on the nat-OUTPUT chain is ACCEPT (by
+// default), so the packet is delivered to 127.0.0.1 on lo, where docker-proxy
+// picks it up and acts as a man-in-the-middle; it receives the packet and
+// re-sends it to the container (or acks a SYN and sets up a second TCP
+// connection to the container). So, the container sees packets arrive with a
+// source address belonging to the network's bridge, and it is able to reply to
+// that address.
+//
+// In WSL2's mirrored networking mode, Linux has a loopback0 device as well as lo
+// (which owns 127.0.0.1 as normal). Packets sent to 127.0.0.1 from Windows to a
+// server listening on Linux's 127.0.0.1 are delivered via loopback0, and
+// processed as packets arriving from outside the Linux host (which they are).
+//
+// So, these packets hit the nat-PREROUTING chain instead of nat-OUTPUT. It would
+// normally be impossible for a packet ->127.0.0.1 to arrive from outside the
+// host, so the nat-PREROUTING jump to nat-DOCKER has no exception for it. The
+// packet is processed by a per-bridge DNAT rule in that chain, so it is
+// delivered directly to the container (not via docker-proxy) with source address
+// 127.0.0.1, so the container can't respond.
+//
+// DNAT is normally skipped by RETURN rules in the nat-DOCKER chain for packets
+// arriving from any other bridge network. Similarly, this function adds (or
+// removes) a rule to RETURN early for packets delivered via loopback0 with
+// destination 127.0.0.0/8.
+func mirroredWSL2Workaround(ctx context.Context, table nftables.TableRef) error {
+	// WSL2 does not (currently) support Windows<->Linux communication via ::1.
+	if table.Family() != nftables.IPv4 {
+		return nil
+	}
+	return table.Chain(natChain).AppendRule(initialRuleGroup, `iifname "loopback0" ip daddr 127.0.0.0/8 counter return`)
+}


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49636

Add an outline `nftabler` ...
- All it does so-far is set up IPv4 and IPv6 tables, with empty maps and base chains
  - And, in the second commit, a single rule for WSL2.
- Instantiate nftabler in the bridge driver instead of an iptabler, when nftables is enabled.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

