### PR TITLE
distribution/xfer: LayerDownloadManager.Download: remove initialRootFS arg

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -642,8 +642,7 @@ func (p *puller) Snapshot(ctx context.Context, g session.Group) (cache.Immutable
 		<-progressDone
 	}()
 
-	r := image.NewRootFS()
-	rootFS, release, err := p.is.DownloadManager.Download(ctx, *r, layers, pkgprogress.ChanOutput(pchan))
+	rootFS, release, err := p.is.DownloadManager.Download(ctx, layers, pkgprogress.ChanOutput(pchan))
 	stopProgress()
 	if err != nil {
 		return nil, err

--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -18,7 +18,6 @@ import (
 	mobyexporter "github.com/docker/docker/builder/builder-next/exporter"
 	distmetadata "github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
-	"github.com/docker/docker/image"
 	"github.com/docker/docker/internal/mod"
 	"github.com/docker/docker/layer"
 	pkgprogress "github.com/docker/docker/pkg/progress"
@@ -453,8 +452,7 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (cache.I
 		}
 	}()
 
-	r := image.NewRootFS()
-	rootFS, release, err := w.DownloadManager.Download(ctx, *r, layers, &discardProgress{})
+	rootFS, release, err := w.DownloadManager.Download(ctx, layers, &discardProgress{})
 	if err != nil {
 		return nil, err
 	}

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -596,8 +596,7 @@ func (p *puller) pullSchema2Layers(ctx context.Context, target distribution.Desc
 				err    error
 				rootFS image.RootFS
 			)
-			downloadRootFS := *image.NewRootFS()
-			rootFS, release, err = p.config.DownloadManager.Download(ctx, downloadRootFS, descriptors, p.config.ProgressOutput)
+			rootFS, release, err = p.config.DownloadManager.Download(ctx, descriptors, p.config.ProgressOutput)
 			if err != nil {
 				// Intentionally do not cancel the config download here
 				// as the error from config download (if there is one)

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -110,7 +110,7 @@ type DigestRegisterer interface {
 // Download method is called to get the layer tar data. Layers are then
 // registered in the appropriate order.  The caller must call the returned
 // release function once it is done with the returned RootFS object.
-func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS image.RootFS, layers []DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error) {
+func (ldm *LayerDownloadManager) Download(ctx context.Context, layers []DownloadDescriptor, progressOutput progress.Output) (image.RootFS, func(), error) {
 	var (
 		topLayer       layer.Layer
 		topDownload    *downloadTransfer
@@ -120,7 +120,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		downloadsByKey = make(map[string]*downloadTransfer)
 	)
 
-	rootFS := initialRootFS
+	rootFS := image.RootFS{Type: image.TypeLayers}
 	for _, descriptor := range layers {
 		key := descriptor.Key()
 		transferKey += key

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -114,7 +114,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 	var (
 		topLayer       layer.Layer
 		topDownload    *downloadTransfer
-		watcher        *watcher
+		xferWatcher    *watcher
 		missingLayer   bool
 		transferKey    = ""
 		downloadsByKey = make(map[string]*downloadTransfer)
@@ -156,8 +156,8 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		var topDownloadUncasted transfer
 		if existingDownload, ok := downloadsByKey[key]; ok {
 			xferFunc := ldm.makeDownloadFuncFromDownload(descriptor, existingDownload, topDownload)
-			defer topDownload.transfer.release(watcher)
-			topDownloadUncasted, watcher = ldm.tm.transfer(transferKey, xferFunc, progressOutput)
+			defer topDownload.transfer.release(xferWatcher)
+			topDownloadUncasted, xferWatcher = ldm.tm.transfer(transferKey, xferFunc, progressOutput)
 			topDownload = topDownloadUncasted.(*downloadTransfer)
 			continue
 		}
@@ -168,11 +168,11 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 		var xferFunc doFunc
 		if topDownload != nil {
 			xferFunc = ldm.makeDownloadFunc(descriptor, "", topDownload)
-			defer topDownload.transfer.release(watcher)
+			defer topDownload.transfer.release(xferWatcher)
 		} else {
 			xferFunc = ldm.makeDownloadFunc(descriptor, rootFS.ChainID(), nil)
 		}
-		topDownloadUncasted, watcher = ldm.tm.transfer(transferKey, xferFunc, progressOutput)
+		topDownloadUncasted, xferWatcher = ldm.tm.transfer(transferKey, xferFunc, progressOutput)
 		topDownload = topDownloadUncasted.(*downloadTransfer)
 		downloadsByKey[key] = topDownload
 	}
@@ -197,7 +197,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 
 	select {
 	case <-ctx.Done():
-		topDownload.transfer.release(watcher)
+		topDownload.transfer.release(xferWatcher)
 		return rootFS, func() {}, ctx.Err()
 	case <-topDownload.done():
 		break
@@ -205,7 +205,7 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 
 	l, err := topDownload.result()
 	if err != nil {
-		topDownload.transfer.release(watcher)
+		topDownload.transfer.release(xferWatcher)
 		return rootFS, func() {}, err
 	}
 
@@ -213,13 +213,13 @@ func (ldm *LayerDownloadManager) Download(ctx context.Context, initialRootFS ima
 	// base layer on Windows.
 	for range layers {
 		if l == nil {
-			topDownload.transfer.release(watcher)
+			topDownload.transfer.release(xferWatcher)
 			return rootFS, func() {}, errors.New("internal error: too few parent layers")
 		}
 		rootFS.DiffIDs = append([]layer.DiffID{l.DiffID()}, rootFS.DiffIDs...)
 		l = l.Parent()
 	}
-	return rootFS, func() { topDownload.transfer.release(watcher) }, err
+	return rootFS, func() { topDownload.transfer.release(xferWatcher) }, err
 }
 
 // makeDownloadFunc returns a function that performs the layer download and

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/docker/distribution"
-	"github.com/docker/docker/image"
 	"github.com/docker/docker/layer"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/opencontainers/go-digest"
@@ -295,7 +294,7 @@ func TestSuccessfulDownload(t *testing.T) {
 	}
 	firstDescriptor.diffID = l.DiffID()
 
-	rootFS, releaseFunc, err := ldm.Download(context.Background(), *image.NewRootFS(), descriptors, progress.ChanOutput(progressChan))
+	rootFS, releaseFunc, err := ldm.Download(context.Background(), descriptors, progress.ChanOutput(progressChan))
 	if err != nil {
 		t.Fatalf("download error: %v", err)
 	}
@@ -350,7 +349,7 @@ func TestCancelledDownload(t *testing.T) {
 	}()
 
 	descriptors := downloadDescriptors(nil)
-	_, _, err := ldm.Download(ctx, *image.NewRootFS(), descriptors, progress.ChanOutput(progressChan))
+	_, _, err := ldm.Download(ctx, descriptors, progress.ChanOutput(progressChan))
 	if !errors.Is(err, context.Canceled) {
 		close(progressChan)
 		t.Fatal("expected download to be cancelled")
@@ -415,7 +414,7 @@ func TestMaxDownloadAttempts(t *testing.T) {
 			descriptors := downloadDescriptors(&currentDownloads)
 			descriptors[4].(*mockDownloadDescriptor).simulateRetries = tc.simulateRetries
 
-			_, _, err := ldm.Download(context.Background(), *image.NewRootFS(), descriptors, progress.ChanOutput(progressChan))
+			_, _, err := ldm.Download(context.Background(), descriptors, progress.ChanOutput(progressChan))
 			if tc.expectedErr == "" {
 				assert.NilError(t, err)
 			} else {


### PR DESCRIPTION
All uses of this method would construct a RootFS from scratch, so we may as well remove the argument.


There's no known consumers of this package.



**- A picture of a cute animal (not mandatory but encouraged)**

