### PR TITLE
hack/validate: remove obsolete exception, fix missing alias for stdcopy.Systemerr

### DIFF
--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -256,15 +256,6 @@ Function Validate-PkgImports($headCommit, $upstreamCommit) {
     $files=@(); $files = Invoke-Expression "git diff $upstreamCommit...$headCommit --diff-filter=ACMR --name-only -- `'pkg\*.go`'"
     $badFiles=@(); $files | ForEach-Object{
         $file=$_
-
-        if ($file -like "pkg\stdcopy\*") {
-            # Temporarily allow pkg/stdcopy to import "github.com/moby/moby/api/stdcopy",
-            # because it's an alias for backward-compatibility.
-            #
-            # TODO(thaJeztah): remove once "github.com/docker/docker/pkg/stdcopy" is removed.
-            return
-        }
-
         # For the current changed file, get its list of dependencies, sorted and uniqued.
         $imports = Invoke-Expression "go list -e -f `'{{ .Deps }}`' $file"
         if ($LASTEXITCODE -ne 0) { Throw "Failed go list for dependencies on $file" }

--- a/hack/validate/pkg-imports
+++ b/hack/validate/pkg-imports
@@ -10,16 +10,6 @@ unset IFS
 
 badFiles=()
 for f in "${files[@]}"; do
-	case "$f" in
-		pkg/stdcopy/*)
-			# Temporarily allow pkg/stdcopy to import "github.com/moby/moby/api/stdcopy",
-			# because it's an alias for backward-compatibility.
-			#
-			# TODO(thaJeztah): remove once "github.com/docker/docker/pkg/stdcopy" is removed.
-			continue
-			;;
-	esac
-
 	IFS=$'\n'
 	badImports=($(go list -e -f '{{ join .Deps "\n" }}' "$f" | sort -u \
 		| grep -vE '^github.com/docker/docker/pkg/' \

--- a/pkg/stdcopy/stdcopy_deprecated.go
+++ b/pkg/stdcopy/stdcopy_deprecated.go
@@ -13,9 +13,10 @@ import (
 type StdType = stdcopy.StdType
 
 const (
-	Stdin  = stdcopy.Stdin  // Deprecated: use [stdcopy.Stderr]. This alias will be removed in the next release.
-	Stdout = stdcopy.Stdout // Deprecated: use [stdcopy.Stdout]. This alias will be removed in the next release.
-	Stderr = stdcopy.Stderr // Deprecated: use [stdcopy.Stderr]. This alias will be removed in the next release.
+	Stdin     = stdcopy.Stdin     // Deprecated: use [stdcopy.Stderr]. This alias will be removed in the next release.
+	Stdout    = stdcopy.Stdout    // Deprecated: use [stdcopy.Stdout]. This alias will be removed in the next release.
+	Stderr    = stdcopy.Stderr    // Deprecated: use [stdcopy.Stderr]. This alias will be removed in the next release.
+	Systemerr = stdcopy.Systemerr // Deprecated: use [stdcopy.Systemerr]. This alias will be removed in the next release.
 )
 
 // NewStdWriter instantiates a new Writer.

--- a/pkg/stdcopy/stdcopy_deprecated.go
+++ b/pkg/stdcopy/stdcopy_deprecated.go
@@ -1,12 +1,10 @@
-package stdcopy // Deprecated: use [github.com/docker/docker/api/stdcopy] instead.
+package stdcopy // Deprecated: use [github.com/moby/moby/api/stdcopy] instead.
 
 import (
 	"io"
 
 	"github.com/moby/moby/api/stdcopy"
 )
-
-// TODO(thaJeztah): remove exception in hack/make.ps1 and hack/validate/pkg-imports when removing.
 
 // StdType is the type of standard stream
 // a writer can multiplex to.


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/50462

This was added in 20d594fb79949fe61a8cdfde52829ba7ef1a69ed, but was written before the API module was added. Now that the API is a separate module, the check will no longer flag packages importing the API.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

