### PR TITLE
daemon/graphdriver: remove deprecated GetDriver(), redundant `init()`, and leftovers for graphdriver-plugins

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -121,13 +121,6 @@ func Register(name string, initFunc InitFunc) error {
 	return nil
 }
 
-// GetDriver initializes and returns the registered driver.
-//
-// Deprecated: this function was exported for (integration-)tests, but no longer used, and will be removed in the next release.
-func GetDriver(name string, config Options) (Driver, error) {
-	return getDriver(name, config)
-}
-
 // getDriver initializes and returns the registered driver.
 func getDriver(name string, config Options) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -16,7 +16,7 @@ import (
 )
 
 // All registered drivers
-var drivers map[string]InitFunc
+var drivers = make(map[string]InitFunc)
 
 // CreateOpts contains optional arguments for Create() and CreateReadWrite()
 // methods.
@@ -109,10 +109,6 @@ type FileGetCloser interface {
 	storage.FileGetter
 	// Close cleans up any resources associated with the FileGetCloser.
 	Close() error
-}
-
-func init() {
-	drivers = make(map[string]InitFunc)
 }
 
 // Register registers an InitFunc for the driver.

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -128,11 +128,6 @@ func getDriver(name string, config Options) (Driver, error) {
 	}
 	log.G(context.TODO()).WithFields(log.Fields{"driver": name, "home-dir": config.Root}).Error("Failed to GetDriver graph")
 
-	// TODO(thaJeztah): remove in next release.
-	if os.Getenv("DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS") != "" {
-		return nil, errors.New("DEPRECATED: Support for experimental graphdriver plugins has been removed. See https://docs.docker.com/go/deprecated/")
-	}
-
 	return nil, ErrNotSupported
 }
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48079
- https://github.com/moby/moby/pull/48072


### daemon/graphdriver: remove redundant init()

This was added in a63ff8da46e11c857cd3d743d72d211c96b637e4, but looks
like the only reason was to just have the var initialized, so let's
do so when we create the var.



### daemon/graphdriver: remove deprecated GetDriver()

This was deprecated in 84cabde357a7b35bce100fea66657b3b520b81ce, which
was part of v28.


### daemon/graphdriver: remove error or deprecated graphdriver-plugins

This error was added in 555dac5e14ad4925e020f1a72e8c39b7a316b0dc to produce
an error for the deprecated graphdriver-plugins.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
daemon/graphdriver: remove deprecated `GetDriver()`
```

**- A picture of a cute animal (not mandatory but encouraged)**

