### PR TITLE
internal/platform: remove NumProcs() stub for Linux

### DIFF
--- a/internal/platform/platform_unix.go
+++ b/internal/platform/platform_unix.go
@@ -14,12 +14,3 @@ func runtimeArchitecture() (string, error) {
 	}
 	return unix.ByteSliceToString(utsname.Machine[:]), nil
 }
-
-// NumProcs returns the number of processors on the system
-//
-// Deprecated: temporary stub for non-Windows to provide an alias for the deprecated github.com/docker/docker/pkg/platform package.
-//
-// FIXME(thaJeztah): remove once we remove  github.com/docker/docker/pkg/platform
-func NumProcs() uint32 {
-	return 0
-}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50208
- relates to https://github.com/moby/moby/pull/48862

Follow-up to 04618dfc0bbe868490b9937bda6f726348be8fc6, which removed the pkg/platform package, but forgot to remove the stub.


**- A picture of a cute animal (not mandatory but encouraged)**

