### PR TITLE
integration-cli: migrate TestAPIErrorNotFoundJSON to integration

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -50,14 +50,3 @@ func (s *DockerAPISuite) TestAPIErrorJSON(c *testing.T) {
 	assert.NilError(c, err)
 	assert.Check(c, is.Contains(getErrorMessage(c, b), "config cannot be empty"))
 }
-
-func (s *DockerAPISuite) TestAPIErrorNotFoundJSON(c *testing.T) {
-	// 404 is a different code path to normal errors, so test separately
-	httpResp, body, err := request.Get(testutil.GetContext(c), "/notfound", request.JSON)
-	assert.NilError(c, err)
-	assert.Equal(c, httpResp.StatusCode, http.StatusNotFound)
-	assert.Assert(c, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
-	b, err := request.ReadBody(body)
-	assert.NilError(c, err)
-	assert.Equal(c, getErrorMessage(c, b), "page not found")
-}

--- a/integration/system/api_test.go
+++ b/integration/system/api_test.go
@@ -1,0 +1,29 @@
+package system
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/testutil/request"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestAPIErrorNotFoundJSON(t *testing.T) {
+	ctx := setupTest(t)
+
+	// 404 is a different code path to normal errors, so test separately
+	httpResp, body, err := request.Get(ctx, "/notfound", request.JSON)
+	assert.NilError(t, err)
+	defer body.Close()
+
+	assert.Equal(t, httpResp.StatusCode, http.StatusNotFound)
+	assert.Assert(t, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
+
+	b, err := request.ReadBody(body)
+	assert.NilError(t, err)
+	var errResp struct{ Message string }
+	_ = json.Unmarshal(b, &errResp)
+	assert.Equal(t, errResp.Message, "page not found")
+}


### PR DESCRIPTION
This integration test migrates TestAPIErrorNotFoundJSON test from integration-cli package to integration package. Resolves #50159 integration test `TestAPIErrorNotFoundJSON`

**- What I did**

Migrated `TestAPIErrorNotFoundJSON` from `integration-cli` package to `integration` package in `integration/system/api_test.go`.

**- How I did it**

- Made use of `ctx := setupTest(t)` to get the context of the test.
- Verified returned status is `http.StatusNotFound` with a non-existent API endpoint.

**- How to verify it**

Verified test result in a development Docker container.

```
Running /go/src/github.com/docker/docker/integration/system (arm64.integration.system) flags=-test.v -test.timeout=10m -test.run TestAPIErrorNotFoundJSON
INFO: Testing against a local daemon
=== RUN   TestAPIErrorNotFoundJSON
time="2025-07-26T07:46:24Z" level=error msg="subsequent attempt to close ReadCloserWrapper"
--- PASS: TestAPIErrorNotFoundJSON (0.01s)
PASS
```