### PR TITLE
client: omit empty auth headers and use registry.RequestAuthConfig

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -1,0 +1,14 @@
+package client
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types/registry"
+)
+
+// staticAuth creates a privilegeFn from the given registryAuth.
+func staticAuth(registryAuth string) registry.RequestAuthConfig {
+	return func(ctx context.Context) (string, error) {
+		return registryAuth, nil
+	}
+}

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -34,13 +34,9 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options image.P
 		query.Set("platform", strings.ToLower(options.Platform))
 	}
 
-	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
+	resp, err := cli.tryImageCreate(ctx, query, staticAuth(options.RegistryAuth))
 	if cerrdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		newAuthHeader, privilegeErr := options.PrivilegeFunc(ctx)
-		if privilegeErr != nil {
-			return nil, privilegeErr
-		}
-		resp, err = cli.tryImageCreate(ctx, query, newAuthHeader)
+		resp, err = cli.tryImageCreate(ctx, query, options.PrivilegeFunc)
 	}
 	if err != nil {
 		return nil, err

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -71,7 +71,7 @@ func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version 
 		headers["version"] = []string{cli.version}
 	}
 	if options.EncodedRegistryAuth != "" {
-		headers[registry.AuthHeader] = []string{options.EncodedRegistryAuth}
+		headers.Set(registry.AuthHeader, options.EncodedRegistryAuth)
 	}
 	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, headers)
 	defer ensureReaderClosed(resp)


### PR DESCRIPTION
### client: Client.ServiceUpdate: don't manually construct header value


### client: add staticAuth utility

Add a small utility to create a "RequestAuthConfig" from

### client: client.tryImageCreate: accept registry.RequestAuthConfig

Directly accept a privilege-func, and set the auth-header optionally.

### client: client.tryImagePush: accept registry.RequestAuthConfig

Directly accept a privilege-func, and set the auth-header optionally.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

