### PR TITLE
[28.x backport] Fix firewalld reload for per-endpoint rules

### DIFF
--- a/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -792,10 +792,19 @@ func releasePortBindings(pbs []portBinding, fwn firewaller.Network) error {
 func (n *bridgeNetwork) reapplyPerPortIptables() {
 	n.Lock()
 	var allPBs []portBinding
+	var allEPs []*bridgeEndpoint
 	for _, ep := range n.endpoints {
 		allPBs = append(allPBs, ep.portMapping...)
+		allEPs = append(allEPs, ep)
 	}
 	n.Unlock()
+
+	for _, ep := range allEPs {
+		netip4, netip6 := ep.netipAddrs()
+		if err := n.firewallerNetwork.AddEndpoint(context.TODO(), netip4, netip6); err != nil {
+			log.G(context.TODO()).Warnf("Failed to reconfigure Endpoint: %s", err)
+		}
+	}
 
 	if err := n.firewallerNetwork.AddPorts(context.Background(), mergeChildHostIPs(allPBs)); err != nil {
 		log.G(context.TODO()).Warnf("Failed to reconfigure NAT: %s", err)


### PR DESCRIPTION
**- What I did**

- partial backport of https://github.com/moby/moby/pull/50443

Make sure per-Endpoint rules are reapplied after a firewalld reload.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Replace per-endpoint iptables rules after a firewalld reload.
```

**- A picture of a cute animal (not mandatory but encouraged)**

