### PR TITLE
gha/bin-image: Don't push sha tags

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -65,13 +65,10 @@ jobs:
           # moby/moby-bin:master
           ## push on 23.0 branch
           # moby/moby-bin:23.0
-          ## any push
-          # moby/moby-bin:sha-ad132f5
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
       -
         name: Rename meta bake definition file
         # see https://github.com/docker/metadata-action/issues/381#issuecomment-1918607161


### PR DESCRIPTION
- related: https://github.com/docker/cli/pull/6117

This change eliminates the automatic creation of image tags in the format `moby/moby-bin:sha-ad132f5` for every push.

They're not too useful, produce noise and use a lot of space.
