### PR TITLE
nftables: per-network rules

### DIFF
--- a/libnetwork/drivers/bridge/internal/iptabler/testdata/.gitattributes
+++ b/libnetwork/drivers/bridge/internal/iptabler/testdata/.gitattributes
@@ -1,0 +1,1 @@
+*.golden linguist-generated=true

--- a/libnetwork/drivers/bridge/internal/nftabler/network.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/network.go
@@ -4,14 +4,19 @@ package nftabler
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/internal/cleanups"
 	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
+	"github.com/docker/docker/libnetwork/internal/nftables"
+	"go.opentelemetry.io/otel"
 )
 
 type network struct {
-	config firewaller.NetworkConfig
-	fw     *nftabler
+	config  firewaller.NetworkConfig
+	cleaner func(ctx context.Context) error
+	fw      *nftabler
 }
 
 func (nft *nftabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig) (_ firewaller.Network, retErr error) {
@@ -19,14 +24,245 @@ func (nft *nftabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig
 		fw:     nft,
 		config: nc,
 	}
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{"bridge": n.config.IfName}))
+
+	var cleaner cleanups.Composite
+	defer func() {
+		if err := cleaner.Call(ctx); err != nil {
+			log.G(ctx).WithError(err).Warn("Failed to clean up nftables rules for network")
+		}
+	}()
+
+	if n.fw.config.IPv4 {
+		clean, err := n.configure(ctx, nft.table4, n.config.Config4)
+		if err != nil {
+			return nil, err
+		}
+		if clean != nil {
+			cleaner.Add(clean)
+		}
+	}
+	if n.fw.config.IPv6 {
+		clean, err := n.configure(ctx, nft.table6, n.config.Config6)
+		if err != nil {
+			return nil, err
+		}
+		if clean != nil {
+			cleaner.Add(clean)
+		}
+	}
+
+	n.cleaner = cleaner.Release()
 	return n, nil
 }
 
