### PR TITLE
remove uses of lazyregexp in tests, test-utilities and packages used externally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -346,6 +346,10 @@ linters:
         path: "libnetwork/cmd/networkdb-test/dbclient"
         linters:
           - forbidigo
+      - text: 'use of `regexp.MustCompile` forbidden'
+        path: "registry/"
+        linters:
+          - forbidigo
 
     # Log a warning if an exclusion rule is unused.
     # Default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -339,6 +339,10 @@ linters:
         linters:
           - forbidigo
       - text: 'use of `regexp.MustCompile` forbidden'
+        path: "internal/testutils"
+        linters:
+          - forbidigo
+      - text: 'use of `regexp.MustCompile` forbidden'
         path: "libnetwork/cmd/networkdb-test/dbclient"
         linters:
           - forbidigo

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
-	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/moby/moby/api/types/image"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -26,8 +25,8 @@ const (
 )
 
 var (
-	pushDigestRegex = lazyregexp.New(`[\S]+: digest: ([\S]+) size: [0-9]+`)
-	digestRegex     = lazyregexp.New(`Digest: ([\S]+)`)
+	pushDigestRegex = regexp.MustCompile(`[\S]+: digest: ([\S]+) size: [0-9]+`)
+	digestRegex     = regexp.MustCompile(`Digest: ([\S]+)`)
 )
 
 func setupImage(t *testing.T) (digest.Digest, error) {

--- a/internal/testutils/networking/firewall.go
+++ b/internal/testutils/networking/firewall.go
@@ -3,10 +3,10 @@ package networking
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/docker/docker/testutil/daemon"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
@@ -21,7 +21,7 @@ const (
 )
 
 // Find the policy in, for example "Chain FORWARD (policy ACCEPT)".
-var rePolicy = lazyregexp.New("policy ([A-Za-z]+)")
+var rePolicy = regexp.MustCompile("policy ([A-Za-z]+)")
 
 // SetFilterForwardPolicies sets the default policy for the FORWARD chain in
 // the filter tables for both IPv4 and IPv6. The original policy is restored

--- a/registry/config.go
+++ b/registry/config.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.23
+
 package registry
 
 import (
@@ -6,13 +9,14 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
-	"github.com/docker/docker/internal/lazyregexp"
 	"github.com/moby/moby/api/types/registry"
 )
 
@@ -57,7 +61,9 @@ var (
 		Host:   DefaultRegistryHost,
 	}
 
-	validHostPortRegex = lazyregexp.New(`^` + reference.DomainRegexp.String() + `$`)
+	validHostPortRegex = sync.OnceValue(func() *regexp.Regexp {
+		return regexp.MustCompile(`^` + reference.DomainRegexp.String() + `$`)
+	})
 )
 
 // runningWithRootlessKit is a fork of [rootless.RunningWithRootlessKit],
@@ -334,7 +340,7 @@ func validateHostPort(s string) error {
 	}
 	// If match against the `host:port` pattern fails,
 	// it might be `IPv6:port`, which will be captured by net.ParseIP(host)
-	if !validHostPortRegex.MatchString(s) && net.ParseIP(host) == nil {
+	if !validHostPortRegex().MatchString(s) && net.ParseIP(host) == nil {
 		return invalidParamf("invalid host %q", host)
 	}
 	if port != "" {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50446

**- A picture of a cute animal (not mandatory but encouraged)**

