### PR TITLE
libnetwork/networkdb: prioritize local table broadcasts over event rebroadcasts

### DIFF
--- a/libnetwork/networkdb/broadcast.go
+++ b/libnetwork/networkdb/broadcast.go
@@ -142,27 +142,16 @@ func (nDB *NetworkDB) sendTableEvent(event TableEvent_Type, nid string, tname st
 		return err
 	}
 
-	var broadcastQ *memberlist.TransmitLimitedQueue
 	nDB.RLock()
-	thisNodeNetworks, ok := nDB.networks[nDB.config.NodeID]
-	if ok {
-		// The network may have been removed
-		network, networkOk := thisNodeNetworks[nid]
-		if !networkOk {
-			nDB.RUnlock()
-			return nil
-		}
-
-		broadcastQ = network.tableBroadcasts
-	}
+	n, ok := nDB.thisNodeNetworks[nid]
 	nDB.RUnlock()
 
 	// The network may have been removed
-	if broadcastQ == nil {
+	if !ok {
 		return nil
 	}
 
-	broadcastQ.QueueBroadcast(&tableEventMessage{
+	n.tableBroadcasts.QueueBroadcast(&tableEventMessage{
 		msg:   raw,
 		id:    nid,
 		tname: tname,

--- a/libnetwork/networkdb/broadcast.go
+++ b/libnetwork/networkdb/broadcast.go
@@ -159,3 +159,18 @@ func (nDB *NetworkDB) sendTableEvent(event TableEvent_Type, nid string, tname st
 	})
 	return nil
 }
+
+func getBroadcasts(overhead, limit int, queues ...*memberlist.TransmitLimitedQueue) [][]byte {
+	var msgs [][]byte
+	for _, q := range queues {
+		b := q.GetBroadcasts(overhead, limit)
+		for _, m := range b {
+			limit -= overhead + len(m)
+		}
+		msgs = append(msgs, b...)
+		if limit <= 0 {
+			break
+		}
+	}
+	return msgs
+}

--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -469,14 +469,15 @@ func (nDB *NetworkDB) gossip() {
 			continue
 		}
 
-		msgs := network.tableBroadcasts.GetBroadcasts(compoundOverhead, bytesAvail)
+		msgs := getBroadcasts(compoundOverhead, bytesAvail, network.tableBroadcasts, network.tableRebroadcasts)
 		// Collect stats and print the queue info, note this code is here also to have a view of the queues empty
 		network.qMessagesSent.Add(int64(len(msgs)))
 		if printStats {
 			msent := network.qMessagesSent.Swap(0)
-			log.G(context.TODO()).Infof("NetworkDB stats %v(%v) - netID:%s leaving:%t netPeers:%d entries:%d Queue qLen:%d netMsg/s:%d",
+			log.G(context.TODO()).Infof("NetworkDB stats %v(%v) - netID:%s leaving:%t netPeers:%d entries:%d Queue qLen:%d+%d netMsg/s:%d",
 				nDB.config.Hostname, nDB.config.NodeID,
-				nid, network.leaving, network.tableBroadcasts.NumNodes(), network.entriesNumber.Load(), network.tableBroadcasts.NumQueued(),
+				nid, network.leaving, network.tableBroadcasts.NumNodes(), network.entriesNumber.Load(),
+				network.tableBroadcasts.NumQueued(), network.tableRebroadcasts.NumQueued(),
 				msent/int64((nDB.config.StatsPrintPeriod/time.Second)))
 		}
 

--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -369,6 +369,15 @@ func (nDB *NetworkDB) reapState() {
 
 func (nDB *NetworkDB) reapNetworks() {
 	nDB.Lock()
+	for id, n := range nDB.thisNodeNetworks {
+		if n.leaving {
+			if n.reapTime <= 0 {
+				delete(nDB.thisNodeNetworks, id)
+				continue
+			}
+			n.reapTime -= reapPeriod
+		}
+	}
 	for _, nn := range nDB.networks {
 		for id, n := range nn {
 			if n.leaving {
@@ -387,7 +396,7 @@ func (nDB *NetworkDB) reapTableEntries() {
 	var nodeNetworks []string
 	// This is best effort, if the list of network changes will be picked up in the next cycle
 	nDB.RLock()
-	for nid := range nDB.networks[nDB.config.NodeID] {
+	for nid := range nDB.thisNodeNetworks {
 		nodeNetworks = append(nodeNetworks, nid)
 	}
 	nDB.RUnlock()
@@ -430,8 +439,7 @@ func (nDB *NetworkDB) reapTableEntries() {
 func (nDB *NetworkDB) gossip() {
 	networkNodes := make(map[string][]string)
 	nDB.RLock()
-	thisNodeNetworks := nDB.networks[nDB.config.NodeID]
-	for nid := range thisNodeNetworks {
+	for nid := range nDB.thisNodeNetworks {
 		networkNodes[nid] = nDB.networkNodes[nid]
 	}
 	printStats := time.Since(nDB.lastStatsTimestamp) >= nDB.config.StatsPrintPeriod
@@ -451,7 +459,7 @@ func (nDB *NetworkDB) gossip() {
 		bytesAvail := nDB.config.PacketBufferSize - compoundHeaderOverhead
 
 		nDB.RLock()
-		network, ok := thisNodeNetworks[nid]
+		network, ok := nDB.thisNodeNetworks[nid]
 		nDB.RUnlock()
 		if !ok || network == nil {
 			// It is normal for the network to be removed
@@ -461,21 +469,14 @@ func (nDB *NetworkDB) gossip() {
 			continue
 		}
 
-		broadcastQ := network.tableBroadcasts
-
-		if broadcastQ == nil {
-			log.G(context.TODO()).Errorf("Invalid broadcastQ encountered while gossiping for network %s", nid)
-			continue
-		}
-
-		msgs := broadcastQ.GetBroadcasts(compoundOverhead, bytesAvail)
+		msgs := network.tableBroadcasts.GetBroadcasts(compoundOverhead, bytesAvail)
 		// Collect stats and print the queue info, note this code is here also to have a view of the queues empty
 		network.qMessagesSent.Add(int64(len(msgs)))
 		if printStats {
 			msent := network.qMessagesSent.Swap(0)
 			log.G(context.TODO()).Infof("NetworkDB stats %v(%v) - netID:%s leaving:%t netPeers:%d entries:%d Queue qLen:%d netMsg/s:%d",
 				nDB.config.Hostname, nDB.config.NodeID,
-				nid, network.leaving, broadcastQ.NumNodes(), network.entriesNumber.Load(), broadcastQ.NumQueued(),
+				nid, network.leaving, network.tableBroadcasts.NumNodes(), network.entriesNumber.Load(), network.tableBroadcasts.NumQueued(),
 				msent/int64((nDB.config.StatsPrintPeriod/time.Second)))
 		}
 
@@ -510,7 +511,7 @@ func (nDB *NetworkDB) gossip() {
 func (nDB *NetworkDB) bulkSyncTables() {
 	var networks []string
 	nDB.RLock()
-	for nid, network := range nDB.networks[nDB.config.NodeID] {
+	for nid, network := range nDB.thisNodeNetworks {
 		if network.leaving {
 			continue
 		}

--- a/libnetwork/networkdb/delegate.go
+++ b/libnetwork/networkdb/delegate.go
@@ -136,7 +136,6 @@ func (nDB *NetworkDB) handleNetworkEvent(nEvent *NetworkEvent) bool {
 
 	// This remote network join is being seen the first time.
 	nodeNetworks[nEvent.NetworkID] = &network{
-		id:    nEvent.NetworkID,
 		ltime: nEvent.LTime,
 	}
 
@@ -452,10 +451,10 @@ func (d *delegate) LocalState(join bool) []byte {
 	}
 
 	for name, nn := range d.nDB.networks {
-		for _, n := range nn {
+		for nid, n := range nn {
 			pp.Networks = append(pp.Networks, &NetworkEntry{
 				LTime:     n.ltime,
-				NetworkID: n.id,
+				NetworkID: nid,
 				NodeName:  name,
 				Leaving:   n.leaving,
 			})

--- a/libnetwork/networkdb/delegate.go
+++ b/libnetwork/networkdb/delegate.go
@@ -292,11 +292,11 @@ func (nDB *NetworkDB) handleTableMessage(buf []byte, isBulkSync bool) {
 		}
 
 		// if the queue is over the threshold, avoid distributing information coming from TCP sync
-		if isBulkSync && n.tableBroadcasts.NumQueued() > maxQueueLenBroadcastOnSync {
+		if isBulkSync && n.tableRebroadcasts.NumQueued() > maxQueueLenBroadcastOnSync {
 			return
 		}
 
-		n.tableBroadcasts.QueueBroadcast(&tableEventMessage{
+		n.tableRebroadcasts.QueueBroadcast(&tableEventMessage{
 			msg:   buf,
 			id:    tEvent.NetworkID,
 			tname: tEvent.TableName,
@@ -419,14 +419,7 @@ func (d *delegate) NotifyMsg(buf []byte) {
 }
 
 func (d *delegate) GetBroadcasts(overhead, limit int) [][]byte {
-	msgs := d.nDB.networkBroadcasts.GetBroadcasts(overhead, limit)
-	for _, m := range msgs {
-		limit -= overhead + len(m)
-	}
-	if limit > 0 {
-		msgs = append(msgs, d.nDB.nodeBroadcasts.GetBroadcasts(overhead, limit)...)
-	}
-	return msgs
+	return getBroadcasts(overhead, limit, d.nDB.networkBroadcasts, d.nDB.nodeBroadcasts)
 }
 
 func (d *delegate) LocalState(join bool) []byte {

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -128,9 +128,6 @@ type node struct {
 
 // network describes the node/network attachment.
 type network struct {
-	// Network ID
-	id string
-
 	// Lamport time for the latest state of the entry.
 	ltime serf.LamportTime
 
@@ -621,7 +618,7 @@ func (nDB *NetworkDB) JoinNetwork(nid string) error {
 	if ok {
 		entries = n.entriesNumber.Load()
 	}
-	nodeNetworks[nid] = &network{id: nid, ltime: ltime}
+	nodeNetworks[nid] = &network{ltime: ltime}
 	nodeNetworks[nid].entriesNumber.Store(entries)
 	nodeNetworks[nid].tableBroadcasts = &memberlist.TransmitLimitedQueue{
 		NumNodes: func() int {

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -6,10 +6,13 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"text/tabwriter"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/go-events"
@@ -27,7 +30,7 @@ func init() {
 
 func TestMain(m *testing.M) {
 	os.WriteFile("/proc/sys/net/ipv6/conf/lo/disable_ipv6", []byte{'0', '\n'}, 0o644)
-	log.SetLevel("error")
+	log.SetLevel("debug")
 	os.Exit(m.Run())
 }
 
@@ -85,18 +88,14 @@ func (nDB *NetworkDB) verifyNodeExistence(t *testing.T, node string, present boo
 		nDB.RLock()
 		_, ok := nDB.nodes[node]
 		nDB.RUnlock()
-		if present && ok {
-			return
-		}
-
-		if !present && !ok {
+		if present == ok {
 			return
 		}
 
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	t.Errorf("%v(%v): Node existence verification for node %s failed", nDB.config.Hostname, nDB.config.NodeID, node)
+	t.Errorf("%v(%v): expected node %s existence in the cluster = %v, got %v", nDB.config.Hostname, nDB.config.NodeID, node, present, !present)
 }
 
 func (nDB *NetworkDB) verifyNetworkExistence(t *testing.T, node string, id string, present bool) {
@@ -109,6 +108,7 @@ func (nDB *NetworkDB) verifyNetworkExistence(t *testing.T, node string, id strin
 	} else {
 		maxRetries = 80
 	}
+	var ok, leaving bool
 	for i := int64(0); i < maxRetries; i++ {
 		nDB.RLock()
 		var vn *network
@@ -123,35 +123,49 @@ func (nDB *NetworkDB) verifyNetworkExistence(t *testing.T, node string, id strin
 				}
 			}
 		}
-		exists := vn != nil && !vn.leaving
+		ok = vn != nil
+		leaving = ok && vn.leaving
 		nDB.RUnlock()
 
-		if present == exists {
+		if present == (ok && !leaving) {
 			return
 		}
 
 		time.Sleep(sleepInterval)
 	}
 
-	t.Error("Network existence verification failed")
+	if present {
+		t.Errorf("%v(%v): want node %v to be a member of network %q, got that it is not a member (ok=%v, leaving=%v)",
+			nDB.config.Hostname, nDB.config.NodeID, node, id, ok, leaving)
+	} else {
+		t.Errorf("%v(%v): want node %v to not be a member of network %q, got that it is a member (ok=%v, leaving=%v)",
+			nDB.config.Hostname, nDB.config.NodeID, node, id, ok, leaving)
+	}
 }
 
 func (nDB *NetworkDB) verifyEntryExistence(t *testing.T, tname, nid, key, value string, present bool) {
 	t.Helper()
 	n := 80
+	var v []byte
 	for i := 0; i < n; i++ {
-		v, err := nDB.GetEntry(tname, nid, key)
+		var err error
+		v, err = nDB.GetEntry(tname, nid, key)
 		if present && err == nil && string(v) == value {
 			return
 		}
-		if err != nil && !present {
+		if cerrdefs.IsNotFound(err) && !present {
 			return
+		}
+		if err != nil && !cerrdefs.IsNotFound(err) {
+			t.Errorf("%v(%v): unexpected error while getting entry %v/%v in network %q: %v",
+				nDB.config.Hostname, nDB.config.NodeID, tname, key, nid, err)
 		}
 
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	t.Errorf("Entry existence verification test failed for %v(%v)", nDB.config.Hostname, nDB.config.NodeID)
+	t.Errorf("%v(%v): want entry %v/%v in network %q to be (present=%v, value=%q), got (present=%v, value=%q)",
+		nDB.config.Hostname, nDB.config.NodeID, tname, key, nid, present, value, !present, string(v))
 }
 
 func testWatch(t *testing.T, ch chan events.Event, ev interface{}, tname, nid, key, value string) {
@@ -274,6 +288,19 @@ func TestNetworkDBCRUDTableEntry(t *testing.T) {
 	closeNetworkDBInstances(t, dbs)
 }
 
+func (nDB *NetworkDB) dumpTable(t *testing.T, tname string) {
+	t.Helper()
+	var b strings.Builder
+	tw := tabwriter.NewWriter(&b, 10, 1, 1, ' ', 0)
+	tw.Write([]byte("NetworkID\tKey\tValue\tFlags\n"))
+	nDB.WalkTable(tname, func(nid, key string, value []byte, deleting bool) bool {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%v\n", nid, key, string(value), map[bool]string{true: "D"}[deleting])
+		return false
+	})
+	tw.Flush()
+	t.Logf("%s(%s): Table %s:\n%s", nDB.config.Hostname, nDB.config.NodeID, tname, b.String())
+}
+
 func TestNetworkDBCRUDTableEntries(t *testing.T) {
 	dbs := createNetworkDBInstances(t, 2, "node", DefaultConfig())
 
@@ -302,18 +329,24 @@ func TestNetworkDBCRUDTableEntries(t *testing.T) {
 		assert.NilError(t, err)
 	}
 
+	for n := range dbs {
+		dbs[n].dumpTable(t, "test_table")
+	}
+
 	for i := 1; i <= n; i++ {
 		dbs[0].verifyEntryExistence(t, "test_table", "network1",
 			fmt.Sprintf("test_key1%d", i),
 			fmt.Sprintf("test_value1%d", i), true)
-		assert.NilError(t, err)
 	}
 
 	for i := 1; i <= n; i++ {
 		dbs[1].verifyEntryExistence(t, "test_table", "network1",
 			fmt.Sprintf("test_key0%d", i),
 			fmt.Sprintf("test_value0%d", i), true)
-		assert.NilError(t, err)
+	}
+
+	for n := range dbs {
+		dbs[n].dumpTable(t, "test_table")
 	}
 
 	// Verify deletes
@@ -332,13 +365,15 @@ func TestNetworkDBCRUDTableEntries(t *testing.T) {
 	for i := 1; i <= n; i++ {
 		dbs[0].verifyEntryExistence(t, "test_table", "network1",
 			fmt.Sprintf("test_key1%d", i), "", false)
-		assert.NilError(t, err)
 	}
 
 	for i := 1; i <= n; i++ {
 		dbs[1].verifyEntryExistence(t, "test_table", "network1",
 			fmt.Sprintf("test_key0%d", i), "", false)
-		assert.NilError(t, err)
+	}
+
+	for n := range dbs {
+		dbs[n].dumpTable(t, "test_table")
 	}
 
 	closeNetworkDBInstances(t, dbs)

--- a/libnetwork/networkdb/networkdbdiagnostic.go
+++ b/libnetwork/networkdb/networkdbdiagnostic.go
@@ -439,8 +439,7 @@ func (nDB *NetworkDB) dbNetworkStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	nDB.RLock()
-	networks := nDB.networks[nDB.config.NodeID]
-	network, ok := networks[r.Form["nid"][0]]
+	network, ok := nDB.thisNodeNetworks[r.Form["nid"][0]]
 
 	entries := -1
 	qLen := -1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed #50089 

**- How I did it**
The flaky TestNetworkDBCRUDTableEntries only waits long enough for a handful of gossip cycles to execute before it asserts that the entries owned by one node exist on the other nodes. It does not wait long enough for a bulk-sync to be performed between the nodes. The test therefore asserts, effectively, that gossip is sufficient to reliably converge in a lossless network scenario. The flaky test failures are always due to the CREATE event for a single table entry not being propagated through gossip. The stats and debug logs (not committed to this PR for being very spammy with a low signal:noise ratio) revealed that when the test flakes, the CREATE event for the offending entry was enqueued but never received by the other node and the owning node's queue is holding a large number of messages. Rebroadcasts for messages received from other nodes are delaying the broadcasting of the local node's messages.

Improve the convergence rate of NetworkDB by preferentially broadcasting event messages for entries owned by the local node before rebroadcasting received messages. Enqueue the messages for rebroadcasting into a separate queue which is only pulled from if there is space left over in the gossip packet after filling it with local event messages.

**- How to verify it**
```console
$ go test -count=100 -run CRUDTableEntries -failfast ./libnetwork/networkdb
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Improve the convergence rate of NetworkDB, part of the management plane for overlay networking, after bursts of updates.
```

**- A picture of a cute animal (not mandatory but encouraged)**

