### PR TITLE
Fix broken links in contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Want to hack on the Moby Project? Awesome! We have a contributor's guide that ex
 [setting up a development environment and the contribution
 process](docs/contributing/). 
 
-[![Contributors guide](docs/static_files/contributors.png)](https://docs.docker.com/opensource/project/who-written-for/)
+[![Contributors guide](docs/static_files/contributors.png)](https://docs.docker.com/contribute/)
 
 This page contains information about reporting issues as well as some tips and
 guidelines useful to experienced open source contributors. Finally, make sure
@@ -80,7 +80,7 @@ You can propose new designs for existing Docker features. You can also design
 entirely new features. We really appreciate contributors who want to refactor or
 otherwise cleanup our project. For information on making these types of
 contributions, see [the advanced contribution
-section](https://docs.docker.com/opensource/workflow/advanced-contributing/) in
+section](https://docs.docker.com/contribute/) in
 the contributors guide.
 
 ### Where to put your changes
@@ -169,8 +169,8 @@ tests in `docker/cli` and end-to-end tests for Docker.
 Update the documentation when creating or modifying features. Test your
 documentation changes for clarity, concision, and correctness, as well as a
 clean documentation build. See our contributors guide for [our style
-guide](https://docs.docker.com/opensource/doc-style) and instructions on [building
-the documentation](https://docs.docker.com/opensource/project/test-and-docs/#build-and-test-the-documentation).
+guide](https://docs.docker.com/contribute/style/grammar/) and instructions on [building
+the documentation](https://docs.docker.com/contribute/guides/).
 
 Write clean code. Universally formatted code promotes ease of writing, reading,
 and maintenance. Always run `gofmt -s -w file.go` on each changed file before


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed broken links in the contributing documentation that pointed to outdated `docs.docker.com/opensource/` pages.
Fixes #45024 

**- How I did it**
Identified and updated all broken URLs with valid ones by checking the current Docker Docs page.

**- How to verify it**
Click the updated links and confirm they lead to working pages.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

![cute hamster](https://wallpaperaccess.com/full/2844691.jpg)