### PR TITLE
Dockerfile: upgrade Delve to v1.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ ARG DOCKER_STATIC=1
 ARG REGISTRY_VERSION=3.0.0
 
 # delve is currently only supported on linux/amd64 and linux/arm64;
-# https://github.com/go-delve/delve/blob/v1.24.1/pkg/proc/native/support_sentinel.go#L1
-# https://github.com/go-delve/delve/blob/v1.24.1/pkg/proc/native/support_sentinel_linux.go#L1
+# https://github.com/go-delve/delve/blob/v1.25.0/pkg/proc/native/support_sentinel.go#L1
+# https://github.com/go-delve/delve/blob/v1.25.0/pkg/proc/native/support_sentinel_linux.go#L1
 #
 # ppc64le support was added in v1.21.1, but is still experimental, and requires
 # the "-tags exp.linuxppc64le" build-tag to be set:
@@ -135,7 +135,7 @@ RUN git init . && git remote add origin "https://github.com/go-delve/delve.git"
 # from the https://github.com/go-delve/delve repository.
 # It can be used to run Docker with a possibility of
 # attaching debugger to it.
-ARG DELVE_VERSION=v1.24.1
+ARG DELVE_VERSION=v1.25.0
 RUN git fetch -q --depth 1 origin "${DELVE_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS delve-supported


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50313

Update to the latest version:

- https://github.com/go-delve/delve/releases/tag/v1.25.0
- https://github.com/go-delve/delve/blob/v1.25.0/CHANGELOG.md#1250-2025-04-16

Also update links to supported platforms.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

