### PR TITLE
api/types/registry: remove deprecated fields for non-distributable artifacts

### DIFF
--- a/api/types/registry/registry.go
+++ b/api/types/registry/registry.go
@@ -12,9 +12,6 @@ import (
 
 // ServiceConfig stores daemon registry services configuration.
 type ServiceConfig struct {
-	AllowNondistributableArtifactsCIDRs     []*NetIPNet `json:"AllowNondistributableArtifactsCIDRs,omitempty"`     // Deprecated: non-distributable artifacts are deprecated and enabled by default. This field will be removed in the next release.
-	AllowNondistributableArtifactsHostnames []string    `json:"AllowNondistributableArtifactsHostnames,omitempty"` // Deprecated: non-distributable artifacts are deprecated and enabled by default. This field will be removed in the next release.
-
 	InsecureRegistryCIDRs []*NetIPNet           `json:"InsecureRegistryCIDRs"`
 	IndexConfigs          map[string]*IndexInfo `json:"IndexConfigs"`
 	Mirrors               []string


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/49065
- https://github.com/moby/moby/pull/49749


These fields were deprecated in 1932091e21b64abc52b42320393b0ac5f6921668, which is part of v28. They were kept in place for responses in older API versions, but no longer used since 7d9c50db2bed62b966347eb926f4c2bd4eb151c3, which implemented a fallback without requiring the fields to be present.

This patch:

- removes `ServiceConfig.AllowNondistributableArtifactsCIDRs`
- removes `ServiceConfig.AllowNondistributableArtifactsHostnames`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types/registry: remove deprecated `ServiceConfig.AllowNondistributableArtifactsCIDRs` and `ServiceConfig.AllowNondistributableArtifactsHostnames` fields.
```

**- A picture of a cute animal (not mandatory but encouraged)**

