### PR TITLE
daemon: normalize device driver registering

### DIFF
--- a/daemon/cdi.go
+++ b/daemon/cdi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/system"
@@ -19,11 +20,15 @@ type cdiHandler struct {
 	registry *cdi.Cache
 }
 
-// RegisterCDIDriver registers the CDI device driver.
+// registerCDIDriver registers the CDI device driver.
 // The driver injects CDI devices into an incoming OCI spec and is called for DeviceRequests associated with CDI devices.
 // If the list of CDI spec directories is empty, the driver is not registered.
-func RegisterCDIDriver(cdiSpecDirs ...string) *cdi.Cache {
+func registerCDIDriver(cdiSpecDirs ...string) *cdi.Cache {
+	if runtime.GOOS != "linux" || len(cdiSpecDirs) == 0 {
+		return nil
+	}
 	driver, cache := newCDIDeviceDriver(cdiSpecDirs...)
+
 	registerDeviceDriver("cdi", driver)
 	return cache
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -793,6 +793,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	// Setup the resolv.conf
 	setupResolvConf(config)
 
+	// register all available device drivers before the daemon starts
+	cdiCache := registerDeviceDrivers(config)
+
 	idMapping, err := setupRemappedRoot(config)
 	if err != nil {
 		return nil, err
@@ -829,6 +832,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	d := &Daemon{
 		PluginStore: pluginStore,
 		startupDone: make(chan struct{}),
+		CDICache:    cdiCache,
 	}
 	cfgStore := &configStore{
 		Config:   *config,

--- a/daemon/devices_nvidia_linux.go
+++ b/daemon/devices_nvidia_linux.go
@@ -32,7 +32,7 @@ var allNvidiaCaps = map[nvidia.Capability]struct{}{
 	nvidia.Display:  {},
 }
 
-func init() {
+func registerNvidiaDriver() {
 	// Register Nvidia driver if Nvidia helper binary is present.
 	if _, err := exec.LookPath(nvidiaHook); err == nil {
 		capset := capabilities.Set{"gpu": struct{}{}, "nvidia": struct{}{}}


### PR DESCRIPTION
Move device driver registration to daemon.NewDaemon.

Fixes #49993

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Refactored device drive registration in the daemon.

**- How I did it**

Refactoring the code.

**- How to verify it**

Spawn the daemon with the feature `cdi` on and off and with and executable `nvidia-container-runtime-hook` in and out the PATH. Verify the daemon starts without log errors nor issues.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

