### PR TITLE
fix: easiest revive rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -210,6 +210,9 @@ linters:
           # FIXME make sure all packages have a description. Currently, there's many packages without.
         - name: package-comments
           disabled: true
+        - name: superfluous-else
+          arguments:
+            - preserve-scope
         - name: var-declaration
 
     staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -207,6 +207,7 @@ linters:
       # Only listed rules are applied
       # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
       rules:
+        - name: increment-decrement
           # FIXME make sure all packages have a description. Currently, there's many packages without.
         - name: package-comments
           disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -213,6 +213,7 @@ linters:
         - name: superfluous-else
           arguments:
             - preserve-scope
+        - name: use-errors-new
         - name: var-declaration
 
     staticcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -211,6 +211,7 @@ linters:
           # FIXME make sure all packages have a description. Currently, there's many packages without.
         - name: package-comments
           disabled: true
+        - name: redefines-builtin-id
         - name: superfluous-else
           arguments:
             - preserve-scope

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -204,10 +204,13 @@ linters:
       max-func-lines: 0
 
     revive:
+      # Only listed rules are applied
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
       rules:
           # FIXME make sure all packages have a description. Currently, there's many packages without.
         - name: package-comments
           disabled: true
+        - name: var-declaration
 
     staticcheck:
       checks:

