### PR TITLE
[DNM] Add IP Utilization for bridge network

### DIFF
--- a/api/types/network/ipam.go
+++ b/api/types/network/ipam.go
@@ -23,6 +23,16 @@ type IPAMConfig struct {
 	AuxAddress map[string]string `json:"AuxiliaryAddresses,omitempty"`
 }
 
+// IPAMState represents IPAM state
+type IPAMState struct {
+	Subnet  string `json:",omitempty"`
+	IPRange string `json:",omitempty"`
+	// Counter of allocated IPs in the subnet
+	AllocatedIPsInSubnet uint64 `json:",omitempty"`
+	// Counter of allocated IPs in the allocation pool
+	AllocatedIPsInPool uint64 `json:",omitempty"`
+}
+
 type ipFamily string
 
 const (

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -70,6 +70,11 @@ type DisconnectOptions struct {
 	Force     bool
 }
 
+type NetworkState struct {
+	// IPAM state of the network
+	IPAM []IPAMState `json:",omitempty"`
+}
+
 // Inspect is the body of the "get network" http response message.
 type Inspect struct {
 	Name       string                      // Name is the name of the network
@@ -80,6 +85,7 @@ type Inspect struct {
 	EnableIPv4 bool                        // EnableIPv4 represents whether IPv4 is enabled
 	EnableIPv6 bool                        // EnableIPv6 represents whether IPv6 is enabled
 	IPAM       IPAM                        // IPAM is the network's IP Address Management
+	State      *NetworkState               `json:",omitempty"` // State holds the state of the network
 	Internal   bool                        // Internal represents if the network is used internal only
 	Attachable bool                        // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
 	Ingress    bool                        // Ingress indicates the network is providing the routing-mesh for the swarm cluster.

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -637,6 +637,7 @@ func buildNetworkResource(nw *libnetwork.Network) networktypes.Inspect {
 		Driver:     nw.Type(),
 		EnableIPv4: nw.IPv4Enabled(),
 		EnableIPv6: nw.IPv6Enabled(),
+		State:      nw.State(),
 		IPAM:       buildIPAMResources(nw),
 		Internal:   nw.Internal(),
 		Attachable: nw.Attachable(),

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -1621,8 +1621,8 @@ func TestAdvertiseAddresses(t *testing.T) {
 				ctr2Id = ""
 			}
 
-			t.Log("Sleeping for 5s to collect ARP/NA messages...")
-			time.Sleep(5 * time.Second)
+			t.Log("Sleeping for 7s to collect ARP/NA messages...")
+			time.Sleep(7 * time.Second)
 
 			// Check ARP/NA messages received for ctr2's new address (all unsolicited).
 

--- a/libnetwork/cnmallocator/networkallocator_test.go
+++ b/libnetwork/cnmallocator/networkallocator_test.go
@@ -754,6 +754,10 @@ func (a *mockIpam) IsBuiltIn() bool {
 	return true
 }
 
+func (a *mockIpam) UsedAddrs(poolID string) (uint64, uint64, error) {
+	return 0, 0, nil
+}
+
 func TestCorrectlyPassIPAMOptions(t *testing.T) {
 	var err error
 	expectedIpamOptions := map[string]string{"network-name": "freddie"}

--- a/libnetwork/internal/addrset/addrset.go
+++ b/libnetwork/internal/addrset/addrset.go
@@ -204,6 +204,10 @@ func (as *AddrSet) Selected() (selected uint64) {
 	return selected
 }
 
+func (as *AddrSet) Pool() netip.Prefix {
+	return as.pool
+}
+
 func (as *AddrSet) addrsPerBitmap() uint64 {
 	bits := as.pool.Addr().BitLen() - as.pool.Bits()
 	if bits > maxBitsPerBitmap {

--- a/libnetwork/internal/addrset/addrset_test.go
+++ b/libnetwork/internal/addrset/addrset_test.go
@@ -29,6 +29,7 @@ func TestIPv4Pool(t *testing.T) {
 	bm := as.bitmaps[subnet.Masked()]
 	assert.Check(t, is.Equal(bm.Bits(), uint64(65536)))
 	assert.Check(t, is.Equal(bm.Unselected(), uint64(65534)))
+	assert.Check(t, is.Equal(as.Selected(), uint64(2)))
 
 	// Add an address that's already present. Expect an error.
 	err = as.Add(netip.MustParseAddr("10.20.255.255"))
@@ -44,6 +45,7 @@ func TestIPv4Pool(t *testing.T) {
 	err = as.Remove(netip.MustParseAddr("10.20.255.255"))
 	assert.Check(t, err)
 	assert.Check(t, is.Len(as.bitmaps, 0))
+	assert.Check(t, is.Equal(as.Selected(), uint64(0)))
 
 	// Remove an address that isn't in the set (now there's no bitmap). Expect no error.
 	err = as.Remove(netip.MustParseAddr("10.20.30.40"))
@@ -56,6 +58,7 @@ func TestIPv4Pool(t *testing.T) {
 	addr, err = as.AddAny(true)
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(addr, netip.MustParseAddr("10.20.0.1")))
+	assert.Check(t, is.Equal(as.Selected(), uint64(2)))
 
 	// Add any address in a range. It shouldn't matter that host bits are set in the
 	// range. Expect the first address in that range.
@@ -89,6 +92,7 @@ func TestIPv6Pool(t *testing.T) {
 	// Add an address that's already present in the "upper" bitmap. Expect an error.
 	err = as.Add(netip.MustParseAddr("fddd::ff:ffff:ffff:ffff:ffff"))
 	assert.Check(t, is.ErrorIs(err, ErrAllocated))
+	assert.Check(t, is.Equal(as.Selected(), uint64(2)))
 
 	// Remove an address that isn't in the set. Expect no error.
 	err = as.Remove(netip.MustParseAddr("fddd::f:0:0:0:0"))
@@ -100,6 +104,7 @@ func TestIPv6Pool(t *testing.T) {
 	err = as.Remove(netip.MustParseAddr("fddd::ff:ffff:ffff:ffff:ffff"))
 	assert.Check(t, err)
 	assert.Check(t, is.Len(as.bitmaps, 0))
+	assert.Check(t, is.Equal(as.Selected(), uint64(0)))
 
 	// Remove an address that isn't in the set (now there's no bitmap). Expect no error.
 	err = as.Remove(netip.MustParseAddr("fddd::f:0:0:0:0"))
@@ -112,6 +117,7 @@ func TestIPv6Pool(t *testing.T) {
 	addr, err = as.AddAny(true)
 	assert.Check(t, err)
 	assert.Check(t, is.Equal(addr, netip.MustParseAddr("fddd::1")))
+	assert.Check(t, is.Equal(as.Selected(), uint64(2)))
 
 	// Add any address in a range, somewhere in the middle of the pool. Expect the first address in that range.
 	addr, err = as.AddAnyInRange(netip.MustParsePrefix("fddd:0:0:f0::/60"), true)

--- a/libnetwork/ipamapi/contract.go
+++ b/libnetwork/ipamapi/contract.go
@@ -55,6 +55,9 @@ type Ipam interface {
 
 	// IsBuiltIn returns true if it is a built-in driver.
 	IsBuiltIn() bool
+
+	// UsedAddrs returns the number of allocated IPs in the subnet and ip range pool for IPv4
+	UsedAddrs(poolID string) (uint64, uint64, error)
 }
 
 type PoolRequest struct {

--- a/libnetwork/ipams/defaultipam/allocator.go
+++ b/libnetwork/ipams/defaultipam/allocator.go
@@ -319,3 +319,18 @@ func getAddress(base netip.Prefix, addrSet *addrset.AddrSet, prefAddress netip.A
 func (a *Allocator) IsBuiltIn() bool {
 	return true
 }
+
+func (a *Allocator) UsedAddrs(poolID string) (usedIPs, usedAllocationIPs uint64, err error) {
+	log.G(context.TODO()).Debugf("UsedAddrs(%s)", poolID)
+	k, err := PoolIDFromString(poolID)
+	if err != nil {
+		return 0, 0, types.InvalidParameterErrorf("invalid pool id: %s", poolID)
+	}
+
+	aSpace, err := a.getAddrSpace(k.AddressSpace, k.Is6())
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return aSpace.UsedAddrs(k.Subnet)
+}

--- a/libnetwork/ipams/null/null.go
+++ b/libnetwork/ipams/null/null.go
@@ -76,6 +76,10 @@ func (a *allocator) IsBuiltIn() bool {
 	return true
 }
 
+func (a *allocator) UsedAddrs(poolID string) (uint64, uint64, error) {
+	return 0, 0, nil
+}
+
 // Register registers the null ipam driver with r.
 func Register(r ipamapi.Registerer) error {
 	return r.RegisterIpamDriver(DriverName, &allocator{})

--- a/libnetwork/ipams/remote/remote.go
+++ b/libnetwork/ipams/remote/remote.go
@@ -253,3 +253,7 @@ func (a *allocator) ReleaseAddress(poolID string, address net.IP) error {
 func (a *allocator) IsBuiltIn() bool {
 	return false
 }
+
+func (a *allocator) UsedAddrs(poolID string) (uint64, uint64, error) {
+	return 0, 0, nil
+}

--- a/libnetwork/ipams/windowsipam/windowsipam.go
+++ b/libnetwork/ipams/windowsipam/windowsipam.go
@@ -87,3 +87,7 @@ func (a *allocator) ReleaseAddress(poolID string, address net.IP) error {
 func (a *allocator) IsBuiltIn() bool {
 	return true
 }
+
+func (a *allocator) UsedAddrs(poolID string) (uint64, uint64, error) {
+	return 0, 0, nil
+}


### PR DESCRIPTION
**- What I did**

Extend network inspect reply with `State` field which can contain some internal network state.
Currently it has only `IPAM` section which consist 2 new created counters of  allocated IPs:
```[
    {
        "Name": "my",
....
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "192.168.10.0/24",
                    "IPRange": "192.168.10.128/29"
                }
            ]
        },
        "State": {
            "IPAM": [
                {
                    "Subnet": "192.168.10.0/24",
                    "IPRange": "192.168.10.128/29",
                    "AllocatedIPsInSubnet": 3,               <---
                    "AllocatedIPsInPool": 1                     <---
                }
            ]
        },
....
    }
]```

- `AllocatedIPsInSubnet` — The number of IP addresses that have been allocated within the entire subnet.
- `AllocatedIPsInPool` — The number of IP addresses allocated within a specified allocation pool (defined by `ip-range`). If no pool is specified, this value is equal to AllocatedIPsInSubnet.

**- How I did it**
`AllocatedIPsInSubnet` is a cumulative counter exposed to the top layer that reflects the number of allocated IP addresses in a subnet. It corresponds to the value of the unselected counter in the `bitmap` implementation ([sequence.go](https://github.com/moby/moby/blob/master/libnetwork/bitmap/sequence.go#L39)), which tracks how many bits (IP addresses) have been marked as in-use.

`AllocatedIPsInPool` newly added counter in the `PoolData` which exposed to the top layer that reflects the number of allocated IP addresses in an allocation pool.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

