### PR TITLE
[28.x backport] dockerfile: update govulncheck to v1.1.4

### DIFF
--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.24.4
-ARG GOVULNCHECK_VERSION=v1.1.3
+ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 
 FROM golang:${GO_VERSION}-alpine AS base
@@ -20,12 +20,6 @@ RUN --mount=type=bind,target=.,rw <<EOT
   ln -s vendor.mod go.mod
   ln -s vendor.sum go.sum
   govulncheck -format ${FORMAT} ./... | tee /out/govulncheck.out
-  if [ "${FORMAT}" = "sarif" ]; then
-    # Make sure "results" field is defined in SARIF output otherwise GitHub Code Scanning
-    # will fail when uploading report with "Invalid SARIF. Missing 'results' array in run."
-    # Relates to https://github.com/golang/vuln/blob/ffdef74cc44d7eb71931d8d414c478b966812488/internal/sarif/sarif.go#L69
-    jq '(.runs[] | select(.results == null) | .results) |= []' /out/govulncheck.out | tee >(sponge /out/govulncheck.out)
-  fi
 EOT
 
 FROM scratch AS output


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50255

similar to https://github.com/docker/buildx/pull/3265