### PR TITLE
Add support for chained RequestAuthConfigs for push/pull

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"errors"
+	"slices"
 
 	"github.com/moby/moby/api/types/registry"
 )
@@ -11,4 +13,68 @@ func staticAuth(registryAuth string) registry.RequestAuthConfig {
 	return func(ctx context.Context) (string, error) {
 		return registryAuth, nil
 	}
+}
+
+var (
+	// errNoMorePrivilegeFuncs is a sentinel error to detect when the list of
+	// chained privilege-funcs is exhausted. It is returned by [chainPrivilegeFuncs].
+	//
+	// This error is not currently exported as we don't want to expose this feature
+	// yet for alternative implementations.
+	errNoMorePrivilegeFuncs = errors.New("no more privilege functions")
+
+	// errTryNextPrivilegeFunc is a sentinel error to detect whether the same
+	// privilegeFunc can be re-tried. It is returned by [chainPrivilegeFuncs].
+	//
+	// This error is not currently exported as we don't want to expose this feature
+	// yet for alternative implementations.
+	errTryNextPrivilegeFunc = errors.New("try next privilege function")
+)
+
+// ChainPrivilegeFuncs returns a PrivilegeFunc that wraps the given funcs.
+// Each call tries the next func in order, returning its result if successful.
+//
+// It returns errTryNextPrivilegeFunc if more funcs are available; errNoMorePrivilegeFuncs
+// when exhausted.
+func ChainPrivilegeFuncs(funcs ...registry.RequestAuthConfig) registry.RequestAuthConfig {
+	acFuncs := slices.DeleteFunc(slices.Clone(funcs), func(f registry.RequestAuthConfig) bool { return f == nil })
+
+	var i int
+	return func(ctx context.Context) (string, error) {
+		if i >= len(acFuncs) {
+			return "", errNoMorePrivilegeFuncs
+		}
+		ac, err := acFuncs[i](ctx)
+		switch {
+		case err == nil:
+			// success; allow caller to retry if the list is not exhausted.
+		case errors.Is(err, errTryNextPrivilegeFunc):
+			// PrivilegeFunc is a chain; return without incrementing.
+			return ac, err
+		case errors.Is(err, errNoMorePrivilegeFuncs):
+			// PrivilegeFunc is a chain and the list is exhausted.
+			// Continue as if no error occurred.
+		default:
+			// terminal error; stop chain
+			acFuncs = nil
+			return ac, err
+		}
+		i++
+		if i >= len(acFuncs) {
+			return ac, nil
+		}
+		return ac, errTryNextPrivilegeFunc
+	}
+}
+
+func getAuth(ctx context.Context, fn registry.RequestAuthConfig) (auth string, tryNext bool, _ error) {
+	if fn == nil {
+		return "", false, nil
+	}
+	auth, err := fn(ctx)
+	if errors.Is(err, errTryNextPrivilegeFunc) {
+		return auth, true, nil
+	}
+	// No error, errNoMorePrivilegeFuncs and any hard failure.
+	return auth, false, err
 }

--- a/client/auth_test.go
+++ b/client/auth_test.go
@@ -1,0 +1,124 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moby/moby/api/types/registry"
+	"gotest.tools/v3/assert"
+)
+
+func TestChainPrivilegeFuncs(t *testing.T) {
+	tests := []struct {
+		doc            string
+		privilegeFunc  registry.RequestAuthConfig
+		expected       []string
+		checkExhausted bool
+	}{
+		{
+			doc:      "no privilege func",
+			expected: []string{""},
+		},
+		{
+			doc:           "no a chain",
+			privilegeFunc: staticAuth("A"),
+			expected:      []string{"A"},
+		},
+		{
+			doc: "not a chain with error",
+			privilegeFunc: func(ctx context.Context) (string, error) {
+				return "", errors.New("terminal error: failed to request auth")
+			},
+		},
+		{
+			doc:            "empty chain",
+			privilegeFunc:  ChainPrivilegeFuncs(),
+			checkExhausted: true,
+		},
+		{
+			doc:            "chain with only nil values",
+			privilegeFunc:  ChainPrivilegeFuncs(nil, nil),
+			checkExhausted: true,
+		},
+		{
+			doc:            "single chain",
+			privilegeFunc:  ChainPrivilegeFuncs(staticAuth("A")),
+			expected:       []string{"A"},
+			checkExhausted: true,
+		},
+		{
+			doc:           "basic chain",
+			privilegeFunc: ChainPrivilegeFuncs(staticAuth("A"), staticAuth("B")),
+			expected:      []string{"A", "B"},
+		},
+		{
+			doc:            "basic chain with nil values",
+			privilegeFunc:  ChainPrivilegeFuncs(staticAuth("A"), nil, staticAuth("B")),
+			expected:       []string{"A", "B"},
+			checkExhausted: true,
+		},
+		{
+			doc: "chain with nested chains",
+			privilegeFunc: ChainPrivilegeFuncs(
+				staticAuth("A"),
+				staticAuth("B"),
+				ChainPrivilegeFuncs(
+					staticAuth("C-1"),
+					staticAuth("C-2"),
+					ChainPrivilegeFuncs(
+						staticAuth("C-2-A"),
+						staticAuth("C-2-B"),
+					),
+					staticAuth("C-3"),
+				),
+				staticAuth("D"),
+				func(ctx context.Context) (string, error) {
+					return "", errors.New("terminal error: failed to request auth")
+				},
+				// Should not be used due to terminal error above.
+				staticAuth("E"),
+			),
+			expected:       []string{"A", "B", "C-1", "C-2", "C-2-A", "C-2-B", "C-3", "D"},
+			checkExhausted: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			assertAuthChain(t, tc.privilegeFunc, tc.expected)
+			if tc.checkExhausted {
+				ac, err := tc.privilegeFunc(context.Background())
+				assert.Equal(t, ac, "", "should not have returned auth after being exhausted")
+				assert.ErrorIs(t, err, errNoMorePrivilegeFuncs, "should be exhausted")
+			}
+		})
+	}
+}
+
+func assertAuthChain(t *testing.T, privilegeFunc registry.RequestAuthConfig, expectedAuth []string) {
+	t.Helper()
+	var actual []string
+
+	var i int
+	for {
+		ac, shouldRetry, err := getAuth(context.Background(), privilegeFunc)
+		if err != nil {
+			// t.Logf("terminating after: %v", err)
+			break
+		}
+		actual = append(actual, ac)
+		// t.Logf("iteration %d: %s", i, strings.Join(actual, ", "))
+		if !shouldRetry {
+			break
+		}
+
+		// Safety-net in tests.
+		i++
+		if i > 10 {
+			t.Fatal("too many calls to chain")
+		}
+	}
+
+	assert.DeepEqual(t, actual, expectedAuth)
+}

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -52,9 +52,9 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		}
 		query.Set("platform", formatPlatform(options.Platforms[0]))
 	}
