### PR TITLE
vendor: github.com/containerd/containerd/v2 v2.1.2

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -27,7 +27,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.4
 	github.com/containerd/cgroups/v3 v3.0.5
 	github.com/containerd/containerd/api v1.9.0
-	github.com/containerd/containerd/v2 v2.1.1
+	github.com/containerd/containerd/v2 v2.1.2
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/errdefs/pkg v0.3.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -125,8 +125,8 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.9.0 h1:HZ/licowTRazus+wt9fM6r/9BQO7S0vD5lMcWspGIg0=
 github.com/containerd/containerd/api v1.9.0/go.mod h1:GhghKFmTR3hNtyznBoQ0EMWr9ju5AqHjcZPsSpTKutI=
-github.com/containerd/containerd/v2 v2.1.1 h1:znnkm7Ajz8lg8BcIPMhc/9yjBRN3B+OkNKqKisKfwwM=
-github.com/containerd/containerd/v2 v2.1.1/go.mod h1:zIfkQj4RIodclYQkX7GSSswSwgP8d/XxDOtOAoSDIGU=
+github.com/containerd/containerd/v2 v2.1.2 h1:4ZQxB+FVYmwXZgpBcKfar6ieppm3KC5C6FRKvtJ6DRU=
+github.com/containerd/containerd/v2 v2.1.2/go.mod h1:8C5QV9djwsYDNhxfTCFjWtTBZrqjditQ4/ghHSYjnHM=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/vendor/github.com/containerd/containerd/v2/core/mount/mount_linux.go
+++ b/vendor/github.com/containerd/containerd/v2/core/mount/mount_linux.go
@@ -459,7 +459,11 @@ func optionsSize(opts []string) int {
 
 func mountAt(chdir string, source, target, fstype string, flags uintptr, data string) error {
 	if chdir == "" {
-		return unix.Mount(source, target, fstype, flags, data)
+		err := unix.Mount(source, target, fstype, flags, data)
+		if err != nil {
+			return fmt.Errorf("mount source: %q, target: %q, fstype: %s, flags: %d, data: %q, err: %w", source, target, fstype, flags, data, err)
+		}
+		return nil
 	}
 
 	ch := make(chan error, 1)
@@ -481,8 +485,11 @@ func mountAt(chdir string, source, target, fstype string, flags uintptr, data st
 			ch <- err
 			return
 		}
-
-		ch <- unix.Mount(source, target, fstype, flags, data)
+		err := unix.Mount(source, target, fstype, flags, data)
+		if err != nil {
+			err = fmt.Errorf("mount source: %q, target: %q, fstype: %s, flags: %d, data: %q, err: %w", source, target, fstype, flags, data, err)
+		}
+		ch <- err
 	}()
 	return <-ch
 }

--- a/vendor/github.com/containerd/containerd/v2/core/unpack/unpacker.go
+++ b/vendor/github.com/containerd/containerd/v2/core/unpack/unpacker.go
@@ -428,7 +428,7 @@ func (u *Unpacker) unpack(
 		diff, err := a.Apply(ctx, desc, mounts, unpack.ApplyOpts...)
 		if err != nil {
 			cleanup.Do(ctx, abort)
-			return fmt.Errorf("failed to extract layer %s: %w", diffIDs[i], err)
+			return fmt.Errorf("failed to extract layer (%s %s) to %s as %q: %w", desc.MediaType, desc.Digest, unpack.SnapshotterKey, key, err)
 		}
 		if diff.Digest != diffIDs[i] {
 			cleanup.Do(ctx, abort)

--- a/vendor/github.com/containerd/containerd/v2/version/version.go
+++ b/vendor/github.com/containerd/containerd/v2/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.1.1+unknown"
+	Version = "2.1.2+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -323,7 +323,7 @@ github.com/containerd/containerd/api/types/runc/options
 github.com/containerd/containerd/api/types/runtimeoptions/v1
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/api/types/transfer
-# github.com/containerd/containerd/v2 v2.1.1
+# github.com/containerd/containerd/v2 v2.1.2
 ## explicit; go 1.23.0
 github.com/containerd/containerd/v2/client
 github.com/containerd/containerd/v2/cmd/containerd/server/config


### PR DESCRIPTION
no significant changes other than error messages that now contain more information

full diff: https://github.com/containerd/containerd/compare/v2.1.1...v2.1.2


**- A picture of a cute animal (not mandatory but encouraged)**

