### PR TITLE
Only "prune" Windows networks created by Docker

### DIFF
--- a/libnetwork/drivers/windows/labels.go
+++ b/libnetwork/drivers/windows/labels.go
@@ -7,6 +7,9 @@ const (
 	// HNSID of the discovered network
 	HNSID = "com.docker.network.windowsshim.hnsid"
 
+	// HNSOwned indicates that the network was learned from the host, not created by docker.
+	HNSOwned = "com.docker.network.windowsshim.hnsowned"
+
 	// RoutingDomain of the network
 	RoutingDomain = "com.docker.network.windowsshim.routingdomain"
 

--- a/libnetwork/network_unix.go
+++ b/libnetwork/network_unix.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/docker/docker/daemon/network"
+	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 	"github.com/docker/docker/libnetwork/netlabel"
 	"github.com/docker/docker/libnetwork/osl"
-
-	"github.com/docker/docker/libnetwork/ipams/defaultipam"
 )
 
 type platformNetwork struct{} //nolint:nolintlint,unused // only populated on windows
@@ -70,4 +70,11 @@ func (n *Network) validatedAdvertiseAddrInterval() (*time.Duration, error) {
 			osl.AdvertiseAddrIntervalMin/time.Millisecond, osl.AdvertiseAddrIntervalMax/time.Millisecond)
 	}
 	return &interval, nil
+}
+
+// IsPruneable returns true if n can be considered for removal as part of a
+// "docker network prune" (or system prune). The caller must still check that the
+// network should be removed. For example, it may have active endpoints.
+func (n *Network) IsPruneable() bool {
+	return !network.IsPredefined(n.Name())
 }


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/41013

For Windows, the source of truth for Docker networks is HNS. On startup, any network in Docker's network store that doesn't exist on the host is removed from the store, and Docker tries to adopt all the HNS networks that are on the host. If any of them already have an entry in its store, it remembers labels etc from the store, then deletes and recreates the store entry with those saved labels and the network config (subnets etc) reported by HNS.

That means it's possible to create containers in any network on the host, the network doesn't have to be created by Docker. (I don't think that's documented.)

So, once started, Docker has no way to tell which networks it created and which were adopted from the host. That means "docker system/network prune" will just remove all the (unused) networks it knows about - including `Default Switch`, `WSL (Hyper-V firewall)`, and any other HNS network it spotted on startup.

**- How I did it**

