### PR TITLE
libnetwork/d/overlay: fix logical race conditions

### DIFF
--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/netip"
 	"strconv"
-	"sync"
 	"syscall"
 
 	"github.com/containerd/log"
@@ -96,16 +95,14 @@ type encrNode struct {
 	count int
 }
 
-type encrMap struct {
-	nodes map[netip.Addr]encrNode
-	mu    sync.Mutex
-}
+// encrMap is a map of node IP addresses to their encryption parameters.
+//
+// Like all Go maps, it is not safe for concurrent use.
+type encrMap map[netip.Addr]encrNode
 
-func (e *encrMap) String() string {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+func (e encrMap) String() string {
 	b := new(bytes.Buffer)
-	for k, v := range e.nodes {
+	for k, v := range e {
 		b.WriteString("\n")
 		b.WriteString(k.String())
 		b.WriteString(":")
@@ -124,16 +121,19 @@ func (e *encrMap) String() string {
 func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 	log.G(context.TODO()).Debugf("setupEncryption(%s)", remoteIP)
 
-	localIP, advIP := d.bindAddress, d.advertiseAddress
-	keys := d.keys // FIXME: data race
-	if len(keys) == 0 {
+	d.encrMu.Lock()
+	defer d.encrMu.Unlock()
+	if len(d.keys) == 0 {
 		return types.ForbiddenErrorf("encryption key is not present")
 	}
+	d.mu.Lock()
+	localIP, advIP := d.bindAddress, d.advertiseAddress
+	d.mu.Unlock()
 	log.G(context.TODO()).Debugf("Programming encryption between %s and %s", localIP, remoteIP)
 
-	indices := make([]spi, 0, len(keys))
+	indices := make([]spi, 0, len(d.keys))
 
-	for i, k := range keys {
+	for i, k := range d.keys {
 		spis := spi{buildSPI(advIP.AsSlice(), remoteIP.AsSlice(), k.tag), buildSPI(remoteIP.AsSlice(), advIP.AsSlice(), k.tag)}
 		dir := reverse
 		if i == 0 {
@@ -153,12 +153,10 @@ func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 		}
 	}
 
-	d.secMap.mu.Lock()
-	node := d.secMap.nodes[remoteIP]
+	node := d.secMap[remoteIP]
 	node.spi = indices
 	node.count++
-	d.secMap.nodes[remoteIP] = node
-	d.secMap.mu.Unlock()
+	d.secMap[remoteIP] = node
 
 	return nil
 }
@@ -166,18 +164,18 @@ func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 func (d *driver) removeEncryption(remoteIP netip.Addr) error {
 	log.G(context.TODO()).Debugf("removeEncryption(%s)", remoteIP)
 
-	spi := func() []spi {
-		d.secMap.mu.Lock()
-		defer d.secMap.mu.Unlock()
-		node := d.secMap.nodes[remoteIP]
-		if node.count == 1 {
-			delete(d.secMap.nodes, remoteIP)
-			return node.spi
-		}
+	d.encrMu.Lock()
+	defer d.encrMu.Unlock()
+
+	var spi []spi
+	node := d.secMap[remoteIP]
+	if node.count == 1 {
+		delete(d.secMap, remoteIP)
+		spi = node.spi
+	} else {
 		node.count--
-		d.secMap.nodes[remoteIP] = node
-		return nil
-	}()
+		d.secMap[remoteIP] = node
+	}
 
 	for i, idxs := range spi {
 		dir := reverse
@@ -452,13 +450,14 @@ func buildAeadAlgo(k *key, s int) *netlink.XfrmStateAlgo {
 }
 
 func (d *driver) setKeys(keys []*key) error {
+	d.encrMu.Lock()
+	defer d.encrMu.Unlock()
+
 	// Remove any stale policy, state
 	clearEncryptionStates()
 	// Accept the encryption keys and clear any stale encryption map
-	d.mu.Lock()
+	d.secMap = encrMap{}
 	d.keys = keys
-	d.secMap = &encrMap{nodes: map[netip.Addr]encrNode{}}
-	d.mu.Unlock()
 	log.G(context.TODO()).Debugf("Initial encryption keys: %v", keys)
 	return nil
 }
@@ -466,6 +465,9 @@ func (d *driver) setKeys(keys []*key) error {
 // updateKeys allows to add a new key and/or change the primary key and/or prune an existing key
 // The primary key is the key used in transmission and will go in first position in the list.
 func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
+	d.encrMu.Lock()
+	defer d.encrMu.Unlock()
+
 	log.G(context.TODO()).Debugf("Updating Keys. New: %v, Primary: %v, Pruned: %v", newKey, primary, pruneKey)
 
 	log.G(context.TODO()).Debugf("Current: %v", d.keys)
@@ -477,9 +479,6 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 		lIP    = d.bindAddress
 		aIP    = d.advertiseAddress
 	)
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	// add new
 	if newKey != nil {
@@ -506,14 +505,12 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 		return types.InvalidParameterErrorf("attempting to both make a key (index %d) primary and delete it", priIdx)
 	}
 
-	d.secMap.mu.Lock()
-	for rIP, node := range d.secMap.nodes {
+	for rIP, node := range d.secMap {
 		idxs := updateNodeKey(lIP.AsSlice(), aIP.AsSlice(), rIP.AsSlice(), node.spi, d.keys, newIdx, priIdx, delIdx)
 		if idxs != nil {
-			d.secMap.nodes[rIP] = encrNode{idxs, node.count}
+			d.secMap[rIP] = encrNode{idxs, node.count}
 		}
 	}
-	d.secMap.mu.Unlock()
 
 	// swap primary
 	if priIdx != -1 {

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -451,21 +451,6 @@ func buildAeadAlgo(k *key, s int) *netlink.XfrmStateAlgo {
 	}
 }
 
-func (d *driver) secMapWalk(f func(netip.Addr, []spi) ([]spi, bool)) error {
-	d.secMap.mu.Lock()
-	for rIP, node := range d.secMap.nodes {
-		idxs, stop := f(rIP, node.spi)
-		if idxs != nil {
-			d.secMap.nodes[rIP] = encrNode{idxs, node.count}
-		}
-		if stop {
-			break
-		}
-	}
-	d.secMap.mu.Unlock()
-	return nil
-}
-
 func (d *driver) setKeys(keys []*key) error {
 	// Remove any stale policy, state
 	clearEncryptionStates()
@@ -521,9 +506,14 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 		return types.InvalidParameterErrorf("attempting to both make a key (index %d) primary and delete it", priIdx)
 	}
 
-	d.secMapWalk(func(rIP netip.Addr, spis []spi) ([]spi, bool) {
-		return updateNodeKey(lIP.AsSlice(), aIP.AsSlice(), rIP.AsSlice(), spis, d.keys, newIdx, priIdx, delIdx), false
-	})
+	d.secMap.mu.Lock()
+	for rIP, node := range d.secMap.nodes {
+		idxs := updateNodeKey(lIP.AsSlice(), aIP.AsSlice(), rIP.AsSlice(), node.spi, d.keys, newIdx, priIdx, delIdx)
+		if idxs != nil {
+			d.secMap.nodes[rIP] = encrNode{idxs, node.count}
+		}
+	}
+	d.secMap.mu.Unlock()
 
 	// swap primary
 	if priIdx != -1 {

--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -98,12 +98,12 @@ type encrNode struct {
 
 type encrMap struct {
 	nodes map[netip.Addr]encrNode
-	sync.Mutex
+	mu    sync.Mutex
 }
 
 func (e *encrMap) String() string {
-	e.Lock()
-	defer e.Unlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	b := new(bytes.Buffer)
 	for k, v := range e.nodes {
 		b.WriteString("\n")
@@ -153,12 +153,12 @@ func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 		}
 	}
 
-	d.secMap.Lock()
+	d.secMap.mu.Lock()
 	node := d.secMap.nodes[remoteIP]
 	node.spi = indices
 	node.count++
 	d.secMap.nodes[remoteIP] = node
-	d.secMap.Unlock()
+	d.secMap.mu.Unlock()
 
 	return nil
 }
@@ -167,8 +167,8 @@ func (d *driver) removeEncryption(remoteIP netip.Addr) error {
 	log.G(context.TODO()).Debugf("removeEncryption(%s)", remoteIP)
 
 	spi := func() []spi {
-		d.secMap.Lock()
-		defer d.secMap.Unlock()
+		d.secMap.mu.Lock()
+		defer d.secMap.mu.Unlock()
 		node := d.secMap.nodes[remoteIP]
 		if node.count == 1 {
 			delete(d.secMap.nodes, remoteIP)
@@ -452,7 +452,7 @@ func buildAeadAlgo(k *key, s int) *netlink.XfrmStateAlgo {
 }
 
 func (d *driver) secMapWalk(f func(netip.Addr, []spi) ([]spi, bool)) error {
-	d.secMap.Lock()
+	d.secMap.mu.Lock()
 	for rIP, node := range d.secMap.nodes {
 		idxs, stop := f(rIP, node.spi)
 		if idxs != nil {
@@ -462,7 +462,7 @@ func (d *driver) secMapWalk(f func(netip.Addr, []spi) ([]spi, bool)) error {
 			break
 		}
 	}
-	d.secMap.Unlock()
+	d.secMap.mu.Unlock()
 	return nil
 }
 
@@ -470,10 +470,10 @@ func (d *driver) setKeys(keys []*key) error {
 	// Remove any stale policy, state
 	clearEncryptionStates()
 	// Accept the encryption keys and clear any stale encryption map
-	d.Lock()
+	d.mu.Lock()
 	d.keys = keys
 	d.secMap = &encrMap{nodes: map[netip.Addr]encrNode{}}
-	d.Unlock()
+	d.mu.Unlock()
 	log.G(context.TODO()).Debugf("Initial encryption keys: %v", keys)
 	return nil
 }
@@ -493,8 +493,8 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 		aIP    = d.advertiseAddress
 	)
 
-	d.Lock()
-	defer d.Unlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	// add new
 	if newKey != nil {

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -45,8 +45,13 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		return fmt.Errorf("could not find endpoint with id %s", eid)
 	}
 
-	if n.secure && len(d.keys) == 0 {
-		return errors.New("cannot join secure network: encryption keys not present")
+	if n.secure {
+		d.encrMu.Lock()
+		nkeys := len(d.keys)
+		d.encrMu.Unlock()
+		if nkeys == 0 {
+			return errors.New("cannot join secure network: encryption keys not present")
+		}
 	}
 
 	nlh := ns.NlHandle()

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -35,12 +35,13 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		return err
 	}
 
-	n := d.network(nid)
-	if n == nil {
-		return fmt.Errorf("could not find network with id %s", nid)
+	n, unlock, err := d.lockNetwork(nid)
+	if err != nil {
+		return err
 	}
+	defer unlock()
 
-	ep := n.endpoint(eid)
+	ep := n.endpoints[eid]
 	if ep == nil {
 		return fmt.Errorf("could not find endpoint with id %s", eid)
 	}
@@ -69,8 +70,6 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		return fmt.Errorf("network sandbox join failed: %v", err)
 	}
 
-	sbox := n.sandbox()
-
 	overlayIfName, containerIfName, err := createVethPair()
 	if err != nil {
 		return err
@@ -92,7 +91,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		return err
 	}
 
-	if err = sbox.AddInterface(ctx, overlayIfName, "veth", "", osl.WithMaster(s.brName)); err != nil {
+	if err = n.sbox.AddInterface(ctx, overlayIfName, "veth", "", osl.WithMaster(s.brName)); err != nil {
 		return fmt.Errorf("could not add veth pair inside the network sandbox: %v", err)
 	}
 
@@ -125,7 +124,9 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 		}
 	}
 
-	d.peerAdd(nid, eid, ep.addr, ep.mac, netip.Addr{})
+	if err := n.peerAdd(eid, ep.addr, ep.mac, netip.Addr{}); err != nil {
+		return fmt.Errorf("overlay: failed to add local endpoint to network peer db: %w", err)
+	}
 
 	buf, err := proto.Marshal(&PeerRecord{
 		EndpointIP:       ep.addr.String(),
@@ -198,12 +199,32 @@ func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key stri
 		return
 	}
 
-	if etype == driverapi.Delete {
-		d.peerDelete(nid, eid, addr, mac, vtep)
+	n, unlock, err := d.lockNetwork(nid)
+	if err != nil {
+		log.G(context.TODO()).WithFields(log.Fields{
+			"error": err,
+			"nid":   nid,
+		}).Error("overlay: handling peer event")
 		return
 	}
+	defer unlock()
 
-	d.peerAdd(nid, eid, addr, mac, vtep)
+	var opname string
+	if etype == driverapi.Delete {
+		opname = "delete"
+		err = n.peerDelete(eid, addr, mac, vtep)
+	} else {
+		opname = "add"
+		err = n.peerAdd(eid, addr, mac, vtep)
+	}
+	if err != nil {
+		log.G(context.TODO()).WithFields(log.Fields{
+			"error": err,
+			"nid":   n.id,
+			"peer":  peer,
+			"op":    opname,
+		}).Warn("Peer operation failed")
+	}
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
@@ -212,18 +233,21 @@ func (d *driver) Leave(nid, eid string) error {
 		return err
 	}
 
-	n := d.network(nid)
-	if n == nil {
-		return fmt.Errorf("could not find network with id %s", nid)
+	n, unlock, err := d.lockNetwork(nid)
+	if err != nil {
+		return err
 	}
+	defer unlock()
 
-	ep := n.endpoint(eid)
+	ep := n.endpoints[eid]
 
 	if ep == nil {
 		return types.InternalMaskableErrorf("could not find endpoint with id %s", eid)
 	}
 
-	d.peerDelete(nid, eid, ep.addr, ep.mac, netip.Addr{})
+	if err := n.peerDelete(eid, ep.addr, ep.mac, netip.Addr{}); err != nil {
+		return fmt.Errorf("overlay: failed to delete local endpoint eid:%s from network peer db: %w", eid, err)
+	}
 
 	n.leaveSandbox()
 

--- a/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/libnetwork/drivers/overlay/ov_endpoint.go
@@ -27,22 +27,22 @@ type endpoint struct {
 }
 
 func (n *network) endpoint(eid string) *endpoint {
-	n.Lock()
-	defer n.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 
 	return n.endpoints[eid]
 }
 
 func (n *network) addEndpoint(ep *endpoint) {
-	n.Lock()
+	n.mu.Lock()
 	n.endpoints[ep.id] = ep
-	n.Unlock()
+	n.mu.Unlock()
 }
 
 func (n *network) deleteEndpoint(eid string) {
-	n.Lock()
+	n.mu.Lock()
 	delete(n.endpoints, eid)
-	n.Unlock()
+	n.mu.Unlock()
 }
 
 func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {

--- a/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/libnetwork/drivers/overlay/ov_endpoint.go
@@ -26,25 +26,6 @@ type endpoint struct {
 	addr   netip.Prefix
 }
 
-func (n *network) endpoint(eid string) *endpoint {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	return n.endpoints[eid]
-}
-
-func (n *network) addEndpoint(ep *endpoint) {
-	n.mu.Lock()
-	n.endpoints[ep.id] = ep
-	n.mu.Unlock()
-}
-
-func (n *network) deleteEndpoint(eid string) {
-	n.mu.Lock()
-	delete(n.endpoints, eid)
-	n.mu.Unlock()
-}
-
 func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
 	var err error
 	if err = validateID(nid, eid); err != nil {
@@ -58,10 +39,11 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 		return err
 	}
 
-	n := d.network(nid)
-	if n == nil {
-		return fmt.Errorf("network id %q not found", nid)
+	n, unlock, err := d.lockNetwork(nid)
+	if err != nil {
+		return err
 	}
+	defer unlock()
 
 	ep := &endpoint{
 		id:  eid,
@@ -85,7 +67,7 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 		}
 	}
 
-	n.addEndpoint(ep)
+	n.endpoints[ep.id] = ep
 
 	return nil
 }
@@ -97,17 +79,18 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 		return err
 	}
 
-	n := d.network(nid)
-	if n == nil {
-		return fmt.Errorf("network id %q not found", nid)
+	n, unlock, err := d.lockNetwork(nid)
+	if err != nil {
+		return err
 	}
+	defer unlock()
 
-	ep := n.endpoint(eid)
+	ep := n.endpoints[eid]
 	if ep == nil {
 		return fmt.Errorf("endpoint id %q not found", eid)
 	}
 
-	n.deleteEndpoint(eid)
+	delete(n.endpoints, eid)
 
 	if ep.ifName == "" {
 		return nil

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -50,10 +50,19 @@ type subnet struct {
 }
 
 type network struct {
-	id        string
+	id     string
+	driver *driver
+	secure bool
+	mtu    int
+
+	// mu must be held when accessing any of the variable struct fields below,
+	// calling any method on the network not noted as safe for concurrent use,
+	// or manipulating the driver.networks key for this network id.
+	// This mutex is at the top of the lock hierarchy: any other locks in
+	// package structs can be locked while holding this lock.
+	mu        sync.Mutex
 	sbox      *osl.Namespace
 	endpoints endpointTable
-	driver    *driver
 	joinCnt   int
 	// Ref count of VXLAN Forwarding Database entries programmed into the kernel
 	fdbCnt    countmap.Map[ipmac]
@@ -61,9 +70,7 @@ type network struct {
 	initEpoch int
 	initErr   error
 	subnets   []*subnet
-	secure    bool
-	mtu       int
-	mu        sync.Mutex
+	peerdb    peerMap
 }
 
 func init() {
@@ -151,10 +158,34 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 		n.subnets = append(n.subnets, s)
 	}
 
+	// Lock the network before adding it to the networks table so we can
+	// release the big driver lock before we finish initializing the network
+	// while continuing to exclude other operations on the network from
+	// proceeding until we are done.
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
 	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.networks[n.id] != nil {
-		return fmt.Errorf("attempt to create overlay network %v that already exists", n.id)
+	oldnet := d.networks[id]
+	if oldnet == nil {
+		d.networks[id] = n
+		d.mu.Unlock()
+	} else {
+		// The network already exists, but we might be racing DeleteNetwork.
+		// Synchronize and check again.
+		d.mu.Unlock()
+		oldnet.mu.Lock()
+		d.mu.Lock()
+		_, ok := d.networks[id]
+		if !ok {
+			// It's gone! Stake our claim to the network id.
+			d.networks[id] = n
+		}
+		d.mu.Unlock()
+		oldnet.mu.Unlock()
+		if ok {
+			return fmt.Errorf("attempt to create overlay network %v that already exists", n.id)
+		}
 	}
 
 	// Make sure no rule is on the way from any stale secure network
@@ -172,8 +203,6 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 		}
 	}
 
-	d.networks[id] = n
-
 	return nil
 }
 
@@ -187,23 +216,14 @@ func (d *driver) DeleteNetwork(nid string) error {
 		return err
 	}
 
-	d.mu.Lock()
-	// Only perform a peer flush operation (if required) AFTER unlocking
-	// the driver lock to avoid deadlocking w/ the peerDB.
-	var doPeerFlush bool
-	defer func() {
-		d.mu.Unlock()
-		if doPeerFlush {
-			d.peerFlush(nid)
-		}
-	}()
-
-	// This is similar to d.network(), but we need to keep holding the lock
-	// until we are done removing this network.
-	n := d.networks[nid]
-	if n == nil {
-		return fmt.Errorf("could not find network with id %s", nid)
+	n, unlock, err := d.lockNetwork(nid)
+	if err != nil {
+		return err
 	}
+	// Unlock the network even if it's going to become garbage as another
+	// goroutine could be blocked waiting for the lock, such as in
+	// (*driver).lockNetwork.
+	defer unlock()
 
 	for _, ep := range n.endpoints {
 		if ep.ifName != "" {
@@ -214,9 +234,6 @@ func (d *driver) DeleteNetwork(nid string) error {
 			}
 		}
 	}
-
-	doPeerFlush = true
-	delete(d.networks, nid)
 
 	if n.secure {
 		for _, s := range n.subnets {
@@ -237,6 +254,10 @@ func (d *driver) DeleteNetwork(nid string) error {
 		}
 	}
 
+	d.mu.Lock()
+	delete(d.networks, nid)
+	d.mu.Unlock()
+
 	return nil
 }
 
@@ -245,22 +266,11 @@ func (n *network) joinSandbox(s *subnet, incJoinCount bool) error {
 	// the other will wait.
 	networkOnce.Do(populateVNITbl)
 
-	n.mu.Lock()
-	// If initialization was successful then tell the peerDB to initialize the
-	// sandbox with all the peers previously received from networkdb. But only
-	// do this after unlocking the network. Otherwise we could deadlock with
-	// on the peerDB channel while peerDB is waiting for the network lock.
-	var doInitPeerDB bool
-	defer func() {
-		n.mu.Unlock()
-		if doInitPeerDB {
-			go n.driver.initSandboxPeerDB(n.id)
-		}
-	}()
+	var initialized bool
 
 	if !n.sboxInit {
 		n.initErr = n.initSandbox()
-		doInitPeerDB = n.initErr == nil
+		initialized = n.initErr == nil
 		// If there was an error, we cannot recover it
 		n.sboxInit = true
 	}
@@ -286,12 +296,19 @@ func (n *network) joinSandbox(s *subnet, incJoinCount bool) error {
 		n.joinCnt++
 	}
 
+	if initialized {
+		if err := n.initSandboxPeerDB(); err != nil {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"nid":   n.id,
+				"error": err,
+			}).Warn("failed to initialize network peer database")
+		}
+	}
+
 	return nil
 }
 
 func (n *network) leaveSandbox() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
 	n.joinCnt--
 	if n.joinCnt != 0 {
 		return
@@ -596,18 +613,35 @@ func (n *network) initSandbox() error {
 	return nil
 }
 
-func (d *driver) network(nid string) *network {
+// lockNetwork returns the network object for nid, locked for exclusive access.
+//
+// It is the caller's responsibility to release the network lock by calling the
+// returned unlock function.
+func (d *driver) lockNetwork(nid string) (n *network, unlock func(), err error) {
 	d.mu.Lock()
-	n := d.networks[nid]
+	n = d.networks[nid]
 	d.mu.Unlock()
-
-	return n
-}
-
-func (n *network) sandbox() *osl.Namespace {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	return n.sbox
+	for {
+		if n == nil {
+			return nil, nil, fmt.Errorf("network %q not found", nid)
+		}
+		// We can't lock the network object while holding the driver
+		// lock or we risk a lock order reversal deadlock.
+		n.mu.Lock()
+		// d.networks[nid] might have been replaced or removed after we
+		// unlocked the driver lock. Double-check that the network we
+		// just locked is the active network object for the nid.
+		d.mu.Lock()
+		n2 := d.networks[nid]
+		d.mu.Unlock()
+		if n2 == n {
+			return n, n.mu.Unlock, nil
+		}
+		// We locked a garbage object. Spin until the network we locked
+		// matches up with the one present in the table.
+		n.mu.Unlock()
+		n = n2
+	}
 }
 
 // getSubnetforIP returns the subnet to which the given IP belongs

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -63,7 +63,7 @@ type network struct {
 	subnets   []*subnet
 	secure    bool
 	mtu       int
-	sync.Mutex
+	mu        sync.Mutex
 }
 
 func init() {
@@ -151,8 +151,8 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 		n.subnets = append(n.subnets, s)
 	}
 
-	d.Lock()
-	defer d.Unlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.networks[n.id] != nil {
 		return fmt.Errorf("attempt to create overlay network %v that already exists", n.id)
 	}
@@ -187,12 +187,12 @@ func (d *driver) DeleteNetwork(nid string) error {
 		return err
 	}
 
-	d.Lock()
+	d.mu.Lock()
 	// Only perform a peer flush operation (if required) AFTER unlocking
 	// the driver lock to avoid deadlocking w/ the peerDB.
 	var doPeerFlush bool
 	defer func() {
-		d.Unlock()
+		d.mu.Unlock()
 		if doPeerFlush {
 			d.peerFlush(nid)
 		}
@@ -245,14 +245,14 @@ func (n *network) joinSandbox(s *subnet, incJoinCount bool) error {
 	// the other will wait.
 	networkOnce.Do(populateVNITbl)
 
-	n.Lock()
+	n.mu.Lock()
 	// If initialization was successful then tell the peerDB to initialize the
 	// sandbox with all the peers previously received from networkdb. But only
 	// do this after unlocking the network. Otherwise we could deadlock with
 	// on the peerDB channel while peerDB is waiting for the network lock.
 	var doInitPeerDB bool
 	defer func() {
-		n.Unlock()
+		n.mu.Unlock()
 		if doInitPeerDB {
 			go n.driver.initSandboxPeerDB(n.id)
 		}
@@ -290,8 +290,8 @@ func (n *network) joinSandbox(s *subnet, incJoinCount bool) error {
 }
 
 func (n *network) leaveSandbox() {
-	n.Lock()
-	defer n.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	n.joinCnt--
 	if n.joinCnt != 0 {
 		return
@@ -597,16 +597,16 @@ func (n *network) initSandbox() error {
 }
 
 func (d *driver) network(nid string) *network {
-	d.Lock()
+	d.mu.Lock()
 	n := d.networks[nid]
-	d.Unlock()
+	d.mu.Unlock()
 
 	return n
 }
 
 func (n *network) sandbox() *osl.Namespace {
-	n.Lock()
-	defer n.Unlock()
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	return n.sbox
 }
 

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -29,32 +29,38 @@ const (
 var _ discoverapi.Discover = (*driver)(nil)
 
 type driver struct {
-	bindAddress, advertiseAddress netip.Addr
+	// Immutable; mu does not need to be held when accessing these fields.
+
+	config map[string]interface{}
+	initOS sync.Once
 
 	// encrMu guards secMap and keys,
 	// and synchronizes the application of encryption parameters
 	// to the kernel.
+	//
+	// This mutex is above mu in the lock hierarchy.
+	// Do not lock any locks aside from mu while holding encrMu.
 	encrMu sync.Mutex
 	secMap encrMap
 	keys   []*key
 
-	config   map[string]interface{}
-	peerDb   peerNetworkMap
-	networks networkTable
-	initOS   sync.Once
-	peerOpMu sync.Mutex
-	mu       sync.Mutex
+	// mu must be held when accessing the fields which follow it
+	// in the struct definition.
+	//
+	// This mutex is at the bottom of the lock hierarchy:
+	// do not lock any other locks while holding it.
+	mu               sync.Mutex
+	bindAddress      netip.Addr
+	advertiseAddress netip.Addr
+	networks         networkTable
 }
 
 // Register registers a new instance of the overlay driver.
 func Register(r driverapi.Registerer, config map[string]interface{}) error {
 	d := &driver{
 		networks: networkTable{},
-		peerDb: peerNetworkMap{
-			mp: map[string]*peerMap{},
-		},
-		secMap: encrMap{},
-		config: config,
+		secMap:   encrMap{},
+		config:   config,
 	}
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{
 		DataScope:         scope.Global,

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -38,7 +38,7 @@ type driver struct {
 	initOS   sync.Once
 	keys     []*key
 	peerOpMu sync.Mutex
-	sync.Mutex
+	mu       sync.Mutex
 }
 
 // Register registers a new instance of the overlay driver.
@@ -91,10 +91,10 @@ func (d *driver) nodeJoin(data discoverapi.NodeDiscoveryData) error {
 		if !advAddr.IsValid() {
 			return errors.New("invalid discovery data")
 		}
-		d.Lock()
+		d.mu.Lock()
 		d.advertiseAddress = advAddr
 		d.bindAddress = bindAddr
-		d.Unlock()
+		d.mu.Unlock()
 	}
 	return nil
 }

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -31,12 +31,17 @@ var _ discoverapi.Discover = (*driver)(nil)
 type driver struct {
 	bindAddress, advertiseAddress netip.Addr
 
+	// encrMu guards secMap and keys,
+	// and synchronizes the application of encryption parameters
+	// to the kernel.
+	encrMu sync.Mutex
+	secMap encrMap
+	keys   []*key
+
 	config   map[string]interface{}
 	peerDb   peerNetworkMap
-	secMap   *encrMap
 	networks networkTable
 	initOS   sync.Once
-	keys     []*key
 	peerOpMu sync.Mutex
 	mu       sync.Mutex
 }
@@ -48,7 +53,7 @@ func Register(r driverapi.Registerer, config map[string]interface{}) error {
 		peerDb: peerNetworkMap{
 			mp: map[string]*peerMap{},
 		},
-		secMap: &encrMap{nodes: map[netip.Addr]encrNode{}},
+		secMap: encrMap{},
 		config: config,
 	}
 	return r.RegisterDriver(NetworkType, d, driverapi.Capability{

--- a/libnetwork/drivers/overlay/peerdb.go
+++ b/libnetwork/drivers/overlay/peerdb.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"sync"
 	"syscall"
 
 	"github.com/containerd/log"
@@ -31,106 +30,51 @@ func (p *peerEntry) isLocal() bool {
 
 type peerMap struct {
 	mp setmatrix.SetMatrix[netip.Prefix, peerEntry]
-	mu sync.Mutex
 }
 
-type peerNetworkMap struct {
-	// map with key peerKey
-	mp map[string]*peerMap
-	mu sync.Mutex
-}
-
-func (d *driver) peerDbNetworkWalk(nid string, f func(netip.Prefix, peerEntry) bool) {
-	d.peerDb.mu.Lock()
-	pMap, ok := d.peerDb.mp[nid]
-	d.peerDb.mu.Unlock()
-
-	if !ok {
-		return
-	}
-
-	mp := map[netip.Prefix]peerEntry{}
-	pMap.mu.Lock()
-	for _, pKey := range pMap.mp.Keys() {
-		entryDBList, ok := pMap.mp.Get(pKey)
+func (pm *peerMap) Walk(f func(netip.Prefix, peerEntry)) {
+	for _, peerAddr := range pm.mp.Keys() {
+		entry, ok := pm.Get(peerAddr)
 		if ok {
-			mp[pKey] = entryDBList[0]
-		}
-	}
-	pMap.mu.Unlock()
-
-	for k, v := range mp {
-		if f(k, v) {
-			return
+			f(peerAddr, entry)
 		}
 	}
 }
 
-func (d *driver) peerDbGet(nid string, peerIP netip.Prefix) (peerEntry, bool) {
-	d.peerDb.mu.Lock()
-	pMap, ok := d.peerDb.mp[nid]
-	d.peerDb.mu.Unlock()
-	if !ok {
-		return peerEntry{}, false
-	}
-
-	pMap.mu.Lock()
-	defer pMap.mu.Unlock()
-	c, _ := pMap.mp.Get(peerIP)
+func (pm *peerMap) Get(peerIP netip.Prefix) (peerEntry, bool) {
+	c, _ := pm.mp.Get(peerIP)
 	if len(c) == 0 {
 		return peerEntry{}, false
 	}
 	return c[0], true
 }
 
-func (d *driver) peerDbAdd(nid, eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) (bool, int) {
-	d.peerDb.mu.Lock()
-	pMap, ok := d.peerDb.mp[nid]
-	if !ok {
-		pMap = &peerMap{}
-		d.peerDb.mp[nid] = pMap
-	}
-	d.peerDb.mu.Unlock()
-
+func (pm *peerMap) Add(eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) (bool, int) {
 	pEntry := peerEntry{
 		eid:  eid,
 		mac:  macAddrOf(peerMac),
 		vtep: vtep,
 	}
-
-	pMap.mu.Lock()
-	defer pMap.mu.Unlock()
-	b, i := pMap.mp.Insert(peerIP, pEntry)
+	b, i := pm.mp.Insert(peerIP, pEntry)
 	if i != 1 {
 		// Transient case, there is more than one endpoint that is using the same IP
-		s, _ := pMap.mp.String(peerIP)
+		s, _ := pm.mp.String(peerIP)
 		log.G(context.TODO()).Warnf("peerDbAdd transient condition - Key:%s cardinality:%d db state:%s", peerIP, i, s)
 	}
-
 	return b, i
 }
 
-func (d *driver) peerDbDelete(nid, eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) (bool, int) {
-	d.peerDb.mu.Lock()
-	pMap, ok := d.peerDb.mp[nid]
-	if !ok {
-		d.peerDb.mu.Unlock()
-		return false, 0
-	}
-	d.peerDb.mu.Unlock()
-
+func (pm *peerMap) Delete(eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) (bool, int) {
 	pEntry := peerEntry{
 		eid:  eid,
 		mac:  macAddrOf(peerMac),
 		vtep: vtep,
 	}
 
-	pMap.mu.Lock()
-	defer pMap.mu.Unlock()
-	b, i := pMap.mp.Remove(peerIP, pEntry)
+	b, i := pm.mp.Remove(peerIP, pEntry)
 	if i != 0 {
 		// Transient case, there is more than one endpoint that is using the same IP
-		s, _ := pMap.mp.String(peerIP)
+		s, _ := pm.mp.String(peerIP)
 		log.G(context.TODO()).Warnf("peerDbDelete transient condition - Key:%s cardinality:%d db state:%s", peerIP, i, s)
 	}
 	return b, i
@@ -143,60 +87,51 @@ func (d *driver) peerDbDelete(nid, eid string, peerIP netip.Prefix, peerMac net.
 // networkDB has already delivered some events of peers already available on remote nodes,
 // these peers are saved into the peerDB and this function is used to properly configure
 // the network sandbox with all those peers that got previously notified.
-// Note also that this method atomically loops on the whole table of peers
-// and programs their state in one single atomic operation.
-// This is fundamental to guarantee consistency, and avoid that
-// new peerAdd or peerDelete gets reordered during the sandbox init.
-func (d *driver) initSandboxPeerDB(nid string) {
-	d.peerOpMu.Lock()
-	defer d.peerOpMu.Unlock()
-	d.peerDbNetworkWalk(nid, func(peerIP netip.Prefix, pEntry peerEntry) bool {
+//
+// The caller is responsible for ensuring that peerAdd and peerDelete are not
+// called concurrently with this function to guarantee consistency.
+func (n *network) initSandboxPeerDB() error {
+	var errs []error
+	n.peerdb.Walk(func(peerIP netip.Prefix, pEntry peerEntry) {
 		if !pEntry.isLocal() {
-			d.addNeighbor(nid, peerIP, pEntry.mac.HardwareAddr(), pEntry.vtep)
+			if err := n.addNeighbor(peerIP, pEntry.mac.HardwareAddr(), pEntry.vtep); err != nil {
+				errs = append(errs, fmt.Errorf("failed to add neighbor entries for %s: %w", peerIP, err))
+			}
 		}
-		return false // walk all entries
 	})
+	return errors.Join(errs...)
 }
 
 // peerAdd adds a new entry to the peer database.
 //
 // Local peers are signified by an invalid vtep (i.e. netip.Addr{}).
-func (d *driver) peerAdd(nid, eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) {
-	if err := validateID(nid, eid); err != nil {
-		log.G(context.TODO()).WithError(err).Warn("Peer add operation failed")
-		return
+func (n *network) peerAdd(eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) error {
+	if eid == "" {
+		return errors.New("invalid endpoint id")
 	}
 
-	d.peerOpMu.Lock()
-	defer d.peerOpMu.Unlock()
-
-	inserted, dbEntries := d.peerDbAdd(nid, eid, peerIP, peerMac, vtep)
+	inserted, dbEntries := n.peerdb.Add(eid, peerIP, peerMac, vtep)
 	if !inserted {
 		log.G(context.TODO()).Warnf("Entry already present in db: nid:%s eid:%s peerIP:%v peerMac:%v vtep:%v",
-			nid, eid, peerIP, peerMac, vtep)
+			n.id, eid, peerIP, peerMac, vtep)
 	}
 	if vtep.IsValid() {
-		err := d.addNeighbor(nid, peerIP, peerMac, vtep)
+		err := n.addNeighbor(peerIP, peerMac, vtep)
 		if err != nil {
 			if dbEntries > 1 && errors.As(err, &osl.NeighborSearchError{}) {
-				// We are in the transient case so only the first configuration is programmed into the kernel.
+				// Conflicting neighbor entries are already programmed into the kernel and we are in the transient case.
 				// Upon deletion if the active configuration is deleted the next one from the database will be restored.
-				return
+				return nil
 			}
-			log.G(context.TODO()).WithFields(log.Fields{"nid": nid, "eid": eid}).WithError(err).Warn("Peer add operation failed")
+			return fmt.Errorf("peer add operation failed: %w", err)
 		}
 	}
+	return nil
 }
 
 // addNeighbor programs the kernel so the given peer is reachable through the VXLAN tunnel.
-func (d *driver) addNeighbor(nid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) error {
-	n := d.network(nid)
-	if n == nil {
-		return nil
-	}
-
-	sbox := n.sandbox()
-	if sbox == nil {
+func (n *network) addNeighbor(peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) error {
+	if n.sbox == nil {
 		// We are hitting this case for all the events that are arriving before that the sandbox
 		// is being created. The peer got already added into the database and the sandbox init will
 		// call the peerDbUpdateSandbox that will configure all these peers from the database
@@ -213,19 +148,19 @@ func (d *driver) addNeighbor(nid string, peerIP netip.Prefix, peerMac net.Hardwa
 	}
 
 	if n.secure {
-		if err := d.setupEncryption(vtep); err != nil {
+		if err := n.driver.setupEncryption(vtep); err != nil {
 			log.G(context.TODO()).Warn(err)
 		}
 	}
 
 	// Add neighbor entry for the peer IP
-	if err := sbox.AddNeighbor(peerIP.Addr().AsSlice(), peerMac, osl.WithLinkName(s.vxlanName)); err != nil {
+	if err := n.sbox.AddNeighbor(peerIP.Addr().AsSlice(), peerMac, osl.WithLinkName(s.vxlanName)); err != nil {
 		return fmt.Errorf("could not add neighbor entry into the sandbox: %w", err)
 	}
 
 	// Add fdb entry to the bridge for the peer mac
 	if n.fdbCnt.Add(ipmacOf(vtep, peerMac), 1) == 1 {
-		if err := sbox.AddNeighbor(vtep.AsSlice(), peerMac, osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
+		if err := n.sbox.AddNeighbor(vtep.AsSlice(), peerMac, osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
 			return fmt.Errorf("could not add fdb entry into the sandbox: %w", err)
 		}
 	}
@@ -236,79 +171,59 @@ func (d *driver) addNeighbor(nid string, peerIP netip.Prefix, peerMac net.Hardwa
 // peerDelete removes an entry from the peer database.
 //
 // Local peers are signified by an invalid vtep (i.e. netip.Addr{}).
-func (d *driver) peerDelete(nid, eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) {
+func (n *network) peerDelete(eid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) error {
+	if eid == "" {
+		return errors.New("invalid endpoint id")
+	}
+
 	logger := log.G(context.TODO()).WithFields(log.Fields{
-		"nid":  nid,
+		"nid":  n.id,
 		"eid":  eid,
 		"ip":   peerIP,
 		"mac":  peerMac,
 		"vtep": vtep,
 	})
-	if err := validateID(nid, eid); err != nil {
-		logger.WithError(err).Warn("Peer delete operation failed")
-		return
-	}
-
-	d.peerOpMu.Lock()
-	defer d.peerOpMu.Unlock()
-
-	deleted, dbEntries := d.peerDbDelete(nid, eid, peerIP, peerMac, vtep)
+	deleted, dbEntries := n.peerdb.Delete(eid, peerIP, peerMac, vtep)
 	if !deleted {
 		logger.Warn("Peer entry was not in db")
 	}
-
 	if vtep.IsValid() {
-		err := d.deleteNeighbor(nid, peerIP, peerMac, vtep)
+		err := n.deleteNeighbor(peerIP, peerMac, vtep)
 		if err != nil {
 			if dbEntries > 0 && errors.As(err, &osl.NeighborSearchError{}) {
 				// We fall in here if there is a transient state and if the neighbor that is being deleted
 				// was never been configured into the kernel (we allow only 1 configuration at the time per <ip,mac> mapping)
-				return
+				return nil
 			}
 			logger.WithError(err).Warn("Peer delete operation failed")
 		}
+	}
 
-		if dbEntries > 0 {
-			// If there is still an entry into the database and the deletion went through without errors means that there is now no
-			// configuration active in the kernel.
-			// Restore one configuration for the ip directly from the database, note that is guaranteed that there is one
-			peerEntry, ok := d.peerDbGet(nid, peerIP)
-			if !ok {
-				log.G(context.TODO()).WithFields(log.Fields{
-					"nid": nid,
-					"ip":  peerIP,
-				}).Error("peerDelete unable to restore a configuration: no entry found in the database")
-				return
-			}
-			err = d.addNeighbor(nid, peerIP, peerEntry.mac.HardwareAddr(), peerEntry.vtep)
-			if err != nil {
-				log.G(context.TODO()).WithFields(log.Fields{
-					"nid":  nid,
-					"eid":  eid,
-					"ip":   peerIP,
-					"mac":  peerEntry.mac,
-					"vtep": peerEntry.vtep,
-				}).WithError(err).Error("Peer delete operation failed")
-			}
+	if dbEntries > 0 {
+		// If there is still an entry into the database and the deletion went through without errors means that there is now no
+		// configuration active in the kernel.
+		// Restore one configuration for the ip directly from the database, note that is guaranteed that there is one
+		peerEntry, ok := n.peerdb.Get(peerIP)
+		if !ok {
+			return fmt.Errorf("peerDelete: unable to restore a configuration: no entry for %v found in the database", peerIP)
+		}
+		err := n.addNeighbor(peerIP, peerEntry.mac.HardwareAddr(), peerEntry.vtep)
+		if err != nil {
+			return fmt.Errorf("peer delete operation failed: %w", err)
 		}
 	}
+	return nil
 }
 
 // deleteNeighbor removes programming from the kernel for the given peer to be
 // reachable through the VXLAN tunnel. It is the inverse of [driver.addNeighbor].
-func (d *driver) deleteNeighbor(nid string, peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) error {
-	n := d.network(nid)
-	if n == nil {
-		return nil
-	}
-
-	sbox := n.sandbox()
-	if sbox == nil {
+func (n *network) deleteNeighbor(peerIP netip.Prefix, peerMac net.HardwareAddr, vtep netip.Addr) error {
+	if n.sbox == nil {
 		return nil
 	}
 
 	if n.secure {
-		if err := d.removeEncryption(vtep); err != nil {
+		if err := n.driver.removeEncryption(vtep); err != nil {
 			log.G(context.TODO()).Warn(err)
 		}
 	}
@@ -319,28 +234,15 @@ func (d *driver) deleteNeighbor(nid string, peerIP netip.Prefix, peerMac net.Har
 	}
 	// Remove fdb entry to the bridge for the peer mac
 	if n.fdbCnt.Add(ipmacOf(vtep, peerMac), -1) == 0 {
-		if err := sbox.DeleteNeighbor(vtep.AsSlice(), peerMac, osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
+		if err := n.sbox.DeleteNeighbor(vtep.AsSlice(), peerMac, osl.WithLinkName(s.vxlanName), osl.WithFamily(syscall.AF_BRIDGE)); err != nil {
 			return fmt.Errorf("could not delete fdb entry in the sandbox: %w", err)
 		}
 	}
 
 	// Delete neighbor entry for the peer IP
-	if err := sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac, osl.WithLinkName(s.vxlanName)); err != nil {
+	if err := n.sbox.DeleteNeighbor(peerIP.Addr().AsSlice(), peerMac, osl.WithLinkName(s.vxlanName)); err != nil {
 		return fmt.Errorf("could not delete neighbor entry in the sandbox:%v", err)
 	}
 
 	return nil
-}
-
-func (d *driver) peerFlush(nid string) {
-	d.peerOpMu.Lock()
-	defer d.peerOpMu.Unlock()
-	d.peerDb.mu.Lock()
-	defer d.peerDb.mu.Unlock()
-	_, ok := d.peerDb.mp[nid]
-	if !ok {
-		log.G(context.TODO()).Warnf("Peer flush operation failed: unable to find the peerDB for nid:%s", nid)
-		return
-	}
-	delete(d.peerDb.mp, nid)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- For #49908 
- Split from #50081 
- Stacked on top of #50106 

**- What I did**
**- How I did it**

The concurrency control in the overlay driver is logically unsound. While the use of mutexes is sufficient to prevent data races -- violations of the Go memory model -- many operations which need to be atomic are performed with unbounded concurrency. For instance, programming the encryption parameters for a peer can race with encryption keys being updated, which could lead to inconsistencies between the parameters programmed into the kernel and the desired state.

Overhaul the use of locks in the overlay network driver. Implement sound locking at the network granularity: operations may proceed concurrently iff they are being applied to distinct networks. Push the responsibility of locking up to the code which calls methods or accesses struct fields to avoid deadlock situations like we had previously with d.initSandboxPeerDB() and to make the code easier to reason about.

Each overlay network has a distinct peer db. The NetworkDB watch for the overlay peer table for the network will only start after (*driver).CreateNetwork returns and will be stopped before libnetwork calls (*driver).DeleteNetwork, therefore the lifetime of the peer db for a network is constrained to the lifetime of the network itself. Yet the peer db for a network is tracked in a dedicated map, separately from the network objects themselves. This has resulted in a parallel set of mutexes to manage concurrency of the peer db distinct from the mutexes for the driver and networks. Move the peer db for a network into a field of the network struct and guard it from concurrent access using the per-network lock. Move the methods for manipulating the peer db into the network struct so that the methods can only be called if the caller has a reference to the network object.

Network creation and deletion is synchronized using the driver-scope mutex, but some of the kernel programming is performed outside of the critical section. It is possible for network deletion to race with recreating the network, interleaving the kernel programming for the network creation and deletion, resulting in inconsistent kernel state. Parallelize network creation and deletion soundly. Use a double-checked locking scheme to soundly handle the case of concurrent CreateNetwork and DeleteNetwork for the same network id without blocking operations on other networks. Synchronize operations on a network so that operations on the network such as adding a neighbor to the peer db are performed atomically, not interleaved with deleting the network.

Handle encryption-key updates in a critical section so they can no longer be interleaved with kernel programming of encryption parameters.

**- How to verify it**
1. Create a multi-node Swarm cluster.
2. Create a user-defined overlay network.
3. `docker service create --mode global --network my-overlay -p 80:8080 nginxdemos/hello:plain-text`
4. Exec into one of the service containers and verify that the other containers can be curl'ed by the IP address of its user-defined overlay network endpoint. Repeat with the other replicas.
5. curl port 8080 on each Swarm node. Verify that the service is reachable. Repeat to verify that the requests are load-balanced among the replicas.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Improve the reliability of the overlay network driver
```

**- A picture of a cute animal (not mandatory but encouraged)**

