### PR TITLE
libnetwork/resolvconf: Build: decorate error for invalid nameservers and use table-tests

### DIFF
--- a/libnetwork/resolvconf/resolvconf.go
+++ b/libnetwork/resolvconf/resolvconf.go
@@ -3,6 +3,7 @@ package resolvconf
 
 import (
 	"bytes"
+	"fmt"
 	"net/netip"
 	"os"
 
@@ -130,7 +131,7 @@ func Build(path string, nameservers, dnsSearch, dnsOptions []string) (*File, err
 	for _, addr := range nameservers {
 		ipAddr, err := netip.ParseAddr(addr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("bad nameserver address: %w", err)
 		}
 		ns = append(ns, ipAddr)
 	}

--- a/libnetwork/resolvconf/resolvconf_unix_test.go
+++ b/libnetwork/resolvconf/resolvconf_unix_test.go
@@ -349,7 +349,7 @@ search search1
 		{
 			doc:         "invalid nameserver",
 			nameServers: []string{"resolver.example.com"},
-			expErr:      `ParseAddr("resolver.example.com"): unexpected character (at "resolver.example.com")`,
+			expErr:      `bad nameserver address: ParseAddr("resolver.example.com"): unexpected character (at "resolver.example.com")`,
 		},
 	}
 

--- a/libnetwork/resolvconf/resolvconf_unix_test.go
+++ b/libnetwork/resolvconf/resolvconf_unix_test.go
@@ -300,93 +300,79 @@ const (
 )
 
 func TestBuild(t *testing.T) {
-	tmpDir := t.TempDir()
-	file, err := os.CreateTemp(tmpDir, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := Build(file.Name(), []string{testNS1, testNS2, testNS3}, []string{"search1"}, []string{"opt1"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	const expected = `nameserver 192.0.2.1
+	tests := []struct {
+		doc         string
+		nameServers []string
+		dnsSearch   []string
+		dnsOptions  []string
+		expOut      string
+		expErr      string
+	}{
+		{
+			doc:    "no options",
+			expOut: ``,
+		},
+		{
+			doc:         "all options",
+			nameServers: []string{testNS1, testNS2, testNS3},
+			dnsSearch:   []string{"search1"},
+			dnsOptions:  []string{"opt1"},
+			expOut: `nameserver 192.0.2.1
 nameserver 2001:db8::1
 nameserver 203.0.113.3
 search search1
 options opt1
-`
-
-	if !bytes.Equal(f.Content, []byte(expected)) {
-		t.Errorf("Expected to find '%s' got '%s'", expected, f.Content)
-	}
-	content, err := os.ReadFile(file.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(content, []byte(expected)) {
-		t.Errorf("Expected to find '%s' got '%s'", expected, content)
-	}
-}
-
-func TestBuildWithZeroLengthDomainSearch(t *testing.T) {
-	tmpDir := t.TempDir()
-	file, err := os.CreateTemp(tmpDir, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := Build(file.Name(), []string{testNS1, testNS2, testNS3}, []string{"."}, []string{"opt1"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	const expected = `nameserver 192.0.2.1
+`,
+		},
+		{
+			doc:         "zero-length dns search",
+			nameServers: []string{testNS1, testNS2, testNS3},
+			dnsSearch:   []string{"."},
+			dnsOptions:  []string{"opt1"},
+			expOut: `nameserver 192.0.2.1
 nameserver 2001:db8::1
 nameserver 203.0.113.3
 options opt1
-`
-
-	if !bytes.Equal(f.Content, []byte(expected)) {
-		t.Errorf("Expected to find '%s' got '%s'", expected, f.Content)
-	}
-	content, err := os.ReadFile(file.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(content, []byte(expected)) {
-		t.Errorf("Expected to find '%s' got '%s'", expected, content)
-	}
-}
-
-func TestBuildWithNoOptions(t *testing.T) {
-	tmpDir := t.TempDir()
-	file, err := os.CreateTemp(tmpDir, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	f, err := Build(file.Name(), []string{testNS1, testNS2, testNS3}, []string{"search1"}, []string{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	const expected = `nameserver 192.0.2.1
+`,
+		},
+		{
+			doc:         "no dns options",
+			nameServers: []string{testNS1, testNS2, testNS3},
+			dnsSearch:   []string{"search1"},
+			dnsOptions:  []string{},
+			expOut: `nameserver 192.0.2.1
 nameserver 2001:db8::1
 nameserver 203.0.113.3
 search search1
-`
+`,
+		},
+		{
+			doc:         "invalid nameserver",
+			nameServers: []string{"resolver.example.com"},
+			expErr:      `ParseAddr("resolver.example.com"): unexpected character (at "resolver.example.com")`,
+		},
+	}
 
-	if !bytes.Equal(f.Content, []byte(expected)) {
-		t.Errorf("Expected to find '%s' got '%s'", expected, f.Content)
-	}
-	content, err := os.ReadFile(file.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(content, []byte(expected)) {
-		t.Errorf("Expected to find '%s' got '%s'", expected, content)
+	tmpDir := t.TempDir()
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			file, err := os.CreateTemp(tmpDir, "")
+			assert.NilError(t, err)
+
+			f, err := Build(file.Name(), tc.nameServers, tc.dnsSearch, tc.dnsOptions)
+			if tc.expErr != "" {
+				assert.Error(t, err, tc.expErr)
+			} else if err != nil {
+				assert.NilError(t, err)
+				assert.Equal(t, string(f.Content), tc.expOut)
+			}
+
+			// Verify the content matches the expected; for error-cases,
+			// this verifies the file is empty.
+			content, err := os.ReadFile(file.Name())
+			assert.NilError(t, err)
+			assert.Equal(t, string(content), tc.expOut)
+		})
 	}
 }
 


### PR DESCRIPTION
- relates to, closes https://github.com/moby/buildkit/issues/6001

### libnetwork/resolvconf: rewrite TestBuild tests to a table-test

Also adding test-cases for;

- empty options for all fields
- invalid nameServer (domain instead of IP).


### libnetwork/resolvconf: Build: decorate error for invalid nameservers

Using the same prefix as is used in `Sandbox.loadResolvConf`, but omiting
the value, as it's already part of the error message;
https://github.com/moby/moby/blob/829b6953756f1ad21769f318ec9717ed854936b3/libnetwork/sandbox_dns_unix.go#L258-L261

Unfortunately, `netip.ParseAddr` returns a non-exported (`parseAddrError`)
error-type; https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/net/netip/netip.go;l=115

So we don't have the option to omit the `` from the error-message, and to
take the underlying `msg` field;
https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/net/netip/netip.go;l=141-153



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

