### PR TITLE
integration/container: fix flaky TestRemoveContainerWithVolume

### DIFF
--- a/integration/container/remove_test.go
+++ b/integration/container/remove_test.go
@@ -6,8 +6,6 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -57,24 +55,24 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
 
-	cID := container.Run(ctx, t, apiClient, container.WithCmd("true"), container.WithVolume(prefix+slash+"srv"))
-	poll.WaitOn(t, container.IsInState(ctx, apiClient, cID, containertypes.StateExited))
+	cID := container.Run(ctx, t, apiClient, container.WithVolume(prefix+slash+"srv"))
 
 	ctrInspect, err := apiClient.ContainerInspect(ctx, cID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(1, len(ctrInspect.Mounts)))
 	volName := ctrInspect.Mounts[0].Name
 
+	_, err = apiClient.VolumeInspect(ctx, volName)
+	assert.NilError(t, err)
+
 	err = apiClient.ContainerRemove(ctx, cID, containertypes.RemoveOptions{
+		Force:         true,
 		RemoveVolumes: true,
 	})
 	assert.NilError(t, err)
 
-	volumes, err := apiClient.VolumeList(ctx, volume.ListOptions{
-		Filters: filters.NewArgs(filters.Arg("name", volName)),
-	})
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(0, len(volumes.Volumes)))
+	_, err = apiClient.VolumeInspect(ctx, volName)
+	assert.ErrorType(t, err, cerrdefs.IsNotFound, "Expected anonymous volume to be removed")
 }
 
 func TestRemoveContainerRunning(t *testing.T) {


### PR DESCRIPTION
- stacked on https://github.com/moby/moby/pull/50383

### integration/container: reduce flakiness of TestRemoveContainerWithVolume

This test depended on the container to die after running the `true` command,
but this condition failed frequently on Windows 2025.

    === Failed
    === FAIL: github.com/docker/docker/integration/container TestRemoveContainerWithVolume (32.68s)
        remove_test.go:61: timeout hit after 10s: waiting for container State.Status to be 'exited', currently 'running'

While this may be revealing an actual issue (and we should have a test for
that), it's irrelevant for this test, which;

- creates and starts a container with an anonymous volume
- verifies the anonymous volume was created
- removes the container
- verifies the anonymous volume was removed

We can force-remove the container to kill, and removed it; we probably
could've sufficed with "container create" (without starting), but it's
good to add extra coverage, in case running the container impacts whether
we're able to remove the volume.


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

