### PR TITLE
Tell libnet's drivers which endpoints have been selected as gateways

### DIFF
--- a/libnetwork/driverapi/driverapi.go
+++ b/libnetwork/driverapi/driverapi.go
@@ -83,7 +83,7 @@ type Driver interface {
 type ExtConner interface {
 	// ProgramExternalConnectivity invokes the driver method which does the necessary
 	// programming to allow the external connectivity dictated by the passed options
-	ProgramExternalConnectivity(ctx context.Context, nid, eid string, options map[string]interface{}) error
+	ProgramExternalConnectivity(ctx context.Context, nid, eid string, options map[string]interface{}, gw4Id, gw6Id string) error
 
 	// RevokeExternalConnectivity asks the driver to remove any external connectivity
 	// programming that was done so far

--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -125,17 +125,18 @@ type connectivityConfiguration struct {
 }
 
 type bridgeEndpoint struct {
-	id              string
-	nid             string
-	srcName         string
-	addr            *net.IPNet
-	addrv6          *net.IPNet
-	macAddress      net.HardwareAddr
-	containerConfig *containerConfiguration
-	extConnConfig   *connectivityConfiguration
-	portMapping     []portBinding // Operational port bindings
-	dbIndex         uint64
-	dbExists        bool
+	id               string
+	nid              string
+	srcName          string
+	addr             *net.IPNet
+	addrv6           *net.IPNet
+	macAddress       net.HardwareAddr
+	containerConfig  *containerConfiguration
+	extConnConfig    *connectivityConfiguration
+	portMapping      []portBinding   // Operational port bindings
+	portBindingState portBindingMode // Not persisted, even on live-restore port mappings are re-created.
+	dbIndex          uint64
+	dbExists         bool
 }
 
 type bridgeNetwork struct {
@@ -1488,10 +1489,17 @@ func (d *driver) Leave(nid, eid string) error {
 	return nil
 }
 
+type portBindingMode struct {
+	ipv4 bool
+	ipv6 bool
+}
+
 func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid string, options map[string]interface{}, gw4Id, gw6Id string) error {
 	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".ProgramExternalConnectivity", trace.WithAttributes(
 		attribute.String("nid", nid),
-		attribute.String("eid", eid)))
+		attribute.String("eid", eid),
+		attribute.String("gw4", gw4Id),
+		attribute.String("gw6", gw6Id)))
 	defer span.End()
 
 	// Make sure the network isn't deleted, or in the middle of a firewalld reload, while
@@ -1518,18 +1526,26 @@ func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid strin
 		return err
 	}
 
+	var pbmReq portBindingMode
+	// Act as the IPv4 gateway if explicitly selected.
+	if gw4Id == eid {
+		pbmReq.ipv4 = true
+	}
+	// Act as the IPv6 gateway if explicitly selected - or if there's no IPv6
+	// gateway, but this endpoint is the IPv4 gateway (in which case, the userland
+	// proxy may proxy between host v6 and container v4 addresses.)
+	if gw6Id == eid || (gw6Id == "" && gw4Id == eid) {
+		pbmReq.ipv6 = true
+	}
+
 	// Program any required port mapping and store them in the endpoint
 	if endpoint.extConnConfig != nil && endpoint.extConnConfig.PortBindings != nil {
-		// noProxy6To4 if another endpoint is the IPv6 gateway
-		noProxy6To4 := gw6Id != "" && gw6Id != eid
-
 		endpoint.portMapping, err = network.addPortMappings(
 			ctx,
-			endpoint.addr,
-			endpoint.addrv6,
+			endpoint,
 			endpoint.extConnConfig.PortBindings,
 			network.config.DefaultBindingIP,
-			noProxy6To4,
+			pbmReq,
 		)
 		if err != nil {
 			return err
@@ -1545,6 +1561,9 @@ func (d *driver) ProgramExternalConnectivity(ctx context.Context, nid, eid strin
 			endpoint.portMapping = nil
 		}
 	}()
+
+	// Remember the new port binding state.
+	endpoint.portBindingState = pbmReq
 
 	// Clean the connection tracker state of the host for the specific endpoint. This is needed because some flows may
 	// be bound to the local proxy, or to the host (for UDP packets), and won't be redirected to the new endpoints.

--- a/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -843,7 +843,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep1", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep1", sbOptions, "ep1", "")
 	if err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
@@ -947,7 +947,7 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep1", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep1", sbOptions, "ep1", "")
 	if err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
@@ -978,7 +978,7 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatal("Failed to link ep1 and ep2")
 	}
 
-	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep2", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep2", sbOptions, "ep2", "ep2")
 	if err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
@@ -1017,7 +1017,7 @@ func TestLinkContainers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep2", sbOptions)
+	err = d.ProgramExternalConnectivity(context.Background(), "net1", "ep2", sbOptions, "ep2", "ep2")
 	assert.Check(t, err != nil, "Expected Join to fail given link conditions are not satisfied")
 	checkLink(false)
 }

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -458,18 +458,22 @@ func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {
 		cfg[i] = b.PortBinding
 	}
 
