### PR TITLE
integration-cli: migrate TestPostContainersCreateShmSizeXXX to integration

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -11,14 +11,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
-	dconfig "github.com/docker/docker/daemon/config"
 	"github.com/docker/docker/daemon/volume"
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
@@ -1137,110 +1135,6 @@ func (s *DockerAPISuite) TestPostContainersCreateWithWrongCpusetValues(c *testin
 	_, err = apiClient.ContainerCreate(testutil.GetContext(c), &config, &hostConfig2, &network.NetworkingConfig{}, nil, name2)
 	expected = "Invalid value 42-3,1-- for cpuset mems"
 	assert.ErrorContains(c, err, expected)
-}
-
-func (s *DockerAPISuite) TestPostContainersCreateShmSizeNegative(c *testing.T) {
-	// ShmSize is not supported on Windows
-	testRequires(c, DaemonIsLinux)
-	config := container.Config{
-		Image: "busybox",
-	}
-	hostConfig := container.HostConfig{
-		ShmSize: -1,
-	}
-
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	_, err = apiClient.ContainerCreate(testutil.GetContext(c), &config, &hostConfig, &network.NetworkingConfig{}, nil, "")
-	assert.ErrorContains(c, err, "SHM size can not be less than 0")
-}
-
-func (s *DockerAPISuite) TestPostContainersCreateShmSizeHostConfigOmitted(c *testing.T) {
-	// ShmSize is not supported on Windows
-	testRequires(c, DaemonIsLinux)
-
-	config := container.Config{
-		Image: "busybox",
-		Cmd:   []string{"mount"},
-	}
-
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	ctr, err := apiClient.ContainerCreate(testutil.GetContext(c), &config, &container.HostConfig{}, &network.NetworkingConfig{}, nil, "")
-	assert.NilError(c, err)
-
-	containerJSON, err := apiClient.ContainerInspect(testutil.GetContext(c), ctr.ID)
-	assert.NilError(c, err)
-
-	assert.Equal(c, containerJSON.HostConfig.ShmSize, dconfig.DefaultShmSize)
-
-	out := cli.DockerCmd(c, "start", "-i", containerJSON.ID).Combined()
-	shmRegexp := regexp.MustCompile(`shm on /dev/shm type tmpfs(.*)size=65536k`)
-	if !shmRegexp.MatchString(out) {
-		c.Fatalf("Expected shm of 64MB in mount command, got %v", out)
-	}
-}
-
-func (s *DockerAPISuite) TestPostContainersCreateShmSizeOmitted(c *testing.T) {
-	// ShmSize is not supported on Windows
-	testRequires(c, DaemonIsLinux)
-	config := container.Config{
-		Image: "busybox",
-		Cmd:   []string{"mount"},
-	}
-
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	ctr, err := apiClient.ContainerCreate(testutil.GetContext(c), &config, &container.HostConfig{}, &network.NetworkingConfig{}, nil, "")
-	assert.NilError(c, err)
-
-	containerJSON, err := apiClient.ContainerInspect(testutil.GetContext(c), ctr.ID)
-	assert.NilError(c, err)
-
-	assert.Equal(c, containerJSON.HostConfig.ShmSize, int64(67108864))
-
-	out := cli.DockerCmd(c, "start", "-i", containerJSON.ID).Combined()
-	shmRegexp := regexp.MustCompile(`shm on /dev/shm type tmpfs(.*)size=65536k`)
-	if !shmRegexp.MatchString(out) {
-		c.Fatalf("Expected shm of 64MB in mount command, got %v", out)
-	}
-}
-
-func (s *DockerAPISuite) TestPostContainersCreateWithShmSize(c *testing.T) {
-	// ShmSize is not supported on Windows
-	testRequires(c, DaemonIsLinux)
-	config := container.Config{
-		Image: "busybox",
-		Cmd:   []string{"mount"},
-	}
-
-	hostConfig := container.HostConfig{
-		ShmSize: 1073741824,
-	}
-
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	ctr, err := apiClient.ContainerCreate(testutil.GetContext(c), &config, &hostConfig, &network.NetworkingConfig{}, nil, "")
-	assert.NilError(c, err)
-
-	containerJSON, err := apiClient.ContainerInspect(testutil.GetContext(c), ctr.ID)
-	assert.NilError(c, err)
-
-	assert.Equal(c, containerJSON.HostConfig.ShmSize, int64(1073741824))
-
-	out := cli.DockerCmd(c, "start", "-i", containerJSON.ID).Combined()
-	shmRegex := regexp.MustCompile(`shm on /dev/shm type tmpfs(.*)size=1048576k`)
-	if !shmRegex.MatchString(out) {
-		c.Fatalf("Expected shm of 1GB in mount command, got %v", out)
-	}
 }
 
 func (s *DockerAPISuite) TestPostContainersCreateMemorySwappinessHostConfigOmitted(c *testing.T) {

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -12,6 +12,9 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// ConfigOpt is an option to apply to a container.
+type ConfigOpt func(*TestContainerConfig)
+
 // WithName sets the name of the container
 func WithName(name string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
@@ -359,5 +362,12 @@ func WithStopSignal(stopSignal string) func(c *TestContainerConfig) {
 func WithContainerWideMacAddress(address string) func(c *TestContainerConfig) {
 	return func(c *TestContainerConfig) {
 		c.Config.MacAddress = address //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
+	}
+}
+
+// WithHostConfig sets a custom [container.HostConfig] for the container.
+func WithHostConfig(hc *container.HostConfig) func(c *TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig = hc
 	}
 }


### PR DESCRIPTION
Some of these tests were making assumptions about the daemon's internals by using `config.DefaultShmSize` from the daemon config package.

Rewrite them to start a daemon with a custom default, and verify the tests to use that default.

This migrates the following tests from integration-cli to integration;

- `DockerAPISuite.TestPostContainersCreateShmSizeNegative`
- `DockerAPISuite.TestPostContainersCreateShmSizeHostConfigOmitted`
- `DockerAPISuite.TestPostContainersCreateShmSizeOmitted`
- `DockerAPISuite.TestPostContainersCreateWithShmSize`


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

