### PR TITLE
Revert "containerd: images overridden by a build are kept dangling"

### DIFF
--- a/builder/builder-next/controller.go
+++ b/builder/builder-next/controller.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/builder/builder-next/adapters/containerimage"
 	"github.com/docker/docker/builder/builder-next/adapters/localinlinecache"
 	"github.com/docker/docker/builder/builder-next/adapters/snapshot"
-	"github.com/docker/docker/builder/builder-next/exporter"
 	"github.com/docker/docker/builder/builder-next/exporter/mobyexporter"
 	"github.com/docker/docker/builder/builder-next/imagerefchecker"
 	mobyworker "github.com/docker/docker/builder/builder-next/worker"
@@ -169,10 +168,7 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 	}
 	wo.Executor = exec
 
-	w, err := mobyworker.NewContainerdWorker(ctx, wo, exporter.Opt{
-		Callbacks:   opt.Callbacks,
-		ImageTagger: opt.ImageTagger,
-	}, rt)
+	w, err := mobyworker.NewContainerdWorker(ctx, wo, opt.Callbacks, rt)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/builder-next/worker/containerdworker.go
+++ b/builder/builder-next/worker/containerdworker.go
@@ -16,11 +16,11 @@ import (
 // ContainerdWorker is a local worker instance with dedicated snapshotter, cache, and so on.
 type ContainerdWorker struct {
 	*base.Worker
-	opt exporter.Opt
+	callbacks exporter.BuildkitCallbacks
 }
 
 // NewContainerdWorker instantiates a local worker.
-func NewContainerdWorker(ctx context.Context, wo base.WorkerOpt, opt exporter.Opt, rt nethttp.RoundTripper) (*ContainerdWorker, error) {
+func NewContainerdWorker(ctx context.Context, wo base.WorkerOpt, callbacks exporter.BuildkitCallbacks, rt nethttp.RoundTripper) (*ContainerdWorker, error) {
 	bw, err := base.NewWorker(ctx, wo)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func NewContainerdWorker(ctx context.Context, wo base.WorkerOpt, opt exporter.Op
 		log.G(ctx).Warnf("Could not register builder http source: %s", err)
 	}
 
-	return &ContainerdWorker{Worker: bw, opt: opt}, nil
+	return &ContainerdWorker{Worker: bw, callbacks: callbacks}, nil
 }
 
 // Exporter returns exporter by name
@@ -46,7 +46,7 @@ func (w *ContainerdWorker) Exporter(name string, sm *session.Manager) (bkexporte
 		if err != nil {
 			return nil, err
 		}
-		return exporter.NewWrapper(exp, w.opt)
+		return exporter.NewWrapper(exp, w.callbacks)
 	default:
 		return w.Worker.Exporter(name, sm)
 	}

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -431,6 +431,7 @@ func initBuildkit(ctx context.Context, d *daemon.Daemon) (_ builderOptions, clos
 		ContainerdNamespace: cfg.ContainerdNamespace,
 		Callbacks: exporter.BuildkitCallbacks{
 			Exported: d.ImageExportedByBuildkit,
+			Named:    d.ImageNamedByBuildkit,
 		},
 		CDISpecDirs: cdiSpecDirs,
 	})

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 
+	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/events"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -13,4 +14,11 @@ import (
 // way of knowing the image was created.
 func (daemon *Daemon) ImageExportedByBuildkit(ctx context.Context, id string, desc ocispec.Descriptor) {
 	daemon.imageService.LogImageEvent(ctx, id, id, events.ActionCreate)
+}
+
+// ImageNamedByBuildkit is a callback that is called when an image is tagged by buildkit.
+// Note: It is only called if the buildkit didn't call the image service itself to perform the tagging.
+// Currently this only happens when the containerd image store is used.
+func (daemon *Daemon) ImageNamedByBuildkit(ctx context.Context, ref reference.NamedTagged, desc ocispec.Descriptor) {
+	daemon.imageService.LogImageEvent(ctx, desc.Digest.String(), reference.FamiliarString(ref), events.ActionTag)
 }


### PR DESCRIPTION
- revert https://github.com/moby/moby/pull/49702
- reopens https://github.com/moby/moby/issues/48907
- related https://github.com/docker/buildx/pull/3210

This reverts commit 50a856157c07ee42ccc6e40a7a25f635eea7bc7a.

```markdown changelog
containerd image store: Fix a regression causing `docker build --push` to fail. This reverts [the fix](https://github.com/moby/moby/pull/49702) for `docker build` not persisting overridden images as dangling. 
```