### PR TITLE
daemon: LogContainerEventWithAttributes: minor optimisation

### DIFF
--- a/daemon/events.go
+++ b/daemon/events.go
@@ -27,7 +27,7 @@ func (daemon *Daemon) LogContainerEventWithAttributes(container *container.Conta
 	if container.Config.Image != "" {
 		attributes["image"] = container.Config.Image
 	}
-	attributes["name"] = strings.TrimLeft(container.Name, "/")
+	attributes["name"] = strings.TrimPrefix(container.Name, "/")
 	daemon.EventsService.Log(action, events.ContainerEventType, events.Actor{
 		ID:         container.ID,
 		Attributes: attributes,


### PR DESCRIPTION
As we're only expecting a single `/` prefix to be trimmed from the container name, it's better to use `TrimPrefix` than `TrimLeft`, as `TrimPrefix` takes a cut-set to remove any character in the set.

Benchmarking both;

    BenchmarkTrimLeft-10      535364544    2.204  ns/op    0 B/op    0 allocs/op
    BenchmarkTrimPrefix-10   1000000000    0.3148 ns/op    0 B/op    0 allocs/op


**- A picture of a cute animal (not mandatory but encouraged)**

