### PR TITLE
integration/container: TestCreateByImageID: minor improvements

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -79,8 +79,13 @@ func TestCreateByImageID(t *testing.T) {
 	assert.NilError(t, err)
 
 	imgIDWithAlgorithm := img.ID
-	imgID, _ := strings.CutPrefix(imgIDWithAlgorithm, "sha256:")
-	imgShortID := stringid.TruncateID(imgID)
+	assert.Assert(t, imgIDWithAlgorithm != "")
+
+	imgID, _ := strings.CutPrefix(img.ID, "sha256:")
+	assert.Assert(t, imgID != "")
+
+	imgShortID := stringid.TruncateID(img.ID)
+	assert.Assert(t, imgShortID != "")
 
 	testCases := []struct {
 		doc             string
@@ -131,8 +136,8 @@ func TestCreateByImageID(t *testing.T) {
 				assert.Check(t, is.Error(err, tc.expectedErr))
 				assert.Check(t, is.ErrorType(err, tc.expectedErrType))
 			} else {
-				assert.Check(t, resp.ID != "")
 				assert.NilError(t, err)
+				assert.Check(t, resp.ID != "")
 			}
 			// cleanup the container if one was created.
 			_ = apiClient.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})


### PR DESCRIPTION
- Assert that we're not using empty IDs
- stringid.TruncateID already truncates algorithm, so we can just feed it the full id
- Fail early on error, and skip asserting the `resp.ID` to reduce some noise;

    === FAIL: github.com/docker/docker/integration/container TestCreateByImageID/image_short-ID (60.33s)
        create_test.go:134: assertion failed: resp.ID is ""
        create_test.go:135: assertion failed: error is not nil: error during connect: Post "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.48/containers/create": EOF

**- A picture of a cute animal (not mandatory but encouraged)**

