### PR TITLE
allow installing as root with --force

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -54,10 +54,13 @@ init() {
 
 	# User verification: deny running as root
 	if [ "$(id -u)" = "0" ]; then
-		ERROR "Refusing to install rootless Docker as the root user"
-		exit 1
+		if [ -z "$OPT_FORCE" ]; then
+			ERROR "Refusing to install rootless Docker as the root user. Use --force to override."
+			exit 1
+		else
+			WARNING "Running installer as root by request (–force)."
+		fi
 	fi
-
 	# set BIN
 	if ! BIN="$(command -v "$DOCKERD_ROOTLESS_SH" 2> /dev/null)"; then
 		ERROR "$DOCKERD_ROOTLESS_SH needs to be present under \$PATH"


### PR DESCRIPTION
dockerd-rootless is useful for people lacking root,  but it's also useful for people lacking systemd.

My current situation is that I have root, but I don't have systemd. I need rootless-docker to run without systemd, not to run without root.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

>ssh -i '/home/hans/projects/rembg_model/training/ssh_keys/rembg_model_ssh' -p 10094 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@213.173.108.102 'mkdir /xdg; export XDG_RUNTIME_DIR=/xdg; dockerd-rootless-setuptool.sh install --force'
>
>[ERROR] Refusing to install rootless Docker as the root user



**- How I did it**
with a bash terminal

**- How to verify it**
`sudo dockerd-rootless-setuptool.sh install --force`
**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

![1750861749752479](https://github.com/user-attachments/assets/d5bc18eb-747f-4ee9-9823-e922f72de9e9)

