### PR TITLE
libnet/pms/proxy: Add a proxy portmapper

### DIFF
--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -72,6 +72,7 @@ type Info struct {
 	ProductLicense      string               `json:",omitempty"`
 	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
 	FirewallBackend     *FirewallInfo        `json:"FirewallBackend,omitempty"`
+	DefaultPortMapper   string               `json:",omitempty"`
 	CDISpecDirs         []string
 	DiscoveredDevices   []DeviceInfo `json:",omitempty"`
 

--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -40,6 +40,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", conf.BridgeConfig.UserlandProxyPath, "Path to the userland proxy binary")
 	flags.BoolVar(&conf.BridgeConfig.AllowDirectRouting, "allow-direct-routing", false, "Allow remote access to published ports on container IP addresses")
 	flags.StringVar(&conf.BridgeConfig.BridgeAcceptFwMark, "bridge-accept-fwmark", "", "In bridge networks, accept packets with this firewall mark/mask")
+	flags.StringVar(&conf.DefaultPortMapper, "default-port-mapper", "", "Default port-mapper to use for publishing ports (by default, nat for gw_mode=nat, and routed for gw_mode=routed)")
 	flags.StringVar(&conf.CgroupParent, "cgroup-parent", "", "Set parent cgroup for all containers")
 	flags.StringVar(&conf.RemappedRoot, "userns-remap", "", "User/Group setting for user namespaces")
 	flags.BoolVar(&conf.LiveRestoreEnabled, "live-restore", false, "Enable live restore of docker when containers are still running")

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/log"
 	"github.com/docker/docker/daemon/libnetwork/drivers/bridge"
+	"github.com/docker/docker/daemon/libnetwork/portmappers/proxy"
 	"github.com/docker/docker/daemon/pkg/opts"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/pkg/rootless"
@@ -255,6 +256,9 @@ func validatePlatformConfig(conf *Config) error {
 	if err := validateFwMarkMask(conf.BridgeAcceptFwMark); err != nil {
 		return errors.Wrap(err, "invalid bridge-accept-fwmark")
 	}
+	if err := validateDefaultPortMapper(conf.DefaultPortMapper, conf.Rootless); err != nil {
+		return errors.Wrap(err, "invalid default-port-mapper")
+	}
 	return verifyDefaultCgroupNsMode(conf.CgroupNamespaceMode)
 }
 
@@ -326,6 +330,21 @@ func validateFwMarkMask(val string) error {
 		if _, err := strconv.ParseUint(mask, 0, 32); err != nil {
 			return fmt.Errorf("invalid firewall mask %q: %w", val, err)
 		}
+	}
+	return nil
+}
+
+func validateDefaultPortMapper(val string, rootless bool) error {
+	if val == "" {
+		return nil
+	}
+	// The proxy portmapper is intended for use on rootful systems with UFW, as
+	// a workaround for UFW's inability to cope with NATed ports.
+	//
+	// Proxying instead of NATing ports in rootless environments would provide
+	// no benefits and inferior performance — disallow this combination.
+	if val == proxy.DriverName && rootless {
+		return errors.New("proxy mapper is not compatible with rootless mode")
 	}
 	return nil
 }

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -51,6 +51,7 @@ type BridgeConfig struct {
 	UserlandProxyPath        string `json:"userland-proxy-path,omitempty"`
 	AllowDirectRouting       bool   `json:"allow-direct-routing,omitempty"`
 	BridgeAcceptFwMark       string `json:"bridge-accept-fwmark,omitempty"`
+	DefaultPortMapper        string `json:"default-port-mapper,omitempty"`
 }
 
 // DefaultBridgeConfig stores all the parameters for the default bridge network.

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -939,6 +939,7 @@ func networkPlatformOptions(conf *config.Config) []nwconfig.Option {
 				"Hairpin":                  !conf.EnableUserlandProxy || conf.UserlandProxyPath == "",
 				"AllowDirectRouting":       conf.BridgeConfig.AllowDirectRouting,
 				"AcceptFwMark":             conf.BridgeConfig.BridgeAcceptFwMark,
+				"DefaultPortMapper":        conf.BridgeConfig.DefaultPortMapper,
 			},
 		}),
 	}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -93,6 +93,7 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*system.Info, error) {
 	daemon.fillLicense(v)
 	daemon.fillDefaultAddressPools(ctx, v, &cfg.Config)
 	daemon.fillFirewallInfo(v)
+	daemon.fillDefaultPortMapper(v, &cfg.Config)
 	daemon.fillDiscoveredDevicesFromDrivers(ctx, v, &cfg.Config)
 
 	return v, nil
@@ -290,6 +291,13 @@ func (daemon *Daemon) fillFirewallInfo(v *system.Info) {
 		return
 	}
 	v.FirewallBackend = daemon.netController.FirewallBackend()
+}
+
+func (daemon *Daemon) fillDefaultPortMapper(v *system.Info, cfg *config.Config) {
+	if daemon.netController == nil {
+		return
+	}
+	v.DefaultPortMapper = cfg.DefaultPortMapper
 }
 
 func hostName(ctx context.Context) string {

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -78,6 +78,7 @@ type configuration struct {
 	Hairpin            bool
 	AllowDirectRouting bool
 	AcceptFwMark       string
+	DefaultPortMapper  string
 }
 
 // networkConfiguration for network specific configuration
@@ -490,6 +491,15 @@ func (n *bridgeNetwork) portMappers() *drvregistry.PortMappers {
 		return nil
 	}
 	return n.driver.portmappers
+}
+
+func (n *bridgeNetwork) defaultPortMapper() string {
+	n.Lock()
+	defer n.Unlock()
+	if n.driver == nil {
+		return ""
+	}
+	return n.driver.config.DefaultPortMapper
 }
 
 func (n *bridgeNetwork) getEndpoint(eid string) (*bridgeEndpoint, error) {

--- a/daemon/libnetwork/drivers_linux.go
+++ b/daemon/libnetwork/drivers_linux.go
@@ -16,8 +16,8 @@ import (
 	"github.com/docker/docker/daemon/libnetwork/drivers/overlay"
 	"github.com/docker/docker/daemon/libnetwork/drvregistry"
 	"github.com/docker/docker/daemon/libnetwork/internal/rlkclient"
-	"github.com/docker/docker/daemon/libnetwork/portmapper"
 	"github.com/docker/docker/daemon/libnetwork/portmappers/nat"
+	"github.com/docker/docker/daemon/libnetwork/portmappers/proxy"
 	"github.com/docker/docker/daemon/libnetwork/portmappers/routed"
 	"github.com/docker/docker/daemon/libnetwork/types"
 )
@@ -63,7 +63,7 @@ func registerPortMappers(ctx context.Context, r *drvregistry.PortMappers, cfg *c
 	if err := nat.Register(r, nat.Config{
 		RlkClient: pdc,
 		StartProxy: func(pb types.PortBinding, file *os.File) (func() error, error) {
-			return portmapper.StartProxy(pb, cfg.UserlandProxyPath, file)
+			return proxy.StartProxy(pb, cfg.UserlandProxyPath, file)
 		},
 		EnableProxy: cfg.EnableUserlandProxy && cfg.UserlandProxyPath != "",
 	}); err != nil {

--- a/daemon/libnetwork/drivers_linux.go
+++ b/daemon/libnetwork/drivers_linux.go
@@ -72,5 +72,9 @@ func registerPortMappers(ctx context.Context, r *drvregistry.PortMappers, cfg *c
 		return fmt.Errorf("registering routed portmapper: %w", err)
 	}
 
+	if err := proxy.Register(r, proxyMgr); err != nil {
+		return fmt.Errorf("registering proxy portmapper: %w", err)
+	}
+
 	return nil
 }

--- a/daemon/libnetwork/portmapperapi/api.go
+++ b/daemon/libnetwork/portmapperapi/api.go
@@ -112,9 +112,9 @@ type PortBinding struct {
 	// PortDriverRemove is a function that will inform the RootlessKit
 	// port driver about removal of a port binding, or nil.
 	PortDriverRemove func() error `json:"-"`
-	// StopProxy is a function to stop the userland proxy for this binding,
-	// if a proxy has been started - else nil.
-	StopProxy func() error `json:"-"`
+	// Proxy is the userland proxy for this binding, if a proxy has been
+	// started - else nil.
+	Proxy Proxy `json:"-"`
 	// RootlesskitUnsupported is set to true when the port binding is not
 	// supported by the port driver of RootlessKit.
 	RootlesskitUnsupported bool `json:"-"`

--- a/daemon/libnetwork/portmapperapi/proxy.go
+++ b/daemon/libnetwork/portmapperapi/proxy.go
@@ -1,0 +1,18 @@
+package portmapperapi
+
+import (
+	"os"
+
+	"github.com/docker/docker/daemon/libnetwork/types"
+)
+
+type ProxyManager interface {
+	// StartProxy starts the proxy process for the given port binding.
+	StartProxy(pb types.PortBinding, listenSock *os.File) (Proxy, error)
+}
+
+// Proxy represents the userland proxy started for a specific port binding.
+type Proxy interface {
+	// Stop stops the userland proxy process.
+	Stop() error
+}

--- a/daemon/libnetwork/portmappers/proxy/mapper_linux.go
+++ b/daemon/libnetwork/portmappers/proxy/mapper_linux.go
@@ -1,0 +1,220 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.23
+
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/containerd/log"
+	"github.com/docker/docker/daemon/libnetwork/portallocator"
+	"github.com/docker/docker/daemon/libnetwork/portmapperapi"
+	"github.com/docker/docker/daemon/libnetwork/types"
+	"github.com/docker/docker/internal/sliceutil"
+)
+
+const (
+	DriverName              = "proxy"
+	maxAllocatePortAttempts = 10
+)
+
+func Register(r portmapperapi.Registerer, proxyMgr ProxyManager) error {
+	return r.Register(DriverName, NewPortMapper(proxyMgr))
+}
+
+var _ portmapperapi.PortMapper = (*PortMapper)(nil)
+
+type PortMapper struct {
+	proxyMgr portmapperapi.ProxyManager
+}
+
+func NewPortMapper(proxyMgr portmapperapi.ProxyManager) *PortMapper {
+	return &PortMapper{
+		proxyMgr: proxyMgr,
+	}
+}
+
+// MapPorts allocates and binds host ports for the given reqs. The caller is
+// responsible for ensuring that all entries in reqs map the same proto,
+// container port, and host port range (their host addresses must differ).
+func (pm PortMapper) MapPorts(
+	ctx context.Context,
+	reqs []portmapperapi.PortBindingReq,
+	_ portmapperapi.Firewaller,
+) (_ []portmapperapi.PortBinding, retErr error) {
+	if len(reqs) == 0 {
+		return nil, nil
+	}
+	proto, port, hostPort, hostPortEnd := reqs[0].Proto, reqs[0].Port, reqs[0].HostPort, reqs[0].HostPortEnd
+	for _, req := range reqs[1:] {
+		if req.Proto != proto || req.Port != port || req.HostPort != hostPort || req.HostPortEnd != hostPortEnd {
+			return nil, types.InternalErrorf("port binding mismatch %d/%s:%d-%d, %d/%s:%d-%d",
+				port, proto, hostPort, hostPortEnd,
+				port, req.Proto, req.HostPort, req.HostPortEnd)
+		}
+	}
+
+	var bindings []portmapperapi.PortBinding
+	defer func() {
+		if retErr != nil {
+			if err := pm.unmapPorts(bindings); err != nil {
+				log.G(ctx).WithFields(log.Fields{
+					"pbs":   bindings,
+					"error": err,
+				}).Warn("Failed to release port bindings")
+			}
+		}
+	}()
+
+	// Try up to maxAllocatePortAttempts times to get a port that's not already allocated.
+	var err error
+	for i := 0; i < maxAllocatePortAttempts; i++ {
+		bindings, err = pm.attemptBindHostPorts(ctx, reqs, proto, hostPort, hostPortEnd)
+		if err == nil {
+			break
+		}
+		// There is no point in immediately retrying to map an explicitly chosen port.
+		if hostPort != 0 && hostPort == hostPortEnd {
+			log.G(ctx).WithError(err).Warnf("Failed to allocate and map port")
+			return nil, err
+		}
+		log.G(ctx).WithFields(log.Fields{
+			"error":   err,
+			"attempt": i + 1,
+		}).Warn("Failed to allocate and map port")
+	}
+
+	if err != nil {
+		// If the retry budget is exhausted and no free port could be found, return
+		// the latest error.
+		return nil, err
+	}
+
+	// Start userland proxy processes.
+	for i := range bindings {
+		var err error
+		bindings[i].Proxy, err = pm.proxyMgr.StartProxy(bindings[i].PortBinding, bindings[i].BoundSocket)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start userland proxy for port mapping %s: %w",
+				bindings[i].PortBinding, err)
+		}
+		if err := bindings[i].BoundSocket.Close(); err != nil {
+			log.G(ctx).WithFields(log.Fields{
+				"error":   err,
+				"mapping": bindings[i].PortBinding,
+			}).Warnf("failed to close proxy socket")
+		}
+		bindings[i].BoundSocket = nil
+	}
+
+	return bindings, nil
+}
+
+// attemptBindHostPorts allocates host ports for each proxied port mapping, and
+// reserves those ports by binding them.
+//
+// If the allocator doesn't have an available port in the required range, or the
+// port can't be bound (perhaps because another process has already bound it),
+// all resources are released and an error is returned. When ports are
+// successfully reserved, a PortBinding is returned for each mapping.
+func (pm PortMapper) attemptBindHostPorts(
+	ctx context.Context,
+	reqs []portmapperapi.PortBindingReq,
+	proto types.Protocol,
+	hostPortStart, hostPortEnd uint16,
+) (_ []portmapperapi.PortBinding, retErr error) {
+	addrs := sliceutil.Map(reqs, func(req portmapperapi.PortBindingReq) net.IP {
+		return req.HostIP
+	})
+
+	pa := portallocator.NewOSAllocator()
+	port, socks, err := pa.RequestPortsInRange(addrs, proto, int(hostPortStart), int(hostPortEnd))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			pa.ReleasePorts(addrs, proto, port)
+		}
+	}()
+
+	res := make([]portmapperapi.PortBinding, 0, len(reqs))
+	defer func() {
+		if retErr != nil {
+			if err := pm.unmapPorts(res); err != nil {
+				log.G(ctx).WithFields(log.Fields{
+					"pbs":   res,
+					"error": err,
+				}).Warn("Failed to release port bindings")
+			}
+		}
+	}()
+
+	for i := range reqs {
+		pb := portmapperapi.PortBinding{
+			PortBinding: reqs[i].PortBinding.GetCopy(),
+			BoundSocket: socks[i],
+		}
+		pb.PortBinding.HostPort = uint16(port)
+		pb.PortBinding.HostPortEnd = pb.HostPort
+		res = append(res, pb)
+	}
+
+	if err := listenBoundPorts(res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func listenBoundPorts(pbs []portmapperapi.PortBinding) error {
+	for i := range pbs {
+		if pbs[i].Proto == types.UDP {
+			continue
+		}
+		rc, err := pbs[i].BoundSocket.SyscallConn()
+		if err != nil {
+			return fmt.Errorf("raw conn not available on %d socket: %w", pbs[i].Proto, err)
+		}
+		if errC := rc.Control(func(fd uintptr) {
+			somaxconn := 0
+			// SCTP sockets do not support somaxconn=0
+			if pbs[i].Proto == types.SCTP {
+				somaxconn = -1 // silently capped to "/proc/sys/net/core/somaxconn"
+			}
+			err = syscall.Listen(int(fd), somaxconn)
+		}); errC != nil {
+			return fmt.Errorf("failed to Control %s socket: %w", pbs[i].Proto, err)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s socket: %w", pbs[i].Proto, err)
+		}
+	}
+	return nil
+}
+
+func (pm PortMapper) UnmapPorts(_ context.Context, pbs []portmapperapi.PortBinding, _ portmapperapi.Firewaller) error {
+	return pm.unmapPorts(pbs)
+}
+
+func (pm PortMapper) unmapPorts(pbs []portmapperapi.PortBinding) error {
+	var errs []error
+	for _, pb := range pbs {
+		if pb.BoundSocket != nil {
+			if err := pb.BoundSocket.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to close socket for port mapping %s: %w", pb, err))
+			}
+		}
+		if pb.Proxy != nil {
+			if err := pb.Proxy.Stop(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to stop userland proxy: %w", err))
+			}
+		}
+
+		portallocator.Get().ReleasePort(pb.HostIP, pb.Proto.String(), int(pb.HostPort))
+	}
+	return errors.Join(errs...)
+}

