### PR TITLE
fix some linting issues

### DIFF
--- a/container/stream/unbuffered_test.go
+++ b/container/stream/unbuffered_test.go
@@ -120,7 +120,10 @@ func TestRaceUnbuffered(t *testing.T) {
 		writer.Add(devNullCloser(0))
 		c <- true
 	}()
-	writer.Write([]byte("hello"))
+	_, err := writer.Write([]byte("hello"))
+	if err != nil {
+		t.Error(err)
+	}
 	<-c
 }
 

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -166,15 +166,12 @@ func (i *ImageService) resolveImage(ctx context.Context, refOrID string) (c8dima
 		return imgs[0], nil
 	}
 
+	// Try resolve by name:tag
 	ref := reference.TagNameOnly(parsed.(reference.Named)).String()
-	img, err := i.images.Get(ctx, ref)
-	if err == nil {
+	if img, err := i.images.Get(ctx, ref); err == nil {
 		return img, nil
-	} else {
-		// TODO(containerd): error translation can use common function
-		if !cerrdefs.IsNotFound(err) {
-			return c8dimages.Image{}, err
-		}
+	} else if !cerrdefs.IsNotFound(err) {
+		return c8dimages.Image{}, err
 	}
 
 	// If the identifier could be a short ID, attempt to match.

--- a/daemon/logger/loggerutils/logfile.go
+++ b/daemon/logger/loggerutils/logfile.go
@@ -371,7 +371,7 @@ func (w *LogFile) Close() error {
 	close(w.closed)
 	// Wait until any in-progress rotation is complete.
 	w.rotateMu.Lock()
-	w.rotateMu.Unlock() //nolint:staticcheck,gocritic
+	defer w.rotateMu.Unlock()
 	return nil
 }
 

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -167,11 +167,12 @@ func windowsValidateAbsolute(p string) error {
 }
 
 func windowsDetectMountType(p string) mount.Type {
-	if strings.HasPrefix(p, `\\.\pipe\`) {
+	switch {
+	case strings.HasPrefix(p, `\\.\pipe\`):
 		return mount.TypeNamedPipe
-	} else if hostDirRegexp.MatchString(p) {
+	case hostDirRegexp.MatchString(p):
 		return mount.TypeBind
-	} else {
+	default:
 		return mount.TypeVolume
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50082#discussion_r2128520245
- and some other PRs; had these stashed locally

### daemon/containerd: ImageService.resolveImage: cleanup resolve by name:tag

- scope variables locally to the if/else if
- use if/else if to try to make it more clear it's a "best effort" before
  falling through to other ways of resolving the image reference
- remove outdated TODO, now that containerd errdefs can be used for either
  moby, or containerd error definitions.


### container/stream: TestRaceUnbuffered: put unused testing.T to use

Some linters were complaining about the testing.T not being used; put
it to use to silence the linter.


### volume/mounts: windowsDetectMountType: rewrite using switch

Mostly for readability, and to avoid linters suggesting to move the
default condition outside of the if/else.



### daemon/logger/loggerutils: use defer to fix gocritic "badlock" linter

    daemon/logger/loggerutils/logfile.go:374:2: badLock: defer is missing, mutex is unlocked immediately (gocritic)
        w.rotateMu.Unlock()
        ^




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

