### PR TITLE
iptables: remove deprecated SCTP checksum rule

### DIFF
--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/port.go
@@ -140,26 +140,6 @@ func setPerPortForwarding(b types.PortBinding, ipv iptables.IPVersion, bridgeNam
 		return err
 	}
 
-	// TODO(robmry) - remove, see https://github.com/moby/moby/pull/48149
-	if b.Proto == types.SCTP && os.Getenv("DOCKER_IPTABLES_SCTP_CHECKSUM") == "1" {
-		// Linux kernel v4.9 and below enables NETIF_F_SCTP_CRC for veth by
-		// the following commit.
-		// This introduces a problem when combined with a physical NIC without
-		// NETIF_F_SCTP_CRC. As for a workaround, here we add an iptables entry
-		// to fill the checksum.
-		//
-		// https://github.com/torvalds/linux/commit/c80fafbbb59ef9924962f83aac85531039395b18
-		rule := iptables.Rule{IPVer: ipv, Table: iptables.Mangle, Chain: "POSTROUTING", Args: []string{
-			"-p", b.Proto.String(),
-			"--sport", strconv.Itoa(int(b.Port)),
-			"-j", "CHECKSUM",
-			"--checksum-fill",
-		}}
-		if err := appendOrDelChainRule(rule, "SCTP CHECKSUM", enable); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

- closes https://github.com/moby/moby/issues/48152

Since 28.0.0, an iptables rule related to SCTP has only been included if escape hatch variable DOCKER_IPTABLES_SCTP_CHECKSUM=1

Nobody's reported that the escape hatch was needed, and the rule it guards doesn't make sense. So, remove.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Since 28.0.0, an `iptables` mangle rule for checksumming SCTP was only added if environment variable `DOCKER_IPTABLES_SCTP_CHECKSUM=1` was set. The rule has now been removed, the environment variable now has no effect.
```

**- A picture of a cute animal (not mandatory but encouraged)**

