### PR TITLE
fix: increase cloudwatch max size per event to 1 MB

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -60,7 +60,7 @@ const (
 	// Unicode replacement character (U+FFFD), which is a 3-byte sequence in UTF-8.  To compensate for that and to avoid
 	// splitting valid UTF-8 characters into invalid byte sequences, we calculate the length of each event assuming that
 	// this replacement happens.
-	maximumBytesPerEvent = 262144 - perEventBytes
+	maximumBytesPerEvent = 1048576 - perEventBytes
 
 	credentialsEndpoint = "http://169.254.170.2" //nolint:gosec // G101: Potential hardcoded credentials
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I increased the log event max change from 256KB to 1MB

**- How I did it**

**- How to verify it**
Unit Testing

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
 increase cloudwatch max size per event to 1 MB
```

**- A picture of a cute animal (not mandatory but encouraged)**

