### PR TITLE
daemon/container: remove deprecated types and functions

### DIFF
--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -99,14 +99,6 @@ func (s *State) String() string {
 	return fmt.Sprintf("Exited (%d) %s ago", s.ExitCodeValue, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
 }
 
-// IsValidHealthString checks if the provided string is a valid
-// [container.HealthStatus].
-//
-// Deprecated: use [container.ValidateHealthStatus] and check for nil-errors.
-func IsValidHealthString(s string) bool {
-	return container.ValidateHealthStatus(s) == nil
-}
-
 // StateString returns the container's current [ContainerState], based on the
 // [State.Running], [State.Paused], [State.Restarting], [State.RemovalInProgress],
 // [State.StartedAt] and [State.Dead] fields.

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -130,13 +130,6 @@ func (s *State) StateString() container.ContainerState {
 	return container.StateExited
 }
 
-// IsValidStateString checks if the provided string is a valid container state.
-//
-// Deprecated: use [container.ValidateContainerState] instead.
-func IsValidStateString(s container.ContainerState) bool {
-	return container.ValidateContainerState(s) == nil
-}
-
 // Wait waits until the container is in a certain state indicated by the given
 // condition. A context must be used for cancelling the request, controlling
 // timeouts, and avoiding goroutine leaks. Wait must be called without holding

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -58,14 +58,6 @@ type State struct {
 	task libcontainerdtypes.Task
 }
 
-// StateStatus is used to return container wait results.
-// Implements exec.ExitCode interface.
-// This type is needed as State include a sync.Mutex field which make
-// copying it unsafe.
-//
-// Deprecated: use [container.StateStatus] instead.
-type StateStatus = container.StateStatus
-
 // NewState creates a default state object.
 func NewState() *State {
 	return &State{}
@@ -152,20 +144,6 @@ func (s *State) StateString() container.ContainerState {
 func IsValidStateString(s container.ContainerState) bool {
 	return container.ValidateContainerState(s) == nil
 }
-
-// WaitCondition is an enum type for different states to wait for.
-//
-// Deprecated: use [container.WaitCondition] instead.
-type WaitCondition = container.WaitCondition
-
-const (
-	// Deprecated: use [container.WaitConditionNotRunning] instead.
-	WaitConditionNotRunning = container.WaitConditionNotRunning
-	// Deprecated: use [container.WaitConditionNextExit] instead.
-	WaitConditionNextExit = container.WaitConditionNextExit
-	// Deprecated: use [container.WaitConditionRemoved] instead.
-	WaitConditionRemoved = container.WaitConditionRemoved
-)
 
 // Wait waits until the container is in a certain state indicated by the given
 // condition. A context must be used for cancelling the request, controlling


### PR DESCRIPTION
relates to

- https://github.com/moby/moby/pull/50279
- https://github.com/moby/moby/pull/49874
- https://github.com/moby/moby/pull/49893
- https://github.com/moby/moby/pull/49965

### daemon/container: remove deprecated StateStatus, WaitCondition

These were deprecated in 100102108b2f096cd43165e4522a6314bc16f07c, which
was part of v28.2, but the container package was moved inside the daemon
in 5419eb1efc01aa36191ac066f43a568579c78f5a, so these aliases were no
longer useful.


### daemon/container: remove deprecated IsValidHealthString

This was deprecated in df662ebc59aecaa8a15fa352fc8a71f90fda230a, which
was part of v28.2, but the container package was moved inside the daemon
in 5419eb1efc01aa36191ac066f43a568579c78f5a, so these aliases were no
longer useful.

### daemon/container: remove deprecated IsValidStateString

This was deprecated in 44b653ef992ed4289631726141663ef6ae7b0da8, which
was part of v28.2, but the container package was moved inside the daemon
in 5419eb1efc01aa36191ac066f43a568579c78f5a, so these aliases were no
longer useful.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: container: remove deprecated `StateStatus`, `WaitCondition`, and the related  `WaitConditionNotRunning`, `WaitConditionNextExit`, and `WaitConditionRemoved` consts.
Go SDK: container: remove deprecated `IsValidStateString`.
Go SDK: container: remove deprecated `IsValidHealthString`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

