### PR TITLE
Fix: HTTP Server Missing Encryption Protection in contrib/httpserver/server.go

### DIFF
--- a/contrib/httpserver/server.go
+++ b/contrib/httpserver/server.go
@@ -8,5 +8,5 @@ import (
 func main() {
 	fs := http.FileServer(http.Dir("/static"))
 	http.Handle("/", fs)
-	log.Panic(http.ListenAndServe(":80", nil)) // #nosec G114 -- Ignoring for test-code: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
+	log.Panic(http.ListenAndServeTLS(":80", nil)) // #nosec G114 -- Ignoring for test-code: G114: Use of net/http serve function that has no support for setting timeouts (gosec, "cert.pem", "key.pem")
 }


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Found an HTTP server without TLS. Use 'http.ListenAndServeTLS' instead. See https://golang.org/pkg/net/http/#ListenAndServeTLS for more information.
- **Rule ID:** go.lang.security.audit.net.use-tls.use-tls
- **Severity:** MEDIUM
- **File:** contrib/httpserver/server.go
- **Lines Affected:** 11 - 11

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `contrib/httpserver/server.go` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.