### PR TITLE
client: Client.doRequest: improve some connection errors

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -158,6 +158,12 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 		// which are irrelevant if we weren't able to connect.
 		return nil, errConnectionFailed{fmt.Errorf("permission denied while trying to connect to the docker API at %v", cli.host)}
 	}
+	if errors.Is(err, os.ErrNotExist) {
+		// Unwrap the error to remove request errors ("Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/version"),
+		// which are irrelevant if we weren't able to connect.
+		err = errors.Unwrap(err)
+		return nil, errConnectionFailed{errors.Wrapf(err, "failed to connect to the docker API at %v; check if the path is correct and if the daemon is running", cli.host)}
+	}
 
 	var nErr net.Error
 	if errors.As(err, &nErr) {

--- a/client/request.go
+++ b/client/request.go
@@ -140,7 +140,7 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	}
 
 	if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
-		return nil, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
+		return nil, errConnectionFailed{fmt.Errorf("%w.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
 	}
 
 	if cli.scheme == "https" && strings.Contains(err.Error(), "bad certificate") {

--- a/client/request.go
+++ b/client/request.go
@@ -135,66 +135,66 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 
 func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	resp, err := cli.client.Do(req)
-	if err != nil {
-		if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
-			return nil, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
-		}
-
-		if cli.scheme == "https" && strings.Contains(err.Error(), "bad certificate") {
-			return nil, errConnectionFailed{errors.Wrap(err, "the server probably has client authentication (--tlsverify) enabled; check your TLS client certification settings")}
-		}
-
-		// Don't decorate context sentinel errors; users may be comparing to
-		// them directly.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, err
-		}
-
-		var uErr *url.Error
-		if errors.As(err, &uErr) {
-			var nErr *net.OpError
-			if errors.As(uErr.Err, &nErr) {
-				if os.IsPermission(nErr.Err) {
-					return nil, errConnectionFailed{errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)}
-				}
-			}
-		}
-
-		var nErr net.Error
-		if errors.As(err, &nErr) {
-			// FIXME(thaJeztah): any net.Error should be considered a connection error (but we should include the original error)?
-			if nErr.Timeout() {
-				return nil, connectionFailed(cli.host)
-			}
-			if strings.Contains(nErr.Error(), "connection refused") || strings.Contains(nErr.Error(), "dial unix") {
-				return nil, connectionFailed(cli.host)
-			}
-		}
-
-		// Although there's not a strongly typed error for this in go-winio,
-		// lots of people are using the default configuration for the docker
-		// daemon on Windows where the daemon is listening on a named pipe
-		// `//./pipe/docker_engine, and the client must be running elevated.
-		// Give users a clue rather than the not-overly useful message
-		// such as `error during connect: Get http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.26/info:
-		// open //./pipe/docker_engine: The system cannot find the file specified.`.
-		// Note we can't string compare "The system cannot find the file specified" as
-		// this is localised - for example in French the error would be
-		// `open //./pipe/docker_engine: Le fichier spécifié est introuvable.`
-		if strings.Contains(err.Error(), `open //./pipe/docker_engine`) {
-			// Checks if client is running with elevated privileges
-			if f, elevatedErr := os.Open(`\\.\PHYSICALDRIVE0`); elevatedErr != nil {
-				err = errors.Wrap(err, "in the default daemon configuration on Windows, the docker client must be run with elevated privileges to connect")
-			} else {
-				_ = f.Close()
-				err = errors.Wrap(err, "this error may indicate that the docker daemon is not running")
-			}
-		}
-
-		return nil, errConnectionFailed{errors.Wrap(err, "error during connect")}
+	if err == nil {
+		return resp, nil
 	}
 
