### PR TITLE
Nftables config base chain priorities

### DIFF
--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -27,6 +27,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.BoolVar(&conf.BridgeConfig.DisableFilterForwardDrop, "ip-forward-no-drop", false, "Do not set the filter-FORWARD policy to DROP when enabling IP forwarding")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPMasq, "ip-masq", true, "Enable IP masquerading for the default bridge network")
 	flags.BoolVar(&conf.BridgeConfig.EnableIPv6, "ipv6", false, "Enable IPv6 networking for the default bridge network")
+	flags.Var(opts.NewNamedMapOpts("bridge-nftables-priorities", conf.BridgeConfig.NftablesPriorities, nil), "bridge-nftables-priority", "Base chain priorities for bridge driver nftables")
 	flags.StringVar(&conf.BridgeConfig.IP, "bip", "", "IPv4 address for the default bridge")
 	flags.StringVar(&conf.BridgeConfig.IP6, "bip6", "", "IPv6 address for the default bridge")
 	flags.StringVarP(&conf.BridgeConfig.Iface, "bridge", "b", "", "Attach containers to a network bridge")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -81,13 +81,14 @@ const (
 // Use this to differentiate these options
 // with others like the ones in TLSOptions.
 var flatOptions = map[string]bool{
-	"cluster-store-opts":   true,
-	"default-network-opts": true,
-	"log-opts":             true,
-	"runtimes":             true,
-	"default-ulimits":      true,
-	"features":             true,
-	"builder":              true,
+	"cluster-store-opts":         true,
+	"default-network-opts":       true,
+	"bridge-nftables-priorities": true,
+	"log-opts":                   true,
+	"runtimes":                   true,
+	"default-ulimits":            true,
+	"features":                   true,
+	"builder":                    true,
 }
 
 // skipValidateOptions contains configuration keys

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -42,15 +42,16 @@ const (
 type BridgeConfig struct {
 	DefaultBridgeConfig
 
-	EnableIPTables           bool   `json:"iptables,omitempty"`
-	EnableIP6Tables          bool   `json:"ip6tables,omitempty"`
-	EnableIPForward          bool   `json:"ip-forward,omitempty"`
-	DisableFilterForwardDrop bool   `json:"ip-forward-no-drop,omitempty"`
-	EnableIPMasq             bool   `json:"ip-masq,omitempty"`
-	EnableUserlandProxy      bool   `json:"userland-proxy,omitempty"`
-	UserlandProxyPath        string `json:"userland-proxy-path,omitempty"`
-	AllowDirectRouting       bool   `json:"allow-direct-routing,omitempty"`
-	BridgeAcceptFwMark       string `json:"bridge-accept-fwmark,omitempty"`
+	EnableIPTables           bool              `json:"iptables,omitempty"`
+	EnableIP6Tables          bool              `json:"ip6tables,omitempty"`
+	EnableIPForward          bool              `json:"ip-forward,omitempty"`
+	DisableFilterForwardDrop bool              `json:"ip-forward-no-drop,omitempty"`
+	EnableIPMasq             bool              `json:"ip-masq,omitempty"`
+	EnableUserlandProxy      bool              `json:"userland-proxy,omitempty"`
+	UserlandProxyPath        string            `json:"userland-proxy-path,omitempty"`
+	AllowDirectRouting       bool              `json:"allow-direct-routing,omitempty"`
+	BridgeAcceptFwMark       string            `json:"bridge-accept-fwmark,omitempty"`
+	NftablesPriorities       map[string]string `json:"bridge-nftables-priorities,omitempty"`
 }
 
 // DefaultBridgeConfig stores all the parameters for the default bridge network.
@@ -154,6 +155,7 @@ func setPlatformDefaults(cfg *Config) error {
 	cfg.SeccompProfile = SeccompProfileDefault
 	cfg.IpcMode = string(DefaultIpcMode)
 	cfg.Runtimes = make(map[string]system.Runtime)
+	cfg.NftablesPriorities = make(map[string]string)
 
 	if cgroups.Mode() != cgroups.Unified {
 		cfg.CgroupNamespaceMode = string(DefaultCgroupV1NamespaceMode)
@@ -247,6 +249,9 @@ func validatePlatformConfig(conf *Config) error {
 	}
 	if err := bridge.ValidateFixedCIDRV6(conf.FixedCIDRv6); err != nil {
 		return errors.Wrap(err, "invalid fixed-cidr-v6")
+	}
+	if err := bridge.ValidateBaseChainPriorities(conf.NftablesPriorities); err != nil {
+		return err
 	}
 	if err := validateFirewallBackend(conf.FirewallBackend); err != nil {
 		return errors.Wrap(err, "invalid firewall-backend")

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -939,6 +939,7 @@ func networkPlatformOptions(conf *config.Config) []nwconfig.Option {
 				"Hairpin":                  !conf.EnableUserlandProxy || conf.UserlandProxyPath == "",
 				"AllowDirectRouting":       conf.BridgeConfig.AllowDirectRouting,
 				"AcceptFwMark":             conf.BridgeConfig.BridgeAcceptFwMark,
+				"NftablesPriorities":       conf.NftablesPriorities,
 			},
 		}),
 	}

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -78,6 +78,7 @@ type configuration struct {
 	Hairpin            bool
 	AllowDirectRouting bool
 	AcceptFwMark       string
+	NftablesPriorities map[string]string
 }
 
 // networkConfiguration for network specific configuration
@@ -530,7 +531,7 @@ func (d *driver) configure(option map[string]interface{}) error {
 		Hairpin:            config.Hairpin,
 		AllowDirectRouting: config.AllowDirectRouting,
 		WSL2Mirrored:       isRunningUnderWSL2MirroredMode(context.Background()),
-	})
+	}, config.NftablesPriorities)
 	if err != nil {
 		return err
 	}
