### PR TITLE
[28.x backport] pkg/idtools: deprecate IdentityMapping, Identity.Chown

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -304,7 +304,7 @@ linters:
           - staticcheck
 
         # FIXME(thaJeztah): ignoring these transitional utilities until BuildKit is vendored with https://github.com/moby/moby/pull/49743
-      - text: "SA1019: idtools\\.(ToUserIdentityMapping|FromUserIdentityMapping) is deprecated"
+      - text: "SA1019: idtools\\.(ToUserIdentityMapping|FromUserIdentityMapping|IdentityMapping) is deprecated"
         linters:
           - staticcheck
 

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -108,12 +108,16 @@ type Identity struct {
 }
 
 // Chown changes the numeric uid and gid of the named file to id.UID and id.GID.
+//
+// Deprecated: this method is deprecated and will be removed in the next release.
 func (id Identity) Chown(name string) error {
 	return os.Chown(name, id.UID, id.GID)
 }
 
 // IdentityMapping contains a mappings of UIDs and GIDs.
 // The zero value represents an empty mapping.
+//
+// Deprecated: this type is deprecated and will be removed in the next release.
 type IdentityMapping struct {
 	UIDMaps []IDMap `json:"UIDMaps"`
 	GIDMaps []IDMap `json:"GIDMaps"`


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/50209

The IdentityMapping and Identity types are still used internally, but should be considered transitional.


(cherry picked from commit b7ef527bdcc200c76273c68ddce06147453191d1)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
pkg/idtools: deprecate `IdentityMapping` and `Identity.Chown`
```

**- A picture of a cute animal (not mandatory but encouraged)**

