### PR TITLE
nftables: per-port rules

### DIFF
--- a/libnetwork/drivers/bridge/internal/iptabler/link.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/link.go
@@ -39,6 +39,7 @@ func (n *network) DelLink(ctx context.Context, parentIP, childIP netip.Addr, por
 				"port":     port.Port,
 				"protocol": port.Proto.String(),
 				"bridge":   n.config.IfName,
+				"error":    err,
 			}).Warn("Failed to remove link between containers")
 		}
 	}

--- a/libnetwork/drivers/bridge/internal/nftabler/link.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/link.go
@@ -4,14 +4,60 @@ package nftabler
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/netip"
 
+	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/types"
 )
 
 func (n *network) AddLink(ctx context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort) error {
+	if !parentIP.IsValid() || parentIP.IsUnspecified() {
+		return errors.New("cannot link to a container with an empty parent IP address")
+	}
+	if !childIP.IsValid() || childIP.IsUnspecified() {
+		return errors.New("cannot link to a container with an empty child IP address")
+	}
+
+	chain := n.fw.table4.Chain(ctx, chainFilterFwdIn(n.config.IfName))
+	for _, port := range ports {
+		for _, rule := range legacyLinkRules(parentIP, childIP, port) {
+			if err := chain.AppendRule(ctx, fwdInLegacyLinksRuleGroup, rule); err != nil {
+				return err
+			}
+		}
+	}
+	if err := nftApply(ctx, n.fw.table4); err != nil {
+		return fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
+	}
 	return nil
 }
 
 func (n *network) DelLink(ctx context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort) {
+	chain := n.fw.table4.Chain(ctx, chainFilterFwdIn(n.config.IfName))
+	for _, port := range ports {
+		for _, rule := range legacyLinkRules(parentIP, childIP, port) {
+			if err := chain.DeleteRule(ctx, fwdInLegacyLinksRuleGroup, rule); err != nil {
+				log.G(ctx).WithFields(log.Fields{
+					"rule":  rule,
+					"error": err,
+				}).Warn("Failed to remove link between containers")
+			}
+		}
+	}
+	if err := nftApply(ctx, n.fw.table4); err != nil {
+		log.G(ctx).WithError(err).Warn("Removing link, failed to update nftables")
+	}
+}
+
+func legacyLinkRules(parentIP, childIP netip.Addr, port types.TransportPort) []string {
+	// TODO(robmry) - could combine rules for each proto by using an anonymous set.
+	return []string{
+		// Match the iptables implementation, but without checking iifname/oifname (not needed
+		// because the addresses belong to the bridge).
+		fmt.Sprintf("ip saddr %s ip daddr %s %s dport %d counter accept", parentIP.Unmap(), childIP.Unmap(), port.Proto, port.Port),
+		// Conntrack will allow responses. So, this must be to allow unsolicited packets from an exposed port.
+		fmt.Sprintf("ip daddr %s ip saddr %s %s sport %d counter accept", parentIP.Unmap(), childIP.Unmap(), port.Proto, port.Port),
+	}
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -34,7 +34,9 @@ const (
 )
 
 const (
-	fwdInICCRuleGroup = iota + initialRuleGroup + 1
+	fwdInLegacyLinksRuleGroup = iota + initialRuleGroup + 1
+	fwdInICCRuleGroup
+	fwdInPortsRuleGroup
 	fwdInFinalRuleGroup
 )
 

--- a/libnetwork/drivers/bridge/internal/nftabler/port.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/port.go
@@ -5,9 +5,22 @@ package nftabler
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
 
+	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
+	"github.com/docker/docker/libnetwork/internal/nftables"
 	"github.com/docker/docker/libnetwork/types"
 )
