### PR TITLE
Always allow access to published ports on addresses in gateway mode "routed" networks

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_store.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_store.go
@@ -471,7 +471,7 @@ func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {
 	// there are no IPv6 bindings, it doesn't matter whether that was because this
 	// endpoint is not an IPv6 gateway and "pbmIPv6" was not set in the port
 	// binding state, or there were just no IPv6 port bindings configured.)
-	var pbm portBindingMode
+	pbm := portBindingMode{routed: true}
 	for _, b := range ep.portMapping {
 		if b.HostIP.To4() == nil {
 			pbm.ipv6 = true

--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -129,8 +129,8 @@ func (n *bridgeNetwork) sortAndNormPBs(
 	hairpin := n.hairpin()
 	disableNAT4, disableNAT6 := n.getNATDisabled()
 
-	add4 := !ep.portBindingState.ipv4 && pbmReq.ipv4
-	add6 := !ep.portBindingState.ipv6 && pbmReq.ipv6
+	add4 := !ep.portBindingState.ipv4 && pbmReq.ipv4 || (disableNAT4 && !ep.portBindingState.routed && pbmReq.routed)
+	add6 := !ep.portBindingState.ipv6 && pbmReq.ipv6 || (disableNAT6 && !ep.portBindingState.routed && pbmReq.routed)
 
 	reqs := make([]portmapperapi.PortBindingReq, 0, len(cfg))
 	for _, c := range cfg {

--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -833,7 +833,7 @@ func TestAddPortMappings(t *testing.T) {
 				addr:   tc.epAddrV4,
 				addrv6: tc.epAddrV6,
 			}
-			var pbm portBindingMode
+			pbm := portBindingMode{routed: true}
 			if ep.addr != nil {
 				pbm.ipv4 = true
 			}

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -912,13 +912,13 @@ func TestRoutedNonGateway(t *testing.T) {
 			name:    "routed/direct/v4",
 			addr:    insp.NetworkSettings.Networks[routedNetName].IPAddress,
 			port:    "80",
-			expHttp: httpFail,
+			expHttp: httpSuccess,
 		},
 		{
 			name:    "routed/direct/v6",
 			addr:    insp.NetworkSettings.Networks[routedNetName].GlobalIPv6Address,
 			port:    "80",
-			expHttp: httpFail,
+			expHttp: httpSuccess,
 		},
 	}
 


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/50066
- related to https://github.com/moby/moby/pull/48323  (https://github.com/moby/moby/commit/18327745c00d4d2e98e5ea7241c1a1ef43b0401b)
- related to https://github.com/moby/moby/pull/47871

When an endpoint in a gateway mode "nat" network is selected as a container's default gateway, the bridge driver sets up
bindings between host and container ports (NAT, userland proxy etc).

When gateway mode "routed" was added as an alternative to the default "nat" mode - port bindings followed the same rules. But, unlike "nat" mode, there's no host port binding to set up - there's routing between remote client and the container, so it doesn't matter what the default gateway is.

So, in "routed" mode, set up the rules to make a container's published ports accessible when the endpoint is added, and remove those rules when the endpoint is removed (when the container is disconnected from the endpoint's network).

**- How I did it**

**- How to verify it**

Existing tests, particularly the ones in `integration/networking/port_mapping_linux_test.go`, including 

New integration test that checks ports in routed-mode networks are accessible when a nat-mode network is the gateway.

**- Human readable description for the release notes**
```markdown changelog
- Published ports are now always accessible in networks with gateway mode "routed". Previously, rules to open those ports were only added when the routed mode network was selected as the container's default gateway.
```
