### PR TITLE
build: index annotations not supported for single platform export

### DIFF
--- a/daemon/internal/builder-next/exporter/mobyexporter/export.go
+++ b/daemon/internal/builder-next/exporter/mobyexporter/export.go
@@ -58,6 +58,12 @@ func (e *imageExporter) Resolve(ctx context.Context, id int, attrs map[string]st
 		attrs:         attrs,
 	}
 	for k, v := range attrs {
+		if ak, ok, err := exptypes.ParseAnnotationKey(k); ok && err == nil {
+			switch ak.Type {
+			case exptypes.AnnotationIndex, exptypes.AnnotationIndexDescriptor:
+				return nil, errors.New("index annotations not supported for single platform export")
+			}
+		}
 		switch exptypes.ImageExporterOptKey(k) {
 		case exptypes.OptKeyName:
 			for _, v := range strings.Split(v, ",") {


### PR DESCRIPTION
**- What I did**

This is a complementary fix for https://github.com/docker/buildx/issues/2605 for moby exporter that does not support index annotations and should therefore trigger an error during export similar to https://github.com/moby/buildkit/blob/b443e4b9b21e39f4b5e957e19d73ae6e0ba25fd5/exporter/containerimage/writer.go#L154-L156

**- How to verify it**

```
$ docker buildx bake https://github.com/moby/moby.git#refs/pull/50295/merge dind
$ docker run -d --restart always --privileged --name devdind -p 12375:2375 docker-dind --debug --$ host=tcp://0.0.0.0:2375 --tlsverify=false
$ docker context create devdind --docker "host=tcp://localhost:12375,skip-tls-verify=true"
$ docker context use devdind
$ docker buildx build --annotation "index:foo=bar" --output type=docker -<<< "FROM alpine"
ERROR: failed to build: failed to solve: index annotations not supported for single platform export
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Build now fails if trying to set index annotations with moby exporter
```

**- A picture of a cute animal (not mandatory but encouraged)**

