### PR TITLE
Update containerd to v2.1.3

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -27,7 +27,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.4
 	github.com/containerd/cgroups/v3 v3.0.5
 	github.com/containerd/containerd/api v1.9.0
-	github.com/containerd/containerd/v2 v2.1.2
+	github.com/containerd/containerd/v2 v2.1.3
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/errdefs/pkg v0.3.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -125,8 +125,8 @@ github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/q
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd/api v1.9.0 h1:HZ/licowTRazus+wt9fM6r/9BQO7S0vD5lMcWspGIg0=
 github.com/containerd/containerd/api v1.9.0/go.mod h1:GhghKFmTR3hNtyznBoQ0EMWr9ju5AqHjcZPsSpTKutI=
-github.com/containerd/containerd/v2 v2.1.2 h1:4ZQxB+FVYmwXZgpBcKfar6ieppm3KC5C6FRKvtJ6DRU=
-github.com/containerd/containerd/v2 v2.1.2/go.mod h1:8C5QV9djwsYDNhxfTCFjWtTBZrqjditQ4/ghHSYjnHM=
+github.com/containerd/containerd/v2 v2.1.3 h1:eMD2SLcIQPdMlnlNF6fatlrlRLAeDaiGPGwmRKLZKNs=
+github.com/containerd/containerd/v2 v2.1.3/go.mod h1:8C5QV9djwsYDNhxfTCFjWtTBZrqjditQ4/ghHSYjnHM=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=
 github.com/containerd/continuity v0.4.5/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/vendor/github.com/containerd/containerd/v2/core/content/helpers.go
