### PR TITLE
integration, integration-cli: remove various deprecated test-utilities, and some minor (linting) fixes

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -422,19 +422,18 @@ func (s *DockerSuite) OnTimeout(t *testing.T) {
 	if testEnv.IsRemoteDaemon() {
 		return
 	}
-	path := filepath.Join(os.Getenv("DEST"), "docker.pid")
-	b, err := os.ReadFile(path)
+	pidFile := filepath.Join(os.Getenv("DEST"), "docker.pid")
+	b, err := os.ReadFile(pidFile)
 	if err != nil {
-		t.Fatalf("Failed to get daemon PID from %s\n", path)
+		t.Fatalf("Failed to get daemon PID from %s\n", pidFile)
 	}
 
 	rawPid, err := strconv.ParseInt(string(b), 10, 32)
 	if err != nil {
-		t.Fatalf("Failed to parse pid from %s: %s\n", path, err)
+		t.Fatalf("Failed to parse pid from %s: %s\n", pidFile, err)
 	}
 
-	daemonPid := int(rawPid)
-	if daemonPid > 0 {
+	if daemonPid := int(rawPid); daemonPid > 0 {
 		testdaemon.SignalDaemonDump(daemonPid)
 	}
 }

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -159,7 +159,7 @@ func (s *DockerRegistrySuite) TestRemoveImageByDigest(t *testing.T) {
 	assert.NilError(t, err, "unexpected error deleting image")
 
 	// try to inspect again - it should error this time
-	_, err = inspectFieldWithError(imageReference, "Id")
+	_, err = inspectFilter(imageReference, ".Id")
 	// unexpected nil err trying to inspect what should be a non-existent image
 	assert.ErrorContains(t, err, "No such object")
 }
@@ -441,7 +441,7 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(t *testing.T
 
 	cli.DockerCmd(t, "rmi", imageID)
 
-	_, err = inspectFieldWithError(imageID, "Id")
+	_, err = inspectFilter(imageID, ".Id")
 	assert.ErrorContains(t, err, "", "image should have been deleted")
 }
 
@@ -468,7 +468,7 @@ func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndTag(t *testing.T) {
 	cli.DockerCmd(t, "rmi", repoTag)
 
 	// rmi should have deleted the tag, the digest reference, and the image itself
-	_, err = inspectFieldWithError(imageID, "Id")
+	_, err = inspectFilter(imageID, ".Id")
 	assert.ErrorContains(t, err, "", "image should have been deleted")
 }
 
@@ -493,16 +493,16 @@ func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndMultiRepoTag(t *testin
 
 	// rmi should have deleted repoTag and image reference, but left repoTag2
 	inspectField(t, repoTag2, "Id")
-	_, err = inspectFieldWithError(imageReference, "Id")
+	_, err = inspectFilter(imageReference, ".Id")
 	assert.ErrorContains(t, err, "", "image digest reference should have been removed")
 
-	_, err = inspectFieldWithError(repoTag, "Id")
+	_, err = inspectFilter(repoTag, ".Id")
 	assert.ErrorContains(t, err, "", "image tag reference should have been removed")
 
 	cli.DockerCmd(t, "rmi", repoTag2)
 
 	// rmi should have deleted the tag, the digest reference, and the image itself
-	_, err = inspectFieldWithError(imageID, "Id")
+	_, err = inspectFilter(imageID, ".Id")
 	assert.ErrorContains(t, err, "", "image should have been deleted")
 }
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -152,10 +152,10 @@ func (s *DockerCLICreateSuite) TestCreateVolumesCreated(c *testing.T) {
 	const name = "test_create_volume"
 	cli.DockerCmd(c, "create", "--name", name, "-v", prefix+slash+"foo", "busybox")
 
-	dir, err := inspectMountSourceField(name, prefix+slash+"foo")
+	mnt, err := inspectMountPoint(name, prefix+slash+"foo")
 	assert.Assert(c, err == nil, "Error getting volume host path: %q", err)
 
-	if _, err := os.Stat(dir); err != nil && os.IsNotExist(err) {
+	if _, err := os.Stat(mnt.Source); err != nil && os.IsNotExist(err) {
 		c.Fatalf("Volume was not created")
 	}
 	if err != nil {

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -690,7 +690,11 @@ func (s *DockerCLIEventSuite) TestEventsSinceInTheFuture(c *testing.T) {
 
 	since := daemonTime(c)
 	until := since.Add(time.Duration(-24) * time.Hour)
-	out, _, err := dockerCmdWithError("events", "--filter", "image=busybox", "--since", parseEventTime(since), "--until", parseEventTime(until))
+	out, _, err := dockerCmdWithError("events",
+		"--filter", "image=busybox",
+		"--since", fmt.Sprintf("%d.%09d", since.Unix(), int64(since.Nanosecond())),
+		"--until", fmt.Sprintf("%d.%09d", until.Unix(), int64(until.Nanosecond())),
+	)
 
 	assert.ErrorContains(c, err, "")
 	assert.Assert(c, is.Contains(out, "cannot be after `until`"))

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -76,7 +76,7 @@ func (s *DockerCLIRestartSuite) TestRestartWithVolumes(c *testing.T) {
 	out = strings.Trim(out, " \n\r")
 	assert.Equal(c, out, "1")
 
-	source, err := inspectMountSourceField(cID, prefix+slash+"test")
+	mnt, err := inspectMountPoint(cID, prefix+slash+"test")
 	assert.NilError(c, err)
 
 	cli.DockerCmd(c, "restart", cID)
@@ -86,9 +86,9 @@ func (s *DockerCLIRestartSuite) TestRestartWithVolumes(c *testing.T) {
 	out = strings.Trim(out, " \n\r")
 	assert.Equal(c, out, "1")
 
-	sourceAfterRestart, err := inspectMountSourceField(cID, prefix+slash+"test")
+	mountAfterRestart, err := inspectMountPoint(cID, prefix+slash+"test")
 	assert.NilError(c, err)
-	assert.Equal(c, source, sourceAfterRestart)
+	assert.Equal(c, mnt.Source, mountAfterRestart.Source)
 }
 
 func (s *DockerCLIRestartSuite) TestRestartDisconnectedContainer(c *testing.T) {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2941,10 +2941,11 @@ func (s *DockerCLIRunSuite) TestRunNetworkFilesBindMount(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
-	expected := "test123"
+	tmpDir := c.TempDir()
+	filename := filepath.Join(tmpDir, "testfile")
 
-	filename := createTmpFile(c, expected)
-	defer os.Remove(filename)
+	const expected = "test123"
+	assert.NilError(c, os.WriteFile(filename, []byte(expected), 0o644))
 
 	// #nosec G302 -- for user namespaced test runs, the temp file must be accessible to unprivileged root
 	if err := os.Chmod(filename, 0o646); err != nil {
@@ -2965,8 +2966,9 @@ func (s *DockerCLIRunSuite) TestRunNetworkFilesBindMountRO(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
-	filename := createTmpFile(c, "test123")
-	defer os.Remove(filename)
+	tmpDir := c.TempDir()
+	filename := filepath.Join(tmpDir, "testfile")
+	assert.NilError(c, os.WriteFile(filename, []byte("test123"), 0o644))
 
 	// #nosec G302 -- for user namespaced test runs, the temp file must be accessible to unprivileged root
 	if err := os.Chmod(filename, 0o646); err != nil {
@@ -2987,8 +2989,9 @@ func (s *DockerCLIRunSuite) TestRunNetworkFilesBindMountROFilesystem(c *testing.
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux, UserNamespaceROMount)
 
-	filename := createTmpFile(c, "test123")
-	defer os.Remove(filename)
+	tmpDir := c.TempDir()
+	filename := filepath.Join(tmpDir, "testfile")
+	assert.NilError(c, os.WriteFile(filename, []byte("test123"), 0o644))
 
 	// #nosec G302 -- for user namespaced test runs, the temp file must be accessible to unprivileged root
 	if err := os.Chmod(filename, 0o646); err != nil {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3080,7 +3080,7 @@ func (s *DockerCLIRunSuite) TestRunCreateContainerFailedCleanUp(c *testing.T) {
 	_, _, err := dockerCmdWithError("run", "--name", name, "--link", "nothing:nothing", "busybox")
 	assert.Assert(c, err != nil, "Expected docker run to fail!")
 
-	containerID, err := inspectFieldWithError(name, "Id")
+	containerID, err := inspectFilter(name, ".Id")
 	assert.Assert(c, err != nil, "Expected not to have this container: %s!", containerID)
 	assert.Equal(c, containerID, "", fmt.Sprintf("Expected not to have this container: %s!", containerID))
 }

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -108,14 +108,6 @@ func inspectFieldJSON(t *testing.T, name, field string) string {
 }
 
 // Deprecated: use cli.Docker
-func inspectFieldMap(t *testing.T, name, path, field string) string {
-	t.Helper()
-	out, err := inspectFilter(name, fmt.Sprintf("index .%s %q", path, field))
-	assert.NilError(t, err)
-	return out
-}
-
-// Deprecated: use cli.Docker
 func inspectMountSourceField(name, destination string) (string, error) {
 	m, err := inspectMountPoint(name, destination)
 	if err != nil {

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -271,19 +271,6 @@ func appendBaseEnv(isTLS bool, env ...string) []string {
 	return env
 }
 
-func createTmpFile(t *testing.T, content string) string {
-	t.Helper()
-	f, err := os.CreateTemp("", "testfile")
-	assert.NilError(t, err)
-
-	filename := f.Name()
-
-	err = os.WriteFile(filename, []byte(content), 0o644)
-	assert.NilError(t, err)
-
-	return filename
-}
-
 // waitInspect will wait for the specified container to have the specified string
 // in the inspect output. It will wait until the specified timeout (in seconds)
 // is reached.

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -102,15 +102,6 @@ func inspectFieldJSON(t *testing.T, name, field string) string {
 	return out
 }
 
-// Deprecated: use cli.Docker
-func inspectMountSourceField(name, destination string) (string, error) {
-	m, err := inspectMountPoint(name, destination)
-	if err != nil {
-		return "", err
-	}
-	return m.Source, nil
-}
-
 var errMountNotFound = errors.New("mount point not found")
 
 // Deprecated: use cli.Docker

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -87,11 +87,6 @@ func inspectFilter(name, filter string) (string, error) {
 }
 
 // Deprecated: use cli.Docker
-func inspectFieldWithError(name, field string) (string, error) {
-	return inspectFilter(name, "."+field)
-}
-
-// Deprecated: use cli.Docker
 func inspectField(t *testing.T, name, field string) string {
 	t.Helper()
 	out, err := inspectFilter(name, "."+field)
@@ -141,7 +136,7 @@ func inspectMountPoint(name, destination string) (container.MountPoint, error) {
 
 func getIDByName(t *testing.T, name string) string {
 	t.Helper()
-	id, err := inspectFieldWithError(name, "Id")
+	id, err := inspectFilter(name, ".Id")
 	assert.NilError(t, err)
 	return id
 }

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -144,7 +144,7 @@ func getIDByName(t *testing.T, name string) string {
 // Deprecated: use cli.Docker
 func buildImageSuccessfully(t *testing.T, name string, cmdOperators ...cli.CmdOperator) {
 	t.Helper()
-	buildImage(name, cmdOperators...).Assert(t, icmd.Success)
+	cli.Docker(cli.Args("build", "-t", name), cmdOperators...).Assert(t, icmd.Success)
 }
 
 // Deprecated: use cli.Docker

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -223,11 +223,8 @@ func daemonTime(t *testing.T) time.Time {
 // It return the time formatted how the client sends timestamps to the server.
 func daemonUnixTime(t *testing.T) string {
 	t.Helper()
-	return parseEventTime(daemonTime(t))
-}
-
-func parseEventTime(t time.Time) string {
-	return fmt.Sprintf("%d.%09d", t.Unix(), int64(t.Nanosecond()))
+	dt := daemonTime(t)
+	return fmt.Sprintf("%d.%09d", dt.Unix(), int64(dt.Nanosecond()))
 }
 
 // appendBaseEnv appends the minimum set of environment variables to exec the

--- a/integration/system/ping_test.go
+++ b/integration/system/ping_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/docker/docker/testutil"
@@ -14,6 +13,7 @@ import (
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/swarm"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
 )
 
@@ -24,8 +24,8 @@ func TestPingCacheHeaders(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, res.StatusCode, http.StatusOK)
 
-	assert.Equal(t, hdr(res, "Cache-Control"), "no-cache, no-store, must-revalidate")
-	assert.Equal(t, hdr(res, "Pragma"), "no-cache")
+	assert.Assert(t, is.DeepEqual(res.Header.Values("Cache-Control"), []string{"no-cache, no-store, must-revalidate"}))
+	assert.Assert(t, is.DeepEqual(res.Header.Values("Pragma"), []string{"no-cache"}))
 }
 
 func TestPingGet(t *testing.T) {
@@ -38,7 +38,7 @@ func TestPingGet(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(b), "OK")
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Check(t, hdr(res, "Api-Version") != "")
+	assert.Check(t, res.Header.Get("Api-Version") != "")
 }
 
 func TestPingHead(t *testing.T) {
@@ -51,7 +51,7 @@ func TestPingHead(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(b))
 	assert.Equal(t, res.StatusCode, http.StatusOK)
-	assert.Check(t, hdr(res, "Api-Version") != "")
+	assert.Check(t, res.Header.Get("Api-Version") != "")
 }
 
 func TestPingSwarmHeader(t *testing.T) {
@@ -133,12 +133,4 @@ func TestPingBuilderHeader(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, p.BuilderVersion, expected)
 	})
-}
-
-func hdr(res *http.Response, name string) string {
-	val, ok := res.Header[http.CanonicalHeaderKey(name)]
-	if !ok || len(val) == 0 {
-		return ""
-	}
-	return strings.Join(val, ", ")
 }

--- a/testutil/daemon/daemon_unix.go
+++ b/testutil/daemon/daemon_unix.go
@@ -22,7 +22,7 @@ func cleanupMount(t testing.TB, d *Daemon) {
 
 // SignalDaemonDump sends a signal to the daemon to write a dump file
 func SignalDaemonDump(pid int) {
-	unix.Kill(pid, unix.SIGQUIT)
+	_ = unix.Kill(pid, unix.SIGQUIT)
 }
 
 func signalDaemonReload(pid int) error {


### PR DESCRIPTION
### integration/system: remove "hdr" utility

It was a very shallow wrapper around reading the response
headers, and querying those directly is more transparent.

### integration-cli: remove deprecated inspectFieldMap utility


### integration-cli: remove createTmpFile utility

### integration-cli: remove deprecated inspectFieldWithError utility

The replacement is also deprecated, but removing one abstraction at a time


### integration-cli: buildImageSuccessfully: don't wrap buildImage

Both are deprecated, but removing one abstraction at a time.

### integration-cli: remove deprecaed inspectMountSourceField

The replacement is also deprecated, but at least returns a strong type,
which may help transitioning to using an api-client for these, and
removing one abstraction at a time.

Also rewriting the TestContainerAPIDeleteRemoveVolume to use the API
client (as it's part of the API suite), and touched-up the
TestRunMountShmMqueueFromHost test a bit.

### integration-cli: remove parseEventTime utility

It was only used in a single test.

### integration-cli/daemon: rewrite CheckActiveContainerCount with client

Use the API-client instead of shelling out to the CLI.

**- A picture of a cute animal (not mandatory but encouraged)**

