### PR TITLE
[25.0] Backport auth fallback and send empty body fix

### DIFF
--- a/api/types/registry/authconfig_test.go
+++ b/api/types/registry/authconfig_test.go
@@ -1,7 +1,5 @@
 package registry // import "github.com/docker/docker/api/types/registry"
 import (
-	"io"
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -44,12 +42,6 @@ func TestDecodeAuthConfig(t *testing.T) {
 		assert.ErrorContains(t, err, "invalid X-Registry-Auth header: unexpected EOF")
 		assert.Equal(t, *token, AuthConfig{})
 	})
-}
-
-func TestDecodeAuthConfigBody(t *testing.T) {
-	token, err := DecodeAuthConfigBody(io.NopCloser(strings.NewReader(unencoded)))
-	assert.NilError(t, err)
-	assert.Equal(t, *token, expected)
 }
 
 func TestEncodeAuthConfig(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Backports https://github.com/moby/moby/pull/50371 to 25.0 LTS branch.

**- How I did it**

```
git cherry-pick -xsS ea29dffaa541289591aa44fa85d2a596ce860e16
```

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`POST /images/{name:}/push`: remove compatibility with API v1.4 auth-config in body.
```

**- A picture of a cute animal (not mandatory but encouraged)**

