### PR TITLE
pkg/process: separate exported funcs from implementation, and fix build-tag for implementation

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,0 +1,29 @@
+package process
+
+import "fmt"
+
+// Alive returns true if process with a given pid is running.
+//
+// It only considers positive PIDs; 0 (all processes in the current process
+// group), -1 (all processes with a PID larger than 1), and negative (-n,
+// all processes in process group "n") values for pid are never considered
+// to be alive.
+func Alive(pid int) bool {
+	if pid < 1 {
+		return false
+	}
+	return alive(pid)
+}
+
+// Kill force-stops a process. It only allows positive PIDs; 0 (all processes
+// in the current process group), -1 (all processes with a PID larger than 1),
+// and negative (-n, all processes in process group "n") values for pid producs
+// an error. Refer to [KILL(2)] for details.
+//
+// [KILL(2)]: https://man7.org/linux/man-pages/man2/kill.2.html
+func Kill(pid int) error {
+	if pid < 1 {
+		return fmt.Errorf("invalid PID (%d): only positive PIDs are allowed", pid)
+	}
+	return kill(pid)
+}

--- a/pkg/process/process_linux.go
+++ b/pkg/process/process_linux.go
@@ -1,0 +1,24 @@
+package process
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+func zombie(pid int) (bool, error) {
+	if pid < 1 {
+		return false, nil
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if cols := bytes.SplitN(data, []byte(" "), 4); len(cols) >= 3 && string(cols[2]) == "Z" {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/process/process_nolinux.go
+++ b/pkg/process/process_nolinux.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package process
+
+func zombie(pid int) (bool, error) {
+	return false, nil
+}

--- a/pkg/process/process_unix.go
+++ b/pkg/process/process_unix.go
@@ -14,17 +14,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Alive returns true if process with a given pid is running. It only considers
-// positive PIDs; 0 (all processes in the current process group), -1 (all processes
-// with a PID larger than 1), and negative (-n, all processes in process group
-// "n") values for pid are never considered to be alive.
-func Alive(pid int) bool {
-	if pid < 1 {
-		return false
-	}
+func alive(pid int) bool {
 	switch runtime.GOOS {
 	case "darwin":
-		// OS X does not have a proc filesystem. Use kill -0 pid to judge if the
+		// macOS does not have a proc filesystem. Use kill -0 pid to judge if the
 		// process exists. From KILL(2): https://www.freebsd.org/cgi/man.cgi?query=kill&sektion=2&manpath=OpenDarwin+7.2.1
 		//
 		// Sig may be one of the signals specified in sigaction(2) or it may
@@ -41,16 +34,7 @@ func Alive(pid int) bool {
 	}
 }
 
-// Kill force-stops a process. It only considers positive PIDs; 0 (all processes
-// in the current process group), -1 (all processes with a PID larger than 1),
-// and negative (-n, all processes in process group "n") values for pid are
-// ignored. Refer to [KILL(2)] for details.
-//
-// [KILL(2)]: https://man7.org/linux/man-pages/man2/kill.2.html
-func Kill(pid int) error {
-	if pid < 1 {
-		return fmt.Errorf("invalid PID (%d): only positive PIDs are allowed", pid)
-	}
+func kill(pid int) error {
 	err := unix.Kill(pid, unix.SIGKILL)
 	if err != nil && !errors.Is(err, unix.ESRCH) {
 		return err

--- a/pkg/process/process_unix.go
+++ b/pkg/process/process_unix.go
@@ -3,9 +3,7 @@
 package process
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -47,20 +45,9 @@ func kill(pid int) error {
 // a PID larger than 1), and negative (-n, all processes in process group "n")
 // values for pid are ignored. Refer to [PROC(5)] for details.
 //
+// Zombie is only implemented on Linux, and returns false on all other platforms.
+//
 // [PROC(5)]: https://man7.org/linux/man-pages/man5/proc.5.html
 func Zombie(pid int) (bool, error) {
-	if pid < 1 {
-		return false, nil
-	}
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	if cols := bytes.SplitN(data, []byte(" "), 4); len(cols) >= 3 && string(cols[2]) == "Z" {
-		return true, nil
-	}
-	return false, nil
+	return zombie(pid)
 }

--- a/pkg/process/process_windows.go
+++ b/pkg/process/process_windows.go
@@ -6,8 +6,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// Alive returns true if process with a given pid is running.
-func Alive(pid int) bool {
+func alive(pid int) bool {
 	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
 		return false
@@ -32,8 +31,7 @@ func Alive(pid int) bool {
 	return true
 }
 
-// Kill force-stops a process.
-func Kill(pid int) error {
+func kill(pid int) error {
 	p, err := os.FindProcess(pid)
 	if err == nil {
 		err = p.Kill()


### PR DESCRIPTION
### pkg/process: separate exported funcs from implementation

This allows us to maintain GoDoc in a single place, and for
"Kill" and "Alive" to have consistent error-handling (Windows
does not support negative process-IDs).

### pkg/process: call out that "Zombie" is only supported on Linux


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