- When adopting a network that's not in the store, mark it as "HNSOwned" using a "generic label".
- Don't delete those networks when pruning.
  - Don't prevent `docker network rm` from removing those networks - it's less likely to happen by-accident, and it could be a breaking change (it'd prevent deletion of docker-created networks that got forgotten when the store was somehow removed).
- Because labels are preserved for networks that have previously been adopted, build in a list of known do-not-delete networks - currently `Default Switch`, `WSL (Hyper-V firewall)`.
  - I'm not sure that list is complete - the reported issue has a `WSL` network, but I've not seen one of those.
  - (So, there may be more to add over time but, even with this, "prune" will do less damage - and new installs will be safe anyway.)

**- How to verify it**

(Hard to automate, we can't currently start/stop daemons in Windows CI tests.)

- remove C:\ProgramData\Docker\network\files\local-kv.db
- start unmodified dockerd
- create some networks (including with the undocumented types)...

```
C:\> docker network create -d nat natnet
eab540e66864f8a3b27cb883b1bae9b95e74182d8491d65f8ae50a53ec21c30c
C:\> docker network create -d internal intnet
595059a72ca0db68f7150c799bc18493ef5707f174a1792a14aaa6fd244f2255
C:\> docker network create -d ics icsnet
30d0591ad4f70aa8dfb9138b6597e063c3f504075a2fb9cefaecf67b5c21df59
C:\> docker network create -d private privnet
6e044501de5ec20247fd3d425178becab04f6e3398f0d329df90591cd95d8e53
C:\> docker network ls
NETWORK ID     NAME                     DRIVER     SCOPE
aab7b0b93c2e   Default Switch           ics        local
61c5b44dcb03   WSL (Hyper-V firewall)   ics        local
30d0591ad4f7   icsnet                   ics        local
595059a72ca0   intnet                   internal   local
739c87bad561   nat                      nat        local
eab540e66864   natnet                   nat        local
44faf878484e   none                     null       local
6e044501de5e   privnet                  private    local
```

- stop docker, and start the modified version
- prune networks and check the Windows networks are still there

```
C:\> docker network prune
WARNING! This will remove all custom networks not used by at least one container.
Are you sure you want to continue? [y/N] y
Deleted Networks:
icsnet
privnet
natnet
intnet

C:\> docker network ls
NETWORK ID     NAME                     DRIVER    SCOPE
aab7b0b93c2e   Default Switch           ics       local
61c5b44dcb03   WSL (Hyper-V firewall)   ics       local
739c87bad561   nat                      nat       local
846a41676aa1   none                     null      local
```

- create some more networks, still with the modified daemon

```
C:\> docker network create -d nat natnet
29d7c156b2c6e942f00b798d18e01a7f9af15e789030ad6e9dab8ef23c4210e1
C:\> docker network create -d internal intnet
dc50871ae5a044b91201599cc1e30c5dc55ebb71aad7dcc5b7df6a1aec73a3a6
C:\> docker network create -d ics icsnet
3a90b684baf9cd5c4c9d58ab033b44acc62ccc725ea7a47f5cfd57dd31f4a94c
C:\> docker network create -d private privnet
45fe81d0fede2bf27b8bd51e9d9f1325b5322e426cb6868b77db92e373087566
```

- check those networks are pruned ...

```
C:\> docker system prune
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all dangling images
  - unused build cache

Are you sure you want to continue? [y/N] y
Deleted Networks:
intnet
icsnet
privnet
natnet

Total reclaimed space: 0B
C:\> docker network ls
NETWORK ID     NAME                     DRIVER    SCOPE
aab7b0b93c2e   Default Switch           ics       local
61c5b44dcb03   WSL (Hyper-V firewall)   ics       local
739c87bad561   nat                      nat       local
846a41676aa1   none                     null      local
```

- create some more networks

```
C:\> docker network create -d nat natnet
4441dd171d4e3b10dae7da290576ac30131ec3558267ea01e31378425fb4a527
C:\> docker network create -d internal intnet
fd943ae444dd6364eeb031364e0a0827ea4be1b30ab6f81a06395519c672446e
C:\> docker network create -d private privnet
7d6b63010b51e8db37586a12488d72880a0c99558e5cad6de7e0c296fdb176e3
C:\> docker network create -d ics icsnet
8a11d313683dbfe1eb33b7966abeb93df4f9073a4825f39795ed435314a333ed
```

- stop the daemon, delete the store again, restart the modified daemon
- the private and internal networks were not adopted from the host - in the snippet below, note that ...
  - the nat and ics networks were adopted, but they lost their names
  - prune - no networks removed because docker doesn't know it created them

```
C:\> docker network prune
WARNING! This will remove all custom networks not used by at least one container.
Are you sure you want to continue? [y/N] y
C:\> docker network ls
NETWORK ID     NAME                                                               DRIVER    SCOPE
5ed625259c52   8a11d313683dbfe1eb33b7966abeb93df4f9073a4825f39795ed435314a333ed   ics       local
9becff341c68   4441dd171d4e3b10dae7da290576ac30131ec3558267ea01e31378425fb4a527   nat       local
796edfe72034   Default Switch                                                     ics       local
8f216a5aa638   WSL (Hyper-V firewall)                                             ics       local
ecf3c2a7cee6   nat                                                                nat       local
83afa55285b0   none                                                               null      local
```

- but, it is still possible to remove those networks (the internal/private
  networks will have to be removed using HNS commands)

```
C:\> docker network rm 5e 9b
5e
9b
C:\> docker network ls
NETWORK ID     NAME                     DRIVER    SCOPE
796edfe72034   Default Switch           ics       local
8f216a5aa638   WSL (Hyper-V firewall)   ics       local
ecf3c2a7cee6   nat                      nat       local
83afa55285b0   none                     null      local
```

**- Human readable description for the release notes**
```markdown changelog
- Windows: Make sure `docker system prune` and `docker network prune` only remove networks created by Docker.
```

