### PR TITLE
daemon: define default (and maximum) API version

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -18,7 +18,6 @@ import (
 	containerddefaults "github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/log"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/daemon"
 	buildbackend "github.com/docker/docker/daemon/builder/backend"
 	"github.com/docker/docker/daemon/builder/dockerfile"
@@ -751,7 +750,7 @@ func initMiddlewares(_ context.Context, s *apiserver.Server, cfg *config.Config,
 	exp := middleware.NewExperimentalMiddleware(cfg.Experimental)
 	s.UseMiddleware(exp)
 
-	vm, err := middleware.NewVersionMiddleware(dockerversion.Version, api.DefaultVersion, cfg.MinAPIVersion)
+	vm, err := middleware.NewVersionMiddleware(dockerversion.Version, config.DefaultAPIVersion, cfg.MinAPIVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -56,6 +56,11 @@ const (
 	DefaultContainersNamespace = "moby"
 	// DefaultPluginNamespace is the name of the default containerd namespace used for plugins.
 	DefaultPluginNamespace = "plugins.moby"
+	// DefaultAPIVersion is the highest REST API version supported by the daemon.
+	//
+	// This version may be lower than the [api.DefaultVersion], which is the default
+	// (and highest supported) version of the api library module used.
+	DefaultAPIVersion = "1.52"
 	// defaultMinAPIVersion is the minimum API version supported by the API.
 	// This version can be overridden through the "DOCKER_MIN_API_VERSION"
 	// environment variable. It currently defaults to the minimum API version
@@ -670,8 +675,8 @@ func ValidateMinAPIVersion(ver string) error {
 	if versions.LessThan(ver, defaultMinAPIVersion) {
 		return errors.Errorf(`minimum supported API version is %s: %s`, defaultMinAPIVersion, ver)
 	}
-	if versions.GreaterThan(ver, api.DefaultVersion) {
-		return errors.Errorf(`maximum supported API version is %s: %s`, api.DefaultVersion, ver)
+	if versions.GreaterThan(ver, DefaultAPIVersion) {
+		return errors.Errorf(`maximum supported API version is %s: %s`, DefaultAPIVersion, ver)
 	}
 	return nil
 }

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"dario.cat/mergo"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/daemon/libnetwork/ipamutils"
 	"github.com/docker/docker/daemon/pkg/opts"
 	"github.com/docker/docker/registry"
@@ -634,7 +633,7 @@ func TestValidateMinAPIVersion(t *testing.T) {
 		},
 		{
 			doc:   "current version",
-			input: api.DefaultVersion,
+			input: DefaultAPIVersion,
 		},
 	}
 

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/log"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/system"
 	"github.com/docker/docker/daemon/command/debug"
@@ -118,7 +117,7 @@ func (daemon *Daemon) SystemVersion(ctx context.Context) (types.Version, error) 
 				Version: dockerversion.Version,
 				Details: map[string]string{
 					"GitCommit":     dockerversion.GitCommit,
-					"ApiVersion":    api.DefaultVersion,
+					"ApiVersion":    config.DefaultAPIVersion,
 					"MinAPIVersion": cfg.MinAPIVersion,
 					"GoVersion":     runtime.Version(),
 					"Os":            runtime.GOOS,
@@ -133,7 +132,7 @@ func (daemon *Daemon) SystemVersion(ctx context.Context) (types.Version, error) 
 		// Populate deprecated fields for older clients
 		Version:       dockerversion.Version,
 		GitCommit:     dockerversion.GitCommit,
-		APIVersion:    api.DefaultVersion,
+		APIVersion:    config.DefaultAPIVersion,
 		MinAPIVersion: cfg.MinAPIVersion,
 		GoVersion:     runtime.Version(),
 		Os:            runtime.GOOS,

--- a/daemon/server/middleware/version.go
+++ b/daemon/server/middleware/version.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/server/httputils"
 )
 
@@ -18,7 +19,7 @@ type VersionMiddleware struct {
 
 	// defaultAPIVersion is the default API version provided by the API server,
 	// specified as "major.minor". It is usually configured to the latest API
-	// version [github.com/docker/docker/api.DefaultVersion].
+	// version [config.DefaultAPIVersion] supported by the daemon.
 	//
 	// API requests for API versions greater than this version are rejected by
 	// the server and produce a [versionUnsupportedError].
@@ -34,11 +35,11 @@ type VersionMiddleware struct {
 
 // NewVersionMiddleware creates a VersionMiddleware with the given versions.
 func NewVersionMiddleware(serverVersion, defaultAPIVersion, minAPIVersion string) (*VersionMiddleware, error) {
-	if versions.LessThan(defaultAPIVersion, api.MinSupportedAPIVersion) || versions.GreaterThan(defaultAPIVersion, api.DefaultVersion) {
-		return nil, fmt.Errorf("invalid default API version (%s): must be between %s and %s", defaultAPIVersion, api.MinSupportedAPIVersion, api.DefaultVersion)
+	if versions.LessThan(defaultAPIVersion, api.MinSupportedAPIVersion) || versions.GreaterThan(defaultAPIVersion, config.DefaultAPIVersion) {
+		return nil, fmt.Errorf("invalid default API version (%s): must be between %s and %s", defaultAPIVersion, api.MinSupportedAPIVersion, config.DefaultAPIVersion)
 	}
-	if versions.LessThan(minAPIVersion, api.MinSupportedAPIVersion) || versions.GreaterThan(minAPIVersion, api.DefaultVersion) {
-		return nil, fmt.Errorf("invalid minimum API version (%s): must be between %s and %s", minAPIVersion, api.MinSupportedAPIVersion, api.DefaultVersion)
+	if versions.LessThan(minAPIVersion, api.MinSupportedAPIVersion) || versions.GreaterThan(minAPIVersion, config.DefaultAPIVersion) {
+		return nil, fmt.Errorf("invalid minimum API version (%s): must be between %s and %s", minAPIVersion, api.MinSupportedAPIVersion, config.DefaultAPIVersion)
 	}
 	if versions.GreaterThan(minAPIVersion, defaultAPIVersion) {
 		return nil, fmt.Errorf("invalid API version: the minimum API version (%s) is higher than the default version (%s)", minAPIVersion, defaultAPIVersion)

--- a/daemon/server/middleware/version_test.go
+++ b/daemon/server/middleware/version_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/server/httputils"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -20,38 +21,38 @@ func TestNewVersionMiddlewareValidation(t *testing.T) {
 	}{
 		{
 			doc:            "defaults",
-			defaultVersion: api.DefaultVersion,
+			defaultVersion: config.DefaultAPIVersion,
 			minVersion:     api.MinSupportedAPIVersion,
 		},
 		{
 			doc:            "invalid default lower than min",
 			defaultVersion: api.MinSupportedAPIVersion,
-			minVersion:     api.DefaultVersion,
-			expectedErr:    fmt.Sprintf("invalid API version: the minimum API version (%s) is higher than the default version (%s)", api.DefaultVersion, api.MinSupportedAPIVersion),
+			minVersion:     config.DefaultAPIVersion,
+			expectedErr:    fmt.Sprintf("invalid API version: the minimum API version (%s) is higher than the default version (%s)", config.DefaultAPIVersion, api.MinSupportedAPIVersion),
 		},
 		{
 			doc:            "invalid default too low",
 			defaultVersion: "0.1",
 			minVersion:     api.MinSupportedAPIVersion,
-			expectedErr:    fmt.Sprintf("invalid default API version (0.1): must be between %s and %s", api.MinSupportedAPIVersion, api.DefaultVersion),
+			expectedErr:    fmt.Sprintf("invalid default API version (0.1): must be between %s and %s", api.MinSupportedAPIVersion, config.DefaultAPIVersion),
 		},
 		{
 			doc:            "invalid default too high",
 			defaultVersion: "9999.9999",
-			minVersion:     api.DefaultVersion,
-			expectedErr:    fmt.Sprintf("invalid default API version (9999.9999): must be between %s and %s", api.MinSupportedAPIVersion, api.DefaultVersion),
+			minVersion:     config.DefaultAPIVersion,
+			expectedErr:    fmt.Sprintf("invalid default API version (9999.9999): must be between %s and %s", api.MinSupportedAPIVersion, config.DefaultAPIVersion),
 		},
 		{
 			doc:            "invalid minimum too low",
 			defaultVersion: api.MinSupportedAPIVersion,
 			minVersion:     "0.1",
-			expectedErr:    fmt.Sprintf("invalid minimum API version (0.1): must be between %s and %s", api.MinSupportedAPIVersion, api.DefaultVersion),
+			expectedErr:    fmt.Sprintf("invalid minimum API version (0.1): must be between %s and %s", api.MinSupportedAPIVersion, config.DefaultAPIVersion),
 		},
 		{
 			doc:            "invalid minimum too high",
-			defaultVersion: api.DefaultVersion,
+			defaultVersion: config.DefaultAPIVersion,
 			minVersion:     "9999.9999",
-			expectedErr:    fmt.Sprintf("invalid minimum API version (9999.9999): must be between %s and %s", api.MinSupportedAPIVersion, api.DefaultVersion),
+			expectedErr:    fmt.Sprintf("invalid minimum API version (9999.9999): must be between %s and %s", api.MinSupportedAPIVersion, config.DefaultAPIVersion),
 		},
 	}
 
@@ -75,7 +76,7 @@ func TestVersionMiddlewareVersion(t *testing.T) {
 		return nil
 	}
 
-	m, err := NewVersionMiddleware("1.2.3", api.DefaultVersion, api.MinSupportedAPIVersion)
+	m, err := NewVersionMiddleware("1.2.3", config.DefaultAPIVersion, api.MinSupportedAPIVersion)
 	assert.NilError(t, err)
 	h := m.WrapHandler(handler)
 
@@ -89,7 +90,7 @@ func TestVersionMiddlewareVersion(t *testing.T) {
 		errString       string
 	}{
 		{
-			expectedVersion: api.DefaultVersion,
+			expectedVersion: config.DefaultAPIVersion,
 		},
 		{
 			reqVersion:      api.MinSupportedAPIVersion,
@@ -101,7 +102,7 @@ func TestVersionMiddlewareVersion(t *testing.T) {
 		},
 		{
 			reqVersion: "9999.9999",
-			errString:  fmt.Sprintf("client version 9999.9999 is too new. Maximum supported API version is %s", api.DefaultVersion),
+			errString:  fmt.Sprintf("client version 9999.9999 is too new. Maximum supported API version is %s", config.DefaultAPIVersion),
 		},
 	}
 
@@ -125,7 +126,7 @@ func TestVersionMiddlewareWithErrorsReturnsHeaders(t *testing.T) {
 		return nil
 	}
 
-	m, err := NewVersionMiddleware("1.2.3", api.DefaultVersion, api.MinSupportedAPIVersion)
+	m, err := NewVersionMiddleware("1.2.3", config.DefaultAPIVersion, api.MinSupportedAPIVersion)
 	assert.NilError(t, err)
 	h := m.WrapHandler(handler)
 
@@ -140,6 +141,6 @@ func TestVersionMiddlewareWithErrorsReturnsHeaders(t *testing.T) {
 	hdr := resp.Result().Header
 	assert.Check(t, is.Contains(hdr.Get("Server"), "Docker/1.2.3"))
 	assert.Check(t, is.Contains(hdr.Get("Server"), runtime.GOOS))
-	assert.Check(t, is.Equal(hdr.Get("Api-Version"), api.DefaultVersion))
+	assert.Check(t, is.Equal(hdr.Get("Api-Version"), config.DefaultAPIVersion))
 	assert.Check(t, is.Equal(hdr.Get("Ostype"), runtime.GOOS))
 }

--- a/daemon/server/server_test.go
+++ b/daemon/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/server/httputils"
 	"github.com/docker/docker/daemon/server/middleware"
 )
@@ -15,7 +16,7 @@ import (
 func TestMiddlewares(t *testing.T) {
 	srv := &Server{}
 
-	m, err := middleware.NewVersionMiddleware("0.1omega2", api.DefaultVersion, api.MinSupportedAPIVersion)
+	m, err := middleware.NewVersionMiddleware("0.1omega2", config.DefaultAPIVersion, api.MinSupportedAPIVersion)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50433
- relates to https://github.com/moby/moby/issues/49873

With the daemon and API migrating to separate modules, users of the daemon module may upgrade the API module to higher versions. Currently, the daemon uses the API's Default version. While the version of the API module is allowed to be updated (following SemVer), we should not allow the Daemon to support higher API versions than it was written for.

This patch introduces a DefaultAPIVersion in the daemon/config package that is used as default version of the API for the daemon to use.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: daemon/config: add `DefaultAPIVersion` const, which defines the default (and maximum) API version supported by the daemon.
```

**- A picture of a cute animal (not mandatory but encouraged)**

