### PR TITLE
Nftables with firewalld

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -144,8 +144,9 @@ jobs:
               // { os: 'ubuntu-24.04', mode: 'rootless-systemd' }, // FIXME: https://github.com/moby/moby/issues/44084
             ];
             if ("${{ inputs.storage }}" == "snapshotter") {
-              includes.push({ os: 'ubuntu-24.04', mode: 'firewalld' });
+              includes.push({ os: 'ubuntu-24.04', mode: 'iptables+firewalld' });
               includes.push({ os: 'ubuntu-24.04', mode: 'nftables' });
+              includes.push({ os: 'ubuntu-24.04', mode: 'nftables+firewalld' });
             }
             await core.group(`Set matrix`, async () => {
               core.info(`matrix: ${JSON.stringify(includes)}`);
@@ -336,15 +337,15 @@ jobs:
             // statically define the list of test suites that we want to run.
             if ("${{ inputs.storage }}" == "snapshotter") {
               matrix.include.push({
-                'mode': 'firewalld',
+                'mode': 'iptables+firewalld',
                 'test': 'DockerCLINetworkSuite|DockerCLIPortSuite|DockerDaemonSuite'
               });
               matrix.include.push({
-                'mode': 'firewalld',
+                'mode': 'iptables+firewalld',
                 'test': 'DockerSwarmSuite'
               });
               matrix.include.push({
-                'mode': 'firewalld',
+                'mode': 'iptables+firewalld',
                 'test': 'DockerNetworkSuite'
               });
               matrix.include.push({
@@ -357,6 +358,18 @@ jobs:
               });
               matrix.include.push({
                 'mode': 'nftables',
+                'test': 'DockerNetworkSuite'
+              });
+              matrix.include.push({
+                'mode': 'nftables+firewalld',
+                'test': 'DockerCLINetworkSuite|DockerCLIPortSuite|DockerDaemonSuite'
+              });
+              matrix.include.push({
+                'mode': 'nftables+firewalld',
+                'test': 'DockerSwarmSuite'
+              });
+              matrix.include.push({
+                'mode': 'nftables+firewalld',
                 'test': 'DockerNetworkSuite'
               });
             }

--- a/daemon/libnetwork/controller_linux.go
+++ b/daemon/libnetwork/controller_linux.go
@@ -17,18 +17,18 @@ import (
 
 // FirewallBackend returns the name of the firewall backend for "docker info".
 func (c *Controller) FirewallBackend() *system.FirewallInfo {
+	var info system.FirewallInfo
+	info.Driver = "iptables"
 	if nftables.Enabled() {
-		return &system.FirewallInfo{Driver: "nftables"}
+		info.Driver = "nftables"
 	}
 	if iptables.UsingFirewalld() {
-		info := &system.FirewallInfo{Driver: "iptables+firewalld"}
-		reloadedAt := iptables.FirewalldReloadedAt()
-		if !reloadedAt.IsZero() {
-			info.Info = append(info.Info, [2]string{"ReloadedAt", reloadedAt.Format(time.RFC3339)})
+		info.Driver += "+firewalld"
+		if reloadedAt := iptables.FirewalldReloadedAt(); !reloadedAt.IsZero() {
+			info.Info = [][2]string{{"ReloadedAt", reloadedAt.Format(time.RFC3339)}}
 		}
-		return info
 	}
-	return &system.FirewallInfo{Driver: "iptables"}
+	return &info
 }
 
 // enabledIptablesVersions returns the iptables versions that are enabled

--- a/daemon/libnetwork/firewall_linux.go
+++ b/daemon/libnetwork/firewall_linux.go
@@ -19,10 +19,6 @@ func (c *Controller) selectFirewallBackend() error {
 	}
 	// If configured to use nftables, but it can't be initialised, return an error.
 	if c.cfg.FirewallBackend == "nftables" {
-		// Don't try to enable nftables if firewalld is running.
-		if iptables.UsingFirewalld() {
-			return errors.New("firewall-backend is set to nftables, but firewalld is running")
-		}
 		if err := nftables.Enable(); err != nil {
 			return fmt.Errorf("firewall-backend is set to nftables: %v", err)
 		}

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -734,7 +734,7 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 
 func testLiveRestoreUserChainsSetup(t *testing.T) {
 	skip.If(t, testEnv.IsRootless(), "rootless daemon uses it's own network namespace")
-	skip.If(t, testEnv.FirewallBackendDriver() == "nftables", "nftables enabled, skipping iptables test")
+	skip.If(t, strings.HasPrefix(testEnv.FirewallBackendDriver(), "nftables"), "nftables enabled, skipping iptables test")
 
 	t.Parallel()
 	ctx := testutil.StartSpan(baseContext, t)

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -607,8 +607,12 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 		}
 	}()
 
-	iptablesSave := icmd.Command("iptables-save")
-	resBeforeDel := icmd.RunCmd(iptablesSave)
+	saveCmd := []string{"iptables-save"}
+	if strings.HasPrefix(d.FirewallBackendDriver(t), "nftables") {
+		saveCmd = []string{"nft", "list ruleset"}
+	}
+	saveRules := icmd.Command(saveCmd[0], saveCmd[1:]...)
+	resBeforeDel := icmd.RunCmd(saveRules)
 	assert.NilError(t, resBeforeDel.Error)
 	assert.Check(t, strings.Contains(resBeforeDel.Combined(), bridgeName),
 		"With container: expected rules for %s in: %s", bridgeName, resBeforeDel.Combined())
@@ -619,7 +623,7 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 	removed = true
 
 	// Check the network does not appear in iptables rules.
-	resAfterDel := icmd.RunCmd(iptablesSave)
+	resAfterDel := icmd.RunCmd(saveRules)
 	assert.NilError(t, resAfterDel.Error)
 	assert.Check(t, !strings.Contains(resAfterDel.Combined(), bridgeName),
 		"After deletes: did not expect rules for %s in: %s", bridgeName, resAfterDel.Combined())
@@ -628,7 +632,7 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 	networking.FirewalldReload(t, d)
 
 	// Check that rules for the deleted container/network have not reappeared.
-	resAfterReload := icmd.RunCmd(iptablesSave)
+	resAfterReload := icmd.RunCmd(saveRules)
 	assert.NilError(t, resAfterReload.Error)
 	assert.Check(t, !strings.Contains(resAfterReload.Combined(), bridgeName),
 		"After deletes: did not expect rules for %s in: %s", bridgeName, resAfterReload.Combined())

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -93,7 +93,7 @@ func TestHostIPv4BridgeLabel(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
 	// Make sure the SNAT rule exists
-	if testEnv.FirewallBackendDriver() == "nftables" {
+	if strings.HasPrefix(testEnv.FirewallBackendDriver(), "nftables") {
 		chain := testutil.RunCommand(ctx, "nft", "--stateless", "list", "chain", "ip", "docker-bridges", "nat-postrouting-out__hostIPv4Bridge").Combined()
 		exp := fmt.Sprintf(`oifname != "hostIPv4Bridge" ip saddr %s counter snat to %s comment "SNAT"`,
 			out.IPAM.Config[0].Subnet, ipv4SNATAddr)

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -1145,7 +1145,7 @@ func TestNoIP6Tables(t *testing.T) {
 			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
 
 			var cmd *exec.Cmd
-			if d.FirewallBackendDriver(t) == "nftables" {
+			if strings.HasPrefix(d.FirewallBackendDriver(t), "nftables") {
 				cmd = exec.Command("nft", "list", "table", "ip6", "docker-bridges")
 			} else {
 				cmd = exec.Command("/usr/sbin/ip6tables-save")
@@ -1302,6 +1302,7 @@ func TestContainerDisabledIPv6(t *testing.T) {
 	ctx := setupTest(t)
 	d := daemon.New(t)
 	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
 
 	c := d.NewClientT(t)
 	defer c.Close()

--- a/integration/networking/firewall_linux_test.go
+++ b/integration/networking/firewall_linux_test.go
@@ -20,8 +20,9 @@ func TestInfoFirewallBackend(t *testing.T) {
 	expDriver := defaultFirewallBackend
 	if val := os.Getenv("DOCKER_FIREWALL_BACKEND"); val != "" {
 		expDriver = val
-	} else if !testEnv.IsRootless() && networking.FirewalldRunning() {
-		expDriver = "iptables+firewalld"
+	}
+	if !testEnv.IsRootless() && networking.FirewalldRunning() {
+		expDriver += "+firewalld"
 	}
 	info, err := c.Info(ctx)
 	assert.NilError(t, err)

--- a/internal/testutils/networking/firewall.go
+++ b/internal/testutils/networking/firewall.go
@@ -32,11 +32,11 @@ var rePolicy = lazyregexp.New("policy ([A-Za-z]+)")
 // behaviour.
 func SetFilterForwardPolicies(t *testing.T, firewallBackend string, policy string) {
 	t.Helper()
-	if strings.Contains(firewallBackend, "iptables") {
+	if strings.HasPrefix(firewallBackend, "iptables") {
 		setIptablesFFP(t, policy)
 		return
 	}
-	if firewallBackend == "nftables" {
+	if strings.HasPrefix(firewallBackend, "nftables") {
 		setNftablesFFP(t, policy)
 		return
 	}


### PR DESCRIPTION
**- What I did**

- close https://github.com/moby/moby/issues/49645
- close https://github.com/moby/moby/issues/49641

Allow nftables to run with firewalld, and test that in CI using the same set of tests as for iptables+firewalld.

**- How I did it**

Like iptables+firewalld, allow the bridge to create its normal set of rules (but with no need to create them via firewalld, because they're a separate table). Use firewalld zones/policies in the same way as for iptables+firewalld.

`docker info` will report `nftables+firewalld`, with the firewalld reload time (as for iptables).

**- How to verify it**

nftables+firewalld test runs in CI

**- Human readable description for the release notes**
```markdown changelog

```
