### PR TITLE
Add option --bridge-accept-fwmark

### DIFF
--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -39,6 +39,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.BoolVar(&conf.BridgeConfig.EnableUserlandProxy, "userland-proxy", true, "Use userland proxy for loopback traffic")
 	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", conf.BridgeConfig.UserlandProxyPath, "Path to the userland proxy binary")
 	flags.BoolVar(&conf.BridgeConfig.AllowDirectRouting, "allow-direct-routing", false, "Allow remote access to published ports on container IP addresses")
+	flags.StringVar(&conf.BridgeConfig.BridgeAcceptFwMark, "bridge-accept-fwmark", "", "In bridge networks, accept packets with this firewall mark/mask")
 	flags.StringVar(&conf.CgroupParent, "cgroup-parent", "", "Set parent cgroup for all containers")
 	flags.StringVar(&conf.RemappedRoot, "userns-remap", "", "User/Group setting for user namespaces")
 	flags.BoolVar(&conf.LiveRestoreEnabled, "live-restore", false, "Enable live restore of docker when containers are still running")

--- a/daemon/config/config_linux_test.go
+++ b/daemon/config/config_linux_test.go
@@ -396,3 +396,71 @@ func TestDaemonLegacyOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAcceptFwMarkMark(t *testing.T) {
+	tests := []struct {
+		name   string
+		val    string
+		expErr string
+	}{
+		{
+			name: "empty",
+			val:  "",
+		},
+		{
+			name: "dec/no-mask",
+			val:  "1",
+		},
+		{
+			name: "hex/no-mask",
+			val:  "0x1",
+		},
+		{
+			name: "dec/mask",
+			val:  "1/2",
+		},
+		{
+			name: "hex/mask",
+			val:  "0x1/0x2",
+		},
+		{
+			name: "octal/mask",
+			val:  "010/0xff",
+		},
+		{
+			name:   "bad/mark",
+			val:    "hello/0x2",
+			expErr: `invalid firewall mark "hello/0x2": strconv.ParseUint: parsing "hello": invalid syntax`,
+		},
+		{
+			name:   "bad/mark",
+			val:    "1/hello",
+			expErr: `invalid firewall mask "1/hello": strconv.ParseUint: parsing "hello": invalid syntax`,
+		},
+		{
+			name:   "bad/sep",
+			val:    "1+hello",
+			expErr: `invalid firewall mark "1+hello": strconv.ParseUint: parsing "1+hello": invalid syntax`,
+		},
+		{
+			name:   "bad/no-mask",
+			val:    "1/",
+			expErr: `invalid firewall mask "1/": strconv.ParseUint: parsing "": invalid syntax`,
+		},
+		{
+			name:   "bad/negative",
+			val:    "-1",
+			expErr: `invalid firewall mark "-1": strconv.ParseUint: parsing "-1": invalid syntax`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFwMarkMask(tc.val)
+			if tc.expErr == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.Check(t, is.ErrorContains(err, tc.expErr))
+			}
+		})
+	}
+}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -938,6 +938,7 @@ func networkPlatformOptions(conf *config.Config) []nwconfig.Option {
 				"EnableIP6Tables":          conf.BridgeConfig.EnableIP6Tables,
 				"Hairpin":                  !conf.EnableUserlandProxy || conf.UserlandProxyPath == "",
 				"AllowDirectRouting":       conf.BridgeConfig.AllowDirectRouting,
+				"AcceptFwMark":             conf.BridgeConfig.BridgeAcceptFwMark,
 			},
 		}),
 	}

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -77,6 +77,7 @@ type configuration struct {
 	// hairpinned.
 	Hairpin            bool
 	AllowDirectRouting bool
+	AcceptFwMark       string
 }
 
 // networkConfiguration for network specific configuration
