### PR TITLE
Remove dependency on lazyregexp from client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -336,7 +336,7 @@ linters:
         linters:
           - forbidigo
       - text: 'use of `regexp.MustCompile` forbidden'
-        path: "internal/lazyregexp"
+        path: "(internal/lazyregexp|api|client)"
         linters:
           - forbidigo
       - text: 'use of `regexp.MustCompile` forbidden'


### PR DESCRIPTION
The internal package from the root module will not be accessible once the client is a separate go module.
