### PR TITLE
[28.x backport] gha: remove GO_VERSION build-arg from builds

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -92,7 +92,6 @@ jobs:
           & docker build `
             --build-arg WINDOWS_BASE_IMAGE `
             --build-arg WINDOWS_BASE_IMAGE_TAG `
-            --build-arg GO_VERSION `
             -t ${{ env.TEST_IMAGE_NAME }} `
             -f Dockerfile.windows .
       -
@@ -172,7 +171,6 @@ jobs:
           & docker build `
             --build-arg WINDOWS_BASE_IMAGE `
             --build-arg WINDOWS_BASE_IMAGE_TAG `
-            --build-arg GO_VERSION `
             -t ${{ env.TEST_IMAGE_NAME }} `
             -f Dockerfile.windows .
       -

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -220,7 +220,6 @@ jobs:
           & docker build `
             --build-arg WINDOWS_BASE_IMAGE `
             --build-arg WINDOWS_BASE_IMAGE_TAG `
-            --build-arg GO_VERSION `
             -t ${{ env.TEST_IMAGE_NAME }} `
             -f Dockerfile.windows .
 


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50314

- relates to https://github.com/moby/moby/pull/50313

The same env-var is used for action/setup-go as for overriding the default Go version in Dockerfiles, however action/setup-go only accepts SemVer (e.g. 1.25.0-rc.1) whereas the official golang image follows the Go project's versioning, which doesn't use a SemVer-compatible format (go1.25rc1 / 1.25rc1).

Trying to use the same "GO_VERSION" value for both will therefore fail.

As we're already updating the default version in the Dockerfile to the version we want to use, let's remove the --build-arg, and use the default that's set in the Dockerfile.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

