### PR TITLE
daemon/logger/fluentd: cap max-retries to MaxInt32

### DIFF
--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -200,9 +200,15 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 
 	maxRetries := defaultMaxRetries
 	if cfg[maxRetriesKey] != "" {
-		mr64, err := strconv.ParseUint(cfg[maxRetriesKey], 10, strconv.IntSize)
+		mr64, err := strconv.ParseUint(cfg[maxRetriesKey], 10, 32)
 		if err != nil {
 			return config, err
+		}
+
+		// cap to MaxInt32 to prevent overflowing, and which is documented on
+		// defaultMaxRetries to be the limit above which things fail.
+		if mr64 > math.MaxInt32 {
+			return config, errors.New("invalid fluentd-max-retries: value out of range")
 		}
 		maxRetries = int(mr64)
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50110
- relates to https://github.com/moby/moby/pull/19439


CodeQL was warning about a potential overflow; the default value was set to MaxInt32 in 13086f387b28ceea5aff5924e430f41608884a9b, which documented that higher values caused problems, so cap it to that value as maximum.

https://github.com/moby/moby/blob/45873be4ae3f5488c9498b3d9f17deaddaf609f4/daemon/logger/fluentd/fluentd.go#L45-L47


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