+func (n *network) configure(ctx context.Context, table nftables.TableRef, conf firewaller.NetworkConfigFam) (func(context.Context) error, error) {
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".newNetwork."+string(table.Family()))
+	defer span.End()
+
+	if !conf.Prefix.IsValid() {
+		return nil, nil
+	}
+
+	var cleanup cleanups.Composite
+	defer cleanup.Call(ctx)
+	var applied bool
+	cleanup.Add(func(ctx context.Context) error {
+		if applied {
+			return nftApply(ctx, table)
+		}
+		return nil
+	})
+
+	// Filter chain
+
+	fwdInChain := table.Chain(ctx, chainFilterFwdIn(n.config.IfName))
+	cleanup.Add(func(ctx context.Context) error { return table.DeleteChain(ctx, chainFilterFwdIn(n.config.IfName)) })
+	fwdOutChain := table.Chain(ctx, chainFilterFwdOut(n.config.IfName))
+	cleanup.Add(func(ctx context.Context) error { return table.DeleteChain(ctx, chainFilterFwdOut(n.config.IfName)) })
+
+	cf, err := table.InterfaceVMap(ctx, filtFwdInVMap).AddElementCf(ctx, n.config.IfName, "jump "+chainFilterFwdIn(n.config.IfName))
+	if err != nil {
+		return nil, fmt.Errorf("adding filter-forward jump for %s to %q: %w", conf.Prefix, chainFilterFwdIn(n.config.IfName), err)
+	}
+	cleanup.Add(cf)
+
+	cf, err = table.InterfaceVMap(ctx, filtFwdOutVMap).AddElementCf(ctx, n.config.IfName, "jump "+chainFilterFwdOut(n.config.IfName))
+	if err != nil {
+		return nil, fmt.Errorf("adding filter-forward jump for %s to %q: %w", conf.Prefix, chainFilterFwdOut(n.config.IfName), err)
+	}
+	cleanup.Add(cf)
+
+	// NAT chain
+
+	natPostroutingIn := table.Chain(ctx, chainNatPostRtIn(n.config.IfName))
+	cleanup.Add(func(ctx context.Context) error { return table.DeleteChain(ctx, chainNatPostRtIn(n.config.IfName)) })
+	cf, err = table.InterfaceVMap(ctx, natPostroutingInVMap).AddElementCf(ctx, n.config.IfName, "jump "+chainNatPostRtIn(n.config.IfName))
+	if err != nil {
+		return nil, fmt.Errorf("adding postrouting ingress jump for %s to %q: %w", conf.Prefix, chainNatPostRtIn(n.config.IfName), err)
+	}
+	cleanup.Add(cf)
+
+	natPostroutingOut := table.Chain(ctx, chainNatPostRtOut(n.config.IfName))
+	cleanup.Add(func(ctx context.Context) error { return table.DeleteChain(ctx, chainNatPostRtOut(n.config.IfName)) })
+	cf, err = table.InterfaceVMap(ctx, natPostroutingOutVMap).AddElementCf(ctx, n.config.IfName, "jump "+chainNatPostRtOut(n.config.IfName))
+	if err != nil {
+		return nil, fmt.Errorf("adding postrouting egress jump for %s to %q: %w", conf.Prefix, chainNatPostRtOut(n.config.IfName), err)
+	}
+	cleanup.Add(cf)
+
+	// Conntrack
+
+	cf, err = fwdInChain.AppendRuleCf(ctx, initialRuleGroup, "ct state established,related counter accept")
+	if err != nil {
+		return nil, fmt.Errorf("adding conntrack ingress rule for %q: %w", n.config.IfName, err)
+	}
+	cleanup.Add(cf)
+
+	cf, err = fwdOutChain.AppendRuleCf(ctx, initialRuleGroup, "ct state established,related counter accept")
+	if err != nil {
+		return nil, fmt.Errorf("adding conntrack egress rule for %q: %w", n.config.IfName, err)
+	}
+	cleanup.Add(cf)
+
+	iccVerdict := "accept"
+	if !n.config.ICC {
+		iccVerdict = "drop"
+	}
+
+	if n.config.Internal {
+		// Drop anything that's not from this network.
+		cf, err = fwdInChain.AppendRuleCf(ctx, initialRuleGroup,
+			`iifname != %s counter drop comment "INTERNAL NETWORK INGRESS"`, n.config.IfName)
+		if err != nil {
+			return nil, fmt.Errorf("adding INTERNAL NETWORK ingress rule for %q: %w", n.config.IfName, err)
+		}
+		cleanup.Add(cf)
+
+		cf, err = fwdOutChain.AppendRuleCf(ctx, initialRuleGroup,
+			`oifname != %s counter drop comment "INTERNAL NETWORK EGRESS"`, n.config.IfName)
+		if err != nil {
+			return nil, fmt.Errorf("adding INTERNAL NETWORK egress rule for %q: %w", n.config.IfName, err)
+		}
+		cleanup.Add(cf)
+
+		// Accept or drop Inter-Container Communication.
+		cf, err = fwdInChain.AppendRuleCf(ctx, fwdInICCRuleGroup, "counter %s comment ICC", iccVerdict)
+		if err != nil {
+			return nil, fmt.Errorf("adding ICC ingress rule for %q: %w", n.config.IfName, err)
+		}
+		cleanup.Add(cf)
+	} else {
+		// Inter-Container Communication
+		cf, err = fwdInChain.AppendRuleCf(ctx, fwdInICCRuleGroup, "iifname == %s counter %s comment ICC",
+			n.config.IfName, iccVerdict)
+		if err != nil {
+			return nil, fmt.Errorf("adding ICC rule for %q: %w", n.config.IfName, err)
+		}
+		cleanup.Add(cf)
+
+		// Outgoing traffic
+		cf, err = fwdOutChain.AppendRuleCf(ctx, initialRuleGroup, "counter accept comment OUTGOING")
+		if err != nil {
+			return nil, fmt.Errorf("adding OUTGOING rule for %q: %w", n.config.IfName, err)
+		}
+		cleanup.Add(cf)
+
+		// Incoming traffic
+		if conf.Unprotected {
+			cf, err = fwdInChain.AppendRuleCf(ctx, fwdInFinalRuleGroup, `counter accept comment "UNPROTECTED"`)
+			if err != nil {
+				return nil, fmt.Errorf("adding UNPROTECTED for %q: %w", n.config.IfName, err)
+			}
+			cleanup.Add(cf)
+		} else {
+			cf, err = fwdInChain.AppendRuleCf(ctx, fwdInFinalRuleGroup, `counter drop comment "UNPUBLISHED PORT DROP"`)
+			if err != nil {
+				return nil, fmt.Errorf("adding UNPUBLISHED PORT DROP for %q: %w", n.config.IfName, err)
+			}
+			cleanup.Add(cf)
+		}
+
+		// ICMP
+		if conf.Routed {
+			rule := "ip protocol icmp"
+			if table.Family() == nftables.IPv6 {
+				rule = "meta l4proto ipv6-icmp"
+			}
+			cf, err = fwdInChain.AppendRuleCf(ctx, initialRuleGroup, rule+" counter accept comment ICMP")
+			if err != nil {
+				return nil, fmt.Errorf("adding ICMP rule for %q: %w", n.config.IfName, err)
+			}
+			cleanup.Add(cf)
+		}
+
+		// Masquerade / SNAT - masquerade picks a source IP address based on next-hop, SNAT uses conf.HostIP.
+		natPostroutingVerdict := "masquerade"
+		natPostroutingComment := "MASQUERADE"
+		if conf.HostIP.IsValid() {
+			natPostroutingVerdict = "snat to " + conf.HostIP.Unmap().String()
+			natPostroutingComment = "SNAT"
+		}
+		if n.config.Masquerade && !conf.Routed {
+			cf, err = natPostroutingOut.AppendRuleCf(ctx, initialRuleGroup, `oifname != %s %s saddr %s counter %s comment "%s"`,
+				n.config.IfName, table.Family(), conf.Prefix, natPostroutingVerdict, natPostroutingComment)
+			if err != nil {
+				return nil, fmt.Errorf("adding NAT rule for %q: %w", n.config.IfName, err)
+			}
+			cleanup.Add(cf)
+		}
+		if n.fw.config.Hairpin {
+			// Masquerade/SNAT traffic from localhost.
+			cf, err = natPostroutingIn.AppendRuleCf(ctx, initialRuleGroup, `fib saddr type local counter %s comment "%s FROM HOST"`,
+				natPostroutingVerdict, natPostroutingComment)
+			if err != nil {
+				return nil, fmt.Errorf("adding NAT local rule for %q: %w", n.config.IfName, err)
+			}
+			cleanup.Add(cf)
+		}
+	}
+
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{
+		"bridge": n.config.IfName,
+		"family": table.Family(),
+	}))
+	if err := nftApply(ctx, table); err != nil {
+		return nil, fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
+	}
+	applied = true
+
+	return cleanup.Release(), nil
+}
+
 func (n *network) ReapplyNetworkLevelRules(ctx context.Context) error {
+	// A firewalld reload doesn't delete nftables rules, this function is not needed.
 	log.G(ctx).Warn("ReapplyNetworkLevelRules is not implemented for nftables")
 	return nil
 }
 
 func (n *network) DelNetworkLevelRules(ctx context.Context) error {
+	if n.cleaner != nil {
+		ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{"bridge": n.config.IfName}))
+		if err := n.cleaner(ctx); err != nil {
+			log.G(ctx).WithError(err).Warn("Failed to remove network rules for network")
+		}
+		n.cleaner = nil
+	}
 	return nil