-	resp, err := cli.tryImageCreate(ctx, query, staticAuth(options.RegistryAuth))
+	resp, err := cli.tryImagePull(ctx, query, staticAuth(options.RegistryAuth))
 	if cerrdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		resp, err = cli.tryImageCreate(ctx, query, options.PrivilegeFunc)
+		resp, err = cli.tryImagePull(ctx, query, options.PrivilegeFunc)
 	}
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func getAPITagFromNamedRef(ref reference.Named) string {
 	return ""
 }
 
-func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, resolveAuth registry.RequestAuthConfig) (*http.Response, error) {
+func (cli *Client) tryImagePull(ctx context.Context, query url.Values, resolveAuth registry.RequestAuthConfig) (*http.Response, error) {
 	hdr := http.Header{}
 	if resolveAuth != nil {
 		registryAuth, err := resolveAuth(ctx)

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -52,10 +52,19 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		}
 		query.Set("platform", formatPlatform(options.Platforms[0]))
 	}
-	resp, err := cli.tryImagePull(ctx, query, staticAuth(options.RegistryAuth))
-	if cerrdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		resp, err = cli.tryImagePull(ctx, query, options.PrivilegeFunc)
-	}
+
+	// PrivilegeFunc was added in [18472] as an alternative to passing static
+	// authentication. The default was still to try the static authentication
+	// before calling the PrivilegeFunc (if present).
+	//
+	// For now, we need to keep this behavior, as PrivilegeFunc may be an
+	// interactive prompt, however, we should change this to only use static
+	// auth if not empty. Ultimately, we should deprecate its use in favor of
+	// callers providing a PrivilegeFunc (which can be chained), or a list of
+	// PrivilegeFuncs.
+	//
+	// [18472]: https://github.com/moby/moby/commit/e78f02c4dbc3cada909c114fef6b6643969ab912
+	resp, err := cli.tryImagePull(ctx, query, ChainPrivilegeFuncs(staticAuth(options.RegistryAuth), options.PrivilegeFunc))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/moby/moby/client/auth.go
+++ b/vendor/github.com/moby/moby/client/auth.go
@@ -1,6 +1,3 @@
-// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
-
 package client
 
 import (

--- a/vendor/github.com/moby/moby/client/auth.go
+++ b/vendor/github.com/moby/moby/client/auth.go
@@ -1,7 +1,12 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.23
+
 package client
 
 import (
 	"context"
+	"errors"
+	"slices"
 
 	"github.com/moby/moby/api/types/registry"
 )
@@ -11,4 +16,68 @@ func staticAuth(registryAuth string) registry.RequestAuthConfig {
 	return func(ctx context.Context) (string, error) {
 		return registryAuth, nil
 	}
+}
+
+var (
+	// errNoMorePrivilegeFuncs is a sentinel error to detect when the list of
+	// chained privilege-funcs is exhausted. It is returned by [chainPrivilegeFuncs].
+	//
+	// This error is not currently exported as we don't want to expose this feature
+	// yet for alternative implementations.
+	errNoMorePrivilegeFuncs = errors.New("no more privilege functions")
+
+	// errTryNextPrivilegeFunc is a sentinel error to detect whether the same
+	// privilegeFunc can be re-tried. It is returned by [chainPrivilegeFuncs].
+	//
+	// This error is not currently exported as we don't want to expose this feature
+	// yet for alternative implementations.
+	errTryNextPrivilegeFunc = errors.New("try next privilege function")
+)
+
+// ChainPrivilegeFuncs returns a PrivilegeFunc that wraps the given funcs.
+// Each call tries the next func in order, returning its result if successful.
+//
+// It returns errTryNextPrivilegeFunc if more funcs are available; errNoMorePrivilegeFuncs
+// when exhausted.
+func ChainPrivilegeFuncs(funcs ...registry.RequestAuthConfig) registry.RequestAuthConfig {
+	acFuncs := slices.DeleteFunc(slices.Clone(funcs), func(f registry.RequestAuthConfig) bool { return f == nil })
+
+	var i int
+	return func(ctx context.Context) (string, error) {
+		if i >= len(acFuncs) {
+			return "", errNoMorePrivilegeFuncs
+		}
+		ac, err := acFuncs[i](ctx)
+		switch {
+		case err == nil:
+			// success; allow caller to retry if the list is not exhausted.
+		case errors.Is(err, errTryNextPrivilegeFunc):
+			// PrivilegeFunc is a chain; return without incrementing.
+			return ac, err
+		case errors.Is(err, errNoMorePrivilegeFuncs):
+			// PrivilegeFunc is a chain and the list is exhausted.
+			// Continue as if no error occurred.
+		default:
+			// terminal error; stop chain
+			acFuncs = nil
+			return ac, err
+		}
+		i++
+		if i >= len(acFuncs) {
+			return ac, nil
+		}
+		return ac, errTryNextPrivilegeFunc
+	}
+}
+
+func getAuth(ctx context.Context, fn registry.RequestAuthConfig) (auth string, tryNext bool, _ error) {
+	if fn == nil {
+		return "", false, nil
+	}
+	auth, err := fn(ctx)
+	if errors.Is(err, errTryNextPrivilegeFunc) {
+		return auth, true, nil
+	}
+	// No error, errNoMorePrivilegeFuncs and any hard failure.
+	return auth, false, err
 }

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -52,9 +52,9 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		}
 		query.Set("platform", formatPlatform(options.Platforms[0]))
 	}
