### PR TITLE
No nftables in swarm

### DIFF
--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -126,6 +126,11 @@ func (conf *Config) IsSwarmCompatible() error {
 	if conf.LiveRestoreEnabled {
 		return errors.New("--live-restore daemon configuration is incompatible with swarm mode")
 	}
+	// Swarm has not yet been updated to use nftables. But, if "iptables" is disabled, it
+	// doesn't add rules anyway.
+	if conf.FirewallBackend == "nftables" && conf.EnableIPTables {
+		return errors.New("--firewall-backend=nftables is incompatible with swarm mode")
+	}
 	return nil
 }
 

--- a/integration/network/overlay/overlay_test.go
+++ b/integration/network/overlay/overlay_test.go
@@ -65,7 +65,7 @@ func TestHostPortMappings(t *testing.T) {
 	ctx := setupTest(t)
 
 	d := daemon.New(t)
-	d.StartWithBusybox(ctx, t)
+	d.StartNodeWithBusybox(ctx, t)
 	defer d.Stop(t)
 
 	d.SwarmInit(ctx, t, swarmtypes.InitRequest{AdvertiseAddr: "127.0.0.1:2377"})

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -60,7 +60,7 @@ func TestPingSwarmHeader(t *testing.T) {
 
 	ctx := setupTest(t)
 	d := daemon.New(t)
-	d.Start(t)
+	d.StartNode(t)
 	defer d.Stop(t)
 	apiClient := d.NewClientT(t)
 	defer apiClient.Close()

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -530,10 +530,10 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		d.args = append(d.args, "--storage-driver", d.storageDriver)
 	}
 
-	hasFwBackendArg := !slices.ContainsFunc(providedArgs, func(s string) bool {
+	hasFwBackendArg := slices.ContainsFunc(providedArgs, func(s string) bool {
 		return strings.HasPrefix(s, "--firewall-backend")
 	})
-	if hasFwBackendArg {
+	if !hasFwBackendArg {
 		if fw := os.Getenv("DOCKER_FIREWALL_BACKEND"); fw != "" {
 			d.args = append(d.args, "--firewall-backend="+fw)
 		}

--- a/testutil/daemon/swarm.go
+++ b/testutil/daemon/swarm.go
@@ -77,8 +77,8 @@ func (d *Daemon) NodeID() string {
 	return d.CachedInfo.Swarm.NodeID
 }
 
-// SwarmInit initializes a new swarm cluster.
-func (d *Daemon) SwarmInit(ctx context.Context, t testing.TB, req swarm.InitRequest) {
+// SwarmInitWithError initializes a new swarm cluster and returns an error.
+func (d *Daemon) SwarmInitWithError(ctx context.Context, t testing.TB, req swarm.InitRequest) error {
 	t.Helper()
 	if req.ListenAddr == "" {
 		req.ListenAddr = fmt.Sprintf("%s:%d", d.swarmListenAddr, d.SwarmPort)
@@ -93,8 +93,17 @@ func (d *Daemon) SwarmInit(ctx context.Context, t testing.TB, req swarm.InitRequ
 	cli := d.NewClientT(t)
 	defer cli.Close()
 	_, err := cli.SwarmInit(ctx, req)
+	if err == nil {
+		d.CachedInfo = d.Info(t)
+	}
+	return err
+}
+
+// SwarmInit initializes a new swarm cluster.
+func (d *Daemon) SwarmInit(ctx context.Context, t testing.TB, req swarm.InitRequest) {
+	t.Helper()
+	err := d.SwarmInitWithError(ctx, t, req)
 	assert.NilError(t, err, "initializing swarm")
-	d.CachedInfo = d.Info(t)
 }
 
 // SwarmJoin joins a daemon to an existing cluster.


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/49638

Because we can't translate Swarm's `iptables --ipvs` rule into nftables without also switching away from its IPVS load balancer, moby 29.0 won't include nftables support for Swarm.

So, prevent the daemon from starting with both Swarm and nftables enabled.

**- How I did it**

**- How to verify it**

New integration test.

**- Human readable description for the release notes**
```markdown changelog

```
