### PR TITLE
Set EnableIPv4=true in overlay network inspect response

### DIFF
--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -160,6 +160,7 @@ func BasicNetworkFromGRPC(n swarmapi.Network) network.Inspect {
 		ID:         n.ID,
 		Name:       n.Spec.Annotations.Name,
 		Scope:      scope.Swarm,
+		EnableIPv4: true,
 		EnableIPv6: spec.Ipv6Enabled,
 		IPAM:       ipam,
 		Internal:   spec.Internal,


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/50139

Overlay networks always have IPv4, so report that in `network inspect` responses.

**- How I did it**

**- How to verify it**

Create an overlay network and inspect it ...

```
$ docker network inspect ovl
[
    {
        "Name": "ovl",
        "Id": "s10uawdvkhyf2iaopfpu3y7o3",
        "Created": "2025-06-05T14:20:44.778231219Z",
        "Scope": "swarm",
        "Driver": "overlay",
        "EnableIPv4": true,
        "EnableIPv6": false,
        ...
    }
]
```

**- Human readable description for the release notes**
```markdown changelog
- The `network inspect` response for an overlay network now reports that `EnableIPv4` is true.
```
