### PR TITLE
registry: remove deprecated Service.ResolveRepository()

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -394,25 +394,6 @@ func GetAuthConfigKey(index *registry.IndexInfo) string {
 	return index.Name
 }
 
-// newRepositoryInfo validates and breaks down a repository name into a RepositoryInfo
-func newRepositoryInfo(config *serviceConfig, name reference.Named) *RepositoryInfo {
-	index := newIndexInfo(config, reference.Domain(name))
-	var officialRepo bool
-	if index.Official {
-		// RepositoryInfo.Official indicates whether the image repository
-		// is an official (docker library official images) repository.
-		//
-		// We only need to check this if the image-repository is on Docker Hub.
-		officialRepo = !strings.ContainsRune(reference.FamiliarName(name), '/')
-	}
-
-	return &RepositoryInfo{
-		Name:     reference.TrimNamed(name),
-		Index:    index,
-		Official: officialRepo,
-	}
-}
-
 // ParseRepositoryInfo performs the breakdown of a repository name into a
 // [RepositoryInfo], but lacks registry configuration.
 //

--- a/registry/service.go
+++ b/registry/service.go
@@ -108,17 +108,6 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 	return "", "", lastErr
 }
 
-// ResolveRepository splits a repository name into its components
-// and configuration of the associated registry.
-//
-// Deprecated: this function was only used internally and is no longer used. It will be removed in the next release.
-func (s *Service) ResolveRepository(name reference.Named) (*RepositoryInfo, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	// TODO(thaJeztah): remove error return as it's no longer used.
-	return newRepositoryInfo(s.config, name), nil
-}
-
 // ResolveAuthConfig looks up authentication for the given reference from the
 // given authConfigs.
 //


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49696

It was deprecated in 6c643bc3667340304af1a4b0598e7a210573f85d, which is part of v28, and had no external consumers.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: registry: remove deprecated `Service.ResolveRepository()`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

