### PR TITLE
Add alumni markdown under project

### DIFF
--- a/project/ALUMNI.md
+++ b/project/ALUMNI.md
@@ -1,0 +1,118 @@
+# Moby Alumni Maintainers
+
+### Aaron Lehmann ([@aaronlehmann](https://github.com/aaronlehmann))
+[![Aaron Lehmann](https://github.com/aaronlehmann.png?size=200)](https://github.com/aaronlehmann)
+
+### Alex Ellis ([@alexellis](https://github.com/alexellis))
+[![Alex Ellis](https://github.com/alexellis.png?size=200)](https://github.com/alexellis)
+
+### Alexander Morozov ([@lk4d4](https://github.com/lk4d4))
+[![Alexander Morozov](https://github.com/lk4d4.png?size=200)](https://github.com/lk4d4)
+
+### Andrea Luzzardi ([@aluzzardi](https://github.com/aluzzardi))
+[![Andrea Luzzardi](https://github.com/aluzzardi.png?size=200)](https://github.com/aluzzardi)
+
+### Andrew Hsu ([@andrewhsu](https://github.com/andrewhsu))
+[![Andrew Hsu](https://github.com/andrewhsu.png?size=200)](https://github.com/andrewhsu)
+
+### Antonio Murdaca ([@runcom](https://github.com/runcom))
+[![Antonio Murdaca](https://github.com/runcom.png?size=200)](https://github.com/runcom)
+
+### Anusha Ragunathan ([@anusha-ragunathan](https://github.com/anusha-ragunathan))
+[![Anusha Ragunathan](https://github.com/anusha-ragunathan.png?size=200)](https://github.com/anusha-ragunathan)
+
+### Arnaud Porterie ([@icecrime](https://github.com/icecrime))
+[![Arnaud Porterie](https://github.com/icecrime.png?size=200)](https://github.com/icecrime)
+
+### Boaz Shuster ([@boaz0](https://github.com/boaz0))
+[![Boaz Shuster](https://github.com/boaz0.png?size=200)](https://github.com/boaz0)
+
+### Bruno de Sousa ([@bsousaa](https://github.com/bsousaa))
+[![Bruno de Sousa](https://github.com/bsousaa.png?size=200)](https://github.com/bsousaa)
+
+### Daniel Nephin ([@dnephin](https://github.com/dnephin))
+[![Daniel Nephin](https://github.com/dnephin.png?size=200)](https://github.com/dnephin)
+
+### David Calavera ([@calavera](https://github.com/calavera))
+[![David Calavera](https://github.com/calavera.png?size=200)](https://github.com/calavera)
+
+### Doug Davis ([@duglin](https://github.com/duglin))
+[![Doug Davis](https://github.com/duglin.png?size=200)](https://github.com/duglin)
+
+### Erik Hollensbe ([@erikh](https://github.com/erikh))
+[![Erik Hollensbe](https://github.com/erikh.png?size=200)](https://github.com/erikh)
+
+### Evan Hazlett ([@ehazlett](https://github.com/ehazlett))
+[![Evan Hazlett](https://github.com/ehazlett.png?size=200)](https://github.com/ehazlett)
+
+### Gianluca Arbezzano ([@gianarb](https://github.com/gianarb))
+[![Gianluca Arbezzano](https://github.com/gianarb.png?size=200)](https://github.com/gianarb)
+
+### Harald Albers ([@albers](https://github.com/albers))
+[![Harald Albers](https://github.com/albers.png?size=200)](https://github.com/albers)
+
+### James Turnbull ([@jamtur01](https://github.com/jamtur01))
+[![James Turnbull](https://github.com/jamtur01.png?size=200)](https://github.com/jamtur01)
+
+### Jana Radhakrishnan ([@mrjana](https://github.com/mrjana))
+[![Jana Radhakrishnan](https://github.com/mrjana.png?size=200)](https://github.com/mrjana)
+
+### Jeff Anderson ([@programmerq](https://github.com/programmerq))
+[![Jeff Anderson](https://github.com/programmerq.png?size=200)](https://github.com/programmerq)
+
+### Jessie Frazelle ([@jessfraz](https://github.com/jessfraz))
+[![Jessie Frazelle](https://github.com/jessfraz.png?size=200)](https://github.com/jessfraz)
+
+### John Howard ([@lowenna](https://github.com/lowenna))
+[![John Howard](https://github.com/lowenna.png?size=200)](https://github.com/lowenna)
+
+### John Stephens ([@johnstep](https://github.com/johnstep))
+[![John Stephens](https://github.com/johnstep.png?size=200)](https://github.com/johnstep)
+
+### Kenfe-Mickaël Laventure ([@mlaventure](https://github.com/mlaventure))
+[![Kenfe-Mickaël Laventure](https://github.com/mlaventure.png?size=200)](https://github.com/mlaventure)
+
+### Lorenzo Fontana ([@fntlnz](https://github.com/fntlnz))
+[![Lorenzo Fontana](https://github.com/fntlnz.png?size=200)](https://github.com/fntlnz)
+
+### Madhu Venugopal ([@mavenugo](https://github.com/mavenugo))
+[![Madhu Venugopal](https://github.com/mavenugo.png?size=200)](https://github.com/mavenugo)
+
+### Mary Anthony ([@moxiegirl](https://github.com/moxiegirl))
+[![Mary Anthony](https://github.com/moxiegirl.png?size=200)](https://github.com/moxiegirl)
+
+### Michael Crosby ([@crosbymichael](https://github.com/crosbymichael))
+[![Michael Crosby](https://github.com/crosbymichael.png?size=200)](https://github.com/crosbymichael)
+
+### Morgan Bauer ([@mhbauer](https://github.com/mhbauer))
+[![Morgan Bauer](https://github.com/mhbauer.png?size=200)](https://github.com/mhbauer)
+
+### Olli Janatuinen ([@olljanat](https://github.com/olljanat))
+[![Olli Janatuinen](https://github.com/olljanat.png?size=200)](https://github.com/olljanat)
+
+### Sam Thibault ([@sam-thibault](https://github.com/sam-thibault))
+[![Sam Thibault](https://github.com/sam-thibault.png?size=200)](https://github.com/sam-thibault)
+
+### Sam Whited ([@samwhited](https://github.com/samwhited))
+[![Sam Whited](https://github.com/samwhited.png?size=200)](https://github.com/samwhited)
+
+### Solomon Hykes ([@shykes](https://github.com/shykes))
+[![Solomon Hykes](https://github.com/shykes.png?size=200)](https://github.com/shykes)
+
+### Sven Dowideit ([@SvenDowideit](https://github.com/SvenDowideit))
+[![Sven Dowideit](https://github.com/SvenDowideit.png?size=200)](https://github.com/SvenDowideit)
+
+### Victor Vieux ([@vieux](https://github.com/vieux))
+[![Victor Vieux](https://github.com/vieux.png?size=200)](https://github.com/vieux)
+
+### Vincent Batts ([@vbatts](https://github.com/vbatts))
+[![Vincent Batts](https://github.com/vbatts.png?size=200)](https://github.com/vbatts)
+
+### Vincent Demeester ([@vdemeester](https://github.com/vdemeester))
+[![Vincent Demeester](https://github.com/vdemeester.png?size=200)](https://github.com/vdemeester)
+
+### Vishnu Kannan ([@vishh](https://github.com/vishh))
+[![Vishnu Kannan](https://github.com/vishh.png?size=200)](https://github.com/vishh)
+
+### Yong Tang ([@yongtang](https://github.com/yongtang))
+[![Yong Tang](https://github.com/yongtang.png?size=200)](https://github.com/yongtang)


### PR DESCRIPTION
Follow up from #49578

Includes a list of all individuals previously in the maintainers file with Github avatar and link

