### PR TITLE
[28.x backport] integration/networking: increase context timeout for attach

### DIFF
--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -57,7 +57,7 @@ func TestNatNetworkICC(t *testing.T) {
 			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctr1Name}
 
 			const ctr2Name = "ctr2"
-			attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
 			res := container.RunAttach(attachCtx, t, c,
 				container.WithName(ctr2Name),
@@ -105,9 +105,9 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	inspect := container.Inspect(ctx, t, c, serverId)
 	hostPort := inspect.NetworkSettings.Ports["80/tcp"][0].HostPort
 
-	clientCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	res := container.RunAttach(clientCtx, t, c,
+	res := container.RunAttach(attachCtx, t, c,
 		container.WithNetworkMode(clientNetName),
 		container.WithCmd("wget", "http://"+hostAddr+":"+hostPort),
 	)


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50347

relates to:

- https://github.com/moby/moby/issues/48881
- https://github.com/moby/moby/issues/48882



The TestNatNetworkICC and TestFlakyPortMappedHairpinWindows (TestPortMappedHairpinWindows) tests were frequently failing on Windows with a context timeout;

    === FAIL: github.com/docker/docker/integration/networking TestNatNetworkICC/User_defined_nat_network (9.67s)
        nat_windows_test.go:62: assertion failed: error is not nil: Post "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.51/containers/4357bd24c9b77b955ee961530d1f552ce099b3dcbeb396db599971b2396d8b08/start": context deadline exceeded
        panic.go:636: assertion failed: error is not nil: Error response from daemon: error while removing network: network mynat has active endpoints (name:"ctr2" id:"dc8d597dafef")

    === FAIL: github.com/docker/docker/integration/networking TestNatNetworkICC (18.34s)

    === FAIL: github.com/docker/docker/integration/networking TestFlakyPortMappedHairpinWindows (13.02s)
        nat_windows_test.go:110: assertion failed: error is not nil: Post "http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.51/containers/65207ae3d6953d85cd2123feac45af60b059842d570d4f897ea53c813cba3cb4/start": context deadline exceeded
        panic.go:636: assertion failed: error is not nil: Error response from daemon: error while removing network: network clientnet has active endpoints (name:"amazing_visvesvaraya" id:"18add58d415e")

These timeouts were set in c1ab6eda4ba0421ad9c91995b8dcb3de1bf89947 and 2df43914737f247ff723242ce6b1f75cc83de1d8, and were shared between Linux and Windows; likely Windows is slower to start, so these timeouts to be expected.

Let's increase the context timeout to give it a bit more time.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

