### PR TITLE
registry: replace pkg/homedir.GetConfigHome for os.UserConfigDir

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/internal/lazyregexp"
-	"github.com/docker/docker/pkg/homedir"
 )
 
 // ServiceOptions holds command line options.
@@ -66,7 +65,7 @@ var (
 //
 // [rootless.RunningWithRootlessKit]: https://github.com/moby/moby/blob/b4bdf12daec84caaf809a639f923f7370d4926ad/pkg/rootless/rootless.go#L5-L8
 func runningWithRootlessKit() bool {
-	return os.Getenv("ROOTLESSKIT_STATE_DIR") != ""
+	return runtime.GOOS == "linux" && os.Getenv("ROOTLESSKIT_STATE_DIR") != ""
 }
 
 // CertsDir is the directory where certificates are stored.
@@ -79,7 +78,7 @@ func runningWithRootlessKit() bool {
 func CertsDir() string {
 	certsDir := "/etc/docker/certs.d"
 	if runningWithRootlessKit() {
-		if configHome, _ := homedir.GetConfigHome(); configHome != "" {
+		if configHome, _ := os.UserConfigDir(); configHome != "" {
 			certsDir = filepath.Join(configHome, "docker", "certs.d")
 		}
 	} else if runtime.GOOS == "windows" {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/49873


The registry package is used in docker/cli, and currently depends on pkg/homedir. This package was anly used when running with rootlesskit, which only is supported on Linux; on other platforms, homedir.GetConfigHome would return an error;
https://github.com/moby/moby/blob/abba330bbfe10765822b59bb68af99db439736ba/pkg/homedir/homedir_others.go#L24-L27

Replace homedir.GetConfigHome with os.UserConfigDir from stdlib, which is similar, with exception of not falling back to `getent` for resolving the user's homedir, which would be a corner-case.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

