### PR TITLE
integration-cli: remove uses of deprecated dockerCmdWithResult utility

### DIFF
--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -100,7 +100,7 @@ func (s *DockerCLIEventSuite) TestEventsOOMDisableTrue(c *testing.T) {
 	}()
 
 	cli.WaitRun(c, "oomTrue")
-	defer dockerCmdWithResult("kill", "oomTrue")
+	defer cli.Docker(cli.Args("kill", "oomTrue"))
 	containerID := inspectField(c, "oomTrue", "Id")
 
 	testActions := map[string]chan bool{

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -327,14 +327,14 @@ func (s *DockerCLIInspectSuite) TestInspectByPrefix(c *testing.T) {
 func (s *DockerCLIInspectSuite) TestInspectStopWhenNotFound(c *testing.T) {
 	runSleepingContainer(c, "--name=busybox1", "-d")
 	runSleepingContainer(c, "--name=busybox2", "-d")
-	result := dockerCmdWithResult("inspect", "--type=container", "--format='{{.Name}}'", "busybox1", "busybox2", "missing")
+	result := cli.Docker(cli.Args("inspect", "--type=container", "--format='{{.Name}}'", "busybox1", "busybox2", "missing"))
 
 	assert.Assert(c, result.Error != nil)
 	assert.Assert(c, is.Contains(result.Stdout(), "busybox1"))
 	assert.Assert(c, is.Contains(result.Stdout(), "busybox2"))
 	assert.Assert(c, is.Contains(result.Stderr(), "Error: No such container: missing"))
 	// test inspect would not fast fail
-	result = dockerCmdWithResult("inspect", "--type=container", "--format='{{.Name}}'", "missing", "busybox1", "busybox2")
+	result = cli.Docker(cli.Args("inspect", "--type=container", "--format='{{.Name}}'", "missing", "busybox1", "busybox2"))
 
 	assert.Assert(c, result.Error != nil)
 	assert.Assert(c, is.Contains(result.Stdout(), "busybox1"))

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -465,7 +465,7 @@ func (s *DockerCLINetworkSuite) TestDockerNetworkInspectWithID(c *testing.T) {
 }
 
 func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetwork(c *testing.T) {
-	result := dockerCmdWithResult("network", "inspect", "host", "none")
+	result := cli.Docker(cli.Args("network", "inspect", "host", "none"))
 	result.Assert(c, icmd.Success)
 
 	var networkResources []network.Inspect
@@ -477,7 +477,7 @@ func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetwork(c *testing.T) {
 func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetworksIncludingNonexistent(c *testing.T) {
 	// non-existent network was not at the beginning of the inspect list
 	// This should print an error, return an exitCode 1 and print the host network
-	result := dockerCmdWithResult("network", "inspect", "host", "nonexistent")
+	result := cli.Docker(cli.Args("network", "inspect", "host", "nonexistent"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "Error: No such network: nonexistent",
@@ -491,7 +491,7 @@ func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetworksIncludingNonexi
 
 	// Only one non-existent network to inspect
 	// Should print an error and return an exitCode, nothing else
-	result = dockerCmdWithResult("network", "inspect", "nonexistent")
+	result = cli.Docker(cli.Args("network", "inspect", "nonexistent"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "Error: No such network: nonexistent",
@@ -500,7 +500,7 @@ func (s *DockerCLINetworkSuite) TestDockerInspectMultipleNetworksIncludingNonexi
 
 	// non-existent network was at the beginning of the inspect list
 	// Should not fail fast, and still print host network but print an error
-	result = dockerCmdWithResult("network", "inspect", "nonexistent", "host")
+	result = cli.Docker(cli.Args("network", "inspect", "nonexistent", "host"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "Error: No such network: nonexistent",

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2441,10 +2441,10 @@ func (s *DockerCLIRunSuite) TestRunTLSVerify(c *testing.T) {
 
 	// Regardless of whether we specify true or false we need to
 	// test to make sure tls is turned on if --tlsverify is specified at all
-	result := dockerCmdWithResult("--tlsverify=false", "ps")
+	result := cli.Docker(cli.Args("--tlsverify=false", "ps"))
 	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "error during connect"})
 
-	result = dockerCmdWithResult("--tlsverify=true", "ps")
+	result = cli.Docker(cli.Args("--tlsverify=true", "ps"))
 	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "cert"})
 }
 
@@ -3804,9 +3804,9 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 	_, err := d.Cmd("run", "--rm", "busybox", "true")
 	assert.NilError(c, err)
 
-	client := d.NewClientT(c)
+	apiClient := d.NewClientT(c)
 
-	nroutines := waitForStableGoroutineCount(ctx, c, client)
+	nroutines := waitForStableGoroutineCount(ctx, c, apiClient)
 
 	out, err := d.Cmd(append([]string{"run", "-d", "--name=test", "-p", "8000:8000", "busybox"}, sleepCommandForDaemonPlatform()...)...)
 	assert.NilError(c, err, out)
@@ -3834,7 +3834,7 @@ func (s *DockerCLIRunSuite) TestRunAttachFailedNoLeak(c *testing.T) {
 	assert.NilError(c, err, out)
 
 	// NGoroutines is not updated right away, so we need to wait before failing
-	waitForGoroutines(ctx, c, client, nroutines)
+	waitForGoroutines(ctx, c, apiClient, nroutines)
 }
 
 // Test for one character directory name case (#20122)

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -66,7 +66,7 @@ func (s *DockerCLIVolumeSuite) TestVolumeCLIInspectMulti(c *testing.T) {
 	cli.DockerCmd(c, "volume", "create", "test2")
 	cli.DockerCmd(c, "volume", "create", "test3")
 
-	result := dockerCmdWithResult("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesnotexist", "test3")
+	result := cli.Docker(cli.Args("volume", "inspect", "--format={{ .Name }}", "test1", "test2", "doesnotexist", "test3"))
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
 		Err:      "No such volume: doesnotexist",

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -42,11 +42,6 @@ func dockerCmdWithError(args ...string) (string, int, error) {
 	return result.Combined(), result.ExitCode, result.Error
 }
 
-// Deprecated: use cli.Docker or cli.DockerCmd
-func dockerCmdWithResult(args ...string) *icmd.Result {
-	return cli.Docker(cli.Args(args...))
-}
-
 func findContainerIP(t *testing.T, id string, network string) string {
 	t.Helper()
 	out := cli.DockerCmd(t, "inspect", fmt.Sprintf("--format='{{ .NetworkSettings.Networks.%s.IPAddress }}'", network), id).Stdout()


### PR DESCRIPTION


**- A picture of a cute animal (not mandatory but encouraged)**

