### PR TITLE
internal/cleanups: don't append nil funcs

### DIFF
--- a/internal/cleanups/composite.go
+++ b/internal/cleanups/composite.go
@@ -12,7 +12,9 @@ type Composite struct {
 
 // Add adds a cleanup to be called.
 func (c *Composite) Add(f func(context.Context) error) {
-	c.cleanups = append(c.cleanups, f)
+	if f != nil {
+		c.cleanups = append(c.cleanups, f)
+	}
 }
 
 // Call calls all cleanups in reverse order and returns an error combining all

--- a/internal/cleanups/composite_test.go
+++ b/internal/cleanups/composite_test.go
@@ -31,6 +31,7 @@ func TestCall(t *testing.T) {
 	c.Add(func(ctx context.Context) error {
 		return errors.Join(errX, fmt.Errorf("joined: %w", errYZ))
 	})
+	c.Add(nil)
 
 	err := c.Call(context.Background())
 


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/50181

**- What I did**

Make `*Composite.Add()` a no-op when `f` is nil.

Stumbled on a panic when running moby/moby#50181:

```
github.com/docker/docker/internal/cleanups.call({0x39fb120, 0x4000b9dbf0}, {0x400089ec30, 0x2, 0x2})
	/go/src/github.com/docker/docker/internal/cleanups/composite.go:41 +0x84
github.com/docker/docker/internal/cleanups.(*Composite).Release.func1({0x39fb120, 0x4000b9dbf0})
	/go/src/github.com/docker/docker/internal/cleanups/composite.go:33 +0x54
github.com/docker/docker/libnetwork/drivers/bridge/internal/nftabler.(*network).DelNetworkLevelRules(0x4000a6a180, {0x39fb120, 0x4000b9dbf0})
	/go/src/github.com/docker/docker/libnetwork/drivers/bridge/internal/nftabler/network.go:235 +0x1e0
```

The issue comes from:

- https://github.com/robmry/moby/blob/7b3db808c4ed4636ebc46873554eaa57f7517ec9/libnetwork/drivers/bridge/internal/nftabler/network.go#L44-L48
- https://github.com/robmry/moby/blob/7b3db808c4ed4636ebc46873554eaa57f7517ec9/libnetwork/drivers/bridge/internal/nftabler/network.go#L59-L61

**- How to verify it**

CI is green.
