### PR TITLE
[28.x backport] api/types/container: deprecate ExecOptions.Detach

### DIFF
--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -18,11 +18,13 @@ type ExecOptions struct {
 	AttachStdin  bool     // Attach the standard input, makes possible user interaction
 	AttachStderr bool     // Attach the standard error
 	AttachStdout bool     // Attach the standard output
-	Detach       bool     // Execute in detach mode
 	DetachKeys   string   // Escape keys for detach
 	Env          []string // Environment variables
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
+
+	// Deprecated: the Detach field is not used, and will be removed in a future release.
+	Detach bool
 }
 
 // ExecStartOptions is a temp struct used by execStart

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -127,9 +127,8 @@ func TestExecResize(t *testing.T) {
 		cmd = []string{"sleep", "240"}
 	}
 	resp, err := apiClient.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
-		Tty:    true, // Windows requires a TTY for the resize to work, otherwise fails with "is not a tty: failed precondition", see https://github.com/moby/moby/pull/48665#issuecomment-2412530345
-		Detach: true,
-		Cmd:    cmd,
+		Tty: true, // Windows requires a TTY for the resize to work, otherwise fails with "is not a tty: failed precondition", see https://github.com/moby/moby/pull/48665#issuecomment-2412530345
+		Cmd: cmd,
 	})
 	assert.NilError(t, err)
 	execID := resp.ID


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/50218

relates to;

- https://github.com/moby/moby/pull/8062
- https://github.com/moby/moby/pull/23759


This field was added in 5130fe5d38837302e72bdc5e4bd1f5fa1df72c7f, which added it for use as intermediate struct when parsing CLI flags (through `runconfig.ParseExec`) in c786a8ee5e9db8f5f609cf8721bd1e1513fb0043.

Commit 9d9dff3d0d9e92adf7c2e59f94c63766659d1d47 rewrote the CLI to use Cobra, and as part of this introduced a separate `execOptions` type in `api/client/container`.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/container: deprecate `ExecOptions.Detach`. This field is not used, and will be removed in a future release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

