### PR TITLE
integration/container: use subtests in some places, add separate test for ContainerInspectWithRaw

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -3,7 +3,6 @@ package container
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -24,7 +23,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -338,74 +336,69 @@ func TestCreateWithCustomReadonlyPaths(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	testCases := []struct {
+		doc           string
+		privileged    bool
 		readonlyPaths []string
 		expected      []string
 	}{
 		{
-			readonlyPaths: []string{},
-			expected:      []string{},
-		},
-		{
+			doc:           "default readonly paths",
 			readonlyPaths: nil,
 			expected:      oci.DefaultSpec().Linux.ReadonlyPaths,
 		},
 		{
+			doc:           "empty readonly paths",
+			readonlyPaths: []string{},
+			expected:      []string{},
+		},
+		{
+			doc:           "custom readonly paths",
 			readonlyPaths: []string{"/proc/asound", "/proc/bus"},
 			expected:      []string{"/proc/asound", "/proc/bus"},
 		},
-	}
-
-	checkInspect := func(t *testing.T, ctx context.Context, name string, expected []string) {
-		_, b, err := apiClient.ContainerInspectWithRaw(ctx, name, false)
-		assert.NilError(t, err)
-
-		var inspectJSON map[string]interface{}
-		err = json.Unmarshal(b, &inspectJSON)
-		assert.NilError(t, err)
-
-		cfg, ok := inspectJSON["HostConfig"].(map[string]interface{})
-		assert.Check(t, is.Equal(true, ok), name)
-
-		readonlyPaths, ok := cfg["ReadonlyPaths"].([]interface{})
-		assert.Check(t, is.Equal(true, ok), name)
-
-		rops := make([]string, 0, len(readonlyPaths))
-		for _, rop := range readonlyPaths {
-			rops = append(rops, rop.(string))
-		}
-		assert.DeepEqual(t, expected, rops)
+		{
+			// privileged containers should have no readonly paths by default
+			doc:           "privileged",
+			privileged:    true,
+			readonlyPaths: nil,
+			expected:      nil,
+		},
 	}
 
 	for i, tc := range testCases {
-		name := fmt.Sprintf("create-readonly-paths-%d", i)
-		config := container.Config{
-			Image: "busybox",
-			Cmd:   []string{"true"},
-		}
-		hc := container.HostConfig{}
-		if tc.readonlyPaths != nil {
-			hc.ReadonlyPaths = tc.readonlyPaths
-		}
+		t.Run(tc.doc, func(t *testing.T) {
+			t.Parallel()
+			ctr, err := apiClient.ContainerCreate(ctx,
+				&container.Config{
+					Image: "busybox",
+					Cmd:   []string{"true"},
+				},
+				&container.HostConfig{
+					Privileged:    tc.privileged,
+					ReadonlyPaths: tc.readonlyPaths,
+				},
+				nil,
+				nil,
+				fmt.Sprintf("create-readonly-paths-%d", i),
+			)
+			assert.NilError(t, err)
 
-		// Create the container.
-		c, err := apiClient.ContainerCreate(ctx,
-			&config,
-			&hc,
-			&network.NetworkingConfig{},
-			nil,
-			name,
-		)
-		assert.NilError(t, err)
+			ctrInspect, err := apiClient.ContainerInspect(ctx, ctr.ID)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, ctrInspect.HostConfig.ReadonlyPaths, tc.expected)
 
-		checkInspect(t, ctx, name, tc.expected)
+			// Start the container.
+			err = apiClient.ContainerStart(ctx, ctr.ID, container.StartOptions{})
+			assert.NilError(t, err)
 
-		// Start the container.
-		err = apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
-		assert.NilError(t, err)
+			// It should die down by itself, but stop it to be sure.
+			err = apiClient.ContainerStop(ctx, ctr.ID, container.StopOptions{})
+			assert.NilError(t, err)
 
-		poll.WaitOn(t, testContainer.IsInState(ctx, apiClient, c.ID, container.StateExited))
-
-		checkInspect(t, ctx, name, tc.expected)
+			ctrInspect, err = apiClient.ContainerInspect(ctx, ctr.ID)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, ctrInspect.HostConfig.ReadonlyPaths, tc.expected)
+		})
 	}
 }
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -263,90 +263,71 @@ func TestCreateWithCustomMaskedPaths(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	testCases := []struct {
+		doc         string
 		privileged  bool
 		maskedPaths []string
 		expected    []string
 	}{
 		{
-			maskedPaths: []string{},
-			expected:    []string{},
-		},
-		{
+			doc:         "default masked paths",
 			maskedPaths: nil,
 			expected:    oci.DefaultSpec().Linux.MaskedPaths,
 		},
 		{
+			doc:         "no masked paths",
+			maskedPaths: []string{},
+			expected:    []string{},
+		},
+		{
+			doc:         "custom masked paths",
 			maskedPaths: []string{"/proc/kcore", "/proc/keys"},
 			expected:    []string{"/proc/kcore", "/proc/keys"},
 		},
 		{
+			// privileged containers should have no masked paths by default
+			doc:         "privileged",
 			privileged:  true,
 			maskedPaths: nil,
 			expected:    nil,
 		},
 	}
 
-	checkInspect := func(t *testing.T, ctx context.Context, name string, expected []string) {
-		_, b, err := apiClient.ContainerInspectWithRaw(ctx, name, false)
-		assert.NilError(t, err)
-
-		var inspectJSON map[string]interface{}
-		err = json.Unmarshal(b, &inspectJSON)
-		assert.NilError(t, err)
-
-		cfg, ok := inspectJSON["HostConfig"].(map[string]interface{})
-		assert.Check(t, is.Equal(true, ok), name)
-
-		if expected != nil {
-			maskedPaths, ok := cfg["MaskedPaths"].([]interface{})
-			assert.Check(t, is.Equal(true, ok), name)
-
-			mps := make([]string, 0, len(maskedPaths))
-			for _, mp := range maskedPaths {
-				mps = append(mps, mp.(string))
-			}
-
-			assert.DeepEqual(t, expected, mps)
-		} else {
-			_, ok := cfg["MaskedPaths"].([]interface{})
-			assert.Check(t, is.Equal(false, ok), name)
-		}
-	}
-
-	// TODO: This should be using subtests
-
 	for i, tc := range testCases {
-		name := fmt.Sprintf("create-masked-paths-%d", i)
-		config := container.Config{
-			Image: "busybox",
-			Cmd:   []string{"true"},
-		}
-		hc := container.HostConfig{
-			Privileged: tc.privileged,
-		}
-		if tc.maskedPaths != nil {
-			hc.MaskedPaths = tc.maskedPaths
-		}
+		t.Run(tc.doc, func(t *testing.T) {
+			t.Parallel()
 
-		// Create the container.
-		c, err := apiClient.ContainerCreate(ctx,
-			&config,
-			&hc,
-			&network.NetworkingConfig{},
-			nil,
-			name,
-		)
-		assert.NilError(t, err)
+			// Create the container.
+			ctr, err := apiClient.ContainerCreate(ctx,
+				&container.Config{
+					Image: "busybox",
+					Cmd:   []string{"true"},
+				},
+				&container.HostConfig{
+					Privileged:  tc.privileged,
+					MaskedPaths: tc.maskedPaths,
+				},
+				nil,
+				nil,
+				fmt.Sprintf("create-masked-paths-%d", i),
+			)
+			assert.NilError(t, err)
 
-		checkInspect(t, ctx, name, tc.expected)
+			ctrInspect, err := apiClient.ContainerInspect(ctx, ctr.ID)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, ctrInspect.HostConfig.MaskedPaths, tc.expected)
 
-		// Start the container.
-		err = apiClient.ContainerStart(ctx, c.ID, container.StartOptions{})
-		assert.NilError(t, err)
+			// Start the container.
+			err = apiClient.ContainerStart(ctx, ctr.ID, container.StartOptions{})
+			assert.NilError(t, err)
 
-		poll.WaitOn(t, testContainer.IsInState(ctx, apiClient, c.ID, container.StateExited))
+			// It should die down by itself, but stop it to be sure.
+			err = apiClient.ContainerStop(ctx, ctr.ID, container.StopOptions{})
+			assert.NilError(t, err)
 
-		checkInspect(t, ctx, name, tc.expected)
+			ctrInspect, err = apiClient.ContainerInspect(ctx, ctr.ID)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, ctrInspect.HostConfig.MaskedPaths, tc.expected)
+		})
 	}
 }
 

