### PR TITLE
api: deprecate NoBaseImageSpecifier

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -16,5 +16,7 @@ const (
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.
+	//
+	// Deprecated: this const is no longer used and will be removed in the next release.
 	NoBaseImageSpecifier = "scratch"
 )

--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/containerd/platforms"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/daemon/builder"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/image"
@@ -29,6 +28,10 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
+
+// noBaseImageSpecifier is the symbol used by the FROM
+// command to specify that no base image is to be used.
+const noBaseImageSpecifier = "scratch"
 
 // ENV foo bar
 //
@@ -242,7 +245,7 @@ func (d *dispatchRequest) getImageOrStage(ctx context.Context, name string, plat
 	}
 
 	// Windows cannot support a container with no base image.
-	if name == api.NoBaseImageSpecifier {
+	if name == noBaseImageSpecifier {
 		// Windows supports scratch. What is not supported is running containers from it.
 		if runtime.GOOS == "windows" {
 			return nil, errors.New("Windows does not support FROM scratch")
@@ -257,11 +260,11 @@ func (d *dispatchRequest) getImageOrStage(ctx context.Context, name string, plat
 		}
 		return builder.Image(imageImage), nil
 	}
-	imageMount, err := d.builder.imageSources.Get(ctx, name, localOnly, platform)
+	imgMount, err := d.builder.imageSources.Get(ctx, name, localOnly, platform)
 	if err != nil {
 		return nil, err
 	}
-	return imageMount.Image(), nil
+	return imgMount.Image(), nil
 }
 
 func (d *dispatchRequest) getFromImage(ctx context.Context, shlex *shell.Lex, basename string, platform *ocispec.Platform) (builder.Image, error) {

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/backend"
 	"github.com/docker/docker/api/types/filters"
 	imagetypes "github.com/docker/docker/api/types/image"
@@ -589,10 +588,14 @@ func (ir *imageRouter) postImagesPrune(ctx context.Context, w http.ResponseWrite
 	return httputils.WriteJSON(w, http.StatusOK, pruneReport)
 }
 
+// noBaseImageSpecifier is the symbol used by the FROM
+// command to specify that no base image is to be used.
+const noBaseImageSpecifier = "scratch"
+
 // validateRepoName validates the name of a repository.
 func validateRepoName(name reference.Named) error {
 	familiarName := reference.FamiliarName(name)
-	if familiarName == api.NoBaseImageSpecifier {
+	if familiarName == noBaseImageSpecifier {
 		return fmt.Errorf("'%s' is a reserved name", familiarName)
 	}
 	return nil

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types/events"
 	refstore "github.com/docker/docker/reference"
 	"github.com/docker/docker/registry"
@@ -45,10 +44,14 @@ func Tags(ctx context.Context, ref reference.Named, config *Config) ([]string, e
 	return tags, err
 }
 
+// noBaseImageSpecifier is the symbol used by the FROM
+// command to specify that no base image is to be used.
+const noBaseImageSpecifier = "scratch"
+
 // validateRepoName validates the name of a repository.
 func validateRepoName(name reference.Named) error {
-	if reference.FamiliarName(name) == api.NoBaseImageSpecifier {
-		return errors.WithStack(reservedNameError(api.NoBaseImageSpecifier))
+	if reference.FamiliarName(name) == noBaseImageSpecifier {
+		return errors.WithStack(reservedNameError(noBaseImageSpecifier))
 	}
 	return nil
 }


### PR DESCRIPTION
This const is no longer used and will be removed in the next release.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api: deprecate `NoBaseImageSpecifier` const. This const is no longer used and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

