### PR TITLE
migrate test api images history integration cli test to integration test

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -61,32 +61,6 @@ func (s *DockerAPISuite) TestAPIImagesDelete(c *testing.T) {
 	assert.NilError(c, err)
 }
 
-func (s *DockerAPISuite) TestAPIImagesHistory(c *testing.T) {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	if testEnv.DaemonInfo.OSType != "windows" {
-		testRequires(c, Network)
-	}
-	name := "test-api-images-history"
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
-	id := getIDByName(c, name)
-
-	historydata, err := apiClient.ImageHistory(testutil.GetContext(c), id)
-	assert.NilError(c, err)
-
-	assert.Assert(c, len(historydata) != 0)
-	var found bool
-	for _, tag := range historydata[0].Tags {
-		if tag == "test-api-images-history:latest" {
-			found = true
-			break
-		}
-	}
-	assert.Assert(c, found)
-}
-
 func (s *DockerAPISuite) TestAPIImagesImportBadSrc(c *testing.T) {
 	testRequires(c, Network, testEnv.IsLocalDaemon)
 

--- a/integration/image/history_test.go
+++ b/integration/image/history_test.go
@@ -1,0 +1,33 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/docker/docker/integration/internal/build"
+	"github.com/docker/docker/testutil/fakecontext"
+	"gotest.tools/v3/assert"
+)
+
+func TestAPIImagesHistory(t *testing.T) {
+	ctx := setupTest(t)
+	client := testEnv.APIClient()
+
+	dockerfile := "FROM busybox\nENV FOO bar"
+
+	imgID := build.Do(ctx, t, client, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)))
+
+	historydata, err := client.ImageHistory(ctx, imgID)
+	assert.NilError(t, err)
+
+	assert.Assert(t, len(historydata) != 0)
+
+	var found bool
+	for _, imageLayer := range historydata {
+		if imageLayer.ID == imgID {
+			found = true
+			break
+		}
+	}
+
+	assert.Assert(t, found)
+}

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -13,12 +13,10 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
-	buildImage "github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -314,30 +312,4 @@ func TestAPIImagesListManifests(t *testing.T) {
 			assert.Check(t, is.DeepEqual(mfst.ImageData.Containers, []string{cid}))
 		}
 	}
-}
-
-func TestAPIImagesHistory(t *testing.T) {
-	ctx := setupTest(t)
-
-	client := testEnv.APIClient()
-
-	dockerfile := "FROM busybox\nENV FOO bar"
-
-	imgID := buildImage.Do(ctx, t, client, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)))
-
-	historydata, err := client.ImageHistory(ctx, imgID)
-
-	assert.NilError(t, err)
-
-	assert.Assert(t, len(historydata) != 0)
-
-	var found bool
-	for _, imageLayer := range historydata {
-		if imageLayer.ID == imgID {
-			found = true
-			break
-		}
-	}
-
-	assert.Assert(t, found)
 }

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -13,10 +13,12 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
+	buildImage "github.com/docker/docker/integration/internal/build"
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/internal/testutils/specialimage"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
+	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
@@ -312,4 +314,30 @@ func TestAPIImagesListManifests(t *testing.T) {
 			assert.Check(t, is.DeepEqual(mfst.ImageData.Containers, []string{cid}))
 		}
 	}
+}
+
+func TestAPIImagesHistory(t *testing.T) {
+	ctx := setupTest(t)
+
+	client := testEnv.APIClient()
+
+	dockerfile := "FROM busybox\nENV FOO bar"
+
+	imgID := buildImage.Do(ctx, t, client, fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile)))
+
+	historydata, err := client.ImageHistory(ctx, imgID)
+
+	assert.NilError(t, err)
+
+	assert.Assert(t, len(historydata) != 0)
+
+	var found bool
+	for _, imageLayer := range historydata {
+		if imageLayer.ID == imgID {
+			found = true
+			break
+		}
+	}
+
+	assert.Assert(t, found)
 }


### PR DESCRIPTION
**- What I did**

Migrated the TestAPIImagesHistory to integration tests in reference to the integration-cli migration epic #50159 

**- How I did it**

I leveraged the integration/internal/build package to build an image and tested the imageHistory on it

**- How to verify it**
Run the integration test as follows

``` TEST_INTEGRATION_DIR=./integration/image TESTFLAGS='-test.run TestAPIImagesHistory' ./hack/make.sh dynbinary test-integration ```

**- Human readable description for the release notes**
```
```

**- A picture of a cute animal (not mandatory but encouraged)**