@@ -429,6 +430,7 @@ func (n *bridgeNetwork) newFirewallerNetwork(ctx context.Context) (_ firewaller.
 		ICC:                   n.config.EnableICC,
 		Masquerade:            n.config.EnableIPMasquerade,
 		TrustedHostInterfaces: n.config.TrustedHostInterfaces,
+		AcceptFwMark:          n.driver.config.AcceptFwMark,
 		Config4:               config4,
 		Config6:               config6,
 	})

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
@@ -48,6 +48,10 @@ type NetworkConfig struct {
 	// bridge itself). In particular, these are not external interfaces for the purpose of
 	// blocking direct-routing to a container's IP address.
 	TrustedHostInterfaces []string
+	// AcceptFwMark is a firewall mark/mask. Packets with this mark will not be dropped by
+	// per-port blocking rules. So, packets with this mark have access to unpublished
+	// container ports.
+	AcceptFwMark string
 	// Config4 contains IPv4-specific configuration for the network.
 	Config4 NetworkConfigFam
 	// Config6 contains IPv6-specific configuration for the network.

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -34,7 +34,8 @@ const (
 )
 
 const (
-	fwdInLegacyLinksRuleGroup = iota + initialRuleGroup + 1
+	fwdInAcceptFwMarkRuleGroup = iota + initialRuleGroup + 1
+	fwdInLegacyLinksRuleGroup
 	fwdInICCRuleGroup
 	fwdInPortsRuleGroup
 	fwdInFinalRuleGroup

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -10,6 +10,7 @@ dockerd - Enable daemon mode
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
 [**--bip6**[=*BIP*]]
+[**--bridge-accept-fwmark**[=*[]*]]
 [**--cgroup-parent**[=*[]*]]
 [**--config-file**[=*path*]]
 [**--containerd**[=*SOCKET-PATH*]]
@@ -139,6 +140,9 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 **--bip6**=""
   Use the provided CIDR notation IPv6 address for the default bridge network;
   Mutually exclusive of \-b
+
+**--bridge-accept-fwmark**=""
+Bridge networks will accept packets with this firewall mark/mask.
 
 **--cgroup-parent**=""
   Set parent cgroup for all containers. Default is "/docker" for fs cgroup


### PR DESCRIPTION
**- What I did**

For iptables, users can add an `ACCEPT` rule to the `DOCKER-USER` chain - and that rule is final, the packet won't be processed by Docker's other filter-FORWARD rules - so it can be used to skip checks for published ports etc.

With nftables, there's no equivalent to the call to `DOCKER-USER` chain embedded in Docker's own base chain ... Docker expects to own the whole table, rules added by users to chains in that table will not be preserved. Users can add rules to chains in their own tables, where they can manipulate and drop packets before or after they're processed by Docker's rules.

However, an "accept" in one nftables chain is only an accept in the base chain that called the rule. So, if Docker's base chain drops the packet, it'll still do that (regardless of the order in which chains are processed) ... meaning there's no way for a user-managed table to override Docker's "drop".

So, make it possible to configure the daemon with a firewall mark/mask that results in an early "accept" in Docker's filter-FORWARD chain.

(It's possible mark/marks will need to be configurable per-network rather than per-daemon. It can be extended to that if a requirement emerges.)

The format of the option must be as follows, the usual base markers are accepted (including `0x` and `0o`):
- `<mark>` - the exact 32-bit unsigned integer mark value to match, or
- `<mark>/<mask>` - the packet's mark is masked, then matched against the given mark.

Will need to update the CLI's `docs/reference/dockerd.md` when this is merged.

**- How I did it**

Add daemon option `--bridge-accept-fwmark`.

Packets with the given firewall mark/mask are accepted by the bridge driver's filter-FORWARD rules.

The value can either be an integer mark, or it can include a mask in the format `<mark>/<mask>`. Mark and mask may include a base prefix (`0x1`).

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
- Add daemon option `--bridge-accept-fwmark`. Packets with this firewall mark will accepted by bridge networks, overriding Docker's iptables or nftables "drop" rules.
```
