### PR TITLE
libnet/d/overlay/overlayutils: prevent uint32 overflow

### DIFF
--- a/libnetwork/drivers/overlay/overlayutils/utils.go
+++ b/libnetwork/drivers/overlay/overlayutils/utils.go
@@ -51,7 +51,7 @@ func AppendVNIList(vnis []uint32, csv string) ([]uint32, error) {
 			found  bool
 		)
 		vniStr, csv, found = strings.Cut(csv, ",")
-		vni, err := strconv.Atoi(vniStr)
+		vni, err := strconv.ParseUint(vniStr, 10, 32)
 		if err != nil {
 			return vnis, fmt.Errorf("invalid vxlan id value %q passed", vniStr)
 		}


### PR DESCRIPTION
CodeQL was complaining about the conversion to uint32


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

