### PR TITLE
[28.x backport] api: swagger: Tweak type of GwPriority to integer

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2913,7 +2913,8 @@ definitions:
           be used. If multiple endpoints have the same priority, endpoints are
           lexicographically sorted based on their network name, and the one
           that sorts first is picked.
-        type: "number"
+        type: "integer"
+        format: "int64"
         example:
           - 10
 

--- a/docs/api/v1.48.yaml
+++ b/docs/api/v1.48.yaml
@@ -3039,7 +3039,8 @@ definitions:
           be used. If multiple endpoints have the same priority, endpoints are
           lexicographically sorted based on their network name, and the one
           that sorts first is picked.
-        type: "number"
+        type: "integer"
+        format: "int64"
         example:
           - 10
 

--- a/docs/api/v1.49.yaml
+++ b/docs/api/v1.49.yaml
@@ -3039,7 +3039,8 @@ definitions:
           be used. If multiple endpoints have the same priority, endpoints are
           lexicographically sorted based on their network name, and the one
           that sorts first is picked.
-        type: "number"
+        type: "integer"
+        format: "int64"
         example:
           - 10
 

--- a/docs/api/v1.50.yaml
+++ b/docs/api/v1.50.yaml
@@ -2914,7 +2914,8 @@ definitions:
           be used. If multiple endpoints have the same priority, endpoints are
           lexicographically sorted based on their network name, and the one
           that sorts first is picked.
-        type: "number"
+        type: "integer"
+        format: "int64"
         example:
           - 10
 

--- a/docs/api/v1.51.yaml
+++ b/docs/api/v1.51.yaml
@@ -2913,7 +2913,8 @@ definitions:
           be used. If multiple endpoints have the same priority, endpoints are
           lexicographically sorted based on their network name, and the one
           that sorts first is picked.
-        type: "number"
+        type: "integer"
+        format: "int64"
         example:
           - 10
 


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50333

- relates to https://github.com/moby/moby/pull/48936
- fixes #50331 

Related to: https://github.com/fussybeaver/bollard/issues/537

**- What I did**

Changed the `GwPriority` API property type to "integer".

**- How I did it**

Modified all API documents in `./docs/api` that contain a `GwPriority` to be an integer. Added a separate commit to modify `./api/swagger.yaml` with the same change.

Verified that the types do not change when running `./hack/generate-swagger-api.sh`

**- How to verify it**

Generated the types based on the new API and verified that `GwPriority` is now an integer.

**- Human readable description for the release notes**


**- A picture of a cute animal (not mandatory but encouraged)**

