### PR TITLE
graphdriver: add support for overlay2.volatile option

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -85,21 +85,23 @@ const (
 )
 
 type overlayOptions struct {
-	quota quota.Quota
+	quota    quota.Quota
+	volatile bool
 }
 
 // Driver contains information about the home directory and the list of active
 // mounts that are created using this driver.
 type Driver struct {
-	home          string
-	idMap         user.IdentityMapping
-	ctr           *mountref.Counter
-	quotaCtl      *quota.Control
-	options       overlayOptions
-	naiveDiff     graphdriver.DiffDriver
-	supportsDType bool
-	usingMetacopy bool
-	locker        *locker.Locker
+	home             string
+	idMap            user.IdentityMapping
+	ctr              *mountref.Counter
+	quotaCtl         *quota.Control
+	options          overlayOptions
+	naiveDiff        graphdriver.DiffDriver
+	supportsDType    bool
+	supportsVolatile bool
+	usingMetacopy    bool
+	locker           *locker.Locker
 }
 
 var (
@@ -111,6 +113,7 @@ var (
 	useNaiveDiffOnly bool
 
 	indexOff  string
+	volatile  string
 	userxattr string
 )
 
@@ -159,6 +162,12 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 		return nil, overlayutils.ErrDTypeNotSupported("overlay2", backingFs)
 	}
 
+	supportsVolatile, err := doesSupportVolatile(testdir)
+	if err != nil {
+		logger.Debugf("Encountered an error checking for overlay volatile support: %s", err)
+		supportsVolatile = false
+	}
+
 	usingMetacopy, err := usingMetacopy(testdir)
 	if err != nil {
 		return nil, err
@@ -174,13 +183,14 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 	}
 
 	d := &Driver{
-		home:          home,
-		idMap:         idMap,
-		ctr:           mountref.NewCounter(isMounted),
-		supportsDType: supportsDType,
-		usingMetacopy: usingMetacopy,
-		locker:        locker.New(),
-		options:       *opts,
+		home:             home,
+		idMap:            idMap,
+		ctr:              mountref.NewCounter(isMounted),
+		supportsDType:    supportsDType,
+		supportsVolatile: supportsVolatile,
+		usingMetacopy:    usingMetacopy,
+		locker:           locker.New(),
+		options:          *opts,
 	}
 
 	d.naiveDiff = graphdriver.NewNaiveDiffDriver(d, idMap)
@@ -208,6 +218,14 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 		logger.Warnf("Unable to detect whether overlay kernel module supports index parameter: %s", err)
 	}
 
+	if opts.volatile {
+		if d.supportsVolatile {
+			volatile = "volatile,"
+		} else {
+			return nil, fmt.Errorf("Storage option overlay2.volatile is not supported by the kernel")
+		}
+	}
+
 	needsUserXattr, err := overlayutils.NeedsUserXAttr(home)
 	if err != nil {
 		logger.Warnf("Unable to detect whether overlay kernel module needs \"userxattr\" parameter: %s", err)
@@ -216,8 +234,8 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 		userxattr = "userxattr,"
 	}
 
-	logger.Debugf("backingFs=%s, projectQuotaSupported=%v, usingMetacopy=%v, indexOff=%q, userxattr=%q",
-		backingFs, projectQuotaSupported, usingMetacopy, indexOff, userxattr)
+	logger.Debugf("backingFs=%s, projectQuotaSupported=%v, usingMetacopy=%v, indexOff=%q, supportsVolatile=%t, userxattr=%q",
+		backingFs, projectQuotaSupported, usingMetacopy, indexOff, supportsVolatile, userxattr)
 
 	return d, nil
 }
@@ -243,6 +261,12 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				return nil, err
 			}
 			o.quota.Size = uint64(size)
+		case "overlay2.volatile":
+			boolVal, err := strconv.ParseBool(val)
+			if err != nil {
+				return nil, err
+			}
+			o.volatile = boolVal
 		default:
 			return nil, fmt.Errorf("overlay2: unknown option %s", key)
 		}
