### PR TITLE
gha: lower timeouts on "build" and "merge" steps

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -91,7 +91,7 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 20 # guardrails timeout for the whole job
     needs:
       - validate-dco
       - prepare
@@ -167,7 +167,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-24.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 40 # guardrails timeout for the whole job
     needs:
       - build
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && github.event_name != 'pull_request' && github.repository == 'moby/moby'


### PR DESCRIPTION
We had some runs timeout after 120 minutes; expected duration is much lower than that, so let's lower the timeout to make actions fail faster.


**- A picture of a cute animal (not mandatory but encouraged)**

