### PR TITLE
libnetwork: fix flaky Swarm service DNS

### DIFF
--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -836,7 +836,7 @@ func (n *Network) handleDriverTableEvent(ev events.Event) {
 		tname = event.Table
 		key = event.Key
 		value = event.Value
-		etype = driverapi.Delete
+		etype = driverapi.Update
 	}
 
 	d.EventNotify(etype, n.ID(), tname, key, value)


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
**- How I did it**

- Fixes #50129

When libnetwork receives a watch event for a driver table entry from NetworkDB it passes the event along to the interested driver. This code contains a subtle bug: update events from NetworkDB are passed along to the driver as Delete events! This bug was lying dormant as driver-table entries can only be added by the driver, not updated. Now that NetworkDB broadcasts an UpdateEvent to watchers if the entry is already known to the local NetworkDB, irrespective of whether the event received from the remote peer was a CREATE or UPDATE event, the bug is causing problems. Whenever a remote node replaces an entry in the overlay_peer_table but the intermediate delete state was not received by the local node, the new CREATE event would be translated to an UpdateEvent by NetworkDB and subsequently handled by the overlay driver as if the entry was deleted!

Bubble table UPDATE events up to the network driver as Update events.

**- How to verify it**
By inspection? I can't find a way to reproducibly trigger the buggy behaviour.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