--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -45,7 +45,7 @@ func TestRemoveContainerWithRemovedVolume(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	_, _, err = apiClient.ContainerInspectWithRaw(ctx, cID, true)
+	_, err = apiClient.ContainerInspect(ctx, cID)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	assert.Check(t, is.ErrorContains(err, "No such container"))
 }
@@ -60,10 +60,10 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
 	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited))
 
-	insp, _, err := apiClient.ContainerInspectWithRaw(ctx, cID, true)
+	ctrInspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(1, len(insp.Mounts)))
-	volName := insp.Mounts[0].Name
+	assert.Check(t, is.Equal(1, len(ctrInspect.Mounts)))
+	volName := ctrInspect.Mounts[0].Name
 
 	err = apiClient.ContainerRemove(ctx, cID, containertypes.RemoveOptions{
 		RemoveVolumes: true,


### PR DESCRIPTION
### integration/container: cleanup TestCreateWithCustomMaskedPaths

- Use ContainerInspect instead of manually unmarshaling the raw JSON
- Explicitly stop the container instead of polling for it to die
- Use subtests and run parallel


### integration/container: cleanup TestCreateWithCustomReadonlyPaths

- Use ContainerInspect instead of manually unmarshaling the raw JSON
- Explicitly stop the container instead of polling for it to die
- Add test for privileged containers
- Use subtests and run parallel

### integration/container: avoid ContainerInspectWithRaw with "size"

These tests didn't use the raw output, and didn't use the size.


### integration/container: add basic test for ContainerInspectWithRaw

Make sure we have basic coverage for this function; integration-cli may
have additional tests covering this as well.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

