### PR TITLE
pkg/system: deprecate EscapeArgs, IsAbs and move them internal

### DIFF
--- a/builder/dockerfile/builder_windows.go
+++ b/builder/dockerfile/builder_windows.go
@@ -1,8 +1,26 @@
 package dockerfile
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 func defaultShellForOS(os string) []string {
 	if os == "linux" {
 		return []string{"/bin/sh", "-c"}
 	}
 	return []string{"cmd", "/S", "/C"}
+}
+
+// isAbs is a platform-agnostic wrapper for filepath.IsAbs.
+//
+// On Windows, golang filepath.IsAbs does not consider a path \windows\system32
+// as absolute as it doesn't start with a drive-letter/colon combination. However,
+// in docker we need to verify things such as WORKDIR /windows/system32 in
+// a Dockerfile (which gets translated to \windows\system32 when being processed
+// by the daemon). This SHOULD be treated as absolute from a docker processing
+// perspective.
+func isAbs(path string) bool {
+	return filepath.IsAbs(path) || strings.HasPrefix(path, string(os.PathSeparator))
 }

--- a/builder/dockerfile/copy_windows.go
+++ b/builder/dockerfile/copy_windows.go
@@ -107,10 +107,10 @@ func normalizeDest(workingDir, requested string) (string, error) {
 
 	// Cannot handle relative where WorkingDir is not the system drive.
 	if len(workingDir) > 0 {
-		if ((len(workingDir) > 1) && !system.IsAbs(workingDir[2:])) || (len(workingDir) == 1) {
+		if ((len(workingDir) > 1) && !isAbs(workingDir[2:])) || (len(workingDir) == 1) {
 			return "", fmt.Errorf("Current WorkingDir %s is not platform consistent", workingDir)
 		}
-		if !system.IsAbs(dest) {
+		if !isAbs(dest) {
 			if string(workingDir[0]) != "C" {
 				return "", fmt.Errorf("Windows does not support relative paths when WORKDIR is not the system drive")
 			}

--- a/builder/dockerfile/dispatchers_windows.go
+++ b/builder/dockerfile/dispatchers_windows.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/internal/lazyregexp"
-	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 )
 
@@ -83,7 +82,7 @@ func normalizeWorkdirWindows(current string, requested string) (string, error) {
 	//	WORKDIR C:/foo \ WORKDIR bar    --> C:\foo --> C:\foo\bar
 	//	WORKDIR C:/foo \ WORKDIR \\bar  --> C:\foo --> C:\bar
 	//	WORKDIR /foo \ WORKDIR c:/bar   --> C:\foo --> C:\bar
-	if len(current) == 0 || system.IsAbs(requested) {
+	if len(current) == 0 || isAbs(requested) {
 		if (requested[0] == os.PathSeparator) ||
 			(len(requested) > 1 && string(requested[1]) != ":") ||
 			(len(requested) == 1) {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/containerd/log"
@@ -19,7 +20,6 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/oci/caps"
 	"github.com/docker/docker/opts"
-	"github.com/docker/docker/pkg/system"
 	volumemounts "github.com/docker/docker/volume/mounts"
 	"github.com/docker/go-connections/nat"
 	"github.com/moby/sys/signal"
@@ -369,7 +369,7 @@ func translateWorkingDir(config *containertypes.Config) error {
 		return nil
 	}
 	wd := filepath.FromSlash(config.WorkingDir) // Ensure in platform semantics
-	if !system.IsAbs(wd) {
+	if !filepath.IsAbs(wd) && !strings.HasPrefix(wd, string(os.PathSeparator)) {
 		return fmt.Errorf("the working directory '%s' is invalid, it needs to be an absolute path", config.WorkingDir)
 	}
 	config.WorkingDir = filepath.Clean(wd)

--- a/daemon/internal/libcontainerd/local/local_windows.go
+++ b/daemon/internal/libcontainerd/local/local_windows.go
@@ -24,7 +24,6 @@ import (
 	"github.com/docker/docker/daemon/internal/libcontainerd/queue"
 	libcontainerdtypes "github.com/docker/docker/daemon/internal/libcontainerd/types"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/system"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
@@ -532,8 +531,17 @@ func setCommandLineAndArgs(process *specs.Process, createProcessParms *hcsshim.P
 	if process.CommandLine != "" {
 		createProcessParms.CommandLine = process.CommandLine
 	} else {
-		createProcessParms.CommandLine = system.EscapeArgs(process.Args)
+		createProcessParms.CommandLine = escapeArgs(process.Args)
 	}
+}
+
+// escapeArgs makes a Windows-style escaped command line from a set of arguments
+func escapeArgs(args []string) string {
+	escapedArgs := make([]string, len(args))
+	for i, a := range args {
+		escapedArgs[i] = windows.EscapeArg(a)
+	}
+	return strings.Join(escapedArgs, " ")
 }
 
 func newIOFromProcess(newProcess hcsshim.Process, terminal bool) (*cio.DirectIO, error) {

--- a/pkg/system/args_windows.go
+++ b/pkg/system/args_windows.go
@@ -7,6 +7,8 @@ import (
 )
 
 // EscapeArgs makes a Windows-style escaped command line from a set of arguments
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func EscapeArgs(args []string) string {
 	escapedArgs := make([]string, len(args))
 	for i, a := range args {

--- a/pkg/system/filesys.go
+++ b/pkg/system/filesys.go
@@ -14,6 +14,8 @@ import (
 // a Dockerfile (which gets translated to \windows\system32 when being processed
 // by the daemon). This SHOULD be treated as absolute from a docker processing
 // perspective.
+//
+// Deprecated: this function was only used internally and will be removed in the next release.
 func IsAbs(path string) bool {
 	return filepath.IsAbs(path) || strings.HasPrefix(path, string(os.PathSeparator))
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: pkg/system: deprecate `EscapeArgs()` and `IsAbs`. These functions were only used internally and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

