### PR TITLE
libnet/d/bridge: pass SCTP sock to the proxy

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -58,7 +58,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/memberlist v0.4.0
 	github.com/hashicorp/serf v0.8.5
-	github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2
+	github.com/ishidawataru/sctp v0.0.0-20250708014235-1989182a9425
 	github.com/miekg/dns v1.1.66
 	github.com/mistifyio/go-zfs/v3 v3.0.1
 	github.com/mitchellh/copystructure v1.2.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -332,8 +332,8 @@ github.com/in-toto/in-toto-golang v0.9.0 h1:tHny7ac4KgtsfrG6ybU8gVOZux2H8jN05AXJ
 github.com/in-toto/in-toto-golang v0.9.0/go.mod h1:xsBVrVsHNsB61++S6Dy2vWosKhuA3lUTQd+eF9HdeMo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2 h1:i2fYnDurfLlJH8AyyMOnkLHnHeP8Ff/DDpuZA/D3bPo=
-github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
+github.com/ishidawataru/sctp v0.0.0-20250708014235-1989182a9425 h1:37AZdk/mVlt6NiksUPgo7MCHBVTLUWWD8CIbQdeLU5E=
+github.com/ishidawataru/sctp v0.0.0-20250708014235-1989182a9425/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/jmoiron/sqlx v1.3.3 h1:j82X0bf7oQ27XeqxicSZsTU5suPwKElg3oyxNn43iTk=
 github.com/jmoiron/sqlx v1.3.3/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=

