### PR TITLE
Add leaked lease cleanup to daemon startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1176,6 +1176,15 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	if err := d.restore(cfgStore); err != nil {
 		return nil, err
 	}
+
+	// TODO(austinvazquez): Remove this workaround to cleanup leaked leases on startup
+	// once the container startup logic has been refactored to use container metadata
+	// for referencing snapshots.
+	// See https://github.com/moby/moby/issues/50508
+	if err := d.containerd.CleanupUnusedLeases(ctx); err != nil {
+		log.G(ctx).WithError(err).Debug("Failed to cleanup unused leases on startup")
+	}
+
 	close(d.startupDone)
 
 	info, err := d.SystemInfo(ctx)

--- a/daemon/internal/libcontainerd/local/local_windows.go
+++ b/daemon/internal/libcontainerd/local/local_windows.go
@@ -385,6 +385,12 @@ func (c *client) extractResourcesFromSpec(spec *specs.Spec, configuration *hcssh
 	}
 }
 
+// CleanupUnusedLeases is a no-op on Windows because moby talks directly to HCS
+// and does not use containerd leases.
+func (c *client) CleanupUnusedLeases(ctx context.Context) error {
+	return nil
+}
+
 func (ctr *container) NewTask(_ context.Context, _ string, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (_ libcontainerdtypes.Task, retErr error) {
 	ctr.mu.Lock()
 	defer ctr.mu.Unlock()

--- a/daemon/internal/libcontainerd/types/types.go
+++ b/daemon/internal/libcontainerd/types/types.go
@@ -60,6 +60,8 @@ type Client interface {
 	LoadContainer(ctx context.Context, containerID string) (Container, error)
 	// NewContainer creates a new containerd container.
 	NewContainer(ctx context.Context, containerID string, spec *specs.Spec, shim string, runtimeOptions interface{}, opts ...containerd.NewContainerOpts) (Container, error)
+	// CleanupUnusedLeases removes leases that are not associated with any resources.
+	CleanupUnusedLeases(context.Context) error
 }
 
 // Container provides access to a containerd container.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Implements https://github.com/moby/moby/issues/46020

This change is a temporary workaround for the leaked lease issue. Going forward it would be good to resolve the root cause of the issue which has been documented in https://github.com/moby/moby/issues/50508.

**- How I did it**
Added a non-critical cleanup step post-container restoration on daemon startup.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

