### PR TITLE
libnetwork/networkdb: fix broadcast queue deadlocks

### DIFF
--- a/libnetwork/networkdb/cluster.go
+++ b/libnetwork/networkdb/cluster.go
@@ -135,22 +135,12 @@ func (nDB *NetworkDB) clusterInit() error {
 	}
 
 	nDB.networkBroadcasts = &memberlist.TransmitLimitedQueue{
-		NumNodes: func() int {
-			nDB.RLock()
-			num := len(nDB.nodes)
-			nDB.RUnlock()
-			return num
-		},
+		NumNodes:       nDB.estNumNodes,
 		RetransmitMult: config.RetransmitMult,
 	}
 
 	nDB.nodeBroadcasts = &memberlist.TransmitLimitedQueue{
-		NumNodes: func() int {
-			nDB.RLock()
-			num := len(nDB.nodes)
-			nDB.RUnlock()
-			return num
-		},
+		NumNodes:       nDB.estNumNodes,
 		RetransmitMult: config.RetransmitMult,
 	}
 

--- a/libnetwork/networkdb/event_delegate.go
+++ b/libnetwork/networkdb/event_delegate.go
@@ -40,6 +40,7 @@ func (e *eventDelegate) NotifyJoin(mn *memberlist.Node) {
 	e.nDB.purgeReincarnation(mn)
 
 	e.nDB.nodes[mn.Name] = &node{Node: *mn}
+	e.nDB.estNodes.Store(int32(len(e.nDB.nodes)))
 	log.G(context.TODO()).Infof("Node %s/%s, added to nodes list", mn.Name, mn.Addr)
 }
 

--- a/libnetwork/networkdb/nodemgmt.go
+++ b/libnetwork/networkdb/nodemgmt.go
@@ -76,6 +76,8 @@ func (nDB *NetworkDB) changeNodeState(nodeName string, newState nodeState) (bool
 		// TODO(thaJeztah): make switch exhaustive; add networkdb.nodeNotFound
 	}
 
+	nDB.estNodes.Store(int32(len(nDB.nodes)))
+
 	log.G(context.TODO()).Infof("Node %s change state %s --> %s", nodeName, nodeStateName[currState], nodeStateName[newState])
 
 	if newState == nodeLeftState || newState == nodeFailedState {
@@ -120,4 +122,8 @@ func (nDB *NetworkDB) purgeReincarnation(mn *memberlist.Node) bool {
 	}
 
 	return false
+}
+
+func (nDB *NetworkDB) estNumNodes() int {
+	return int(nDB.estNodes.Load())
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Updates #50193 (51f31826eea3bd33b3175c879d38901fe8c55ceb)

**- What I did**
Fixed deadlocks in NetworkDB introduced by recent changes.
(The cherry-pick labels are only so we don't forget to pick this one when we pick #50193)

**- How I did it**
NetworkDB's JoinNetwork function enqueues a message onto a TransmitLimitedQueue while holding the NetworkDB mutex locked for writing. The TransmitLimitedQueue has its own synchronization; it locks its mutex when enqueueing a message. Locking order:
  1. (NetworkDB).RWMutex.Lock()
  2. (TransmitLimitedQueue).mu.Lock()

NetworkDB's gossip periodic task calls GetBroadcasts on the same TransmitLimitedQueue to retrieve the enqueued messages. GetBroadcasts invokes the queue's NumNodes callback while the mutex is locked. The NumNodes callback function that NetworkDB sets locks the NetworkDB mutex for reading to take the length of the nodes map. Locking order:
  1. (TransmitLimitedQueue).mu.Lock()
  2. (NetworkDB).RWMutex.RLock()

If one goroutine calls GetBroadcasts on the queue concurrently with another goroutine calling JoinNetwork on the NetworkDB, the goroutines may deadlock due to the lock inversion.

Fix the deadlock by caching the number of nodes in an atomic variable so that the NumNodes callback can load the value without blocking or violating Go's memory model. And fix a similar deadlock situation with the table-event broadcast queues.

**- How to verify it**
Stress-test NetworkDB using a property-based test (#50345)

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

