### PR TITLE
registry: remove deprecated APIEndpoint fields

### DIFF
--- a/registry/service.go
+++ b/registry/service.go
@@ -142,7 +142,6 @@ type APIEndpoint struct {
 	Mirror                         bool
 	URL                            *url.URL
 	AllowNondistributableArtifacts bool // Deprecated: non-distributable artifacts are deprecated and enabled by default. This field will be removed in the next release.
-	Official                       bool // Deprecated: this field was only used internally, and will be removed in the next release.
 	TLSConfig                      *tls.Config
 }
 

--- a/registry/service.go
+++ b/registry/service.go
@@ -139,10 +139,9 @@ func (s *Service) ResolveAuthConfig(authConfigs map[string]registry.AuthConfig, 
 
 // APIEndpoint represents a remote API endpoint
 type APIEndpoint struct {
-	Mirror                         bool
-	URL                            *url.URL
-	AllowNondistributableArtifacts bool // Deprecated: non-distributable artifacts are deprecated and enabled by default. This field will be removed in the next release.
-	TLSConfig                      *tls.Config
+	Mirror    bool
+	URL       *url.URL
+	TLSConfig *tls.Config
 }
 
 // LookupPullEndpoints creates a list of v2 endpoints to try to pull from, in order of preference.

--- a/registry/service.go
+++ b/registry/service.go
@@ -143,7 +143,6 @@ type APIEndpoint struct {
 	URL                            *url.URL
 	AllowNondistributableArtifacts bool // Deprecated: non-distributable artifacts are deprecated and enabled by default. This field will be removed in the next release.
 	Official                       bool // Deprecated: this field was only used internally, and will be removed in the next release.
-	TrimHostname                   bool // Deprecated: hostname is now trimmed unconditionally for remote names. This field will be removed in the next release.
 	TLSConfig                      *tls.Config
 }
 

--- a/registry/service_v2.go
+++ b/registry/service_v2.go
@@ -37,7 +37,6 @@ func (s *Service) lookupV2Endpoints(ctx context.Context, hostname string, includ
 		}
 		endpoints = append(endpoints, APIEndpoint{
 			URL:       DefaultV2Registry,
-			Official:  true,
 			TLSConfig: tlsconfig.ServerDefault(),
 		})
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/49005
- https://github.com/moby/moby/pull/49706
- https://github.com/moby/moby/pull/49065

### registry: remove deprecated APIEndpoint.TrimHostName

This field was deprecated in 3014d6d7a324d99102c78187eed2a6c1831ed309,
which is part of v28.

### registry: remove deprecated APIEndpoint.Official

This field was deprecated in d8fa2f8071036537253d1c6cf821fe5e866f461a,
which is part of v28.


### registry: remove deprecated APIEndpoint.AllowNondistributableArtifacts

This field was deprecated in 1932091e21b64abc52b42320393b0ac5f6921668,
which is part of v28.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: registry: remove deprecated `APIEndpoint.TrimHostName`, `APIEndpoint.Official`, and `APIEndpoint.AllowNondistributableArtifacts` fields.
```

**- A picture of a cute animal (not mandatory but encouraged)**

