### PR TITLE
daemon/server/router/checkpoint: remove unused httputils.ContainerDecoder

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -712,7 +712,7 @@ func buildRouters(opts routerOptions) []router.Router {
 
 	routers := []router.Router{
 		// we need to add the checkpoint router before the container router or the DELETE gets masked
-		checkpointrouter.NewRouter(opts.daemon, decoder),
+		checkpointrouter.NewRouter(opts.daemon),
 		container.NewRouter(opts.daemon, decoder, opts.daemon.RawSysInfo().CgroupUnified),
 		image.NewRouter(
 			opts.daemon.ImageService(),

--- a/daemon/server/router/checkpoint/checkpoint.go
+++ b/daemon/server/router/checkpoint/checkpoint.go
@@ -1,22 +1,19 @@
 package checkpoint
 
 import (
-	"github.com/docker/docker/daemon/server/httputils"
 	"github.com/docker/docker/daemon/server/router"
 )
 
 // checkpointRouter is a router to talk with the checkpoint controller
 type checkpointRouter struct {
 	backend Backend
-	decoder httputils.ContainerDecoder
 	routes  []router.Route
 }
 
 // NewRouter initializes a new checkpoint router
-func NewRouter(b Backend, decoder httputils.ContainerDecoder) router.Router {
+func NewRouter(b Backend) router.Router {
 	r := &checkpointRouter{
 		backend: b,
-		decoder: decoder,
 	}
 	r.initRoutes()
 	return r


### PR DESCRIPTION
Relates to (re)moving the `runconfig` package.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

