### PR TITLE
api: ContainerCreate: warn on port bindings with no proto

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -22,7 +22,7 @@ consumes:
 basePath: "/v1.50"
 info:
   title: "Docker Engine API"
-  version: "1.50"
+  version: "1.51"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,14 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.51 API changes
+
+[Docker Engine API v1.51](https://docs.docker.com/reference/api/engine/version/v1.51/) documentation
+
+* Deprecated: The keys in `HostConfig.PortBindings` in `POST /containers/create`
+  should always specify the port protocol. Starting with v1.51, the API returns
+  a warning when that's not the case. This will be a hard error in v1.52.
+
 ## v1.50 API changes
 
 [Docker Engine API v1.50](https://docs.docker.com/reference/api/engine/version/v1.50/) documentation


### PR DESCRIPTION
**- What I did**

So far, the API was liberal about the port bindings it accepted. For instance invalid container ports (the keys in `HostConfig.PortBindings`) or ports with no protocol specified were accepted. In the latter case, the Engine would default to 'tcp'.

However, this wasn't documented in the API spec, leading to interoprability issues since one cannot solely rely on the API docs to know which formats are accepted.

Moreover, the Engine requires all container ports specified in `HostConfig.PortBindings` to have an entry matching exactly in `Config.ExposedPorts`. For instance, you can't specify `8080` in one, and `8080/tcp` in the other, although both are equivalent.

Finally, when the starting a container, the Engine always puts the container port _with_ the protocol fragment set in `NetworkSettings.Ports` but it doesn't touch `Config.ExposedPorts` and `HostConfig.PortBindings` leading to inconsistent ContainerInspect responses.

Address that by considering port bindings with no proto specified invalid, and return a warning on invalid PBs for all API version < v1.52.

Starting with v1.52, this will become a hard error and ContainerCreate will fail.

**- How to verify it**

A new integration test is added to the `network` test suite.

**- Human readable description for the release notes**

```markdown changelog
- Deprecate container ports with no protocol specified in `POST /containers/create` requests.
```

