### PR TITLE
integration/container: try fix flaky TestExecResize on Windows

### DIFF
--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -114,6 +115,14 @@ func TestExec(t *testing.T) {
 	}
 	assert.Check(t, is.Contains(out, expected), "exec command not running in expected /tmp working directory")
 	assert.Check(t, is.Contains(out, "FOO=BAR"), "exec command not running with expected environment variable FOO")
+}
+
+func TestExecResizeStress(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType != "windows")
+
+	for i := range 100 {
+		t.Run(strconv.Itoa(i), TestExecResize)
+	}
 }
 
 func TestExecResize(t *testing.T) {

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -19,6 +19,7 @@ import (
 	req "github.com/docker/docker/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -135,6 +136,23 @@ func TestExecResize(t *testing.T) {
 	assert.NilError(t, err)
 	err = apiClient.ContainerExecStart(ctx, execID, containertypes.ExecStartOptions{Detach: true})
 	assert.NilError(t, err)
+
+	if runtime.GOOS == "windows" {
+		// Try to fix flakiness on Windows 2025, which often fails:
+		//
+		//	=== FAIL: github.com/docker/docker/integration/container TestExecResize/success (0.01s)
+		//		exec_test.go:144: assertion failed: error is not nil: Error response from daemon: NotFound: exec: '9c19c467436132df24d8b606b0c462b1110dacfbbd13b63e5b42579eda76d7fc' in task: '7d1f371218285a0c653ae77024a1ab3f5d61a5d097c651ddf7df97364fafb454' not found: not found
+		poll.WaitOn(t, func(poll.LogT) poll.Result {
+			i, err := apiClient.ContainerExecInspect(ctx, execID)
+			if cerrdefs.IsNotFound(err) {
+				return poll.Continue("waiting for exec %s to exist", execID)
+			}
+			if !i.Running {
+				return poll.Continue("waiting for exec %s to be running", execID)
+			}
+			return poll.Success()
+		})
+	}
 
 	t.Run("success", func(t *testing.T) {
 		err := apiClient.ContainerExecResize(ctx, execID, containertypes.ResizeOptions{


### PR DESCRIPTION
This test is failing frequenty on Windows; try to wait for the exec to exist and for it to be running;

    === FAIL: github.com/docker/docker/integration/container TestExecResize/success (0.01s)
        exec_test.go:144: assertion failed: error is not nil: Error response from daemon: NotFound: exec: '9c19c467436132df24d8b606b0c462b1110dacfbbd13b63e5b42579eda76d7fc' in task: '7d1f371218285a0c653ae77024a1ab3f5d61a5d097c651ddf7df97364fafb454' not found: not found


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

