### PR TITLE
gha/bin-image: add major and minor version image tags

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -69,6 +69,8 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=branch
             type=ref,event=pr
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
       -
         name: Rename meta bake definition file
         # see https://github.com/docker/metadata-action/issues/381#issuecomment-1918607161


### PR DESCRIPTION
Adding image tags that follow the semver major and minor versions (e.g., `28` and `28.3`) for the moby-bin images.

This makes it easier for users to reference the latest build within a major or minor version series without having to know the exact minor/patch version.
