### PR TITLE
Add progress aux emitter to build backend

### DIFF
--- a/api/types/backend/build.go
+++ b/api/types/backend/build.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/pkg/streamformatter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -26,8 +25,13 @@ type ProgressWriter struct {
 	Output             io.Writer
 	StdoutFormatter    io.Writer
 	StderrFormatter    io.Writer
-	AuxFormatter       *streamformatter.AuxFormatter
+	AuxFormatter       AuxEmitter
 	ProgressReaderFunc func(io.ReadCloser) io.ReadCloser
+}
+
+// AuxEmitter is an interface for emitting aux messages during build progress
+type AuxEmitter interface {
+	Emit(string, interface{}) error
 }
 
 // BuildConfig is the configuration used by a BuildManager to start a build

--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/remotecontext"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
@@ -113,7 +112,7 @@ type Builder struct {
 
 	Stdout io.Writer
 	Stderr io.Writer
-	Aux    *streamformatter.AuxFormatter
+	Aux    backend.AuxEmitter
 	Output io.Writer
 
 	docker builder.Backend
@@ -218,7 +217,7 @@ func (b *Builder) build(ctx context.Context, source builder.Source, dockerfile *
 	return &builder.Result{ImageID: state.imageID, FromImage: state.baseImage}, nil
 }
 
-func emitImageID(aux *streamformatter.AuxFormatter, state *dispatchState) error {
+func emitImageID(aux backend.AuxEmitter, state *dispatchState) error {
 	if aux == nil || state.imageID == "" {
 		return nil
 	}


### PR DESCRIPTION
Avoid importing structs from the root package in favor of defining an interface for the functions which are called.
