### PR TITLE
api/types/container: move StateStatus, NewStateStatus internal again

### DIFF
--- a/api/types/container/state.go
+++ b/api/types/container/state.go
@@ -34,31 +34,3 @@ func ValidateContainerState(s ContainerState) error {
 		return errInvalidParameter{error: fmt.Errorf("invalid value for state (%s): must be one of %s", s, strings.Join(validStates, ", "))}
 	}
 }
-
-// StateStatus is used to return container wait results.
-// Implements exec.ExitCode interface.
-// This type is needed as State include a sync.Mutex field which make
-// copying it unsafe.
-type StateStatus struct {
-	exitCode int
-	err      error
-}
-
-// ExitCode returns current exitcode for the state.
-func (s StateStatus) ExitCode() int {
-	return s.exitCode
-}
-
-// Err returns current error for the state. Returns nil if the container had
-// exited on its own.
-func (s StateStatus) Err() error {
-	return s.err
-}
-
-// NewStateStatus returns a new StateStatus with the given exit code and error.
-func NewStateStatus(exitCode int, err error) StateStatus {
-	return StateStatus{
-		exitCode: exitCode,
-		err:      err,
-	}
-}

--- a/daemon/builder/builder.go
+++ b/daemon/builder/builder.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 
+	containerpkg "github.com/docker/docker/daemon/container"
 	"github.com/docker/docker/daemon/internal/image"
 	"github.com/docker/docker/daemon/internal/layer"
 	"github.com/docker/docker/daemon/server/backend"
@@ -65,7 +66,7 @@ type ExecBackend interface {
 	// ContainerStart starts a new container
 	ContainerStart(ctx context.Context, containerID string, checkpoint string, checkpointDir string) error
 	// ContainerWait stops processing until the given container is stopped.
-	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan containerpkg.StateStatus, error)
 }
 
 // Result is the output produced by a Builder

--- a/daemon/builder/dockerfile/mockbackend_test.go
+++ b/daemon/builder/dockerfile/mockbackend_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/docker/docker/daemon/builder"
+	containerpkg "github.com/docker/docker/daemon/container"
 	"github.com/docker/docker/daemon/internal/image"
 	"github.com/docker/docker/daemon/internal/layer"
 	"github.com/docker/docker/daemon/server/backend"
@@ -49,7 +50,7 @@ func (m *MockBackend) ContainerStart(ctx context.Context, containerID string, ch
 	return nil
 }
 
