### PR TITLE
nftables: per-endpoint rules

### DIFF
--- a/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
@@ -4,13 +4,63 @@ package nftabler
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
+	"strings"
+
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
+	"github.com/docker/docker/libnetwork/internal/nftables"
 )
 
 func (n *network) AddEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
-	return nil
+	return n.modEndpoint(ctx, epIPv4, epIPv6, true)
 }
 
 func (n *network) DelEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
+	return n.modEndpoint(ctx, epIPv4, epIPv6, false)
+}
+
+func (n *network) modEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr, enable bool) error {
+	if n.fw.config.IPv4 && epIPv4.IsValid() {
+		if err := n.filterDirectAccess(ctx, n.fw.table4, n.config.Config4, epIPv4, enable); err != nil {
+			return err
+		}
+		if err := nftApply(ctx, n.fw.table4); err != nil {
+			return fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
+		}
+	}
+	if n.fw.config.IPv6 && epIPv6.IsValid() {
+		if err := n.filterDirectAccess(ctx, n.fw.table6, n.config.Config6, epIPv6, enable); err != nil {
+			return err
+		}
+		if err := nftApply(ctx, n.fw.table6); err != nil {
+			return fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
+		}
+	}
 	return nil
+}
+
+// filterDirectAccess drops packets addressed directly to the container's IP address,
+// when direct routing is not permitted by network configuration.
+//
+// It is a no-op if:
+//   - gateway mode is "nat-unprotected" or "routed".
+//   - direct routing is enabled at the daemon level.
+//   - "raw" rules are disabled (possibly because the host doesn't have the necessary
+//     kernel support).
+//
+// Packets originating on the bridge's own interface and addressed directly to the
+// container are allowed - the host always has direct access to its own containers
+// (it doesn't need to use the port mapped to its own addresses, although it can).
+//
+// "Trusted interfaces" are treated in the same way as the bridge itself.
+func (n *network) filterDirectAccess(ctx context.Context, table nftables.TableRef, conf firewaller.NetworkConfigFam, epIP netip.Addr, enable bool) error {
+	if n.config.Internal || conf.Unprotected || conf.Routed || n.fw.config.AllowDirectRouting {
+		return nil
+	}
+	updater := table.ChainUpdateFunc(ctx, rawPreroutingChain, enable)
+	ifNames := strings.Join(n.config.TrustedHostInterfaces, ", ")
+	return updater(ctx, rawPreroutingPortsRuleGroup,
+		`%s daddr %s iifname != { %s, %s } counter drop comment "DROP DIRECT ACCESS"`,
+		table.Family(), epIP, n.config.IfName, ifNames)
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -38,6 +38,10 @@ const (
 	fwdInFinalRuleGroup
 )
 
+const (
+	rawPreroutingPortsRuleGroup = iota + initialRuleGroup + 1
+)
+
 type nftabler struct {
 	config firewaller.Config
 	table4 nftables.TableRef

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -46,6 +46,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -46,6 +46,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
 	}
 
 	chain filter-forward-in__br-dummy {


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49636

Implement `firewaller.Network.AddEndpoint` and `firewaller.Network.DelEndpoint` in the `nftabler`.

There's some description of the (current view of) the final state of the bridge driver's nftables rules at:
- https://github.com/robmry/moby/blob/nftables/integration/network/bridge/nftablesdoc/index.md

**- How I did it**

As pointed out in a community-Slack thread [here, until the thread ages out](https://dockercommunity.slack.com/archives/C7GKACWDV/p1750336225156119?thread_ts=1750277205.644689&cid=C7GKACWDV), the rule added here should probably be per-network rather than per-container. But, we can figure that out, and make the change for iptables/nftables at the same time.

> Florian Apolloner
>   Jun 19th at 1:30 PM
> FWIW it also feels kinda weird that the raw-PREROUTING rules are generated per container and not per network, after all this is a network setting and switching to simply DROP the whole network instead of the individual container IPs might be faster and result in way less rules
> 
> [...]
> 
> Rob Murray
>   Jun 24th at 10:36 PM [...] (As you say, those rules can probably be per-network - I recently changed them to be per-container rather than per-published-port, but probably could/should have gone further).

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```
