### PR TITLE
client: Client.addHeaders: remove special handling for api < 1.25

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
 )
 
@@ -277,9 +276,6 @@ func (cli *Client) addHeaders(req *http.Request, headers http.Header) *http.Requ
 	// Add CLI Config's HTTP Headers BEFORE we set the Docker headers
 	// then the user can't change OUR headers
 	for k, v := range cli.customHTTPHeaders {
-		if versions.LessThan(cli.version, "1.25") && http.CanonicalHeaderKey(k) == "User-Agent" {
-			continue
-		}
 		req.Header.Set(k, v)
 	}
 


### PR DESCRIPTION
Commit e98e4a71110fd33852bb755a9b8b4ebc9df904db introduced functionality to hide experimental commands, and hide commands based on API version negotiation. Before that commit, the user-agent header was used to detect version-mismatches between the daemon and client based on their binary version;
https://github.com/moby/moby/blob/3975d648b70f2f18c1ba15c4b590de5c418d34db/api/server/middleware/user_agent.go#L32-L44

Because of the above, a check was added to prevent custom headers from modifying the User-Agent, but given that the user-agent header changed formatting, and api < 1.25 is long deprecated, it's not very meaningful to add this check, so let's remove it.


**- A picture of a cute animal (not mandatory but encouraged)**

