### PR TITLE
Replace integration import test use of image type

### DIFF
--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 	imagetypes "github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/image"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
@@ -71,32 +71,32 @@ func TestImportWithCustomPlatform(t *testing.T) {
 	tests := []struct {
 		name     string
 		platform string
-		expected image.V1Image
+		expected platforms.Platform
 	}{
 		{
 			platform: "",
-			expected: image.V1Image{
+			expected: platforms.Platform{
 				OS:           runtime.GOOS,
 				Architecture: runtime.GOARCH, // this may fail on armhf due to normalization?
 			},
 		},
 		{
 			platform: runtime.GOOS,
-			expected: image.V1Image{
+			expected: platforms.Platform{
 				OS:           runtime.GOOS,
 				Architecture: runtime.GOARCH, // this may fail on armhf due to normalization?
 			},
 		},
 		{
 			platform: strings.ToUpper(runtime.GOOS),
-			expected: image.V1Image{
+			expected: platforms.Platform{
 				OS:           runtime.GOOS,
 				Architecture: runtime.GOARCH, // this may fail on armhf due to normalization?
 			},
 		},
 		{
 			platform: runtime.GOOS + "/sparc64",
-			expected: image.V1Image{
+			expected: platforms.Platform{
 				OS:           runtime.GOOS,
 				Architecture: "sparc64",
 			},
@@ -141,7 +141,6 @@ func TestImportWithCustomPlatformReject(t *testing.T) {
 	tests := []struct {
 		name        string
 		platform    string
-		expected    image.V1Image
 		expectedErr string
 	}{
 		{


### PR DESCRIPTION
This is the only non-daemon import of the image package. The platform type is also the better type to use.
