### PR TITLE
Fix: Missing Lock Release Could Cause Application Crashes in cmd/docker-proxy/udp_proxy_linux.go

### DIFF
--- a/cmd/docker-proxy/udp_proxy_linux.go
+++ b/cmd/docker-proxy/udp_proxy_linux.go
@@ -102,6 +102,7 @@ func (proxy *UDPProxy) replyLoop(cte *connTrackEntry, serverAddr net.IP, clientA
 		proxy.connTrackLock.Lock()
 		delete(proxy.connTrackTable, *clientKey)
 		cte.mu.Lock()
+		defer cte.mu.Unlock()
 		proxy.connTrackLock.Unlock()
 		cte.conn.Close()
 	}()
@@ -205,7 +206,6 @@ func (proxy *UDPProxy) Run() {
 			i += written
 			cte.lastW = time.Now()
 		}
-		cte.mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Missing mutex unlock (`cte.mu` variable) before returning from a function.  This could result in panics resulting from double lock operations
- **Rule ID:** trailofbits.go.missing-unlock-before-return.missing-unlock-before-return
- **Severity:** MEDIUM
- **File:** cmd/docker-proxy/udp_proxy_linux.go
- **Lines Affected:** 106 - 106

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `cmd/docker-proxy/udp_proxy_linux.go` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.