### PR TITLE
api/types/container: remove deprecated ContainerUpdateOKBody, ContainerTopOKBody

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -10,11 +10,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// ContainerUpdateOKBody OK response to ContainerUpdate operation
-//
-// Deprecated: use [UpdateResponse]. This alias will be removed in the next release.
-type ContainerUpdateOKBody = UpdateResponse
-
 // ContainerTopOKBody OK response to ContainerTop operation
 //
 // Deprecated: use [TopResponse]. This alias will be removed in the next release.

--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -10,11 +10,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// ContainerTopOKBody OK response to ContainerTop operation
-//
-// Deprecated: use [TopResponse]. This alias will be removed in the next release.
-type ContainerTopOKBody = TopResponse
-
 // PruneReport contains the response for Engine API:
 // POST "/containers/prune"
 type PruneReport struct {


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/49442


### api/types/container: remove deprecated ContainerUpdateOKBody alias

This was deprecated in f4dc38cd36a929eb2f1f07177cd60411eeb5ec6a, which
was part of v28, so we can remove it for v29


### api/types/container: remove deprecated ContainerTopOKBody alias

This was deprecated in be1ac5d8e5cbcd9223df36007024795919ebdd01, which
was part of v28, so we can remove it for v29

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Go SDK: api/types/container: remove deprecated `ContainerUpdateOKBody` alias.
- Go SDK: api/types/container: remove deprecated `ContainerTopOKBody` alias.
```

**- A picture of a cute animal (not mandatory but encouraged)**