-	return resp, nil
+	if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
+		return nil, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
+	}
+
+	if cli.scheme == "https" && strings.Contains(err.Error(), "bad certificate") {
+		return nil, errConnectionFailed{errors.Wrap(err, "the server probably has client authentication (--tlsverify) enabled; check your TLS client certification settings")}
+	}
+
+	// Don't decorate context sentinel errors; users may be comparing to
+	// them directly.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, err
+	}
+
+	var uErr *url.Error
+	if errors.As(err, &uErr) {
+		var nErr *net.OpError
+		if errors.As(uErr.Err, &nErr) {
+			if os.IsPermission(nErr.Err) {
+				return nil, errConnectionFailed{errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)}
+			}
+		}
+	}
+
+	var nErr net.Error
+	if errors.As(err, &nErr) {
+		// FIXME(thaJeztah): any net.Error should be considered a connection error (but we should include the original error)?
+		if nErr.Timeout() {
+			return nil, connectionFailed(cli.host)
+		}
+		if strings.Contains(nErr.Error(), "connection refused") || strings.Contains(nErr.Error(), "dial unix") {
+			return nil, connectionFailed(cli.host)
+		}
+	}
+
+	// Although there's not a strongly typed error for this in go-winio,
+	// lots of people are using the default configuration for the docker
+	// daemon on Windows where the daemon is listening on a named pipe
+	// `//./pipe/docker_engine, and the client must be running elevated.
+	// Give users a clue rather than the not-overly useful message
+	// such as `error during connect: Get http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.26/info:
+	// open //./pipe/docker_engine: The system cannot find the file specified.`.
+	// Note we can't string compare "The system cannot find the file specified" as
+	// this is localised - for example in French the error would be
+	// `open //./pipe/docker_engine: Le fichier spécifié est introuvable.`
+	if strings.Contains(err.Error(), `open //./pipe/docker_engine`) {
+		// Checks if client is running with elevated privileges
+		if f, elevatedErr := os.Open(`\\.\PHYSICALDRIVE0`); elevatedErr != nil {
+			err = errors.Wrap(err, "in the default daemon configuration on Windows, the docker client must be run with elevated privileges to connect")
+		} else {
+			_ = f.Close()
+			err = errors.Wrap(err, "this error may indicate that the docker daemon is not running")
+		}
+	}
+
+	return nil, errConnectionFailed{errors.Wrap(err, "error during connect")}
 }
 
 func (cli *Client) checkResponseErr(serverResp *http.Response) (retErr error) {

--- a/client/request.go
+++ b/client/request.go
@@ -164,6 +164,10 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 		err = errors.Unwrap(err)
 		return nil, errConnectionFailed{errors.Wrapf(err, "failed to connect to the docker API at %v; check if the path is correct and if the daemon is running", cli.host)}
 	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return nil, errConnectionFailed{errors.Wrapf(dnsErr, "failed to connect to the docker API at %v", cli.host)}
+	}
 
 	var nErr net.Error
 	if errors.As(err, &nErr) {

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -158,6 +158,12 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 		// which are irrelevant if we weren't able to connect.
 		return nil, errConnectionFailed{fmt.Errorf("permission denied while trying to connect to the docker API at %v", cli.host)}
 	}
+	if errors.Is(err, os.ErrNotExist) {
+		// Unwrap the error to remove request errors ("Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/version"),
+		// which are irrelevant if we weren't able to connect.
+		err = errors.Unwrap(err)
+		return nil, errConnectionFailed{errors.Wrapf(err, "failed to connect to the docker API at %v; check if the path is correct and if the daemon is running", cli.host)}
+	}
 
 	var nErr net.Error
 	if errors.As(err, &nErr) {

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -140,7 +140,7 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	}
 
 	if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
-		return nil, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
+		return nil, errConnectionFailed{fmt.Errorf("%w.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
 	}
 
 	if cli.scheme == "https" && strings.Contains(err.Error(), "bad certificate") {

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -135,66 +135,66 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 
 func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	resp, err := cli.client.Do(req)
-	if err != nil {
-		if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
-			return nil, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
-		}
-
-		if cli.scheme == "https" && strings.Contains(err.Error(), "bad certificate") {
-			return nil, errConnectionFailed{errors.Wrap(err, "the server probably has client authentication (--tlsverify) enabled; check your TLS client certification settings")}
-		}
-
-		// Don't decorate context sentinel errors; users may be comparing to
-		// them directly.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, err
-		}
-
-		var uErr *url.Error
-		if errors.As(err, &uErr) {
-			var nErr *net.OpError
-			if errors.As(uErr.Err, &nErr) {
-				if os.IsPermission(nErr.Err) {
-					return nil, errConnectionFailed{errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)}
-				}
-			}
-		}
-
-		var nErr net.Error
-		if errors.As(err, &nErr) {
-			// FIXME(thaJeztah): any net.Error should be considered a connection error (but we should include the original error)?
-			if nErr.Timeout() {
-				return nil, connectionFailed(cli.host)
-			}
-			if strings.Contains(nErr.Error(), "connection refused") || strings.Contains(nErr.Error(), "dial unix") {
-				return nil, connectionFailed(cli.host)
-			}
-		}
-
-		// Although there's not a strongly typed error for this in go-winio,
-		// lots of people are using the default configuration for the docker
-		// daemon on Windows where the daemon is listening on a named pipe
-		// `//./pipe/docker_engine, and the client must be running elevated.
-		// Give users a clue rather than the not-overly useful message
-		// such as `error during connect: Get http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.26/info:
-		// open //./pipe/docker_engine: The system cannot find the file specified.`.
-		// Note we can't string compare "The system cannot find the file specified" as
-		// this is localised - for example in French the error would be
-		// `open //./pipe/docker_engine: Le fichier spécifié est introuvable.`
-		if strings.Contains(err.Error(), `open //./pipe/docker_engine`) {
-			// Checks if client is running with elevated privileges
-			if f, elevatedErr := os.Open(`\\.\PHYSICALDRIVE0`); elevatedErr != nil {
-				err = errors.Wrap(err, "in the default daemon configuration on Windows, the docker client must be run with elevated privileges to connect")
-			} else {
-				_ = f.Close()
-				err = errors.Wrap(err, "this error may indicate that the docker daemon is not running")
-			}
-		}
-
-		return nil, errConnectionFailed{errors.Wrap(err, "error during connect")}
+	if err == nil {
+		return resp, nil
 	}
 
