### PR TITLE
daemon/listeners: extract utility for DACL, and improve docs

### DIFF
--- a/daemon/listeners/listeners_windows.go
+++ b/daemon/listeners/listeners_windows.go
@@ -23,24 +23,21 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 		ls = append(ls, l)
 
 	case "npipe":
-		// allow Administrators and SYSTEM, plus whatever additional users or groups were specified
-		sddl := "D:P(A;;GA;;;BA)(A;;GA;;;SY)"
+		// Windows allows a comma-separated list of groups and/or users to be set.
+		var additionalUsersAndGroups []string
 		if socketGroup != "" {
-			for _, g := range strings.Split(socketGroup, ",") {
-				sid, err := winio.LookupSidByName(g)
-				if err != nil {
-					return nil, err
-				}
-				sddl += fmt.Sprintf("(A;;GRGW;;;%s)", sid)
-			}
+			additionalUsersAndGroups = strings.Split(socketGroup, ",")
 		}
-		c := winio.PipeConfig{
+		sddl, err := getSecurityDescriptor(additionalUsersAndGroups)
+		if err != nil {
+			return nil, err
+		}
+		l, err := winio.ListenPipe(addr, &winio.PipeConfig{
 			SecurityDescriptor: sddl,
 			MessageMode:        true,  // Use message mode so that CloseWrite() is supported
 			InputBufferSize:    65536, // Use 64KB buffers to improve performance
 			OutputBufferSize:   65536,
-		}
-		l, err := winio.ListenPipe(addr, &c)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -51,4 +48,33 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 	}
 
 	return ls, nil
+}
+
+// Default DACL allows Administrators and LocalSystem full access;
+//
+// - D:P: DACL without inheritance (protected, (P)).
+// - (A;;GA;;;BA): Allow full access (GA) for built-in Administrators (BA).
+// - (A;;GA;;;SY); Allow full access (GA) for LocalSystem (SY).
+// - Any other user is denied access.
+const defaultPermissions = "D:P(A;;GA;;;BA)(A;;GA;;;SY)"
+
+// getSecurityDescriptor returns the DACL for the API socket or named pipe.
+//
+// By default, it grants [defaultPermissions], but allows for additional
+// users and groups to get generic read (GR) and write (GW) access. It
+// returns an error when failing to resolve any of the additional users
+// and groups.
+func getSecurityDescriptor(additionalUsersAndGroups []string) (sddl string, _ error) {
+	sddl = defaultPermissions
+
+	// Grant generic read (GR) and write (GW) access to whatever
+	// additional users or groups were specified.
+	for _, g := range additionalUsersAndGroups {
+		sid, err := winio.LookupSidByName(strings.TrimSpace(g))
+		if err != nil {
+			return "", err
+		}
+		sddl += fmt.Sprintf("(A;;GRGW;;;%s)", sid)
+	}
+	return sddl, nil
 }


### PR DESCRIPTION
- Outline the DACL used on Windows.
- Extract constructing the SDDL to a utility, to allow re-using for unix sockets in future.
- Improve documentation to mention that Windows allows multiple groups and/or users to be given access.

Also removing an intermediate variable.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

