### PR TITLE
build: device entitlement support

### DIFF
--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -135,6 +135,7 @@ type BuilderHistoryConfig struct {
 type BuilderEntitlements struct {
 	NetworkHost      *bool `json:"network-host,omitempty"`
 	SecurityInsecure *bool `json:"security-insecure,omitempty"`
+	Device           *bool `json:"device,omitempty"`
 }
 
 // BuilderConfig contains config for the builder

--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -537,12 +537,16 @@ func parseGCPolicy(p config.BuilderGCRule, prefix string) (reservedSpace, maxUse
 
 func getEntitlements(conf config.BuilderConfig) []string {
 	var ents []string
-	// Incase of no config settings, NetworkHost should be enabled & SecurityInsecure must be disabled.
+	// In case of no config settings, NetworkHost and Device should be enabled
+	// but SecurityInsecure must be disabled.
 	if conf.Entitlements.NetworkHost == nil || *conf.Entitlements.NetworkHost {
 		ents = append(ents, string(entitlements.EntitlementNetworkHost))
 	}
 	if conf.Entitlements.SecurityInsecure != nil && *conf.Entitlements.SecurityInsecure {
 		ents = append(ents, string(entitlements.EntitlementSecurityInsecure))
+	}
+	if conf.Entitlements.Device == nil || *conf.Entitlements.Device {
+		ents = append(ents, string(entitlements.EntitlementDevice))
 	}
 	return ents
 }


### PR DESCRIPTION
follow-up:
* https://github.com/moby/buildkit/pull/6080
* https://github.com/docker/buildx/issues/3295#issuecomment-3036696549

Adds `device` entitlement support in Docker daemon configuration. This entitlement is enabled by default to match current behavior in moby when requesting devices.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add `device` entitlement to builder configuration
```

**- A picture of a cute animal (not mandatory but encouraged)**

