### PR TITLE
Allow specifying the subnet size for networks allocated from default pools

### DIFF
--- a/daemon/libnetwork/cnmallocator/networkallocator.go
+++ b/daemon/libnetwork/cnmallocator/networkallocator.go
@@ -949,7 +949,10 @@ func (na *cnmNetworkAllocator) allocatePools(n *api.Network) (map[netip.Prefix]s
 			}
 		}
 
-		if ic.Subnet == "" {
+		// The IPAM config contain an unspecified subnet if a network with a specific prefix size
+		// was requested from the default pools. Therefore it's important to update the value in the
+		// config with the actual allocated subnet if available.
+		if alloc.Pool.String() != "" {
 			ic.Subnet = alloc.Pool.String()
 		}
 

--- a/integration/daemon/daemon_linux_test.go
+++ b/integration/daemon/daemon_linux_test.go
@@ -70,8 +70,8 @@ func TestDaemonDefaultBridgeIPAM_Docker0(t *testing.T) {
 				"--fixed-cidr-v6", "fdd1:8161:2d2c::/64",
 			},
 			expIPAMConfig: []network.IPAMConfig{
-				{Subnet: netip.MustParsePrefix("192.168.176.0/24"), IPRange: netip.MustParsePrefix("192.168.176.0/24")},
-				{Subnet: netip.MustParsePrefix("fdd1:8161:2d2c::/64"), IPRange: netip.MustParsePrefix("fdd1:8161:2d2c::/64")},
+				{Subnet: netip.MustParsePrefix("192.168.176.0/24"), IPRange: netip.MustParsePrefix("192.168.176.0/24"), Gateway: netip.MustParseAddr("192.168.176.1")},
+				{Subnet: netip.MustParsePrefix("fdd1:8161:2d2c::/64"), IPRange: netip.MustParsePrefix("fdd1:8161:2d2c::/64"), Gateway: netip.MustParseAddr("fdd1:8161:2d2c::1")},
 			},
 		},
 		{
@@ -123,7 +123,7 @@ func TestDaemonDefaultBridgeIPAM_Docker0(t *testing.T) {
 				"--fixed-cidr-v6", "fe80::/64",
 			},
 			expIPAMConfig: []network.IPAMConfig{
-				{Subnet: netip.MustParsePrefix("192.168.176.0/24"), IPRange: netip.MustParsePrefix("192.168.176.0/24")},
+				{Subnet: netip.MustParsePrefix("192.168.176.0/24"), IPRange: netip.MustParsePrefix("192.168.176.0/24"), Gateway: netip.MustParseAddr("192.168.176.1")},
 				{Subnet: netip.MustParsePrefix("fe80::/64"), IPRange: netip.MustParsePrefix("fe80::/64"), Gateway: llGwPlaceholder},
 			},
 		},
@@ -173,15 +173,8 @@ func TestDaemonDefaultBridgeIPAM_Docker0(t *testing.T) {
 			// The bridge's address/subnet should be ignored, this is a change
 			// of fixed-cidr.
 			expIPAMConfig: []network.IPAMConfig{
-				{Subnet: netip.MustParsePrefix("192.168.177.0/24"), IPRange: netip.MustParsePrefix("192.168.177.0/24")},
-				{Subnet: netip.MustParsePrefix("fdd1:8161:2d2c:1::/64"), IPRange: netip.MustParsePrefix("fdd1:8161:2d2c:1::/64")},
-				// No Gateway is configured, because the address could not be learnt from the
-				// bridge. An address will have been allocated but, because there's config (the
-				// fixed-cidr), inspect shows just the config. (Surprisingly, when there's no
-				// config at all, the inspect output still says its showing config but actually
-				// shows the running state.) When the daemon is restarted, after a gateway
-				// address has been assigned to the bridge, that address will become config - so
-				// a Gateway address will show up in the inspect output.
+				{Subnet: netip.MustParsePrefix("192.168.177.0/24"), IPRange: netip.MustParsePrefix("192.168.177.0/24"), Gateway: netip.MustParseAddr("192.168.177.1")},
+				{Subnet: netip.MustParsePrefix("fdd1:8161:2d2c:1::/64"), IPRange: netip.MustParsePrefix("fdd1:8161:2d2c:1::/64"), Gateway: netip.MustParseAddr("fdd1:8161:2d2c:1::1")},
 			},
 		},
 		{
@@ -225,8 +218,8 @@ func TestDaemonDefaultBridgeIPAM_UserBr(t *testing.T) {
 				"--fixed-cidr-v6", "fdd1:8161:2d2c::/64",
 			},
 			expIPAMConfig: []network.IPAMConfig{
-				{Subnet: netip.MustParsePrefix("192.168.176.0/24"), IPRange: netip.MustParsePrefix("192.168.176.0/24")},
-				{Subnet: netip.MustParsePrefix("fdd1:8161:2d2c::/64"), IPRange: netip.MustParsePrefix("fdd1:8161:2d2c::/64")},
+				{Subnet: netip.MustParsePrefix("192.168.176.0/24"), IPRange: netip.MustParsePrefix("192.168.176.0/24"), Gateway: netip.MustParseAddr("192.168.176.1")},
+				{Subnet: netip.MustParsePrefix("fdd1:8161:2d2c::/64"), IPRange: netip.MustParsePrefix("fdd1:8161:2d2c::/64"), Gateway: netip.MustParseAddr("fdd1:8161:2d2c::1")},
 			},
 		},
 		{
@@ -428,7 +421,7 @@ func testDefaultBridgeIPAM(ctx context.Context, t *testing.T, tc defaultBridgeIP
 					expIPAMConfig[i].Gateway = llAddr
 				}
 			}
