### PR TITLE
oci: deprecate SetCapabilities, and some minor cleanups/fixes

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -153,19 +153,20 @@ func WithApparmor(c *container.Container) coci.SpecOpts {
 	}
 }
 
-// WithCapabilities sets the container's capabilities
-func WithCapabilities(c *container.Container) coci.SpecOpts {
-	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
+// WithCapabilities adjusts the container's capabilities based on the
+// "CapAdd", "CapDrop", and "Privileged" fields in the container's HostConfig.
+func WithCapabilities(ctr *container.Container) coci.SpecOpts {
+	return func(ctx context.Context, client coci.Client, c *containers.Container, s *specs.Spec) (err error) {
 		capabilities, err := caps.TweakCapabilities(
 			caps.DefaultCapabilities(),
-			c.HostConfig.CapAdd,
-			c.HostConfig.CapDrop,
-			c.HostConfig.Privileged,
+			ctr.HostConfig.CapAdd,
+			ctr.HostConfig.CapDrop,
+			ctr.HostConfig.Privileged,
 		)
 		if err != nil {
 			return err
 		}
-		return oci.SetCapabilities(s, capabilities)
+		return coci.WithCapabilities(capabilities)(ctx, client, c, s)
 	}
 }
 

--- a/oci/caps/utils.go
+++ b/oci/caps/utils.go
@@ -79,7 +79,8 @@ func NormalizeLegacyCapabilities(caps []string) ([]string, error) {
 }
 
 // TweakCapabilities tweaks capabilities by adding, dropping, or overriding
-// capabilities in the basics capabilities list.
+// capabilities in the basics capabilities list. All capabilities are added
+// if privileged is true.
 func TweakCapabilities(basics, adds, drops []string, privileged bool) ([]string, error) {
 	switch {
 	case privileged:

--- a/oci/defaults.go
+++ b/oci/defaults.go
@@ -195,18 +195,18 @@ func DefaultLinuxSpec() specs.Spec {
 // compute them once.
 var defaultLinuxMaskedPaths = sync.OnceValue(func() []string {
 	maskedPaths := []string{
-		"/proc/asound",
 		"/proc/acpi",
+		"/proc/asound",
 		"/proc/interrupts", // https://github.com/moby/moby/security/advisories/GHSA-6fw5-f8r9-fgfm
 		"/proc/kcore",
 		"/proc/keys",
 		"/proc/latency_stats",
-		"/proc/timer_list",
-		"/proc/timer_stats",
 		"/proc/sched_debug",
 		"/proc/scsi",
-		"/sys/firmware",
+		"/proc/timer_list",
+		"/proc/timer_stats",
 		"/sys/devices/virtual/powercap", // https://github.com/moby/moby/security/advisories/GHSA-jq35-85cj-fj4p
+		"/sys/firmware",
 	}
 
 	// https://github.com/moby/moby/security/advisories/GHSA-6fw5-f8r9-fgfm

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -18,6 +18,8 @@ import (
 var deviceCgroupRuleRegex = lazyregexp.New("^([acb]) ([0-9]+|\\*):([0-9]+|\\*) ([rwm]{1,3})$")
 
 // SetCapabilities sets the provided capabilities on the spec.
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func SetCapabilities(s *specs.Spec, caplist []string) error {
 	if s.Process == nil {
 		s.Process = &specs.Process{}

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -17,8 +17,7 @@ import (
 // early for "a" (all); https://github.com/torvalds/linux/blob/v5.10/security/device_cgroup.c#L614-L642
 var deviceCgroupRuleRegex = lazyregexp.New("^([acb]) ([0-9]+|\\*):([0-9]+|\\*) ([rwm]{1,3})$")
 
-// SetCapabilities sets the provided capabilities on the spec
-// All capabilities are added if privileged is true.
+// SetCapabilities sets the provided capabilities on the spec.
 func SetCapabilities(s *specs.Spec, caplist []string) error {
 	if s.Process == nil {
 		s.Process = &specs.Process{}


### PR DESCRIPTION
### oci: sort defaultLinuxMaskedPaths

### oci: fix godoc for SetCapabilities, TweakCapabilities

TweakCapabilities takes privileged into account, but SetCapabilities
does not, so fix the GoDoc.


### oci: deprecate SetCapabilities

rewrite daemon.WithCapabilities using c8d's oci.WithCapabilities.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: oci: deprecate SetCapabilities, and some minor cleanups/fixes
```

**- A picture of a cute animal (not mandatory but encouraged)**