+}
+
+func chainFilterFwdIn(ifName string) string {
+	return "filter-forward-in__" + ifName
+}
+
+func chainFilterFwdOut(ifName string) string {
+	return "filter-forward-out__" + ifName
+}
+
+func chainNatPostRtOut(ifName string) string {
+	return "nat-postrouting-out__" + ifName
+}
+
+func chainNatPostRtIn(ifName string) string {
+	return "nat-postrouting-in__" + ifName
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -33,6 +33,11 @@ const (
 	initialRuleGroup nftables.RuleGroup = iota
 )
 
+const (
+	fwdInICCRuleGroup = iota + initialRuleGroup + 1
+	fwdInFinalRuleGroup
+)
+
 type nftabler struct {
 	config firewaller.Config
 	table4 nftables.TableRef

--- a/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -81,7 +81,7 @@ func (nft *nftabler) getTable(ipv firewaller.IPVersion) nftables.TableRef {
 
 func (nft *nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
 	table := nft.getTable(ipv)
-	if err := table.Chain(forwardChain).SetPolicy("drop"); err != nil {
+	if err := table.Chain(ctx, forwardChain).SetPolicy("drop"); err != nil {
 		return err
 	}
 	return nftApply(ctx, table)
@@ -104,7 +104,7 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 	// So, packets that aren't related to docker don't need to traverse any per-network filter forward
 	// rules - and packets that are entering or leaving docker networks only need to traverse rules
 	// related to those networks.
-	fwdChain, err := table.BaseChain(forwardChain,
+	fwdChain, err := table.BaseChain(ctx, forwardChain,
 		nftables.BaseChainTypeFilter,
 		nftables.BaseChainHookForward,
 		nftables.BaseChainPriorityFilter)
@@ -112,51 +112,51 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
 	// Instantiate the verdict maps and add the jumps.
-	_ = table.InterfaceVMap(filtFwdInVMap)
-	if err := fwdChain.AppendRule(initialRuleGroup, "oifname vmap @"+filtFwdInVMap); err != nil {
+	_ = table.InterfaceVMap(ctx, filtFwdInVMap)
+	if err := fwdChain.AppendRule(ctx, initialRuleGroup, "oifname vmap @"+filtFwdInVMap); err != nil {
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
-	_ = table.InterfaceVMap(filtFwdOutVMap)
-	if err := fwdChain.AppendRule(initialRuleGroup, "iifname vmap @"+filtFwdOutVMap); err != nil {
+	_ = table.InterfaceVMap(ctx, filtFwdOutVMap)
+	if err := fwdChain.AppendRule(ctx, initialRuleGroup, "iifname vmap @"+filtFwdOutVMap); err != nil {
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
 
 	// Set up the NAT postrouting base chain.
 	//
 	// Like the filter-forward chain, its only rules are jumps to network-specific ingress and egress chains.
-	natPostRtChain, err := table.BaseChain(postroutingChain,
+	natPostRtChain, err := table.BaseChain(ctx, postroutingChain,
 		nftables.BaseChainTypeNAT,
 		nftables.BaseChainHookPostrouting,
 		nftables.BaseChainPrioritySrcNAT)
 	if err != nil {
 		return nftables.TableRef{}, err
 	}
-	_ = table.InterfaceVMap(natPostroutingOutVMap)
-	if err := natPostRtChain.AppendRule(initialRuleGroup, "iifname vmap @"+natPostroutingOutVMap); err != nil {
+	_ = table.InterfaceVMap(ctx, natPostroutingOutVMap)
+	if err := natPostRtChain.AppendRule(ctx, initialRuleGroup, "iifname vmap @"+natPostroutingOutVMap); err != nil {
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
-	_ = table.InterfaceVMap(natPostroutingInVMap)
-	if err := natPostRtChain.AppendRule(initialRuleGroup, "oifname vmap @"+natPostroutingInVMap); err != nil {
+	_ = table.InterfaceVMap(ctx, natPostroutingInVMap)
+	if err := natPostRtChain.AppendRule(ctx, initialRuleGroup, "oifname vmap @"+natPostroutingInVMap); err != nil {
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
 
 	// Instantiate natChain, for the NAT prerouting and output base chains to jump to.
-	_ = table.Chain(natChain)
+	_ = table.Chain(ctx, natChain)
 
 	// Set up the NAT prerouting base chain.
-	natPreRtChain, err := table.BaseChain(preroutingChain,
+	natPreRtChain, err := table.BaseChain(ctx, preroutingChain,
 		nftables.BaseChainTypeNAT,
 		nftables.BaseChainHookPrerouting,
 		nftables.BaseChainPriorityDstNAT)
 	if err != nil {
 		return nftables.TableRef{}, err
 	}
-	if err := natPreRtChain.AppendRule(initialRuleGroup, "fib daddr type local counter jump "+natChain); err != nil {
+	if err := natPreRtChain.AppendRule(ctx, initialRuleGroup, "fib daddr type local counter jump "+natChain); err != nil {
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
 
 	// Set up the NAT output base chain
-	natOutputChain, err := table.BaseChain(outputChain,
+	natOutputChain, err := table.BaseChain(ctx, outputChain,
 		nftables.BaseChainTypeNAT,
 		nftables.BaseChainHookOutput,
 		nftables.BaseChainPriorityDstNAT)
@@ -172,12 +172,12 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 			skipLoopback = "ip6 daddr != ::1 "
 		}
 	}
-	if err := natOutputChain.AppendRule(initialRuleGroup, skipLoopback+"fib daddr type local counter jump "+natChain); err != nil {
+	if err := natOutputChain.AppendRule(ctx, initialRuleGroup, skipLoopback+"fib daddr type local counter jump "+natChain); err != nil {
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
 
 	// Set up the raw prerouting base chain
-	if _, err := table.BaseChain(rawPreroutingChain,
+	if _, err := table.BaseChain(ctx, rawPreroutingChain,
 		nftables.BaseChainTypeFilter,
 		nftables.BaseChainHookPrerouting,
 		nftables.BaseChainPriorityRaw); err != nil {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/.gitattributes
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/.gitattributes
@@ -1,0 +1,1 @@
+*.golden linguist-generated=true

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 drop comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 drop comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 drop comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -43,5 +47,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 accept comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 accept comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=true,icc=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 accept comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,23 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 masquerade comment "MASQUERADE"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip saddr 192.168.0.0/24 counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 accept comment "UNPROTECTED"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
+		oifname != "br-dummy" ip6 saddr fd49:efd7:54aa::/64 counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT"
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,24 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
+		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		counter packets 0 bytes 0 accept comment "OUTGOING"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=false,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 drop comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=false__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 drop comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=false__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 drop comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=true,wsl2mirrored=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 accept comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=true__ip.golden
@@ -1,18 +1,22 @@
 table ip docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 accept comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=true,icc=true__ip6.golden
@@ -1,18 +1,22 @@
 table ip6 docker-bridges {
 	map filter-forward-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-in__br-dummy }
 	}
 
 	map filter-forward-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump filter-forward-out__br-dummy }
 	}
 
 	map nat-postrouting-in-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-in__br-dummy }
 	}
 
 	map nat-postrouting-out-jumps {
 		type ifname : verdict
+		elements = { "br-dummy" : jump nat-postrouting-out__br-dummy }
 	}
 
 	chain filter-FORWARD {
@@ -42,5 +46,22 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+	}
+
+	chain filter-forward-in__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		iifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK INGRESS"
+		counter packets 0 bytes 0 accept comment "ICC"
+	}
+
+	chain filter-forward-out__br-dummy {
+		ct state established,related counter packets 0 bytes 0 accept
+		oifname != "br-dummy" counter packets 0 bytes 0 drop comment "INTERNAL NETWORK EGRESS"
+	}
+
+	chain nat-postrouting-in__br-dummy {
+	}
+
+	chain nat-postrouting-out__br-dummy {
 	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/wsl2.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/wsl2.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/libnetwork/internal/nftables"
 )
 
-// mirroredWSL2Workaround adds  IPv4 NAT rule if docker's host Linux appears to
+// mirroredWSL2Workaround adds IPv4 NAT rule if docker's host Linux appears to
 // be a guest running under WSL2 in with mirrored mode networking.
 // https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking
 //
@@ -44,5 +44,6 @@ func mirroredWSL2Workaround(ctx context.Context, table nftables.TableRef) error 
 	if table.Family() != nftables.IPv4 {
 		return nil
 	}
-	return table.Chain(natChain).AppendRule(initialRuleGroup, `iifname "loopback0" ip daddr 127.0.0.0/8 counter return`)
+	return table.Chain(ctx, natChain).AppendRule(ctx,
+		initialRuleGroup, `iifname "loopback0" ip daddr 127.0.0.0/8 counter return`)
 }

--- a/libnetwork/internal/nftables/nftables_linux_test.go
+++ b/libnetwork/internal/nftables/nftables_linux_test.go
@@ -58,6 +58,7 @@ func TestTable(t *testing.T) {
 
 func TestChain(t *testing.T) {
 	defer testSetup(t)()
+	ctx := context.Background()
 
 	// Create a table.
 	tbl, err := NewTable(IPv4, "this_is_a_table")
@@ -65,68 +66,68 @@ func TestChain(t *testing.T) {
 
 	// Create a base chain.
 	const bcName = "this_is_a_base_chain"
-	bc1, err := tbl.BaseChain(bcName, BaseChainTypeFilter, BaseChainHookForward, BaseChainPriorityFilter+10)
+	bc1, err := tbl.BaseChain(ctx, bcName, BaseChainTypeFilter, BaseChainHookForward, BaseChainPriorityFilter+10)
 	assert.NilError(t, err)
 
 	// Check that it's an error to add a new base chain with the same name.
-	_, err = tbl.BaseChain(bcName, BaseChainTypeNAT, BaseChainHookPrerouting, BaseChainPriorityDstNAT)
+	_, err = tbl.BaseChain(ctx, bcName, BaseChainTypeNAT, BaseChainHookPrerouting, BaseChainPriorityDstNAT)
 	assert.Check(t, is.ErrorContains(err, "already exists"))
 
 	// Add a rule.
-	err = bc1.AppendRule(0, "counter")
+	err = bc1.AppendRule(ctx, 0, "counter")
 	assert.NilError(t, err)
 
 	// Add a regular chain.
 	const regularChainName = "this_is_a_regular_chain"
-	_ = tbl.Chain(regularChainName)
+	_ = tbl.Chain(ctx, regularChainName)
 
 	// Add a rule to the regular chain, use string formatting and a func retrieved
 	// from the table.
-	f := tbl.ChainUpdateFunc(regularChainName, true)
-	err = f(0, "counter %s", "accept")
+	f := tbl.ChainUpdateFunc(ctx, regularChainName, true)
+	err = f(ctx, 0, "counter %s", "accept")
 	assert.Check(t, err)
 
 	// Fetch the base chain by name.
-	bc1 = tbl.Chain(bcName)
+	bc1 = tbl.Chain(ctx, bcName)
 
 	// Add another rule to the base chain, using the newly-retrieved handle.
-	err = bc1.AppendRule(0, "jump %s", regularChainName)
+	err = bc1.AppendRule(ctx, 0, "jump %s", regularChainName)
 	assert.Check(t, err)
 
 	// Update nftables and check what happened.
 	applyAndCheck(t, tbl, t.Name()+"_created.golden")
 
 	// Delete a rule from the base chain.
-	f = tbl.ChainUpdateFunc(bcName, false)
-	err = f(0, "counter")
+	f = tbl.ChainUpdateFunc(ctx, bcName, false)
+	err = f(ctx, 0, "counter")
 	assert.Check(t, err)
 
 	// Check it's an error to delete that rule again. This time, call the delete
 	// function directly on a newly retrieved handle.
-	err = tbl.Chain(bcName).DeleteRule(0, "counter")
+	err = tbl.Chain(ctx, bcName).DeleteRule(ctx, 0, "counter")
 	assert.Check(t, is.ErrorContains(err, "does not exist"))
 
 	// Update the base chain's policy.
-	err = tbl.Chain(bcName).SetPolicy("drop")
+	err = tbl.Chain(ctx, bcName).SetPolicy("drop")
 	assert.Check(t, err)
 
 	// Check it's an error to set a policy on a regular chain.
-	err = tbl.Chain(regularChainName).SetPolicy("drop")
+	err = tbl.Chain(ctx, regularChainName).SetPolicy("drop")
 	assert.Check(t, is.ErrorContains(err, "not a base chain"))
 
 	// Update nftables and check what happened.
 	applyAndCheck(t, tbl, t.Name()+"_modified.golden")
 
 	// Delete the base chain.
-	err = tbl.DeleteChain(bcName)
+	err = tbl.DeleteChain(ctx, bcName)
 	assert.Check(t, err)
 
 	// Delete the regular chain.
-	err = tbl.DeleteChain(regularChainName)
+	err = tbl.DeleteChain(ctx, regularChainName)
 	assert.Check(t, err)
 
 	// Check that it's an error to delete it again.
-	err = tbl.DeleteChain(regularChainName)
+	err = tbl.DeleteChain(ctx, regularChainName)
 	assert.Check(t, is.ErrorContains(err, "does not exist"))
 
 	// Update nftables and check what happened.
@@ -135,19 +136,20 @@ func TestChain(t *testing.T) {
 
 func TestChainRuleGroups(t *testing.T) {
 	defer testSetup(t)()
+	ctx := context.Background()
 
 	tbl, err := NewTable(IPv4, "testtable")
 	assert.NilError(t, err)
-	c := tbl.Chain("testchain")
-	err = c.AppendRule(100, "hello100")
+	c := tbl.Chain(ctx, "testchain")
+	err = c.AppendRule(ctx, 100, "hello100")
 	assert.Check(t, err)
-	err = c.AppendRule(200, "hello200")
+	err = c.AppendRule(ctx, 200, "hello200")
 	assert.Check(t, err)
-	err = c.AppendRule(100, "hello101")
+	err = c.AppendRule(ctx, 100, "hello101")
 	assert.Check(t, err)
-	err = c.AppendRule(200, "hello201")
+	err = c.AppendRule(ctx, 200, "hello201")
 	assert.Check(t, err)
-	err = c.AppendRule(100, "hello102")
+	err = c.AppendRule(ctx, 100, "hello102")
 	assert.Check(t, err)
 
 	assert.Check(t, is.DeepEqual(c.c.Rules(), []string{
@@ -158,6 +160,7 @@ func TestChainRuleGroups(t *testing.T) {
 
 func TestVMap(t *testing.T) {
 	defer testSetup(t)()
+	ctx := context.Background()
 
 	// Create a table.
 	tbl, err := NewTable(IPv6, "this_is_a_table")
@@ -165,32 +168,32 @@ func TestVMap(t *testing.T) {
 
 	// Create a verdict map.
 	const mapName = "this_is_a_vmap"
-	m := tbl.InterfaceVMap(mapName)
+	m := tbl.InterfaceVMap(ctx, mapName)
 
 	// Add an element.
-	err = m.AddElement("eth0", "return")
+	err = m.AddElement(ctx, "eth0", "return")
 	assert.Check(t, err)
 
 	// Check that it's an error to add the element again.
-	err = m.AddElement("eth0", "return")
+	err = m.AddElement(ctx, "eth0", "return")
 	assert.Check(t, is.ErrorContains(err, "already contains element"))
 
 	// Fetch the existing vmap.
-	m = tbl.InterfaceVMap(mapName)
+	m = tbl.InterfaceVMap(ctx, mapName)
 
 	// Add another element.
-	err = m.AddElement("eth1", "drop")
+	err = m.AddElement(ctx, "eth1", "drop")
 	assert.Check(t, err)
 
 	// Update nftables and check what happened.
 	applyAndCheck(t, tbl, t.Name()+"_created.golden")
 
 	// Delete an element.
-	err = m.DeleteElement("eth1")
+	err = m.DeleteElement(ctx, "eth1")
 	assert.Check(t, err)
 
 	// Check it's an error to delete it again.
-	err = m.DeleteElement("eth1")
+	err = m.DeleteElement(ctx, "eth1")
 	assert.Check(t, is.ErrorContains(err, "does not contain element"))
 
 	// Update nftables and check what happened.
@@ -199,6 +202,7 @@ func TestVMap(t *testing.T) {
 
 func TestSet(t *testing.T) {
 	defer testSetup(t)()
+	ctx := context.Background()
 
 	// Create v4 and v6 tables.
 	tbl4, err := NewTable(IPv4, "table4")
@@ -207,19 +211,19 @@ func TestSet(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Create a set in each table.
-	s4 := tbl4.PrefixSet("set4")
-	s6 := tbl6.PrefixSet("set6")
+	s4 := tbl4.PrefixSet(ctx, "set4")
+	s6 := tbl6.PrefixSet(ctx, "set6")
 
 	// Add elements to each set.
-	err = s4.AddElement("192.0.2.1/24")
+	err = s4.AddElement(ctx, "192.0.2.1/24")
 	assert.Check(t, err)
-	err = s6.AddElement("2001:db8::1/64")
+	err = s6.AddElement(ctx, "2001:db8::1/64")
 	assert.Check(t, err)
 
 	// Check it's an error to add those elements again.
-	err = s4.AddElement("192.0.2.1/24")
+	err = s4.AddElement(ctx, "192.0.2.1/24")
 	assert.Check(t, is.ErrorContains(err, "already contains element"))
-	err = s6.AddElement("2001:db8::1/64")
+	err = s6.AddElement(ctx, "2001:db8::1/64")
 	assert.Check(t, is.ErrorContains(err, "already contains element"))
 
 	// Update nftables and check what happened.
@@ -227,15 +231,15 @@ func TestSet(t *testing.T) {
 	applyAndCheck(t, tbl6, t.Name()+"_created46.golden")
 
 	// Delete elements.
-	err = s4.DeleteElement("192.0.2.1/24")
+	err = s4.DeleteElement(ctx, "192.0.2.1/24")
 	assert.Check(t, err)
-	err = s6.DeleteElement("2001:db8::1/64")
+	err = s6.DeleteElement(ctx, "2001:db8::1/64")
 	assert.Check(t, err)
 
 	// Check it's an error to delete those elements again.
-	err = s4.DeleteElement("192.0.2.1/24")
+	err = s4.DeleteElement(ctx, "192.0.2.1/24")
 	assert.Check(t, is.ErrorContains(err, "does not contain element"))
-	err = s6.DeleteElement("2001:db8::1/64")
+	err = s6.DeleteElement(ctx, "2001:db8::1/64")
 	assert.Check(t, is.ErrorContains(err, "does not contain element"))
 
 	// Update nftables and check what happened.
@@ -245,21 +249,22 @@ func TestSet(t *testing.T) {
 
 func TestReload(t *testing.T) {
 	defer testSetup(t)()
+	ctx := context.Background()
 
 	// Create a table with some stuff in it.
 	const tableName = "this_is_a_table"
 	tbl, err := NewTable(IPv4, tableName)
 	assert.NilError(t, err)
-	bc, err := tbl.BaseChain("a_base_chain", BaseChainTypeFilter, BaseChainHookForward, BaseChainPriorityFilter)
+	bc, err := tbl.BaseChain(ctx, "a_base_chain", BaseChainTypeFilter, BaseChainHookForward, BaseChainPriorityFilter)
 	assert.NilError(t, err)
-	err = bc.AppendRule(0, "counter")
+	err = bc.AppendRule(ctx, 0, "counter")
 	assert.NilError(t, err)
-	m := tbl.InterfaceVMap("this_is_a_vmap")
-	err = m.AddElement("eth0", "return")
+	m := tbl.InterfaceVMap(ctx, "this_is_a_vmap")
+	err = m.AddElement(ctx, "eth0", "return")
 	assert.Check(t, err)
-	err = m.AddElement("eth1", "return")
+	err = m.AddElement(ctx, "eth1", "return")
 	assert.Check(t, err)
-	err = tbl.PrefixSet("set4").AddElement("192.0.2.0/24")
+	err = tbl.PrefixSet(ctx, "set4").AddElement(ctx, "192.0.2.0/24")
 	assert.Check(t, err)
 	applyAndCheck(t, tbl, t.Name()+"_created.golden")
 
@@ -284,7 +289,7 @@ func TestReload(t *testing.T) {
 
 	// Check implicit/recovery reload - only deleting something that's gone missing
 	// from a vmap/set will trigger this.
-	err = m.DeleteElement("eth1")
+	err = m.DeleteElement(ctx, "eth1")
 	assert.Check(t, err)
 	applyAndCheck(t, tbl, t.Name()+"_recovered.golden")
 }

--- a/libnetwork/resolver_unix.go
+++ b/libnetwork/resolver_unix.go
@@ -98,25 +98,25 @@ func (r *Resolver) setupNftablesNAT(ctx context.Context, laddr, ltcpaddr, resolv
 		return err
 	}
 
-	dnatChain, err := table.BaseChain("dns-dnat", nftables.BaseChainTypeNAT, nftables.BaseChainHookOutput, nftables.BaseChainPriorityDstNAT)
+	dnatChain, err := table.BaseChain(ctx, "dns-dnat", nftables.BaseChainTypeNAT, nftables.BaseChainHookOutput, nftables.BaseChainPriorityDstNAT)
 	if err != nil {
 		return err
 	}
-	if err := dnatChain.AppendRule(0, "ip daddr %s udp dport %s counter dnat to %s", resolverIP, dnsPort, laddr); err != nil {
+	if err := dnatChain.AppendRule(ctx, 0, "ip daddr %s udp dport %s counter dnat to %s", resolverIP, dnsPort, laddr); err != nil {
 		return err
 	}
-	if err := dnatChain.AppendRule(0, "ip daddr %s tcp dport %s counter dnat to %s", resolverIP, dnsPort, ltcpaddr); err != nil {
+	if err := dnatChain.AppendRule(ctx, 0, "ip daddr %s tcp dport %s counter dnat to %s", resolverIP, dnsPort, ltcpaddr); err != nil {
 		return err
 	}
 
-	snatChain, err := table.BaseChain("dns-snat", nftables.BaseChainTypeNAT, nftables.BaseChainHookPostrouting, nftables.BaseChainPrioritySrcNAT)
+	snatChain, err := table.BaseChain(ctx, "dns-snat", nftables.BaseChainTypeNAT, nftables.BaseChainHookPostrouting, nftables.BaseChainPrioritySrcNAT)
 	if err != nil {
 		return err
 	}
-	if err := snatChain.AppendRule(0, "ip saddr %s udp sport %s counter snat to :%s", resolverIP, ipPort, dnsPort); err != nil {
+	if err := snatChain.AppendRule(ctx, 0, "ip saddr %s udp sport %s counter snat to :%s", resolverIP, ipPort, dnsPort); err != nil {
 		return err
 	}
-	if err := snatChain.AppendRule(0, "ip saddr %s tcp sport %s counter snat to :%s", resolverIP, tcpPort, dnsPort); err != nil {
+	if err := snatChain.AppendRule(ctx, 0, "ip saddr %s tcp sport %s counter snat to :%s", resolverIP, tcpPort, dnsPort); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49636

Implement `firewaller.NewNetwork` and `firewaller.Network.DelNetworkLevelRules` in the `nftabler`.

There's some description of the (current view of) the final state of the bridge driver's nftables rules at:
- https://github.com/robmry/moby/blob/nftables/integration/network/bridge/nftablesdoc/index.md

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```
