### PR TITLE
daemon: Fix mounting same image multiple times with different destinations

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -2,7 +2,7 @@ package daemon
 
 import (
 	"context"
-	"fmt"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"sort"
@@ -257,7 +257,10 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 				StorageOpt: container.HostConfig.StorageOpt,
 			}
 
-			layerName := fmt.Sprintf("%s-%s", container.ID, mp.Source)
+			// Include the destination in the layer name to make it unique for each mount point and container.
+			// This makes sure that the same image can be mounted multiple times with different destinations.
+			// Hex encode the destination to create a safe, unique identifier
+			layerName := hex.EncodeToString([]byte(container.ID + ",src=" + mp.Source + ",dst=" + mp.Destination))
 			layer, err := daemon.imageService.CreateLayerFromImage(img, layerName, rwLayerOpts)
 			if err != nil {
 				return err


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/50122

The previous implementation generated layer names based on container ID and source image, which would cause conflicts when mounting the same image to multiple destinations within a container.

This fixes the issue by changing the layer naming strategy to include the destination path in the layer name, making it unique for each mount point.

To avoid filesystem paths producing unexpected names, the combined string is hex-encoded and used as a layer name.


**- How to verify it**
TestRunMountImageMultipleTimes

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `--mount type=image` failure when mounting the same image multiple times to a different destinations.
```

**- A picture of a cute animal (not mandatory but encouraged)**

