### PR TITLE
api/types: move client.go contents into moby/moby/client

### DIFF
--- a/api/types/backend/backend.go
+++ b/api/types/backend/backend.go
@@ -150,6 +150,11 @@ type CommitConfig struct {
 	ParentImageID       string
 }
 
+// PluginCreateConfig hold all options to plugin create.
+type PluginCreateConfig struct {
+	RepoName string
+}
+
 // PluginRmConfig holds arguments for plugin remove.
 type PluginRmConfig struct {
 	ForceRemove bool

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -1,6 +1,0 @@
-package types
-
-// PluginCreateOptions hold all options to plugin create.
-type PluginCreateOptions struct {
-	RepoName string
-}

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -1,42 +1,5 @@
 package types
 
-import (
-	"context"
-)
-
-// PluginRemoveOptions holds parameters to remove plugins.
-type PluginRemoveOptions struct {
-	Force bool
-}
-
-// PluginEnableOptions holds parameters to enable plugins.
-type PluginEnableOptions struct {
-	Timeout int
-}
-
-// PluginDisableOptions holds parameters to disable plugins.
-type PluginDisableOptions struct {
-	Force bool
-}
-
-// PluginInstallOptions holds parameters to install a plugin.
-type PluginInstallOptions struct {
-	Disabled             bool
-	AcceptAllPermissions bool
-	RegistryAuth         string // RegistryAuth is the base64 encoded credentials for the registry
-	RemoteRef            string // RemoteRef is the plugin name on the registry
-
-	// PrivilegeFunc is a function that clients can supply to retry operations
-	// after getting an authorization error. This function returns the registry
-	// authentication header value in base64 encoded format, or an error if the
-	// privilege request fails.
-	//
-	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
-	PrivilegeFunc         func(context.Context) (string, error)
-	AcceptPermissionsFunc func(context.Context, PluginPrivileges) (bool, error)
-	Args                  []string
-}
-
 // PluginCreateOptions hold all options to plugin create.
 type PluginCreateOptions struct {
 	RepoName string

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -1,50 +1,8 @@
 package types
 
 import (
-	"bufio"
 	"context"
-	"net"
 )
-
-// NewHijackedResponse initializes a [HijackedResponse] type.
-func NewHijackedResponse(conn net.Conn, mediaType string) HijackedResponse {
-	return HijackedResponse{Conn: conn, Reader: bufio.NewReader(conn), mediaType: mediaType}
-}
-
-// HijackedResponse holds connection information for a hijacked request.
-type HijackedResponse struct {
-	mediaType string
-	Conn      net.Conn
-	Reader    *bufio.Reader
-}
-
-// Close closes the hijacked connection and reader.
-func (h *HijackedResponse) Close() {
-	h.Conn.Close()
-}
-
-// MediaType let client know if HijackedResponse hold a raw or multiplexed stream.
-// returns false if HTTP Content-Type is not relevant, and container must be inspected
-func (h *HijackedResponse) MediaType() (string, bool) {
-	if h.mediaType == "" {
-		return "", false
-	}
-	return h.mediaType, true
-}
-
-// CloseWriter is an interface that implements structs
-// that close input streams to prevent from writing.
-type CloseWriter interface {
-	CloseWrite() error
-}
-
-// CloseWrite closes a readWriter for writing.
-func (h *HijackedResponse) CloseWrite() error {
-	if conn, ok := h.Conn.(CloseWriter); ok {
-		return conn.CloseWrite()
-	}
-	return nil
-}
 
 // PluginRemoveOptions holds parameters to remove plugins.
 type PluginRemoveOptions struct {

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -64,11 +64,11 @@ type HijackDialer interface {
 
 // ContainerAPIClient defines API client methods for the containers
 type ContainerAPIClient interface {
-	ContainerAttach(ctx context.Context, container string, options container.AttachOptions) (types.HijackedResponse, error)
+	ContainerAttach(ctx context.Context, container string, options container.AttachOptions) (HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options container.CommitOptions) (container.CommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
-	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (types.HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -148,11 +148,11 @@ type NodeAPIClient interface {
 // PluginAPIClient defines API client methods for the plugins
 type PluginAPIClient interface {
 	PluginList(ctx context.Context, filter filters.Args) (types.PluginsListResponse, error)
-	PluginRemove(ctx context.Context, name string, options types.PluginRemoveOptions) error
-	PluginEnable(ctx context.Context, name string, options types.PluginEnableOptions) error
-	PluginDisable(ctx context.Context, name string, options types.PluginDisableOptions) error
-	PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) (io.ReadCloser, error)
-	PluginUpgrade(ctx context.Context, name string, options types.PluginInstallOptions) (io.ReadCloser, error)
+	PluginRemove(ctx context.Context, name string, options PluginRemoveOptions) error
+	PluginEnable(ctx context.Context, name string, options PluginEnableOptions) error
+	PluginDisable(ctx context.Context, name string, options PluginDisableOptions) error
+	PluginInstall(ctx context.Context, name string, options PluginInstallOptions) (io.ReadCloser, error)
+	PluginUpgrade(ctx context.Context, name string, options PluginInstallOptions) (io.ReadCloser, error)
 	PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error)
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -156,7 +156,7 @@ type PluginAPIClient interface {
 	PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error)
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)
-	PluginCreate(ctx context.Context, createContext io.Reader, options types.PluginCreateOptions) error
+	PluginCreate(ctx context.Context, createContext io.Reader, options PluginCreateOptions) error
 }
 
 // ServiceAPIClient defines API client methods for the services

--- a/client/container_attach.go
+++ b/client/container_attach.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 )
 
@@ -33,10 +32,10 @@ import (
 //
 // You can use github.com/moby/moby/api/stdcopy.StdCopy to demultiplex this
 // stream.
-func (cli *Client) ContainerAttach(ctx context.Context, containerID string, options container.AttachOptions) (types.HijackedResponse, error) {
+func (cli *Client) ContainerAttach(ctx context.Context, containerID string, options container.AttachOptions) (HijackedResponse, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return types.HijackedResponse{}, err
+		return HijackedResponse{}, err
 	}
 
 	query := url.Values{}

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/versions"
 )
@@ -80,7 +79,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 // You can use [github.com/moby/moby/api/stdcopy.StdCopy] to demultiplex this
 // stream. Refer to [Client.ContainerAttach] for details about the multiplexed
 // stream.
-func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (HijackedResponse, error) {
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
 		config.ConsoleSize = nil
 	}

--- a/client/hijack_test.go
+++ b/client/hijack_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moby/moby/api/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -94,7 +93,7 @@ func TestTLSCloseWriter(t *testing.T) {
 	assert.NilError(t, err)
 	defer resp.Close()
 
-	_, ok := resp.Conn.(types.CloseWriter)
+	_, ok := resp.Conn.(CloseWriter)
 	assert.Check(t, ok, "tls conn did not implement the CloseWrite interface")
 
 	_, err = resp.Conn.Write([]byte("hello"))

--- a/client/plugin_create.go
+++ b/client/plugin_create.go
@@ -5,12 +5,15 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginCreateOptions hold all options to plugin create.
+type PluginCreateOptions struct {
+	RepoName string
+}
+
 // PluginCreate creates a plugin
-func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, createOptions types.PluginCreateOptions) error {
+func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, createOptions PluginCreateOptions) error {
 	headers := http.Header(make(map[string][]string))
 	headers.Set("Content-Type", "application/x-tar")
 

--- a/client/plugin_disable.go
+++ b/client/plugin_disable.go
@@ -3,12 +3,15 @@ package client
 import (
 	"context"
 	"net/url"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginDisableOptions holds parameters to disable plugins.
+type PluginDisableOptions struct {
+	Force bool
+}
+
 // PluginDisable disables a plugin
-func (cli *Client) PluginDisable(ctx context.Context, name string, options types.PluginDisableOptions) error {
+func (cli *Client) PluginDisable(ctx context.Context, name string, options PluginDisableOptions) error {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return err

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -20,14 +19,14 @@ func TestPluginDisableError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
+	err := client.PluginDisable(context.Background(), "plugin_name", PluginDisableOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.PluginDisable(context.Background(), "", types.PluginDisableOptions{})
+	err = client.PluginDisable(context.Background(), "", PluginDisableOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.PluginDisable(context.Background(), "    ", types.PluginDisableOptions{})
+	err = client.PluginDisable(context.Background(), "    ", PluginDisableOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -50,6 +49,6 @@ func TestPluginDisable(t *testing.T) {
 		}),
 	}
 
-	err := client.PluginDisable(context.Background(), "plugin_name", types.PluginDisableOptions{})
+	err := client.PluginDisable(context.Background(), "plugin_name", PluginDisableOptions{})
 	assert.NilError(t, err)
 }

--- a/client/plugin_enable.go
+++ b/client/plugin_enable.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"net/url"
 	"strconv"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginEnableOptions holds parameters to enable plugins.
+type PluginEnableOptions struct {
+	Timeout int
+}
+
 // PluginEnable enables a plugin
-func (cli *Client) PluginEnable(ctx context.Context, name string, options types.PluginEnableOptions) error {
+func (cli *Client) PluginEnable(ctx context.Context, name string, options PluginEnableOptions) error {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return err

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -20,14 +19,14 @@ func TestPluginEnableError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.PluginEnable(context.Background(), "plugin_name", types.PluginEnableOptions{})
+	err := client.PluginEnable(context.Background(), "plugin_name", PluginEnableOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.PluginEnable(context.Background(), "", types.PluginEnableOptions{})
+	err = client.PluginEnable(context.Background(), "", PluginEnableOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.PluginEnable(context.Background(), "    ", types.PluginEnableOptions{})
+	err = client.PluginEnable(context.Background(), "    ", PluginEnableOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -50,6 +49,6 @@ func TestPluginEnable(t *testing.T) {
 		}),
 	}
 
-	err := client.PluginEnable(context.Background(), "plugin_name", types.PluginEnableOptions{})
+	err := client.PluginEnable(context.Background(), "plugin_name", PluginEnableOptions{})
 	assert.NilError(t, err)
 }

--- a/client/plugin_remove.go
+++ b/client/plugin_remove.go
@@ -3,12 +3,15 @@ package client
 import (
 	"context"
 	"net/url"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginRemoveOptions holds parameters to remove plugins.
+type PluginRemoveOptions struct {
+	Force bool
+}
+
 // PluginRemove removes a plugin
-func (cli *Client) PluginRemove(ctx context.Context, name string, options types.PluginRemoveOptions) error {
+func (cli *Client) PluginRemove(ctx context.Context, name string, options PluginRemoveOptions) error {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return err

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -20,14 +19,14 @@ func TestPluginRemoveError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
+	err := client.PluginRemove(context.Background(), "plugin_name", PluginRemoveOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.PluginRemove(context.Background(), "", types.PluginRemoveOptions{})
+	err = client.PluginRemove(context.Background(), "", PluginRemoveOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.PluginRemove(context.Background(), "   ", types.PluginRemoveOptions{})
+	err = client.PluginRemove(context.Background(), "   ", PluginRemoveOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -50,6 +49,6 @@ func TestPluginRemove(t *testing.T) {
 		}),
 	}
 
-	err := client.PluginRemove(context.Background(), "plugin_name", types.PluginRemoveOptions{})
+	err := client.PluginRemove(context.Background(), "plugin_name", PluginRemoveOptions{})
 	assert.NilError(t, err)
 }

--- a/client/plugin_upgrade.go
+++ b/client/plugin_upgrade.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PluginUpgrade upgrades a plugin
-func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types.PluginInstallOptions) (io.ReadCloser, error) {
+func (cli *Client) PluginUpgrade(ctx context.Context, name string, options PluginInstallOptions) (io.ReadCloser, error) {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return nil, err

--- a/daemon/pkg/plugin/backend_linux.go
+++ b/daemon/pkg/plugin/backend_linux.go
@@ -626,7 +626,7 @@ func (pm *Manager) Set(name string, args []string) error {
 
 // CreateFromContext creates a plugin from the given pluginDir which contains
 // both the rootfs and the config.json and a repoName with optional tag.
-func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *types.PluginCreateOptions) (retErr error) {
+func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *backend.PluginCreateConfig) (retErr error) {
 	pm.muGC.RLock()
 	defer pm.muGC.RUnlock()
 

--- a/daemon/pkg/plugin/backend_unsupported.go
+++ b/daemon/pkg/plugin/backend_unsupported.go
@@ -69,6 +69,6 @@ func (pm *Manager) Set(name string, args []string) error {
 
 // CreateFromContext creates a plugin from the given pluginDir which contains
 // both the rootfs and the config.json and a repoName with optional tag.
-func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *types.PluginCreateOptions) error {
+func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *backend.PluginCreateConfig) error {
 	return errNotSupported
 }

--- a/daemon/server/router/plugin/backend.go
+++ b/daemon/server/router/plugin/backend.go
@@ -25,5 +25,5 @@ type Backend interface {
 	Pull(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer, opts ...plugin.CreateOpt) error
 	Push(ctx context.Context, name string, metaHeaders http.Header, authConfig *registry.AuthConfig, outStream io.Writer) error
 	Upgrade(ctx context.Context, ref reference.Named, name string, metaHeaders http.Header, authConfig *registry.AuthConfig, privileges types.PluginPrivileges, outStream io.Writer) error
-	CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *types.PluginCreateOptions) error
+	CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, options *backend.PluginCreateConfig) error
 }

--- a/daemon/server/router/plugin/plugin_routes.go
+++ b/daemon/server/router/plugin/plugin_routes.go
@@ -186,7 +186,7 @@ func (pr *pluginRouter) createPlugin(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	options := &types.PluginCreateOptions{
+	options := &backend.PluginCreateConfig{
 		RepoName: r.FormValue("name"),
 	}
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/docker/docker/integration-cli/daemon"
 	"github.com/docker/docker/testutil"
 	testdaemon "github.com/docker/docker/testutil/daemon"
-	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/client"
 	"github.com/moby/sys/mount"
 	"golang.org/x/sys/unix"
 	"gotest.tools/v3/assert"
@@ -2198,7 +2198,7 @@ func (s *DockerDaemonSuite) TestFailedPluginRemove(c *testing.T) {
 	defer cancel()
 
 	name := "test-plugin-rm-fail"
-	out, err := apiClient.PluginInstall(ctx, name, types.PluginInstallOptions{
+	out, err := apiClient.PluginInstall(ctx, name, client.PluginInstallOptions{
 		Disabled:             true,
 		AcceptAllPermissions: true,
 		RemoteRef:            "cpuguy83/docker-logdriver-test",

--- a/integration/internal/container/container.go
+++ b/integration/internal/container/container.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/stdcopy"
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -129,7 +128,7 @@ type streams struct {
 // demultiplexStreams starts a goroutine to demultiplex stdout and stderr from the types.HijackedResponse resp and
 // waits until either multiplexed stream reaches EOF or the context expires. It unconditionally closes resp and waits
 // until the demultiplexing goroutine has finished its work before returning.
-func demultiplexStreams(ctx context.Context, resp types.HijackedResponse) (streams, error) {
+func demultiplexStreams(ctx context.Context, resp client.HijackedResponse) (streams, error) {
 	var s streams
 	outputDone := make(chan error, 1)
 

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/environment"
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
@@ -212,7 +211,7 @@ func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClien
 }
 
 // ExecTask runs the passed in exec config on the given task
-func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, options container.ExecOptions) types.HijackedResponse {
+func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, options container.ExecOptions) client.HijackedResponse {
 	t.Helper()
 	apiClient := d.NewClientT(t)
 	defer apiClient.Close()

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/requirement"
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/client"
@@ -74,7 +73,7 @@ func TestAuthZPluginV2Disable(t *testing.T) {
 	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
 	// disable the plugin
-	err = c.PluginDisable(ctx, authzPluginNameWithTag, types.PluginDisableOptions{})
+	err = c.PluginDisable(ctx, authzPluginNameWithTag, client.PluginDisableOptions{})
 	assert.NilError(t, err)
 
 	// now test to see if the docker api works.
@@ -146,12 +145,12 @@ func TestAuthZPluginV2NonexistentFailsDaemonStart(t *testing.T) {
 	d.Start(t)
 }
 
-func pluginInstallGrantAllPermissions(ctx context.Context, client client.APIClient, name string) error {
-	options := types.PluginInstallOptions{
+func pluginInstallGrantAllPermissions(ctx context.Context, c client.APIClient, name string) error {
+	options := client.PluginInstallOptions{
 		RemoteRef:            name,
 		AcceptAllPermissions: true,
 	}
-	responseReader, err := client.PluginInstall(ctx, "", options)
+	responseReader, err := c.PluginInstall(ctx, "", options)
 	if err != nil {
 		return err
 	}

--- a/integration/plugin/logging/logging_linux_test.go
+++ b/integration/plugin/logging/logging_linux_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/moby/moby/api/types"
 	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -27,19 +27,19 @@ func TestContinueAfterPluginCrash(t *testing.T) {
 	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false", "--init")
 	defer d.Stop(t)
 
-	client := d.NewClientT(t)
-	createPlugin(ctx, t, client, "test", "close_on_start", asLogDriver)
+	apiclient := d.NewClientT(t)
+	createPlugin(ctx, t, apiclient, "test", "close_on_start", asLogDriver)
 
 	ctxT, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
-	assert.Assert(t, client.PluginEnable(ctxT, "test", types.PluginEnableOptions{Timeout: 30}))
+	assert.Assert(t, apiclient.PluginEnable(ctxT, "test", client.PluginEnableOptions{Timeout: 30}))
 	cancel()
-	defer client.PluginRemove(ctx, "test", types.PluginRemoveOptions{Force: true})
+	defer apiclient.PluginRemove(ctx, "test", client.PluginRemoveOptions{Force: true})
 
 	ctxT, cancel = context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	id := container.Run(ctxT, t, client,
+	id := container.Run(ctxT, t, apiclient,
 		container.WithAutoRemove,
 		container.WithLogDriver("test"),
 		container.WithCmd(
@@ -47,10 +47,10 @@ func TestContinueAfterPluginCrash(t *testing.T) {
 		),
 	)
 	cancel()
-	defer client.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
+	defer apiclient.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
 
 	// Attach to the container to make sure it's written a few times to stdout
-	attach, err := client.ContainerAttach(ctx, id, containertypes.AttachOptions{Stream: true, Stdout: true})
+	attach, err := apiclient.ContainerAttach(ctx, id, containertypes.AttachOptions{Stream: true, Stdout: true})
 	assert.NilError(t, err)
 
 	chErr := make(chan error, 1)

--- a/integration/plugin/logging/validation_test.go
+++ b/integration/plugin/logging/validation_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -29,9 +29,9 @@ func TestDaemonStartWithLogOpt(t *testing.T) {
 	c := d.NewClientT(t)
 
 	createPlugin(ctx, t, c, "test", "dummy", asLogDriver)
-	err := c.PluginEnable(ctx, "test", types.PluginEnableOptions{Timeout: 30})
+	err := c.PluginEnable(ctx, "test", client.PluginEnableOptions{Timeout: 30})
 	assert.Check(t, err)
-	defer c.PluginRemove(ctx, "test", types.PluginRemoveOptions{Force: true})
+	defer c.PluginRemove(ctx, "test", client.PluginRemoveOptions{Force: true})
 
 	d.Stop(t)
 	d.Start(t, "--iptables=false", "--ip6tables=false", "--log-driver=test", "--log-opt=foo=bar")

--- a/integration/plugin/volumes/mounts_test.go
+++ b/integration/plugin/volumes/mounts_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fixtures/plugin"
 	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
 )
@@ -46,10 +47,10 @@ func TestPluginWithDevMounts(t *testing.T) {
 		c.IpcHost = true
 	})
 
-	err = c.PluginEnable(ctx, "test", types.PluginEnableOptions{Timeout: 30})
+	err = c.PluginEnable(ctx, "test", client.PluginEnableOptions{Timeout: 30})
 	assert.NilError(t, err)
 	defer func() {
-		err := c.PluginRemove(ctx, "test", types.PluginRemoveOptions{Force: true})
+		err := c.PluginRemove(ctx, "test", client.PluginRemoveOptions{Force: true})
 		assert.Check(t, err)
 	}()
 

--- a/integration/service/plugin_test.go
+++ b/integration/service/plugin_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fixtures/plugin"
 	"github.com/docker/docker/testutil/registry"
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/filters"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/api/types/swarm/runtime"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
@@ -41,7 +41,7 @@ func TestServicePlugin(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = io.Copy(io.Discard, r)
 	assert.NilError(t, err)
-	err = apiclient.PluginRemove(ctx, repo, types.PluginRemoveOptions{})
+	err = apiclient.PluginRemove(ctx, repo, client.PluginRemoveOptions{})
 	assert.NilError(t, err)
 	err = plugin.Create(ctx, apiclient, repo2)
 	assert.NilError(t, err)
@@ -49,7 +49,7 @@ func TestServicePlugin(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = io.Copy(io.Discard, r)
 	assert.NilError(t, err)
-	err = apiclient.PluginRemove(ctx, repo2, types.PluginRemoveOptions{})
+	err = apiclient.PluginRemove(ctx, repo2, client.PluginRemoveOptions{})
 	assert.NilError(t, err)
 	d.Stop(t)
 

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/image"
@@ -177,7 +176,7 @@ func deleteAllPlugins(ctx context.Context, t testing.TB, c client.PluginAPIClien
 		if _, ok := protectedPlugins[p.Name]; ok {
 			continue
 		}
-		err := c.PluginRemove(ctx, p.Name, types.PluginRemoveOptions{Force: true})
+		err := c.PluginRemove(ctx, p.Name, client.PluginRemoveOptions{Force: true})
 		assert.Check(t, err, "failed to remove plugin %s", p.ID)
 	}
 }

--- a/testutil/fixtures/plugin/plugin.go
+++ b/testutil/fixtures/plugin/plugin.go
@@ -13,8 +13,10 @@ import (
 	registrypkg "github.com/docker/docker/daemon/pkg/registry"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/api/types/backend"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/registry"
+	"github.com/moby/moby/client"
 	"github.com/pkg/errors"
 )
 
@@ -49,7 +51,7 @@ func WithBinary(bin string) CreateOpt {
 // CreateClient is the interface used for `BuildPlugin` to interact with the
 // daemon.
 type CreateClient interface {
-	PluginCreate(context.Context, io.Reader, types.PluginCreateOptions) error
+	PluginCreate(context.Context, io.Reader, client.PluginCreateOptions) error
 }
 
 // Create creates a new plugin with the specified name
@@ -69,7 +71,7 @@ func Create(ctx context.Context, c CreateClient, name string, opts ...CreateOpt)
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.PluginCreate(ctx, tar, types.PluginCreateOptions{RepoName: name})
+	return c.PluginCreate(ctx, tar, client.PluginCreateOptions{RepoName: name})
 }
 
 // CreateInRegistry makes a plugin (locally) and pushes it to a registry.
@@ -127,7 +129,7 @@ func CreateInRegistry(ctx context.Context, repo string, auth *registry.AuthConfi
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if err := manager.CreateFromContext(ctx, tar, &types.PluginCreateOptions{RepoName: repo}); err != nil {
+	if err := manager.CreateFromContext(ctx, tar, &backend.PluginCreateConfig{RepoName: repo}); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/moby/moby/api/types/backend/backend.go
+++ b/vendor/github.com/moby/moby/api/types/backend/backend.go
@@ -150,6 +150,11 @@ type CommitConfig struct {
 	ParentImageID       string
 }
 
+// PluginCreateConfig hold all options to plugin create.
+type PluginCreateConfig struct {
+	RepoName string
+}
+
 // PluginRmConfig holds arguments for plugin remove.
 type PluginRmConfig struct {
 	ForceRemove bool

--- a/vendor/github.com/moby/moby/api/types/client.go
+++ b/vendor/github.com/moby/moby/api/types/client.go
@@ -1,6 +1,0 @@
-package types
-
-// PluginCreateOptions hold all options to plugin create.
-type PluginCreateOptions struct {
-	RepoName string
-}

--- a/vendor/github.com/moby/moby/api/types/client.go
+++ b/vendor/github.com/moby/moby/api/types/client.go
@@ -1,42 +1,5 @@
 package types
 
-import (
-	"context"
-)
-
-// PluginRemoveOptions holds parameters to remove plugins.
-type PluginRemoveOptions struct {
-	Force bool
-}
-
-// PluginEnableOptions holds parameters to enable plugins.
-type PluginEnableOptions struct {
-	Timeout int
-}
-
-// PluginDisableOptions holds parameters to disable plugins.
-type PluginDisableOptions struct {
-	Force bool
-}
-
-// PluginInstallOptions holds parameters to install a plugin.
-type PluginInstallOptions struct {
-	Disabled             bool
-	AcceptAllPermissions bool
-	RegistryAuth         string // RegistryAuth is the base64 encoded credentials for the registry
-	RemoteRef            string // RemoteRef is the plugin name on the registry
-
-	// PrivilegeFunc is a function that clients can supply to retry operations
-	// after getting an authorization error. This function returns the registry
-	// authentication header value in base64 encoded format, or an error if the
-	// privilege request fails.
-	//
-	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
-	PrivilegeFunc         func(context.Context) (string, error)
-	AcceptPermissionsFunc func(context.Context, PluginPrivileges) (bool, error)
-	Args                  []string
-}
-
 // PluginCreateOptions hold all options to plugin create.
 type PluginCreateOptions struct {
 	RepoName string

--- a/vendor/github.com/moby/moby/api/types/client.go
+++ b/vendor/github.com/moby/moby/api/types/client.go
@@ -1,50 +1,8 @@
 package types
 
 import (
-	"bufio"
 	"context"
-	"net"
 )
-
-// NewHijackedResponse initializes a [HijackedResponse] type.
-func NewHijackedResponse(conn net.Conn, mediaType string) HijackedResponse {
-	return HijackedResponse{Conn: conn, Reader: bufio.NewReader(conn), mediaType: mediaType}
-}
-
-// HijackedResponse holds connection information for a hijacked request.
-type HijackedResponse struct {
-	mediaType string
-	Conn      net.Conn
-	Reader    *bufio.Reader
-}
-
-// Close closes the hijacked connection and reader.
-func (h *HijackedResponse) Close() {
-	h.Conn.Close()
-}
-
-// MediaType let client know if HijackedResponse hold a raw or multiplexed stream.
-// returns false if HTTP Content-Type is not relevant, and container must be inspected
-func (h *HijackedResponse) MediaType() (string, bool) {
-	if h.mediaType == "" {
-		return "", false
-	}
-	return h.mediaType, true
-}
-
-// CloseWriter is an interface that implements structs
-// that close input streams to prevent from writing.
-type CloseWriter interface {
-	CloseWrite() error
-}
-
-// CloseWrite closes a readWriter for writing.
-func (h *HijackedResponse) CloseWrite() error {
-	if conn, ok := h.Conn.(CloseWriter); ok {
-		return conn.CloseWrite()
-	}
-	return nil
-}
 
 // PluginRemoveOptions holds parameters to remove plugins.
 type PluginRemoveOptions struct {

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -64,11 +64,11 @@ type HijackDialer interface {
 
 // ContainerAPIClient defines API client methods for the containers
 type ContainerAPIClient interface {
-	ContainerAttach(ctx context.Context, container string, options container.AttachOptions) (types.HijackedResponse, error)
+	ContainerAttach(ctx context.Context, container string, options container.AttachOptions) (HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options container.CommitOptions) (container.CommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
-	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (types.HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -148,11 +148,11 @@ type NodeAPIClient interface {
 // PluginAPIClient defines API client methods for the plugins
 type PluginAPIClient interface {
 	PluginList(ctx context.Context, filter filters.Args) (types.PluginsListResponse, error)
-	PluginRemove(ctx context.Context, name string, options types.PluginRemoveOptions) error
-	PluginEnable(ctx context.Context, name string, options types.PluginEnableOptions) error
-	PluginDisable(ctx context.Context, name string, options types.PluginDisableOptions) error
-	PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) (io.ReadCloser, error)
-	PluginUpgrade(ctx context.Context, name string, options types.PluginInstallOptions) (io.ReadCloser, error)
+	PluginRemove(ctx context.Context, name string, options PluginRemoveOptions) error
+	PluginEnable(ctx context.Context, name string, options PluginEnableOptions) error
+	PluginDisable(ctx context.Context, name string, options PluginDisableOptions) error
+	PluginInstall(ctx context.Context, name string, options PluginInstallOptions) (io.ReadCloser, error)
+	PluginUpgrade(ctx context.Context, name string, options PluginInstallOptions) (io.ReadCloser, error)
 	PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error)
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -156,7 +156,7 @@ type PluginAPIClient interface {
 	PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error)
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)
-	PluginCreate(ctx context.Context, createContext io.Reader, options types.PluginCreateOptions) error
+	PluginCreate(ctx context.Context, createContext io.Reader, options PluginCreateOptions) error
 }
 
 // ServiceAPIClient defines API client methods for the services

--- a/vendor/github.com/moby/moby/client/container_attach.go
+++ b/vendor/github.com/moby/moby/client/container_attach.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 )
 
@@ -33,10 +32,10 @@ import (
 //
 // You can use github.com/moby/moby/api/stdcopy.StdCopy to demultiplex this
 // stream.
-func (cli *Client) ContainerAttach(ctx context.Context, containerID string, options container.AttachOptions) (types.HijackedResponse, error) {
+func (cli *Client) ContainerAttach(ctx context.Context, containerID string, options container.AttachOptions) (HijackedResponse, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return types.HijackedResponse{}, err
+		return HijackedResponse{}, err
 	}
 
 	query := url.Values{}

--- a/vendor/github.com/moby/moby/client/container_exec.go
+++ b/vendor/github.com/moby/moby/client/container_exec.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/versions"
 )
@@ -80,7 +79,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 // You can use [github.com/moby/moby/api/stdcopy.StdCopy] to demultiplex this
 // stream. Refer to [Client.ContainerAttach] for details about the multiplexed
 // stream.
-func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (HijackedResponse, error) {
 	if versions.LessThan(cli.ClientVersion(), "1.42") {
 		config.ConsoleSize = nil
 	}

--- a/vendor/github.com/moby/moby/client/plugin_create.go
+++ b/vendor/github.com/moby/moby/client/plugin_create.go
@@ -5,12 +5,15 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginCreateOptions hold all options to plugin create.
+type PluginCreateOptions struct {
+	RepoName string
+}
+
 // PluginCreate creates a plugin
-func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, createOptions types.PluginCreateOptions) error {
+func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, createOptions PluginCreateOptions) error {
 	headers := http.Header(make(map[string][]string))
 	headers.Set("Content-Type", "application/x-tar")
 

--- a/vendor/github.com/moby/moby/client/plugin_disable.go
+++ b/vendor/github.com/moby/moby/client/plugin_disable.go
@@ -3,12 +3,15 @@ package client
 import (
 	"context"
 	"net/url"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginDisableOptions holds parameters to disable plugins.
+type PluginDisableOptions struct {
+	Force bool
+}
+
 // PluginDisable disables a plugin
-func (cli *Client) PluginDisable(ctx context.Context, name string, options types.PluginDisableOptions) error {
+func (cli *Client) PluginDisable(ctx context.Context, name string, options PluginDisableOptions) error {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return err

--- a/vendor/github.com/moby/moby/client/plugin_enable.go
+++ b/vendor/github.com/moby/moby/client/plugin_enable.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"net/url"
 	"strconv"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginEnableOptions holds parameters to enable plugins.
+type PluginEnableOptions struct {
+	Timeout int
+}
+
 // PluginEnable enables a plugin
-func (cli *Client) PluginEnable(ctx context.Context, name string, options types.PluginEnableOptions) error {
+func (cli *Client) PluginEnable(ctx context.Context, name string, options PluginEnableOptions) error {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return err

--- a/vendor/github.com/moby/moby/client/plugin_remove.go
+++ b/vendor/github.com/moby/moby/client/plugin_remove.go
@@ -3,12 +3,15 @@ package client
 import (
 	"context"
 	"net/url"
-
-	"github.com/moby/moby/api/types"
 )
 
+// PluginRemoveOptions holds parameters to remove plugins.
+type PluginRemoveOptions struct {
+	Force bool
+}
+
 // PluginRemove removes a plugin
-func (cli *Client) PluginRemove(ctx context.Context, name string, options types.PluginRemoveOptions) error {
+func (cli *Client) PluginRemove(ctx context.Context, name string, options PluginRemoveOptions) error {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return err

--- a/vendor/github.com/moby/moby/client/plugin_upgrade.go
+++ b/vendor/github.com/moby/moby/client/plugin_upgrade.go
@@ -13,7 +13,7 @@ import (
 )
 
 // PluginUpgrade upgrades a plugin
-func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types.PluginInstallOptions) (io.ReadCloser, error) {
+func (cli *Client) PluginUpgrade(ctx context.Context, name string, options PluginInstallOptions) (io.ReadCloser, error) {
 	name, err := trimID("plugin", name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Moved API client utility code into the client from api.

Moved struct definitions that are only used by the client into the client module from api.

**- How I did it**
Almost everything was only referenced by the client and test code which uses the client, making the changes trivial. The only exception was that `PluginCreateOptions` was also used by the daemon, but that was easily solved by duplicating the struct definition into `api/types/backend` alongside all the other plugin-options structs used inside the daemon.

**- How to verify it**
CI

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

