### PR TITLE
Don't log a warning when stopping a stopped docker-proxy

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -799,7 +799,7 @@ func releasePortBindings(pbs []portBinding, fwn firewaller.Network) error {
 			}
 		}
 		if pb.stopProxy != nil {
-			if err := pb.stopProxy(); err != nil {
+			if err := pb.stopProxy(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 				errs = append(errs, fmt.Errorf("failed to stop userland proxy for port mapping %s: %w", pb, err))
 			}
 		}


### PR DESCRIPTION
**- What I did**

@thaJeztah noticed that when stopping the daemon with ctrl-C while a container was running, it logged this ...

```
ERRO[2025-07-11T16:00:38.144805542Z] Failed to release port bindings               eid=605e81843598 ep=hopeful_booth error="failed to stop userland proxy for port mapping 127.0.0.1:5001:172.18.0.2:5000/tcp: os: process already finished" gw4=false gw6=false net=bridge nid=22848982e1b2
WARN[2025-07-11T16:00:38.144855334Z] driver failed revoking external connectivity on endpoint  eid=605e818435988881598d0438eddbd93fae7c78ab658db4f6ebc969c743e208c8 ep=hopeful_booth error="failed to stop userland proxy for port mapping 127.0.0.1:5001:172.18.0.2:5000/tcp: os: process already finished" net=bridge nid=22848982e1b25feb00dccddaa3957a7869a45fc8654818cd44710f550eb22fed
```

It's nothing new - v27.0.1 does the same. I've not checked older builds, but don't think it's changed for a long time.

Apart from the disconcerting log messages, it's harmless - the error is only logged, cleanup completes as normal.

The ctrl-C [stops the proxy process](https://github.com/moby/moby/blob/381d9d072304482dcb5f3885a0690ad615cf81d7/libnetwork/portmapper/proxy_linux.go#L49-L69), so it's already stopped when the bridge driver tries to `SIGINT` it.

Also - when a docker-proxy exits unexpectedly, we don't currently log anything - we should.

**- How I did it**

- Log a message when the process exits, but wasn't stopped by the bridge driver.
- Don't treat `os.ErrProcessDone` as an error when trying to stop the proxy.

**- How to verify it**

Run a container with a port mapping, then kill a `docker-proxy` process. It should log something like ...

```
INFO[2025-07-11T17:31:28.015970800Z] Userland proxy exited early (this is expected during daemon shutdown)  container-ip=172.18.0.2 container-port=80 host-ip="::" host-port=32768 proto=tcp
```

Ctrl-C-ing the daemon when a container's running with a port mapping should log a similar message.

Stopping a container with a port mapping shouldn't log anything proxy-related.

**- Human readable description for the release notes**
```markdown changelog

```

