### PR TITLE
adjust minimum API-version for multiple platforms on save/load

### DIFF
--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -286,7 +286,7 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, platf
 			for _, p := range platformList {
 				platformNames = append(platformNames, platforms.FormatAll(p))
 			}
-			log.G(ctx).WithFields(log.Fields{"error": err, "platform(s)": platformNames}).Debug("failed to import image to containerd")
+			log.G(ctx).WithFields(log.Fields{"error": err, "platforms": platformNames}).Debug("failed to import image to containerd")
 
 			// Note: ErrEmptyWalk will not be returned in most cases as
 			// index.json will contain a descriptor of the actual OCI index or

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -244,13 +244,13 @@ func (ir *imageRouter) getImagesGet(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	var platformList []ocispec.Platform
-	// platform param was introduce in API version 1.48
+	// platform param was introduced in API version 1.48
 	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.48") {
 		var err error
 		formPlatforms := r.Form["platform"]
-		// multi-platform params were introduced in API version 1.51
-		if versions.LessThan(httputils.VersionFromContext(ctx), "1.51") && len(formPlatforms) > 1 {
-			return errdefs.InvalidParameter(errors.New("multiple platform parameters are not supported in this API version; use API version 1.51 or later."))
+		// multi-platform params were introduced in API version 1.52
+		if versions.LessThan(httputils.VersionFromContext(ctx), "1.52") && len(formPlatforms) > 1 {
+			return errdefs.InvalidParameter(errors.New("multiple platform parameters are not supported in this API version; use API version 1.52 or later"))
 		}
 		platformList, err = httputils.DecodePlatforms(formPlatforms)
 		if err != nil {
@@ -274,13 +274,13 @@ func (ir *imageRouter) postImagesLoad(ctx context.Context, w http.ResponseWriter
 	}
 
 	var platformList []ocispec.Platform
-	// platform param was introduce in API version 1.48
+	// platform param was introduced in API version 1.48
 	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.48") {
 		var err error
 		formPlatforms := r.Form["platform"]
-		// multi-platform params were introduced in API version 1.51
-		if versions.LessThan(httputils.VersionFromContext(ctx), "1.51") && len(formPlatforms) > 1 {
-			return errdefs.InvalidParameter(errors.New("multiple platform parameters are not supported in this API version; use API version 1.51 or later."))
+		// multi-platform params were introduced in API version 1.52
+		if versions.LessThan(httputils.VersionFromContext(ctx), "1.52") && len(formPlatforms) > 1 {
+			return errdefs.InvalidParameter(errors.New("multiple platform parameters are not supported in this API version; use API version 1.52 or later"))
 		}
 		platformList, err = httputils.DecodePlatforms(formPlatforms)
 		if err != nil {

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -17,6 +17,11 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 [Docker Engine API v1.52](https://docs.docker.com/reference/api/engine/version/v1.52/) documentation
 
+* `GET /images/{name}/get` now accepts multiple `platform` query-arguments
+  to allow selecting which platform(s) of a multi-platform image must be
+  saved.
+* `POST /images/load` now accepts multiple `platform` query-arguments
+  to allow selecting which platform(s) of a multi-platform image to load.
 
 ## v1.51 API changes
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/50166

Follow-up to fcc8209e12ea1a7e1230d3d7c7040526d63a0468, which didn't make the window for API v1.51, so had to be adjusted for the API version it requires.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

