### PR TITLE
fix errorlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - dogsled                   # Detects assignments with too many blank identifiers.
     - dupword                   # Detects duplicate words.
     - durationcheck             # Detect cases where two time.Duration values are being multiplied in possibly erroneous ways.
+    - errorlint                 # Detects code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     - errchkjson                # Detects unsupported types passed to json encoding functions and reports if checks for the returned error can be omitted.
     - exhaustive                # Detects missing options in enum switch statements.
     - exptostd                  # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
@@ -74,6 +75,13 @@ linters:
         - "true"    # some tests use this as expected output
         - "false"   # some tests use this as expected output
         - "root"    # for tests using "ls" output with files owned by "root:root"
+
+    errorlint:
+      # Check whether fmt.Errorf uses the %w verb for formatting errors.
+      # See the https://github.com/polyfloyd/go-errorlint for caveats.
+      errorf: false
+      # Check for plain type assertions and type switches.
+      asserts: false
 
     exhaustive:
       # Program elements to check for exhaustiveness.

--- a/api/server/httputils/httputils.go
+++ b/api/server/httputils/httputils.go
@@ -74,7 +74,7 @@ func ReadJSON(r *http.Request, out interface{}) error {
 	err = dec.Decode(out)
 	defer r.Body.Close()
 	if err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return errdefs.InvalidParameter(errors.New("invalid JSON: got EOF while reading request body"))
 		}
 		return errdefs.InvalidParameter(errors.Wrap(err, "invalid JSON"))

--- a/api/server/router/distribution/distribution_routes.go
+++ b/api/server/router/distribution/distribution_routes.go
@@ -108,14 +108,14 @@ func (dr *distributionRouter) fetchManifest(ctx context.Context, distrepo distri
 	}
 	mnfst, err := mnfstsrvc.Get(ctx, distributionInspect.Descriptor.Digest)
 	if err != nil {
-		switch err {
-		case reference.ErrReferenceInvalidFormat,
-			reference.ErrTagInvalidFormat,
-			reference.ErrDigestInvalidFormat,
-			reference.ErrNameContainsUppercase,
-			reference.ErrNameEmpty,
-			reference.ErrNameTooLong,
-			reference.ErrNameNotCanonical:
+		switch {
+		case errors.Is(err, reference.ErrReferenceInvalidFormat),
+			errors.Is(err, reference.ErrTagInvalidFormat),
+			errors.Is(err, reference.ErrDigestInvalidFormat),
+			errors.Is(err, reference.ErrNameContainsUppercase),
+			errors.Is(err, reference.ErrNameEmpty),
+			errors.Is(err, reference.ErrNameTooLong),
+			errors.Is(err, reference.ErrNameNotCanonical):
 			return registry.DistributionInspect{}, errdefs.InvalidParameter(err)
 		}
 		return registry.DistributionInspect{}, err

--- a/builder/remotecontext/remote.go
+++ b/builder/remotecontext/remote.go
@@ -96,7 +96,7 @@ func inspectResponse(ct string, r io.Reader, clen int64) (string, io.Reader, err
 	if rlen == 0 {
 		return ct, r, errors.New("empty response")
 	}
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return ct, r, err
 	}
 

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -167,7 +168,7 @@ func ExampleClient_ContainerLogs_withTimeout() {
 	}
 
 	_, err = io.Copy(os.Stdout, reader)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		log.Fatal(err)
 	}
 }