-	resp, err := cli.tryImageCreate(ctx, query, staticAuth(options.RegistryAuth))
+	resp, err := cli.tryImagePull(ctx, query, staticAuth(options.RegistryAuth))
 	if cerrdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		resp, err = cli.tryImageCreate(ctx, query, options.PrivilegeFunc)
+		resp, err = cli.tryImagePull(ctx, query, options.PrivilegeFunc)
 	}
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func getAPITagFromNamedRef(ref reference.Named) string {
 	return ""
 }
 
-func (cli *Client) tryImageCreate(ctx context.Context, query url.Values, resolveAuth registry.RequestAuthConfig) (*http.Response, error) {
+func (cli *Client) tryImagePull(ctx context.Context, query url.Values, resolveAuth registry.RequestAuthConfig) (*http.Response, error) {
 	hdr := http.Header{}
 	if resolveAuth != nil {
 		registryAuth, err := resolveAuth(ctx)

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -52,10 +52,19 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		}
 		query.Set("platform", formatPlatform(options.Platforms[0]))
 	}
-	resp, err := cli.tryImagePull(ctx, query, staticAuth(options.RegistryAuth))
-	if cerrdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
-		resp, err = cli.tryImagePull(ctx, query, options.PrivilegeFunc)
-	}
+
+	// PrivilegeFunc was added in [18472] as an alternative to passing static
+	// authentication. The default was still to try the static authentication
+	// before calling the PrivilegeFunc (if present).
+	//
+	// For now, we need to keep this behavior, as PrivilegeFunc may be an
+	// interactive prompt, however, we should change this to only use static
+	// auth if not empty. Ultimately, we should deprecate its use in favor of
+	// callers providing a PrivilegeFunc (which can be chained), or a list of
+	// PrivilegeFuncs.
+	//
+	// [18472]: https://github.com/moby/moby/commit/e78f02c4dbc3cada909c114fef6b6643969ab912
+	resp, err := cli.tryImagePull(ctx, query, ChainPrivilegeFuncs(staticAuth(options.RegistryAuth), options.PrivilegeFunc))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### client: implement chainPrivilegeFuncs utility

This utility allows chaining privilegeFuncs to try multiple options for authentication.

### Add support for chained RequestAuthConfigs for push/pull

PrivilegeFunc was added in [18472] as an alternative to passing static
authentication. The default was still to try the static authentication
before calling the PrivilegeFunc (if present).

For now, we need to keep this behavior, as PrivilegeFunc may be an
interactive prompt, however, we should change this to only use static
auth if not empty. Ultimately, we should deprecate its use in favor of
callers providing a PrivilegeFunc (which can be chained), or a list of
PrivilegeFuncs.

[18472]: https://github.com/moby/moby/commit/e78f02c4dbc3cada909c114fef6b6643969ab912



**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

