### PR TITLE
Validate BIND_DIR variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ build: shell_target := --target=dev-base
 else
 build: shell_target := --target=dev
 endif
-build: bundles
+build: validate-bind-dir bundles
 	$(BUILD_CMD) $(BUILD_OPTS) $(shell_target) --load -t "$(DOCKER_IMAGE)" .
 
 .PHONY: shell
@@ -284,3 +284,10 @@ generate-files:
 		--file "./hack/dockerfiles/generate-files.Dockerfile" .
 	cp -R "$($@_TMP_OUT)"/. .
 	rm -rf "$($@_TMP_OUT)"/*
+
+.PHONY: validate-bind-dir
+validate-bind-dir:
+	@case "$(BIND_DIR)" in \
+		".."*|"/"*) echo "Make needs to be run from the project-root directory, with BIND_DIR set to \".\" or a subdir"; \
+		exit 1 ;; \
+	esac


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added validation for the variable BIND_DIR, so now it is not allowed to set it to absolute paths (start with "/") and relative paths (start with ".."). Although it was allowed without the validation it didn't work correctly.

**- How I did it**
I added validation to Makefile in targets that use this variable to run a container with mounted directory pointed at BIND_DIR

**- How to verify it**
Running `make BIND_DIR=.. shell` will show a hint about allowed values for BIND_DIR
- instead of ".." can be anything starting from ".." and "/" ("../something/", "/something/else/")
- instead of `shell` can be any target that runs a container

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