--- a/daemon/libnetwork/portmappers/proxy/mapper_linux_test.go
+++ b/daemon/libnetwork/portmappers/proxy/mapper_linux_test.go
@@ -1,0 +1,182 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/daemon/libnetwork/portmapperapi"
+	"github.com/docker/docker/daemon/libnetwork/types"
+	"github.com/docker/docker/internal/sliceutil"
+	"github.com/docker/docker/internal/testutils/netnsutils"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestPortMapping(t *testing.T) {
+	ctrIP4 := net.ParseIP("10.0.10.1")
+
+	testcases := []struct {
+		name         string
+		busyPortIPv4 int
+		reqs         []portmapperapi.PortBindingReq
+
+		expErr        string
+		expPBs        []types.PortBinding
+		expReleaseErr string
+	}{
+		{
+			name: "successful mapping",
+			reqs: []portmapperapi.PortBindingReq{
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv4zero, HostPort: 9000, HostPortEnd: 9000}},
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv6zero, HostPort: 9000, HostPortEnd: 9000}},
+			},
+			expPBs: []types.PortBinding{
+				{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv4zero, HostPort: 9000, HostPortEnd: 9000},
+				{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv6zero, HostPort: 9000, HostPortEnd: 9000},
+			},
+		},
+		{
+			name:         "busy port",
+			busyPortIPv4: 9000,
+			reqs: []portmapperapi.PortBindingReq{
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv4zero, HostPort: 9000, HostPortEnd: 9001}},
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv6zero, HostPort: 9000, HostPortEnd: 9001}},
+			},
+			expPBs: []types.PortBinding{
+				{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv4zero, HostPort: 9001, HostPortEnd: 9001},
+				{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv6zero, HostPort: 9001, HostPortEnd: 9001},
+			},
+		},
+		{
+			name: "error unmapping ports",
+			reqs: []portmapperapi.PortBindingReq{
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv4zero, HostPort: 9000, HostPortEnd: 9001}},
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv6zero, HostPort: 9000, HostPortEnd: 9001}},
+			},
+			expPBs: []types.PortBinding{
+				{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv4zero, HostPort: 9000, HostPortEnd: 9000},
+				{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv6zero, HostPort: 9000, HostPortEnd: 9000},
+			},
+			expReleaseErr: "failed to stop userland proxy: can't stop now",
+		},
+		{
+			name:         "error mapping ports",
+			busyPortIPv4: 9000,
+			reqs: []portmapperapi.PortBindingReq{
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv4zero, HostPort: 9000, HostPortEnd: 9000}},
+				{PortBinding: types.PortBinding{Proto: types.TCP, IP: ctrIP4, Port: 9000, HostIP: net.IPv6zero, HostPort: 9000, HostPortEnd: 9000}},
+			},
+			expErr: "failed to bind host port 0.0.0.0:9000/tcp: address already in use",
+			expPBs: []types.PortBinding{},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer netnsutils.SetupTestOSContext(t)()
+
+			proxyMgr := stubProxyManager{
+				proxies:        make(map[proxyCall]*stubProxy),
+				runningProxies: make(map[proxyCall]bool),
+				busyPortIPv4:   tc.busyPortIPv4,
+				expReleaseErr:  tc.expReleaseErr,
+			}
+			pm := NewPortMapper(proxyMgr)
+
+			if tc.busyPortIPv4 != 0 {
+				tl, err := net.ListenTCP("tcp4", &net.TCPAddr{IP: net.IPv4zero, Port: tc.busyPortIPv4})
+				assert.NilError(t, err)
+				defer tl.Close()
+				ul, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: tc.busyPortIPv4})
+				assert.NilError(t, err)
+				defer ul.Close()
+			}
+
+			pbs, err := pm.MapPorts(context.Background(), tc.reqs, nil)
+			bindings := sliceutil.Map(pbs, func(pb portmapperapi.PortBinding) types.PortBinding { return pb.PortBinding })
+			assert.DeepEqual(t, tc.expPBs, bindings)
+
+			if tc.expErr != "" {
+				assert.ErrorContains(t, err, tc.expErr)
+				return
+			} else {
+				assert.NilError(t, err)
+			}
+
+			err = pm.UnmapPorts(context.Background(), pbs, nil)
+			if tc.expReleaseErr != "" {
+				assert.ErrorContains(t, err, tc.expReleaseErr)
+			} else {
+				assert.NilError(t, err)
+			}
+
+			// Check a docker-proxy was started and stopped for each expected port binding.
+			expProxies := map[proxyCall]bool{}
+			for _, expPB := range tc.expPBs {
+				p := newProxyCall(expPB.Proto.String(),
+					expPB.HostIP, int(expPB.HostPort),
+					expPB.IP, int(expPB.Port))
+				expProxies[p] = tc.expReleaseErr != ""
+			}
+			assert.Check(t, is.DeepEqual(expProxies, proxyMgr.runningProxies))
+		})
+	}
+}
+
+// Type for tracking calls to StartProxy.
+type proxyCall struct{ proto, host, container string }
+
+func newProxyCall(proto string,
+	hostIP net.IP, hostPort int,
+	containerIP net.IP, containerPort int,
+) proxyCall {
+	return proxyCall{
+		proto:     proto,
+		host:      fmt.Sprintf("%v:%v", hostIP, hostPort),
+		container: fmt.Sprintf("%v:%v", containerIP, containerPort),
+	}
+}
+
+type stubProxyManager struct {
+	busyPortIPv4   int
+	expReleaseErr  string
+	proxies        map[proxyCall]*stubProxy
+	runningProxies map[proxyCall]bool // proxy -> is not stopped
+}
+
+func (pm stubProxyManager) StartProxy(pb types.PortBinding, _ *os.File) (portmapperapi.Proxy, error) {
+	if pm.busyPortIPv4 > 0 && pm.busyPortIPv4 == int(pb.HostPort) && pb.HostIP.To4() != nil {
+		return nil, errors.New("busy port")
+	}
+	c := newProxyCall(pb.Proto.String(), pb.HostIP, int(pb.HostPort), pb.IP, int(pb.Port))
+	if _, ok := pm.proxies[c]; ok {
+		return nil, fmt.Errorf("duplicate proxy: %#v", c)
+	}
+	pm.proxies[c] = &stubProxy{
+		stop: func() error {
+			if pm.expReleaseErr != "" {
+				return errors.New("can't stop now")
+			}
+			if pm.proxies[c] == nil {
+				return errors.New("already stopped")
+			}
+			delete(pm.proxies, c)
+			pm.runningProxies[c] = false
+			return nil
+		},
+	}
+	pm.runningProxies[c] = true
+	return pm.proxies[c], nil
+}
+
+type stubProxy struct {
+	stop func() error
+}
+
+func (sp *stubProxy) Stop() error {
+	return sp.stop()
+}