@@ -548,9 +549,14 @@ func (d *driver) configure(option map[string]interface{}) error {
 	return d.initStore()
 }
 
-var newFirewaller = func(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
+// ValidateBaseChainPriorities checks nftables base chain priority configuration.
+func ValidateBaseChainPriorities(prios map[string]string) error {
+	return nftabler.ValidateBaseChainPriorities(prios)
+}
+
+var newFirewaller = func(ctx context.Context, config firewaller.Config, nftablesPriorities map[string]string) (firewaller.Firewaller, error) {
 	if nftables.Enabled() {
-		fw, err := nftabler.NewNftabler(ctx, config)
+		fw, err := nftabler.NewNftabler(ctx, config, nftablesPriorities)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1337,7 +1337,7 @@ func TestCreateParallel(t *testing.T) {
 
 func useStubFirewaller(t *testing.T) {
 	origNewFirewaller := newFirewaller
-	newFirewaller = func(_ context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
+	newFirewaller = func(_ context.Context, config firewaller.Config, _ map[string]string) (firewaller.Firewaller, error) {
 		return firewaller.NewStubFirewaller(config), nil
 	}
 	t.Cleanup(func() { newFirewaller = origNewFirewaller })

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -4,7 +4,9 @@ package nftabler
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/containerd/log"
 	"github.com/docker/docker/daemon/libnetwork/drivers/bridge/internal/firewaller"
@@ -45,6 +47,14 @@ const (
 	rawPreroutingPortsRuleGroup = iota + initialRuleGroup + 1
 )
 
+var baseChainNames = map[string]struct{}{
+	forwardChain:       {},
+	postroutingChain:   {},
+	preroutingChain:    {},
+	outputChain:        {},
+	rawPreroutingChain: {},
+}
+
 type nftabler struct {
 	config  firewaller.Config
 	cleaner firewaller.FirewallCleaner
@@ -52,12 +62,25 @@ type nftabler struct {
 	table6  nftables.TableRef
 }
 
-func NewNftabler(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
+func NewNftabler(ctx context.Context, config firewaller.Config, baseChainPriorities map[string]string) (firewaller.Firewaller, error) {
 	nft := &nftabler{config: config}
+
+	// Convert base chain priorities to integers. (We may want to allow expressions
+	// nftables will understand here, like "mangle - 5" instead of "-155". But
+	// that'll require different validation, so it's limited to the integer
+	// equivalent at the moment.)
+	bcps := map[string]int{}
+	for chain, prio := range baseChainPriorities {
+		p, err := strconv.Atoi(prio)
+		if err != nil {
+			return nil, fmt.Errorf("nftables priority %q for base chain %q must be an integer: %w", prio, chain, err)
+		}
+		bcps[chain] = p
+	}
 
 	if nft.config.IPv4 {
 		var err error
-		nft.table4, err = nft.init(ctx, nftables.IPv4)
+		nft.table4, err = nft.init(ctx, nftables.IPv4, bcps)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +91,7 @@ func NewNftabler(ctx context.Context, config firewaller.Config) (firewaller.Fire
 
 	if nft.config.IPv6 {
 		var err error
-		nft.table6, err = nft.init(ctx, nftables.IPv6)
+		nft.table6, err = nft.init(ctx, nftables.IPv6, bcps)
 		if err != nil {
 			return nil, err
 		}
@@ -83,6 +106,20 @@ func NewNftabler(ctx context.Context, config firewaller.Config) (firewaller.Fire
 	}
 
 	return nft, nil
+}
+
+// ValidateBaseChainPriorities checks nftables base chain priority configuration.
+func ValidateBaseChainPriorities(prios map[string]string) error {
+	var errs []error
+	for c, p := range prios {
+		if _, ok := baseChainNames[c]; !ok {
+			errs = append(errs, fmt.Errorf("%q is not a valid base chain name", c))
+		}
+		if _, ok := strconv.Atoi(p); ok != nil {
+			errs = append(errs, fmt.Errorf("priority %q for base chain %q is not an integer", p, c))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (nft *nftabler) getTable(ipv firewaller.IPVersion) nftables.TableRef {
@@ -101,11 +138,19 @@ func (nft *nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVer
 }
 
 // init creates the bridge driver's nftables table for IPv4 or IPv6.
-func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables.TableRef, error) {
+func (nft *nftabler) init(ctx context.Context, family nftables.Family, baseChainPriorities map[string]int) (nftables.TableRef, error) {
 	// Instantiate the table.
 	table, err := nftables.NewTable(family, dockerTable)
 	if err != nil {
 		return table, err
+	}
+
+	// Reload the table while it's got no elements to clear an old table if one
+	// exists. This is necessary because, if base chain priorities have changed and
+	// the old table isn't removed, nft produces an error message for the base chain
+	// (but seems to apply the change anyway).
+	if err := table.Reload(ctx); err != nil {
+		return nftables.TableRef{}, err
 	}
 
 	// Set up the filter forward chain.
@@ -120,7 +165,7 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 	fwdChain, err := table.BaseChain(ctx, forwardChain,
 		nftables.BaseChainTypeFilter,
 		nftables.BaseChainHookForward,
-		nftables.BaseChainPriorityFilter)
+		baseChainPriority(forwardChain, nftables.BaseChainPriorityFilter, baseChainPriorities))
 	if err != nil {
 		return nftables.TableRef{}, fmt.Errorf("initialising nftables: %w", err)
 	}
@@ -140,7 +185,7 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 	natPostRtChain, err := table.BaseChain(ctx, postroutingChain,
 		nftables.BaseChainTypeNAT,
 		nftables.BaseChainHookPostrouting,
-		nftables.BaseChainPrioritySrcNAT)
+		baseChainPriority(postroutingChain, nftables.BaseChainPrioritySrcNAT, baseChainPriorities))
 	if err != nil {
 		return nftables.TableRef{}, err
 	}
@@ -160,7 +205,7 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 	natPreRtChain, err := table.BaseChain(ctx, preroutingChain,
 		nftables.BaseChainTypeNAT,
 		nftables.BaseChainHookPrerouting,
-		nftables.BaseChainPriorityDstNAT)
+		baseChainPriority(preroutingChain, nftables.BaseChainPriorityDstNAT, baseChainPriorities))
 	if err != nil {
 		return nftables.TableRef{}, err
 	}
@@ -172,7 +217,7 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 	natOutputChain, err := table.BaseChain(ctx, outputChain,
 		nftables.BaseChainTypeNAT,
 		nftables.BaseChainHookOutput,
-		nftables.BaseChainPriorityDstNAT)
+		baseChainPriority(outputChain, nftables.BaseChainPriorityDstNAT, baseChainPriorities))
 	if err != nil {
 		return nftables.TableRef{}, err
 	}
@@ -193,7 +238,7 @@ func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables
 	if _, err := table.BaseChain(ctx, rawPreroutingChain,
 		nftables.BaseChainTypeFilter,
 		nftables.BaseChainHookPrerouting,
-		nftables.BaseChainPriorityRaw); err != nil {
+		baseChainPriority(rawPreroutingChain, nftables.BaseChainPriorityRaw, baseChainPriorities)); err != nil {
 		return nftables.TableRef{}, err
 	}
 
@@ -213,4 +258,11 @@ func nftApply(ctx context.Context, table nftables.TableRef) error {
 		return fmt.Errorf("applying nftables rules: %w", err)
 	}
 	return nil
+}
+
+func baseChainPriority(chainName string, def int, overrides map[string]int) int {
+	if p, ok := overrides[chainName]; ok {
+		return p
+	}
+	return def
 }

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
@@ -125,7 +125,7 @@ func testNftabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 
 	// Initialise iptables, check the iptables config looks like it should look at the
 	// end of the test (after deleting per-network and per-port rules).
-	fw, err := NewNftabler(context.Background(), config)
+	fw, err := NewNftabler(context.Background(), config, nil)
 	assert.NilError(t, err)
 	checkResults("ip", rnWSL2Mirrored(fmt.Sprintf("%s_cleaned,hairpin=%v", tn, config.Hairpin)), config.IPv4)
 	checkResults("ip6", fmt.Sprintf("%s_cleaned,hairpin=%v", tn, config.Hairpin), config.IPv6)

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -938,4 +940,98 @@ func TestFirewallBackendSwitch(t *testing.T) {
 	assert.Check(t, numRules > 0, "Expected iptables to have at least one rule")
 	assert.Check(t, len(dockerChains) > 0, "Expected iptables to have at least one docker chain")
 	assert.Check(t, !nftablesTablesExist(), "nftables tables exist after running with iptables")
+}
+
+// TestBaseChainPriorityOverride checks that priorities of nftables base chains can be configured.
+func TestBaseChainPriorityOverride(t *testing.T) {
+	skip.If(t, !strings.Contains(testEnv.FirewallBackendDriver(), "nftables"),
+		"test is nftables specific, and nftables isn't in use")
+	_ = setupTest(t)
+	d := daemon.New(t)
+	defer d.Stop(t)
+
+	baseChains := []string{"filter-FORWARD", "nat-POSTROUTING", "nat-PREROUTING", "nat-OUTPUT", "raw-PREROUTING"}
+
+	re := regexp.MustCompile("priority ([-]?[0-9]+)")
+	chainPriority := func(name string) int {
+		t.Helper()
+		res := icmd.RunCommand("nft", "-n", "list chain "+name)
+		assert.Assert(t, res.ExitCode == 0, "failed to list chain %s", name)
+		m := re.FindStringSubmatch(res.Stdout())
+		assert.Assert(t, is.Len(m, 2), "failed to find chain priority in %s", res.Stdout())
+		i, err := strconv.Atoi(m[1])
+		assert.NilError(t, err)
+		return i
+	}
+	chainPriorities := func(fam string) map[string]int {
+		t.Helper()
+		res := map[string]int{}
+		for _, chain := range baseChains {
+			res[chain] = chainPriority(fam + " docker-bridges " + chain)
+		}
+		return res
+	}
+
+	d.Start(t)
+	defaults4 := chainPriorities("ip")
+	defaults6 := chainPriorities("ip6")
+	assert.Check(t, is.DeepEqual(defaults4, defaults6), "Expected ip/ip6 base chain priorities to be the same")
+
+	args := make([]string, 0, len(baseChains))
+	for _, chain := range baseChains {
+		args = append(args, fmt.Sprintf("--bridge-nftables-priority=%s=%d", chain, defaults4[chain]+1))
+	}
+
+	d.Stop(t)
+	d.Start(t, args...)
+
+	modified4 := chainPriorities("ip")
+	modified6 := chainPriorities("ip6")
+	assert.Check(t, is.DeepEqual(modified4, modified6), "Expected ip/ip6 base chain priorities to be the same")
+	for _, chain := range baseChains {
+		assert.Check(t, is.Equal(modified4[chain], defaults4[chain]+1))
+	}
+}
+
+// TestBaseChainPriorityValidation checks that nftables priority overrides are validated on startup.
+func TestBaseChainPriorityValidation(t *testing.T) {
+	skip.If(t, !strings.Contains(testEnv.FirewallBackendDriver(), "nftables"),
+		"test is nftables specific, and nftables isn't in use")
+	_ = setupTest(t)
+
+	testcases := []struct {
+		name   string
+		opt    string
+		expErr string
+	}{
+		{
+			name:   "bad base chain name",
+			opt:    "nosuchchain=0",
+			expErr: `"nosuchchain" is not a valid base chain name`,
+		},
+		{
+			name:   "non-integer priority",
+			opt:    "filter-FORWARD=filter+1",
+			expErr: `priority "filter+1" for base chain "filter-FORWARD" is not an integer`,
+		},
+		{
+			name:   "missing priority",
+			opt:    "filter-FORWARD",
+			expErr: `priority "" for base chain "filter-FORWARD" is not an integer`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := daemon.New(t)
+			defer d.Stop(t)
+
+			err := d.StartWithError("--bridge-nftables-priority=" + tc.opt)
+			assert.Check(t, err != nil, "expected startup error")
+			logLine, err := d.TailLogs(1)
+			assert.Check(t, err)
+			assert.Check(t, len(logLine) == 1)
+			assert.Check(t, is.Contains(string(logLine[0]), tc.expErr))
+		})
+	}
 }


### PR DESCRIPTION
**- What I did**

Unlike iptables, nftables has no built-in chains - it has "base chains" associated with hook points in the kernel, and any number of base chains may be registered with that hook point ... they run in priority order. By default, docker's basse chain priorities are the standard priorities for the type of chain. But, users with existing nftables may want Docker's rules to run before or after their own ... so, make it possible to configure the bridge driver's base chain priorities (in daemon.json, or on the dockerd command line).

For example, in daemon.json:

```
        "bridge-nftables-priorities": {
                "filter-FORWARD": "3",
                "nat-POSTROUTING": "101",
                "nat-PREROUTING": "-101",
                "nat-OUTPUT": "-102",
                "raw-PREROUTING": "-301"
        },
```

Or, on the command line:

```
    dockerd --bridge-nftables-priority filter-FORWARD=3 ...
```

Will need to update the CLI's docs/reference/dockerd.md when this is merged.

**- How I did it**

**- How to verify it**

New integration test.

**- Human readable description for the release notes**
```markdown changelog
- Add daemon config option `bridge-nftables-priorities`.
```
