### PR TITLE
libnet: split ProgramExternalConnectivity/RevokeExternalConnectivity out of driverapi

### DIFF
--- a/libnetwork/cnmallocator/manager.go
+++ b/libnetwork/cnmallocator/manager.go
@@ -70,11 +70,3 @@ func (d *manager) Type() string {
 func (d *manager) IsBuiltIn() bool {
 	return true
 }
-
-func (d *manager) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *manager) RevokeExternalConnectivity(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}

--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -56,14 +56,6 @@ type Driver interface {
 	// Leave method is invoked when a Sandbox detaches from an endpoint.
 	Leave(nid, eid string) error
 
-	// ProgramExternalConnectivity invokes the driver method which does the necessary
-	// programming to allow the external connectivity dictated by the passed options
-	ProgramExternalConnectivity(ctx context.Context, nid, eid string, options map[string]interface{}) error
-
-	// RevokeExternalConnectivity asks the driver to remove any external connectivity
-	// programming that was done so far
-	RevokeExternalConnectivity(nid, eid string) error
-
 	// EventNotify notifies the driver when a CRUD operation has
 	// happened on a table of its interest as soon as this node
 	// receives such an event in the gossip layer. This method is
@@ -85,6 +77,17 @@ type Driver interface {
 
 	// IsBuiltIn returns true if it is a built-in driver
 	IsBuiltIn() bool
+}
+
+// ExtConner is an optional interface for a network driver.
+type ExtConner interface {
+	// ProgramExternalConnectivity invokes the driver method which does the necessary
+	// programming to allow the external connectivity dictated by the passed options
+	ProgramExternalConnectivity(ctx context.Context, nid, eid string, options map[string]interface{}) error
+
+	// RevokeExternalConnectivity asks the driver to remove any external connectivity
+	// programming that was done so far
+	RevokeExternalConnectivity(nid, eid string) error
 }
 
 // GwAllocChecker is an optional interface for a network driver.

--- a/libnetwork/drivers/bridge/brmanager/brmanager.go
+++ b/libnetwork/drivers/bridge/brmanager/brmanager.go
@@ -70,11 +70,3 @@ func (d *driver) Type() string {
 func (d *driver) IsBuiltIn() bool {
 	return true
 }
-
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}

--- a/libnetwork/drivers/host/host.go
+++ b/libnetwork/drivers/host/host.go
@@ -77,14 +77,6 @@ func (d *driver) Leave(nid, eid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
-}
-
 func (d *driver) Type() string {
 	return NetworkType
 }

--- a/libnetwork/drivers/ipvlan/ipvlan.go
+++ b/libnetwork/drivers/ipvlan/ipvlan.go
@@ -3,7 +3,6 @@
 package ipvlan
 
 import (
-	"context"
 	"net"
 	"sync"
 
@@ -95,14 +94,6 @@ func (d *driver) Type() string {
 
 func (d *driver) IsBuiltIn() bool {
 	return true
-}
-
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
 }
 
 func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {

--- a/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
+++ b/libnetwork/drivers/ipvlan/ivmanager/ivmanager.go
@@ -70,11 +70,3 @@ func (d *driver) Type() string {
 func (d *driver) IsBuiltIn() bool {
 	return true
 }
-
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}

--- a/libnetwork/drivers/macvlan/macvlan.go
+++ b/libnetwork/drivers/macvlan/macvlan.go
@@ -3,7 +3,6 @@
 package macvlan
 
 import (
-	"context"
 	"net"
 	"sync"
 
@@ -89,14 +88,6 @@ func (d *driver) Type() string {
 
 func (d *driver) IsBuiltIn() bool {
 	return true
-}
-
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
 }
 
 func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {

--- a/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
+++ b/libnetwork/drivers/macvlan/mvmanager/mvmanager.go
@@ -70,11 +70,3 @@ func (d *driver) Type() string {
 func (d *driver) IsBuiltIn() bool {
 	return true
 }
-
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}

--- a/libnetwork/drivers/null/null.go
+++ b/libnetwork/drivers/null/null.go
@@ -77,14 +77,6 @@ func (d *driver) Leave(nid, eid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
-}
-
 func (d *driver) Type() string {
 	return NetworkType
 }

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -235,14 +235,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
-}
-
 func (n *network) joinSandbox(s *subnet, incJoinCount bool) error {
 	// If there is a race between two go routines here only one will win
 	// the other will wait.

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -206,11 +206,3 @@ func (d *driver) Type() string {
 func (d *driver) IsBuiltIn() bool {
 	return true
 }
-
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return types.NotImplementedErrorf("not implemented")
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return types.NotImplementedErrorf("not implemented")
-}

--- a/libnetwork/drivers/windows/overlay/ov_network_windows.go
+++ b/libnetwork/drivers/windows/overlay/ov_network_windows.go
@@ -212,14 +212,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
-}
-
 func (d *driver) addNetwork(n *network) {
 	d.Lock()
 	d.networks[n.id] = n

--- a/libnetwork/drivers/windows/windows.go
+++ b/libnetwork/drivers/windows/windows.go
@@ -954,14 +954,6 @@ func (d *driver) Leave(nid, eid string) error {
 	return nil
 }
 
-func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
-}
-
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
 	return nil, types.NotImplementedErrorf("not implemented")
 }

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -823,14 +823,6 @@ func (b *badDriver) IsBuiltIn() bool {
 	return false
 }
 
-func (b *badDriver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}) error {
-	return nil
-}
-
-func (b *badDriver) RevokeExternalConnectivity(nid, eid string) error {
-	return nil
-}
-
 func (b *badDriver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
 	return nil, types.NotImplementedErrorf("not implemented")
 }


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/50066

This is split out of https://github.com/moby/moby/pull/50140, which will eventually change the rules for routed mode port publishing.

In order to do that, the interface between libnet and its network drivers needs to change. In particular, ProgramExternalConnectivity and RevokeExternalConnectivity - which are part of interface `driverapi.Driver`, but they're only implemented by the bridge and remote drivers.

**- How I did it**

Moved those two functions out of the `Driver` interface into a new `driverapi.ExtConner` interface, removed the not-implemented implementations, and use the new interface where it's needed.

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```