--- a/daemon/libnetwork/portmappers/proxy/proxy_manager_linux.go
+++ b/daemon/libnetwork/portmappers/proxy/proxy_manager_linux.go
@@ -14,17 +14,29 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/daemon/libnetwork/portmapperapi"
 	"github.com/docker/docker/daemon/libnetwork/types"
 )
 
-// StartProxy starts the proxy process at proxyPath.
-// If listenSock is not nil, it must be a bound socket that can be passed to
-// the proxy process for it to listen on.
-func StartProxy(pb types.PortBinding,
-	proxyPath string,
+// ProxyManager is a struct that manages userland proxies.
+type ProxyManager struct {
+	ProxyPath string
+}
+
+type Proxy struct {
+	p       *os.Process
+	pidfd   int // pidfd might be -1 on systems that don't support it
+	wait    chan error
+	stopped *atomic.Bool
+}
+
+// StartProxy starts the proxy process. If listenSock is not nil, it must be a
+// bound socket that can be passed to the proxy process for it to listen on.
+func (pm ProxyManager) StartProxy(
+	pb types.PortBinding,
 	listenSock *os.File,
-) (stop func() error, retErr error) {
-	if proxyPath == "" {
+) (_ portmapperapi.Proxy, retErr error) {
+	if pm.ProxyPath == "" {
 		return nil, errors.New("no path provided for userland-proxy binary")
 	}
 	r, w, err := os.Pipe()
@@ -38,10 +50,11 @@ func StartProxy(pb types.PortBinding,
 		r.Close()
 	}()
 
+	var pidfd int
 	cmd := &exec.Cmd{
-		Path: proxyPath,
+		Path: pm.ProxyPath,
 		Args: []string{
-			proxyPath,
+			pm.ProxyPath,
 			"-proto", pb.Proto.String(),
 			"-host-ip", pb.HostIP.String(),
 			"-host-port", strconv.FormatUint(uint64(pb.HostPort), 10),
@@ -50,6 +63,7 @@ func StartProxy(pb types.PortBinding,
 		},
 		ExtraFiles: []*os.File{w},
 		SysProcAttr: &syscall.SysProcAttr{
+			PidFD:     &pidfd,
 			Pdeathsig: syscall.SIGTERM, // send a sigterm to the proxy if the creating thread in the daemon process dies (https://go.dev/issue/27505)
 		},
 	}
@@ -130,15 +144,37 @@ func StartProxy(pb types.PortBinding,
 		return nil, errors.New("timed out starting the userland proxy")
 	}
 
-	stopFn := func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		stopped.Store(true)
-		if err := cmd.Process.Signal(os.Interrupt); err != nil {
-			return err
-		}
-		return <-wait
+	return &Proxy{
+		p:       cmd.Process,
+		pidfd:   pidfd,
+		wait:    wait,
+		stopped: &stopped,
+	}, nil
+}
+
+// Stop stops the proxy process. It cannot be called multiple times — it'll
+// return a nil error on subsequent calls, irrespective of the original error.
+func (p *Proxy) Stop() error {
+	if p.p == nil || p.stopped.Load() {
+		return nil
 	}
-	return stopFn, nil
+
+	p.stopped.Store(true)
+	if err := p.p.Signal(os.Interrupt); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+
+	err := <-p.wait
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return err
+	}
+
+	wstatus := exitErr.Sys().(syscall.WaitStatus)
+	if wstatus.Signal() != os.Interrupt || wstatus.ExitStatus() > 0 {
+		return err
+	}
+
+	return nil
 }

--- a/daemon/libnetwork/portmappers/proxy/proxy_manager_linux.go
+++ b/daemon/libnetwork/portmappers/proxy/proxy_manager_linux.go
@@ -1,4 +1,4 @@
-package portmapper
+package proxy
 
 import (
 	"context"

--- a/daemon/libnetwork/portmappers/proxy/proxy_manager_linux_test.go
+++ b/daemon/libnetwork/portmappers/proxy/proxy_manager_linux_test.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/docker/docker/daemon/libnetwork/types"
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+)
+
+const proxyPath = "/usr/local/bin/docker-proxy"
+
+func TestStartAndStopProxy(t *testing.T) {
+	if _, err := os.Stat(proxyPath); err != nil {
+		t.Skipf("proxy binary %s not found", proxyPath)
+		return
+	}
+
+	pm := ProxyManager{ProxyPath: proxyPath}
+	proxy, err := pm.StartProxy(types.PortBinding{
+		Proto:    types.TCP,
+		IP:       net.ParseIP("127.0.0.1"),
+		Port:     0,
+		HostIP:   net.ParseIP("127.0.0.1"),
+		HostPort: 61234,
+	}, nil)
+	assert.NilError(t, err)
+
+	p := proxy.(*Proxy)
+
+	if p.pidfd == -1 {
+		_ = proxy.Stop()
+		t.Skip("pidfd not supported on this system")
+		return
+	}
+
+	pidfd := os.NewFile(uintptr(p.pidfd), "")
+	assert.Assert(t, isRunning(pidfd))
+
+	err = proxy.Stop()
+	assert.NilError(t, err)
+	assert.Assert(t, !isRunning(pidfd))
+}
+
+func TestKillProxy(t *testing.T) {
+	if _, err := os.Stat(proxyPath); err != nil {
+		t.Skipf("proxy binary %s not found", proxyPath)
+		return
+	}
+
+	pm := ProxyManager{ProxyPath: proxyPath}
+	proxy, err := pm.StartProxy(types.PortBinding{
+		Proto:    types.TCP,
+		IP:       net.ParseIP("127.0.0.1"),
+		Port:     0,
+		HostIP:   net.ParseIP("127.0.0.1"),
+		HostPort: 61234,
+	}, nil)
+	assert.NilError(t, err)
+
+	p := proxy.(*Proxy)
+
+	if p.pidfd == -1 {
+		_ = proxy.Stop()
+		t.Skip("pidfd not supported on this system")
+		return
+	}
+
+	pidfd := os.NewFile(uintptr(p.pidfd), "")
+	assert.Assert(t, isRunning(pidfd))
+
+	// Kill the proxy process and verify that Proxy.Stop() returns an error
+	err = p.p.Kill()
+	assert.NilError(t, err)
+
+	err = proxy.Stop()
+	assert.ErrorContains(t, err, "signal: killed")
+	assert.Assert(t, !isRunning(pidfd))
+}
+
+func isRunning(pidfd *os.File) bool {
+	err := unix.Waitid(unix.P_PIDFD, int(pidfd.Fd()), nil, unix.WEXITED|unix.WNOHANG, nil)
+	return err == nil
+}

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -1577,3 +1577,30 @@ func TestMixAnyWithSpecificHostAddrs(t *testing.T) {
 		})
 	}
 }