-	// If there were no IPv6 host ports in the bindings, set noProxy6To4 to make
-	// sure none will be set up this time.
-	var noProxy6To4 bool
+	// Calculate a portBindingMode - it need not be accurate but, if there were
+	// IPv4/IPv6 bindings before, ensure they are re-created. (If, for example,
+	// there are no IPv6 bindings, it doesn't matter whether that was because this
+	// endpoint is not an IPv6 gateway and "pbmIPv6" was not set in the port
+	// binding state, or there were just no IPv6 port bindings configured.)
+	var pbm portBindingMode
 	for _, b := range ep.portMapping {
-		if b.HostIP.To4() != nil {
-			noProxy6To4 = true
-			break
+		if b.HostIP.To4() == nil {
+			pbm.ipv6 = true
+		} else {
+			pbm.ipv4 = true
 		}
 	}
 
 	var err error
-	ep.portMapping, err = n.addPortMappings(context.TODO(), ep.addr, ep.addrv6, cfg, n.config.DefaultBindingIP, noProxy6To4)
+	ep.portMapping, err = n.addPortMappings(context.TODO(), ep, cfg, n.config.DefaultBindingIP, pbm)
 	if err != nil {
 		log.G(context.TODO()).Warnf("Failed to reserve existing port mapping for endpoint %.7s:%v", ep.id, err)
 	}

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -458,8 +458,18 @@ func (n *bridgeNetwork) restorePortAllocations(ep *bridgeEndpoint) {
 		cfg[i] = b.PortBinding
 	}
 
+	// If there were no IPv6 host ports in the bindings, set noProxy6To4 to make
+	// sure none will be set up this time.
+	var noProxy6To4 bool
+	for _, b := range ep.portMapping {
+		if b.HostIP.To4() != nil {
+			noProxy6To4 = true
+			break
+		}
+	}
+
 	var err error
-	ep.portMapping, err = n.addPortMappings(context.TODO(), ep.addr, ep.addrv6, cfg, n.config.DefaultBindingIP, ep.extConnConfig.NoProxy6To4)
+	ep.portMapping, err = n.addPortMappings(context.TODO(), ep.addr, ep.addrv6, cfg, n.config.DefaultBindingIP, noProxy6To4)
 	if err != nil {
 		log.G(context.TODO()).Warnf("Failed to reserve existing port mapping for endpoint %.7s:%v", ep.id, err)
 	}

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -73,7 +73,7 @@ func TestPortMappingConfig(t *testing.T) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	if err = d.ProgramExternalConnectivity(context.Background(), "dummy", "ep1", sbOptions); err != nil {
+	if err = d.ProgramExternalConnectivity(context.Background(), "dummy", "ep1", sbOptions, "ep1", ""); err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
 
@@ -159,7 +159,7 @@ func TestPortMappingV6Config(t *testing.T) {
 		t.Fatalf("Failed to join the endpoint: %v", err)
 	}
 
-	if err = d.ProgramExternalConnectivity(context.Background(), "dummy", "ep1", sbOptions); err != nil {
+	if err = d.ProgramExternalConnectivity(context.Background(), "dummy", "ep1", sbOptions, "ep1", ""); err != nil {
 		t.Fatalf("Failed to program external connectivity: %v", err)
 	}
 

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -876,7 +876,20 @@ func TestAddPortMappings(t *testing.T) {
 				}
 			})
 
-			pbs, err := n.addPortMappings(ctx, tc.epAddrV4, tc.epAddrV6, tc.cfg, tc.defHostIP, tc.noProxy6To4)
+			ep := &bridgeEndpoint{
+				id:     "dummyep",
+				nid:    "dummynetwork",
+				addr:   tc.epAddrV4,
+				addrv6: tc.epAddrV6,
+			}
+			var pbm portBindingMode
+			if ep.addr != nil {
+				pbm.ipv4 = true
+			}
+			if ep.addrv6 != nil || (!tc.noProxy6To4 && ep.addr != nil) {
+				pbm.ipv6 = true
+			}
+			pbs, err := n.addPortMappings(ctx, ep, tc.cfg, tc.defHostIP, pbm)
 			if tc.expErr != "" {
 				assert.ErrorContains(t, err, tc.expErr)
 				return

--- a/libnetwork/drivers/remote/driver.go
+++ b/libnetwork/drivers/remote/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/libnetwork/discoverapi"
@@ -25,6 +26,13 @@ type driver struct {
 	endpoint       *plugins.Client
 	networkType    string
 	gwAllocChecker bool
+	nwEndpoints    map[string]*nwEndpoint // Set of endpoint ids that are currently acting as container gateways.
+	nwEndpointsMu  sync.Mutex
+}
+
+type nwEndpoint struct {
+	isGateway4 bool
+	isGateway6 bool
 }
 
 type maybeError interface {
@@ -32,7 +40,11 @@ type maybeError interface {
 }
 
 func newDriver(name string, client *plugins.Client) *driver {
-	return &driver{networkType: name, endpoint: client}
+	return &driver{
+		networkType: name,
+		endpoint:    client,
+		nwEndpoints: make(map[string]*nwEndpoint),
+	}
 }
 
 // Register makes sure a remote driver is registered with r when a network
@@ -337,6 +349,10 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 	if res.DisableGatewayService {
 		jinfo.DisableGatewayService()
 	}
+
+	d.nwEndpointsMu.Lock()
+	defer d.nwEndpointsMu.Unlock()
+	d.nwEndpoints[eid] = &nwEndpoint{}
 	return nil
 }
 
@@ -346,22 +362,41 @@ func (d *driver) Leave(nid, eid string) error {
 		NetworkID:  nid,
 		EndpointID: eid,
 	}
-	return d.call("Leave", leave, &api.LeaveResponse{})
+	if err := d.call("Leave", leave, &api.LeaveResponse{}); err != nil {
+		return err
+	}
+	d.nwEndpointsMu.Lock()
+	defer d.nwEndpointsMu.Unlock()
+	delete(d.nwEndpoints, eid)
+	return nil
 }
 
 // ProgramExternalConnectivity is invoked to program the rules to allow external connectivity for the endpoint.
 func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string, options map[string]interface{}, gw4Id, gw6Id string) error {
-	// If there is an IPv6 gateway, but it's not eid, set NoProxy6To4. This label was
-	// used to tell the bridge driver not to try to use the userland proxy for dual
-	// stack port mappings between host IPv6 and container IPv4 (because a different
-	// endpoint may be dealing with IPv6 host addresses). It was undocumented for the
-	// remote driver, marked as being for internal use and subject to later removal.
-	// But, preserve it here for now as there's no other way for a remote driver to
-	// know it shouldn't try to deal with IPv6 in this case.
-	if gw6Id != "" && gw6Id != eid {
+	d.nwEndpointsMu.Lock()
+	ep, ok := d.nwEndpoints[eid]
+	d.nwEndpointsMu.Unlock()
+	if !ok {
+		return fmt.Errorf("remote network driver: endpoint %s not found", eid)
+	}
+	isGw4, isGw6 := gw4Id == eid, gw6Id == eid
+	if ep.isGateway4 == isGw4 && ep.isGateway6 == isGw6 {
+		return nil
+	}
+	if !isGw4 && !isGw6 {
+		return nil
+	}
+	ep.isGateway4, ep.isGateway6 = isGw4, isGw6
+	if !isGw6 && gw6Id != "" {
+		// If there is an IPv6 gateway, but it's not eid, set NoProxy6To4. This label was
+		// used to tell the bridge driver not to try to use the userland proxy for dual
+		// stack port mappings between host IPv6 and container IPv4 (because a different
+		// endpoint may be dealing with IPv6 host addresses). It was undocumented for the
+		// remote driver, marked as being for internal use and subject to later removal.
+		// But, preserve it here for now as there's no other way for a remote driver to
+		// know it shouldn't try to deal with IPv6 in this case.
 		options[netlabel.NoProxy6To4] = true
 	}
-
 	data := &api.ProgramExternalConnectivityRequest{
 		NetworkID:  nid,
 		EndpointID: eid,
@@ -377,10 +412,17 @@ func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string,
 
 // RevokeExternalConnectivity method is invoked to remove any external connectivity programming related to the endpoint.
 func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
+	d.nwEndpointsMu.Lock()
+	ep, ok := d.nwEndpoints[eid]
+	d.nwEndpointsMu.Unlock()
+	if !ok {
+		return fmt.Errorf("remote network driver: endpoint %s not found", eid)
+	}
 	data := &api.RevokeExternalConnectivityRequest{
 		NetworkID:  nid,
 		EndpointID: eid,
 	}
+	ep.isGateway4, ep.isGateway6 = false, false
 	err := d.call("RevokeExternalConnectivity", data, &api.RevokeExternalConnectivityResponse{})
 	if err != nil && plugins.IsNotFound(err) {
 		// It is not mandatory yet to support this method


### PR DESCRIPTION
**- What I did**

- split out of https://github.com/moby/moby/pull/50140

Currently, when libnetwork selects gateway endpoints for a container (following an endpoint join/leave) it has to do a lot of work to decide whether old gateway configuration needs to be updated ... the new and old gateway endpoints may have different network drivers, gateway endpoints for IPv4/IPv6 need not be the same - and it's made particularly complicated by drivers being able to proxy from IPv6 host addresses to IPv4 container addresses. For example, when a container only has an IPv4 endpoint, proxying needs to be set up, then when an IPv6 endpoint is added, that proxying needs to be removed even if the IPv4 gateway hasn't changed.

Rather than trying to manage all that in libnetwork - just tell the driver whether its endpoint is currently acting as a gateway, and let the driver work out whether anything changed and what it needs to do about it.

With these changes - libnet is still tracking the gateway-ness itself, the simplifications are to-follow. But, libnet no longer needs to tell the driver whether it needs to proxy from IPv6-to-IPv4, the driver can work that out for itself based on whether there's an IPv6 gateway / whether it's the same as the IPv4 gateway.

**- How I did it**

See individual commits - libnet driver API change, remote-driver change, bridge-driver change.

**- How to verify it**

Existing tests.

**- Human readable description for the release notes**
```markdown changelog

```