+++ b/vendor/github.com/containerd/containerd/v2/core/content/helpers.go
@@ -200,7 +200,7 @@ func Copy(ctx context.Context, cw Writer, or io.Reader, size int64, expected dig
 		}
 		if size != 0 && copied < size-ws.Offset {
 			// Short writes would return its own error, this indicates a read failure
-			return fmt.Errorf("failed to read expected number of bytes: %w", io.ErrUnexpectedEOF)
+			return fmt.Errorf("short read: expected %d bytes but got %d: %w", size-ws.Offset, copied, io.ErrUnexpectedEOF)
 		}
 		if err := cw.Commit(ctx, size, expected, opts...); err != nil {
 			if errors.Is(err, ErrReset) {

--- a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/errcode.go
+++ b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/errcode.go
@@ -18,8 +18,12 @@ package docker
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
 )
 
 // ErrorCoder is the base interface for ErrorCode and Error allowing
@@ -280,4 +284,22 @@ func (errs *Errors) UnmarshalJSON(data []byte) error {
 
 	*errs = newErrs
 	return nil
+}
+
+func unexpectedResponseErr(resp *http.Response) (retErr error) {
+	retErr = remoteerrors.NewUnexpectedStatusErr(resp)
+
+	// Decode registry error if provided
+	if rerr := retErr.(remoteerrors.ErrUnexpectedStatus); len(rerr.Body) > 0 {
+		var registryErr Errors
+		if err := json.Unmarshal(rerr.Body, &registryErr); err == nil && registryErr.Len() > 0 {
+			// Join the unexpected error with the typed errors, when printed it will
+			// show the unexpected error message and the registry errors. The body
+			// is always excluded from the unexpected error message. This also allows
+			// clients to decode into either type.
+			retErr = errors.Join(rerr, registryErr)
+		}
+	}
+
+	return
 }

--- a/vendor/github.com/containerd/containerd/v2/core/remotes/docker/fetcher.go
+++ b/vendor/github.com/containerd/containerd/v2/core/remotes/docker/fetcher.go
@@ -442,7 +442,7 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 
 	chunkSize := int64(r.performances.ConcurrentLayerFetchBuffer)
 	parallelism := int64(r.performances.MaxConcurrentDownloads)
-	if chunkSize < minChunkSize {
+	if chunkSize < minChunkSize || req.body != nil {
 		parallelism = 1
 	}
 	log.G(ctx).WithField("initial_parallelism", r.performances.MaxConcurrentDownloads).
@@ -452,7 +452,9 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 		Debug("fetching layer")
 	req.setMediaType(mediatype)
 	req.header.Set("Accept-Encoding", "zstd;q=1.0, gzip;q=0.8, deflate;q=0.5")
-	req.setOffset(offset)
+	if parallelism > 1 || offset > 0 {
+		req.setOffset(offset)
+	}
 
 	if err := r.Acquire(ctx, 1); err != nil {
 		return nil, err
@@ -478,7 +480,11 @@ func (r dockerFetcher) open(ctx context.Context, req *request, mediatype string,
 	})
 
 	remaining, _ := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 0)
-	if parallelism > 1 && req.body == nil {
+	if remaining <= chunkSize {
+		parallelism = 1
+	}
+
+	if parallelism > 1 {
 		// If we have a content length, we can use multiple requests to fetch
 		// the content in parallel. This will make download of bigger bodies
 		// faster, at the cost of parallelism more requests and max

--- a/vendor/github.com/containerd/containerd/v2/core/remotes/errors/errors.go
+++ b/vendor/github.com/containerd/containerd/v2/core/remotes/errors/errors.go
@@ -20,16 +20,23 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/containerd/typeurl/v2"
 )
 
 var _ error = ErrUnexpectedStatus{}
 
+func init() {
+	typeurl.Register(&ErrUnexpectedStatus{}, "github.com/containerd/containerd/v2/core/remotes/errors", "ErrUnexpectedStatus")
+}
+
 // ErrUnexpectedStatus is returned if a registry API request returned with unexpected HTTP status
 type ErrUnexpectedStatus struct {
-	Status                    string
-	StatusCode                int
-	Body                      []byte
-	RequestURL, RequestMethod string
+	Status        string `json:"status"`
+	StatusCode    int    `json:"statusCode"`
+	Body          []byte `json:"body,omitempty"`
+	RequestURL    string `json:"requestURL,omitempty"`
+	RequestMethod string `json:"requestMethod,omitempty"`
 }
 
 func (e ErrUnexpectedStatus) Error() string {

--- a/vendor/github.com/containerd/containerd/v2/core/transfer/proxy/transfer.go
+++ b/vendor/github.com/containerd/containerd/v2/core/transfer/proxy/transfer.go
@@ -28,15 +28,17 @@ import (
 
 	transferapi "github.com/containerd/containerd/api/services/transfer/v1"
 	transfertypes "github.com/containerd/containerd/api/types/transfer"
-	"github.com/containerd/containerd/v2/core/streaming"
-	"github.com/containerd/containerd/v2/core/transfer"
-	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
-	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
 	"github.com/containerd/ttrpc"
 	"github.com/containerd/typeurl/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/streaming"
+	"github.com/containerd/containerd/v2/core/transfer"
+	tstreaming "github.com/containerd/containerd/v2/core/transfer/streaming"
+	"github.com/containerd/containerd/v2/pkg/oci"
 )
 
 type proxyTransferrer struct {
@@ -150,7 +152,7 @@ func (p *proxyTransferrer) Transfer(ctx context.Context, src interface{}, dst in
 		Options: apiOpts,
 	}
 	_, err = p.client.Transfer(ctx, req)
-	return err
+	return errgrpc.ToNative(err)
 }
 func (p *proxyTransferrer) marshalAny(ctx context.Context, i interface{}) (typeurl.Any, error) {
 	switch m := i.(type) {

--- a/vendor/github.com/containerd/containerd/v2/version/version.go
+++ b/vendor/github.com/containerd/containerd/v2/version/version.go
@@ -24,7 +24,7 @@ var (
 	Package = "github.com/containerd/containerd/v2"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "2.1.2+unknown"
+	Version = "2.1.3+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -323,7 +323,7 @@ github.com/containerd/containerd/api/types/runc/options
 github.com/containerd/containerd/api/types/runtimeoptions/v1
 github.com/containerd/containerd/api/types/task
 github.com/containerd/containerd/api/types/transfer
-# github.com/containerd/containerd/v2 v2.1.2
+# github.com/containerd/containerd/v2 v2.1.3
 ## explicit; go 1.23.0
 github.com/containerd/containerd/v2/client
 github.com/containerd/containerd/v2/cmd/containerd/server/config


### PR DESCRIPTION
Fixes various issues with pulling from registries

See https://github.com/containerd/containerd/releases/tag/v2.1.3

