### PR TITLE
fix: daemon: state of stopped container visible to other queries when container is stopped

### DIFF
--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -93,6 +93,9 @@ func (daemon *Daemon) containerStop(ctx context.Context, ctr *container.Containe
 	defer cancel()
 
 	if status := <-ctr.Wait(subCtx, containertypes.WaitConditionNotRunning); status.Err() == nil {
+		// Ensure container status changes are committed by handler of container exit before returning control to the caller
+		ctr.Lock()
+		defer ctr.Unlock()
 		// container did exit, so ignore any previous errors and return
 		return nil
 	}
@@ -121,6 +124,10 @@ func (daemon *Daemon) containerStop(ctx context.Context, ctr *container.Containe
 		}
 		// container did exit, so ignore previous errors and continue
 	}
+
+	// Ensure container status changes are committed by handler of container exit before returning control to the caller
+	ctr.Lock()
+	defer ctr.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
daemon: ensuring state of stopped container is visible to other queries when container is stopped using [/containers/{id}/stop](https://docs.docker.com/reference/api/engine/version/v1.49/#tag/Container/operation/ContainerStop) API and before API response is sent back to the client. Fixes #50133.

**- What I did**

Made state of stopped container visible to other queries when container is stopped using [/containers/{id}/stop](https://docs.docker.com/reference/api/engine/version/v1.49/#tag/Container/operation/ContainerStop) Docker Engine API and before response is sent back to the API client.

**- How I did it**

Waiting until state of stopped container is committed to daemon database (only when container is stopped successfully), i.e. until container stop handler of container monitor completes, before replying to client of [/containers/{id}/stop](https://docs.docker.com/reference/api/engine/version/v1.49/#tag/Container/operation/ContainerStop) Docker Engine API.

**- How to verify it**

Refer to "Reproduce" section of https://github.com/moby/moby/issues/50133.

**- Human readable description for the release notes**

```markdown changelog
Ensure that the state of the container in the daemon database (used by [/containers/json](https://docs.docker.com/reference/api/engine/version/v1.49/#tag/Container/operation/ContainerList) API) is up to date when the container is stopped using the [/containers/{id}/stop](https://docs.docker.com/reference/api/engine/version/v1.49/#tag/Container/operation/ContainerStop) API (before response of API).
```
