### PR TITLE
hack/buildkit-ref: temporarily bump BuildKit to head of v0.23 branch

### DIFF
--- a/hack/buildkit-ref
+++ b/hack/buildkit-ref
@@ -19,6 +19,9 @@ if [[ "${buildkit_ref}" == *-*-* ]]; then
 	buildkit_ref=$(curl -s "https://api.github.com/repos/${buildkit_repo}/commits/${buildkit_ref}" | jq -r .sha)
 fi
 
+# FIXME(thaJeztah) temporarily overriding version to use for tests; remove with the next release of buildkit; see https://github.com/moby/moby/issues/50389
+buildkit_ref=dd2b4e18663c58ac3762d7b60b2c3301f71d5fa9
+
 cat << EOF
 BUILDKIT_REPO=$buildkit_repo
 BUILDKIT_REF=$buildkit_ref

--- a/vendor.mod
+++ b/vendor.mod
@@ -62,7 +62,7 @@ require (
 	github.com/miekg/dns v1.1.66
 	github.com/mistifyio/go-zfs/v3 v3.0.1
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/moby/buildkit v0.23.2
+	github.com/moby/buildkit v0.23.2 // FIXME(thaJeztah): remove override from hack/buildkit-ref when updating.
 	github.com/moby/docker-image-spec v1.3.1
 	github.com/moby/go-archive v0.1.0
 	github.com/moby/ipvs v1.1.0


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/50389

To skip some flaky tests on Windows

diff: https://github.com/moby/buildkit/compare/v0.23.2...dd2b4e18663c58ac3762d7b60b2c3301f71d5fa9

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

