### PR TITLE
libnet/d/bridge: split NATed and routed port mappings

### DIFF
--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -97,8 +97,8 @@ func TestDisableNAT(t *testing.T) {
 			gwMode6: "nat",
 			expPortMap: nat.PortMap{
 				"80/tcp": []nat.PortBinding{
-					{HostIP: "0.0.0.0", HostPort: ""},
 					{HostIP: "::", HostPort: "8080"},
+					{HostIP: "0.0.0.0", HostPort: ""},
 				},
 			},
 		},

--- a/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -193,55 +193,62 @@ func loopbackUp() error {
 	return nlHandle.LinkSetUp(iface)
 }
 
-func TestCmpPortBindings(t *testing.T) {
-	pb := types.PortBinding{
-		Proto:       types.TCP,
-		IP:          net.ParseIP("172.17.0.2"),
-		Port:        80,
-		HostIP:      net.ParseIP("192.168.1.2"),
-		HostPort:    8080,
-		HostPortEnd: 8080,
+func TestCmpPortBindingReqs(t *testing.T) {
+	pb := portBindingReq{
+		PortBinding: types.PortBinding{
+			Proto:       types.TCP,
+			IP:          net.ParseIP("172.17.0.2"),
+			Port:        80,
+			HostIP:      net.ParseIP("192.168.1.2"),
+			HostPort:    8080,
+			HostPortEnd: 8080,
+		},
 	}
-	var pbA, pbB types.PortBinding
+	var pbA, pbB portBindingReq
 
-	assert.Check(t, cmpPortBinding(pb, pb) == 0)
+	assert.Check(t, cmpPortBindingReqs(pb, pb) == 0)
+
+	pbA, pbB = pb, pb
+	pbB.disableNAT = true
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 
 	pbA, pbB = pb, pb
 	pbA.Port = 22
-	assert.Check(t, cmpPortBinding(pbA, pbB) < 0)
-	assert.Check(t, cmpPortBinding(pbB, pbA) > 0)
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 
 	pbA, pbB = pb, pb
 	pbB.Proto = types.UDP
-	assert.Check(t, cmpPortBinding(pbA, pbB) < 0)
-	assert.Check(t, cmpPortBinding(pbB, pbA) > 0)
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 
 	pbA, pbB = pb, pb
 	pbA.Port = 22
 	pbA.Proto = types.UDP
-	assert.Check(t, cmpPortBinding(pbA, pbB) < 0)
-	assert.Check(t, cmpPortBinding(pbB, pbA) > 0)
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 
 	pbA, pbB = pb, pb
 	pbB.HostPort = 8081
-	assert.Check(t, cmpPortBinding(pbA, pbB) < 0)
-	assert.Check(t, cmpPortBinding(pbB, pbA) > 0)
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 
 	pbA, pbB = pb, pb
 	pbB.HostPort, pbB.HostPortEnd = 0, 0
-	assert.Check(t, cmpPortBinding(pbA, pbB) < 0)
-	assert.Check(t, cmpPortBinding(pbB, pbA) > 0)
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 
 	pbA, pbB = pb, pb
 	pbB.HostPortEnd = 8081
-	assert.Check(t, cmpPortBinding(pbA, pbB) < 0)
-	assert.Check(t, cmpPortBinding(pbB, pbA) > 0)
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 
 	pbA, pbB = pb, pb
 	pbA.HostPortEnd = 8080
 	pbB.HostPortEnd = 8081
-	assert.Check(t, cmpPortBinding(pbA, pbB) < 0)
-	assert.Check(t, cmpPortBinding(pbB, pbA) > 0)
+	assert.Check(t, cmpPortBindingReqs(pbA, pbB) < 0)
+	assert.Check(t, cmpPortBindingReqs(pbB, pbA) > 0)
 }
 
 func TestBindHostPortsError(t *testing.T) {


### PR DESCRIPTION
- Related to https://github.com/moby/moby/issues/50259
- Stacked on top of https://github.com/moby/moby/pull/50307

**- What I did**

Port bindings were sorted — to form groups that should be mapped in one go — and then normalized by `configurePortBindingIPv[4|6]`. However, gw_modes might not be the same for IPv4/v6, so the upcoming split of NATed / routed portmappers will require that they're processed independently.

They're now normalized and then sorted. This gives the sort func a chance of taking `disableNAT` into account such that NATed and routed port mappings are processed independently.

**- How I did it**

**- How to verify it**

Unit and integration tests are left untouched — CI is green.