@@ -270,7 +294,9 @@ func (d *Driver) Status() [][2]string {
 	return [][2]string{
 		{"Backing Filesystem", backingFs},
 		{"Supports d_type", strconv.FormatBool(d.supportsDType)},
+		{"Supports volatile", strconv.FormatBool(d.supportsVolatile)},
 		{"Using metacopy", strconv.FormatBool(d.usingMetacopy)},
+		{"Using volatile", strconv.FormatBool(volatile != "")},
 		{"Native Overlay Diff", strconv.FormatBool(!useNaiveDiff(d.home))},
 		{"userxattr", strconv.FormatBool(userxattr != "")},
 	}
@@ -557,9 +583,9 @@ func (d *Driver) Get(id, mountLabel string) (_ string, retErr error) {
 
 	var opts string
 	if readonly {
-		opts = indexOff + userxattr + "lowerdir=" + diffDir + ":" + strings.Join(absLowers, ":")
+		opts = indexOff + volatile + userxattr + "lowerdir=" + diffDir + ":" + strings.Join(absLowers, ":")
 	} else {
-		opts = indexOff + userxattr + "lowerdir=" + strings.Join(absLowers, ":") + ",upperdir=" + diffDir + ",workdir=" + workDir
+		opts = indexOff + volatile + userxattr + "lowerdir=" + strings.Join(absLowers, ":") + ",upperdir=" + diffDir + ",workdir=" + workDir
 	}
 
 	mountData := label.FormatMountLabel(opts, mountLabel)
@@ -579,9 +605,9 @@ func (d *Driver) Get(id, mountLabel string) (_ string, retErr error) {
 	// smaller at the expense of requiring a fork exec to chroot.
 	if len(mountData) > pageSize-1 {
 		if readonly {
-			opts = indexOff + userxattr + "lowerdir=" + path.Join(id, diffDirName) + ":" + string(lowers)
+			opts = indexOff + volatile + userxattr + "lowerdir=" + path.Join(id, diffDirName) + ":" + string(lowers)
 		} else {
-			opts = indexOff + userxattr + "lowerdir=" + string(lowers) + ",upperdir=" + path.Join(id, diffDirName) + ",workdir=" + path.Join(id, workDirName)
+			opts = indexOff + volatile + userxattr + "lowerdir=" + string(lowers) + ",upperdir=" + path.Join(id, diffDirName) + ",workdir=" + path.Join(id, workDirName)
 		}
 		mountData = label.FormatMountLabel(opts, mountLabel)
 		if len(mountData) > pageSize-1 {
@@ -592,6 +618,14 @@ func (d *Driver) Get(id, mountLabel string) (_ string, retErr error) {
 			return mountFrom(d.home, source, target, mType, flags, label)
 		}
 		mountTarget = path.Join(id, mergedDirName)
+	}
+
+	if volatile != "" {
+		// overlay has a check in place to prevent mounting "volatile" system twice
+		volatileIncompatFile := path.Join(workDir, "work", "incompat", "volatile")
+		if err := os.RemoveAll(volatileIncompatFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("error removing volatile incompat file %s: %v", volatileIncompatFile, err)
+		}
 	}
 
 	if err := mount("overlay", mountTarget, "overlay", 0, mountData); err != nil {


### PR DESCRIPTION
**- What I did**
- Provided support for mounting overlayfs graph driver mounts with [volatile](https://docs.kernel.org/filesystems/overlayfs.html#volatile-mount ) configuration option which disables all forms of fsync to the upper filesystem, trading off consistency for [performance](https://www.redhat.com/en/blog/container-volatile-overlay-mounts).
- Closes https://github.com/moby/moby/issues/50150. 

**- How I did it**

- Added a new `overlay2.volatile=(true|false)`graph driver option which, when enabled, ensures to mount container's overlayfs as volatile. The option is disabled (set to `false`) by default. 
- Added a check to confirm whether `volatile` overlayfs feature is supported by the host's kernel. If it does not and a user supplies `overlay2.volatile=true` an error is returned. 

**- How to verify it**
- Start dockerd with `{"storage-driver": "overlay2", "storage-opts": ["overlay2.volatile=true"]}` configured in `/etc/docker/daemon.json`
- Confirm that volatile is supported by the kernel and is enabled: `docker info | grep volatile`
- Start any container, e.g. `docker run -d -it --name test ubuntu /bin/bash`
- Check that overlayfs is mounted with `volatile` flag: `mount | grep $(docker container inspect test | jq -r '.[0].GraphDriver.Data.WorkDir') | grep volatile`

**- Human readable description for the release notes**
```markdown changelog
Add support for volatile overlayfs mounts via `"overlay2.volatile"` storage option
```