### PR TITLE
libn/d/overlay: delete FDB entry from AF_BRIDGE

### DIFF
--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -311,7 +311,7 @@ func (d *driver) peerDeleteOp(nid, eid string, peerIP netip.Prefix, peerMac net.
 			return fmt.Errorf("could not find the subnet %q in network %q", peerIP.String(), n.id)
 		}
 		// Remove fdb entry to the bridge for the peer mac
-		if err := sbox.DeleteNeighbor(vtep.AsSlice(), peerMac, osl.WithLinkName(s.vxlanName)); err != nil {
+		if err := sbox.DeleteNeighbor(vtep.AsSlice(), peerMac, osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
 			if _, ok := err.(osl.NeighborSearchError); ok && dbEntries > 0 {
 				// We fall in here if there is a transient state and if the neighbor that is being deleted
 				// was never been configured into the kernel (we allow only 1 configuration at the time per <ip,mac> mapping)
@@ -321,7 +321,7 @@ func (d *driver) peerDeleteOp(nid, eid string, peerIP netip.Prefix, peerMac net.
 		}
 
 		// Delete neighbor entry for the peer IP
-		if err := sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac, osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
+		if err := sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac, osl.WithLinkName(s.vxlanName)); err != nil {
 			return fmt.Errorf("could not delete neighbor entry for nid:%s eid:%s into the sandbox:%v", nid, eid, err)
 		}
 	}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
**- How I did it**

- Updates #50088 
- Fixes #50232 

Starting with commit 0d6e7cd9834878a9003e8184852bd627bead1388 DeleteNeighbor() needs to be called with the same options as the AddNeighbor() call that created the neighbor entry. The calls in peerdb were modified incorrectly, resulting in the deletes failing and leaking neighbor entries. Fix up the DeleteNeighbor calls so that the FDB entry is deleted from the FDB instead of the neighbor table, and the neighbor is deleted from the neighbor table instead of the FDB.

**- How to verify it**

1. Set up a multi-node Swarm cluster.
2. Create a user-defined overlay network.
3. Run a dummy task or basic container connected to the overlay on one of the nodes (henceforth referred to as the node under test) in order to force libnetwork to keep the network namespace around for the duration of the test.
4. Create a Swarm service with tasks attached to the overlay network, scheduled such that at least one task is scheduled on a different node than the node under test.
5. Scale the service up and down, or repeatedly force-update the service -- something to repeatedly connect and disconnect containers from the overlay.
6. Verify that the daemon on the node under test did not log any `Peer delete operation failed` messages.
7. Verify that the ARP table and VXLAN FDB in the overlay network's netns on the node under test are free of stale entries.
   ```
   nsenter --net="/run/docker/netns/1-$(docker network inspect $NETWORK_NAME --format '{{slice .ID 0 10}}')" \
     sh -c 'bridge fdb show brport vxlan0; ip neigh'
   ```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