+
+func TestProxyPortMapping(t *testing.T) {
+	skip.If(t, testEnv.IsRootless, "the proxy portmapper isn't available in rootless mode")
+
+	ctx := setupTest(t)
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "--default-port-mapper=proxy")
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	ctrId := container.Run(ctx, t, c,
+		container.WithCmd("httpd", "-f"),
+		container.WithExposedPorts("80/tcp"),
+		container.WithPortMap(nat.PortMap{"80/tcp": {{}}}))
+	defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
+
+	inspect := container.Inspect(ctx, t, c, ctrId)
+	assert.Assert(t, len(inspect.NetworkSettings.Ports["80/tcp"]) > 0)
+	assert.Check(t, inspect.NetworkSettings.Ports["80/tcp"][0].HostPort != "")
+
+	addr := "http://127.0.0.1:" + inspect.NetworkSettings.Ports["80/tcp"][0].HostPort
+	resp, err := http.Get(addr) // #nosec G107 -- Ignore "Potential HTTP request made with variable url"
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(resp.StatusCode, 404))
+}

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -21,6 +21,7 @@ dockerd - Enable daemon mode
 [**--default-gateway-v6**[=*DEFAULT-GATEWAY-V6*]]
 [**--default-address-pool**[=*DEFAULT-ADDRESS-POOL*]]
 [**--default-network-opt**[=*DRIVER=OPT=VALUE*]]
