### PR TITLE
client: fix datarace when accessing cli.Version field

### DIFF
--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -46,6 +46,15 @@ func (cli *Client) ContainerExecCreate(ctx context.Context, containerID string, 
 
 // ContainerExecStart starts an exec process already created in the docker host.
 func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config container.ExecStartOptions) error {
+	// Make sure we negotiated (if the client is configured to do so),
+	// as code below contains API-version specific handling of options.
+	//
+	// Normally, version-negotiation (if enabled) would not happen until
+	// the API request is made.
+	if err := cli.checkVersion(ctx); err != nil {
+		return err
+	}
+
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
 		config.ConsoleSize = nil
 	}

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -35,6 +35,15 @@ func (cli *Client) ContainerList(ctx context.Context, options container.ListOpti
 	}
 
 	if options.Filters.Len() > 0 {
+		// Make sure we negotiated (if the client is configured to do so),
+		// as code below contains API-version specific handling of options.
+		//
+		// Normally, version-negotiation (if enabled) would not happen until
+		// the API request is made.
+		if err := cli.checkVersion(ctx); err != nil {
+			return nil, err
+		}
+
 		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {

--- a/client/events.go
+++ b/client/events.go
@@ -23,6 +23,16 @@ func (cli *Client) Events(ctx context.Context, options events.ListOptions) (<-ch
 	go func() {
 		defer close(errs)
 
+		// Make sure we negotiated (if the client is configured to do so),
+		// as code below contains API-version specific handling of options.
+		//
+		// Normally, version-negotiation (if enabled) would not happen until
+		// the API request is made.
+		if err := cli.checkVersion(ctx); err != nil {
+			close(started)
+			errs <- err
+			return
+		}
 		query, err := buildEventsQueryParams(cli.version, options)
 		if err != nil {
 			close(started)


### PR DESCRIPTION
Originally I've found this datarace on a project I'm working at. I'm not able to consistently reproduce this. But by looking at the codebase I took a chance to fix other 2 possible function that might produce such data race.

Original stack trace produced when running `go test -race` on GH CI:

```
WARNING: DATA RACE
Write at 0x00c0005dc688 by goroutine 43:
  github.com/docker/docker/client.(*Client).negotiateAPIVersionPing()
      /home/runner/go/pkg/mod/github.com/docker/docker@v28.2.2+incompatible/client/client.go:389 +0x12f
  github.com/docker/docker/client.(*Client).checkVersion()
      /home/runner/go/pkg/mod/github.com/docker/docker@v28.2.2+incompatible/client/client.go:298 +0x249
  github.com/docker/docker/client.(*Client).getAPIPath()
      /home/runner/go/pkg/mod/github.com/docker/docker@v28.2.2+incompatible/client/client.go:307 +0x76
  github.com/docker/docker/client.(*Client).sendRequest()
      /home/runner/go/pkg/mod/github.com/docker/docker@v28.2.2+incompatible/client/request.go:111 +0x9b
  github.com/docker/docker/client.(*Client).get()
      /home/runner/go/pkg/mod/github.com/docker/docker@v28.2.2+incompatible/client/request.go:28 +0x736
  github.com/docker/docker/client.(*Client).ContainerList()
      /home/runner/go/pkg/mod/github.com/docker/docker@v28.2.2+incompatible/client/container_list.go:47 +0x6f0

Previous read at 0x00c0005dc688 by goroutine 42:
  github.com/docker/docker/client.(*Client).ContainerList()
      /home/runner/go/pkg/mod/github.com/docker/docker@v28.2.2+incompatible/client/container_list.go:39 +0x5ef
```


```markdown changelog
Go SDK: Fix data race in `ContainerExecStart`, `ContainerList`, and `Events`.
```
