### PR TITLE
[28.x backport] daemon/config: Validate: add missing validation for registry mirrors and improve errors

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -748,6 +748,12 @@ func Validate(config *Config) error {
 		}
 	}
 
+	for _, mirror := range config.ServiceOptions.Mirrors {
+		if _, err := registry.ValidateMirror(mirror); err != nil {
+			return err
+		}
+	}
+
 	if config.CorsHeaders != "" {
 		// TODO(thaJeztah): option is used to produce error when used; remove in next release
 		return errors.New(`DEPRECATED: The "api-cors-header" config parameter and the dockerd "--api-cors-header" option have been removed; use a reverse proxy if you need CORS headers`)

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/libnetwork/ipamutils"
 	"github.com/docker/docker/opts"
+	"github.com/docker/docker/registry"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/pflag"
@@ -427,6 +428,17 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			},
 			platform:    "windows",
 			expectedErr: "invalid exec-opt (native.cgroupdriver=systemd): option 'native.cgroupdriver' is only supported on linux",
+		},
+		{
+			name: "invalid mirror",
+			config: &Config{
+				CommonConfig: CommonConfig{
+					ServiceOptions: registry.ServiceOptions{
+						Mirrors: []string{"ftp://example.com"},
+					},
+				},
+			},
+			expectedErr: `invalid mirror: unsupported scheme "ftp" in "ftp://example.com": must use either 'https://' or 'http://'`,
 		},
 	}
 	for _, tc := range testCases {

--- a/registry/config_test.go
+++ b/registry/config_test.go
@@ -78,8 +78,16 @@ func TestValidateMirror(t *testing.T) {
 			expectedErr: `invalid mirror: "!invalid!://%as%" is not a valid URI: parse "!invalid!://%as%": first path segment in URL cannot contain colon`,
 		},
 		{
+			input:       "mirror-1.example.com",
+			expectedErr: `invalid mirror: no scheme specified for "mirror-1.example.com": must use either 'https://' or 'http://'`,
+		},
+		{
+			input:       "mirror-1.example.com:5000",
+			expectedErr: `invalid mirror: no scheme specified for "mirror-1.example.com:5000": must use either 'https://' or 'http://'`,
+		},
+		{
 			input:       "ftp://mirror-1.example.com",
-			expectedErr: `invalid mirror: unsupported scheme "ftp" in "ftp://mirror-1.example.com"`,
+			expectedErr: `invalid mirror: unsupported scheme "ftp" in "ftp://mirror-1.example.com": must use either 'https://' or 'http://'`,
 		},
 		{
 			input:       "http://mirror-1.example.com/?q=foo",
@@ -235,7 +243,7 @@ func TestNewServiceConfig(t *testing.T) {
 			opts: ServiceOptions{
 				Mirrors: []string{"example.com:5000"},
 			},
-			errStr: `invalid mirror: unsupported scheme "example.com" in "example.com:5000"`,
+			errStr: `invalid mirror: no scheme specified for "example.com:5000": must use either 'https://' or 'http://'`,
 		},
 		{
 			doc: "valid mirror",


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/50233
- relates to https://github.com/docker/for-mac/issues/7705#issuecomment-2987404650

----



### registry: ValidateMirror: improve validation for missing schemes

Before this patch, a missing scheme would sometimes produce a confusing
error message. If no scheme was specified at all, an empty "" would be
included in the message;

```bash
echo '{"registry-mirrors":["example.com"]}' > my-config.json
dockerd --config-file ./my-config.json
# ...
failed to start daemon: invalid mirror: unsupported scheme "" in "example.com"
```

If a scheme was missing, but a port was included, the hostname would be
printed as the scheme;

```bash
echo '{"registry-mirrors":["example.com:8080"]}' > my-config.json
dockerd --config-file ./my-config.json
# ...
failed to start daemon: invalid mirror: unsupported scheme "example.com" in "example.com:8080"
```

With this patch applied, the error messages are slightly more user-friendly;

```bash
echo '{"registry-mirrors":["example.com"]}' > my-config.json
dockerd --config-file ./my-config.json
# ...
failed to start daemon: invalid mirror: no scheme specified for "example.com": must use either 'https://' or 'http://'

echo '{"registry-mirrors":["example.com:8080"]}' > my-config.json
dockerd --config-file ./my-config.json
# ...
failed to start daemon: invalid mirror: no scheme specified for "example.com:8080": must use either 'https://' or 'http://'
```




### daemon/config: Validate: add missing validation for registry mirrors

Validation of registry mirrors was performed during daemon startup,
but after the config-file was validated. As a result, the `--validate`
option would incorrectly print that the configuration was valid, but
the daemon would fail to start;

```bash
echo '{"registry-mirrors":["example.com"]}' > my-config.json
dockerd --config-file ./my-config.json --validate
configuration OK

dockerd --config-file ./my-config.json
# ...
failed to start daemon: invalid mirror: no scheme specified for "example.com": must use either 'https://' or 'http://'
```

With this patch applied, validation is also performed as part of the
daemon config validation;

```bash
echo '{"registry-mirrors":["example.com"]}' > my-config.json
dockerd --config-file ./my-config.json --validate
unable to configure the Docker daemon with file ./my-config.json: merged configuration validation from file and command line flags failed: invalid mirror: no scheme specified for "example.com": must use either 'https://' or 'http://'

# fix the invalid config
echo '{"registry-mirrors":["https://example.com"]}' > my-config.json
dockerd --config-file ./my-config.json --validate
configuration OK
```




**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Validate registry-mirrors configuration as part of `dockerd --validate` and improve error messages for invalid mirrors.
```

**- A picture of a cute animal (not mandatory but encouraged)**
