### PR TITLE
registry: fix assorted linting issues

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -40,9 +40,9 @@ type staticCredentialStore struct {
 
 // NewStaticCredentialStore returns a credential store
 // which always returns the same credential values.
-func NewStaticCredentialStore(auth *registry.AuthConfig) auth.CredentialStore {
+func NewStaticCredentialStore(ac *registry.AuthConfig) auth.CredentialStore {
 	return staticCredentialStore{
-		auth: auth,
+		auth: ac,
 	}
 }
 
@@ -60,7 +60,7 @@ func (scs staticCredentialStore) RefreshToken(*url.URL, string) string {
 	return scs.auth.IdentityToken
 }
 
-func (scs staticCredentialStore) SetRefreshToken(*url.URL, string, string) {
+func (staticCredentialStore) SetRefreshToken(*url.URL, string, string) {
 }
 
 // loginV2 tries to login to the v2 registry server. The given registry
@@ -131,8 +131,8 @@ func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifi
 // to just its hostname. It is used to match credentials, which may be either
 // stored as hostname or as hostname including scheme (in legacy configuration
 // files).
-func ConvertToHostname(url string) string {
-	stripped := url
+func ConvertToHostname(maybeURL string) string {
+	stripped := maybeURL
 	if strings.HasPrefix(stripped, "http://") {
 		stripped = strings.TrimPrefix(stripped, "http://")
 	} else if strings.HasPrefix(stripped, "https://") {
@@ -175,9 +175,9 @@ func (err PingResponseError) Error() string {
 // PingV2Registry attempts to ping a v2 registry and on success return a
 // challenge manager for the supported authentication types.
 // If a response is received but cannot be interpreted, a PingResponseError will be returned.
-func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.Manager, error) {
+func PingV2Registry(endpoint *url.URL, authTransport http.RoundTripper) (challenge.Manager, error) {
 	pingClient := &http.Client{
-		Transport: transport,
+		Transport: authTransport,
 		Timeout:   15 * time.Second,
 	}
 	endpointStr := strings.TrimRight(endpoint.String(), "/") + "/v2/"

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -133,10 +133,13 @@ func v2AuthHTTPClient(endpoint *url.URL, authTransport http.RoundTripper, modifi
 // files).
 func ConvertToHostname(maybeURL string) string {
 	stripped := maybeURL
-	if strings.HasPrefix(stripped, "http://") {
-		stripped = strings.TrimPrefix(stripped, "http://")
-	} else if strings.HasPrefix(stripped, "https://") {
-		stripped = strings.TrimPrefix(stripped, "https://")
+	if scheme, remainder, ok := strings.Cut(stripped, "://"); ok {
+		switch scheme {
+		case "http", "https":
+			stripped = remainder
+		default:
+			// unknown, or no scheme; doing nothing for now, as we never did.
+		}
 	}
 	stripped, _, _ = strings.Cut(stripped, "/")
 	return stripped

--- a/registry/config.go
+++ b/registry/config.go
@@ -241,18 +241,18 @@ func (config *serviceConfig) isSecureIndex(indexName string) bool {
 // for mocking in unit tests.
 var lookupIP = net.LookupIP
 
-// isCIDRMatch returns true if URLHost matches an element of cidrs. URLHost is a URL.Host (`host:port` or `host`)
+// isCIDRMatch returns true if urlHost matches an element of cidrs. urlHost is a URL.Host ("host:port" or "host")
 // where the `host` part can be either a domain name or an IP address. If it is a domain name, then it will be
 // resolved to IP addresses for matching. If resolution fails, false is returned.
-func isCIDRMatch(cidrs []*registry.NetIPNet, URLHost string) bool {
+func isCIDRMatch(cidrs []*registry.NetIPNet, urlHost string) bool {
 	if len(cidrs) == 0 {
 		return false
 	}
 
-	host, _, err := net.SplitHostPort(URLHost)
+	host, _, err := net.SplitHostPort(urlHost)
 	if err != nil {
-		// Assume URLHost is a host without port and go on.
-		host = URLHost
+		// Assume urlHost is a host without port and go on.
+		host = urlHost
 	}
 
 	var addresses []net.IP

--- a/registry/errors.go
+++ b/registry/errors.go
@@ -8,17 +8,13 @@ import (
 )
 
 func translateV2AuthError(err error) error {
-	switch e := err.(type) {
-	case *url.Error:
-		switch e2 := e.Err.(type) {
-		case errcode.Error:
-			switch e2.Code {
-			case errcode.ErrorCodeUnauthorized:
-				return unauthorizedErr{err}
-			}
+	var e *url.Error
+	if errors.As(err, &e) {
+		var e2 errcode.Error
+		if errors.As(e, &e2) && errors.Is(e2.Code, errcode.ErrorCodeUnauthorized) {
+			return unauthorizedErr{err}
 		}
 	}
-
 	return err
 }
 

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -116,4 +116,5 @@ func TestPing(t *testing.T) {
 	}
 	assert.Equal(t, res.StatusCode, http.StatusOK, "")
 	assert.Equal(t, res.Header.Get("Server"), "docker-tests/mock")
+	_ = res.Body.Close()
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -363,15 +363,6 @@ func TestNewIndexInfo(t *testing.T) {
 		},
 	}
 
-	testIndexInfo := func(t *testing.T, config *serviceConfig, expectedIndexInfos map[string]*registry.IndexInfo) {
-		for indexName, expected := range expectedIndexInfos {
-			t.Run(indexName, func(t *testing.T) {
-				actual := newIndexInfo(config, indexName)
-				assert.Check(t, is.DeepEqual(actual, expected))
-			})
-		}
-	}
-
 	expectedIndexInfos := map[string]*registry.IndexInfo{
 		IndexName: {
 			Name:     IndexName,
@@ -399,7 +390,12 @@ func TestNewIndexInfo(t *testing.T) {
 		},
 	}
 	t.Run("no mirrors", func(t *testing.T) {
-		testIndexInfo(t, emptyServiceConfig, expectedIndexInfos)
+		for indexName, expected := range expectedIndexInfos {
+			t.Run(indexName, func(t *testing.T) {
+				actual := newIndexInfo(emptyServiceConfig, indexName)
+				assert.Check(t, is.DeepEqual(actual, expected))
+			})
+		}
 	})
 
 	expectedIndexInfos = map[string]*registry.IndexInfo{
@@ -494,7 +490,12 @@ func TestNewIndexInfo(t *testing.T) {
 			InsecureRegistries: []string{"example.com"},
 		})
 		assert.NilError(t, err)
-		testIndexInfo(t, config, expectedIndexInfos)
+		for indexName, expected := range expectedIndexInfos {
+			t.Run(indexName, func(t *testing.T) {
+				actual := newIndexInfo(config, indexName)
+				assert.Check(t, is.DeepEqual(actual, expected))
+			})
+		}
 	})
 
 	expectedIndexInfos = map[string]*registry.IndexInfo{
@@ -546,7 +547,12 @@ func TestNewIndexInfo(t *testing.T) {
 			InsecureRegistries: []string{"42.42.0.0/16"},
 		})
 		assert.NilError(t, err)
-		testIndexInfo(t, config, expectedIndexInfos)
+		for indexName, expected := range expectedIndexInfos {
+			t.Run(indexName, func(t *testing.T) {
+				actual := newIndexInfo(config, indexName)
+				assert.Check(t, is.DeepEqual(actual, expected))
+			})
+		}
 	})
 }
 

--- a/registry/search_session.go
+++ b/registry/search_session.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -219,7 +220,7 @@ func (r *session) searchRepositories(ctx context.Context, term string, limit int
 	if limit < 1 || limit > 100 {
 		return nil, invalidParamf("limit %d is outside the range of [1, 100]", limit)
 	}
-	u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(fmt.Sprintf("%d", limit))
+	u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(strconv.Itoa(limit))
 	log.G(ctx).WithField("url", u).Debug("searchRepositories")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
@@ -236,7 +237,7 @@ func (r *session) searchRepositories(ctx context.Context, term string, limit int
 	if res.StatusCode != http.StatusOK {
 		// TODO(thaJeztah): return upstream response body for errors (see https://github.com/moby/moby/issues/27286).
 		// TODO(thaJeztah): handle other status-codes to return correct error-type
-		return nil, errUnknown{fmt.Errorf("Unexpected status code %d", res.StatusCode)}
+		return nil, errUnknown{fmt.Errorf("unexpected status code %d", res.StatusCode)}
 	}
 	result := &registry.SearchResults{}
 	err = json.NewDecoder(res.Body).Decode(result)

--- a/registry/search_test.go
+++ b/registry/search_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func spawnTestRegistrySession(t *testing.T) *session {
+	t.Helper()
 	authConfig := &registry.AuthConfig{}
 	endpoint, err := newV1Endpoint(context.Background(), makeIndex("/v1/"), nil)
 	if err != nil {
@@ -89,7 +90,7 @@ func TestSearchErrors(t *testing.T) {
 		expectedError     string
 	}{
 		{
-			expectedError:     "Unexpected status code 500",
+			expectedError:     "unexpected status code 500",
 			shouldReturnError: true,
 		},
 		{


### PR DESCRIPTION
- This will conflict with https://github.com/moby/moby/pull/50171 (sorry!), but making minimal changes related to 👇 
-  https://github.com/docker/cli/pull/6207

-----


### registry: serviceConfig.loadInsecureRegistries: fix ifElseChain (gocritic)

    registry/config.go:171:3: ifElseChain: rewrite if-else to switch statement (gocritic)
            if strings.HasPrefix(strings.ToLower(r), "http://") {
            ^

### registry: isCIDRMatch: fix captLocal (gocritic)

    registry/config.go:267:46: captLocal: `URLHost' should not be capitalized (gocritic)
        func isCIDRMatch(cidrs []*registry.NetIPNet, URLHost string) bool {

### registry: translateV2AuthError: fix singleCaseSwitch (gocritic)

     registry/errors.go:11:2: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
        switch e := err.(type) {
        ^
     registry/errors.go:13:3: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
            switch e2 := e.Err.(type) {
            ^
     registry/errors.go:15:4: singleCaseSwitch: should rewrite switch statement to if statement (gocritic)
                switch e2.Code {
                ^

### registry: fix assorted gocritic issues

    registry/auth.go:43:31: import-shadowing: The name 'auth' shadows an import name (revive)
    func NewStaticCredentialStore(auth *registry.AuthConfig) auth.CredentialStore {
                                  ^
    registry/auth.go:63:7: unused-receiver: method receiver 'scs' is not referenced in method's body, consider removing or renaming it as _ (revive)
    func (scs staticCredentialStore) SetRefreshToken(*url.URL, string, string) {
          ^
    registry/auth.go:143:40: import-shadowing: The name 'transport' shadows an import name (revive)
    func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.Manager, error) {
                                           ^
    registry/registry_mock_test.go:85:22: response body must be closed (bodyclose)
        res, err := http.Get(makeURL("/v1/_ping"))
                            ^
    registry/search_session.go:222:96: integer-format: fmt.Sprintf can be replaced with faster strconv.Itoa (perfsprint)
      u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(fmt.Sprintf("%d", limit))
                                                                                                    ^
    registry/auth.go:134:24: import-shadowing: The name 'url' shadows an import name (revive)
    func ConvertToHostname(url string) string {
                           ^
    registry/search_endpoint_v1.go:61: line-length-limit: line is 437 characters, out of limit 200 (revive)
                      return nil, invalidParamf("invalid registry endpoint %s: %v. If this private registry supports only HTTP or HTTPS with an unknown CA certificate, please add `--insecure-registry %s` to the daemon's arguments. In the case of HTTPS, if you have access to the registry's CA certificate, no need for the flag; simply place the CA certificate at /etc/docker/certs.d/%s/ca.crt", endpoint, err, endpoint.URL.Host, endpoint.URL.Host)
    registry/search_endpoint_v1.go:166:17: import-shadowing: The name 'transport' shadows an import name (revive)
    func httpClient(transport http.RoundTripper) *http.Client {
                    ^
    registry/search_session.go:239:26: ST1005: error strings should not be capitalized (staticcheck)
              return nil, errUnknown{fmt.Errorf("Unexpected status code %d", res.StatusCode)}
                                     ^
    registry/search_test.go:18:6: test helper function should start from t.Helper() (thelper)
    func spawnTestRegistrySession(t *testing.T) *session {
         ^

### registry: TestNewIndexInfo: inline testIndexInfo (thelper)

It's not really a helper, and it's trivial to inline it;

    registry/registry_test.go:366:19: test helper function should start from t.Helper() (thelper)
      testIndexInfo := func(t *testing.T, config *serviceConfig, expectedIndexInfos map[string]*registry.IndexInfo) {
                       ^

### registry: ConvertToHostname: use strings.Cut

Also prevents linters from flagging the use of "http://".

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

