### PR TITLE
libnetwork/d/overlay: properly model peer db

### DIFF
--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -91,8 +91,13 @@ func (s *spi) String() string {
 	return fmt.Sprintf("SPI(FWD: 0x%x, REV: 0x%x)", uint32(s.forward), uint32(s.reverse))
 }
 
+type encrNode struct {
+	spi   []spi
+	count int
+}
+
 type encrMap struct {
-	nodes map[netip.Addr][]*spi
+	nodes map[netip.Addr]encrNode
 	sync.Mutex
 }
 
@@ -105,7 +110,7 @@ func (e *encrMap) String() string {
 		b.WriteString(k.String())
 		b.WriteString(":")
 		b.WriteString("[")
-		for _, s := range v {
+		for _, s := range v.spi {
 			b.WriteString(s.String())
 			b.WriteString(",")
 		}
@@ -126,10 +131,10 @@ func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 	}
 	log.G(context.TODO()).Debugf("Programming encryption between %s and %s", localIP, remoteIP)
 
-	indices := make([]*spi, 0, len(keys))
+	indices := make([]spi, 0, len(keys))
 
 	for i, k := range keys {
-		spis := &spi{buildSPI(advIP.AsSlice(), remoteIP.AsSlice(), k.tag), buildSPI(remoteIP.AsSlice(), advIP.AsSlice(), k.tag)}
+		spis := spi{buildSPI(advIP.AsSlice(), remoteIP.AsSlice(), k.tag), buildSPI(remoteIP.AsSlice(), advIP.AsSlice(), k.tag)}
 		dir := reverse
 		if i == 0 {
 			dir = bidir
@@ -149,7 +154,10 @@ func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 	}
 
 	d.secMap.Lock()
-	d.secMap.nodes[remoteIP] = indices
+	node := d.secMap.nodes[remoteIP]
+	node.spi = indices
+	node.count++
+	d.secMap.nodes[remoteIP] = node
 	d.secMap.Unlock()
 
 	return nil
@@ -158,13 +166,20 @@ func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 func (d *driver) removeEncryption(remoteIP netip.Addr) error {
 	log.G(context.TODO()).Debugf("removeEncryption(%s)", remoteIP)
 
-	d.secMap.Lock()
-	indices, ok := d.secMap.nodes[remoteIP]
-	d.secMap.Unlock()
-	if !ok {
+	spi := func() []spi {
+		d.secMap.Lock()
+		defer d.secMap.Unlock()
+		node := d.secMap.nodes[remoteIP]
+		if node.count == 1 {
+			delete(d.secMap.nodes, remoteIP)
+			return node.spi
+		}
+		node.count--
+		d.secMap.nodes[remoteIP] = node
 		return nil
-	}
-	for i, idxs := range indices {
+	}()
+
+	for i, idxs := range spi {
 		dir := reverse
 		if i == 0 {
 			dir = bidir
@@ -263,7 +278,7 @@ func (d *driver) programInput(vni uint32, add bool) error {
 	return nil
 }
 
-func programSA(localIP, remoteIP net.IP, spi *spi, k *key, dir int, add bool) (fSA *netlink.XfrmState, rSA *netlink.XfrmState, lastErr error) {
+func programSA(localIP, remoteIP net.IP, spi spi, k *key, dir int, add bool) (fSA *netlink.XfrmState, rSA *netlink.XfrmState, lastErr error) {
 	var (
 		action      = "Removing"
 		xfrmProgram = ns.NlHandle().XfrmStateDel
@@ -436,12 +451,12 @@ func buildAeadAlgo(k *key, s int) *netlink.XfrmStateAlgo {
 	}
 }
 
-func (d *driver) secMapWalk(f func(netip.Addr, []*spi) ([]*spi, bool)) error {
+func (d *driver) secMapWalk(f func(netip.Addr, []spi) ([]spi, bool)) error {
 	d.secMap.Lock()
-	for node, indices := range d.secMap.nodes {
-		idxs, stop := f(node, indices)
+	for rIP, node := range d.secMap.nodes {
+		idxs, stop := f(rIP, node.spi)
 		if idxs != nil {
-			d.secMap.nodes[node] = idxs
+			d.secMap.nodes[rIP] = encrNode{idxs, node.count}
 		}
 		if stop {
 			break
@@ -457,7 +472,7 @@ func (d *driver) setKeys(keys []*key) error {
 	// Accept the encryption keys and clear any stale encryption map
 	d.Lock()
 	d.keys = keys
-	d.secMap = &encrMap{nodes: map[netip.Addr][]*spi{}}
+	d.secMap = &encrMap{nodes: map[netip.Addr]encrNode{}}
 	d.Unlock()
 	log.G(context.TODO()).Debugf("Initial encryption keys: %v", keys)
 	return nil
@@ -506,7 +521,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 		return types.InvalidParameterErrorf("attempting to both make a key (index %d) primary and delete it", priIdx)
 	}
 
-	d.secMapWalk(func(rIP netip.Addr, spis []*spi) ([]*spi, bool) {
+	d.secMapWalk(func(rIP netip.Addr, spis []spi) ([]spi, bool) {
 		return updateNodeKey(lIP.AsSlice(), aIP.AsSlice(), rIP.AsSlice(), spis, d.keys, newIdx, priIdx, delIdx), false
 	})
 
@@ -534,7 +549,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
  *********************************************************/
 
 // Spis and keys are sorted in such away the one in position 0 is the primary
-func updateNodeKey(lIP, aIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, priIdx, delIdx int) []*spi {
+func updateNodeKey(lIP, aIP, rIP net.IP, idxs []spi, curKeys []*key, newIdx, priIdx, delIdx int) []spi {
 	log.G(context.TODO()).Debugf("Updating keys for node: %s (%d,%d,%d)", rIP, newIdx, priIdx, delIdx)
 
 	spis := idxs
@@ -542,7 +557,7 @@ func updateNodeKey(lIP, aIP, rIP net.IP, idxs []*spi, curKeys []*key, newIdx, pr
 
 	// add new
 	if newIdx != -1 {
-		spis = append(spis, &spi{
+		spis = append(spis, spi{
 			forward: buildSPI(aIP, rIP, curKeys[newIdx].tag),
 			reverse: buildSPI(rIP, aIP, curKeys[newIdx].tag),
 		})

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -1,4 +1,5 @@
-//go:build linux
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.23 && linux
 
 package overlay
 
@@ -18,6 +19,7 @@ import (
 	"github.com/docker/docker/internal/nlwrap"
 	"github.com/docker/docker/libnetwork/driverapi"
 	"github.com/docker/docker/libnetwork/drivers/overlay/overlayutils"
+	"github.com/docker/docker/libnetwork/internal/countmap"
 	"github.com/docker/docker/libnetwork/internal/netiputil"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/ns"
@@ -53,6 +55,8 @@ type network struct {
 	endpoints endpointTable
 	driver    *driver
 	joinCnt   int
+	// Ref count of VXLAN Forwarding Database entries programmed into the kernel
+	fdbCnt    countmap.Map[ipmac]
 	sboxInit  bool
 	initEpoch int
 	initErr   error
@@ -99,6 +103,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 		driver:    d,
 		endpoints: endpointTable{},
 		subnets:   []*subnet{},
+		fdbCnt:    countmap.Map[ipmac]{},
 	}
 
 	vnis := make([]uint32, 0, len(ipV4Data))
@@ -586,6 +591,7 @@ func (n *network) initSandbox() error {
 
 	// this is needed to let the peerAdd configure the sandbox
 	n.sbox = sbox
+	n.fdbCnt = countmap.Map[ipmac]{}
 
 	return nil
 }

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -47,7 +47,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		peerDb: peerNetworkMap{
 			mp: map[string]*peerMap{},
 		},
-		secMap: &encrMap{nodes: map[netip.Addr][]*spi{}},
+		secMap: &encrMap{nodes: map[netip.Addr]encrNode{}},
 		config: config,
 	}
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -212,7 +212,7 @@ func (d *driver) addNeighbor(nid string, peerIP netip.Prefix, peerMac net.Hardwa
 		return fmt.Errorf("subnet sandbox join failed for %q: %v", s.subnetIP.String(), err)
 	}
 
-	if n.secure && len(n.endpoints) > 0 {
+	if n.secure {
 		if err := d.setupEncryption(vtep); err != nil {
 			log.G(context.TODO()).Warn(err)
 		}
@@ -307,7 +307,7 @@ func (d *driver) deleteNeighbor(nid string, peerIP netip.Prefix, peerMac net.Har
 		return nil
 	}
 
-	if n.secure && len(n.endpoints) == 0 {
+	if n.secure {
 		if err := d.removeEncryption(vtep); err != nil {
 			log.G(context.TODO()).Warn(err)
 		}

--- a/libnetwork/internal/countmap/countmap.go
+++ b/libnetwork/internal/countmap/countmap.go
@@ -1,0 +1,19 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.23
+
+package countmap
+
+// Map is a map of counters.
+type Map[T comparable] map[T]int
+
+// Add adds delta to the counter for v and returns the new value.
+//
+// If the new value is 0, the entry is removed from the map.
+func (m Map[T]) Add(v T, delta int) int {
+	m[v] += delta
+	c := m[v]
+	if c == 0 {
+		delete(m, v)
+	}
+	return c
+}

--- a/libnetwork/internal/countmap/countmap_test.go
+++ b/libnetwork/internal/countmap/countmap_test.go
@@ -1,0 +1,27 @@
+package countmap_test
+
+import (
+	"testing"
+
+	"github.com/docker/docker/libnetwork/internal/countmap"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestMap(t *testing.T) {
+	m := countmap.Map[string]{}
+	m["foo"] = 7
+	m["bar"] = 2
+	m["zeroed"] = -2
+
+	m.Add("bar", -3)
+	m.Add("foo", -8)
+	m.Add("baz", 1)
+	m.Add("zeroed", 2)
+	assert.Check(t, is.DeepEqual(m, countmap.Map[string]{"foo": -1, "bar": -1, "baz": 1}))
+
+	m.Add("foo", 1)
+	m.Add("bar", 1)
+	m.Add("baz", -1)
+	assert.Check(t, is.DeepEqual(m, countmap.Map[string]{}))
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Split from #50081 
- For #49908

**- What I did**
The overlay network driver's peer database is responsible for configuring the data plane in response to control-plane updates to the NetworkDB `overlay_peer_table`. It maintains the Forwarding Database (FDB) for the VXLAN interface which maps destination MAC addresses to the VXLAN Tunnel Endpoint (VTEP) IP:port of the remote host which encapsulated packets should be forwarded onto, and the neighbour tables which map IP addresses to MAC addresses. Note that when a userland process sends a packet addressed to the IP address of a remote endpoint, the kernel first resolves the MAC address for the IP when the packet enters the network stack, then later resolves the VTEP from the MAC address when forwarding the packet out the VXLAN interface. The kernel is therefore capable of handling n:1 mappings of IP->MAC and n:1 mappings of MAC->VTEP.

The overlay peer db receives control-plane updates in the form of (Endpoint-ID, IP, MAC, VTEP) tuples. The trouble is that it assumes the `overlay_peer_table` will eventually converge to a state where each entry has a unique IP address and MAC address. The peer db deletes both the IP->MAC neighbour entry and the MAC->VTEP FDB entry when a peer entry is deleted from `overlay_peer_table`, without checking whether any other neighbour entries still need the FDB entry. Consequently, the data plane can fall out of sync with the control plane if the assumption is violated.

I modified the overlay driver's peer database to correctly handle cases where multiple endpoint IP addresses map to the same MAC address, or multiple MAC addresses map to the same VTEP. This change lifts one of the major limitations which has been blocking our ability to implement support for IPv6 endpoints on overlay networks.

**- How I did it**
With reference counting. See the individual commit messages for more detail.

**- How to verify it**
1. Create a multi-node Swarm cluster.
2. Create a user-defined encrypted overlay network.
3. `docker service create --mode global --network my-overlay nginxdemos/hello:plain-text`
4. Exec into one of the service containers and verify that the other containers can be curl'ed by the IP address of its user-defined overlay network endpoint. Repeat with the other replicas.
5. curl port 8080 on each Swarm node. Verify that the service is reachable. Repeat to verify that the requests are load-balanced among the replicas.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

