### PR TITLE
integration-cli: remove uses of legacy distribution types

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
@@ -565,7 +564,7 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(t *testing.T) {
 	// Load the target manifest blob.
 	manifestBlob := s.reg.ReadBlobContents(t, manifestDigest)
 
-	var imgManifest schema2.Manifest
+	var imgManifest ocispec.Manifest
 	err = json.Unmarshal(manifestBlob, &imgManifest)
 	assert.NilError(t, err)
 

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -518,7 +519,7 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredManifest(t *testing.T) {
 	// Load the target manifest blob.
 	manifestBlob := s.reg.ReadBlobContents(t, manifestDigest)
 
-	var imgManifest schema2.Manifest
+	var imgManifest ocispec.Manifest
 	err = json.Unmarshal(manifestBlob, &imgManifest)
 	assert.NilError(t, err, "unable to decode image manifest from blob")
 

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -9,13 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/distribution"
-	"github.com/docker/distribution/manifest"
-	"github.com/docker/distribution/manifest/manifestlist"
-	"github.com/docker/distribution/manifest/schema2"
+	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
@@ -242,30 +241,26 @@ func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
 	assert.NilError(c, err, "error setting up image")
 
 	// Inject a manifest list into the registry
-	manifestList := &manifestlist.ManifestList{
-		Versioned: manifest.Versioned{
+	manifestList := &ocispec.Index{
+		Versioned: specs.Versioned{
 			SchemaVersion: 2,
-			MediaType:     manifestlist.MediaTypeManifestList,
 		},
-		Manifests: []manifestlist.ManifestDescriptor{
+		MediaType: c8dimages.MediaTypeDockerSchema2ManifestList,
+		Manifests: []ocispec.Descriptor{
 			{
-				Descriptor: distribution.Descriptor{
-					Digest:    "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
-					Size:      3253,
-					MediaType: schema2.MediaTypeManifest,
-				},
-				Platform: manifestlist.PlatformSpec{
+				Digest:    "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
+				Size:      3253,
+				MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
+				Platform: &ocispec.Platform{
 					Architecture: "bogus_arch",
 					OS:           "bogus_os",
 				},
 			},
 			{
-				Descriptor: distribution.Descriptor{
-					Digest:    pushDigest,
-					Size:      3253,
-					MediaType: schema2.MediaTypeManifest,
-				},
-				Platform: manifestlist.PlatformSpec{
+				Digest:    pushDigest,
+				Size:      3253,
+				MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
+				Platform: &ocispec.Platform{
 					Architecture: runtime.GOARCH,
 					OS:           runtime.GOOS,
 				},

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/opencontainers/go-digest"
@@ -245,12 +244,12 @@ func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
-		MediaType: c8dimages.MediaTypeDockerSchema2ManifestList,
+		MediaType: ocispec.MediaTypeImageIndex,
 		Manifests: []ocispec.Descriptor{
 			{
 				Digest:    "sha256:1a9ec845ee94c202b2d5da74a24f0ed2058318bfa9879fa541efaecba272e86b",
 				Size:      3253,
-				MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
+				MediaType: ocispec.MediaTypeImageManifest,
 				Platform: &ocispec.Platform{
 					Architecture: "bogus_arch",
 					OS:           "bogus_os",
@@ -259,7 +258,7 @@ func (s *DockerRegistrySuite) TestPullManifestList(c *testing.T) {
 			{
 				Digest:    pushDigest,
 				Size:      3253,
-				MediaType: c8dimages.MediaTypeDockerSchema2Manifest,
+				MediaType: ocispec.MediaTypeImageManifest,
 				Platform: &ocispec.Platform{
 					Architecture: runtime.GOARCH,
 					OS:           runtime.GOOS,


### PR DESCRIPTION
### integration-cli: TestPullManifestList: rewrite using OCI types

Trying to reduce the places where we depend on the legacy distribution
dependency. For this test, we used it to generate the JSON for a manifest-list,
which we can do with the OCI types as well.

### integration-cli: TestPullManifestList: use OCI media-types

This test is verifying that push/pull works; current versions of the registry
used should support both the legacy (docker distribution) and OCI media-types,
so let's use the OCI types.


### integration-cli: TestPullFailsWithAlteredManifest: use OCI manifest

The OCI types should be able to unmarshal the image manifest (regardless
if it was created from the legacy distribution types or otherwise), so
we can drop the use of the legacy distribution types here.

### integration-cli: TestPullFailsWithAlteredLayer: use OCI manifest

The OCI types should be able to unmarshal the image manifest (regardless
if it was created from the legacy distribution types or otherwise), so
we can drop the use of the legacy distribution types here.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

