### PR TITLE
client: use go-winio.DialPipe directly

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -463,7 +463,9 @@ func (cli *Client) dialer() func(context.Context) (net.Conn, error) {
 		case "unix":
 			return net.Dial(cli.proto, cli.addr)
 		case "npipe":
-			return sockets.DialPipe(cli.addr, 32*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 32*time.Second)
+			defer cancel()
+			return dialPipeContext(ctx, cli.addr)
 		default:
 			if tlsConfig := cli.tlsConfig(); tlsConfig != nil {
 				return tls.Dial(cli.proto, cli.addr, tlsConfig)

--- a/client/client_unix.go
+++ b/client/client_unix.go
@@ -2,6 +2,17 @@
 
 package client
 
+import (
+	"context"
+	"net"
+	"syscall"
+)
+
 // DefaultDockerHost defines OS-specific default host if the DOCKER_HOST
 // (EnvOverrideHost) environment variable is unset or empty.
 const DefaultDockerHost = "unix:///var/run/docker.sock"
+
+// dialPipeContext connects to a Windows named pipe. It is not supported on non-Windows.
+func dialPipeContext(_ context.Context, _ string) (net.Conn, error) {
+	return nil, syscall.EAFNOSUPPORT
+}

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -1,5 +1,17 @@
 package client
 
+import (
+	"context"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
 // DefaultDockerHost defines OS-specific default host if the DOCKER_HOST
 // (EnvOverrideHost) environment variable is unset or empty.
 const DefaultDockerHost = "npipe:////./pipe/docker_engine"
+
+// dialPipeContext connects to a Windows named pipe. It is not supported on non-Windows.
+func dialPipeContext(ctx context.Context, addr string) (net.Conn, error) {
+	return winio.DialPipeContext(ctx, addr)
+}


### PR DESCRIPTION
- relates to https://github.com/docker/go-connections/pull/133

The go-connections package implementation is only a shallow wrapper around go-winio for named pipes; use the go-winio implementation directly.


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