+
+type pbContext struct {
+	table nftables.TableRef
+	conf  firewaller.NetworkConfigFam
+	ipv   firewaller.IPVersion
+}
 
 func (n *network) AddPorts(ctx context.Context, pbs []types.PortBinding) error {
 	return n.modPorts(ctx, pbs, true)
@@ -18,5 +31,187 @@ func (n *network) DelPorts(ctx context.Context, pbs []types.PortBinding) error {
 }
 
 func (n *network) modPorts(ctx context.Context, pbs []types.PortBinding, enable bool) error {
+	if n.config.Internal {
+		return nil
+	}
+
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{"bridge": n.config.IfName}))
+
+	pbs4, pbs6 := splitByContainerFam(pbs)
+	if n.fw.config.IPv4 && n.config.Config4.Prefix.IsValid() {
+		pbc := pbContext{table: n.fw.table4, conf: n.config.Config4, ipv: firewaller.IPv4}
+		if err := n.setPerPortRules(ctx, pbs4, pbc, enable); err != nil {
+			return err
+		}
+	}
+	if n.fw.config.IPv6 && n.config.Config6.Prefix.IsValid() {
+		pbc := pbContext{table: n.fw.table6, conf: n.config.Config6, ipv: firewaller.IPv6}
+		if err := n.setPerPortRules(ctx, pbs6, pbc, enable); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func splitByContainerFam(pbs []types.PortBinding) ([]types.PortBinding, []types.PortBinding) {
+	var pbs4, pbs6 []types.PortBinding
+	for _, pb := range pbs {
+		if pb.IP.To4() != nil {
+			pbs4 = append(pbs4, pb)
+		} else {
+			pbs6 = append(pbs6, pb)
+		}
+	}
+	return pbs4, pbs6
+}
+
+func (n *network) setPerPortRules(ctx context.Context, pbs []types.PortBinding, pbc pbContext, enable bool) error {
+	if err := n.setPerPortForwarding(ctx, pbs, pbc, enable); err != nil {
+		return err
+	}
+	if err := n.setPerPortDNAT(ctx, pbs, pbc, enable); err != nil {
+		return err
+	}
+	if err := n.setPerPortHairpinMasq(ctx, pbs, pbc, enable); err != nil {
+		return err
+	}
+	if err := n.filterPortMappedOnLoopback(ctx, pbs, pbc, enable); err != nil {
+		return err
+	}
+	if err := nftApply(ctx, pbc.table); err != nil {
+		return fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
+	}
+	return nil
+}
+
+func (n *network) setPerPortForwarding(ctx context.Context, pbs []types.PortBinding, pbc pbContext, enable bool) error {
+	if pbc.conf.Unprotected {
+		return nil
+	}
+	updateFwdIn := pbc.table.ChainUpdateFunc(ctx, chainFilterFwdIn(n.config.IfName), enable)
+	for _, pb := range pbs {
+		// When more than one host port is mapped to a single container port, this will
+		// generate the same rule for each host port. So, ignore duplicates when adding,
+		// and missing rules when removing. (No ref-counting is currently needed because
+		// when bindings are added or removed for an endpoint, they're all added or
+		// removed for an address family. So, a rule that's added more than once will
+		// also be deleted more than once.)
+		//
+		// TODO(robmry) - track port mappings, use that to edit nftables sets when bindings are added/removed.
+		rule := fmt.Sprintf("%s daddr %s %s dport %d counter accept", pbc.table.Family(), pb.IP, pb.Proto, pb.Port)
+		if err := updateFwdIn(ctx, fwdInPortsRuleGroup, rule); err != nil &&
+			!errors.Is(err, nftables.ErrRuleExist) && !errors.Is(err, nftables.ErrRuleNotExist) {
+			return fmt.Errorf("updating forwarding rule for port %s %s:%d/%s on %s, enable=%v: %w",
+				pbc.table.Family(), pb.IP, pb.Port, pb.Proto, n.config.IfName, enable, err)
+		}
+	}
+	return nil
+}
+
+func (n *network) setPerPortDNAT(ctx context.Context, pbs []types.PortBinding, pbc pbContext, enable bool) error {
+	updater := pbc.table.ChainUpdateFunc(ctx, natChain, enable)
+	var proxySkip string
+	if !n.fw.config.Hairpin {
+		proxySkip = fmt.Sprintf("iifname != %s ", n.config.IfName)
+	}
+	var v6LLSkip string
+	if pbc.ipv == firewaller.IPv6 {
+		v6LLSkip = "ip6 saddr != fe80::/10 "
+	}
+	for _, pb := range pbs {
+		// Nothing to do if NAT is disabled.
+		if pb.HostPort == 0 {
+			continue
+		}
+		// If the binding is between containerV4 and hostV6, NAT isn't possible (the mapping
+		// is handled by docker-proxy).
+		if (pb.IP.To4() != nil) != (pb.HostIP.To4() != nil) {
+			continue
+		}
+		var daddrMatch string
+		if !pb.HostIP.IsUnspecified() {
+			daddrMatch = fmt.Sprintf("%s daddr %s ", pbc.table.Family(), pb.HostIP)
+		}
+		rule := fmt.Sprintf("%s%s%s%s dport %d counter dnat to %s comment DNAT",
+			proxySkip, v6LLSkip, daddrMatch, pb.Proto, pb.HostPort,
+			net.JoinHostPort(pb.IP.String(), strconv.Itoa(int(pb.Port))))
+		if err := updater(ctx, initialRuleGroup, rule); err != nil {
+			return fmt.Errorf("adding DNAT for %s %s:%d -> %s:%d/%s on %s: %w",
+				pbc.table.Family(), pb.HostIP, pb.HostPort, pb.IP, pb.Port, pb.Proto, n.config.IfName, err)
+		}
+	}
+	return nil
+}
+
+// setPerPortHairpinMasq allows containers to access their own published ports on the host
+// when hairpin is enabled (no docker-proxy), by masquerading.
+func (n *network) setPerPortHairpinMasq(ctx context.Context, pbs []types.PortBinding, pbc pbContext, enable bool) error {
+	if !n.fw.config.Hairpin {
+		return nil
+	}
+	updater := pbc.table.ChainUpdateFunc(ctx, chainNatPostRtIn(n.config.IfName), enable)
+	for _, pb := range pbs {
+		// Nothing to do if NAT is disabled.
+		if pb.HostPort == 0 {
+			continue
+		}
+		// If the binding is between containerV4 and hostV6, NAT isn't possible (it's
+		// handled by docker-proxy).
+		if (pb.IP.To4() != nil) != (pb.HostIP.To4() != nil) {
+			continue
+		}
+		// When more than one host port is mapped to a single container port, this will
+		// generate the same rule for each host port. So, ignore duplicates when adding,
+		// and missing rules when removing. (No ref-counting is currently needed because
+		// when bindings are added or removed for an endpoint, they're all added or
+		// removed. So, a rule that's added more than once will also be deleted more
+		// than once.)
+		//
+		// TODO(robmry) - track port mappings, use that to edit nftables sets when bindings are added/removed.
+		rule := fmt.Sprintf(`%s saddr %s %s daddr %s %s dport %d counter masquerade comment "MASQ TO OWN PORT"`,
+			pbc.table.Family(), pb.IP, pbc.table.Family(), pb.IP, pb.Proto, pb.Port)
+		if err := updater(ctx, initialRuleGroup, rule); err != nil &&
+			!errors.Is(err, nftables.ErrRuleExist) && !errors.Is(err, nftables.ErrRuleNotExist) {
+			return fmt.Errorf("adding MASQ TO OWN PORT for %d -> %s:%d/%s: %w",
+				pb.Port, pb.IP, pb.Port, pb.Proto, err)
+		}
+	}
+	return nil
+}
+
+// filterPortMappedOnLoopback adds a rule that drops remote connections to ports
+// mapped to loopback addresses.
+//
+// This is a no-op if the portBinding is for IPv6 (IPv6 loopback address is
+// non-routable), or over a network with gw_mode=routed (PBs in routed mode
+// don't map ports on the host).
+func (n *network) filterPortMappedOnLoopback(ctx context.Context, pbs []types.PortBinding, pbc pbContext, enable bool) error {
+	if pbc.ipv == firewaller.IPv6 {
+		return nil
+	}
+	updater := pbc.table.ChainUpdateFunc(ctx, rawPreroutingChain, enable)
+	for _, pb := range pbs {
+		// Nothing to do if not binding to the loopback address.
+		if pb.HostPort == 0 || !pb.HostIP.IsLoopback() {
+			continue
+		}
+		// Mappings from host IPv6 to container IPv4 are handled by docker-proxy.
+		if pb.HostIP.To4() == nil {
+			continue
+		}
+		if n.fw.config.WSL2Mirrored {
+			if err := updater(ctx, rawPreroutingPortsRuleGroup,
+				`iifname loopback0 ip daddr %s %s dport %d counter accept comment "%s"`,
+				pb.HostIP, pb.Proto, pb.HostPort, "ACCEPT WSL2 LOOPBACK"); err != nil {
+				return fmt.Errorf("adding WSL2 loopback rule for %d: %w", pb.HostPort, err)
+			}
+		}
+		if err := updater(ctx, rawPreroutingPortsRuleGroup,
+			`iifname != lo ip daddr %s %s dport %d counter drop comment "DROP REMOTE LOOPBACK"`,
+			pb.HostIP, pb.Proto, pb.HostPort); err != nil {
+			return fmt.Errorf("adding loopback filter rule for %d: %w", pb.HostPort, err)
+		}
+	}
+
 	return nil
 }

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,10 +43,13 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -43,6 +43,7 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -53,6 +54,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -43,16 +43,20 @@ table ip docker-bridges {
 
 	chain nat-prerouting-and-output {
 		iifname "loopback0" ip daddr 127.0.0.0/8 counter packets 0 bytes 0 return
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		iifname != "br-dummy" ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 drop comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 masquerade comment "MASQUERADE FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
 		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,10 +42,13 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -42,10 +42,12 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
@@ -61,6 +63,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -61,6 +62,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -42,6 +42,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -42,16 +42,20 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +66,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -42,16 +42,19 @@ table ip docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 dnat to 192.168.0.2:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 
 	chain filter-forward-in__br-dummy {
 		ct state established,related counter packets 0 bytes 0 accept
 		ip protocol icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +65,7 @@ table ip docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to 192.168.123.0 comment "SNAT FROM HOST"
+		ip saddr 192.168.0.2 ip daddr 192.168.0.2 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {

--- a/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler_hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -42,6 +42,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-prerouting-and-output {
+		ip6 saddr != fe80::/10 ip6 daddr ::1 tcp dport 8080 counter packets 0 bytes 0 dnat to [fd49:efd7:54aa::1]:80 comment "DNAT"
 	}
 
 	chain raw-PREROUTING {
@@ -52,6 +53,7 @@ table ip6 docker-bridges {
 		ct state established,related counter packets 0 bytes 0 accept
 		meta l4proto ipv6-icmp counter packets 0 bytes 0 accept comment "ICMP"
 		iifname "br-dummy" counter packets 0 bytes 0 accept comment "ICC"
+		ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 accept
 		counter packets 0 bytes 0 drop comment "UNPUBLISHED PORT DROP"
 	}
 
@@ -62,6 +64,7 @@ table ip6 docker-bridges {
 
 	chain nat-postrouting-in__br-dummy {
 		fib saddr type local counter packets 0 bytes 0 snat to fd34:d0d4:672f::123 comment "SNAT FROM HOST"
+		ip6 saddr fd49:efd7:54aa::1 ip6 daddr fd49:efd7:54aa::1 tcp dport 80 counter packets 0 bytes 0 masquerade comment "MASQ TO OWN PORT"
 	}
 
 	chain nat-postrouting-out__br-dummy {


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49636

Implement the following in the `nftabler`:
- `firewaller.Network.AddPort`
- `firewaller.Network.DelPort` 
- `firewaller.Network.AddLink`
- `firewaller.Network.DelLink`

There's some description of the (current view of) the final state of the bridge driver's nftables rules at:
- https://github.com/robmry/moby/blob/nftables/integration/network/bridge/nftablesdoc/index.md

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```
