### PR TITLE
api/types/container: remove deprecated Stats type

### DIFF
--- a/api/types/container/stats.go
+++ b/api/types/container/stats.go
@@ -147,11 +147,6 @@ type PidsStats struct {
 	Limit uint64 `json:"limit,omitempty"`
 }
 
-// Stats is Ultimate struct aggregating all types of stats of one container
-//
-// Deprecated: use [StatsResponse] instead. This type will be removed in the next release.
-type Stats = StatsResponse
-
 // StatsResponse aggregates all types of stats of one container.
 type StatsResponse struct {
 	Name string `json:"name,omitempty"`

--- a/vendor/github.com/moby/moby/api/types/container/stats.go
+++ b/vendor/github.com/moby/moby/api/types/container/stats.go
@@ -147,11 +147,6 @@ type PidsStats struct {
 	Limit uint64 `json:"limit,omitempty"`
 }
 
-// Stats is Ultimate struct aggregating all types of stats of one container
-//
-// Deprecated: use [StatsResponse] instead. This type will be removed in the next release.
-type Stats = StatsResponse
-
 // StatsResponse aggregates all types of stats of one container.
 type StatsResponse struct {
 	Name string `json:"name,omitempty"`


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49287

This type was deprecated in ca06b222e3c0480a50fc2fd3129f7fc13a1b55f1, and is no longer used. Now that the API is in a new module, we can remove the alias.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types/container: remove deprecated `Stats` type.
```

**- A picture of a cute animal (not mandatory but encouraged)**

