### PR TITLE
Remove iptables rules when using nftables, and vice-versa

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -553,8 +553,21 @@ func (d *driver) configure(option map[string]interface{}) error {
 
 var newFirewaller = func(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
 	if nftables.Enabled() {
-		return nftabler.NewNftabler(ctx, config)
+		fw, err := nftabler.NewNftabler(ctx, config)
+		if err != nil {
+			return nil, err
+		}
+		// Without seeing config (interface names, addresses, and so on), the iptabler's
+		// cleaner can't clean up network or port-specific rules that may have been added
+		// to iptables built-in chains. So, if cleanup is needed, give the cleaner to
+		// the nftabler. Then, it'll use it to delete old rules as networks are restored.
+		fw.(firewaller.FirewallCleanerSetter).SetFirewallCleaner(iptabler.NewCleaner(ctx, config))
+		return fw, nil
 	}
+
+	// The nftabler can clean all of its rules in one go. So, even if there's cleanup
+	// to do, there's no need to pass a cleaner to the iptabler.
+	nftabler.Cleanup(ctx, config)
 	return iptabler.NewIptabler(ctx, config)
 }
 

--- a/libnetwork/drivers/bridge/bridge_store.go
+++ b/libnetwork/drivers/bridge/bridge_store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/docker/docker/internal/otelutil"
 	"github.com/docker/docker/libnetwork/datastore"
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
 	"github.com/docker/docker/libnetwork/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -37,6 +38,12 @@ func (d *driver) initStore() error {
 	err = d.populateEndpoints()
 	if err != nil {
 		return err
+	}
+
+	// If there's a firewall cleaner, it's done its job by cleaning up rules
+	// belonging to the restored networks. So, drop it.
+	if fcs, ok := d.firewaller.(firewaller.FirewallCleanerSetter); ok {
+		fcs.SetFirewallCleaner(nil)
 	}
 
 	return nil

--- a/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
+++ b/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
@@ -105,3 +105,31 @@ type Network interface {
 	// DelLink deletes the configuration needed for a legacy link.
 	DelLink(ctx context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort)
 }
+
+// FirewallCleanerSetter is an optional interface for a Firewaller.
+type FirewallCleanerSetter interface {
+	// SetFirewallCleaner replaces the FirewallCleaner (possibly with 'nil').
+	SetFirewallCleaner(FirewallCleaner)
+}
+
+// FirewallCleaner is used to delete rules created by previous incarnations of
+// the daemon. On startup, once a Firewaller implementation has been selected, if
+// rules may have been left behind by a different Firewaller implementation, get
+// a FirewallCleaner from the old Firewaller and pass it to the new/current
+// Firewaller's SetFirewallCleaner.
+type FirewallCleaner interface {
+	// DelNetwork removes all firewall rules related to the specified network configuration.
+	// It should be called by the new Firewaller when adding a new network.
+	DelNetwork(ctx context.Context, nc NetworkConfig)
+	// DelEndpoint removes firewall rules related to a specific endpoint.
+	// It should be called by the new Firewaller when adding a new endpoint.
+	DelEndpoint(ctx context.Context, nc NetworkConfig, epIPv4, epIPv6 netip.Addr)
+	// DelPorts removes firewall rules associated with the specified port bindings.
+	// It should be called by the new Firewaller when adding new port mappings.
+	DelPorts(ctx context.Context, nc NetworkConfig, pbs []types.PortBinding)
+	// DelLink removes firewall rules associated with a legacy link.
+	// It should be called by the new Firewaller when adding a new legacy link.
+	// (Excluded from the interface at present, it's not required by any current
+	// Firewaller.)
+	// DelLink(ctx context.Context, nc NetworkConfig, parentIP, childIP netip.Addr, ports []types.TransportPort)
+}

--- a/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package iptabler
+
+import (
+	"context"
+	"net/netip"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
+	"github.com/docker/docker/libnetwork/iptables"
+	"github.com/docker/docker/libnetwork/types"
+)
+
+type iptablesCleaner struct {
+	config firewaller.Config
+}
+
+// NewCleaner checks for iptables rules left behind by an old daemon that was using
+// the iptabler.
+//
+// If there are old rules present, it deletes as much as possible straight away
+// (user-defined chains and jumps from the built-in chains).
+//
+// But, it can't delete network or port-specific rules from built-in chains
+// without flushing those chains which would be very antisocial - because, at
+// this stage, interface names, addresses, etc. are unknown. So, also return
+// FirewallCleaner that the new Firewaller can use to delete those rules while
+// it's setting up those networks/ports (probably on replay from persistent
+// storage).
+//
+// If there are no old rules to clean up, return nil.
+func NewCleaner(ctx context.Context, config firewaller.Config) firewaller.FirewallCleaner {
+	clean := func(ipv iptables.IPVersion, enabled bool) bool {
+		if !enabled {
+			return false
+		}
+		t := iptables.GetIptable(ipv)
+		// Since 28.0, the jump in the filter-FORWARD chain is DOCKER-FORWARD.
+		// In earlier releases, there was a jump to DOCKER-ISOLATION-STAGE-1.
+		if !t.Exists("filter", "FORWARD", "-j", DockerForwardChain) &&
+			!t.Exists("filter", "FORWARD", "-j", isolationChain1) {
+			return false
+		}
+		log.G(ctx).WithField("ipv", ipv).Info("Cleaning iptables")
+		_ = t.DeleteJumpRule("FORWARD", DockerForwardChain)
+		_ = deleteLegacyTopLevelRules(ctx, t, ipv)
+		removeIPChains(ctx, ipv)
+		return true
+	}
+	cleaned4 := clean(iptables.IPv4, config.IPv4)
+	cleaned6 := clean(iptables.IPv6, config.IPv6)
+	if !cleaned4 && !cleaned6 {
+		return nil
+	}
+	return &iptablesCleaner{config: config}
+}
+
+func (ic iptablesCleaner) DelNetwork(ctx context.Context, nc firewaller.NetworkConfig) {
+	if nc.Internal {
+		return
+	}
+	n := network{
+		config: nc,
+		ipt:    &iptabler{config: ic.config},
+	}
+	if ic.config.IPv4 && nc.Config4.Prefix.IsValid() {
+		_ = deleteLegacyFilterRules(iptables.IPv4, nc.IfName)
+		_ = n.setupNonInternalNetworkRules(ctx, iptables.IPv4, nc.Config4, false)
+	}
+	if ic.config.IPv6 && nc.Config6.Prefix.IsValid() {
+		_ = deleteLegacyFilterRules(iptables.IPv6, nc.IfName)
+		_ = n.setupNonInternalNetworkRules(ctx, iptables.IPv6, nc.Config6, false)
+	}
+}
+
+func (ic iptablesCleaner) DelEndpoint(ctx context.Context, nc firewaller.NetworkConfig, epIPv4, epIPv6 netip.Addr) {
+	n := network{
+		config: nc,
+		ipt:    &iptabler{config: ic.config},
+	}
+	if n.ipt.config.IPv4 && epIPv4.IsValid() {
+		_ = n.filterDirectAccess(ctx, iptables.IPv4, n.config.Config4, epIPv4, false)
+	}
+	if n.ipt.config.IPv6 && epIPv6.IsValid() {
+		_ = n.filterDirectAccess(ctx, iptables.IPv6, n.config.Config6, epIPv6, false)
+	}
+}
+
+func (ic iptablesCleaner) DelPorts(ctx context.Context, nc firewaller.NetworkConfig, pbs []types.PortBinding) {
+	n := network{
+		config: nc,
+		ipt:    &iptabler{config: ic.config},
+	}
+	_ = n.DelPorts(ctx, pbs)
+}

--- a/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
@@ -223,7 +223,11 @@ func setupIPChains(ctx context.Context, version iptables.IPVersion, iptCfg firew
 		return err
 	}
 
-	// Delete rules that may have been added to the FORWARD chain by moby 28.0.0.
+	return deleteLegacyTopLevelRules(ctx, iptable, version)
+}
+
+// Delete rules that may have been added to the FORWARD chain by moby 28.0.0 or earlier.
+func deleteLegacyTopLevelRules(ctx context.Context, iptable *iptables.IPTable, version iptables.IPVersion) error {
 	ipsetName := "docker-ext-bridges-v4"
 	if version == iptables.IPv6 {
 		ipsetName = "docker-ext-bridges-v6"

--- a/libnetwork/drivers/bridge/internal/iptabler/network.go
+++ b/libnetwork/drivers/bridge/internal/iptabler/network.go
@@ -411,9 +411,9 @@ func removeIPChains(ctx context.Context, version iptables.IPVersion) {
 	// Remove chains
 	for _, chainInfo := range []iptables.ChainInfo{
 		{Name: dockerChain, Table: iptables.Nat, IPVersion: version},
-		{Name: dockerChain, Table: iptables.Filter, IPVersion: version},
 		{Name: DockerForwardChain, Table: iptables.Filter, IPVersion: version},
 		{Name: dockerBridgeChain, Table: iptables.Filter, IPVersion: version},
+		{Name: dockerChain, Table: iptables.Filter, IPVersion: version},
 		{Name: dockerCTChain, Table: iptables.Filter, IPVersion: version},
 		{Name: dockerInternalChain, Table: iptables.Filter, IPVersion: version},
 		{Name: isolationChain1, Table: iptables.Filter, IPVersion: version},

--- a/libnetwork/drivers/bridge/internal/nftabler/cleaner.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/cleaner.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package nftabler
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/libnetwork/drivers/bridge/internal/firewaller"
+	"github.com/docker/docker/libnetwork/internal/nftables"
+)
+
+// Cleanup deletes all rules created by nftabler; it's intended to be used
+// during startup, to clean up rules created by an old incarnation of the daemon
+// after switching to a different Firewaller implementation.
+func Cleanup(ctx context.Context, config firewaller.Config) {
+	if config.IPv4 {
+		if err := exec.Command("nft", "delete", "table", string(nftables.IPv4), dockerTable).Run(); err != nil {
+			log.G(ctx).WithError(err).Info("Deleting nftables IPv4 rules")
+		} else {
+			log.G(ctx).Info("Deleted nftables IPv4 rules")
+		}
+	}
+	if config.IPv6 {
+		if err := exec.Command("nft", "delete", "table", string(nftables.IPv6), dockerTable).Run(); err != nil {
+			log.G(ctx).WithError(err).Info("Deleting nftables IPv6 rules")
+		} else {
+			log.G(ctx).Info("Deleted nftables IPv6 rules")
+		}
+	}
+}
+
+func (nft *nftabler) SetFirewallCleaner(fc firewaller.FirewallCleaner) {
+	nft.cleaner = fc
+}

--- a/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
@@ -13,6 +13,9 @@ import (
 )
 
 func (n *network) AddEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
+	if n.fw.cleaner != nil {
+		n.fw.cleaner.DelEndpoint(ctx, n.config, epIPv4, epIPv6)
+	}
 	return n.modEndpoint(ctx, epIPv4, epIPv6, true)
 }
 

--- a/libnetwork/drivers/bridge/internal/nftabler/network.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/network.go
@@ -33,6 +33,10 @@ func (nft *nftabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig
 		}
 	}()
 
+	if nft.cleaner != nil {
+		nft.cleaner.DelNetwork(ctx, nc)
+	}
+
 	if n.fw.config.IPv4 {
 		clean, err := n.configure(ctx, nft.table4, n.config.Config4)
 		if err != nil {

--- a/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -45,9 +45,10 @@ const (
 )
 
 type nftabler struct {
-	config firewaller.Config
-	table4 nftables.TableRef
-	table6 nftables.TableRef
+	config  firewaller.Config
+	cleaner firewaller.FirewallCleaner
+	table4  nftables.TableRef
+	table6  nftables.TableRef
 }
 
 func NewNftabler(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {

--- a/libnetwork/drivers/bridge/internal/nftabler/port.go
+++ b/libnetwork/drivers/bridge/internal/nftabler/port.go
@@ -37,6 +37,10 @@ func (n *network) modPorts(ctx context.Context, pbs []types.PortBinding, enable 
 
 	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{"bridge": n.config.IfName}))
 
+	if enable && n.fw.cleaner != nil {
+		n.fw.cleaner.DelPorts(ctx, n.config, pbs)
+	}
+
 	pbs4, pbs6 := splitByContainerFam(pbs)
 	if n.fw.config.IPv4 && n.config.Config4.Prefix.IsValid() {
 		pbc := pbContext{table: n.fw.table4, conf: n.config.Config4, ipv: firewaller.IPv4}


### PR DESCRIPTION
**- What I did**

Remove iptables rules when using nftables, and vice-versa

**- How I did it**

Delete the bridge driver's nftables tables when iptables is enabled.

When nftables is enabled, pass a cleaner from the iptabler to the nftabler to clean up chains that can't just be removed/flushed.

**- How to verify it**

New integration test.

**- Human readable description for the release notes**
```markdown changelog

```
