### PR TITLE
docs(client/ContainerExecAttach): add a mention to stdcopy.StdCopy

### DIFF
--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -55,9 +55,25 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 }
 
 // ContainerExecAttach attaches a connection to an exec process in the server.
+//
 // It returns a types.HijackedConnection with the hijacked connection
 // and the a reader to get output. It's up to the called to close
 // the hijacked connection by calling types.HijackedResponse.Close.
+//
+// The stream format on the response will be in one of two formats:
+//
+// If the container is using a TTY, there is only a single stream (stdout), and
+// data is copied directly from the container output stream, no extra
+// multiplexing or headers.
+//
+// If the container is *not* using a TTY, streams for stdout and stderr are
+// multiplexed.
+//
+// You can use github.com/docker/docker/pkg/stdcopy.StdCopy to demultiplex this
+// stream.
+//
+// For more technical informations about the multiplexed stream, check the
+// [ContainerAttach] documentation.
 func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
 		config.ConsoleSize = nil


### PR DESCRIPTION
Add a mention to stdcopy.StdCopy to the documentation, as the stream returned in the HijackedResponse is multiplexed.

Closes #50118 
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added a mention to `stdcopy.StdCopy` to the documentation of the `client.ContainerExecAttach` method.

**- How I did it**
I simply added a few lines of documentation under the existing one for the `client.ContainerExecAttach` method.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