-	return resp, nil
+	if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
+		return nil, errConnectionFailed{fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)}
+	}
+
+	if cli.scheme == "https" && strings.Contains(err.Error(), "bad certificate") {
+		return nil, errConnectionFailed{errors.Wrap(err, "the server probably has client authentication (--tlsverify) enabled; check your TLS client certification settings")}
+	}
+
+	// Don't decorate context sentinel errors; users may be comparing to
+	// them directly.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, err
+	}
+
+	var uErr *url.Error
+	if errors.As(err, &uErr) {
+		var nErr *net.OpError
+		if errors.As(uErr.Err, &nErr) {
+			if os.IsPermission(nErr.Err) {
+				return nil, errConnectionFailed{errors.Wrapf(err, "permission denied while trying to connect to the Docker daemon socket at %v", cli.host)}
+			}
+		}
+	}
+
+	var nErr net.Error
+	if errors.As(err, &nErr) {
+		// FIXME(thaJeztah): any net.Error should be considered a connection error (but we should include the original error)?
+		if nErr.Timeout() {
+			return nil, connectionFailed(cli.host)
+		}
+		if strings.Contains(nErr.Error(), "connection refused") || strings.Contains(nErr.Error(), "dial unix") {
+			return nil, connectionFailed(cli.host)
+		}
+	}
+
+	// Although there's not a strongly typed error for this in go-winio,
+	// lots of people are using the default configuration for the docker
+	// daemon on Windows where the daemon is listening on a named pipe
+	// `//./pipe/docker_engine, and the client must be running elevated.
+	// Give users a clue rather than the not-overly useful message
+	// such as `error during connect: Get http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.26/info:
+	// open //./pipe/docker_engine: The system cannot find the file specified.`.
+	// Note we can't string compare "The system cannot find the file specified" as
+	// this is localised - for example in French the error would be
+	// `open //./pipe/docker_engine: Le fichier spécifié est introuvable.`
+	if strings.Contains(err.Error(), `open //./pipe/docker_engine`) {
+		// Checks if client is running with elevated privileges
+		if f, elevatedErr := os.Open(`\\.\PHYSICALDRIVE0`); elevatedErr != nil {
+			err = errors.Wrap(err, "in the default daemon configuration on Windows, the docker client must be run with elevated privileges to connect")
+		} else {
+			_ = f.Close()
+			err = errors.Wrap(err, "this error may indicate that the docker daemon is not running")
+		}
+	}
+
+	return nil, errConnectionFailed{errors.Wrap(err, "error during connect")}
 }
 
 func (cli *Client) checkResponseErr(serverResp *http.Response) (retErr error) {

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -164,6 +164,10 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 		err = errors.Unwrap(err)
 		return nil, errConnectionFailed{errors.Wrapf(err, "failed to connect to the docker API at %v; check if the path is correct and if the daemon is running", cli.host)}
 	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return nil, errConnectionFailed{errors.Wrapf(dnsErr, "failed to connect to the docker API at %v", cli.host)}
+	}
 
 	var nErr net.Error
 	if errors.As(err, &nErr) {


### PR DESCRIPTION
### client: Client.doRequest: use early return

### client: Client.doRequest: preserve wrapped error


### client: Client.doRequest: simplify permission check and unwrap error

Previously, we were using os.IsPermission, which doesn't unwrap errors;
change to use `errors.Is` to detect permission errors, and unwrap the
error to remove information about the request, which is irrelevant if
we weren't able to connect in the first place.

Also tweak the error slightly to not assume "docker socket", instead
mentioning "docker API".

Before this;

    permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/version": dial unix /var/run/docker.sock: connect: permission denied

With this patch applied:

    permission denied while trying to connect to the docker API at unix:///var/run/docker.sock: dial unix /var/run/docker.sock: connect: permission denied

### client: Client.doRequest: add special handling for "not found" errors

Before this change, a generic "Cannot connect to the docker daemon" error
was produced which, while helpful, instructed the user to check if the daemon
was running, but didn't provide context on the reason we failed (i.e., the
socket was not found).

This patch adds a dedicated check for cases where the socket was not found,
and preserves the original error.

Before this patch:

    DOCKER_HOST=unix:///var/run/no.sock docker version
    Cannot connect to the Docker daemon at unix:///var/run/no.sock. Is the docker daemon running?

With this patch:

    DOCKER_HOST=unix:///var/run/no.sock docker version
    failed to connect to the docker API at unix:///var/run/no.sock; check if the path is correct and the daemon is running: dial unix /var/run/no.sock: connect: no such file or directory


### client: Client.doRequest: add special handling for DNS resolution errors

Before this patch:

    DOCKER_HOST=tcp://example.invalid/docker docker version
    error during connect: Get "http://example.invalid:2375/docker/v1.51/version": dial tcp: lookup example.invalid: no such host

With this patch:

    DOCKER_HOST=tcp://example.invalid/docker docker version
    failed to connect to the docker API at tcp://example.invalid:2375/docker: lookup example.invalid: no such host





**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Improve errors when failing to connect to the API to provide more context to the user.
```

**- A picture of a cute animal (not mandatory but encouraged)**

