### PR TITLE
daemon/server: remove compatibility with API v1.4 auth-config on push

### DIFF
--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -83,6 +83,8 @@ func DecodeAuthConfig(authEncoded string) (*AuthConfig, error) {
 // Like [DecodeAuthConfig], this function always returns an [AuthConfig], even if an
 // error occurs. It is up to the caller to decide if authentication is required,
 // and if the error can be ignored.
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func DecodeAuthConfigBody(rdr io.ReadCloser) (*AuthConfig, error) {
 	return decodeAuthConfigFromReader(rdr)
 }

--- a/api/types/registry/authconfig_test.go
+++ b/api/types/registry/authconfig_test.go
@@ -1,8 +1,6 @@
 package registry
 
 import (
-	"io"
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -45,12 +43,6 @@ func TestDecodeAuthConfig(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid X-Registry-Auth header: unexpected EOF")
 		assert.Equal(t, *token, AuthConfig{})
 	})
-}
-
-func TestDecodeAuthConfigBody(t *testing.T) {
-	token, err := DecodeAuthConfigBody(io.NopCloser(strings.NewReader(unencoded)))
-	assert.NilError(t, err)
-	assert.Equal(t, *token, expected)
 }
 
 func TestEncodeAuthConfig(t *testing.T) {


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/1796
- https://github.com/moby/moby/pull/1564


Docker [API v1.4] and lower expected registry authentication to be sent in the request body when pushing or pulling ("creating") images. [API v1.5] (Docker v0.6.1) changed this to this to use a `X-Registry-Auth` header instead.

This change was implemented in d04beb7f4315c6b659958227954398437a69e5d6, which kept a fallback for clients using old (< v1.5) API versions which would send authentication in the request body.

Given that we no longer support API versions older than v1.24, and clients using API v1.5 would be over 12 Years old.

[API v1.4]: https://github.com/moby/moby/blob/v0.6.1/docs/sources/api/docker_remote_api_v1.4.rst#push-an-image-on-the-registry
[API v1.5]: https://github.com/moby/moby/blob/v0.6.2/docs/sources/api/docker_remote_api_v1.5.rst#push-an-image-on-the-registry

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`POST /images/{name:}/push`: remove compatibility with API v1.4 auth-config in body.
```

**- A picture of a cute animal (not mandatory but encouraged)**

