### PR TITLE
libnetwork/networkdb: always shut down memberlist

### DIFF
--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -224,11 +224,11 @@ func (nDB *NetworkDB) clusterLeave() error {
 	mlist := nDB.memberlist
 
 	if err := nDB.sendNodeEvent(NodeEventTypeLeave); err != nil {
-		log.G(context.TODO()).Errorf("failed to send node leave: %v", err)
+		log.G(context.TODO()).WithError(err).Error("failed to send node leave event")
 	}
 
 	if err := mlist.Leave(time.Second); err != nil {
-		return err
+		log.G(context.TODO()).WithError(err).Error("failed to broadcast memberlist leave message")
 	}
 
 	// cancel the context


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Fixes #47859 

**- What I did**
**- How I did it**
Gracefully leaving the memberlist cluster is a best-effort operation. Failing to successfully broadcast the leave message to a peer should not prevent NetworkDB from cleaning up the memberlist instance on close. But that was not the case in practice. Log the error returned from (*memberlist.Memberlist).Leave instead of returning it and proceed with shutting down irrespective of whether Leave() returns an error.

**- How to verify it**
By inspection.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix a potential resource leak when a node leaves a Swarm
```

**- A picture of a cute animal (not mandatory but encouraged)**

