### PR TITLE
libnetwork/networkdb: make TestNetworkDBIslands not flaky

### DIFF
--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	rnd "math/rand"
 	"net"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -296,17 +297,22 @@ func (nDB *NetworkDB) rejoinClusterBootStrap() {
 	bootStrapIPs := make([]string, 0, len(nDB.bootStrapIP))
 	for _, bootIP := range nDB.bootStrapIP {
 		// bootstrap IPs are usually IP:port from the Join
-		var bootstrapIP net.IP
-		ipStr, _, err := net.SplitHostPort(bootIP)
+		bootstrapIP, err := netip.ParseAddrPort(bootIP)
 		if err != nil {
-			// try to parse it as an IP with port
+			// try to parse it as an IP without port
 			// Note this seems to be the case for swarm that do not specify any port
-			ipStr = bootIP
+			addr, err := netip.ParseAddr(bootIP)
+			if err == nil {
+				bootstrapIP = netip.AddrPortFrom(addr, uint16(nDB.config.BindPort))
+			}
 		}
-		bootstrapIP = net.ParseIP(ipStr)
-		if bootstrapIP != nil {
+		if bootstrapIP.IsValid() {
 			for _, node := range nDB.nodes {
-				if node.Addr.Equal(bootstrapIP) && !node.Addr.Equal(myself.Addr) {
+				if node == myself {
+					continue
+				}
+				nodeIP, _ := netip.AddrFromSlice(node.Addr)
+				if bootstrapIP == netip.AddrPortFrom(nodeIP, node.Port) {
 					// One of the bootstrap nodes (and not myself) is part of the cluster, return
 					nDB.RUnlock()
 					return

--- a/libnetwork/networkdb/networkdb_test.go
+++ b/libnetwork/networkdb/networkdb_test.go
@@ -881,7 +881,7 @@ func TestParallelDelete(t *testing.T) {
 	closeNetworkDBInstances(t, dbs)
 }
 
-func TestFlakyNetworkDBIslands(t *testing.T) {
+func TestNetworkDBIslands(t *testing.T) {
 	pollTimeout := func() time.Duration {
 		const defaultTimeout = 120 * time.Second
 		dl, ok := t.Deadline()
@@ -933,7 +933,7 @@ func TestFlakyNetworkDBIslands(t *testing.T) {
 		// Verify that the nodes are actually all gone and marked appropriately
 		for name, db := range checkDBs {
 			db.RLock()
-			if (len(db.leftNodes) != 3) || (len(db.failedNodes) != 0) {
+			if (len(db.leftNodes) + len(db.failedNodes)) != 3 {
 				for name := range db.leftNodes {
 					t.Logf("%s: Node %s left", db.config.Hostname, name)
 				}
@@ -941,7 +941,7 @@ func TestFlakyNetworkDBIslands(t *testing.T) {
 					t.Logf("%s: Node %s failed", db.config.Hostname, name)
 				}
 				db.RUnlock()
-				return poll.Continue("%s:Waiting for all nodes to cleanly leave, left: %d, failed nodes: %d", name, len(db.leftNodes), len(db.failedNodes))
+				return poll.Continue("%s:Waiting for all nodes to leave, left: %d, failed nodes: %d", name, len(db.leftNodes), len(db.failedNodes))
 			}
 			db.RUnlock()
 			t.Logf("%s: OK", name)
@@ -981,9 +981,9 @@ func TestFlakyNetworkDBIslands(t *testing.T) {
 				}
 			} else {
 				// nodes from 4 to 5 has the 3 previous left nodes
-				if len(db.leftNodes) != 3 {
+				if (len(db.leftNodes) + len(db.failedNodes)) != 3 {
 					db.RUnlock()
-					return poll.Continue("%s:Waiting to have 3 leftNodes", dbs[i].config.Hostname)
+					return poll.Continue("%s:Waiting to have 3 leftNodes+failedNodes", dbs[i].config.Hostname)
 				}
 			}
 			db.RUnlock()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixes #42459 

**- How I did it**
I identified a bug in the rejoin logic that TestNetworkDBIslands is supposed to be validating which only manifests in tests as that is the only time where more than one node can be advertising the same IP address, only differing by port. I updated the logic to use both the IP address and port number when identifying nodes so that it behaves the same in tests as in production. I also updated the test itself to be more tolerant of nodes being spuriously marked as failed.

**- How to verify it**
`go test -count=...`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