-			assert.Check(t, is.DeepEqual(res.Network.IPAM.Config, expIPAMConfig, cmpopts.EquateComparable(netip.Addr{}, netip.Prefix{})))
+			assert.Check(t, is.DeepEqual(res.Network.IPAM.Config, expIPAMConfig, cmpopts.EquateComparable(netip.Addr{}, netip.Prefix{})), "unexpected IPAM config '%s'", tc.name)
 		})
 	})
 }

--- a/integration/internal/network/network.go
+++ b/integration/internal/network/network.go
@@ -33,6 +33,21 @@ func CreateNoError(ctx context.Context, t *testing.T, apiClient client.APIClient
 	return name
 }
 
+// Inspect inspects a network with the specified options
+func Inspect(ctx context.Context, apiClient client.APIClient, name string, options client.NetworkInspectOptions) (client.NetworkInspectResult, error) {
+	return apiClient.NetworkInspect(ctx, name, options)
+}
+
+// InspectNoError inspects a network with the specified options and verifies there were no errors
+func InspectNoError(ctx context.Context, t *testing.T, apiClient client.APIClient, name string, options client.NetworkInspectOptions) client.NetworkInspectResult {
+	t.Helper()
+
+	c, err := apiClient.NetworkInspect(ctx, name, options)
+	assert.NilError(t, err)
+
+	return c
+}
+
 func RemoveNoError(ctx context.Context, t *testing.T, apiClient client.APIClient, name string) {
 	t.Helper()
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated how subnet arguments are processed to treat `0.0.0.0/<size>`, `::/<size>`, or `/<size>` as requests for a subnet from the default pools with the given prefix size (rather than the default prefix size for the pool)

Networks with both IPv4 and IPv6 subnets are supported:

`docker network create --ipv6 --subnet ::/65 --subnet 0.0.0.0/24 test` results in an IPv6 subnet of size /65 and an IPv4 subnet of size /24, both from the default pools. Fixed address subnets can be combined with default pool subnets as well.

Implements #50107 

**- How I did it**

Added support for treating `0.0.0.0` and `::` subnet addresses as requests for networks from the default pools. If a prefix length is provided as well (i.e. `0.0.0.0/24` or `::/64`), it will be used when allocating the network instead of the pool default prefix length. If no pool   

**- How to verify it**

I've added unit tests for the new behavior, but the logic can be manually verified by specifying a global subnet to `docker network create` (i.e. `docker network create --subnet 0.0.0.0/24 test`, or `docker network create --subnet /24 test`).

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Users can request a specific prefix size for networks allocated from the default pools by using the unspecified address, for example `--subnet 0.0.0.0/24 --subnet ::/96`.
  - If Docker is downgraded to a version that does not have this support the network will become unusable, it must be deleted and re-created.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="1820" height="1213" alt="image" src="https://github.com/user-attachments/assets/2a157b60-ef23-40b3-b440-4feb408f8700" />