--- a/api/server/httputils/form.go
+++ b/api/server/httputils/form.go
@@ -91,7 +91,7 @@ func RepoTagReference(repo, tag string) (reference.NamedTagged, error) {
 	}
 
 	if _, isDigested := ref.(reference.Digested); isDigested {
-		return nil, fmt.Errorf("cannot import digest reference")
+		return nil, errors.New("cannot import digest reference")
 	}
 
 	if tag != "" {

--- a/api/server/router/swarm/cluster_routes.go
+++ b/api/server/router/swarm/cluster_routes.go
@@ -470,7 +470,7 @@ func (sr *swarmRouter) updateSecret(ctx context.Context, w http.ResponseWriter, 
 	rawVersion := r.URL.Query().Get("version")
 	version, err := strconv.ParseUint(rawVersion, 10, 64)
 	if err != nil {
-		return errdefs.InvalidParameter(fmt.Errorf("invalid secret version"))
+		return errdefs.InvalidParameter(errors.New("invalid secret version"))
 	}
 
 	id := vars["id"]
@@ -542,7 +542,7 @@ func (sr *swarmRouter) updateConfig(ctx context.Context, w http.ResponseWriter, 
 	rawVersion := r.URL.Query().Get("version")
 	version, err := strconv.ParseUint(rawVersion, 10, 64)
 	if err != nil {
-		return errdefs.InvalidParameter(fmt.Errorf("invalid config version"))
+		return errdefs.InvalidParameter(errors.New("invalid config version"))
 	}
 
 	id := vars["id"]

--- a/api/server/router/swarm/helpers.go
+++ b/api/server/router/swarm/helpers.go
@@ -2,7 +2,7 @@ package swarm
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 
 	"github.com/docker/docker/api/server/httputils"
@@ -23,7 +23,7 @@ func (sr *swarmRouter) swarmLogs(ctx context.Context, w http.ResponseWriter, r *
 	// with the appropriate status code.
 	stdout, stderr := httputils.BoolValue(r, "stdout"), httputils.BoolValue(r, "stderr")
 	if !stdout && !stderr {
-		return fmt.Errorf("Bad parameters: you must choose at least one stream")
+		return errors.New("Bad parameters: you must choose at least one stream")
 	}
 
 	// there is probably a neater way to manufacture the LogsOptions

--- a/api/server/router/volume/volume_routes_test.go
+++ b/api/server/router/volume/volume_routes_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -605,7 +606,7 @@ func (b *fakeVolumeBackend) Get(_ context.Context, name string, _ ...opts.GetOpt
 func (b *fakeVolumeBackend) Create(_ context.Context, name, driverName string, _ ...opts.CreateOption) (*volume.Volume, error) {
 	if _, ok := b.volumes[name]; ok {
 		// TODO(dperny): return appropriate error type
-		return nil, fmt.Errorf("already exists")
+		return nil, errors.New("already exists")
 	}
 
 	v := &volume.Volume{
@@ -634,7 +635,7 @@ func (b *fakeVolumeBackend) Remove(_ context.Context, name string, o ...opts.Rem
 			return errdefs.NotFound(fmt.Errorf("volume %s not found", name))
 		}
 	} else if v.Name == "inuse" {
-		return errdefs.Conflict(fmt.Errorf("volume in use"))
+		return errdefs.Conflict(errors.New("volume in use"))
 	}
 
 	delete(b.volumes, name)
@@ -655,9 +656,9 @@ type fakeClusterBackend struct {
 
 func (c *fakeClusterBackend) checkSwarm() error {
 	if !c.swarm {
-		return errdefs.Unavailable(fmt.Errorf("this node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again"))
+		return errdefs.Unavailable(errors.New("this node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again"))
 	} else if !c.manager {
-		return errdefs.Unavailable(fmt.Errorf("this node is not a swarm manager. Worker nodes can't be used to view or modify cluster state. Please run this command on a manager node or promote the current node to a manager"))
+		return errdefs.Unavailable(errors.New("this node is not a swarm manager. Worker nodes can't be used to view or modify cluster state. Please run this command on a manager node or promote the current node to a manager"))
 	}
 
 	return nil
@@ -697,7 +698,7 @@ func (c *fakeClusterBackend) CreateVolume(volumeCreate volume.CreateOptions) (*v
 
 	if _, ok := c.volumes[volumeCreate.Name]; ok {
 		// TODO(dperny): return appropriate already exists error
-		return nil, fmt.Errorf("already exists")
+		return nil, errors.New("already exists")
 	}
 
 	v := &volume.Volume{
@@ -751,7 +752,7 @@ func (c *fakeClusterBackend) UpdateVolume(nameOrID string, version uint64, _ vol
 
 	if v, ok := c.volumes[nameOrID]; ok {
 		if v.ClusterVolume.Meta.Version.Index != version {
-			return fmt.Errorf("wrong version")
+			return errors.New("wrong version")
 		}
 		v.ClusterVolume.Meta.Version.Index = v.ClusterVolume.Meta.Version.Index + 1
 		// for testing, we don't actually need to change anything about the

--- a/builder/builder-next/builder.go
+++ b/builder/builder-next/builder.go
@@ -617,7 +617,7 @@ func toBuildkitExtraHosts(inp []string, hostGatewayIPs []netip.Addr) (string, er
 		// IP address(es) stored in the daemon level HostGatewayIPs config variable.
 		if ip == opts.HostGatewayName {
 			if len(hostGatewayIPs) == 0 {
-				return "", fmt.Errorf("unable to derive the IP value for host-gateway")
+				return "", errors.New("unable to derive the IP value for host-gateway")
 			}
 			for _, gip := range hostGatewayIPs {
 				hosts = append(hosts, host+"="+gip.String())

--- a/builder/builder-next/exporter/mobyexporter/export.go
+++ b/builder/builder-next/exporter/mobyexporter/export.go
@@ -106,12 +106,12 @@ func (e *imageExporterInstance) Attrs() map[string]string {
 
 func (e *imageExporterInstance) Export(ctx context.Context, inp *exporter.Source, inlineCache exptypes.InlineCache, sessionID string) (map[string]string, exporter.DescriptorReference, error) {
 	if len(inp.Refs) > 1 {
-		return nil, nil, fmt.Errorf("exporting multiple references to image store is currently unsupported")
+		return nil, nil, errors.New("exporting multiple references to image store is currently unsupported")
 	}
 
 	ref := inp.Ref
 	if ref != nil && len(inp.Refs) == 1 {
-		return nil, nil, fmt.Errorf("invalid exporter input: Ref and Refs are mutually exclusive")
+		return nil, nil, errors.New("invalid exporter input: Ref and Refs are mutually exclusive")
 	}
 
 	// only one loop

--- a/builder/dockerfile/imagecontext_test.go
+++ b/builder/dockerfile/imagecontext_test.go
@@ -2,7 +2,7 @@ package dockerfile
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"runtime"
 	"testing"
 
@@ -31,7 +31,7 @@ func getMockImageMount() *imageMount {
 }
 
 func TestAddScratchImageAddsToMounts(t *testing.T) {
-	is := getMockImageSource(nil, nil, fmt.Errorf("getImage is not implemented"))
+	is := getMockImageSource(nil, nil, errors.New("getImage is not implemented"))
 	im := getMockImageMount()
 
 	// We are testing whether the imageMount is added to is.mounts
@@ -41,7 +41,7 @@ func TestAddScratchImageAddsToMounts(t *testing.T) {
 }
 
 func TestAddFromScratchPopulatesPlatform(t *testing.T) {
-	is := getMockImageSource(nil, nil, fmt.Errorf("getImage is not implemented"))
+	is := getMockImageSource(nil, nil, errors.New("getImage is not implemented"))
 
 	platforms := []*ocispec.Platform{
 		{
@@ -68,7 +68,7 @@ func TestAddFromScratchPopulatesPlatform(t *testing.T) {
 }
 
 func TestAddFromScratchDoesNotModifyArgPlatform(t *testing.T) {
-	is := getMockImageSource(nil, nil, fmt.Errorf("getImage is not implemented"))
+	is := getMockImageSource(nil, nil, errors.New("getImage is not implemented"))
 	im := getMockImageMount()
 
 	platform := &ocispec.Platform{
@@ -84,7 +84,7 @@ func TestAddFromScratchDoesNotModifyArgPlatform(t *testing.T) {
 }
 
 func TestAddFromScratchPopulatesPlatformIfNil(t *testing.T) {
-	is := getMockImageSource(nil, nil, fmt.Errorf("getImage is not implemented"))
+	is := getMockImageSource(nil, nil, errors.New("getImage is not implemented"))
 	im := getMockImageMount()
 	is.Add(im, nil)
 	image, ok := im.image.(*image.Image)

--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,7 +62,7 @@ func TestCheckpointCreate(t *testing.T) {
 			}
 
 			if !createOptions.Exit {
-				return nil, fmt.Errorf("expected Exit to be true")
+				return nil, errors.New("expected Exit to be true")
 			}
 
 			return &http.Response{

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -69,7 +70,7 @@ func TestContainerStatPath(t *testing.T) {
 			query := req.URL.Query()
 			path := query.Get("path")
 			if path != expectedPath {
-				return nil, fmt.Errorf("path not set in URL query properly")
+				return nil, errors.New("path not set in URL query properly")
 			}
 			content, err := json.Marshal(container.PathStat{
 				Name: "name",

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -156,13 +156,13 @@ func normalizeCapabilities(caps []string) []string {
 // normalizeCap normalizes a capability to its canonical format by upper-casing
 // and adding a "CAP_" prefix (if not yet present). It also accepts the "ALL"
 // magic-value.
-func normalizeCap(cap string) string {
-	cap = strings.ToUpper(cap)
-	if cap == allCapabilities {
-		return cap
+func normalizeCap(capability string) string {
+	capability = strings.ToUpper(capability)
+	if capability == allCapabilities {
+		return capability
 	}
-	if !strings.HasPrefix(cap, "CAP_") {
-		cap = "CAP_" + cap
+	if !strings.HasPrefix(capability, "CAP_") {
+		capability = "CAP_" + capability
 	}
-	return cap
+	return capability
 }

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -48,7 +49,7 @@ func TestImagePullWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
 	privilegeFunc := func(_ context.Context) (string, error) {
-		return "", fmt.Errorf("Error requesting privilege")
+		return "", errors.New("Error requesting privilege")
 	}
 	_, err := client.ImagePull(context.Background(), "myimage", image.PullOptions{
 		PrivilegeFunc: privilegeFunc,

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -51,7 +52,7 @@ func TestImagePushWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
 	privilegeFunc := func(_ context.Context) (string, error) {
-		return "", fmt.Errorf("Error requesting privilege")
+		return "", errors.New("Error requesting privilege")
 	}
 	_, err := client.ImagePush(context.Background(), "myimage", image.PushOptions{
 		PrivilegeFunc: privilegeFunc,

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,7 +39,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
 	privilegeFunc := func(_ context.Context) (string, error) {
-		return "", fmt.Errorf("Error requesting privilege")
+		return "", errors.New("Error requesting privilege")
 	}
 	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
 		PrivilegeFunc: privilegeFunc,

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -156,7 +157,7 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 				serviceCreateImage = ""
 				var service swarm.ServiceSpec
 				if err := json.NewDecoder(req.Body).Decode(&service); err != nil {
-					return nil, fmt.Errorf("could not parse service create request")
+					return nil, errors.New("could not parse service create request")
 				}
 				serviceCreateImage = service.TaskTemplate.ContainerSpec.Image
 
@@ -172,7 +173,7 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 				}, nil
 			} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/cannotresolve") {
 				// unresolvable image
-				return nil, fmt.Errorf("cannot resolve image")
+				return nil, errors.New("cannot resolve image")
 			} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/") {
 				// resolvable images
 				b, err := json.Marshal(registrytypes.DistributionInspect{

--- a/container/health.go
+++ b/container/health.go
@@ -46,11 +46,11 @@ func (s *Health) Status() container.HealthStatus {
 // obeying the locking semantics.
 //
 // Status may be set directly if another lock is used.
-func (s *Health) SetStatus(new container.HealthStatus) {
+func (s *Health) SetStatus(healthStatus container.HealthStatus) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.Health.Status = new
+	s.Health.Status = healthStatus
 }
 
 // OpenMonitorChannel creates and returns a new monitor channel. If there

--- a/container/view.go
+++ b/container/view.go
@@ -447,7 +447,7 @@ func (e *containerByIDIndexer) FromObject(obj any) (bool, []byte, error) {
 // FromArgs implements the memdb.Indexer interface
 func (e *containerByIDIndexer) FromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf("must provide only a single argument")
+		return nil, errors.New("must provide only a single argument")
 	}
 	arg, ok := args[0].(string)
 	if !ok {
@@ -482,7 +482,7 @@ func (e *namesByNameIndexer) FromObject(obj any) (bool, []byte, error) {
 
 func (e *namesByNameIndexer) FromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf("must provide only a single argument")
+		return nil, errors.New("must provide only a single argument")
 	}
 	arg, ok := args[0].(string)
 	if !ok {
@@ -507,7 +507,7 @@ func (e *namesByContainerIDIndexer) FromObject(obj any) (bool, []byte, error) {
 
 func (e *namesByContainerIDIndexer) FromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
-		return nil, fmt.Errorf("must provide only a single argument")
+		return nil, errors.New("must provide only a single argument")
 	}
 	arg, ok := args[0].(string)
 	if !ok {

--- a/daemon/cdi.go
+++ b/daemon/cdi.go
@@ -66,7 +66,7 @@ func newCDIDeviceDriver(cdiSpecDirs ...string) (*deviceDriver, *cdi.Cache) {
 // If the list of CDI specification directories is empty or the creation of the CDI cache fails, an error is returned.
 func createCDICache(cdiSpecDirs ...string) (*cdi.Cache, error) {
 	if len(cdiSpecDirs) == 0 {
-		return nil, fmt.Errorf("no CDI specification directories specified")
+		return nil, errors.New("no CDI specification directories specified")
 	}
 
 	cache, err := cdi.NewCache(cdi.WithSpecDirs(cdiSpecDirs...))

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -318,7 +318,7 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 	}
 
 	if numModes > 1 {
-		return swarmapi.ServiceSpec{}, fmt.Errorf("must specify only one service mode")
+		return swarmapi.ServiceSpec{}, errors.New("must specify only one service mode")
 	}
 
 	if s.Mode.Global != nil {

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -166,7 +166,7 @@ func (c *containerAdapter) waitNodeAttachments(ctx context.Context) error {
 	// we'll wait and try again.
 	attachmentStore := c.backend.GetAttachmentStore()
 	if attachmentStore == nil {
-		return fmt.Errorf("error getting attachment store")
+		return errors.New("error getting attachment store")
 	}
 
 	// essentially, we're long-polling here. this is really sub-optimal, but a
@@ -199,7 +199,7 @@ func (c *containerAdapter) waitNodeAttachments(ctx context.Context) error {
 		// otherwise, try polling again, or wait for context canceled.
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("node is missing network attachments, ip addresses may be exhausted")
+			return errors.New("node is missing network attachments, ip addresses may be exhausted")
 		case <-poll.C:
 		}
 	}

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -114,12 +114,12 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 	}
 
 	if rootless.RunningWithRootlessKit() && !cli.Config.IsRootless() {
-		return fmt.Errorf("rootless mode needs to be enabled for running with RootlessKit")
+		return errors.New("rootless mode needs to be enabled for running with RootlessKit")
 	}
 
 	// return human-friendly error before creating files
 	if runtime.GOOS == "linux" && os.Geteuid() != 0 {
-		return fmt.Errorf("dockerd needs to be started with root privileges. To run dockerd in rootless mode as an unprivileged user, see https://docs.docker.com/go/rootless/")
+		return errors.New("dockerd needs to be started with root privileges. To run dockerd in rootless mode as an unprivileged user, see https://docs.docker.com/go/rootless/")
 	}
 
 	if err := setDefaultUmask(); err != nil {

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -124,7 +124,7 @@ func (conf *Config) GetResolvConf() string {
 // IsSwarmCompatible defines if swarm mode can be enabled in this config
 func (conf *Config) IsSwarmCompatible() error {
 	if conf.LiveRestoreEnabled {
-		return fmt.Errorf("--live-restore daemon configuration is incompatible with swarm mode")
+		return errors.New("--live-restore daemon configuration is incompatible with swarm mode")
 	}
 	return nil
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -179,7 +179,7 @@ func getEntrypointAndArgs(configEntrypoint, configCmd []string) (string, []strin
 // GetByName returns a container given a name.
 func (daemon *Daemon) GetByName(name string) (*container.Container, error) {
 	if name == "" {
-		return nil, fmt.Errorf("No container name supplied")
+		return nil, errors.New("No container name supplied")
 	}
 	fullName := name
 	if name[0] != '/' {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -92,7 +92,7 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 		// config variable
 		if ip == opts.HostGatewayName {
 			if len(cfg.HostGatewayIPs) == 0 {
-				return nil, fmt.Errorf("unable to derive the IP value for host-gateway")
+				return nil, errors.New("unable to derive the IP value for host-gateway")
 			}
 			for _, gip := range cfg.HostGatewayIPs {
 				sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, gip.String()))

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -236,7 +236,7 @@ func (daemon *Daemon) setupIPCDirs(ctr *container.Container) error {
 
 	case ipcMode.IsHost():
 		if _, err := os.Stat("/dev/shm"); err != nil {
-			return fmt.Errorf("/dev/shm is not mounted, but must be for --ipc=host")
+			return errors.New("/dev/shm is not mounted, but must be for --ipc=host")
 		}
 		ctr.ShmPath = "/dev/shm"
 
@@ -294,7 +294,7 @@ func (daemon *Daemon) setupSecretDir(ctr *container.Container) (setupErr error) 
 	}()
 
 	if ctr.DependencyStore == nil {
-		return fmt.Errorf("secret store is not initialized")
+		return errors.New("secret store is not initialized")
 	}
 
 	// retrieve possible remapped range start for root UID, GID

--- a/daemon/containerd/fake_service_test.go
+++ b/daemon/containerd/fake_service_test.go
@@ -110,11 +110,11 @@ func (s *blobsDirContentStore) ReaderAt(ctx context.Context, desc ocispec.Descri
 }
 
 func (s *blobsDirContentStore) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
-	return nil, fmt.Errorf("read-only")
+	return nil, errors.New("read-only")
 }
 
 func (s *blobsDirContentStore) Status(ctx context.Context, _ string) (content.Status, error) {
-	return content.Status{}, fmt.Errorf("not implemented")
+	return content.Status{}, errors.New("not implemented")
 }
 
 func (s *blobsDirContentStore) Delete(ctx context.Context, dgst digest.Digest) error {
@@ -127,7 +127,7 @@ func (s *blobsDirContentStore) ListStatuses(ctx context.Context, filters ...stri
 }
 
 func (s *blobsDirContentStore) Abort(ctx context.Context, ref string) error {
-	return fmt.Errorf("not implemented")
+	return errors.New("not implemented")
 }
 
 func (s *blobsDirContentStore) Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error {
@@ -181,7 +181,7 @@ func (s *blobsDirContentStore) Info(ctx context.Context, dgst digest.Digest) (co
 }
 
 func (s *blobsDirContentStore) Update(ctx context.Context, info content.Info, fieldpaths ...string) (content.Info, error) {
-	return content.Info{}, fmt.Errorf("read-only")
+	return content.Info{}, errors.New("read-only")
 }
 
 // delayedStore is a content store wrapper that adds a constant delay to all

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -67,7 +67,7 @@ const (
 func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error) {
 	if refOrID == "" { // FROM scratch
 		if runtime.GOOS == "windows" {
-			return nil, nil, fmt.Errorf(`"FROM scratch" is not supported on Windows`)
+			return nil, nil, errors.New(`"FROM scratch" is not supported on Windows`)
 		}
 		if opts.Platform != nil {
 			if err := image.CheckOS(opts.Platform.OS); err != nil {
@@ -189,7 +189,7 @@ Please notify the image author to correct the configuration.`,
 
 func newROLayerForImage(ctx context.Context, imgDesc *ocispec.Descriptor, i *ImageService, platform *ocispec.Platform) (builder.ROLayer, error) {
 	if imgDesc == nil {
-		return nil, fmt.Errorf("can't make an RO layer for a nil image :'(")
+		return nil, errors.New("can't make an RO layer for a nil image :'(")
 	}
 
 	platMatcher := platforms.Default()
@@ -376,7 +376,7 @@ func (rw *rwlayer) Commit() (_ builder.ROLayer, outErr error) {
 	}
 	diffIDStr, ok := info.Labels["containerd.io/uncompressed"]
 	if !ok {
-		return nil, fmt.Errorf("invalid differ response with no diffID")
+		return nil, errors.New("invalid differ response with no diffID")
 	}
 	diffID, err := digest.Parse(diffIDStr)
 	if err != nil {

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -239,7 +239,7 @@ func (i *ImageService) createDiff(ctx context.Context, name string, sn snapshots
 
 	diffIDStr, ok := cinfo.Labels["containerd.io/uncompressed"]
 	if !ok {
-		return nil, "", fmt.Errorf("invalid differ response with no diffID")
+		return nil, "", errors.New("invalid differ response with no diffID")
 	}
 
 	diffID, err := digest.Parse(diffIDStr)

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -108,7 +108,7 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 	// Images considered for pruning.
 	imagesToPrune := map[string]c8dimages.Image{}
 	for _, img := range allImages {
-		digestRefCount[img.Target.Digest] += 1
+		digestRefCount[img.Target.Digest]++
 
 		if !danglingOnly || isDanglingImage(img) {
 			canBePruned := filterFunc(img)
@@ -138,7 +138,7 @@ func (i *ImageService) pruneUnused(ctx context.Context, filterFunc imageFilterFu
 		dgst := img.Target.Digest
 
 		if digestRefCount[dgst] > 1 {
-			digestRefCount[dgst] -= 1
+			digestRefCount[dgst]--
 			continue
 		}
 

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -131,7 +131,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 		}
 	}()
 
-	var limiter *semaphore.Weighted = nil // TODO: Respect max concurrent downloads/uploads
+	var limiter *semaphore.Weighted // TODO: Respect max concurrent downloads/uploads
 
 	mountableBlobs, err := findMissingMountable(ctx, store, jobsQueue, target, targetRef, limiter)
 	if err != nil {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -5,6 +5,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -330,7 +331,7 @@ func (daemon *Daemon) generateSecurityOpt(hostConfig *containertypes.HostConfig)
 	if pidLabel != nil && ipcLabel != nil {
 		for i := 0; i < len(pidLabel); i++ {
 			if pidLabel[i] != ipcLabel[i] {
-				return nil, fmt.Errorf("--ipc and --pid containers SELinux labels aren't the same")
+				return nil, errors.New("--ipc and --pid containers SELinux labels aren't the same")
 			}
 		}
 		return toHostConfigSelinuxLabels(pidLabel), nil
@@ -349,7 +350,7 @@ func (daemon *Daemon) mergeAndVerifyConfig(config *containertypes.Config, img *i
 		config.Entrypoint = nil
 	}
 	if len(config.Entrypoint) == 0 && len(config.Cmd) == 0 {
-		return fmt.Errorf("no command specified")
+		return errors.New("no command specified")
 	}
 	return nil
 }

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -66,7 +66,7 @@ func (daemon *Daemon) rmLink(cfg *config.Config, ctr *container.Container, name 
 	}
 	parent, n := path.Split(name)
 	if parent == "/" {
-		return fmt.Errorf("Conflict, cannot remove the default link name of the container")
+		return errors.New("Conflict, cannot remove the default link name of the container")
 	}
 
 	parent = strings.TrimSuffix(parent, "/")

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -22,7 +23,7 @@ func (daemon *Daemon) ContainerExport(ctx context.Context, name string, out io.W
 	}
 
 	if isWindows && ctr.ImagePlatform.OS == "windows" {
-		return fmt.Errorf("the daemon on this operating system does not support exporting Windows containers")
+		return errors.New("the daemon on this operating system does not support exporting Windows containers")
 	}
 
 	if ctr.IsDead() {

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -181,7 +181,7 @@ func openDir(path string) (*C.DIR, error) {
 
 	dir := C.opendir(Cpath)
 	if dir == nil {
-		return nil, fmt.Errorf("Can't open dir")
+		return nil, errors.New("Can't open dir")
 	}
 	return dir, nil
 }

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -141,7 +141,7 @@ func getDriver(name string, config Options) (Driver, error) {
 
 	// TODO(thaJeztah): remove in next release.
 	if os.Getenv("DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS") != "" {
-		return nil, fmt.Errorf("DEPRECATED: Support for experimental graphdriver plugins has been removed. See https://docs.docker.com/go/deprecated/")
+		return nil, errors.New("DEPRECATED: Support for experimental graphdriver plugins has been removed. See https://docs.docker.com/go/deprecated/")
 	}
 
 	return nil, ErrNotSupported

--- a/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
+++ b/daemon/graphdriver/fuse-overlayfs/fuseoverlayfs.go
@@ -5,7 +5,6 @@ package fuseoverlayfs
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -155,7 +154,7 @@ func (d *Driver) Cleanup() error {
 // file system.
 func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
 	if opts != nil && len(opts.StorageOpt) != 0 {
-		return fmt.Errorf("--storage-opt is not supported")
+		return errors.New("--storage-opt is not supported")
 	}
 	return d.create(id, parent, opts)
 }
@@ -164,7 +163,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // The parent filesystem is used to configure these directories for the overlay.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr error) {
 	if opts != nil && len(opts.StorageOpt) != 0 {
-		return fmt.Errorf("--storage-opt is not supported")
+		return errors.New("--storage-opt is not supported")
 	}
 	return d.create(id, parent, opts)
 }
@@ -188,7 +187,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 	}()
 
 	if opts != nil && len(opts.StorageOpt) > 0 {
-		return fmt.Errorf("--storage-opt is not supported")
+		return errors.New("--storage-opt is not supported")
 	}
 
 	if err := user.MkdirAndChown(path.Join(dir, diffDirName), 0o755, uid, gid); err != nil {
@@ -281,7 +280,7 @@ func (d *Driver) getLowerDirs(id string) ([]string, error) {
 // Remove cleans the directories that are created for this id.
 func (d *Driver) Remove(id string) error {
 	if id == "" {
-		return fmt.Errorf("refusing to remove the directories: id is empty")
+		return errors.New("refusing to remove the directories: id is empty")
 	}
 	d.locker.Lock(id)
 	defer d.locker.Unlock(id)

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -325,7 +325,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 	}
 
 	if _, ok := opts.StorageOpt["size"]; ok && !projectQuotaSupported {
-		return fmt.Errorf("--storage-opt is supported only for overlay over xfs with 'pquota' mount option")
+		return errors.New("--storage-opt is supported only for overlay over xfs with 'pquota' mount option")
 	}
 
 	return d.create(id, parent, opts)
@@ -336,7 +336,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr error) {
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		if _, ok := opts.StorageOpt["size"]; ok {
-			return fmt.Errorf("--storage-opt size is only supported for ReadWrite Layers")
+			return errors.New("--storage-opt size is only supported for ReadWrite Layers")
 		}
 	}
 	return d.create(id, parent, opts)
@@ -485,7 +485,7 @@ func (d *Driver) getLowerDirs(id string) ([]string, error) {
 // Remove cleans the directories that are created for this id.
 func (d *Driver) Remove(id string) error {
 	if id == "" {
-		return fmt.Errorf("refusing to remove the directories: id is empty")
+		return errors.New("refusing to remove the directories: id is empty")
 	}
 	d.locker.Lock(id)
 	defer d.locker.Unlock(id)

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -150,7 +150,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 // Create prepares the filesystem for the VFS driver and copies the directory for the given id under the parent.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	if opts != nil && len(opts.StorageOpt) != 0 {
-		return fmt.Errorf("--storage-opt is not supported for vfs on read-only layers")
+		return errors.New("--storage-opt is not supported for vfs on read-only layers")
 	}
 
 	return d.create(id, parent, 0)

--- a/daemon/images/image_builder.go
+++ b/daemon/images/image_builder.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"runtime"
 
@@ -195,7 +194,7 @@ Please notify the image author to correct the configuration.`,
 func (i *ImageService) GetImageAndReleasableLayer(ctx context.Context, refOrID string, opts backend.GetImageAndLayerOptions) (builder.Image, builder.ROLayer, error) {
 	if refOrID == "" { // FROM scratch
 		if runtime.GOOS == "windows" {
-			return nil, nil, fmt.Errorf(`"FROM scratch" is not supported on Windows`)
+			return nil, nil, errors.New(`"FROM scratch" is not supported on Windows`)
 		}
 		if opts.Platform != nil {
 			if err := image.CheckOS(opts.Platform.OS); err != nil {

--- a/daemon/images/image_history.go
+++ b/daemon/images/image_history.go
@@ -2,7 +2,7 @@ package images
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/distribution/reference"
@@ -33,7 +33,7 @@ func (i *ImageService) ImageHistory(ctx context.Context, name string, platform *
 
 		if !h.EmptyLayer {
 			if len(img.RootFS.DiffIDs) <= layerCounter {
-				return nil, fmt.Errorf("too many non-empty layers in History section")
+				return nil, errors.New("too many non-empty layers in History section")
 			}
 			rootFS.Append(img.RootFS.DiffIDs[layerCounter])
 			l, err := i.layerStore.Get(rootFS.ChainID())

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -192,7 +191,7 @@ func getUntilFromPruneFilters(pruneFilters filters.Args) (time.Time, error) {
 	}
 	untilFilters := pruneFilters.Get("until")
 	if len(untilFilters) > 1 {
-		return until, fmt.Errorf("more than one until filter specified")
+		return until, errors.New("more than one until filter specified")
 	}
 	ts, err := timetypes.GetTimestamp(untilFilters[0], time.Now())
 	if err != nil {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -514,7 +514,7 @@ func includeContainerInList(container *container.Snapshot, filter *listContext) 
 			}
 		}
 
-		volumeExist := fmt.Errorf("volume mounted in container")
+		volumeExist := errors.New("volume mounted in container")
 		err := filter.filters.WalkValues("volume", func(value string) error {
 			if _, exist := volumesByDestination[value]; exist {
 				return volumeExist

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -116,7 +116,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		project = projectID
 	}
 	if project == "" {
-		return nil, fmt.Errorf("No project was specified and couldn't read project from the metadata server. Please specify a project")
+		return nil, errors.New("No project was specified and couldn't read project from the metadata server. Please specify a project")
 	}
 
 	c, err := logging.NewClient(context.Background(), project)

--- a/daemon/logger/journald/internal/sdjournal/sdjournal.go
+++ b/daemon/logger/journald/internal/sdjournal/sdjournal.go
@@ -224,17 +224,17 @@ func (j *Journal) Data() (map[string]string, error) {
 	j.restartData()
 	for {
 		var (
-			data unsafe.Pointer
-			len  C.size_t
+			data   unsafe.Pointer
+			length C.size_t
 		)
-		rc := C.sd_journal_enumerate_data(j.j, &data, &len)
+		rc := C.sd_journal_enumerate_data(j.j, &data, &length)
 		if rc == 0 {
 			return m, nil
 		} else if rc < 0 {
 			return m, fmt.Errorf("journald: error enumerating entry data: %w", syscall.Errno(-rc))
 		}
 
-		k, v, _ := strings.Cut(C.GoStringN((*C.char)(data), C.int(len)), "=")
+		k, v, _ := strings.Cut(C.GoStringN((*C.char)(data), C.int(length)), "=")
 		m[k] = v
 	}
 }

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -3,6 +3,7 @@
 package journald
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"sync/atomic"
@@ -100,7 +101,7 @@ func sanitizeKeyMod(s string) string {
 // the context.
 func New(info logger.Info) (logger.Logger, error) {
 	if !journal.Enabled() {
-		return nil, fmt.Errorf("journald is not enabled on this host")
+		return nil, errors.New("journald is not enabled on this host")
 	}
 
 	return newJournald(info)

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -54,7 +54,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			return nil, err
 		}
 		if capval <= 0 {
-			return nil, fmt.Errorf("max-size must be a positive number")
+			return nil, errors.New("max-size must be a positive number")
 		}
 	}
 	maxFiles := 1
@@ -65,7 +65,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			return nil, err
 		}
 		if maxFiles < 1 {
-			return nil, fmt.Errorf("max-file cannot be less than 1")
+			return nil, errors.New("max-file cannot be less than 1")
 		}
 	}
 
@@ -77,7 +77,7 @@ func New(info logger.Info) (logger.Logger, error) {
 			return nil, err
 		}
 		if compress && (maxFiles == 1 || capval == -1) {
-			return nil, fmt.Errorf("compress cannot be true when max-file is less than 2 or max-size is not set")
+			return nil, errors.New("compress cannot be true when max-file is less than 2 or max-size is not set")
 		}
 	}
 

--- a/daemon/logger/loggertest/logreader.go
+++ b/daemon/logger/loggertest/logreader.go
@@ -511,12 +511,12 @@ func logMessages(t *testing.T, l logger.Logger, messages []*logger.Message) []*l
 // existing behavior of the json-file log driver.
 func transformToExpected(m *logger.Message) *logger.Message {
 	// Copy the log message again so as not to mutate the input.
-	copy := copyLogMessage(m)
+	logMessageCopy := copyLogMessage(m)
 	if m.PLogMetaData == nil || m.PLogMetaData.Last {
-		copy.Line = append(copy.Line, '\n')
+		logMessageCopy.Line = append(logMessageCopy.Line, '\n')
 	}
 
-	return copy
+	return logMessageCopy
 }
 
 func copyLogMessage(src *logger.Message) *logger.Message {

--- a/daemon/logger/plugin.go
+++ b/daemon/logger/plugin.go
@@ -22,7 +22,7 @@ const extName = "LogDriver"
 type logPlugin interface {
 	StartLogging(streamPath string, info Info) (err error)
 	StopLogging(streamPath string) (err error)
-	Capabilities() (cap Capability, err error)
+	Capabilities() (capability Capability, err error)
 	ReadLogs(info Info, config ReadConfig) (stream io.ReadCloser, err error)
 }
 

--- a/daemon/migration_test.go
+++ b/daemon/migration_test.go
@@ -52,7 +52,7 @@ func TestContainerMigrateOS(t *testing.T) {
 	var mock mockPlatformReader
 
 	// ImageManifest is nil for containers created with graphdrivers image store
-	var graphdrivers *ocispec.Descriptor = nil
+	var graphdrivers *ocispec.Descriptor
 
 	for _, tc := range []struct {
 		name     string

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -22,12 +21,12 @@ var (
 
 func (daemon *Daemon) registerName(container *container.Container) error {
 	if container.ID == "" {
-		return fmt.Errorf("invalid empty id")
+		return errors.New("invalid empty id")
 	}
 	if daemon.containers.Get(container.ID) != nil {
 		// TODO(thaJeztah): should this be a panic (duplicate IDs due to invalid state on disk?)
 		// TODO(thaJeztah): should this also check for container.ID being a prefix of another container's ID? (daemon.containersReplica.GetByPrefix); only should happen due to corruption / truncated ID.
-		return fmt.Errorf("container is already loaded")
+		return errors.New("container is already loaded")
 	}
 	if container.Name == "" {
 		name, err := daemon.generateAndReserveName(container.ID)

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -252,7 +252,7 @@ func (daemon *Daemon) SetNetworkBootstrapKeys(keys []*lntypes.EncryptionKey) err
 // UpdateAttachment notifies the attacher about the attachment config.
 func (daemon *Daemon) UpdateAttachment(networkName, networkID, containerID string, config *networktypes.NetworkingConfig) error {
 	if daemon.clusterProvider == nil {
-		return fmt.Errorf("cluster provider is not initialized")
+		return errors.New("cluster provider is not initialized")
 	}
 
 	if err := daemon.clusterProvider.UpdateAttachment(networkName, containerID, config); err != nil {
@@ -266,7 +266,7 @@ func (daemon *Daemon) UpdateAttachment(networkName, networkID, containerID strin
 // the container from the network.
 func (daemon *Daemon) WaitForDetachment(ctx context.Context, networkName, networkID, taskID, containerID string) error {
 	if daemon.clusterProvider == nil {
-		return fmt.Errorf("cluster provider is not initialized")
+		return errors.New("cluster provider is not initialized")
 	}
 
 	return daemon.clusterProvider.WaitForDetachment(ctx, networkName, networkID, taskID, containerID)

--- a/daemon/seccomp_linux.go
+++ b/daemon/seccomp_linux.go
@@ -2,7 +2,7 @@ package daemon
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	coci "github.com/containerd/containerd/v2/pkg/oci"
@@ -30,7 +30,7 @@ func WithSeccomp(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		}
 		if !daemon.RawSysInfo().Seccomp {
 			if c.SeccompProfile != "" && c.SeccompProfile != dconfig.SeccompProfileDefault {
-				return fmt.Errorf("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
+				return errors.New("seccomp is not enabled in your kernel, cannot run a custom seccomp profile")
 			}
 			log.G(ctx).Warn("seccomp is not enabled in your kernel, running container without default profile")
 			c.SeccompProfile = dconfig.SeccompProfileUnconfined

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -348,7 +348,7 @@ func readSystemCPUUsage(r io.Reader) (cpuUsage uint64, cpuNum uint32, _ error) {
 		if line[3] == ' ' {
 			parts := strings.Fields(line)
 			if len(parts) < 8 {
-				return 0, 0, fmt.Errorf("invalid number of cpu fields")
+				return 0, 0, errors.New("invalid number of cpu fields")
 			}
 			var totalClockTicks uint64
 			for _, i := range parts[1:8] {

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -79,7 +79,7 @@ func parsePSOutput(output []byte, procs []uint32) (*container.TopResponse, error
 		}
 	}
 	if pidIndex == -1 {
-		return nil, fmt.Errorf("Couldn't find PID field in ps output")
+		return nil, errors.New("Couldn't find PID field in ps output")
 	}
 
 	// loop through the output and extract the PID from each line

--- a/daemon/update.go
+++ b/daemon/update.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
@@ -56,7 +55,7 @@ func (daemon *Daemon) update(name string, hostConfig *container.HostConfig) erro
 
 	if ctr.RemovalInProgress || ctr.Dead {
 		ctr.Unlock()
-		return errCannotUpdate(ctr.ID, fmt.Errorf(`container is marked for removal and cannot be "update"`))
+		return errCannotUpdate(ctr.ID, errors.New(`container is marked for removal and cannot be "update"`))
 	}
 
 	if err := ctr.UpdateContainer(hostConfig); err != nil {

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -595,7 +595,7 @@ func getMaxMountAndExistenceCheckAttempts(layer PushLayer) (maxMountAttempts, ma
 func getRepositoryMountCandidates(
 	repoInfo reference.Named,
 	hmacKey []byte,
-	max int,
+	maxCandidates int,
 	v2Metadata []metadata.V2Metadata,
 ) []metadata.V2Metadata {
 	candidates := []metadata.V2Metadata{}
@@ -612,9 +612,9 @@ func getRepositoryMountCandidates(
 	}
 
 	sortV2MetadataByLikenessAndAge(repoInfo, hmacKey, candidates)
-	if max >= 0 && len(candidates) > max {
+	if maxCandidates >= 0 && len(candidates) > maxCandidates {
 		// select the youngest metadata
-		candidates = candidates[:max]
+		candidates = candidates[:maxCandidates]
 	}
 
 	return candidates

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -52,9 +52,9 @@ type DownloadOption func(*LayerDownloadManager)
 
 // WithMaxDownloadAttempts configures the maximum number of download
 // attempts for a download manager.
-func WithMaxDownloadAttempts(max int) DownloadOption {
+func WithMaxDownloadAttempts(maxDownloadAttempts int) DownloadOption {
 	return func(dlm *LayerDownloadManager) {
-		dlm.maxDownloadAttempts = max
+		dlm.maxDownloadAttempts = maxDownloadAttempts
 	}
 }
 

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -33,7 +33,7 @@ func (ml *mockLayer) TarStream() (io.ReadCloser, error) {
 }
 
 func (ml *mockLayer) TarStreamFrom(layer.ChainID) (io.ReadCloser, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (ml *mockLayer) ChainID() layer.ChainID {

--- a/errdefs/http_helpers_test.go
+++ b/errdefs/http_helpers_test.go
@@ -1,13 +1,13 @@
 package errdefs
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"testing"
 )
 
 func TestFromStatusCode(t *testing.T) {
-	testErr := fmt.Errorf("some error occurred")
+	testErr := errors.New("some error occurred")
 
 	testCases := []struct {
 		err    error

--- a/image/fs.go
+++ b/image/fs.go
@@ -114,7 +114,7 @@ func (s *fs) Set(data []byte) (digest.Digest, error) {
 	defer s.Unlock()
 
 	if len(data) == 0 {
-		return "", fmt.Errorf("invalid empty data")
+		return "", errors.New("invalid empty data")
 	}
 
 	dgst := digest.FromBytes(data)

--- a/image/tarexport/save.go
+++ b/image/tarexport/save.go
@@ -419,7 +419,7 @@ func (s *saveSession) saveImage(ctx context.Context, id image.ID) (_ map[layer.D
 
 	img := s.images[id].image
 	if len(img.RootFS.DiffIDs) == 0 {
-		return nil, fmt.Errorf("empty export - not implemented")
+		return nil, errors.New("empty export - not implemented")
 	}
 
 	ts := time.Unix(0, 0)

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -187,7 +188,7 @@ func (d *Daemon) CheckLeader(ctx context.Context) func(t *testing.T) (interface{
 				return nil, ""
 			}
 		}
-		return fmt.Errorf("no leader"), "could not find leader"
+		return errors.New("no leader"), "could not find leader"
 	}
 }
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -242,7 +243,7 @@ func (c *ChannelBuffer) ReadTimeout(p []byte, n time.Duration) (int, error) {
 	case b := <-c.C:
 		return copy(p[0:], b), nil
 	case <-time.After(n):
-		return -1, fmt.Errorf("timeout reading from channel")
+		return -1, errors.New("timeout reading from channel")
 	}
 }
 

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -136,7 +137,7 @@ func (s *DockerCLIAttachSuite) TestAttachTTYWithoutStdin(c *testing.T) {
 			Stdout:  cmd.Stdout,
 		})
 		if result.Error == nil {
-			done <- fmt.Errorf("attach should have failed")
+			done <- errors.New("attach should have failed")
 			return
 		} else if !strings.Contains(result.Combined(), expected) {
 			done <- fmt.Errorf("attach failed with error %q: expected %q", out, expected)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1557,7 +1558,7 @@ func compareDirectoryEntries(e1 []os.DirEntry, e2 []os.DirEntry) error {
 		e2Entries[e.Name()] = struct{}{}
 	}
 	if !reflect.DeepEqual(e1Entries, e2Entries) {
-		return fmt.Errorf("entries differ")
+		return errors.New("entries differ")
 	}
 	return nil
 }

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -196,7 +197,7 @@ func (s *DockerCLIExecSuite) TestExecTTYWithoutStdin(c *testing.T) {
 			expected += ".  If you are using mintty, try prefixing the command with 'winpty'"
 		}
 		if out, _, err := runCommandWithOutput(cmd); err == nil {
-			errChan <- fmt.Errorf("exec should have failed")
+			errChan <- errors.New("exec should have failed")
 			return
 		} else if !strings.Contains(out, expected) {
 			errChan <- fmt.Errorf("exec failed with error %q: expected %q", out, expected)

--- a/integration-cli/docker_cli_external_volume_driver_test.go
+++ b/integration-cli/docker_cli_external_volume_driver_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -218,7 +219,7 @@ func newVolumePlugin(t *testing.T, name string) *volumePlugin {
 		if v, exists := s.vols[pr.Name]; exists {
 			// Use this to simulate a mount failure
 			if _, exists := v.Options["invalidOption"]; exists {
-				send(w, fmt.Errorf("invalid argument"))
+				send(w, errors.New("invalid argument"))
 				return
 			}
 		}

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -225,10 +226,10 @@ func assertPortRange(ctx context.Context, id string, expectedTCP, expectedUDP []
 		}
 	}
 	if !validTCP {
-		return fmt.Errorf("tcp port not found")
+		return errors.New("tcp port not found")
 	}
 	if !validUDP {
-		return fmt.Errorf("udp port not found")
+		return errors.New("udp port not found")
 	}
 	return nil
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2493,7 +2493,7 @@ func (s *DockerCLIRunSuite) TestRunTTYWithPipe(c *testing.T) {
 			expected += ".  If you are using mintty, try prefixing the command with 'winpty'"
 		}
 		if out, _, err := runCommandWithOutput(cmd); err == nil {
-			errChan <- fmt.Errorf("run should have failed")
+			errChan <- errors.New("run should have failed")
 			return
 		} else if !strings.Contains(out, expected) {
 			errChan <- fmt.Errorf("run failed with error %q: expected %q", out, expected)

--- a/integration-cli/docker_cli_swarm_test.go
+++ b/integration-cli/docker_cli_swarm_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1066,7 +1067,7 @@ func checkKeyIsEncrypted(d *daemon.Daemon) func(*testing.T) (interface{}, string
 
 		keyBlock, _ := pem.Decode(keyBytes)
 		if keyBlock == nil {
-			return fmt.Errorf("invalid PEM-encoded private key"), ""
+			return errors.New("invalid PEM-encoded private key"), ""
 		}
 
 		return keyutils.IsEncryptedPEMBlock(keyBlock), ""

--- a/integration/build/build_traces_test.go
+++ b/integration/build/build_traces_test.go
@@ -2,7 +2,7 @@ package build
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -107,7 +107,7 @@ func TestBuildkitHistoryTracePropagation(t *testing.T) {
 		}
 
 		if msg.Record.Ref != he.Record.Ref {
-			return poll.Error(fmt.Errorf("got incorrect history record"))
+			return poll.Error(errors.New("got incorrect history record"))
 		}
 		if msg.Record.Trace != nil {
 			return poll.Success()

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -1751,7 +1751,7 @@ func TestAdvertiseAddresses(t *testing.T) {
 					if pa != matchIP || slices.Compare(ha, ctr2NewHwAddr) != 0 {
 						continue
 					}
-					count += 1
+					count++
 					var interval time.Duration
 					if !lastTimestamp.IsZero() {
 						interval = p.ReceivedAt.Sub(lastTimestamp)

--- a/internal/nlwrap/nlwrap_linux.go
+++ b/internal/nlwrap/nlwrap_linux.go
@@ -57,7 +57,7 @@ func (nlh Handle) Close() {
 }
 
 func retryOnIntr(f func() error) {
-	for attempt := 0; attempt < maxAttempts; attempt += 1 {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if err := f(); !errors.Is(err, netlink.ErrDumpInterrupted) {
 			return
 		}

--- a/internal/testutils/specialimage/load.go
+++ b/internal/testutils/specialimage/load.go
@@ -52,9 +52,8 @@ func Load(ctx context.Context, t *testing.T, apiClient client.APIClient, imageFu
 		err := decoder.Decode(&msg)
 		if errors.Is(err, io.EOF) {
 			break
-		} else {
-			assert.NilError(t, err)
 		}
+		assert.NilError(t, err)
 
 		msg.Stream = strings.TrimSpace(msg.Stream)
 

--- a/internal/usergroup/add_linux.go
+++ b/internal/usergroup/add_linux.go
@@ -1,6 +1,7 @@
 package usergroup
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"sort"
@@ -81,7 +82,7 @@ func addUser(name string) error {
 	case "useradd":
 		args = []string{"-r", "-s", "/bin/false", name}
 	default:
-		return fmt.Errorf("cannot add user; no useradd/adduser binary found")
+		return errors.New("cannot add user; no useradd/adduser binary found")
 	}
 
 	if out, err := exec.Command(userCommand, args...).CombinedOutput(); err != nil {

--- a/internal/usergroup/lookup_unix.go
+++ b/internal/usergroup/lookup_unix.go
@@ -4,6 +4,7 @@ package usergroup
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -112,11 +113,11 @@ func callGetent(database, key string) (io.Reader, error) {
 		}
 		switch exitCode {
 		case 1:
-			return nil, fmt.Errorf("getent reported invalid parameters/database unknown")
+			return nil, errors.New("getent reported invalid parameters/database unknown")
 		case 2:
 			return nil, fmt.Errorf("getent unable to find entry %q in %s database", key, database)
 		case 3:
-			return nil, fmt.Errorf("getent database doesn't support enumeration")
+			return nil, errors.New("getent database doesn't support enumeration")
 		default:
 			return nil, err
 		}
@@ -133,7 +134,7 @@ func getExitCode(err error) (int, error) {
 			return procExit.ExitStatus(), nil
 		}
 	}
-	return exitCode, fmt.Errorf("failed to get exit code")
+	return exitCode, errors.New("failed to get exit code")
 }
 
 // LoadIdentityMapping takes a requested username and

--- a/layer/empty.go
+++ b/layer/empty.go
@@ -3,7 +3,7 @@ package layer
 import (
 	"archive/tar"
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 )
 
@@ -27,7 +27,7 @@ func (el *emptyLayer) TarStreamFrom(p ChainID) (io.ReadCloser, error) {
 	if p == "" {
 		return el.TarStream()
 	}
-	return nil, fmt.Errorf("can't get parent tar stream of an empty layer")
+	return nil, errors.New("can't get parent tar stream of an empty layer")
 }
 
 func (el *emptyLayer) ChainID() ChainID {

--- a/libnetwork/agent.go
+++ b/libnetwork/agent.go
@@ -5,6 +5,7 @@ package libnetwork
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -81,7 +82,7 @@ func getBindAddr(ifaceName string) (net.IP, error) {
 		return addrIP, nil
 	}
 
-	return nil, fmt.Errorf("failed to get bind address")
+	return nil, errors.New("failed to get bind address")
 }
 
 // resolveAddr resolves the given address, which can be one of, and

--- a/libnetwork/bitmap/sequence.go
+++ b/libnetwork/bitmap/sequence.go
@@ -232,7 +232,7 @@ func (h *Bitmap) IsSet(ordinal uint64) bool {
 }
 
 // set/reset the bit
-func (h *Bitmap) set(ordinal, start, end uint64, any bool, release bool, serial bool) (uint64, error) {
+func (h *Bitmap) set(ordinal, start, end uint64, isAvailable bool, release bool, serial bool) (uint64, error) {
 	var (
 		bitPos  uint64
 		bytePos uint64
@@ -248,7 +248,7 @@ func (h *Bitmap) set(ordinal, start, end uint64, any bool, release bool, serial 
 	if release {
 		bytePos, bitPos = ordinalToPos(ordinal)
 	} else {
-		if any {
+		if isAvailable {
 			bytePos, bitPos, err = getAvailableFromCurrent(h.head, start, curr, end)
 			ret = posToOrdinal(bytePos, bitPos)
 			if err == nil {

--- a/libnetwork/controller.go
+++ b/libnetwork/controller.go
@@ -247,7 +247,7 @@ func (c *Controller) SetKeys(keys []*types.EncryptionKey) error {
 	for _, key := range keys {
 		if key.Subsystem != subsysGossip &&
 			key.Subsystem != subsysIPSec {
-			return fmt.Errorf("key received for unrecognized subsystem")
+			return errors.New("key received for unrecognized subsystem")
 		}
 		subsysKeys[key.Subsystem]++
 	}

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -674,7 +674,7 @@ func parseNetworkOptions(id string, option options.Generic) (*networkConfigurati
 	}
 
 	if (config.GwModeIPv4.isolated() || config.GwModeIPv6.isolated()) && !config.Internal {
-		return nil, fmt.Errorf("gateway mode 'isolated' can only be used for an internal network")
+		return nil, errors.New("gateway mode 'isolated' can only be used for an internal network")
 	}
 
 	if !exists {

--- a/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
@@ -260,10 +260,10 @@ func programChainRule(rule iptables.Rule, ruleDescr string, insert bool) error {
 	return nil
 }
 
-func appendOrDelChainRule(rule iptables.Rule, ruleDescr string, append bool) error {
+func appendOrDelChainRule(rule iptables.Rule, ruleDescr string, shouldAppend bool) error {
 	operation := "disable"
 	fn := rule.Delete
-	if append {
+	if shouldAppend {
 		operation = "enable"
 		fn = rule.Append
 	}

--- a/libnetwork/drivers/bridge/internal/iptabler/link.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/link.go
@@ -4,7 +4,7 @@ package iptabler
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/netip"
 
 	"github.com/containerd/log"
@@ -14,10 +14,10 @@ import (
 
 func (n *network) AddLink(ctx context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort) error {
 	if !parentIP.IsValid() || parentIP.IsUnspecified() {
-		return fmt.Errorf("cannot link to a container with an empty parent IP address")
+		return errors.New("cannot link to a container with an empty parent IP address")
 	}
 	if !childIP.IsValid() || childIP.IsUnspecified() {
-		return fmt.Errorf("cannot link to a container with an empty child IP address")
+		return errors.New("cannot link to a container with an empty child IP address")
 	}
 
 	chain := iptables.ChainInfo{Name: dockerChain}

--- a/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
+++ b/libnetwork/drivers/bridge/setup_bridgenetfiltering.go
@@ -34,7 +34,7 @@ func setupIPv6BridgeNetFiltering(config *networkConfiguration, _ *bridgeInterfac
 		return nil
 	}
 	if config.BridgeName == "" {
-		return fmt.Errorf("unable to check IPv6 forwarding, no bridge name specified")
+		return errors.New("unable to check IPv6 forwarding, no bridge name specified")
 	}
 	if enabled, err := getKernelBoolParam("/proc/sys/net/ipv6/conf/" + config.BridgeName + "/forwarding"); err != nil {
 		log.G(context.TODO()).Warnf("failed to check IPv6 forwarding: %v", err)

--- a/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -4,6 +4,7 @@ package ipvlan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/log"
@@ -24,7 +25,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 		return errdefs.System(fmt.Errorf("network id %q not found", nid))
 	}
 	if ifInfo.MacAddress() != nil {
-		return fmt.Errorf("ipvlan interfaces do not support custom mac address assignment")
+		return errors.New("ipvlan interfaces do not support custom mac address assignment")
 	}
 	ep := &endpoint{
 		id:     eid,

--- a/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -4,6 +4,7 @@ package ipvlan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/log"
@@ -30,13 +31,13 @@ func (d *driver) CreateNetwork(ctx context.Context, nid string, option map[strin
 	// reject a null v4 network if ipv4 is required
 	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
 		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-			return errdefs.InvalidParameter(fmt.Errorf("ipv4 pool is empty"))
+			return errdefs.InvalidParameter(errors.New("ipv4 pool is empty"))
 		}
 	}
 	// reject a null v6 network if ipv6 is required
 	if v, ok := option[netlabel.EnableIPv6]; ok && v.(bool) {
 		if len(ipV6Data) == 0 || ipV6Data[0].Pool.String() == "::/0" {
-			return errdefs.InvalidParameter(fmt.Errorf("ipv6 pool is empty"))
+			return errdefs.InvalidParameter(errors.New("ipv6 pool is empty"))
 		}
 	}
 	// parse and validate the config and bind to networkConfiguration
@@ -226,7 +227,7 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 
 	// loopback is not a valid parent link
 	if config.Parent == "lo" {
-		return nil, fmt.Errorf("loopback interface is not a valid ipvlan parent link")
+		return nil, errors.New("loopback interface is not a valid ipvlan parent link")
 	}
 
 	// With no parent interface, the network is "internal".

--- a/libnetwork/drivers/ipvlan/ipvlan_state.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_state.go
@@ -4,6 +4,7 @@ package ipvlan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/log"
@@ -80,10 +81,10 @@ func (n *network) getEndpoint(eid string) (*endpoint, error) {
 
 func validateID(nid, eid string) error {
 	if nid == "" {
-		return fmt.Errorf("invalid network id")
+		return errors.New("invalid network id")
 	}
 	if eid == "" {
-		return fmt.Errorf("invalid endpoint id")
+		return errors.New("invalid endpoint id")
 	}
 
 	return nil

--- a/libnetwork/drivers/ipvlan/ipvlan_test.go
+++ b/libnetwork/drivers/ipvlan/ipvlan_test.go
@@ -16,7 +16,7 @@ type driverTester struct {
 	d *driver
 }
 
-func (dt *driverTester) RegisterDriver(name string, drv driverapi.Driver, cap driverapi.Capability) error {
+func (dt *driverTester) RegisterDriver(name string, drv driverapi.Driver, capability driverapi.Capability) error {
 	if name != testNetworkType {
 		dt.t.Fatalf("Expected driver register name to be %q. Instead got %q",
 			testNetworkType, name)

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -4,6 +4,7 @@ package macvlan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/log"
@@ -20,13 +21,13 @@ func (d *driver) CreateNetwork(ctx context.Context, nid string, option map[strin
 	// reject a null v4 network if ipv4 is required
 	if v, ok := option[netlabel.EnableIPv4]; ok && v.(bool) {
 		if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
-			return errdefs.InvalidParameter(fmt.Errorf("ipv4 pool is empty"))
+			return errdefs.InvalidParameter(errors.New("ipv4 pool is empty"))
 		}
 	}
 	// reject a null v6 network if ipv6 is required
 	if v, ok := option[netlabel.EnableIPv6]; ok && v.(bool) {
 		if len(ipV6Data) == 0 || ipV6Data[0].Pool.String() == "::/0" {
-			return errdefs.InvalidParameter(fmt.Errorf("ipv6 pool is empty"))
+			return errdefs.InvalidParameter(errors.New("ipv6 pool is empty"))
 		}
 	}
 
@@ -227,7 +228,7 @@ func parseNetworkOptions(id string, option options.Generic) (*configuration, err
 
 	// loopback is not a valid parent link
 	if config.Parent == "lo" {
-		return nil, fmt.Errorf("loopback interface is not a valid macvlan parent link")
+		return nil, errors.New("loopback interface is not a valid macvlan parent link")
 	}
 
 	// With no parent interface, the network is "internal".

--- a/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/libnetwork/drivers/macvlan/macvlan_network.go
@@ -146,7 +146,7 @@ func (d *driver) parentHasSingleUser(n *network) bool {
 	networkList := d.getNetworks()
 	for _, testN := range networkList {
 		if n.config.Parent == testN.config.Parent {
-			users += 1
+			users++
 		}
 	}
 	return users == 1

--- a/libnetwork/drivers/macvlan/macvlan_state.go
+++ b/libnetwork/drivers/macvlan/macvlan_state.go
@@ -4,6 +4,7 @@ package macvlan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/containerd/log"
@@ -80,10 +81,10 @@ func (n *network) getEndpoint(eid string) (*endpoint, error) {
 
 func validateID(nid, eid string) error {
 	if nid == "" {
-		return fmt.Errorf("invalid network id")
+		return errors.New("invalid network id")
 	}
 	if eid == "" {
-		return fmt.Errorf("invalid endpoint id")
+		return errors.New("invalid endpoint id")
 	}
 	return nil
 }

--- a/libnetwork/drivers/macvlan/macvlan_test.go
+++ b/libnetwork/drivers/macvlan/macvlan_test.go
@@ -16,7 +16,7 @@ type driverTester struct {
 	d *driver
 }
 
-func (dt *driverTester) RegisterDriver(name string, drv driverapi.Driver, cap driverapi.Capability) error {
+func (dt *driverTester) RegisterDriver(name string, drv driverapi.Driver, capability driverapi.Capability) error {
 	if name != testNetworkType {
 		dt.t.Fatalf("Expected driver register name to be %q. Instead got %q",
 			testNetworkType, name)

--- a/libnetwork/drivers/overlay/joinleave.go
+++ b/libnetwork/drivers/overlay/joinleave.go
@@ -4,6 +4,7 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -45,13 +46,13 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 	}
 
 	if n.secure && len(d.keys) == 0 {
-		return fmt.Errorf("cannot join secure network: encryption keys not present")
+		return errors.New("cannot join secure network: encryption keys not present")
 	}
 
 	nlh := ns.NlHandle()
 
 	if n.secure && !nlh.SupportsNetlinkFamily(syscall.NETLINK_XFRM) {
-		return fmt.Errorf("cannot join secure network: required modules to install IPSEC rules are missing on host")
+		return errors.New("cannot join secure network: required modules to install IPSEC rules are missing on host")
 	}
 
 	s := n.getSubnetforIP(ep.addr)

--- a/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/libnetwork/drivers/overlay/ov_endpoint.go
@@ -4,6 +4,7 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -70,7 +71,7 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 	var ok bool
 	ep.addr, ok = netiputil.ToPrefix(ifInfo.Address())
 	if !ok {
-		return fmt.Errorf("create endpoint was not passed interface IP address")
+		return errors.New("create endpoint was not passed interface IP address")
 	}
 
 	if s := n.getSubnetforIP(ep.addr); s == nil {

--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -82,7 +82,7 @@ func (d *driver) NetworkFree(id string) error {
 
 func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	if id == "" {
-		return fmt.Errorf("invalid network id")
+		return errors.New("invalid network id")
 	}
 	if len(ipV4Data) == 0 || ipV4Data[0].Pool.String() == "0.0.0.0/0" {
 		return types.InvalidParameterErrorf("ipv4 pool is empty")
@@ -174,7 +174,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 
 func (d *driver) DeleteNetwork(nid string) error {
 	if nid == "" {
-		return fmt.Errorf("invalid network id")
+		return errors.New("invalid network id")
 	}
 
 	// Make sure driver resources are initialized before proceeding

--- a/libnetwork/drivers/overlay/ov_utils.go
+++ b/libnetwork/drivers/overlay/ov_utils.go
@@ -4,6 +4,7 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"syscall"
@@ -21,11 +22,11 @@ var soTimeout = ns.NetlinkSocketsTimeout
 
 func validateID(nid, eid string) error {
 	if nid == "" {
-		return fmt.Errorf("invalid network id")
+		return errors.New("invalid network id")
 	}
 
 	if eid == "" {
-		return fmt.Errorf("invalid endpoint id")
+		return errors.New("invalid endpoint id")
 	}
 
 	return nil

--- a/libnetwork/drivers/overlay/overlay.go
+++ b/libnetwork/drivers/overlay/overlay.go
@@ -6,6 +6,7 @@ package overlay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"sync"
@@ -78,7 +79,7 @@ func (d *driver) isIPv6Transport() (bool, error) {
 	// reasonable inference to make as Linux VXLAN links do not support
 	// mixed-address-family remote peers.
 	if !d.advertiseAddress.IsValid() {
-		return false, fmt.Errorf("overlay: cannot determine address family of transport: the local data-plane address is not currently known")
+		return false, errors.New("overlay: cannot determine address family of transport: the local data-plane address is not currently known")
 	}
 	return d.advertiseAddress.Is6(), nil
 }
@@ -88,7 +89,7 @@ func (d *driver) nodeJoin(data discoverapi.NodeDiscoveryData) error {
 		advAddr, _ := netip.ParseAddr(data.Address)
 		bindAddr, _ := netip.ParseAddr(data.BindAddress)
 		if !advAddr.IsValid() {
-			return fmt.Errorf("invalid discovery data")
+			return errors.New("invalid discovery data")
 		}
 		d.Lock()
 		d.advertiseAddress = advAddr
@@ -110,7 +111,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 	case discoverapi.EncryptionKeysConfig:
 		encrData, ok := data.(discoverapi.DriverEncryptionConfig)
 		if !ok {
-			return fmt.Errorf("invalid encryption key notification data")
+			return errors.New("invalid encryption key notification data")
 		}
 		keys := make([]*key, 0, len(encrData.Keys))
 		for i := 0; i < len(encrData.Keys); i++ {
@@ -127,7 +128,7 @@ func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) 
 		var newKey, delKey, priKey *key
 		encrData, ok := data.(discoverapi.DriverEncryptionUpdate)
 		if !ok {
-			return fmt.Errorf("invalid encryption key notification data")
+			return errors.New("invalid encryption key notification data")
 		}
 		if encrData.Key != nil {
 			newKey = &key{

--- a/libnetwork/drivers/overlay/overlay_test.go
+++ b/libnetwork/drivers/overlay/overlay_test.go
@@ -20,7 +20,7 @@ func (dt *driverTester) GetPluginGetter() plugingetter.PluginGetter {
 	return nil
 }
 
-func (dt *driverTester) RegisterDriver(name string, drv driverapi.Driver, cap driverapi.Capability) error {
+func (dt *driverTester) RegisterDriver(name string, drv driverapi.Driver, capability driverapi.Capability) error {
 	if name != testNetworkType {
 		dt.t.Fatalf("Expected driver register name to be %q. Instead got %q",
 			testNetworkType, name)

--- a/libnetwork/drivers/overlay/ovmanager/ovmanager.go
+++ b/libnetwork/drivers/overlay/ovmanager/ovmanager.go
@@ -2,6 +2,7 @@ package ovmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -62,11 +63,11 @@ func newDriver() *driver {
 
 func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
 	if id == "" {
-		return nil, fmt.Errorf("invalid network id for overlay network")
+		return nil, errors.New("invalid network id for overlay network")
 	}
 
 	if ipV4Data == nil {
-		return nil, fmt.Errorf("empty ipv4 data passed during overlay network creation")
+		return nil, errors.New("empty ipv4 data passed during overlay network creation")
 	}
 
 	n := &network{
@@ -136,7 +137,7 @@ func (d *driver) NetworkAllocate(id string, option map[string]string, ipV4Data, 
 
 func (d *driver) NetworkFree(id string) error {
 	if id == "" {
-		return fmt.Errorf("invalid network id passed while freeing overlay network")
+		return errors.New("invalid network id passed while freeing overlay network")
 	}
 
 	d.mu.Lock()

--- a/libnetwork/drvregistry/ipams.go
+++ b/libnetwork/drvregistry/ipams.go
@@ -60,7 +60,7 @@ func (ir *IPAMs) RegisterIpamDriver(name string, driver ipamapi.Ipam) error {
 }
 
 // IPAMWalkFunc defines the IPAM driver table walker function signature.
-type IPAMWalkFunc func(name string, driver ipamapi.Ipam, cap *ipamapi.Capability) bool
+type IPAMWalkFunc func(name string, driver ipamapi.Ipam, capability *ipamapi.Capability) bool
 
 // WalkIPAMs walks the IPAM drivers registered in the registry and invokes the passed walk function and each one of them.
 func (ir *IPAMs) WalkIPAMs(ifn IPAMWalkFunc) {

--- a/libnetwork/drvregistry/ipams_test.go
+++ b/libnetwork/drvregistry/ipams_test.go
@@ -32,7 +32,7 @@ func TestIPAMs(t *testing.T) {
 		reg := getNewIPAMs(t)
 
 		ipams := make([]string, 0, 2)
-		reg.WalkIPAMs(func(name string, driver ipamapi.Ipam, cap *ipamapi.Capability) bool {
+		reg.WalkIPAMs(func(name string, driver ipamapi.Ipam, capability *ipamapi.Capability) bool {
 			ipams = append(ipams, name)
 			return false
 		})

--- a/libnetwork/drvregistry/networks_test.go
+++ b/libnetwork/drvregistry/networks_test.go
@@ -49,9 +49,9 @@ func TestNetworks(t *testing.T) {
 		err := reg.RegisterDriver(mockDriverName, &md, mockDriverCaps)
 		assert.NilError(t, err)
 
-		d, cap := reg.Driver(mockDriverName)
-		assert.Check(t, d != nil)
-		assert.Check(t, is.DeepEqual(cap, mockDriverCaps))
+		driver, capability := reg.Driver(mockDriverName)
+		assert.Check(t, driver != nil)
+		assert.Check(t, is.DeepEqual(capability, mockDriverCaps))
 	})
 
 	t.Run("WalkDrivers", func(t *testing.T) {

--- a/libnetwork/internal/resolvconf/resolvconf.go
+++ b/libnetwork/internal/resolvconf/resolvconf.go
@@ -181,7 +181,7 @@ func (rc *ResolvConf) Options() []string {
 //	Option("ndots") -> ("1", true)
 //	Option("edns0") -> ("", true)
 func (rc *ResolvConf) Option(search string) (string, bool) {
-	for i := len(rc.options) - 1; i >= 0; i -= 1 {
+	for i := len(rc.options) - 1; i >= 0; i-- {
 		k, v, _ := strings.Cut(rc.options[i], ":")
 		if k == search {
 			return v, true

--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -52,7 +52,7 @@ func UsingFirewalld() (bool, error) {
 	// But, if running rootless, the init function is not called because
 	// firewalld will be running in the host's netns, not in rootlesskit's.
 	if !firewalldInitCalled && !rootless.RunningWithRootlessKit() {
-		return false, fmt.Errorf("iptables.firewalld is not initialised")
+		return false, errors.New("iptables.firewalld is not initialised")
 	}
 	return firewalldRunning, nil
 }

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -166,7 +166,7 @@ func GetIptable(version IPVersion) *IPTable {
 // NewChain adds a new chain to ip table.
 func (iptable IPTable) NewChain(name string, table Table) (*ChainInfo, error) {
 	if name == "" {
-		return nil, fmt.Errorf("could not create chain: chain name is empty")
+		return nil, errors.New("could not create chain: chain name is empty")
 	}
 	if table == "" {
 		return nil, fmt.Errorf("could not create chain %s: invalid table name: table name is empty", name)
@@ -189,7 +189,7 @@ func (iptable IPTable) NewChain(name string, table Table) (*ChainInfo, error) {
 // RemoveExistingChain removes existing chain from the table.
 func (iptable IPTable) RemoveExistingChain(name string, table Table) error {
 	if name == "" {
-		return fmt.Errorf("could not remove chain: chain name is empty")
+		return errors.New("could not remove chain: chain name is empty")
 	}
 	if table == "" {
 		return fmt.Errorf("could not remove chain %s: invalid table name: table name is empty", name)
@@ -354,7 +354,7 @@ func (iptable IPTable) raw(args ...string) ([]byte, error) {
 	commandName := "iptables"
 	if iptable.ipVersion == IPv6 {
 		if ip6tablesPath == "" {
-			return nil, fmt.Errorf("ip6tables is missing")
+			return nil, errors.New("ip6tables is missing")
 		}
 		path = ip6tablesPath
 		commandName = "ip6tables"

--- a/libnetwork/libnetwork_internal_test.go
+++ b/libnetwork/libnetwork_internal_test.go
@@ -3,6 +3,7 @@ package libnetwork
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
@@ -786,7 +787,7 @@ func badDriverRegister(reg driverapi.Registerer) error {
 
 func (b *badDriver) CreateNetwork(ctx context.Context, nid string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
 	if b.failNetworkCreation {
-		return fmt.Errorf("I will not create any network")
+		return errors.New("I will not create any network")
 	}
 	return nil
 }
@@ -796,7 +797,7 @@ func (b *badDriver) DeleteNetwork(nid string) error {
 }
 
 func (b *badDriver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, options map[string]interface{}) error {
-	return fmt.Errorf("I will not create any endpoint")
+	return errors.New("I will not create any endpoint")
 }
 
 func (b *badDriver) DeleteEndpoint(nid, eid string) error {
@@ -808,7 +809,7 @@ func (b *badDriver) EndpointOperInfo(nid, eid string) (map[string]interface{}, e
 }
 
 func (b *badDriver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, _ map[string]interface{}) error {
-	return fmt.Errorf("I will not allow any join")
+	return errors.New("I will not allow any join")
 }
 
 func (b *badDriver) Leave(nid, eid string) error {

--- a/libnetwork/netutils/utils_linux.go
+++ b/libnetwork/netutils/utils_linux.go
@@ -100,9 +100,9 @@ func queryOnLinkRoutes() []netip.Prefix {
 // GenerateIfaceName returns an interface name using the passed in
 // prefix and the length of random bytes. The api ensures that the
 // there is no interface which exists with that name.
-func GenerateIfaceName(nlh nlwrap.Handle, prefix string, len int) (string, error) {
+func GenerateIfaceName(nlh nlwrap.Handle, prefix string, length int) (string, error) {
 	for i := 0; i < 3; i++ {
-		name, err := GenerateRandomName(prefix, len)
+		name, err := GenerateRandomName(prefix, length)
 		if err != nil {
 			return "", err
 		}

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -268,7 +268,7 @@ func DefaultConfig() *Config {
 // New creates a new instance of NetworkDB using the Config passed by
 // the caller.
 func New(c *Config) (*NetworkDB, error) {
-	nDB := new(c)
+	nDB := newNetworkDB(c)
 	log.G(context.TODO()).Infof("New memberlist node - Node:%v will use memberlist nodeID:%v with config:%+v", c.Hostname, c.NodeID, c)
 	if err := nDB.clusterInit(); err != nil {
 		return nil, err
@@ -277,7 +277,7 @@ func New(c *Config) (*NetworkDB, error) {
 	return nDB, nil
 }
 
-func new(c *Config) *NetworkDB {
+func newNetworkDB(c *Config) *NetworkDB {
 	// The garbage collection logic for entries leverage the presence of the network.
 	// For this reason the expiration time of the network is put slightly higher than the entry expiration so that
 	// there is at least 5 extra cycle to make sure that all the entries are properly deleted before deleting the network.

--- a/libnetwork/networkdb/watch_test.go
+++ b/libnetwork/networkdb/watch_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWatch_out_of_order(t *testing.T) {
-	nDB := new(DefaultConfig())
+	nDB := newNetworkDB(DefaultConfig())
 	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{}
 	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{}
 	assert.Assert(t, nDB.JoinNetwork("network1"))
@@ -93,7 +93,7 @@ func TestWatch_out_of_order(t *testing.T) {
 }
 
 func TestWatch_filters(t *testing.T) {
-	nDB := new(DefaultConfig())
+	nDB := newNetworkDB(DefaultConfig())
 	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{}
 	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{}
 	assert.Assert(t, nDB.JoinNetwork("network1"))

--- a/libnetwork/osl/interface_linux.go
+++ b/libnetwork/osl/interface_linux.go
@@ -184,7 +184,7 @@ func (i *Interface) Statistics() (*types.InterfaceStatistics, error) {
 
 	stats := l.Attrs().Statistics
 	if stats == nil {
-		return nil, fmt.Errorf("no statistics were returned")
+		return nil, errors.New("no statistics were returned")
 	}
 
 	return &types.InterfaceStatistics{

--- a/libnetwork/osl/route_linux.go
+++ b/libnetwork/osl/route_linux.go
@@ -4,6 +4,7 @@
 package osl
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"slices"
@@ -243,12 +244,12 @@ func (n *Namespace) SetDefaultRouteIPv6(srcName string) error {
 func (n *Namespace) setDefaultRoute(srcName string, routeMatcher func(*net.IPNet) bool) error {
 	iface := n.ifaceBySrcName(srcName)
 	if iface == nil {
-		return fmt.Errorf("no interface")
+		return errors.New("no interface")
 	}
 
 	ridx := slices.IndexFunc(iface.routes, routeMatcher)
 	if ridx == -1 {
-		return fmt.Errorf("no default route")
+		return errors.New("no default route")
 	}
 
 	link, err := n.nlHandle.LinkByName(iface.dstName)
@@ -316,12 +317,12 @@ func (n *Namespace) unsetDefaultRoute(srcName string, routeMatcher func(*net.IPN
 
 	ridx := slices.IndexFunc(iface.routes, routeMatcher)
 	if ridx == -1 {
-		return fmt.Errorf("no default route")
+		return errors.New("no default route")
 	}
 
 	link, err := n.nlHandle.LinkByName(iface.dstName)
 	if err != nil {
-		return fmt.Errorf("no link")
+		return errors.New("no link")
 	}
 
 	return n.nlHandle.RouteDel(&netlink.Route{

--- a/libnetwork/portallocator/portallocator.go
+++ b/libnetwork/portallocator/portallocator.go
@@ -143,7 +143,7 @@ func (p *PortAllocator) RequestPortsInRange(ips []net.IP, proto string, portStar
 		}
 	}
 	if len(ips) == 0 {
-		return 0, fmt.Errorf("no IP addresses specified")
+		return 0, errors.New("no IP addresses specified")
 	}
 
 	p.mutex.Lock()

--- a/libnetwork/portallocator/portallocator_test.go
+++ b/libnetwork/portallocator/portallocator_test.go
@@ -338,7 +338,7 @@ func TestRequestPortForMultipleIPs(t *testing.T) {
 	assert.Check(t, is.Equal(port, 10000))
 
 	// Multi-port range.
-	for i := 20000; i < 20004; i += 1 {
+	for i := 20000; i < 20004; i++ {
 		port, err = p.RequestPortsInRange(addrs, "tcp", 20000, 20004)
 		assert.Check(t, err)
 		assert.Check(t, is.Equal(port, i))

--- a/libnetwork/portmapper/proxy_linux.go
+++ b/libnetwork/portmapper/proxy_linux.go
@@ -22,7 +22,7 @@ func StartProxy(pb types.PortBinding,
 	listenSock *os.File,
 ) (stop func() error, retErr error) {
 	if proxyPath == "" {
-		return nil, fmt.Errorf("no path provided for userland-proxy binary")
+		return nil, errors.New("no path provided for userland-proxy binary")
 	}
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -113,7 +113,7 @@ func StartProxy(pb types.PortBinding,
 			return nil, err
 		}
 	case <-time.After(16 * time.Second):
-		return nil, fmt.Errorf("timed out starting the userland proxy")
+		return nil, errors.New("timed out starting the userland proxy")
 	}
 
 	stopFn := func() error {

--- a/libnetwork/resolver.go
+++ b/libnetwork/resolver.go
@@ -98,7 +98,7 @@ type Resolver struct {
 func NewResolver(address string, proxyDNS bool, backend DNSBackend) *Resolver {
 	r := &Resolver{
 		backend:     backend,
-		err:         fmt.Errorf("setup not done yet"),
+		err:         errors.New("setup not done yet"),
 		startCh:     make(chan struct{}, 1),
 		fwdSem:      semaphore.NewWeighted(maxConcurrent),
 		logInterval: rate.Sometimes{Interval: logInterval},
@@ -216,7 +216,7 @@ func (r *Resolver) Stop() {
 	}
 	r.conn = nil
 	r.tcpServer = nil
-	r.err = fmt.Errorf("setup not done yet")
+	r.err = errors.New("setup not done yet")
 	r.fwdSem = semaphore.NewWeighted(maxConcurrent)
 }
 

--- a/libnetwork/sandbox_dns_unix.go
+++ b/libnetwork/sandbox_dns_unix.go
@@ -327,7 +327,7 @@ func (sb *Sandbox) rebuildDNS() error {
 
 	intNS := sb.resolver.NameServer()
 	if !intNS.IsValid() {
-		return fmt.Errorf("no listen-address for internal resolver")
+		return errors.New("no listen-address for internal resolver")
 	}
 
 	// Work out whether ndots has been set from host config or overrides.

--- a/opts/env_test.go
+++ b/opts/env_test.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -54,7 +55,7 @@ func TestValidateEnv(t *testing.T) {
 		},
 		{
 			value: "=a",
-			err:   fmt.Errorf("invalid environment variable: =a"),
+			err:   errors.New("invalid environment variable: =a"),
 		},
 		{
 			value:    "PATH=",
@@ -90,7 +91,7 @@ func TestValidateEnv(t *testing.T) {
 		},
 		{
 			value: "=",
-			err:   fmt.Errorf("invalid environment variable: ="),
+			err:   errors.New("invalid environment variable: ="),
 		},
 	}
 

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"path"
@@ -365,7 +366,7 @@ func ValidateSingleGenericResource(val string) (string, error) {
 // ParseLink parses and validates the specified string as a link format (name:alias)
 func ParseLink(val string) (string, string, error) {
 	if val == "" {
-		return "", "", fmt.Errorf("empty string specified for links")
+		return "", "", errors.New("empty string specified for links")
 	}
 	arr := strings.Split(val, ":")
 	if len(arr) > 2 {

--- a/pkg/authorization/response.go
+++ b/pkg/authorization/response.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 
@@ -147,7 +147,7 @@ func (rm *responseModifier) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 	hijacker, ok := rm.rw.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("Internal response writer doesn't support the Hijacker interface")
+		return nil, nil, errors.New("Internal response writer doesn't support the Hijacker interface")
 	}
 	return hijacker.Hijack()
 }

--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -2,7 +2,6 @@ package plugins
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/fs"
 	"net/url"
 	"os"
@@ -152,7 +151,7 @@ func readPluginInfo(name, path string) (*Plugin, error) {
 	}
 
 	if u.Scheme == "" {
-		return nil, fmt.Errorf("Unknown protocol")
+		return nil, errors.New("Unknown protocol")
 	}
 
 	return NewLocalPlugin(name, addr), nil

--- a/pkg/plugins/pluginrpc-gen/main.go
+++ b/pkg/plugins/pluginrpc-gen/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"go/format"
@@ -49,10 +50,10 @@ func errorOut(msg string, err error) {
 
 func checkFlags() error {
 	if *outputFile == "" {
-		return fmt.Errorf("missing required flag `-o`")
+		return errors.New("missing required flag `-o`")
 	}
 	if *inputFile == "" {
-		return fmt.Errorf("missing required flag `-i`")
+		return errors.New("missing required flag `-i`")
 	}
 	return nil
 }

--- a/plugin/manager_linux_test.go
+++ b/plugin/manager_linux_test.go
@@ -70,7 +70,7 @@ func TestManagerWithPluginMounts(t *testing.T) {
 	}
 }
 
-func newTestPlugin(t *testing.T, name, cap, root string) *v2.Plugin {
+func newTestPlugin(t *testing.T, name, capability, root string) *v2.Plugin {
 	id := stringid.GenerateRandomID()
 	rootfs := filepath.Join(root, id)
 	if err := os.MkdirAll(rootfs, 0o755); err != nil {
@@ -79,7 +79,7 @@ func newTestPlugin(t *testing.T, name, cap, root string) *v2.Plugin {
 
 	p := v2.Plugin{PluginObj: types.Plugin{ID: id, Name: name}}
 	p.Rootfs = rootfs
-	iType := types.PluginInterfaceType{Capability: cap, Prefix: "docker", Version: "1.0"}
+	iType := types.PluginInterfaceType{Capability: capability, Prefix: "docker", Version: "1.0"}
 	i := types.PluginConfigInterface{Socket: "plugin.sock", Types: []types.PluginInterfaceType{iType}}
 	p.PluginObj.Config.Interface = i
 	p.PluginObj.ID = id

--- a/plugin/store.go
+++ b/plugin/store.go
@@ -205,8 +205,8 @@ func (ps *Store) GetAllByCap(capability string) ([]plugingetter.CompatPlugin, er
 	return result, nil
 }
 
-func pluginType(cap string) string {
-	return fmt.Sprintf("docker.%s/%s", strings.ToLower(cap), defaultAPIVersion)
+func pluginType(capability string) string {
+	return fmt.Sprintf("docker.%s/%s", strings.ToLower(capability), defaultAPIVersion)
 }
 
 // Handle sets a callback for a given capability. It is only used by network
@@ -233,10 +233,10 @@ func (ps *Store) Handle(capability string, callback func(string, *plugins.Client
 
 // RegisterRuntimeOpt stores a list of SpecOpts for the provided capability.
 // These options are applied to the runtime spec before a plugin is started for the specified capability.
-func (ps *Store) RegisterRuntimeOpt(cap string, opts ...SpecOpt) {
+func (ps *Store) RegisterRuntimeOpt(capability string, opts ...SpecOpt) {
 	ps.Lock()
 	defer ps.Unlock()
-	typ := pluginType(cap)
+	typ := pluginType(capability)
 	ps.specOpts[typ] = append(ps.specOpts[typ], opts...)
 }
 

--- a/plugin/v2/plugin.go
+++ b/plugin/v2/plugin.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -117,7 +118,7 @@ func (p *Plugin) Set(args []string) error {
 	defer p.mu.Unlock()
 
 	if p.PluginObj.Enabled {
-		return fmt.Errorf("cannot set on an active plugin, disable plugin before setting")
+		return errors.New("cannot set on an active plugin, disable plugin before setting")
 	}
 
 	sets, err := newSettables(args)
@@ -160,7 +161,7 @@ next:
 
 				// it is, so lets update the settings in memory
 				if mount.Source == nil {
-					return fmt.Errorf("Plugin config has no mount source")
+					return errors.New("Plugin config has no mount source")
 				}
 				*mount.Source = s.value
 				continue next
@@ -180,7 +181,7 @@ next:
 
 				// it is, so lets update the settings in memory
 				if device.Path == nil {
-					return fmt.Errorf("Plugin config has no device path")
+					return errors.New("Plugin config has no device path")
 				}
 				*device.Path = s.value
 				continue next

--- a/profiles/seccomp/kernel_linux_test.go
+++ b/profiles/seccomp/kernel_linux_test.go
@@ -1,7 +1,7 @@
 package seccomp
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 )
 
@@ -34,19 +34,19 @@ func TestParseRelease(t *testing.T) {
 		{in: "3.12-1-amd64", out: KernelVersion{Kernel: 3, Major: 12}},
 		{in: "3.12foobar", out: KernelVersion{Kernel: 3, Major: 12}},
 		{in: "99.999.999-19-generic", out: KernelVersion{Kernel: 99, Major: 999}},
-		{in: "", expectedErr: fmt.Errorf(`failed to parse kernel version "": EOF`)},
-		{in: "3", expectedErr: fmt.Errorf(`failed to parse kernel version "3": unexpected EOF`)},
-		{in: "3.", expectedErr: fmt.Errorf(`failed to parse kernel version "3.": EOF`)},
-		{in: "3a", expectedErr: fmt.Errorf(`failed to parse kernel version "3a": input does not match format`)},
-		{in: "3.a", expectedErr: fmt.Errorf(`failed to parse kernel version "3.a": expected integer`)},
-		{in: "a", expectedErr: fmt.Errorf(`failed to parse kernel version "a": expected integer`)},
-		{in: "a.a", expectedErr: fmt.Errorf(`failed to parse kernel version "a.a": expected integer`)},
-		{in: "a.a.a-a", expectedErr: fmt.Errorf(`failed to parse kernel version "a.a.a-a": expected integer`)},
-		{in: "-3", expectedErr: fmt.Errorf(`failed to parse kernel version "-3": expected integer`)},
-		{in: "-3.", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.": expected integer`)},
-		{in: "-3.8", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.8": expected integer`)},
-		{in: "-3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "-3.-8": expected integer`)},
-		{in: "3.-8", expectedErr: fmt.Errorf(`failed to parse kernel version "3.-8": expected integer`)},
+		{in: "", expectedErr: errors.New(`failed to parse kernel version "": EOF`)},
+		{in: "3", expectedErr: errors.New(`failed to parse kernel version "3": unexpected EOF`)},
+		{in: "3.", expectedErr: errors.New(`failed to parse kernel version "3.": EOF`)},
+		{in: "3a", expectedErr: errors.New(`failed to parse kernel version "3a": input does not match format`)},
+		{in: "3.a", expectedErr: errors.New(`failed to parse kernel version "3.a": expected integer`)},
+		{in: "a", expectedErr: errors.New(`failed to parse kernel version "a": expected integer`)},
+		{in: "a.a", expectedErr: errors.New(`failed to parse kernel version "a.a": expected integer`)},
+		{in: "a.a.a-a", expectedErr: errors.New(`failed to parse kernel version "a.a.a-a": expected integer`)},
+		{in: "-3", expectedErr: errors.New(`failed to parse kernel version "-3": expected integer`)},
+		{in: "-3.", expectedErr: errors.New(`failed to parse kernel version "-3.": expected integer`)},
+		{in: "-3.8", expectedErr: errors.New(`failed to parse kernel version "-3.8": expected integer`)},
+		{in: "-3.-8", expectedErr: errors.New(`failed to parse kernel version "-3.-8": expected integer`)},
+		{in: "3.-8", expectedErr: errors.New(`failed to parse kernel version "3.-8": expected integer`)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {

--- a/registry/resumable/resumablerequestreader.go
+++ b/registry/resumable/resumablerequestreader.go
@@ -37,7 +37,7 @@ func NewRequestReaderWithInitialResponse(c *http.Client, r *http.Request, maxfai
 
 func (r *requestReader) Read(p []byte) (n int, _ error) {
 	if r.client == nil || r.request == nil {
-		return 0, fmt.Errorf("client and request can't be nil")
+		return 0, errors.New("client and request can't be nil")
 	}
 
 	var err error
@@ -65,13 +65,13 @@ func (r *requestReader) Read(p []byte) (n int, _ error) {
 		return 0, io.EOF
 	} else if r.currentResponse.StatusCode != http.StatusPartialContent && r.lastRange != 0 && isFreshRequest {
 		r.cleanUpResponse()
-		return 0, fmt.Errorf("the server doesn't support byte ranges")
+		return 0, errors.New("the server doesn't support byte ranges")
 	}
 	if r.totalSize == 0 {
 		r.totalSize = r.currentResponse.ContentLength
 	} else if r.totalSize <= 0 {
 		r.cleanUpResponse()
-		return 0, fmt.Errorf("failed to auto detect content length")
+		return 0, errors.New("failed to auto detect content length")
 	}
 	n, err = r.currentResponse.Body.Read(p)
 	r.lastRange += int64(n)

--- a/registry/resumable/resumablerequestreader_test.go
+++ b/registry/resumable/resumablerequestreader_test.go
@@ -1,6 +1,7 @@
 package resumable
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -86,7 +87,7 @@ type errorReaderCloser struct{}
 func (errorReaderCloser) Close() error { return nil }
 
 func (errorReaderCloser) Read(p []byte) (int, error) {
-	return 0, fmt.Errorf("an error occurred")
+	return 0, errors.New("an error occurred")
 }
 
 // If an unknown error is encountered, return 0, nil and log it

--- a/restartmanager/restartmanager.go
+++ b/restartmanager/restartmanager.go
@@ -2,7 +2,6 @@ package restartmanager
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -61,7 +60,7 @@ func (rm *RestartManager) ShouldRestart(exitCode uint32, hasBeenManuallyStopped 
 	}
 
 	if rm.active {
-		return false, nil, fmt.Errorf("invalid call on an active restart manager")
+		return false, nil, errors.New("invalid call on an active restart manager")
 	}
 	// if the container ran for more than 10s, regardless of status and policy reset
 	// the timeout back to the default.

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -81,15 +81,15 @@ func (a *volumeDriverAdapter) Get(name string) (volume.Volume, error) {
 }
 
 func (a *volumeDriverAdapter) Scope() string {
-	cap := a.getCapabilities()
-	return cap.Scope
+	capabilities := a.getCapabilities()
+	return capabilities.Scope
 }
 
 func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 	if a.capabilities != nil {
 		return *a.capabilities
 	}
-	cap, err := a.proxy.Capabilities()
+	capabilities, err := a.proxy.Capabilities()
 	if err != nil {
 		// `GetCapabilities` is a not a required endpoint.
 		// On error assume it's a local-only driver
@@ -98,18 +98,18 @@ func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 	}
 
 	// don't spam the warn log below just because the plugin didn't provide a scope
-	if cap.Scope == "" {
-		cap.Scope = volume.LocalScope
+	if capabilities.Scope == "" {
+		capabilities.Scope = volume.LocalScope
 	}
 
-	cap.Scope = strings.ToLower(cap.Scope)
-	if cap.Scope != volume.LocalScope && cap.Scope != volume.GlobalScope {
+	capabilities.Scope = strings.ToLower(capabilities.Scope)
+	if capabilities.Scope != volume.LocalScope && capabilities.Scope != volume.GlobalScope {
 		log.G(context.TODO()).WithField("driver", a.Name()).WithField("scope", a.Scope).Warn("Volume driver returned an invalid scope")
-		cap.Scope = volume.LocalScope
+		capabilities.Scope = volume.LocalScope
 	}
 
-	a.capabilities = &cap
-	return cap
+	a.capabilities = &capabilities
+	return capabilities
 }
 
 type volumeAdapter struct {

--- a/volume/local/local_unix.go
+++ b/volume/local/local_unix.go
@@ -120,7 +120,7 @@ func (v *localVolume) needsMount() bool {
 
 func getMountOptions(opts *optsConfig, resolveIP func(string, string) (*net.IPAddr, error)) (mountDevice string, mountOpts string, _ error) {
 	if opts.MountDevice == "" {
-		return "", "", fmt.Errorf("missing device in volume options")
+		return "", "", errors.New("missing device in volume options")
 	}
 
 	mountOpts = opts.MountOpts

--- a/volume/mounts/linux_parser.go
+++ b/volume/mounts/linux_parser.go
@@ -113,7 +113,7 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 			}
 		}
 		if mnt.ReadOnly && anonymousVolume {
-			return &errMountConfig{mnt, fmt.Errorf("must not set ReadOnly mode when using anonymous volumes")}
+			return &errMountConfig{mnt, errors.New("must not set ReadOnly mode when using anonymous volumes")}
 		}
 	case mount.TypeTmpfs:
 		if mnt.BindOptions != nil {
@@ -394,7 +394,7 @@ func (p *linuxParser) parseMountSpec(cfg mount.Mount, validateBindSourceExists b
 
 func (p *linuxParser) ParseVolumesFrom(spec string) (string, string, error) {
 	if spec == "" {
-		return "", "", fmt.Errorf("volumes-from specification cannot be an empty string")
+		return "", "", errors.New("volumes-from specification cannot be an empty string")
 	}
 
 	id, mode, _ := strings.Cut(spec, ":")

--- a/volume/mounts/linux_parser_test.go
+++ b/volume/mounts/linux_parser_test.go
@@ -1,7 +1,7 @@
 package mounts
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
@@ -284,7 +284,7 @@ func TestLinuxParseMountRawSplit(t *testing.T) {
 // This is confusing to users.
 func TestLinuxParseMountSpecBindWithFileinfoError(t *testing.T) {
 	parser := NewLinuxParser()
-	testErr := fmt.Errorf("some crazy error")
+	testErr := errors.New("some crazy error")
 	if pr, ok := parser.(*linuxParser); ok {
 		pr.fi = &mockFiProviderWithError{err: testErr}
 	}

--- a/volume/mounts/mounts.go
+++ b/volume/mounts/mounts.go
@@ -2,7 +2,6 @@ package mounts
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"runtime/debug"
 	"syscall"
@@ -234,7 +233,7 @@ func (m *MountPoint) Setup(ctx context.Context, mountLabel string, rootIDs idtoo
 	}
 
 	if m.Source == "" {
-		return "", noCleanup, fmt.Errorf("Unable to setup mount point, neither source nor volume defined")
+		return "", noCleanup, errors.New("Unable to setup mount point, neither source nor volume defined")
 	}
 
 	if m.Type == mounttypes.TypeBind {

--- a/volume/mounts/windows_parser.go
+++ b/volume/mounts/windows_parser.go
@@ -250,7 +250,7 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 			return &errMountConfig{mnt, errBindSourceDoesNotExist(mnt.Source)}
 		}
 		if !isdir {
-			return &errMountConfig{mnt, fmt.Errorf("source path must be a directory")}
+			return &errMountConfig{mnt, errors.New("source path must be a directory")}
 		}
 
 	case mount.TypeVolume:
@@ -271,7 +271,7 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 		}
 
 		if anonymousVolume && mnt.ReadOnly {
-			return &errMountConfig{mnt, fmt.Errorf("must not set ReadOnly mode when using anonymous volumes")}
+			return &errMountConfig{mnt, errors.New("must not set ReadOnly mode when using anonymous volumes")}
 		}
 
 		if mnt.Source != "" {
@@ -425,7 +425,7 @@ func (p *windowsParser) parseMountSpec(cfg mount.Mount, convertTargetToBackslash
 
 func (p *windowsParser) ParseVolumesFrom(spec string) (string, string, error) {
 	if spec == "" {
-		return "", "", fmt.Errorf("volumes-from specification cannot be an empty string")
+		return "", "", errors.New("volumes-from specification cannot be an empty string")
 	}
 
 	id, mode, _ := strings.Cut(spec, ":")

--- a/volume/mounts/windows_parser_test.go
+++ b/volume/mounts/windows_parser_test.go
@@ -1,7 +1,7 @@
 package mounts
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
@@ -314,7 +314,7 @@ func TestWindowsParseMountRawSplit(t *testing.T) {
 // This is confusing to users.
 func TestWindowsParseMountSpecBindWithFileinfoError(t *testing.T) {
 	parser := NewWindowsParser()
-	testErr := fmt.Errorf("some crazy error")
+	testErr := errors.New("some crazy error")
 	if pr, ok := parser.(*windowsParser); ok {
 		pr.fi = &mockFiProviderWithError{err: testErr}
 	}


### PR DESCRIPTION
**- What I did**

Related to https://github.com/moby/moby/pull/50001#pullrequestreview-2954238912

Revive rules configuration use a default list when no rules are listed but in the current state no rules are applied as only one rule is listed and deactivated. This PR enables and fixes the following revive rules:

* [increment-decrement](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#increment-decrement)
* [redefines-builtin-id](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#redefines-builtin-id)
* [superfluous-else](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#superfluous-else)
* [use-errors-new](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#use-errors-new)
* [var-declaration](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-declaration)

**- How I did it**

Edit golangci-lint and fix one rule per commit

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

