### PR TITLE
Add HealthStatus attribute on the docker ps command

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5346,6 +5346,29 @@ definitions:
           List of mounts used by the container.
         items:
           $ref: "#/definitions/MountPoint"
+      Health:
+        type: "object"
+        description: |-
+          Summary of health status
+
+          Added in v1.52, before that version all container summary not include Health.
+          After this attribute introduced, it includes containers with no health checks configured,
+          or containers that are not running with none
+        properties:
+          Status:
+            type: "string"
+            description: |-
+              the health status of the container
+            enum:
+              - "none"
+              - "starting"
+              - "healthy"
+              - "unhealthy"
+            example: "healthy"
+          FailingStreak:
+            description: "FailingStreak is the number of consecutive failures"
+            type: "integer"
+            example: 0
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -128,6 +128,7 @@ type Summary struct {
 		NetworkMode string            `json:",omitempty"`
 		Annotations map[string]string `json:",omitempty"`
 	}
+	Health          *HealthSummary `json:",omitempty"`
 	NetworkSettings *NetworkSettingsSummary
 	Mounts          []MountPoint
 }

--- a/api/types/container/health.go
+++ b/api/types/container/health.go
@@ -26,6 +26,12 @@ type Health struct {
 	Log           []*HealthcheckResult // Log contains the last few results (oldest first)
 }
 
+// HealthSummary stores a summary of the container's healthcheck results.
+type HealthSummary struct {
+	Status        HealthStatus // Status is one of [NoHealthcheck], [Starting], [Healthy] or [Unhealthy].
+	FailingStreak int          // FailingStreak is the number of consecutive failures
+}
+
 // HealthcheckResult stores information about a single run of a healthcheck probe
 type HealthcheckResult struct {
 	Start    time.Time // Start is the time this check started

--- a/daemon/container/view.go
+++ b/daemon/container/view.go
@@ -296,9 +296,17 @@ func (v *View) GetAllNames() map[string][]string {
 // A lock on the Container is not held because these are immutable deep copies.
 func (v *View) transform(ctr *Container) *Snapshot {
 	health := container.NoHealthcheck
+	failingStreak := 0
 	if ctr.Health != nil {
 		health = ctr.Health.Status()
+		failingStreak = ctr.Health.FailingStreak
 	}
+
+	healthSummary := &container.HealthSummary{
+		Status:        health,
+		FailingStreak: failingStreak,
+	}
+
 	snapshot := &Snapshot{
 		Summary: container.Summary{
 			ID:      ctr.ID,
@@ -308,6 +316,7 @@ func (v *View) transform(ctr *Container) *Snapshot {
 			Mounts:  ctr.GetMountPoints(),
 			State:   ctr.State.StateString(),
 			Status:  ctr.State.String(),
+			Health:  healthSummary,
 			Created: ctr.Created.Unix(),
 		},
 		CreatedAt:    ctr.Created,

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -119,6 +119,12 @@ func (c *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 		}
 	}
 
+	if versions.LessThan(version, "1.52") {
+		for _, c := range containers {
+			c.Health = nil
+		}
+	}
+
 	return httputils.WriteJSON(w, http.StatusOK, containers)
 }
 

--- a/vendor/github.com/moby/moby/api/swagger.yaml
+++ b/vendor/github.com/moby/moby/api/swagger.yaml
@@ -5346,6 +5346,29 @@ definitions:
           List of mounts used by the container.
         items:
           $ref: "#/definitions/MountPoint"
+      Health:
+        type: "object"
+        description: |-
+          Summary of health status
+
+          Added in v1.52, before that version all container summary not include Health.
+          After this attribute introduced, it includes containers with no health checks configured,
+          or containers that are not running with none
+        properties:
+          Status:
+            type: "string"
+            description: |-
+              the health status of the container
+            enum:
+              - "none"
+              - "starting"
+              - "healthy"
+              - "unhealthy"
+            example: "healthy"
+          FailingStreak:
+            description: "FailingStreak is the number of consecutive failures"
+            type: "integer"
+            example: 0
 
   Driver:
     description: "Driver represents a driver (network, logging, secrets)."

--- a/vendor/github.com/moby/moby/api/types/container/container.go
+++ b/vendor/github.com/moby/moby/api/types/container/container.go
@@ -128,6 +128,7 @@ type Summary struct {
 		NetworkMode string            `json:",omitempty"`
 		Annotations map[string]string `json:",omitempty"`
 	}
+	Health          *HealthSummary `json:",omitempty"`
 	NetworkSettings *NetworkSettingsSummary
 	Mounts          []MountPoint
 }

--- a/vendor/github.com/moby/moby/api/types/container/health.go
+++ b/vendor/github.com/moby/moby/api/types/container/health.go
@@ -26,6 +26,12 @@ type Health struct {
 	Log           []*HealthcheckResult // Log contains the last few results (oldest first)
 }
 
+// HealthSummary stores a summary of the container's healthcheck results.
+type HealthSummary struct {
+	Status        HealthStatus // Status is one of [NoHealthcheck], [Starting], [Healthy] or [Unhealthy].
+	FailingStreak int          // FailingStreak is the number of consecutive failures
+}
+
 // HealthcheckResult stores information about a single run of a healthcheck probe
 type HealthcheckResult struct {
 	Start    time.Time // Start is the time this check started


### PR DESCRIPTION
- fixes: #50253
 
**- What I did**
Add HealthStatus attribute for dokcer ps command

**- How I did it**
1. Add new attribute with type HealthSummary on ContainerSummary

**- How to verify it**
1. Run container with health check
```bash
# healthy status
docker run -d   --name traefik-test   --health-cmd="wget -qO- http://localhost:8080/ping || exit 1"   --health-interval=5s   --health-retries=3   traefik:v2.11   --ping
# unhealthy status
docker run -d --name test-fail   --health-cmd="exit 1"   --health-interval=3s   busybox:latest   sleep 300
```
2. Run this command `curl --unix-socket /var/run/docker.sock http://localhost/containers/json | jq`

**- Human readable description for the release notes**
```markdown changelog
`GET /containers/json` now includes a `Health` field describing container healthcheck status.
```


