### PR TITLE
libn/networkdb: stop forging tombstone entries

### DIFF
--- a/libnetwork/networkdb/delegate.go
+++ b/libnetwork/networkdb/delegate.go
@@ -109,9 +109,7 @@ func (nDB *NetworkDB) handleNetworkEvent(nEvent *NetworkEvent) bool {
 			n.reapTime = nDB.config.reapNetworkInterval
 
 			// The remote node is leaving the network, but not the gossip cluster.
-			// Mark all its entries in deleted state, this will guarantee that
-			// if some node bulk sync with us, the deleted state of
-			// these entries will be propagated.
+			// Delete all the entries for this network owned by the node.
 			nDB.deleteNodeNetworkEntries(nEvent.NetworkID, nEvent.NodeName)
 		}
 

--- a/libnetwork/networkdb/networkdb.go
+++ b/libnetwork/networkdb/networkdb.go
@@ -512,92 +512,44 @@ func (nDB *NetworkDB) deleteNodeFromNetworks(deletedNode string) {
 	delete(nDB.networks, deletedNode)
 }
 
-// deleteNodeNetworkEntries is called in 2 conditions with 2 different outcomes:
-// 1) when a notification is coming of a node leaving the network
-//   - Walk all the network entries and mark the leaving node's entries for deletion
-//     These will be garbage collected when the reap timer will expire
-//
-// 2) when the local node is leaving the network
-//   - Walk all the network entries:
-//     A) if the entry is owned by the local node
-//     then we will mark it for deletion. This will ensure that if a node did not
-//     yet received the notification that the local node is leaving, will be aware
-//     of the entries to be deleted.
-//     B) if the entry is owned by a remote node, then we can safely delete it. This
-//     ensures that if we join back this network as we receive the CREATE event for
-//     entries owned by remote nodes, we will accept them and we notify the application
+// deleteNodeNetworkEntries deletes all table entries for a network owned by
+// node from the local store.
 func (nDB *NetworkDB) deleteNodeNetworkEntries(nid, node string) {
-	// Indicates if the delete is triggered for the local node
-	isNodeLocal := node == nDB.config.NodeID
-
 	nDB.indexes[byNetwork].Root().WalkPrefix([]byte("/"+nid),
-		func(path []byte, v *entry) bool {
-			oldEntry := v
-
-			// If the entry is owned by a remote node and this node is not leaving the network
-			if oldEntry.node != node && !isNodeLocal {
-				// Don't do anything because the event is triggered for a node that does not own this entry
+		func(path []byte, oldEntry *entry) bool {
+			// Do nothing if the entry is owned by a remote node that is not leaving the network
+			// because the event is triggered for a node that does not own this entry.
+			if oldEntry.node != node {
 				return false
 			}
-
-			// If this entry is already marked for deletion and this node is not leaving the network
-			if oldEntry.deleting && !isNodeLocal {
-				// Don't do anything this entry will be already garbage collected using the old reapTime
-				return false
-			}
-
-			newEntry := &entry{
-				ltime:    oldEntry.ltime,
-				node:     oldEntry.node,
-				value:    oldEntry.value,
-				deleting: true,
-				reapTime: nDB.config.reapEntryInterval,
-			}
-
-			// we arrived at this point in 2 cases:
-			// 1) this entry is owned by the node that is leaving the network
-			// 2) the local node is leaving the network
 			params := strings.Split(string(path[1:]), "/")
 			nwID, tName, key := params[0], params[1], params[2]
-			if oldEntry.node == node {
-				if isNodeLocal {
-					// TODO fcrisciani: this can be removed if there is no way to leave the network
-					// without doing a delete of all the objects
-					newEntry.ltime++
-				}
 
-				if !oldEntry.deleting {
-					nDB.createOrUpdateEntry(nwID, tName, key, newEntry)
-				}
-			} else {
-				// the local node is leaving the network, all the entries of remote nodes can be safely removed
-				nDB.deleteEntry(nwID, tName, key)
-			}
+			nDB.deleteEntry(nwID, tName, key)
 
 			// Notify to the upper layer only entries not already marked for deletion
 			if !oldEntry.deleting {
-				nDB.broadcaster.Write(makeEvent(opDelete, tName, nwID, key, newEntry.value))
+				nDB.broadcaster.Write(makeEvent(opDelete, tName, nwID, key, oldEntry.value))
 			}
 			return false
 		})
 }
 
+// deleteNodeTableEntries deletes all table entries owned by node from the local
+// store, across all networks.
 func (nDB *NetworkDB) deleteNodeTableEntries(node string) {
-	nDB.indexes[byTable].Root().Walk(func(path []byte, v *entry) bool {
-		oldEntry := v
+	nDB.indexes[byTable].Root().Walk(func(path []byte, oldEntry *entry) bool {
 		if oldEntry.node != node {
 			return false
 		}
 
 		params := strings.Split(string(path[1:]), "/")
-		tname := params[0]
-		nid := params[1]
-		key := params[2]
+		tName, nwID, key := params[0], params[1], params[2]
 
-		nDB.deleteEntry(nid, tname, key)
+		nDB.deleteEntry(nwID, tName, key)
 
 		if !oldEntry.deleting {
-			nDB.broadcaster.Write(makeEvent(opDelete, tname, nid, key, oldEntry.value))
+			nDB.broadcaster.Write(makeEvent(opDelete, tName, nwID, key, oldEntry.value))
 		}
 		return false
 	})
@@ -700,8 +652,40 @@ func (nDB *NetworkDB) LeaveNetwork(nid string) error {
 	// Remove myself from the list of the nodes participating to the network
 	nDB.deleteNetworkNode(nid, nDB.config.NodeID)
 
-	// Update all the local entries marking them for deletion and delete all the remote entries
-	nDB.deleteNodeNetworkEntries(nid, nDB.config.NodeID)
+	// Mark all the local entries for deletion
+	// so that if we rejoin the network
+	// before another node has received the network-leave notification,
+	// the old entries owned by us will still be purged as expected.
+	// Delete all the remote entries from our local store
+	// without leaving any tombstone.
+	// This ensures that we will accept the CREATE events
+	// for entries owned by remote nodes
+	// if we later rejoin the network.
+	nDB.indexes[byNetwork].Root().WalkPrefix([]byte("/"+nid), func(path []byte, oldEntry *entry) bool {
+		owned := oldEntry.node == nDB.config.NodeID
+		if owned && oldEntry.deleting {
+			return false
+		}
+
+		params := strings.Split(string(path[1:]), "/")
+		nwID, tName, key := params[0], params[1], params[2]
+		if owned {
+			newEntry := &entry{
+				ltime:    nDB.tableClock.Increment(),
+				node:     oldEntry.node,
+				value:    oldEntry.value,
+				deleting: true,
+				reapTime: nDB.config.reapEntryInterval,
+			}
+			nDB.createOrUpdateEntry(nwID, tName, key, newEntry)
+		} else {
+			nDB.deleteEntry(nwID, tName, key)
+		}
+		if !oldEntry.deleting {
+			nDB.broadcaster.Write(makeEvent(opDelete, tName, nwID, key, oldEntry.value))
+		}
+		return false
+	})
 
 	n, ok := nDB.thisNodeNetworks[nid]
 	if !ok {

--- a/libnetwork/networkdb/tableevent_test.go
+++ b/libnetwork/networkdb/tableevent_test.go
@@ -1,6 +1,7 @@
 package networkdb
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -221,6 +222,62 @@ L:
 		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "network1.table1", Value: []byte("a")}),
 		CreateEvent(event{Table: "table1", NetworkID: "network1", Key: "network1.table1.update", Value: []byte("updated")}),
 	}))
+}
+
+func TestLeaveRejoinOutOfOrder(t *testing.T) {
+	// Regression test for https://github.com/moby/moby/issues/47728
+
+	nDB := newNetworkDB(DefaultConfig())
+	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{}
+	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{}
+	assert.Assert(t, nDB.JoinNetwork("network1"))
+
+	(&eventDelegate{nDB}).NotifyJoin(&memberlist.Node{
+		Name: "node1",
+		Addr: net.IPv4(1, 2, 3, 4),
+	})
+
+	d := &delegate{nDB}
+
+	msgs := messageBuffer{t: t}
+	appendTableEvent := tableEventHelper(&msgs, "node1", "network1", "table1")
+
+	msgs.Append(MessageTypeNetworkEvent, &NetworkEvent{
+		Type:      NetworkEventTypeJoin,
+		LTime:     1,
+		NodeName:  "node1",
+		NetworkID: "network1",
+	})
+	// Simulate node1 leaving, rejoining, and creating an entry,
+	// but the table events are broadcast before the network events.
+	appendTableEvent(1, TableEventTypeCreate, "key1", []byte("a"))
+	msgs.Append(MessageTypeNetworkEvent, &NetworkEvent{
+		Type:      NetworkEventTypeLeave,
+		LTime:     2,
+		NodeName:  "node1",
+		NetworkID: "network1",
+	})
+	msgs.Append(MessageTypeNetworkEvent, &NetworkEvent{
+		Type:      NetworkEventTypeJoin,
+		LTime:     3,
+		NodeName:  "node1",
+		NetworkID: "network1",
+	})
+	// Simulate a bulk sync or receiving a rebroadcasted copy of the table
+	// event from another node.
+	appendTableEvent(1, TableEventTypeCreate, "key1", []byte("a"))
+
+	d.NotifyMsg(msgs.Compound())
+
+	got := make(map[string]string)
+	nDB.WalkTable("table1", func(nw, key string, value []byte, deleted bool) bool {
+		got[nw+"/"+key] = fmt.Sprintf("%s (deleted=%t)", value, deleted)
+		return false
+	})
+	want := map[string]string{
+		"network1/key1": "a (deleted=false)",
+	}
+	assert.Check(t, is.DeepEqual(got, want))
 }
 
 func drainChannel(ch <-chan events.Event) []events.Event {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed #47728 

**- How I did it**
When a node leaves a network, all entries owned by that node are implicitly deleted. The other NetworkDB nodes handle the leave by setting the deleted flag on the entries owned by the left node in their local stores. This behaviour is problematic as it results in two conflicting entries with the same Lamport timestamp propagating through the cluster.

Consider two NetworkDB nodes, A, and B, which are both joined to some network. Node A in quick succession leaves the network, immediately rejoins it, then creates an entry. If Node B processes the entry-creation event first, it will add the entry to its local store then set the deleted flag upon processing the network-leave. No matter how many times B bulk-syncs with A, B will ignore the live entry for having the same timestamp as its local tombstone entry. Once this situation occurs, the only way to recover is for the entry to get updated by A with a new timestamp.

There is no need for a node to store forged tombstones for another node's entries. All nodes will purge the entries naturally when they process the network-leave or node-leave event. Simply delete the non-owned entries from the local store so there is no inconsistent state to interfere with convergence when nodes rejoin a network. Have nodes update their local store with tombstones for entries when leaving a network so that after a rapid leave-then-rejoin the entry deletions propagate to nodes which may have missed the leave event.

**- How to verify it**
With a new unit test.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Fix a bug in NetworkDB which would sometimes cause entries to get stuck deleted on some of the nodes, leading to connectivity issues between containers on overlay networks.
```

**- A picture of a cute animal (not mandatory but encouraged)**

