### PR TITLE
api/types/container: add missing type for exec-inspect response.

### DIFF
--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -109,29 +109,11 @@ type ExecStartConfig struct {
 
 // ExecInspect holds information about a running process started
 // with docker exec.
-type ExecInspect struct {
-	ID            string
-	Running       bool
-	ExitCode      *int
-	ProcessConfig *ExecProcessConfig
-	OpenStdin     bool
-	OpenStderr    bool
-	OpenStdout    bool
-	CanRemove     bool
-	ContainerID   string
-	DetachKeys    []byte
-	Pid           int
-}
+type ExecInspect = container.ExecInspectResponse
 
 // ExecProcessConfig holds information about the exec process
 // running on the host.
-type ExecProcessConfig struct {
-	Tty        bool     `json:"tty"`
-	Entrypoint string   `json:"entrypoint"`
-	Arguments  []string `json:"arguments"`
-	Privileged *bool    `json:"privileged,omitempty"`
-	User       string   `json:"user,omitempty"`
-}
+type ExecProcessConfig = container.ExecProcessConfig
 
 // CreateImageConfig is the configuration for creating an image from a
 // container.

--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -44,10 +44,42 @@ type ExecStartOptions struct {
 type ExecAttachOptions = ExecStartOptions
 
 // ExecInspect holds information returned by exec inspect.
+//
+// It is used by the client to unmarshal a [ExecInspectResponse],
+// but currently only provides a subset of the information included
+// in that type.
+//
+// TODO(thaJeztah): merge [ExecInspect] and [ExecInspectResponse],
 type ExecInspect struct {
 	ExecID      string `json:"ID"`
-	ContainerID string
-	Running     bool
-	ExitCode    int
-	Pid         int
+	ContainerID string `json:"ContainerID"`
+	Running     bool   `json:"Running"`
+	ExitCode    int    `json:"ExitCode"`
+	Pid         int    `json:"Pid"`
+}
+
+// ExecInspectResponse is the API response for the "GET /exec/{id}/json"
+// endpoint and holds information about and exec.
+type ExecInspectResponse struct {
+	ID            string `json:"ID"`
+	Running       bool   `json:"Running"`
+	ExitCode      *int   `json:"ExitCode"`
+	ProcessConfig *ExecProcessConfig
+	OpenStdin     bool   `json:"OpenStdin"`
+	OpenStderr    bool   `json:"OpenStderr"`
+	OpenStdout    bool   `json:"OpenStdout"`
+	CanRemove     bool   `json:"CanRemove"`
+	ContainerID   string `json:"ContainerID"`
+	DetachKeys    []byte `json:"DetachKeys"`
+	Pid           int    `json:"Pid"`
+}
+
+// ExecProcessConfig holds information about the exec process
+// running on the host.
+type ExecProcessConfig struct {
+	Tty        bool     `json:"tty"`
+	Entrypoint string   `json:"entrypoint"`
+	Arguments  []string `json:"arguments"`
+	Privileged *bool    `json:"privileged,omitempty"`
+	User       string   `json:"user,omitempty"`
 }

--- a/vendor/github.com/moby/moby/api/types/backend/backend.go
+++ b/vendor/github.com/moby/moby/api/types/backend/backend.go
@@ -109,29 +109,11 @@ type ExecStartConfig struct {
 
 // ExecInspect holds information about a running process started
 // with docker exec.
-type ExecInspect struct {
-	ID            string
-	Running       bool
-	ExitCode      *int
-	ProcessConfig *ExecProcessConfig
-	OpenStdin     bool
-	OpenStderr    bool
-	OpenStdout    bool
-	CanRemove     bool
-	ContainerID   string
-	DetachKeys    []byte
-	Pid           int
-}
+type ExecInspect = container.ExecInspectResponse
 
 // ExecProcessConfig holds information about the exec process
 // running on the host.
-type ExecProcessConfig struct {
-	Tty        bool     `json:"tty"`
-	Entrypoint string   `json:"entrypoint"`
-	Arguments  []string `json:"arguments"`
-	Privileged *bool    `json:"privileged,omitempty"`
-	User       string   `json:"user,omitempty"`
-}
+type ExecProcessConfig = container.ExecProcessConfig
 
 // CreateImageConfig is the configuration for creating an image from a
 // container.

--- a/vendor/github.com/moby/moby/api/types/container/exec.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec.go
@@ -44,10 +44,42 @@ type ExecStartOptions struct {
 type ExecAttachOptions = ExecStartOptions
 
 // ExecInspect holds information returned by exec inspect.
+//
+// It is used by the client to unmarshal a [ExecInspectResponse],
+// but currently only provides a subset of the information included
+// in that type.
+//
+// TODO(thaJeztah): merge [ExecInspect] and [ExecInspectResponse],
 type ExecInspect struct {
 	ExecID      string `json:"ID"`
-	ContainerID string
-	Running     bool
-	ExitCode    int
-	Pid         int
+	ContainerID string `json:"ContainerID"`
+	Running     bool   `json:"Running"`
+	ExitCode    int    `json:"ExitCode"`
+	Pid         int    `json:"Pid"`
+}
+
+// ExecInspectResponse is the API response for the "GET /exec/{id}/json"
+// endpoint and holds information about and exec.
+type ExecInspectResponse struct {
+	ID            string `json:"ID"`
+	Running       bool   `json:"Running"`
+	ExitCode      *int   `json:"ExitCode"`
+	ProcessConfig *ExecProcessConfig
+	OpenStdin     bool   `json:"OpenStdin"`
+	OpenStderr    bool   `json:"OpenStderr"`
+	OpenStdout    bool   `json:"OpenStdout"`
+	CanRemove     bool   `json:"CanRemove"`
+	ContainerID   string `json:"ContainerID"`
+	DetachKeys    []byte `json:"DetachKeys"`
+	Pid           int    `json:"Pid"`
+}
+
+// ExecProcessConfig holds information about the exec process
+// running on the host.
+type ExecProcessConfig struct {
+	Tty        bool     `json:"tty"`
+	Entrypoint string   `json:"entrypoint"`
+	Arguments  []string `json:"arguments"`
+	Privileged *bool    `json:"privileged,omitempty"`
+	User       string   `json:"user,omitempty"`
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50384

While the container package had a type for `ExecInspect`, this type only contained the information currently used by the client, which was a subset of the information returned by the API endpoint;

    curl --unix-socket /var/run/docker.sock http://localhost/v1.51/exec/2f8fc8b4b5003e9a58d97459e6561f2bf2d88bc059bc59c6633e7f765fb8d1e9/json | jq .
    {
      "ID": "2f8fc8b4b5003e9a58d97459e6561f2bf2d88bc059bc59c6633e7f765fb8d1e9",
      "Running": true,
      "ExitCode": null,
      "ProcessConfig": {
        "tty": true,
        "entrypoint": "bash",
        "arguments": [],
        "privileged": false
      },
      "OpenStdin": true,
      "OpenStderr": true,
      "OpenStdout": true,
      "CanRemove": false,
      "ContainerID": "8b7cd6b151613ccc20ebe9fc24d72cc7865b04c592848ab1415a80da9b315479",
      "DetachKeys": "EBE=",
      "Pid": 19964
    }

The API documentation for the endpoint documented the full response, but we did not have a type for this, other than a type used by the backend.

This patch adds a type for the response. It currently aliases the backend type to this type to preserve backward compatibility (and allow the API module to be used in older branches). We can probably switch the backend to use this type directly though (unless we want the backend to be decoupled from the API response).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

