### PR TITLE
libn/d/overlay: drop obsolete writeToStore comment

### DIFF
--- a/libnetwork/drivers/overlay/ov_network.go
+++ b/libnetwork/drivers/overlay/ov_network.go
@@ -167,7 +167,6 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 
 	if nInfo != nil {
 		if err := nInfo.TableEventRegister(ovPeerTable, driverapi.EndpointObject); err != nil {
-			// XXX Undo writeToStore?  No method to so.  Why?
 			return err
 		}
 	}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Updates #44965 

**- What I did**
As discussed in https://github.com/moby/moby/pull/50260#discussion_r2185572958, the writeToStore() call was removed from CreateNetwork in commit 0fa873c0fef0c117d7561b08b083292cc3305b79 but a comment about undoing the write remained. I removed the obsolete comment.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

