### PR TITLE
api/swagger: quote maxUint64 example value

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5863,7 +5863,7 @@ definitions:
         type: "integer"
         format: "uint64"
         x-nullable: true
-        example: 18446744073709551615
+        example: "18446744073709551615"
 
   ContainerThrottlingData:
     description: |

--- a/docs/api/v1.48.yaml
+++ b/docs/api/v1.48.yaml
@@ -5988,7 +5988,7 @@ definitions:
         type: "integer"
         format: "uint64"
         x-nullable: true
-        example: 18446744073709551615
+        example: "18446744073709551615"
 
   ContainerThrottlingData:
     description: |

--- a/docs/api/v1.49.yaml
+++ b/docs/api/v1.49.yaml
@@ -5988,7 +5988,7 @@ definitions:
         type: "integer"
         format: "uint64"
         x-nullable: true
-        example: 18446744073709551615
+        example: "18446744073709551615"
 
   ContainerThrottlingData:
     description: |

--- a/docs/api/v1.50.yaml
+++ b/docs/api/v1.50.yaml
@@ -5863,7 +5863,7 @@ definitions:
         type: "integer"
         format: "uint64"
         x-nullable: true
-        example: 18446744073709551615
+        example: "18446744073709551615"
 
   ContainerThrottlingData:
     description: |


### PR DESCRIPTION
More recent versions of go-swagger failed on this, because the value
is interpolated as JSON numberic value, which assumes int64 (signed).

Quote the value to prevent it being handled before validated against
uint64.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

