### PR TITLE
docs: api: improve the docs of the `outputs` parameter

### DIFF
--- a/api/docs/v1.40.yaml
+++ b/api/docs/v1.40.yaml
@@ -7948,7 +7948,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.41.yaml
+++ b/api/docs/v1.41.yaml
@@ -8237,7 +8237,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.42.yaml
+++ b/api/docs/v1.42.yaml
@@ -8487,7 +8487,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.43.yaml
+++ b/api/docs/v1.43.yaml
@@ -8505,7 +8505,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.44.yaml
+++ b/api/docs/v1.44.yaml
@@ -8662,7 +8662,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.45.yaml
+++ b/api/docs/v1.45.yaml
@@ -8648,7 +8648,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.46.yaml
+++ b/api/docs/v1.46.yaml
@@ -8769,7 +8769,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.47.yaml
+++ b/api/docs/v1.47.yaml
@@ -8910,7 +8910,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.48.yaml
+++ b/api/docs/v1.48.yaml
@@ -9455,7 +9455,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.49.yaml
+++ b/api/docs/v1.49.yaml
@@ -9455,7 +9455,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.50.yaml
+++ b/api/docs/v1.50.yaml
@@ -9339,7 +9339,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -9338,7 +9338,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -9302,7 +9302,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9313,7 +9313,18 @@ paths:
           default: ""
         - name: "outputs"
           in: "query"
-          description: "BuildKit output configuration"
+          description: |
+            BuildKit output configuration in the format of a stringified JSON array of objects.
+            Each object must have two top-level properties: `Type` and `Attrs`.
+            The `Type` property must be set to 'moby'.
+            The `Attrs` property is a map of attributes for the BuildKit output configuration.
+            See https://docs.docker.com/build/exporters/oci-docker/ for more information.
+
+            Example:
+
+            ```
+            [{"Type":"moby","Attrs":{"type":"image","force-compression":"true","compression":"zstd"}}]
+            ```
           type: "string"
           default: ""
         - name: "version"


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/38898


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I improved the documentation of the `outputs` query parameter for the `/build` endpoint by explaining what should be passed in and what should be the format. 
**- How I did it**
I changed the `swagger.yaml` and also the versioned `.yaml` files that had the parameter in them.
**- How to verify it**
Run `make swagger-docs` and check http://localhost:9000/#operation/ImageBuild

This is how it looks like on my local machine:
<img width="1317" alt="image" src="https://github.com/user-attachments/assets/1f3a3250-b673-42f7-8024-a07259efb160" />

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.

Improved the documentation of the `outputs` query parameter for the `/build` endpoint.
```
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/c2246be8-e137-4ae2-a665-62030c54d057)

