### PR TITLE
registry: remove deprecated RepositoryInfo.Official, Class fields

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -396,7 +396,6 @@ func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
 				Secure:   true,
 				Official: true,
 			},
-			Official: !strings.ContainsRune(reference.FamiliarName(reposName), '/'),
 		}, nil
 	}
 

--- a/registry/types.go
+++ b/registry/types.go
@@ -10,12 +10,6 @@ type RepositoryInfo struct {
 	Name reference.Named
 	// Index points to registry information
 	Index *registry.IndexInfo
-	// Official indicates whether the repository is considered official.
-	// If the registry is official, and the normalized name does not
-	// contain a '/' (e.g. "foo"), then it is considered an official repo.
-	//
-	// Deprecated: this field is no longer used and will be removed in the next release. The information captured in this field can be obtained from the [Name] field instead.
-	Official bool
 	// Class represents the class of the repository, such as "plugin"
 	// or "image".
 	//

--- a/registry/types.go
+++ b/registry/types.go
@@ -10,9 +10,4 @@ type RepositoryInfo struct {
 	Name reference.Named
 	// Index points to registry information
 	Index *registry.IndexInfo
-	// Class represents the class of the repository, such as "plugin"
-	// or "image".
-	//
-	// Deprecated: this field is no longer used, and will be removed in the next release.
-	Class string
 }


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/49567
- https://github.com/moby/moby/pull/49006


### registry: remove deprecated RepositoryInfo.Official field

This was deprecated in 08654b0b3052e1e2fba670a9445144a97e87536f, which
was part of the v28.x release, and is no longer used so we can remove.

### registry: remove deprecated RepositoryInfo.Class field

This was deprecated in 5f91c769f54f8e1da66de096fe09cf3f3d48c414, which
was part of the v28.x release, and is no longer used so we can remove.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: registry: remove deprecated `RepositoryInfo.Official` and `RepositoryInfo.Class` field
```

**- A picture of a cute animal (not mandatory but encouraged)**