-func (m *MockBackend) ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan container.StateStatus, error) {
+func (m *MockBackend) ContainerWait(ctx context.Context, containerID string, condition container.WaitCondition) (<-chan containerpkg.StateStatus, error) {
 	return nil, nil
 }
 

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
+	containerpkg "github.com/docker/docker/daemon/container"
 	"github.com/docker/docker/daemon/internal/image"
 	"github.com/docker/docker/daemon/libnetwork"
 	"github.com/docker/docker/daemon/libnetwork/cluster"
@@ -44,7 +45,7 @@ type Backend interface {
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
 	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (*container.InspectResponse, error)
-	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	ContainerRm(name string, config *backend.ContainerRmConfig) error
 	ContainerKill(name string, sig string) error
 	SetContainerDependencyStore(name string, store exec.DependencyGetter) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemon/cluster/convert"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
+	containerpkg "github.com/docker/docker/daemon/container"
 	"github.com/docker/docker/daemon/libnetwork"
 	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/daemon/server/backend"
@@ -415,7 +416,7 @@ func (c *containerAdapter) events(ctx context.Context) <-chan events.Message {
 	return eventsq
 }
 
-func (c *containerAdapter) wait(ctx context.Context) (<-chan containertypes.StateStatus, error) {
+func (c *containerAdapter) wait(ctx context.Context) (<-chan containerpkg.StateStatus, error) {
 	return c.backend.ContainerWait(ctx, c.container.nameOrID(), containertypes.WaitConditionNotRunning)
 }
 

--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -46,8 +46,8 @@ type State struct {
 	Health            *Health
 	Removed           bool `json:"-"`
 
-	stopWaiters       []chan<- container.StateStatus
-	removeOnlyWaiters []chan<- container.StateStatus
+	stopWaiters       []chan<- StateStatus
+	removeOnlyWaiters []chan<- StateStatus
 
 	// The libcontainerd reference fields are unexported to force consumers
 	// to access them through the getter methods with multi-valued returns
@@ -56,6 +56,26 @@ type State struct {
 
 	ctr  libcontainerdtypes.Container
 	task libcontainerdtypes.Task
+}
+
+// StateStatus is used to return container wait results.
+// Implements exec.ExitCode interface.
+// This type is needed as State include a sync.Mutex field which make
+// copying it unsafe.
+type StateStatus struct {
+	exitCode int
+	err      error
+}
+
+// ExitCode returns current exitcode for the state.
+func (s StateStatus) ExitCode() int {
+	return s.exitCode
+}
+
+// Err returns current error for the state. Returns nil if the container had
+// exited on its own.
+func (s StateStatus) Err() error {
+	return s.err
 }
 
 // NewState creates a default state object.
@@ -138,20 +158,23 @@ func (s *State) StateString() container.ContainerState {
 // be nil and its ExitCode() method will return the container's exit code,
 // otherwise, the results Err() method will return an error indicating why the
 // wait operation failed.
-func (s *State) Wait(ctx context.Context, condition container.WaitCondition) <-chan container.StateStatus {
+func (s *State) Wait(ctx context.Context, condition container.WaitCondition) <-chan StateStatus {
 	s.Lock()
 	defer s.Unlock()
 
 	// Buffer so we can put status and finish even nobody receives it.
-	resultC := make(chan container.StateStatus, 1)
+	resultC := make(chan StateStatus, 1)
 
 	if s.conditionAlreadyMet(condition) {
-		resultC <- container.NewStateStatus(s.ExitCode(), s.Err())
+		resultC <- StateStatus{
+			exitCode: s.ExitCodeValue,
+			err:      s.Err(),
+		}
 
 		return resultC
 	}
 
-	waitC := make(chan container.StateStatus, 1)
+	waitC := make(chan StateStatus, 1)
 
 	// Removal wakes up both removeOnlyWaiters and stopWaiters
 	// Container could be removed while still in "created" state
@@ -166,8 +189,10 @@ func (s *State) Wait(ctx context.Context, condition container.WaitCondition) <-c
 		select {
 		case <-ctx.Done():
 			// Context timeout or cancellation.
-			resultC <- container.NewStateStatus(-1, ctx.Err())
-
+			resultC <- StateStatus{
+				exitCode: -1,
+				err:      ctx.Err(),
+			}
 			return
 		case status := <-waitC:
 			resultC <- status
@@ -397,8 +422,11 @@ func (s *State) Err() error {
 	return nil
 }
 
-func (s *State) notifyAndClear(waiters *[]chan<- container.StateStatus) {
-	result := container.NewStateStatus(s.ExitCodeValue, s.Err())
+func (s *State) notifyAndClear(waiters *[]chan<- StateStatus) {
+	result := StateStatus{
+		exitCode: s.ExitCodeValue,
+		err:      s.Err(),
+	}
 
 	for _, c := range *waiters {
 		c <- result

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	containerpkg "github.com/docker/docker/daemon/container"
 	"github.com/docker/docker/daemon/server/backend"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/types/container"
@@ -40,7 +41,7 @@ type stateBackend interface {
 	ContainerStop(ctx context.Context, name string, options container.StopOptions) error
 	ContainerUnpause(name string) error
 	ContainerUpdate(name string, hostConfig *container.HostConfig) (container.UpdateResponse, error)
-	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan container.StateStatus, error)
+	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan containerpkg.StateStatus, error)
 }
 
 // monitorBackend includes functions to implement to provide containers monitoring functionality.

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 
+	"github.com/docker/docker/daemon/container"
 	containertypes "github.com/moby/moby/api/types/container"
 )
 
@@ -13,7 +14,7 @@ import (
 // condition is met or if an error occurs waiting for the container (such as a
 // context timeout or cancellation). On a successful wait, the exit code of the
 // container is returned in the status with a non-nil Err() value.
-func (daemon *Daemon) ContainerWait(ctx context.Context, name string, condition containertypes.WaitCondition) (<-chan containertypes.StateStatus, error) {
+func (daemon *Daemon) ContainerWait(ctx context.Context, name string, condition containertypes.WaitCondition) (<-chan container.StateStatus, error) {
 	cntr, err := daemon.GetContainer(name)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/moby/moby/api/types/container/state.go
+++ b/vendor/github.com/moby/moby/api/types/container/state.go
@@ -34,31 +34,3 @@ func ValidateContainerState(s ContainerState) error {
 		return errInvalidParameter{error: fmt.Errorf("invalid value for state (%s): must be one of %s", s, strings.Join(validStates, ", "))}
 	}
 }
-
-// StateStatus is used to return container wait results.
-// Implements exec.ExitCode interface.
-// This type is needed as State include a sync.Mutex field which make
-// copying it unsafe.
-type StateStatus struct {
-	exitCode int
-	err      error
-}
-
-// ExitCode returns current exitcode for the state.
-func (s StateStatus) ExitCode() int {
-	return s.exitCode
-}
-
-// Err returns current error for the state. Returns nil if the container had
-// exited on its own.
-func (s StateStatus) Err() error {
-	return s.err
-}
-
-// NewStateStatus returns a new StateStatus with the given exit code and error.
-func NewStateStatus(exitCode int, err error) StateStatus {
-	return StateStatus{
-		exitCode: exitCode,
-		err:      err,
-	}
-}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/26158
- relates to https://github.com/moby/moby/pull/49874
- alternative to https://github.com/moby/moby/pull/50493


These types used to be internal to the container package, but were moved to the API in 100102108b2f096cd43165e4522a6314bc16f07c.

However, the `StateStatus` type is only used internally; it's used as an intermediate type because [`container.State`] contains a sync.Mutex field which would make copying it unsafe (see [moby@2998945]).

This deprecates the type and re-introduces an internal type in the original location.

[`container.State`]: https://github.com/moby/moby/blob/19e79906cb347ab12deaade16bf9d82c41d777c4/container/state.go#L15-L23
[moby@2998945]: https://github.com/moby/moby/commit/2998945a54577e24a6414d576bc861e58fa87359

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

