### PR TITLE
builder/dockerfile: BuildFromConfig: combine loops

### DIFF
--- a/builder/dockerfile/builder.go
+++ b/builder/dockerfile/builder.go
@@ -330,6 +330,19 @@ func BuildFromConfig(ctx context.Context, config *container.Config, changes []st
 		return nil, errdefs.InvalidParameter(err)
 	}
 
+	// ensure that the commands are valid
+	var commands []instructions.Command
+	for _, n := range dockerfile.AST.Children {
+		if !validCommitCommands[strings.ToLower(n.Value)] {
+			return nil, errdefs.InvalidParameter(errors.Errorf("%s is not a valid change command", n.Value))
+		}
+		cmd, err := instructions.ParseCommand(n)
+		if err != nil {
+			return nil, errdefs.InvalidParameter(err)
+		}
+		commands = append(commands, cmd)
+	}
+
 	b, err := newBuilder(ctx, builderOptions{
 		Options: &build.ImageBuildOptions{NoCache: true},
 	})
@@ -337,25 +350,9 @@ func BuildFromConfig(ctx context.Context, config *container.Config, changes []st
 		return nil, err
 	}
 
-	// ensure that the commands are valid
-	for _, n := range dockerfile.AST.Children {
-		if !validCommitCommands[strings.ToLower(n.Value)] {
-			return nil, errdefs.InvalidParameter(errors.Errorf("%s is not a valid change command", n.Value))
-		}
-	}
-
 	b.Stdout = io.Discard
 	b.Stderr = io.Discard
 	b.disableCommit = true
-
-	var commands []instructions.Command
-	for _, n := range dockerfile.AST.Children {
-		cmd, err := instructions.ParseCommand(n)
-		if err != nil {
-			return nil, errdefs.InvalidParameter(err)
-		}
-		commands = append(commands, cmd)
-	}
 
 	req := newDispatchRequest(b, dockerfile.EscapeToken, nil, NewBuildArgs(b.options.BuildArgs), newStagesBuildResults())
 	// We make mutations to the configuration, ensure we have a copy


### PR DESCRIPTION
This function effectively is looping three times over the given commands to apply to the image. The first two loops did not yet invoke the builder instance, so we can combine those and execute then before constructing the builder. We could even consider combining all of them to a single loop, but keeping it closer to the existing logic or now.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

