### PR TITLE
api/types/container.StatsResponseReader: move to client

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"io"
 	"os"
 	"time"
 
@@ -33,18 +32,6 @@ type PathStat struct {
 type CopyToContainerOptions struct {
 	AllowOverwriteDirWithFile bool
 	CopyUIDGID                bool
-}
-
-// StatsResponseReader wraps an io.ReadCloser to read (a stream of) stats
-// for a container, as produced by the GET "/stats" endpoint.
-//
-// The OSType field is set to the server's platform to allow
-// platform-specific handling of the response.
-//
-// TODO(thaJeztah): remove this wrapper, and make OSType part of [StatsResponse].
-type StatsResponseReader struct {
-	Body   io.ReadCloser `json:"body"`
-	OSType string        `json:"ostype"`
 }
 
 // MountPoint represents a mount point configuration inside the container.

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -85,8 +85,8 @@ type ContainerAPIClient interface {
 	ContainerResize(ctx context.Context, container string, options container.ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
-	ContainerStats(ctx context.Context, container string, stream bool) (container.StatsResponseReader, error)
-	ContainerStatsOneShot(ctx context.Context, container string) (container.StatsResponseReader, error)
+	ContainerStats(ctx context.Context, container string, stream bool) (StatsResponseReader, error)
+	ContainerStatsOneShot(ctx context.Context, container string) (StatsResponseReader, error)
 	ContainerStart(ctx context.Context, container string, options container.StartOptions) error
 	ContainerStop(ctx context.Context, container string, options container.StopOptions) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (container.TopResponse, error)

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -2,17 +2,28 @@ package client
 
 import (
 	"context"
+	"io"
 	"net/url"
-
-	"github.com/moby/moby/api/types/container"
 )
+
+// StatsResponseReader wraps an io.ReadCloser to read (a stream of) stats
+// for a container, as produced by the GET "/stats" endpoint.
+//
+// The OSType field is set to the server's platform to allow
+// platform-specific handling of the response.
+//
+// TODO(thaJeztah): remove this wrapper, and make OSType part of [github.com/moby/moby/api/types/container.StatsResponse].
+type StatsResponseReader struct {
+	Body   io.ReadCloser `json:"body"`
+	OSType string        `json:"ostype"`
+}
 
 // ContainerStats returns near realtime stats for a given container.
 // It's up to the caller to close the io.ReadCloser returned.
-func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error) {
+func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (StatsResponseReader, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
 	query := url.Values{}
@@ -23,10 +34,10 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
-	return container.StatsResponseReader{
+	return StatsResponseReader{
 		Body:   resp.Body,
 		OSType: resp.Header.Get("Ostype"),
 	}, nil
@@ -34,10 +45,10 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 // ContainerStatsOneShot gets a single stat entry from a container.
 // It differs from `ContainerStats` in that the API should not wait to prime the stats
-func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (container.StatsResponseReader, error) {
+func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (StatsResponseReader, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
 	query := url.Values{}
@@ -46,10 +57,10 @@ func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
-	return container.StatsResponseReader{
+	return StatsResponseReader{
 		Body:   resp.Body,
 		OSType: resp.Header.Get("Ostype"),
 	}, nil

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -48,7 +48,7 @@ func TestContainerStats(t *testing.T) {
 		client := &Client{
 			client: newMockClient(func(r *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(r.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, r.URL)
+					return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, r.URL)
 				}
 
 				query := r.URL.Query()
@@ -65,7 +65,9 @@ func TestContainerStats(t *testing.T) {
 		}
 		resp, err := client.ContainerStats(context.Background(), "container_id", c.stream)
 		assert.NilError(t, err)
-		defer resp.Body.Close()
+		t.Cleanup(func() {
+			_ = resp.Body.Close()
+		})
 		content, err := io.ReadAll(resp.Body)
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(string(content), "response"))

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -151,7 +151,7 @@ func (s *DockerAPISuite) TestGetContainerStats(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats container.StatsResponseReader
+		stats client.StatsResponseReader
 		err   error
 	}
 
@@ -255,7 +255,7 @@ func (s *DockerAPISuite) TestGetContainerStatsStream(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats container.StatsResponseReader
+		stats client.StatsResponseReader
 		err   error
 	}
 
@@ -296,7 +296,7 @@ func (s *DockerAPISuite) TestGetContainerStatsNoStream(c *testing.T) {
 	runSleepingContainer(c, "--name", name)
 
 	type b struct {
-		stats container.StatsResponseReader
+		stats client.StatsResponseReader
 		err   error
 	}
 
@@ -1332,7 +1332,7 @@ func (s *DockerAPISuite) TestContainerAPIStatsWithNetworkDisabled(c *testing.T) 
 	cli.WaitRun(c, name)
 
 	type b struct {
-		stats container.StatsResponseReader
+		stats client.StatsResponseReader
 		err   error
 	}
 	bc := make(chan b, 1)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -112,10 +112,10 @@ func (s *DockerAPISuite) TestContainerAPIGetExport(c *testing.T) {
 	found := false
 	for tarReader := tar.NewReader(body); ; {
 		h, err := tarReader.Next()
-		if err != nil && err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
-		if h.Name == "test" {
+		if h != nil && h.Name == "test" {
 			found = true
 			break
 		}
@@ -177,10 +177,11 @@ func (s *DockerAPISuite) TestGetContainerStats(c *testing.T) {
 		c.Fatal("stream was not closed after container was removed")
 	case sr := <-bc:
 		dec := json.NewDecoder(sr.stats.Body)
-		defer sr.stats.Body.Close()
 		var s *container.StatsResponse
 		// decode only one object from the stream
-		assert.NilError(c, dec.Decode(&s))
+		err := dec.Decode(&s)
+		_ = sr.stats.Body.Close()
+		assert.NilError(c, err)
 	}
 }
 

--- a/vendor/github.com/moby/moby/api/types/container/container.go
+++ b/vendor/github.com/moby/moby/api/types/container/container.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"io"
 	"os"
 	"time"
 
@@ -33,18 +32,6 @@ type PathStat struct {
 type CopyToContainerOptions struct {
 	AllowOverwriteDirWithFile bool
 	CopyUIDGID                bool
-}
-
-// StatsResponseReader wraps an io.ReadCloser to read (a stream of) stats
-// for a container, as produced by the GET "/stats" endpoint.
-//
-// The OSType field is set to the server's platform to allow
-// platform-specific handling of the response.
-//
-// TODO(thaJeztah): remove this wrapper, and make OSType part of [StatsResponse].
-type StatsResponseReader struct {
-	Body   io.ReadCloser `json:"body"`
-	OSType string        `json:"ostype"`
 }
 
 // MountPoint represents a mount point configuration inside the container.

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -85,8 +85,8 @@ type ContainerAPIClient interface {
 	ContainerResize(ctx context.Context, container string, options container.ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
-	ContainerStats(ctx context.Context, container string, stream bool) (container.StatsResponseReader, error)
-	ContainerStatsOneShot(ctx context.Context, container string) (container.StatsResponseReader, error)
+	ContainerStats(ctx context.Context, container string, stream bool) (StatsResponseReader, error)
+	ContainerStatsOneShot(ctx context.Context, container string) (StatsResponseReader, error)
 	ContainerStart(ctx context.Context, container string, options container.StartOptions) error
 	ContainerStop(ctx context.Context, container string, options container.StopOptions) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (container.TopResponse, error)

--- a/vendor/github.com/moby/moby/client/container_stats.go
+++ b/vendor/github.com/moby/moby/client/container_stats.go
@@ -2,17 +2,28 @@ package client
 
 import (
 	"context"
+	"io"
 	"net/url"
-
-	"github.com/moby/moby/api/types/container"
 )
+
+// StatsResponseReader wraps an io.ReadCloser to read (a stream of) stats
+// for a container, as produced by the GET "/stats" endpoint.
+//
+// The OSType field is set to the server's platform to allow
+// platform-specific handling of the response.
+//
+// TODO(thaJeztah): remove this wrapper, and make OSType part of [github.com/moby/moby/api/types/container.StatsResponse].
+type StatsResponseReader struct {
+	Body   io.ReadCloser `json:"body"`
+	OSType string        `json:"ostype"`
+}
 
 // ContainerStats returns near realtime stats for a given container.
 // It's up to the caller to close the io.ReadCloser returned.
-func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error) {
+func (cli *Client) ContainerStats(ctx context.Context, containerID string, stream bool) (StatsResponseReader, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
 	query := url.Values{}
@@ -23,10 +34,10 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
-	return container.StatsResponseReader{
+	return StatsResponseReader{
 		Body:   resp.Body,
 		OSType: resp.Header.Get("Ostype"),
 	}, nil
@@ -34,10 +45,10 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, strea
 
 // ContainerStatsOneShot gets a single stat entry from a container.
 // It differs from `ContainerStats` in that the API should not wait to prime the stats
-func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (container.StatsResponseReader, error) {
+func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string) (StatsResponseReader, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
 	query := url.Values{}
@@ -46,10 +57,10 @@ func (cli *Client) ContainerStatsOneShot(ctx context.Context, containerID string
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/stats", query, nil)
 	if err != nil {
-		return container.StatsResponseReader{}, err
+		return StatsResponseReader{}, err
 	}
 
-	return container.StatsResponseReader{
+	return StatsResponseReader{
 		Body:   resp.Body,
 		OSType: resp.Header.Get("Ostype"),
 	}, nil


### PR DESCRIPTION
This type was only used in the client, and needs a rewrite; let's move it to the client first.

Also fix some minor linting issues in tests.


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types/container: move `StatsResponseReader` to `client` package
```

**- A picture of a cute animal (not mandatory but encouraged)**

