### PR TITLE
daemon: consolidate platform-specific inspectExecProcessConfig

### DIFF
--- a/daemon/inspect_linux.go
+++ b/daemon/inspect_linux.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"github.com/moby/moby/api/types/container"
 	containerpkg "github.com/moby/moby/v2/daemon/container"
-	"github.com/moby/moby/v2/daemon/server/backend"
 )
 
 // This sets platform-specific fields
@@ -14,14 +13,4 @@ func setPlatformSpecificContainerFields(container *containerpkg.Container, contJ
 	contJSONBase.HostsPath = container.HostsPath
 
 	return contJSONBase
-}
-
-func inspectExecProcessConfig(e *containerpkg.ExecConfig) *backend.ExecProcessConfig {
-	return &backend.ExecProcessConfig{
-		Tty:        e.Tty,
-		Entrypoint: e.Entrypoint,
-		Arguments:  e.Args,
-		Privileged: &e.Privileged,
-		User:       e.User,
-	}
 }

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -3,18 +3,9 @@ package daemon
 import (
 	"github.com/moby/moby/api/types/container"
 	containerpkg "github.com/moby/moby/v2/daemon/container"
-	"github.com/moby/moby/v2/daemon/server/backend"
 )
 
 // This sets platform-specific fields
 func setPlatformSpecificContainerFields(container *containerpkg.Container, contJSONBase *container.ContainerJSONBase) *container.ContainerJSONBase {
 	return contJSONBase
-}
-
-func inspectExecProcessConfig(e *containerpkg.ExecConfig) *backend.ExecProcessConfig {
-	return &backend.ExecProcessConfig{
-		Tty:        e.Tty,
-		Entrypoint: e.Entrypoint,
-		Arguments:  e.Args,
-	}
 }


### PR DESCRIPTION
This function was introduced in 1af76ef5970202bdbc7024d825c0fcfcc4ec6ede and based on the previous code in the daemon, which had platform-specific handling for exec inspect in [setPlatformSpecificExecProcessConfig], which was added in 5fa2e4d4f2be7787ad29b1e6ffd9c026ea0c1925 to account for Windows not having "Privileged" and not setting the "User".

Given that "User" would be empty and "Privileged" not set, we may as well combine both platforms, and just return the info we have.

[setPlatformSpecificExecProcessConfig]: https://github.com/moby/moby/blob/1af76ef5970202bdbc7024d825c0fcfcc4ec6ede/daemon/exec_unix.go#L11-L21


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