--- a/vendor/github.com/ishidawataru/sctp/ipsock_linux.go
+++ b/vendor/github.com/ishidawataru/sctp/ipsock_linux.go
@@ -119,7 +119,7 @@ func supportsIPv4map() bool {
 // general. Unfortunately, we need to run on kernels built without
 // IPv6 support too. So probe the kernel to figure it out.
 func (p *ipStackCapabilities) probe() {
-	s, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	s, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, syscall.IPPROTO_TCP)
 	switch err {
 	case syscall.EAFNOSUPPORT, syscall.EPROTONOSUPPORT:
 	case nil:
@@ -137,7 +137,7 @@ func (p *ipStackCapabilities) probe() {
 	}
 
 	for i := range probes {
-		s, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+		s, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, syscall.IPPROTO_TCP)
 		if err != nil {
 			continue
 		}

--- a/vendor/github.com/ishidawataru/sctp/sctp.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp.go
@@ -83,7 +83,10 @@ const (
 	SCTP_EVENT_ALL = SCTP_EVENT_DATA_IO | SCTP_EVENT_ASSOCIATION | SCTP_EVENT_ADDRESS | SCTP_EVENT_SEND_FAILURE | SCTP_EVENT_PEER_ERROR | SCTP_EVENT_SHUTDOWN | SCTP_EVENT_PARTIAL_DELIVERY | SCTP_EVENT_ADAPTATION_LAYER | SCTP_EVENT_AUTHENTICATION | SCTP_EVENT_SENDER_DRY
 )
 
-type SCTPNotificationType int
+type (
+	SCTPNotificationType int
+	SCTPAssocID          int32
+)
 
 const (
 	SCTP_SN_TYPE_BASE = SCTPNotificationType(iota + (1 << 15))
@@ -140,11 +143,69 @@ type InitMsg struct {
 	MaxInitTimeout uint16
 }
 
+// SackTimer Parameters defined in RFC 6458 8.1.19 - SCTP_DELAYED_SACK Delayed Sack Timer sack_timeout
+type SackTimer struct {
+	AssocID       SCTPAssocID
+	SackDelay     uint32
+	SackFrequency uint32
+}
+
+type PeerState int32
+
+const (
+	SCTP_UNCONFIRMED PeerState = iota
+	SCTP_ACTIVE
+	SCTP_INACTIVE
+)
+
+// PeerAddrinfo Parameters defined in RFC 6458 8.2.2 - Peer Address Information (SCTP_GET_PEER_ADDR_INFO)
+type PeerAddrinfo struct {
+	AssocID SCTPAssocID
+	Address [128]byte // if needed from here, retrieve using resolveFromRawAddr(unsafe.Pointer(&PeerAddrinfo.Address), 1), or get it from *SCTPConn.SCTPGetPrimaryPeerAddr()
+	State   PeerState
+	CWND    uint32
+	SRTT    uint32
+	RTO     uint32
+	MTU     uint32
+}
+
+type StatusState int32
+
+const (
+	SCTP_CLOSED StatusState = iota
+	SCTP_BOUND
+	SCTP_LISTEN
+	SCTP_COOKIE_WAIT
+	SCTP_COOKIE_ECHOED
+	SCTP_ESTABLISHED
+	SCTP_SHUTDOWN_PENDING
+	SCTP_SHUTDOWN_SENT
+	SCTP_SHUTDOWN_RECEIVED
+	SCTP_SHUTDOWN_ACK_SENT
+)
+
+// Status Parameters defined in RFC 6458 8.2.1 - Association Status (SCTP_STATUS)
+type Status struct {
+	AssocID            SCTPAssocID
+	State              StatusState
+	RWND               uint32
+	Unackdata          uint16
+	Penddata           uint16
+	Instreams          uint16
+	Ostreams           uint16
+	FragmentationPoint uint32
+	PrimaryPeerAddr    PeerAddrinfo
+}
+
 type SndRcvInfo struct {
-	Stream  uint16
-	SSN     uint16
-	Flags   uint16
-	_       uint16
+	Stream uint16
+	SSN    uint16
+	Flags  uint16
+	_      uint16
+	// This parameter’s endianness is not specified in the SCTP standards, but as is the case with Wireshark, it seems
+	// that it is generally treated as network byte order.
+	//
+	// IANA defines them as integer values, hence we would assume that our users would use the trouble-free host
 	PPID    uint32
 	Context uint32
 	TTL     uint32
@@ -211,6 +272,15 @@ func htons(h uint16) uint16 {
 }
 
 var ntohs = htons
+
+func htonl(h uint32) uint32 {
+	if nativeEndian == binary.LittleEndian {
+		return (h << 24 & 0xff000000) | (h << 8 & 0x00ff0000) | (h >> 8 & 0x0000ff00) | (h >> 24 & 0x000000ff)
+	}
+	return h
+}
+
+var ntohl = htonl
 
 // setInitOpts sets options for an SCTP association initialization
 // see https://tools.ietf.org/html/rfc4960#page-25
@@ -505,6 +575,36 @@ func (c *SCTPConn) GetDefaultSentParam() (*SndRcvInfo, error) {
 	return info, err
 }
 
+func (c *SCTPConn) SetSackTimer(timer *SackTimer) error { // SackTimer
+	optlen := unsafe.Sizeof(*timer)
+	_, _, err := setsockopt(c.fd(), SCTP_DELAYED_SACK, uintptr(unsafe.Pointer(timer)), optlen)
+	return err
+}
+
+func (c *SCTPConn) GetSackTimer() (*SackTimer, error) { // SackTimer
+	timer := &SackTimer{}
+	optlen := unsafe.Sizeof(*timer)
+	_, _, err := getsockopt(
+		c.fd(),
+		SCTP_DELAYED_SACK,
+		uintptr(unsafe.Pointer(timer)),
+		uintptr(unsafe.Pointer(&optlen)),
+	)
+	return timer, err
+}
+
+func (c *SCTPConn) GetStatus() (*Status, error) { // Status
+	sctpStatus := &Status{}
+	optlen := unsafe.Sizeof(*sctpStatus)
+	_, _, err := getsockopt(
+		c.fd(),
+		SCTP_STATUS,
+		uintptr(unsafe.Pointer(sctpStatus)),
+		uintptr(unsafe.Pointer(&optlen)),
+	)
+	return sctpStatus, err
+}
+
 func (c *SCTPConn) Getsockopt(optname, optval, optlen uintptr) (uintptr, uintptr, error) {
 	return getsockopt(c.fd(), optname, optval, optlen)
 }
@@ -636,8 +736,9 @@ func (c *SCTPConn) SetWriteDeadline(t time.Time) error {
 }
 
 type SCTPListener struct {
-	fd int
-	m  sync.Mutex
+	fd                  int
+	m                   sync.Mutex
+	notificationHandler NotificationHandler
 }
 
 func (ln *SCTPListener) Addr() net.Addr {
@@ -723,15 +824,16 @@ type SocketConfig struct {
 	// If Control is not nil it is called after the socket is created but before
 	// it is bound or connected.
 	Control func(network, address string, c syscall.RawConn) error
-
+	// NotificationHandler defines actions taken on received notifications when MSG_NOTIFICATION flag is set.
+	NotificationHandler NotificationHandler
 	// InitMsg is the options to send in the initial SCTP message
 	InitMsg InitMsg
 }
 
 func (cfg *SocketConfig) Listen(net string, laddr *SCTPAddr) (*SCTPListener, error) {
-	return listenSCTPExtConfig(net, laddr, cfg.InitMsg, cfg.Control)
+	return listenSCTPExtConfig(net, laddr, cfg.InitMsg, cfg.Control, cfg.NotificationHandler)
 }
 
 func (cfg *SocketConfig) Dial(net string, laddr, raddr *SCTPAddr) (*SCTPConn, error) {
-	return dialSCTPExtConfig(net, laddr, raddr, cfg.InitMsg, cfg.Control)
+	return dialSCTPExtConfig(net, laddr, raddr, cfg.InitMsg, cfg.Control, cfg.NotificationHandler)
 }

--- a/vendor/github.com/ishidawataru/sctp/sctp_unsupported.go
+++ b/vendor/github.com/ishidawataru/sctp/sctp_unsupported.go
@@ -69,7 +69,7 @@ func ListenSCTPExt(net string, laddr *SCTPAddr, options InitMsg) (*SCTPListener,
 	return nil, ErrUnsupported
 }
 
-func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, control func(network, address string, c syscall.RawConn) error) (*SCTPListener, error) {
+func listenSCTPExtConfig(network string, laddr *SCTPAddr, options InitMsg, control func(network string, address string, c syscall.RawConn) error, handler NotificationHandler) (*SCTPListener, error) {
 	return nil, ErrUnsupported
 }
 
@@ -93,6 +93,6 @@ func DialSCTPExt(network string, laddr, raddr *SCTPAddr, options InitMsg) (*SCTP
 	return nil, ErrUnsupported
 }
 
-func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, control func(network, address string, c syscall.RawConn) error) (*SCTPConn, error) {
+func dialSCTPExtConfig(network string, laddr, raddr *SCTPAddr, options InitMsg, control func(network string, address string, c syscall.RawConn) error, handler NotificationHandler) (*SCTPConn, error) {
 	return nil, ErrUnsupported
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -726,7 +726,7 @@ github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap
-# github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2
+# github.com/ishidawataru/sctp v0.0.0-20250708014235-1989182a9425
 ## explicit; go 1.12
 github.com/ishidawataru/sctp
 # github.com/jmoiron/sqlx v1.3.3


### PR DESCRIPTION
- Related to https://github.com/moby/moby/issues/50259

**- What I did**

Since commit https://github.com/moby/moby/commit/b3fabedecc0f408f674972d87803f41faedf4de8, the bridge driver maps ports following a 3-step process: 1. create a socket, and bind it to the host port; 2. create iptables rules; 3. start the userland proxy (if it's enabled). This ensures that the port is really free before inserting iptables rules that could disrupt host services.

However, this 3-step process wasn't implemented for SCTP, because we had no way to pass the SCTP socket to the userland proxy. Since ishidawataru/sctp@4719921f9, we do have a way to do that.

**- How I did it**

Unfortunately there's no unit or integration test for SCTP port mapping. Writing an integration test isn't straightforward since AFAIK no busybox packages provide an SCTP listener that could be used in a test. So, we'd need to build an Alpine-based image including the `lksctp-tools` package. This PR isn't making it worse, so do not address that yet.

**- How to verify it**

```terminal
$ docker run --rm -it -p 3102:3102/sctp alpine /bin/sh -c 'apk add --no-cache lksctp-tools; sctp_darn -H 0.0.0.0 -P 3102 -l'
```

Then, in the dockerd container:

```terminal
$ apt-get update && apt-get install -y lksctp-tools
$ echo foo | sctp_darn -H 127.0.0.1 -h 127.0.0.1 -p 3102 -s
```

The sctp container should show:

```terminal
sctp_darn listening...
…
DATA(5):  foo.
…
```