+[**--default-port-mapper**=[=*port-mapper*]]
 [**--default-runtime**[=*runc*]]
 [**--default-ipc-mode**=*MODE*]
 [**--default-shm-size**[=*64MiB*]]
@@ -182,6 +183,11 @@ Bridge networks will accept packets with this firewall mark/mask.
 
 **--default-network-opt**=*DRIVER=OPT=VALUE*
   Default network driver options
+
+**--default-port-mapper**=*"port-mapper"*
+  Set the default port-mapper used to publish ports. This can be one of the
+  built-in port-mapper (nat or proxy). Note that the proxy port-mapper is
+  experimental.
 
 **--default-runtime**=*"runtime"*
   Set default runtime if there're more than one specified by **--add-runtime**.

--- a/vendor/github.com/moby/moby/api/types/system/info.go
+++ b/vendor/github.com/moby/moby/api/types/system/info.go
@@ -72,6 +72,7 @@ type Info struct {
 	ProductLicense      string               `json:",omitempty"`
 	DefaultAddressPools []NetworkAddressPool `json:",omitempty"`
 	FirewallBackend     *FirewallInfo        `json:"FirewallBackend,omitempty"`
+	DefaultPortMapper   string               `json:",omitempty"`
 	CDISpecDirs         []string
 	DiscoveredDevices   []DeviceInfo `json:",omitempty"`
 


### PR DESCRIPTION
- Related to https://github.com/moby/moby/issues/50259
- Related to https://github.com/moby/moby/issues/22054

**- What I did**

First commit adds a new daemon option `--default-port-mapper` (or daemon.json field `default-port-mapper`) taking a string that can reference any port-mapper. This value isn't validated because next PR is going to add support for port-mapper plugins. This option should be considered experimental for now.

Second and third commits move the `StartProxy` func from the `daemon/libnetwork/portmapper` package into a new `daemon/libnet/portmappers/proxy` pkg, and make it a method of a new `ProxyManager` struct. That struct takes the proxy path, removing that argument from `StartProxy`. A couple of unit tests are added to verify that the `ProxyManager` correctly starts proxies.

Fourth commit adds a new 'proxy' portmapper.

**- How to verify it**

A new integration test is added to verify that ports mapped with the `proxy` portmapper are working properly.

Manually, by starting the daemon with `--default-port-mapper=proxy`, then starting a container with a port-mapping, and verifying it's working properly and no iptables rules have been added for that port:

```
$ DOCKERD_ARGS="--default-port-mapper=proxy" ./hack/make.sh binary install-binary run
$ docker run --rm -d -p 80:80 traefik/whoami
$ curl -v http://localhost
$ iptables -S | grep 80
```

**- Human readable description for the release notes**

```markdown changelog
- EXPERIMENTAL: Add a daemon config `default-port-mapper` to choose which port-mapper should be used to map ports
```
