### PR TITLE
Wait for container dependencies upon daemon start up

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -575,8 +575,8 @@ func (daemon *Daemon) restore(cfg *configStore) error {
 			logger.Debug("starting container")
 
 			// ignore errors here as this is a best effort to wait for children
-			// (legacy links) to be running before we try to start the container
-			if children := daemon.linkIndex.children(c); len(children) > 0 {
+			// (legacy links or container network) to be running before we try to start the container
+			if children := daemon.GetDependentContainers(c); len(children) > 0 {
 				timeout := time.NewTimer(5 * time.Second)
 				defer timeout.Stop()
 


### PR DESCRIPTION
- Fixes: #50326

**- What I did**
Wait for container dependencies upon daemon start up 


**- How I did it**
- List all dependent containers upon registration
- Dependent containers can be either from legacy link or container network
- Wait on a best effort basis for the dependent containers

**- How to verify it**
 1. Create a docker-dind container with bind mounted /var/lib/docker : 
`docker run -d --privileged --name docker -v ./docker:/var/lib/docker docker-dind:latest --debug`
 
 2. Launch a compose application that creates 500 containers in docker-dind image to maximize the chances to encounter the issue
```
services:
  net:
    image: alpine
    command: sleep infinity
    restart: always

  app:
    image: alpine
    command: sleep infinity
    network_mode: "service:net"
    restart: always
    scale: 500

```

3. Stop and restart the docker-dind container and check for stopped containers 
```
CONTAINER=docker
EXEC="docker exec $CONTAINER"
while true;
do 
	echo "Stopping $CONTAINER"
	docker stop $CONTAINER
	echo "Removing $CONTAINER" 
	docker rm -v $CONTAINER
	echo "Starting $CONTAINER"
        docker run -d --privileged --name docker -v ./docker:/var/lib/docker docker-dind:latest --debug
	timeout 30 bash -c "until $EXEC docker info >/dev/null 2>&1; do sleep 1; done"
	echo "$CONTAINER started successfully"

	containers=$($EXEC docker ps -aq   --filter status=created   --filter status=exited   --filter status=dead)
        if [ -n "$containers" ]
	then 
    		echo "Inspecting stopped/exited/dead containers:"
    		for i in $containers; do
		      echo "Container ID: $i"
		      $EXEC docker inspect "$i" -f "{{ .State | json }}" | jq
	        done
		exit 
	else
		echo "No created/exited/dead containers found."
	fi
done 
```


**- Human readable description for the release notes**
```markdown changelog
- On daemon startup, restart containers that share their network stacks before containers that need those stacks.
```


**- A picture of a cute animal (not mandatory but encouraged)**

