### PR TITLE
integration-cli: migrate TestAPIClientVersionOldNotSupported to integration

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -1,18 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"net/http"
-	"runtime"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
-	"github.com/moby/moby/api/types/versions"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -45,30 +39,6 @@ func (s *DockerAPISuite) TestAPIGetEnabledCORS(c *testing.T) {
 	// c.Log(res.Header)
 	// assert.Equal(c, res.Header.Get("Access-Control-Allow-Origin"), "*")
 	// assert.Equal(c, res.Header.Get("Access-Control-Allow-Headers"), "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
-}
-
-func (s *DockerAPISuite) TestAPIClientVersionOldNotSupported(c *testing.T) {
-	if testEnv.DaemonInfo.OSType != runtime.GOOS {
-		c.Skip("Daemon platform doesn't match test platform")
-	}
-
-	major, minor, _ := strings.Cut(testEnv.DaemonVersion.MinAPIVersion, ".")
-	vMinInt, err := strconv.Atoi(minor)
-	assert.NilError(c, err)
-	vMinInt--
-	version := fmt.Sprintf("%s.%d", major, vMinInt)
-
-	resp, body, err := request.Get(testutil.GetContext(c), "/v"+version+"/version")
-	assert.NilError(c, err)
-	assert.Equal(c, resp.StatusCode, http.StatusBadRequest)
-	expected := fmt.Sprintf("client version %s is too old. Minimum supported API version is %s, please upgrade your client to a newer version", version, testEnv.DaemonVersion.MinAPIVersion)
-	b, err := request.ReadBody(body)
-	assert.NilError(c, err)
-	errMessage := string(bytes.TrimSpace(b))
-	if versions.GreaterThanOrEqualTo(version, "1.24") {
-		errMessage = getErrorMessage(c, b)
-	}
-	assert.Equal(c, errMessage, expected)
 }
 
 func (s *DockerAPISuite) TestAPIErrorJSON(c *testing.T) {

--- a/integration/system/version_test.go
+++ b/integration/system/version_test.go
@@ -1,8 +1,13 @@
 package system
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/docker/docker/testutil/request"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -19,4 +24,18 @@ func TestVersion(t *testing.T) {
 	assert.Check(t, version.MinAPIVersion != "")
 	assert.Check(t, is.Equal(testEnv.DaemonInfo.ExperimentalBuild, version.Experimental))
 	assert.Check(t, is.Equal(testEnv.DaemonInfo.OSType, version.Os))
+}
+
+func TestAPIClientVersionOldNotSupported(t *testing.T) {
+	ctx := setupTest(t)
+	major, minor, _ := strings.Cut(testEnv.DaemonVersion.MinAPIVersion, ".")
+	vMinInt, err := strconv.Atoi(minor)
+	assert.NilError(t, err)
+	vMinInt--
+	version := fmt.Sprintf("%s.%d", major, vMinInt)
+	apiClient := request.NewAPIClient(t, client.WithVersion(version))
+
+	expectedErrorMessage := fmt.Sprintf("Error response from daemon: client version %s is too old. Minimum supported API version is %s, please upgrade your client to a newer version", version, testEnv.DaemonVersion.MinAPIVersion)
+	_, err = apiClient.ServerVersion(ctx)
+	assert.Error(t, err, expectedErrorMessage)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Migrated the TestAPIClientVersionOldNotSupported to integration tests in reference to the integration-cli migration epic https://github.com/moby/moby/issues/50159

**- How I did it**

Using test on `integration-cli/docker_api_test.go`

**- How to verify it**

Run the integration test

