### PR TITLE
api/image/list: Return `Containers` count

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -459,6 +459,7 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 	useNone := versions.LessThan(version, "1.43")
 	withVirtualSize := versions.LessThan(version, "1.44")
 	noDescriptor := versions.LessThan(version, "1.48")
+	noContainers := versions.LessThan(version, "1.51")
 	for _, img := range images {
 		if useNone {
 			if len(img.RepoTags) == 0 && len(img.RepoDigests) == 0 {
@@ -478,6 +479,9 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		}
 		if noDescriptor {
 			img.Descriptor = nil
+		}
+		if noContainers {
+			img.Containers = -1
 		}
 	}
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2196,8 +2196,7 @@ definitions:
           Number of containers using this image. Includes both stopped and running
           containers.
 
-          This size is not calculated by default, and depends on which API endpoint
-          is used. `-1` indicates that the value has not been set / calculated.
+          `-1` indicates that the value has not been set / calculated.
         x-nullable: false
         type: "integer"
         example: 2

--- a/api/types/image/opts.go
+++ b/api/types/image/opts.go
@@ -75,6 +75,8 @@ type ListOptions struct {
 	SharedSize bool
 
 	// ContainerCount indicates whether container count should be computed.
+	//
+	// Deprecated: This field has been unused and is no longer required and will be removed in a future version.
 	ContainerCount bool
 
 	// Manifests indicates whether the image manifests should be returned.

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -409,10 +409,7 @@ func (i *ImageService) imageSummary(ctx context.Context, img c8dimages.Image, pl
 	image.Manifests = summary.Manifests
 	target := img.Target
 	image.Descriptor = &target
-
-	if opts.ContainerCount {
-		image.Containers = summary.ContainersCount
-	}
+	image.Containers = summary.ContainersCount
 	return image, summary, nil
 }
 

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -57,9 +57,8 @@ func (daemon *Daemon) imageDiskUsage(ctx context.Context) ([]*image.Summary, err
 	imgs, _, err := daemon.usageImages.Do(ctx, struct{}{}, func(ctx context.Context) ([]*image.Summary, error) {
 		// Get all top images with extra attributes
 		imgs, err := daemon.imageService.Images(ctx, image.ListOptions{
-			Filters:        filters.NewArgs(),
-			SharedSize:     true,
-			ContainerCount: true,
+			Filters:    filters.NewArgs(),
+			SharedSize: true,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to retrieve image list")

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.51](https://docs.docker.com/reference/api/engine/version/v1.51/) documentation
 
+* `GET /images/json` now sets the value of `Containers` field for all images
+  to the count of containers using the image.
+  This field was previously always -1.
 
 ## v1.50 API changes
 


### PR DESCRIPTION
- needs: https://github.com/moby/moby/pull/50145
- replaces: https://github.com/moby/moby/pull/47501
- replaces: https://github.com/moby/moby/pull/43350
- related to: https://github.com/moby/moby/pull/42531
- needed by: https://github.com/docker/cli/issues/6122
- fixes https://github.com/moby/moby/issues/43244

This parameter was already supported for some time in the backend (for purposes related to `docker system prune`).
It was also already present in the `imagetypes.ListOptions` but was never actually handled by the client.

Make it available by default in the response.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
`GET /images/json` now sets the value of the `Containers` field for all images to the count of containers using the image.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/moby/moby/assets/5046555/8ba4e302-f31b-4cea-ab6b-a525c7ce0bfd)
