### PR TITLE
api: bump to 1.52

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,7 +3,7 @@ package api
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of the current REST API.
-	DefaultVersion = "1.51"
+	DefaultVersion = "1.52"
 
 	// MinSupportedAPIVersion is the minimum API version that can be supported
 	// by the API server, specified as "major.minor". Note that the daemon

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.51"
+basePath: "/v1.52"
 info:
   title: "Docker Engine API"
-  version: "1.51"
+  version: "1.52"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -56,7 +56,7 @@ info:
     is returned.
 
     If you omit the version-prefix, the current version of the API (v1.50) is used.
-    For example, calling `/info` is the same as calling `/v1.51/info`. Using the
+    For example, calling `/info` is the same as calling `/v1.52/info`. Using the
     API without a version-prefix is deprecated and will be removed in a future release.
 
     Engine releases in the near future should support this version of the API,

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -13,6 +13,11 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.52 API changes
+
+[Docker Engine API v1.52](https://docs.docker.com/reference/api/engine/version/v1.52/) documentation
+
+
 ## v1.51 API changes
 
 [Docker Engine API v1.51](https://docs.docker.com/reference/api/engine/version/v1.51/) documentation


### PR DESCRIPTION
All changes targeting 29.0.0 will be a part of the API 1.52.

```markdown changelog
Update API version to 1.52
```