### PR TITLE
api/types/registry: DecodeAuthConfig: add early returns and improve errors

### DIFF
--- a/api/types/registry/authconfig_test.go
+++ b/api/types/registry/authconfig_test.go
@@ -139,3 +139,46 @@ func TestEncodeAuthConfig(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkDecodeAuthConfig(b *testing.B) {
+	cases := []struct {
+		doc         string
+		inputBase64 string
+		invalid     bool
+	}{
+		{
+			doc:         "empty",
+			inputBase64: ``,
+		},
+		{
+			doc:         "empty JSON",
+			inputBase64: `e30=`,
+		},
+		{
+			doc:         "valid",
+			inputBase64: base64.URLEncoding.EncodeToString([]byte(`{"username":"testuser","password":"testpassword","serveraddress":"example.com"}`)),
+		},
+		{
+			doc:         "invalid base64",
+			inputBase64: "not-base64",
+			invalid:     true,
+		},
+		{
+			doc:         "malformed JSON",
+			inputBase64: `ew==`,
+			invalid:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.doc, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := DecodeAuthConfig(tc.inputBase64)
+				if !tc.invalid && err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/api/types/registry/authconfig_test.go
+++ b/api/types/registry/authconfig_test.go
@@ -34,7 +34,7 @@ func TestDecodeAuthConfig(t *testing.T) {
 			input:       `{`,
 			inputBase64: `ew==`,
 			expected:    AuthConfig{},
-			expectedErr: `invalid X-Registry-Auth header: unexpected EOF`,
+			expectedErr: `invalid X-Registry-Auth header: invalid JSON: unexpected EOF`,
 		},
 		{
 			doc:         "test authConfig",
@@ -67,25 +67,27 @@ func TestDecodeAuthConfig(t *testing.T) {
 			input:       `{}`,
 			inputBase64: `e30`,
 			expected:    AuthConfig{},
-			expectedErr: `invalid X-Registry-Auth header: unexpected EOF`,
+			expectedErr: `invalid X-Registry-Auth header: must be a valid base64url-encoded string`,
 		},
 		{
 			doc:         "test authConfig",
 			input:       `{"username":"testuser","password":"testpassword","serveraddress":"example.com"}`,
 			inputBase64: `eyJ1c2VybmFtZSI6InRlc3R1c2VyIiwicGFzc3dvcmQiOiJ0ZXN0cGFzc3dvcmQiLCJzZXJ2ZXJhZGRyZXNzIjoiZXhhbXBsZS5jb20ifQ`,
 			expected:    AuthConfig{},
-			expectedErr: `invalid X-Registry-Auth header: unexpected EOF`,
+			expectedErr: `invalid X-Registry-Auth header: must be a valid base64url-encoded string`,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			// Sanity check to make sure our fixtures are correct.
-			b64 := base64.URLEncoding.EncodeToString([]byte(tc.input))
-			if !strings.HasSuffix(tc.inputBase64, "=") {
-				b64 = strings.TrimRight(b64, "=")
+			if tc.inputBase64 != "" {
+				// Sanity check to make sure our fixtures are correct.
+				b64 := base64.URLEncoding.EncodeToString([]byte(tc.input))
+				if !strings.HasSuffix(tc.inputBase64, "=") {
+					b64 = strings.TrimRight(b64, "=")
+				}
+				assert.Check(t, is.Equal(b64, tc.inputBase64))
 			}
-			assert.Check(t, is.Equal(b64, tc.inputBase64))
 
 			out, err := DecodeAuthConfig(tc.inputBase64)
 			if tc.expectedErr != "" {


### PR DESCRIPTION
### api/types/registry: add BenchmarkDecodeAuthConfig

Basic benchmark;

    go test -bench=DecodeAuthConfig -benchmem ./api/types/registry/
    goos: darwin
    goarch: arm64
    pkg: github.com/docker/docker/api/types/registry
    cpu: Apple M1 Pro
    BenchmarkDecodeAuthConfig/empty-10           47380755        25.44 ns/op      112 B/op          1 allocs/op
    BenchmarkDecodeAuthConfig/empty_JSON-10       2426870       491.70 ns/op     3056 B/op          8 allocs/op
    BenchmarkDecodeAuthConfig/valid-10             909601      1255.00 ns/op     3160 B/op         13 allocs/op
    BenchmarkDecodeAuthConfig/invalid_base64-10   1679551       703.40 ns/op     3410 B/op         15 allocs/op
    BenchmarkDecodeAuthConfig/malformed_JSON-10   1387849       817.10 ns/op     4795 B/op         12 allocs/op
    PASS

### api/types/registry: DecodeAuthConfig: add early returns and improve errors

Add an early return for empty JSON or malformed base64url values.

Before:

    go test -bench=DecodeAuthConfig -benchmem ./api/types/registry/
    goos: darwin
    goarch: arm64
    pkg: github.com/docker/docker/api/types/registry
    cpu: Apple M1 Pro
    BenchmarkDecodeAuthConfig/empty-10           47380755        25.44 ns/op      112 B/op          1 allocs/op
    BenchmarkDecodeAuthConfig/empty_JSON-10       2426870       491.70 ns/op     3056 B/op          8 allocs/op
    BenchmarkDecodeAuthConfig/valid-10             909601      1255.00 ns/op     3160 B/op         13 allocs/op
    BenchmarkDecodeAuthConfig/invalid_base64-10   1679551       703.40 ns/op     3410 B/op         15 allocs/op
    BenchmarkDecodeAuthConfig/malformed_JSON-10   1387849       817.10 ns/op     4795 B/op         12 allocs/op
    PASS

After:

    go test -bench=DecodeAuthConfig -benchmem ./api/types/registry/
    goos: darwin
    goarch: arm64
    pkg: github.com/docker/docker/api/types/registry
    cpu: Apple M1 Pro
    BenchmarkDecodeAuthConfig/empty-10           45892863        25.11 ns/op      112 B/op          1 allocs/op
    BenchmarkDecodeAuthConfig/empty_JSON-10      25347739        46.50 ns/op      115 B/op          2 allocs/op
    BenchmarkDecodeAuthConfig/valid-10            1292016       928.10 ns/op     1208 B/op         12 allocs/op
    BenchmarkDecodeAuthConfig/invalid_base64-10   5728990       208.50 ns/op      160 B/op          6 allocs/op
    BenchmarkDecodeAuthConfig/malformed_JSON-10   1821925       646.80 ns/op     2833 B/op         13 allocs/op
    PASS


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

