### PR TITLE
minor cleanups and reduce logs in tests

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1140,7 +1140,7 @@ func (s *DockerNetworkSuite) TestDockerNetworkHostModeUngracefulDaemonRestart(c 
 
 	// Kill daemon ungracefully and restart
 	assert.NilError(c, s.d.Kill())
-	s.d.Restart(c)
+	s.d.Start(c)
 
 	// make sure all the containers are up and running
 	for i := 0; i < 10; i++ {

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -732,7 +732,7 @@ func (d *Daemon) StopWithError() (retErr error) {
 	d.log.Logf("[%s] stopping daemon", d.id)
 
 	if err := d.cmd.Process.Signal(os.Interrupt); err != nil {
-		if strings.Contains(err.Error(), "os: process already finished") {
+		if errors.Is(err, os.ErrProcessDone) {
 			return errDaemonNotStarted
 		}
 		return errors.Wrapf(err, "[%s] could not send signal", d.id)

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -155,7 +155,7 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 
 	if d.resolvConfContent != "" {
 		path := filepath.Join(d.Folder, "resolv.conf")
-		if err := os.WriteFile(path, []byte(d.resolvConfContent), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(d.resolvConfContent), 0o644); err != nil {
 			return nil, fmt.Errorf("failed to write docker resolv.conf to %q: %v", path, err)
 		}
 		d.extraEnv = append(d.extraEnv, "DOCKER_TEST_RESOLV_CONF_PATH="+path)

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -692,12 +692,8 @@ func (d *Daemon) DumpStackAndQuit() {
 func (d *Daemon) Stop(t testing.TB) {
 	t.Helper()
 	err := d.StopWithError()
-	if err != nil {
-		if !errors.Is(err, errDaemonNotStarted) {
-			t.Fatalf("[%s] error while stopping the daemon: %v", d.id, err)
-		} else {
-			t.Logf("[%s] daemon is not started", d.id)
-		}
+	if err != nil && !errors.Is(err, errDaemonNotStarted) {
+		t.Fatalf("[%s] error while stopping the daemon: %v", d.id, err)
 	}
 }
 


### PR DESCRIPTION
### testutil/daemon: gofumpt

### testutil/daemon: remove string-matching for error

### integration-cli: TestDockerNetworkHostModeUngracefulDaemonRestart start, not restart

This test was testing a non-gracceful kill od the daemon, after which it
started it again, however `d.Stop()` would log that the daemon wasn't running,
which is expected, so let's reduce noise;

    docker_cli_network_unix_test.go:1143: [dadd2ae3b638b] daemon is not started

### testutil/daemon: Daemon.Stop() don't log when already stopped

`Daemon.Stop()` is called in teardown of tests, resulting in a lot of noise;

    docker_cli_network_unix_test.go:52: [d124e10f67e01] daemon is not started
    docker_cli_network_unix_test.go:1143: [dadd2ae3b638b] daemon is not started
    docker_cli_external_volume_driver_test.go:59: [d50e371ba1d6f] daemon is not started

Let's ignore if the daemon is already stopped, as that's what we want to here.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

