### PR TITLE
api/types/registry: EncodeAuthConfig: use empty string for zero value

### DIFF
--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -51,6 +51,9 @@ type AuthConfig struct {
 //
 // [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
 func EncodeAuthConfig(authConfig AuthConfig) (string, error) {
+	if authConfig == (AuthConfig{}) {
+		return "", nil
+	}
 	buf, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", errInvalidParameter{err}

--- a/api/types/registry/authconfig_test.go
+++ b/api/types/registry/authconfig_test.go
@@ -109,8 +109,8 @@ func TestEncodeAuthConfig(t *testing.T) {
 		{
 			doc:       "empty",
 			input:     AuthConfig{},
-			outBase64: `e30=`,
-			outPlain:  `{}`,
+			outBase64: ``,
+			outPlain:  ``,
 		},
 		{
 			doc: "test authConfig",


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/pull/50415
- https://github.com/moby/moby/pull/50256


Currently, EncodeAuthConfig always returns a base64url-encoded JSON doc, even if an empty auth-config passed. As a result, it's more complicated to detect if authentication was present.

This patch changes the behavior to return an empty string for these cases so that teh client can skip setting the `X-Registry-Auth` header, and the daemon can detect whether authentication is sent or not.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: `api/types/registry`: `EncodeAuthConfig`: use empty string for zero value
```

**- A picture of a cute animal (not mandatory but encouraged)**

