### PR TITLE
windows: include labels when re-creating non-default nat networks

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -285,6 +285,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 						netlabel.GenericData: netOption,
 					}),
 					libnetwork.NetworkOptionIpam("default", "", v4Conf, v6Conf, nil),
+					libnetwork.NetworkOptionLabels(v.Labels()),
 				)
 				if err != nil {
 					log.G(context.TODO()).Errorf("Error occurred when creating network %v", err)


### PR DESCRIPTION
I noticed that this was missing.

- Fixes #50192
- Related to https://github.com/moby/moby/pull/43836

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Ensure that Windows NAT networks are recreated with their original labels when the Engine restarts
```