--- a/client/events_test.go
+++ b/client/events_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -143,7 +144,7 @@ func TestEvents(t *testing.T) {
 		for {
 			select {
 			case err := <-errs:
-				if err != nil && err != io.EOF {
+				if err != nil && !errors.Is(err, io.EOF) {
 					t.Fatal(err)
 				}
 

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -138,7 +139,7 @@ func ExampleClient_ServiceLogs_withTimeout() {
 	}
 
 	_, err = io.Copy(os.Stdout, reader)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		log.Fatal(err)
 	}
 }

--- a/cmd/docker-proxy/udp_proxy_linux.go
+++ b/cmd/docker-proxy/udp_proxy_linux.go
@@ -121,7 +121,7 @@ func (proxy *UDPProxy) replyLoop(cte *connTrackEntry, serverAddr net.IP, clientA
 	again:
 		read, err := cte.conn.Read(readBuf)
 		if err != nil {
-			if err, ok := err.(*net.OpError); ok && err.Err == syscall.ECONNREFUSED {
+			if err, ok := err.(*net.OpError); ok && errors.Is(err.Err, syscall.ECONNREFUSED) {
 				// This will happen if the last write failed
 				// (e.g: nothing is actually listening on the
 				// proxied port on the container), ignore it

--- a/container/stream/attach.go
+++ b/container/stream/attach.go
@@ -86,7 +86,7 @@ func (c *Config) CopyStreams(ctx context.Context, cfg *AttachConfig) <-chan erro
 			} else {
 				_, err = pools.Copy(cfg.CStdin, cfg.Stdin)
 			}
-			if err == io.ErrClosedPipe {
+			if errors.Is(err, io.ErrClosedPipe) {
 				err = nil
 			}
 			if err != nil {
@@ -109,7 +109,7 @@ func (c *Config) CopyStreams(ctx context.Context, cfg *AttachConfig) <-chan erro
 		}()
 
 		_, err := pools.Copy(stream, streamPipe)
-		if err == io.ErrClosedPipe {
+		if errors.Is(err, io.ErrClosedPipe) {
 			err = nil
 		}
 		if err != nil {

--- a/container/stream/bytespipe/buffer_test.go
+++ b/container/stream/bytespipe/buffer_test.go
@@ -2,6 +2,7 @@ package bytespipe
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -42,7 +43,7 @@ func TestFixedBufferLen(t *testing.T) {
 	if n != 0 {
 		t.Fatalf("expected no bytes to be written to buffer, got %d", n)
 	}
-	if err != errBufferFull {
+	if !errors.Is(err, errBufferFull) {
 		t.Fatalf("expected errBufferFull, got %v", err)
 	}
 
@@ -99,7 +100,7 @@ func TestFixedBufferWrite(t *testing.T) {
 	if n != 59 {
 		t.Fatalf("expected 59 bytes written before buffer is full, got %d", n)
 	}
-	if err != errBufferFull {
+	if !errors.Is(err, errBufferFull) {
 		t.Fatalf("expected errBufferFull, got %v - %v", err, buf.buf[:64])
 	}
 }

--- a/container/stream/bytespipe/bytespipe.go
+++ b/container/stream/bytespipe/bytespipe.go
@@ -71,7 +71,7 @@ loop0:
 		bp.bufLen += n
 
 		// errBufferFull is an error we expect to get if the buffer is full
-		if err != nil && err != errBufferFull {
+		if err != nil && !errors.Is(err, errBufferFull) {
 			bp.wait.Broadcast()
 			return written, err
 		}

--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -354,7 +354,7 @@ func (c *Cluster) errNoManager(st nodeState) error {
 		if errors.Is(st.err, errSwarmLocked) {
 			return errSwarmLocked
 		}
-		if st.err == errSwarmCertificatesExpired {
+		if errors.Is(st.err, errSwarmCertificatesExpired) {
 			return errSwarmCertificatesExpired
 		}
 		return errors.WithStack(notAvailableError(`This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.`))
@@ -426,7 +426,7 @@ func managerStats(client swarmapi.ControlClient, currentNodeID string) (current 
 }
 
 func detectLockedError(err error) error {
-	if err == swarmnode.ErrInvalidUnlockKey {
+	if errors.Is(err, swarmnode.ErrInvalidUnlockKey) {
 		return errors.WithStack(errSwarmLocked)
 	}
 	return err

--- a/daemon/cluster/controllers/plugin/controller_test.go
+++ b/daemon/cluster/controllers/plugin/controller_test.go
@@ -117,7 +117,7 @@ func TestWaitCancel(t *testing.T) {
 	cancel()
 	select {
 	case err := <-chErr:
-		if err != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			t.Fatal(err)
 		}
 	case <-time.After(10 * time.Second):

--- a/daemon/cluster/convert/service_test.go
+++ b/daemon/cluster/convert/service_test.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"errors"
 	"testing"
 
 	containertypes "github.com/docker/docker/api/types/container"
@@ -148,7 +149,7 @@ func TestServiceConvertToGRPCGenericRuntimeCustom(t *testing.T) {
 		},
 	}
 
-	if _, err := ServiceSpecToGRPC(s); err != ErrUnsupportedRuntime {
+	if _, err := ServiceSpecToGRPC(s); !errors.Is(err, ErrUnsupportedRuntime) {
 		t.Fatal(err)
 	}
 }
@@ -409,7 +410,7 @@ func TestServiceConvertToGRPCNetworkAttachmentRuntime(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error %v but got no error", ErrUnsupportedRuntime)
 	}
-	if err != ErrUnsupportedRuntime {
+	if !errors.Is(err, ErrUnsupportedRuntime) {
 		t.Fatalf("expected error %v but got error %v", ErrUnsupportedRuntime, err)
 	}
 }
@@ -436,7 +437,7 @@ func TestServiceConvertToGRPCMismatchedRuntime(t *testing.T) {
 			}
 			s.TaskTemplate.Runtime = rt
 
-			if _, err := ServiceSpecToGRPC(s); err != ErrMismatchedRuntime {
+			if _, err := ServiceSpecToGRPC(s); !errors.Is(err, ErrMismatchedRuntime) {
 				t.Fatalf("expected %v got %v", ErrMismatchedRuntime, err)
 			}
 		}

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -305,7 +305,7 @@ func (r *controller) Wait(pctx context.Context) error {
 	go func() {
 		ectx, cancel := context.WithCancel(ctx) // cancel event context on first event
 		defer cancel()
-		if err := r.checkHealth(ectx); err == ErrContainerUnhealthy {
+		if err := r.checkHealth(ectx); errors.Is(err, ErrContainerUnhealthy) {
 			healthErr <- ErrContainerUnhealthy
 			if err := r.Shutdown(ectx); err != nil {
 				log.G(ectx).WithError(err).Debug("shutdown failed on unhealthy")

--- a/daemon/cluster/executor/container/health_test.go
+++ b/daemon/cluster/executor/container/health_test.go
@@ -4,6 +4,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -80,7 +81,7 @@ func TestHealthStates(t *testing.T) {
 
 		select {
 		case err := <-errChan:
-			if err != expectedErr {
+			if !errors.Is(err, expectedErr) {
 				t.Fatalf("expect error %v, but get %v", expectedErr, err)
 			}
 		case <-timer.C:

--- a/daemon/cluster/listen_addr.go
+++ b/daemon/cluster/listen_addr.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -26,7 +27,7 @@ func resolveListenAddr(specifiedAddr string) (string, string, error) {
 	// system? If so, use the address from that interface.
 	specifiedIP, err := resolveInputIPAddr(specifiedHost, true)
 	if err != nil {
-		if err == errBadNetworkIdentifier {
+		if errors.Is(err, errBadNetworkIdentifier) {
 			err = errBadListenAddr
 		}
 		return "", "", err
@@ -57,7 +58,7 @@ func (c *Cluster) resolveAdvertiseAddr(advertiseAddr, listenAddrPort string) (st
 		// system? If so, use the address from that interface.
 		advertiseIP, err := resolveInputIPAddr(advertiseHost, false)
 		if err != nil {
-			if err == errBadNetworkIdentifier {
+			if errors.Is(err, errBadNetworkIdentifier) {
 				err = errBadAdvertiseAddr
 			}
 			return "", "", err
@@ -72,7 +73,7 @@ func (c *Cluster) resolveAdvertiseAddr(advertiseAddr, listenAddrPort string) (st
 		// that interface.
 		defaultAdvertiseIP, err := resolveInputIPAddr(c.config.DefaultAdvertiseAddr, false)
 		if err != nil {
-			if err == errBadNetworkIdentifier {
+			if errors.Is(err, errBadNetworkIdentifier) {
 				err = errBadDefaultAdvertiseAddr
 			}
 			return "", "", err
@@ -151,7 +152,7 @@ func resolveDataPathAddr(dataPathAddr string) (string, error) {
 	// If a data path flag is specified try to resolve the IP address.
 	dataPathIP, err := resolveInputIPAddr(dataPathAddr, false)
 	if err != nil {
-		if err == errBadNetworkIdentifier {
+		if errors.Is(err, errBadNetworkIdentifier) {
 			err = errBadDataPathAddr
 		}
 		return "", err
@@ -216,7 +217,7 @@ func resolveInputIPAddr(input string, isUnspecifiedValid bool) (net.IP, error) {
 		return interfaceAddr, nil
 	}
 	// String matched interface but there is a potential ambiguity to be resolved
-	if err != errNoSuchInterface {
+	if !errors.Is(err, errNoSuchInterface) {
 		return nil, err
 	}
 

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -513,7 +513,7 @@ func (c *Cluster) ServiceLogs(ctx context.Context, selector *backend.LogSelector
 			default:
 			}
 			subscribeMsg, err := stream.Recv()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return
 			}
 			// if we're not io.EOF, push the message in and return

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -314,7 +314,7 @@ func (c *Cluster) UnlockSwarm(req types.UnlockRequest) error {
 	if !state.IsActiveManager() {
 		// when manager is not active,
 		// unless it is locked, otherwise return error.
-		if err := c.errNoManager(state); err != errSwarmLocked {
+		if err := c.errNoManager(state); !errors.Is(err, errSwarmLocked) {
 			c.mu.RUnlock()
 			return err
 		}

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -462,7 +462,7 @@ func killProcessDirectly(ctr *container.Container) error {
 	}
 
 	if err := unix.Kill(pid, syscall.SIGKILL); err != nil {
-		if err != unix.ESRCH {
+		if !errors.Is(err, unix.ESRCH) {
 			return errdefs.System(err)
 		}
 		err = errNoSuchProcess{pid, syscall.SIGKILL}

--- a/daemon/containerd/cache.go
+++ b/daemon/containerd/cache.go
@@ -102,7 +102,7 @@ func (c cacheAdaptor) Get(id image.ID) (*image.Image, error) {
 		}
 		return nil
 	})
-	if err != nil && err != errFound {
+	if err != nil && !errors.Is(err, errFound) {
 		return nil, err
 	}
 
@@ -217,7 +217,7 @@ func findContentByUncompressedDigest(ctx context.Context, cs content.Manager, un
 		return errStopWalk
 	}, `labels."containerd.io/uncompressed"==`+uncompressed.String())
 
-	if err != nil && err != errStopWalk {
+	if err != nil && !errors.Is(err, errStopWalk) {
 		return out, err
 	}
 	if out.Digest == "" {

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -699,7 +699,7 @@ func setupLabelFilter(ctx context.Context, store content.Store, fltrs filters.Ar
 			return nil, errFoundConfig
 		})), nil, image.Target)
 
-		if err == errFoundConfig {
+		if errors.Is(err, errFoundConfig) {
 			return true
 		}
 		if err != nil {

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -31,7 +31,7 @@ func (i *ImageService) walkImageManifests(ctx context.Context, img c8dimages.Ima
 	handleManifest := func(ctx context.Context, d ocispec.Descriptor) error {
 		platformImg, err := i.NewImageManifest(ctx, img, d)
 		if err != nil {
-			if err == errNotManifest {
+			if errors.Is(err, errNotManifest) {
 				return nil
 			}
 			return err
@@ -59,7 +59,7 @@ func (i *ImageService) walkReachableImageManifests(ctx context.Context, img c8di
 	handleManifest := func(ctx context.Context, d ocispec.Descriptor) error {
 		platformImg, err := i.NewImageManifest(ctx, img, d)
 		if err != nil {
-			if err == errNotManifest {
+			if errors.Is(err, errNotManifest) {
 				return nil
 			}
 			return err

--- a/daemon/graphdriver/copy/copy.go
+++ b/daemon/graphdriver/copy/copy.go
@@ -49,7 +49,7 @@ func copyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRang
 		}
 
 		*copyWithFileClone = false
-		if err == unix.EXDEV {
+		if errors.Is(err, unix.EXDEV) {
 			*copyWithFileRange = false
 		}
 	}
@@ -57,7 +57,7 @@ func copyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRang
 		err = doCopyWithFileRange(srcFile, dstFile, fileinfo)
 		// Trying the file_clone may not have caught the exdev case
 		// as the ioctl may not have been available (therefore EINVAL)
-		if err == unix.EXDEV || err == unix.ENOSYS {
+		if errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOSYS) {
 			*copyWithFileRange = false
 		} else {
 			return err

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -269,7 +269,7 @@ func isEmptyDir(name string) bool {
 	}
 	defer f.Close()
 
-	if _, err = f.Readdirnames(1); err == io.EOF {
+	if _, err = f.Readdirnames(1); errors.Is(err, io.EOF) {
 		return true
 	}
 	return false

--- a/daemon/graphdriver/overlay2/check.go
+++ b/daemon/graphdriver/overlay2/check.go
@@ -106,7 +106,7 @@ func doesSupportNativeDiff(d string) error {
 	// rename "d1" to "d2"
 	if err := os.Rename(filepath.Join(td, mergedDirName, "d1"), filepath.Join(td, mergedDirName, "d2")); err != nil {
 		// if rename failed with syscall.EXDEV, the kernel doesn't have CONFIG_OVERLAY_FS_REDIRECT_DIR enabled
-		if err.(*os.LinkError).Err == syscall.EXDEV {
+		if errors.Is(err.(*os.LinkError).Err, syscall.EXDEV) {
 			return nil
 		}
 		return errors.Wrap(err, "failed to rename dir in merged directory")

--- a/daemon/graphdriver/vfs/quota_linux.go
+++ b/daemon/graphdriver/vfs/quota_linux.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/quota"
@@ -15,7 +16,7 @@ type driverQuota struct {
 func setupDriverQuota(driver *Driver) {
 	if quotaCtl, err := quota.NewControl(driver.home); err == nil {
 		driver.quotaCtl = quotaCtl
-	} else if err != quota.ErrQuotaNotSupported {
+	} else if !errors.Is(err, quota.ErrQuotaNotSupported) {
 		log.G(context.TODO()).Warnf("Unable to setup quota: %v\n", err)
 	}
 }

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -524,7 +524,7 @@ func includeContainerInList(container *container.Snapshot, filter *listContext) 
 			}
 			return nil
 		})
-		if err != volumeExist {
+		if !errors.Is(err, volumeExist) {
 			return excludeContainer
 		}
 	}
@@ -560,7 +560,7 @@ func includeContainerInList(container *container.Snapshot, filter *listContext) 
 			}
 			return nil
 		})
-		if err != networkExist {
+		if !errors.Is(err, networkExist) {
 			return excludeContainer
 		}
 	}

--- a/daemon/logger/adapter.go
+++ b/daemon/logger/adapter.go
@@ -107,7 +107,7 @@ func (a *pluginAdapterWithRead) ReadLogs(ctx context.Context, config ReadConfig)
 
 			var buf logdriver.LogEntry
 			if err := dec.Decode(&buf); err != nil {
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					return
 				}
 				watcher.Err <- errors.Wrap(err, "error decoding log message")

--- a/daemon/logger/adapter_test.go
+++ b/daemon/logger/adapter_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"sync"
 	"testing"
@@ -118,7 +119,7 @@ func (l *mockLoggingPlugin) waitLen(i int) {
 }
 
 func (l *mockLoggingPlugin) check(t *testing.T) {
-	if l.err != nil && l.err != io.EOF {
+	if l.err != nil && !errors.Is(l.err, io.EOF) {
 		t.Fatal(l.err)
 	}
 }

--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -431,7 +431,7 @@ func (l *logStream) Log(msg *logger.Message) error {
 	// (i.e. returns false) in this case.
 	ctx := context.TODO()
 	if err := l.messages.Enqueue(ctx, msg); err != nil {
-		if err == loggerutils.ErrQueueClosed {
+		if errors.Is(err, loggerutils.ErrQueueClosed) {
 			return errClosed
 		}
 		return err

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -2,6 +2,7 @@ package gcplogs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -187,7 +188,7 @@ func New(info logger.Info) (logger.Logger, error) {
 	// without overly spamming /var/log/docker.log so we log the first time
 	// we overflow and every 1000th time after.
 	c.OnError = func(err error) {
-		if err == logging.ErrOverflow {
+		if errors.Is(err, logging.ErrOverflow) {
 			if i := droppedLogs.Add(1); i%1000 == 1 {
 				log.G(context.TODO()).Errorf("gcplogs driver has dropped %v logs", i)
 			}

--- a/daemon/logger/jsonfilelog/read_test.go
+++ b/daemon/logger/jsonfilelog/read_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -104,7 +105,7 @@ func TestEncodeDecode(t *testing.T) {
 	assert.Assert(t, string(msg.Line) == "hello 3\n")
 
 	_, err = dec.Decode()
-	assert.Assert(t, err == io.EOF)
+	assert.Assert(t, errors.Is(err, io.EOF))
 }
 
 func TestReadLogs(t *testing.T) {

--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -46,7 +46,7 @@ func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (lo
 		}
 
 		n, err := r.ReadAt(buf, offset-encodeBinaryLen64)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, 0, errors.Wrap(err, "error reading log message footer")
 		}
 
@@ -57,7 +57,7 @@ func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (lo
 		msgLen := binary.BigEndian.Uint32(buf)
 
 		n, err = r.ReadAt(buf, offset-encodeBinaryLen64-encodeBinaryLen64-int64(msgLen))
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, 0, errors.Wrap(err, "error reading log message header")
 		}
 

--- a/daemon/logger/ring_test.go
+++ b/daemon/logger/ring_test.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -97,7 +98,7 @@ func TestRingClose(t *testing.T) {
 		t.Fatal(err)
 	}
 	r.Close()
-	if err := r.Enqueue(&Message{}); err != errClosed {
+	if err := r.Enqueue(&Message{}); !errors.Is(err, errClosed) {
 		t.Fatalf("expected errClosed, got: %v", err)
 	}
 	if len(r.queue) != 1 {

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -153,7 +153,7 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 				c.CheckpointTo(context.TODO(), daemon.containersReplica)
 				c.Unlock()
 				defer daemon.autoRemove(&cfg.Config, c)
-				if waitErr != restartmanager.ErrRestartCanceled {
+				if !errors.Is(waitErr, restartmanager.ErrRestartCanceled) {
 					log.G(ctx).Errorf("restartmanger wait error: %+v", waitErr)
 				}
 			}

--- a/distribution/errors.go
+++ b/distribution/errors.go
@@ -164,15 +164,15 @@ func retryOnError(err error) error {
 			return xfer.DoNotRetry{Err: err}
 		}
 	case *url.Error:
-		switch v.Err {
-		case auth.ErrNoBasicAuthCredentials, auth.ErrNoToken:
+		switch {
+		case errors.Is(v.Err, auth.ErrNoBasicAuthCredentials), errors.Is(v.Err, auth.ErrNoToken):
 			return xfer.DoNotRetry{Err: v.Err}
 		}
 		return retryOnError(v.Err)
 	case *client.UnexpectedHTTPResponseError, unsupportedMediaTypeError:
 		return xfer.DoNotRetry{Err: err}
 	case error:
-		if err == distribution.ErrBlobUnknown {
+		if errors.Is(err, distribution.ErrBlobUnknown) {
 			return xfer.DoNotRetry{Err: err}
 		}
 		if strings.Contains(err.Error(), strings.ToLower(syscall.ENOSPC.Error())) {

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -65,7 +65,7 @@ func addDigestReference(store refstore.Store, ref reference.Named, dgst digest.D
 			log.G(context.TODO()).Errorf("Image ID for digest %s changed from %s to %s, cannot update", dgst.String(), oldTagID, id)
 		}
 		return nil
-	} else if err != refstore.ErrDoesNotExist {
+	} else if !errors.Is(err, refstore.ErrDoesNotExist) {
 		return err
 	}
 

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -248,7 +248,7 @@ func (ld *layerDescriptor) Download(ctx context.Context, progressOutput progress
 
 	_, err = io.Copy(tmpFile, io.TeeReader(reader, ld.verifier))
 	if err != nil {
-		if err == transport.ErrWrongCodeForByteRange {
+		if errors.Is(err, transport.ErrWrongCodeForByteRange) {
 			if err := ld.truncateDownloadFile(); err != nil {
 				return nil, 0, xfer.DoNotRetry{Err: err}
 			}
@@ -421,7 +421,7 @@ func (p *puller) pullTag(ctx context.Context, ref reference.Named, platform *oci
 			if oldTagID == id {
 				return false, addDigestReference(p.config.ReferenceStore, ref, manifestDigest, id)
 			}
-		} else if err != refstore.ErrDoesNotExist {
+		} else if !errors.Is(err, refstore.ErrDoesNotExist) {
 			return false, err
 		}
 

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -525,8 +525,8 @@ attempts:
 		var err error
 		desc, err = pd.repo.Blobs(ctx).Stat(ctx, dgst)
 		pd.checkedDigests[meta.Digest] = struct{}{}
-		switch err {
-		case nil:
+		switch {
+		case err == nil:
 			if m, ok := digestToMetadata[desc.Digest]; !ok || m.SourceRepository != pd.repoName.Name() || !metadata.CheckV2MetadataHMAC(m, pd.hmacKey) {
 				// cache mapping from this layer's DiffID to the blobsum
 				if err := pd.metadataService.TagAndAdd(diffID, pd.hmacKey, metadata.V2Metadata{
@@ -539,7 +539,7 @@ attempts:
 			desc.MediaType = schema2.MediaTypeLayer
 			exists = true
 			break attempts
-		case distribution.ErrBlobUnknown:
+		case errors.Is(err, distribution.ErrBlobUnknown):
 			if meta.SourceRepository == pd.repoName.Name() {
 				// remove the mapping to the target repository
 				if err := pd.metadataService.Remove(*meta); err != nil {

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -351,7 +351,7 @@ func TestCancelledDownload(t *testing.T) {
 
 	descriptors := downloadDescriptors(nil)
 	_, _, err := ldm.Download(ctx, *image.NewRootFS(), descriptors, progress.ChanOutput(progressChan))
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		close(progressChan)
 		t.Fatal("expected download to be cancelled")
 	}

--- a/distribution/xfer/upload_test.go
+++ b/distribution/xfer/upload_test.go
@@ -125,7 +125,7 @@ func TestCancelledUpload(t *testing.T) {
 
 	descriptors := uploadDescriptors(nil)
 	err := lum.Upload(ctx, descriptors, progress.ChanOutput(progressChan))
-	if err != context.Canceled {
+	if !errors.Is(err, context.Canceled) {
 		t.Fatal("expected upload to be cancelled")
 	}
 

--- a/errdefs/helpers_test.go
+++ b/errdefs/helpers_test.go
@@ -22,7 +22,7 @@ func TestNotFound(t *testing.T) {
 	if !cerrdefs.IsNotFound(e) {
 		t.Fatalf("expected not found error, got: %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -43,7 +43,7 @@ func TestConflict(t *testing.T) {
 	if !cerrdefs.IsConflict(e) {
 		t.Fatalf("expected conflict error, got: %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -64,7 +64,7 @@ func TestForbidden(t *testing.T) {
 	if !cerrdefs.IsPermissionDenied(e) {
 		t.Fatalf("expected forbidden error, got: %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -85,7 +85,7 @@ func TestInvalidParameter(t *testing.T) {
 	if !cerrdefs.IsInvalidArgument(e) {
 		t.Fatalf("expected invalid argument error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -106,7 +106,7 @@ func TestNotImplemented(t *testing.T) {
 	if !cerrdefs.IsNotImplemented(e) {
 		t.Fatalf("expected not implemented error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -127,7 +127,7 @@ func TestNotModified(t *testing.T) {
 	if !cerrdefs.IsNotModified(e) {
 		t.Fatalf("expected not modified error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -148,7 +148,7 @@ func TestUnauthorized(t *testing.T) {
 	if !cerrdefs.IsUnauthorized(e) {
 		t.Fatalf("expected unauthorized error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -169,7 +169,7 @@ func TestUnknown(t *testing.T) {
 	if !cerrdefs.IsUnknown(e) {
 		t.Fatalf("expected unknown error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -190,7 +190,7 @@ func TestCancelled(t *testing.T) {
 	if !cerrdefs.IsCanceled(e) {
 		t.Fatalf("expected cancelled error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -211,7 +211,7 @@ func TestDeadline(t *testing.T) {
 	if !cerrdefs.IsDeadlineExceeded(e) {
 		t.Fatalf("expected deadline error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -232,7 +232,7 @@ func TestDataLoss(t *testing.T) {
 	if !cerrdefs.IsDataLoss(e) {
 		t.Fatalf("expected data loss error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -253,7 +253,7 @@ func TestUnavailable(t *testing.T) {
 	if !cerrdefs.IsUnavailable(e) {
 		t.Fatalf("expected unavaillable error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {
@@ -274,7 +274,7 @@ func TestSystem(t *testing.T) {
 	if !cerrdefs.IsInternal(e) {
 		t.Fatalf("expected system error, got %T", e)
 	}
-	if cause := e.(wrapped).Unwrap(); cause != errTest {
+	if cause := e.(wrapped).Unwrap(); cause != errTest { //nolint:errorlint // not using errors.Is, as this tests for the unwrapped error.
 		t.Fatalf("causual should be errTest, got: %v", cause)
 	}
 	if !errors.Is(e, errTest) {

--- a/image/store.go
+++ b/image/store.go
@@ -199,7 +199,7 @@ func (imageNotFoundError) NotFound() {}
 func (is *store) Search(term string) (ID, error) {
 	dgst, err := is.digestSet.Lookup(term)
 	if err != nil {
-		if err == digestset.ErrDigestNotFound {
+		if errors.Is(err, digestset.ErrDigestNotFound) {
 			err = imageNotFoundError(term)
 		}
 		return "", errors.WithStack(err)

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -71,7 +71,7 @@ func (s *DockerAPISuite) TestExecResizeImmediatelyAfterExecStart(c *testing.T) {
 		_, rc, err := request.Post(testutil.GetContext(c), fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), request.ContentType("text/plain"))
 		if err != nil {
 			// It's probably a panic of the daemon if io.ErrUnexpectedEOF is returned.
-			if err == io.ErrUnexpectedEOF {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
 				return errors.New("the daemon might have crashed")
 			}
 			// Other error happened, should be reported.

--- a/integration-cli/docker_cli_daemon_plugins_test.go
+++ b/integration-cli/docker_cli_daemon_plugins_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -143,7 +144,7 @@ func (s *DockerDaemonSuite) TestDaemonShutdownWithPlugins(c *testing.T) {
 	}
 
 	for {
-		if err := unix.Kill(s.d.Pid(), 0); err == unix.ESRCH {
+		if err := unix.Kill(s.d.Pid(), 0); errors.Is(err, unix.ESRCH) {
 			break
 		}
 	}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -2190,7 +2191,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesCleanPaths(c *testing.T) {
 	cli.DockerCmd(c, "run", "-v", prefix+"/foo", "-v", prefix+"/bar/", "--name", "dark_helmet", "run_volumes_clean_paths")
 
 	out, err := inspectMountSourceField("dark_helmet", prefix+slash+"foo"+slash)
-	if err != errMountNotFound {
+	if !errors.Is(err, errMountNotFound) {
 		c.Fatalf("Found unexpected volume entry for '%s/foo/' in volumes\n%q", prefix, out)
 	}
 
@@ -2201,7 +2202,7 @@ func (s *DockerCLIRunSuite) TestRunVolumesCleanPaths(c *testing.T) {
 	}
 
 	out, err = inspectMountSourceField("dark_helmet", prefix+slash+"bar"+slash)
-	if err != errMountNotFound {
+	if !errors.Is(err, errMountNotFound) {
 		c.Fatalf("Found unexpected volume entry for '%s/bar/' in volumes\n%q", prefix, out)
 	}
 

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -780,7 +781,7 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 						imageCreateEvts++
 					}
 				case err := <-errs:
-					assert.Check(t, err == nil || err == io.EOF)
+					assert.Check(t, err == nil || errors.Is(err, io.EOF))
 					finished = true
 				}
 			}

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -335,7 +336,7 @@ func TestCopyFromContainer(t *testing.T) {
 			tr := tar.NewReader(rdr)
 			for numFound < len(x.expect) {
 				h, err := tr.Next()
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					break
 				}
 				assert.NilError(t, err)

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -80,7 +81,7 @@ func getEventActions(t *testing.T, messages <-chan events.Message, errs <-chan e
 	for {
 		select {
 		case err := <-errs:
-			assert.Check(t, err == nil || err == io.EOF)
+			assert.Check(t, err == nil || errors.Is(err, io.EOF))
 			return actions
 		case e := <-messages:
 			actions = append(actions, e.Action)

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -4,6 +4,7 @@ package authz
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -255,7 +256,7 @@ func TestAuthZPluginAllowEventStream(t *testing.T) {
 				}
 			}
 		case err := <-errs:
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				t.Fatal("premature end of event stream")
 			}
 			assert.NilError(t, err)

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -136,7 +136,7 @@ func TestEventsVolumeCreate(t *testing.T) {
 			case m := <-messages:
 				evts = append(evts, m)
 			case err := <-errs:
-				if err == io.EOF {
+				if errors.Is(err, io.EOF) {
 					return evts, nil
 				}
 				return nil, err

--- a/internal/containerfs/rm.go
+++ b/internal/containerfs/rm.go
@@ -61,7 +61,7 @@ func EnsureRemoveAll(dir string) error {
 			continue
 		}
 
-		if pe.Err != syscall.EBUSY {
+		if !errors.Is(pe.Err, syscall.EBUSY) {
 			return err
 		}
 

--- a/libnetwork/bitmap/sequence_test.go
+++ b/libnetwork/bitmap/sequence_test.go
@@ -1,6 +1,7 @@
 package bitmap
 
 import (
+	"errors"
 	"math/rand"
 	"testing"
 	"time"
@@ -677,13 +678,13 @@ func TestSetUnset(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := hnd.SetAny(false); err != ErrNoBitAvailable {
+	if _, err := hnd.SetAny(false); !errors.Is(err, ErrNoBitAvailable) {
 		t.Fatal("Expected error. Got success")
 	}
-	if _, err := hnd.SetAnyInRange(10, 20, false); err != ErrNoBitAvailable {
+	if _, err := hnd.SetAnyInRange(10, 20, false); !errors.Is(err, ErrNoBitAvailable) {
 		t.Fatal("Expected error. Got success")
 	}
-	if err := hnd.Set(50); err != ErrBitAllocated {
+	if err := hnd.Set(50); !errors.Is(err, ErrBitAllocated) {
 		t.Fatalf("Expected error. Got %v: %s", err, hnd)
 	}
 	i := uint64(0)
@@ -706,11 +707,11 @@ func TestOffsetSetUnset(t *testing.T) {
 		}
 	}
 
-	if _, err := hnd.SetAny(false); err != ErrNoBitAvailable {
+	if _, err := hnd.SetAny(false); !errors.Is(err, ErrNoBitAvailable) {
 		t.Fatal("Expected error. Got success")
 	}
 
-	if _, err := hnd.SetAnyInRange(10, 20, false); err != ErrNoBitAvailable {
+	if _, err := hnd.SetAnyInRange(10, 20, false); !errors.Is(err, ErrNoBitAvailable) {
 		t.Fatal("Expected error. Got success")
 	}
 
@@ -812,7 +813,7 @@ func TestSetInRange(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
-	if err != ErrNoBitAvailable {
+	if !errors.Is(err, ErrNoBitAvailable) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
@@ -829,7 +830,7 @@ func TestSetInRange(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
-	if err != ErrNoBitAvailable {
+	if !errors.Is(err, ErrNoBitAvailable) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
@@ -844,7 +845,7 @@ func TestSetInRange(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected failure. Got success with ordinal:%d", o)
 	}
-	if err != ErrNoBitAvailable {
+	if !errors.Is(err, ErrNoBitAvailable) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }

--- a/libnetwork/cnmallocator/networkallocator.go
+++ b/libnetwork/cnmallocator/networkallocator.go
@@ -591,7 +591,7 @@ func (na *cnmNetworkAllocator) allocateVIP(vip *api.Endpoint_VirtualIP) error {
 
 	for _, poolID := range localNet.pools {
 		ip, _, err := ipam.RequestAddress(poolID, addr, opts)
-		if err != nil && err != ipamapi.ErrNoAvailableIPs && err != ipamapi.ErrIPOutOfRange {
+		if err != nil && !errors.Is(err, ipamapi.ErrNoAvailableIPs) && !errors.Is(err, ipamapi.ErrIPOutOfRange) {
 			return errors.Wrap(err, "could not allocate VIP from IPAM")
 		}
 
@@ -682,7 +682,7 @@ func (na *cnmNetworkAllocator) allocateNetworkIPs(nAttach *api.NetworkAttachment
 			var err error
 
 			ip, _, err = ipam.RequestAddress(poolID, addr, opts)
-			if err != nil && err != ipamapi.ErrNoAvailableIPs && err != ipamapi.ErrIPOutOfRange {
+			if err != nil && !errors.Is(err, ipamapi.ErrNoAvailableIPs) && !errors.Is(err, ipamapi.ErrIPOutOfRange) {
 				return errors.Wrap(err, "could not allocate IP from IPAM")
 			}
 

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -1076,7 +1076,7 @@ func (c *Controller) loadDriver(networkType string) error {
 	}
 
 	if err != nil {
-		if errors.Cause(err) == plugins.ErrNotFound {
+		if errors.Is(err, plugins.ErrNotFound) {
 			return types.NotFoundErrorf("%v", err)
 		}
 		return err
@@ -1095,7 +1095,7 @@ func (c *Controller) loadIPAMDriver(name string) error {
 	}
 
 	if err != nil {
-		if errors.Cause(err) == plugins.ErrNotFound {
+		if errors.Is(err, plugins.ErrNotFound) {
 			return types.NotFoundErrorf("%v", err)
 		}
 		return err

--- a/libnetwork/datastore/cache.go
+++ b/libnetwork/datastore/cache.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -35,7 +36,7 @@ func (c *cache) kmap(kvObject KVObject) (kvMap, error) {
 
 	kvList, err := c.ds.List(keyPrefix)
 	if err != nil {
-		if err == store.ErrKeyNotFound {
+		if errors.Is(err, store.ErrKeyNotFound) {
 			// If the store doesn't have anything then there is nothing to
 			// populate in the cache. Just bail out.
 			goto out

--- a/libnetwork/datastore/datastore.go
+++ b/libnetwork/datastore/datastore.go
@@ -121,7 +121,7 @@ func (ds *Store) PutObjectAtomic(kvObject KVObject) error {
 
 		pair, err := ds.store.AtomicPut(Key(kvObject.Key()...), kvObjValue, previous)
 		if err != nil {
-			if err == store.ErrKeyExists {
+			if errors.Is(err, store.ErrKeyExists) {
 				return ErrKeyModified
 			}
 			return err
@@ -245,7 +245,7 @@ func (ds *Store) DeleteObjectAtomic(kvObject KVObject) error {
 
 	if !kvObject.Skip() {
 		if err := ds.store.AtomicDelete(Key(kvObject.Key()...), previous); err != nil {
-			if err == store.ErrKeyExists {
+			if errors.Is(err, store.ErrKeyExists) {
 				return ErrKeyModified
 			}
 			return err

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -956,7 +956,7 @@ func (d *driver) deleteNetwork(nid string) error {
 		// it's not in d.networks. To prevent the driver's state from getting out of step
 		// with its parent, make sure it's not in the store before reporting that it does
 		// not exist.
-		if err := d.storeDelete(&networkConfiguration{ID: nid}); err != nil && err != datastore.ErrKeyNotFound {
+		if err := d.storeDelete(&networkConfiguration{ID: nid}); err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
 			log.G(context.TODO()).WithFields(log.Fields{
 				"error":   err,
 				"network": nid,

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -5,6 +5,7 @@ package bridge
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -43,12 +44,12 @@ func (d *driver) initStore() error {
 
 func (d *driver) populateNetworks() error {
 	kvol, err := d.store.List(&networkConfiguration{})
-	if err != nil && err != datastore.ErrKeyNotFound {
-		return fmt.Errorf("failed to get bridge network configurations from store: %v", err)
+	if err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
+		return fmt.Errorf("failed to get bridge network configurations from store: %w", err)
 	}
 
 	// It's normal for network configuration state to be empty. Just return.
-	if err == datastore.ErrKeyNotFound {
+	if errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil
 	}
 
@@ -68,11 +69,11 @@ func (d *driver) populateNetworks() error {
 
 func (d *driver) populateEndpoints() error {
 	kvol, err := d.store.List(&bridgeEndpoint{})
-	if err != nil && err != datastore.ErrKeyNotFound {
-		return fmt.Errorf("failed to get bridge endpoints from store: %v", err)
+	if err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
+		return fmt.Errorf("failed to get bridge endpoints from store: %w", err)
 	}
 
-	if err == datastore.ErrKeyNotFound {
+	if errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil
 	}
 

--- a/libnetwork/drivers/ipvlan/ipvlan_store.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_store.go
@@ -5,6 +5,7 @@ package ipvlan
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 
@@ -56,11 +57,11 @@ func (d *driver) initStore() error {
 // populateNetworks is invoked at driver init to recreate persistently stored networks
 func (d *driver) populateNetworks() error {
 	kvol, err := d.store.List(&configuration{})
-	if err != nil && err != datastore.ErrKeyNotFound {
-		return fmt.Errorf("failed to get ipvlan network configurations from store: %v", err)
+	if err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
+		return fmt.Errorf("failed to get ipvlan network configurations from store: %w", err)
 	}
 	// If empty it simply means no ipvlan networks have been created yet
-	if err == datastore.ErrKeyNotFound {
+	if errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil
 	}
 	for _, kvo := range kvol {
@@ -75,11 +76,11 @@ func (d *driver) populateNetworks() error {
 
 func (d *driver) populateEndpoints() error {
 	kvol, err := d.store.List(&endpoint{})
-	if err != nil && err != datastore.ErrKeyNotFound {
-		return fmt.Errorf("failed to get ipvlan endpoints from store: %v", err)
+	if err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
+		return fmt.Errorf("failed to get ipvlan endpoints from store: %w", err)
 	}
 
-	if err == datastore.ErrKeyNotFound {
+	if errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil
 	}
 

--- a/libnetwork/drivers/macvlan/macvlan_store.go
+++ b/libnetwork/drivers/macvlan/macvlan_store.go
@@ -5,6 +5,7 @@ package macvlan
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 
@@ -55,11 +56,11 @@ func (d *driver) initStore() error {
 // populateNetworks is invoked at driver init to recreate persistently stored networks
 func (d *driver) populateNetworks() error {
 	kvol, err := d.store.List(&configuration{})
-	if err != nil && err != datastore.ErrKeyNotFound {
-		return fmt.Errorf("failed to get macvlan network configurations from store: %v", err)
+	if err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
+		return fmt.Errorf("failed to get macvlan network configurations from store: %w", err)
 	}
 	// If empty it simply means no macvlan networks have been created yet
-	if err == datastore.ErrKeyNotFound {
+	if errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil
 	}
 	for _, kvo := range kvol {
@@ -74,11 +75,11 @@ func (d *driver) populateNetworks() error {
 
 func (d *driver) populateEndpoints() error {
 	kvol, err := d.store.List(&endpoint{})
-	if err != nil && err != datastore.ErrKeyNotFound {
-		return fmt.Errorf("failed to get macvlan endpoints from store: %v", err)
+	if err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
+		return fmt.Errorf("failed to get macvlan endpoints from store: %w", err)
 	}
 
-	if err == datastore.ErrKeyNotFound {
+	if errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil
 	}
 

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -431,10 +432,10 @@ func programSP(fSA *netlink.XfrmState, rSA *netlink.XfrmState, add bool) error {
 
 func saExists(sa *netlink.XfrmState) (bool, error) {
 	_, err := ns.NlHandle().XfrmStateGet(sa)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return true, nil
-	case syscall.ESRCH:
+	case errors.Is(err, syscall.ESRCH):
 		return false, nil
 	default:
 		err = fmt.Errorf("Error while checking for SA existence: %v", err)
@@ -445,10 +446,10 @@ func saExists(sa *netlink.XfrmState) (bool, error) {
 
 func spExists(sp *netlink.XfrmPolicy) (bool, error) {
 	_, err := ns.NlHandle().XfrmPolicyGet(sp)
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return true, nil
-	case syscall.ENOENT:
+	case errors.Is(err, syscall.ENOENT):
 		return false, nil
 	default:
 		err = fmt.Errorf("Error while checking for SP existence: %v", err)

--- a/libnetwork/drivers/remote/driver_test.go
+++ b/libnetwork/drivers/remote/driver_test.go
@@ -28,7 +28,7 @@ func handle(t *testing.T, mux *http.ServeMux, method string, h func(map[string]i
 	mux.HandleFunc(fmt.Sprintf("/%s.%s", driverapi.NetworkPluginEndpointType, method), func(w http.ResponseWriter, r *http.Request) {
 		var ask map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&ask)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			t.Fatal(err)
 		}
 		answer := h(ask)

--- a/libnetwork/endpoint.go
+++ b/libnetwork/endpoint.go
@@ -6,6 +6,7 @@ package libnetwork
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -1334,7 +1335,7 @@ func (ep *Endpoint) assignAddressVersion(ipVer int, ipam ipamapi.Ipam) error {
 			ep.mu.Unlock()
 			return nil
 		}
-		if err != ipamapi.ErrNoAvailableIPs || progAdd != nil {
+		if !errors.Is(err, ipamapi.ErrNoAvailableIPs) || progAdd != nil {
 			return err
 		}
 	}

--- a/libnetwork/ipams/defaultipam/allocator_test.go
+++ b/libnetwork/ipams/defaultipam/allocator_test.go
@@ -2,6 +2,7 @@ package defaultipam
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -404,7 +405,7 @@ func TestRequestReleaseAddressFromSubPool(t *testing.T) {
 			ip = c
 		}
 	}
-	if err != ipamapi.ErrNoAvailableIPs {
+	if !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		t.Fatal(err)
 	}
 	if !types.CompareIPNet(expected, ip) {
@@ -436,7 +437,7 @@ func TestRequestReleaseAddressFromSubPool(t *testing.T) {
 			ip = c
 		}
 	}
-	if err != ipamapi.ErrNoAvailableIPs {
+	if !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		t.Fatal(err)
 	}
 	if !types.CompareIPNet(expected, ip) {
@@ -528,7 +529,7 @@ func TestSerializeRequestReleaseAddressFromSubPool(t *testing.T) {
 			ip = c
 		}
 	}
-	if err != ipamapi.ErrNoAvailableIPs {
+	if !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		t.Fatal(err)
 	}
 	if !types.CompareIPNet(expected, ip) {
@@ -560,7 +561,7 @@ func TestSerializeRequestReleaseAddressFromSubPool(t *testing.T) {
 			ip = c
 		}
 	}
-	if err != ipamapi.ErrNoAvailableIPs {
+	if !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		t.Fatal(err)
 	}
 	if !types.CompareIPNet(expected, ip) {
@@ -853,7 +854,7 @@ func TestUnusualSubnets(t *testing.T) {
 
 	for _, outside := range outsideTheRangeAddresses {
 		_, _, errx := allocator.RequestAddress(alloc.PoolID, net.ParseIP(outside.address), nil)
-		if errx != ipamapi.ErrIPOutOfRange {
+		if !errors.Is(errx, ipamapi.ErrIPOutOfRange) {
 			t.Fatalf("Address %s failed to throw expected error: %s", outside.address, errx.Error())
 		}
 	}
@@ -873,7 +874,7 @@ func TestUnusualSubnets(t *testing.T) {
 	}
 
 	_, _, err = allocator.RequestAddress(alloc.PoolID, nil, nil)
-	if err != ipamapi.ErrNoAvailableIPs {
+	if !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		t.Fatal("Did not get expected error when pool is exhausted.")
 	}
 }
@@ -890,7 +891,7 @@ func TestRelease(t *testing.T) {
 	}
 
 	// Allocate all addresses
-	for err != ipamapi.ErrNoAvailableIPs {
+	for !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		_, _, err = a.RequestAddress(alloc.PoolID, nil, nil)
 	}
 
@@ -948,7 +949,7 @@ func assertGetAddress(t *testing.T, subnet string) {
 
 	start := time.Now()
 	run := 0
-	for err != ipamapi.ErrNoAvailableIPs {
+	for !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		_, err = getAddress(sub, bm, netip.Addr{}, netip.Prefix{}, false)
 		run++
 	}
@@ -997,7 +998,7 @@ func assertNRequests(t *testing.T, subnet string, numReq int, lastExpectedIP str
 
 func benchmarkRequest(b *testing.B, a *Allocator, subnet string) {
 	alloc, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: subnet})
-	for err != ipamapi.ErrNoAvailableIPs {
+	for !errors.Is(err, ipamapi.ErrNoAvailableIPs) {
 		_, _, err = a.RequestAddress(alloc.PoolID, nil, nil)
 	}
 }

--- a/libnetwork/ipams/remote/remote_test.go
+++ b/libnetwork/ipams/remote/remote_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -22,7 +23,7 @@ func handle(t *testing.T, mux *http.ServeMux, method string, h func(map[string]i
 	mux.HandleFunc(fmt.Sprintf("/%s.%s", ipamapi.PluginEndpointType, method), func(w http.ResponseWriter, r *http.Request) {
 		var ask map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&ask)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			t.Fatal(err)
 		}
 		answer := h(ask)

--- a/libnetwork/network.go
+++ b/libnetwork/network.go
@@ -1619,7 +1619,7 @@ func (n *Network) ipamAllocateVersion(ipVer int, ipam ipamapi.Ipam) error {
 					return types.ForbiddenErrorf("auxiliary address: (%s:%s) must belong to the master pool: %s", k, v, d.Pool)
 				}
 				// Attempt reservation in the container addressable pool, silent the error if address does not belong to that pool
-				if d.IPAMData.AuxAddresses[k], _, err = ipam.RequestAddress(d.PoolID, ip, nil); err != nil && err != ipamapi.ErrIPOutOfRange {
+				if d.IPAMData.AuxAddresses[k], _, err = ipam.RequestAddress(d.PoolID, ip, nil); err != nil && !errors.Is(err, ipamapi.ErrIPOutOfRange) {
 					return types.InternalErrorf("failed to allocate secondary ip address (%s:%s): %v", k, v, err)
 				}
 			}
@@ -1673,7 +1673,7 @@ func (n *Network) ipamReleaseVersion(ipVer int, ipam ipamapi.Ipam) {
 		if d.IPAMData.AuxAddresses != nil {
 			for k, nw := range d.IPAMData.AuxAddresses {
 				if d.Pool.Contains(nw.IP) {
-					if err := ipam.ReleaseAddress(d.PoolID, nw.IP); err != nil && err != ipamapi.ErrIPOutOfRange {
+					if err := ipam.ReleaseAddress(d.PoolID, nw.IP); err != nil && !errors.Is(err, ipamapi.ErrIPOutOfRange) {
 						log.G(context.TODO()).Warnf("Failed to release secondary ip address %s (%v) on delete of network %s (%s): %v", k, nw.IP, n.Name(), n.ID(), err)
 					}
 				}

--- a/libnetwork/portallocator/portallocator_test.go
+++ b/libnetwork/portallocator/portallocator_test.go
@@ -93,7 +93,7 @@ func TestReleaseUnreadledPort(t *testing.T) {
 func TestUnknowProtocol(t *testing.T) {
 	p := newInstance()
 
-	if _, err := p.RequestPort(net.IPv4zero, "tcpp", 0); err != errUnknownProtocol {
+	if _, err := p.RequestPort(net.IPv4zero, "tcpp", 0); !errors.Is(err, errUnknownProtocol) {
 		t.Fatalf("Expected error %s got %s", errUnknownProtocol, err)
 	}
 }
@@ -112,7 +112,7 @@ func TestAllocateAllPorts(t *testing.T) {
 		}
 	}
 
-	if _, err := p.RequestPort(net.IPv4zero, "tcp", 0); err != errAllPortsAllocated {
+	if _, err := p.RequestPort(net.IPv4zero, "tcp", 0); !errors.Is(err, errAllPortsAllocated) {
 		t.Fatalf("Expected error %s got %s", errAllPortsAllocated, err)
 	}
 
@@ -281,7 +281,7 @@ func TestPortAllocationWithCustomRange(t *testing.T) {
 		t.Fatal("Allocated the same port from a custom range")
 	}
 	// request 3rd port from the range of 2
-	if _, err := p.RequestPortInRange(net.IPv4zero, "tcp", start, end); err != errAllPortsAllocated {
+	if _, err := p.RequestPortInRange(net.IPv4zero, "tcp", start, end); !errors.Is(err, errAllPortsAllocated) {
 		t.Fatalf("Expected error %s got %s", errAllPortsAllocated, err)
 	}
 }

--- a/libnetwork/resolver_test.go
+++ b/libnetwork/resolver_test.go
@@ -125,7 +125,7 @@ func waitForLocalDNSServer(t *testing.T) {
 		if err != nil {
 			if oerr, ok := err.(*net.OpError); ok {
 				// server is probably initializing
-				if oerr.Err == syscall.ECONNREFUSED {
+				if errors.Is(oerr.Err, syscall.ECONNREFUSED) {
 					continue
 				}
 			} else {

--- a/libnetwork/sandbox_store.go
+++ b/libnetwork/sandbox_store.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/log"
@@ -147,7 +148,7 @@ retry:
 	}
 
 	err := sb.controller.updateToStore(ctx, sbs)
-	if err == datastore.ErrKeyModified {
+	if errors.Is(err, datastore.ErrKeyModified) {
 		// When we get ErrKeyModified it is sufficient to just
 		// go back and retry.  No need to get the object from
 		// the store because we always regenerate the store
@@ -171,7 +172,7 @@ func (sb *Sandbox) storeDelete() error {
 func (c *Controller) sandboxRestore(activeSandboxes map[string]interface{}) error {
 	sandboxStates, err := c.store.List(&sbState{c: c})
 	if err != nil {
-		if err == datastore.ErrKeyNotFound {
+		if errors.Is(err, datastore.ErrKeyNotFound) {
 			// It's normal for no sandboxes to be found. Just bail out.
 			return nil
 		}

--- a/oci/devices_linux.go
+++ b/oci/devices_linux.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ func DevicesFromPath(pathOnHost, pathInContainer, cgroupPermissions string) (dev
 
 	// if the device is not a device node
 	// try to see if it's a directory holding many devices
-	if err == coci.ErrNotADevice {
+	if errors.Is(err, coci.ErrNotADevice) {
 		// check if it is a directory
 		if src, e := os.Stat(resolvedPathOnHost); e == nil && src.IsDir() {
 			// mount the internal devices recursively

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -46,7 +46,7 @@ func TestCancelReadCloser(t *testing.T) {
 	for {
 		var buf [128]byte
 		_, err := crc.Read(buf[:])
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			break
 		} else if err != nil {
 			t.Fatalf("got unexpected error: %v", err)

--- a/pkg/process/process_unix.go
+++ b/pkg/process/process_unix.go
@@ -4,6 +4,7 @@ package process
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ func Alive(pid int) bool {
 
 		// Either the PID was found (no error) or we get an EPERM, which means
 		// the PID exists, but we don't have permissions to signal it.
-		return err == nil || err == unix.EPERM
+		return err == nil || errors.Is(err, unix.EPERM)
 	default:
 		_, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid)))
 		return err == nil
@@ -51,7 +52,7 @@ func Kill(pid int) error {
 		return fmt.Errorf("invalid PID (%d): only positive PIDs are allowed", pid)
 	}
 	err := unix.Kill(pid, unix.SIGKILL)
-	if err != nil && err != unix.ESRCH {
+	if err != nil && !errors.Is(err, unix.ESRCH) {
 		return err
 	}
 	return nil

--- a/pkg/stdcopy/stdcopy.go
+++ b/pkg/stdcopy/stdcopy.go
@@ -107,7 +107,7 @@ func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, _ error) {
 			var nr2 int
 			nr2, err = src.Read(buf[nr:])
 			nr += nr2
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				if nr < stdWriterPrefixLen {
 					return written, nil
 				}
@@ -153,7 +153,7 @@ func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, _ error) {
 			var nr2 int
 			nr2, err = src.Read(buf[nr:])
 			nr += nr2
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				if nr < frameSize+stdWriterPrefixLen {
 					return written, nil
 				}

--- a/pkg/stdcopy/stdcopy_test.go
+++ b/pkg/stdcopy/stdcopy_test.go
@@ -67,7 +67,7 @@ func TestWriteWithWriterError(t *testing.T) {
 	}, Stdout)
 	data := []byte("This won't get written, sigh")
 	n, err := writer.Write(data)
-	if err != expectedError {
+	if !errors.Is(err, expectedError) {
 		t.Fatalf("Didn't get expected error.")
 	}
 	if n != expectedReturnedBytes {
@@ -139,7 +139,7 @@ func TestStdCopyReturnsErrorReadingHeader(t *testing.T) {
 	if written != 0 {
 		t.Fatalf("Expected 0 bytes read, got %d", written)
 	}
-	if err != expectedError {
+	if !errors.Is(err, expectedError) {
 		t.Fatalf("Didn't get expected error")
 	}
 }
@@ -162,7 +162,7 @@ func TestStdCopyReturnsErrorReadingFrame(t *testing.T) {
 	if written != 0 {
 		t.Fatalf("Expected 0 bytes read, got %d", written)
 	}
-	if err != expectedError {
+	if !errors.Is(err, expectedError) {
 		t.Fatalf("Didn't get expected error")
 	}
 }
@@ -226,7 +226,7 @@ func TestStdCopyReturnsWriteErrors(t *testing.T) {
 	if written != 0 {
 		t.Fatalf("StdCopy should have written 0, but has written %d", written)
 	}
-	if err != expectedError {
+	if !errors.Is(err, expectedError) {
 		t.Fatalf("Didn't get expected error, got %v", err)
 	}
 }
@@ -244,7 +244,7 @@ func TestStdCopyDetectsNotFullyWrittenFrames(t *testing.T) {
 	if written != 0 {
 		t.Fatalf("StdCopy should have return 0 written bytes, but returned %d", written)
 	}
-	if err != io.ErrShortWrite {
+	if !errors.Is(err, io.ErrShortWrite) {
 		t.Fatalf("Didn't get expected io.ErrShortWrite error")
 	}
 }

--- a/pkg/system/utimes_unix.go
+++ b/pkg/system/utimes_unix.go
@@ -3,6 +3,7 @@
 package system
 
 import (
+	"errors"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -16,7 +17,7 @@ func LUtimesNano(path string, ts []syscall.Timespec) error {
 		unix.NsecToTimespec(syscall.TimespecToNsec(ts[1])),
 	}
 	err := unix.UtimesNanoAt(unix.AT_FDCWD, path, uts, unix.AT_SYMLINK_NOFOLLOW)
-	if err != nil && err != unix.ENOSYS {
+	if err != nil && !errors.Is(err, unix.ENOSYS) {
 		return err
 	}
 

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -1,6 +1,8 @@
 package system
 
 import (
+	"errors"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -16,7 +18,7 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 	dest := make([]byte, 128)
 	sz, errno := unix.Lgetxattr(path, attr, dest)
 
-	for errno == unix.ERANGE {
+	for errors.Is(errno, unix.ERANGE) {
 		// Buffer too small, use zero-sized buffer to get the actual size
 		sz, errno = unix.Lgetxattr(path, attr, []byte{})
 		if errno != nil {
@@ -27,7 +29,7 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 	}
 
 	switch {
-	case errno == unix.ENODATA:
+	case errors.Is(errno, unix.ENODATA):
 		return nil, nil
 	case errno != nil:
 		return sysErr(errno)

--- a/pkg/tailfile/tailfile.go
+++ b/pkg/tailfile/tailfile.go
@@ -189,7 +189,7 @@ func (s *scanner) Scan(ctx context.Context) bool {
 
 			offset := s.pos - int64(readSize)
 			n, err := s.r.ReadAt(s.buf[:readSize], offset)
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				s.err = err
 				return false
 			}

--- a/pkg/tailfile/tailfile_test.go
+++ b/pkg/tailfile/tailfile_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -130,10 +131,10 @@ truncated line`)
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := TailFile(f, -1); err != ErrNonPositiveLinesNumber {
+	if _, err := TailFile(f, -1); !errors.Is(err, ErrNonPositiveLinesNumber) {
 		t.Fatalf("Expected ErrNonPositiveLinesNumber, got %v", err)
 	}
-	if _, err := TailFile(f, 0); err != ErrNonPositiveLinesNumber {
+	if _, err := TailFile(f, 0); !errors.Is(err, ErrNonPositiveLinesNumber) {
 		t.Fatalf("Expected ErrNonPositiveLinesNumber, got %s", err)
 	}
 }
@@ -255,7 +256,7 @@ func TestNewTailReader(t *testing.T) {
 							return
 						}
 						if len(test.data) == 0 {
-							assert.Assert(t, err == ErrNonPositiveLinesNumber, err)
+							assert.Assert(t, errors.Is(err, ErrNonPositiveLinesNumber), err)
 							return
 						}
 
@@ -285,7 +286,7 @@ func TestNewTailReader(t *testing.T) {
 			assert.Check(t, string(data) == "b", string(data))
 
 			_, _, err = rdr.ReadLine()
-			assert.Assert(t, err == io.EOF, err)
+			assert.Assert(t, errors.Is(err, io.EOF), err)
 		})
 	})
 	t.Run("truncated last line", func(t *testing.T) {
@@ -304,7 +305,7 @@ func TestNewTailReader(t *testing.T) {
 			assert.Check(t, string(data) == "b", string(data))
 
 			_, _, err = rdr.ReadLine()
-			assert.Assert(t, err == io.EOF, err)
+			assert.Assert(t, errors.Is(err, io.EOF), err)
 		})
 	})
 
@@ -320,7 +321,7 @@ func TestNewTailReader(t *testing.T) {
 			assert.Check(t, string(data) == "b", string(data))
 
 			_, _, err = rdr.ReadLine()
-			assert.Assert(t, err == io.EOF, err)
+			assert.Assert(t, errors.Is(err, io.EOF), err)
 		})
 	})
 }

--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -208,7 +208,7 @@ func (ts *tarSum) Read(buf []byte) (int, error) {
 
 	n, err := ts.tarR.Read(buf2)
 	if err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			if _, err := ts.h.Write(buf2[:n]); err != nil {
 				return 0, err
 			}

--- a/pkg/tarsum/tarsum_test.go
+++ b/pkg/tarsum/tarsum_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -545,7 +546,7 @@ func renderSumForHeader(v Version, h *tar.Header, data []byte) (string, error) {
 	tr := tar.NewReader(ts)
 	for {
 		hdr, err := tr.Next()
-		if hdr == nil || err == io.EOF {
+		if hdr == nil || errors.Is(err, io.EOF) {
 			// Signals the end of the archive.
 			break
 		}

--- a/pkg/tarsum/versioning_test.go
+++ b/pkg/tarsum/versioning_test.go
@@ -2,6 +2,7 @@ package tarsum
 
 import (
 	"archive/tar"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -74,7 +75,7 @@ func TestGetVersion(t *testing.T) {
 	// test one that does not exist, to ensure it errors
 	str := "weak+md5:abcdeabcde"
 	_, err := GetVersionFromTarsum(str)
-	if err != ErrNotVersion {
+	if !errors.Is(err, ErrNotVersion) {
 		t.Fatalf("%q : %s", err, str)
 	}
 }

--- a/plugin/v2/settable_test.go
+++ b/plugin/v2/settable_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -23,7 +24,7 @@ func TestNewSettable(t *testing.T) {
 
 	for _, c := range contexts {
 		s, err := newSettable(c.arg)
-		if err != c.err {
+		if !errors.Is(err, c.err) {
 			t.Fatalf("expected error to be %v, got %v", c.err, err)
 		}
 
@@ -61,7 +62,7 @@ func TestIsSettable(t *testing.T) {
 	for _, c := range contexts {
 		if res, err := c.set.isSettable(c.allowedSettableFields, c.settable); res != c.result {
 			t.Fatalf("expected result to be %t, got %t", c.result, res)
-		} else if err != c.err {
+		} else if !errors.Is(err, c.err) {
 			t.Fatalf("expected error to be %v, got %v", c.err, err)
 		}
 	}

--- a/quota/projectquota.go
+++ b/quota/projectquota.go
@@ -413,11 +413,11 @@ func makeBackingFsDev(home string) (string, error) {
 	// Re-create just in case someone copied the home directory over to a new device
 	unix.Unlink(backingFsBlockDev)
 	err := unix.Mknod(backingFsBlockDev, unix.S_IFBLK|0o600, int(stat.Dev))
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		return backingFsBlockDev, nil
 
-	case unix.ENOSYS, unix.EPERM:
+	case errors.Is(err, unix.ENOSYS), errors.Is(err, unix.EPERM):
 		return "", ErrQuotaNotSupported
 
 	default:

--- a/quota/projectquota_test.go
+++ b/quota/projectquota_test.go
@@ -3,6 +3,7 @@
 package quota
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -62,7 +63,7 @@ func testBiggerThanQuota(t *testing.T, ctrl *Control, homeDir, testDir, testSubD
 	biggerThanQuotaFile := filepath.Join(testSubDir, "bigger-than-quota")
 	err := os.WriteFile(biggerThanQuotaFile, make([]byte, testQuotaSize+1), 0o644)
 	assert.ErrorContains(t, err, "")
-	if err == io.ErrShortWrite {
+	if errors.Is(err, io.ErrShortWrite) {
 		assert.NilError(t, os.Remove(biggerThanQuotaFile))
 	}
 }

--- a/reference/store_test.go
+++ b/reference/store_test.go
@@ -2,6 +2,7 @@ package reference
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -228,7 +229,7 @@ func TestAddDeleteGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not parse reference: %v", err)
 	}
-	if _, err = store.Get(nonExistRepo); err != ErrDoesNotExist {
+	if _, err = store.Get(nonExistRepo); !errors.Is(err, ErrDoesNotExist) {
 		t.Fatal("Expected ErrDoesNotExist from Get")
 	}
 
@@ -237,7 +238,7 @@ func TestAddDeleteGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not parse reference: %v", err)
 	}
-	if _, err = store.Get(nonExistTag); err != ErrDoesNotExist {
+	if _, err = store.Get(nonExistTag); !errors.Is(err, ErrDoesNotExist) {
 		t.Fatal("Expected ErrDoesNotExist from Get")
 	}
 
@@ -289,12 +290,12 @@ func TestAddDeleteGet(t *testing.T) {
 	}
 
 	// Delete should return ErrDoesNotExist for a nonexistent repo
-	if _, err = store.Delete(nonExistRepo); err != ErrDoesNotExist {
+	if _, err = store.Delete(nonExistRepo); !errors.Is(err, ErrDoesNotExist) {
 		t.Fatal("Expected ErrDoesNotExist from Delete")
 	}
 
 	// Delete should return ErrDoesNotExist for a nonexistent tag
-	if _, err = store.Delete(nonExistTag); err != ErrDoesNotExist {
+	if _, err = store.Delete(nonExistTag); !errors.Is(err, ErrDoesNotExist) {
 		t.Fatal("Expected ErrDoesNotExist from Delete")
 	}
 
@@ -302,19 +303,19 @@ func TestAddDeleteGet(t *testing.T) {
 	if deleted, err := store.Delete(ref1); err != nil || !deleted {
 		t.Fatal("Delete failed")
 	}
-	if _, err := store.Get(ref1); err != ErrDoesNotExist {
+	if _, err := store.Get(ref1); !errors.Is(err, ErrDoesNotExist) {
 		t.Fatal("Expected ErrDoesNotExist from Get")
 	}
 	if deleted, err := store.Delete(ref5); err != nil || !deleted {
 		t.Fatal("Delete failed")
 	}
-	if _, err := store.Get(ref5); err != ErrDoesNotExist {
+	if _, err := store.Get(ref5); !errors.Is(err, ErrDoesNotExist) {
 		t.Fatal("Expected ErrDoesNotExist from Get")
 	}
 	if deleted, err := store.Delete(nameOnly); err != nil || !deleted {
 		t.Fatal("Delete failed")
 	}
-	if _, err := store.Get(nameOnly); err != ErrDoesNotExist {
+	if _, err := store.Get(nameOnly); !errors.Is(err, ErrDoesNotExist) {
 		t.Fatal("Expected ErrDoesNotExist from Get")
 	}
 }

--- a/registry/resumable/resumablerequestreader.go
+++ b/registry/resumable/resumablerequestreader.go
@@ -2,6 +2,7 @@ package resumable
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,7 +78,7 @@ func (r *requestReader) Read(p []byte) (n int, _ error) {
 	if err != nil {
 		r.cleanUpResponse()
 	}
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		log.G(context.TODO()).Infof("encountered error during pull and clearing it before resume: %s", err)
 		err = nil
 	}

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -693,7 +693,7 @@ func (d *Daemon) Stop(t testing.TB) {
 	t.Helper()
 	err := d.StopWithError()
 	if err != nil {
-		if err != errDaemonNotStarted {
+		if !errors.Is(err, errDaemonNotStarted) {
 			t.Fatalf("[%s] error while stopping the daemon: %v", d.id, err)
 		} else {
 			t.Logf("[%s] daemon is not started", d.id)

--- a/testutil/daemon/daemon_linux.go
+++ b/testutil/daemon/daemon_linux.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,7 +20,7 @@ func cleanupNetworkNamespace(t testing.TB, d *Daemon) {
 	// cleaned up when a new daemon is instantiated with a
 	// new exec root.
 	filepath.WalkDir(filepath.Join(d.execRoot, "netns"), func(path string, _ os.DirEntry, _ error) error {
-		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && err != unix.EINVAL && err != unix.ENOENT {
+		if err := unix.Unmount(path, unix.MNT_DETACH); err != nil && !errors.Is(err, unix.EINVAL) && !errors.Is(err, unix.ENOENT) {
 			t.Logf("[%s] unmount of %s failed: %v", d.id, path, err)
 		}
 		os.Remove(path)

--- a/volume/service/errors.go
+++ b/volume/service/errors.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"strings"
 )
 
@@ -101,5 +102,5 @@ func isErr(err error, expected error) bool {
 		}
 		return false
 	}
-	return err == expected
+	return errors.Is(err, expected)
 }

--- a/volume/service/restore.go
+++ b/volume/service/restore.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/containerd/log"
@@ -35,7 +36,7 @@ func (s *VolumeStore) restore() {
 			var err error
 			if meta.Driver != "" {
 				v, err = lookupVolume(ctx, s.drivers, meta.Driver, meta.Name)
-				if err != nil && err != errNoSuchVolume {
+				if err != nil && !errors.Is(err, errNoSuchVolume) {
 					log.G(ctx).WithError(err).WithField("driver", meta.Driver).WithField("volume", meta.Name).Warn("Error restoring volume")
 					return
 				}
@@ -47,7 +48,7 @@ func (s *VolumeStore) restore() {
 			} else {
 				v, err = s.getVolume(ctx, meta.Name, meta.Driver)
 				if err != nil {
-					if err == errNoSuchVolume {
+					if errors.Is(err, errNoSuchVolume) {
 						chRemove <- &meta
 					}
 					return


### PR DESCRIPTION
**- What I did**

Enables [errorlint](https://golangci-lint.run/usage/linters/#errorlint) linter with `comparison` rule and fixes issues. The `errorf`, `errorf-multi` and `assert` rules are disabled because it requires a number of changes that deserves a dedicated PR

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

