### PR TITLE
Fix custom runtimes handling on Windows

### DIFF
--- a/daemon/command/daemon_windows.go
+++ b/daemon/command/daemon_windows.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/config"
-	"github.com/moby/moby/v2/daemon/internal/libcontainerd"
 	"golang.org/x/sys/windows"
 )
 
@@ -101,17 +100,12 @@ func newCgroupParent(*config.Config) string {
 }
 
 func (cli *daemonCLI) initContainerd(ctx context.Context) (func(time.Duration) error, error) {
-	defer func() {
-		if cli.Config.ContainerdAddr != "" {
-			libcontainerd.ContainerdRuntimeEnabled = true
-		}
-	}()
-
 	if cli.Config.ContainerdAddr != "" {
 		return nil, nil
 	}
 
-	if cli.Config.DefaultRuntime != config.WindowsV2RuntimeName {
+	if cli.Config.DefaultRuntime == "" || cli.Config.DefaultRuntime == config.WindowsV1RuntimeName {
+		// Legacy non-containerd runtime is used
 		return nil, nil
 	}
 

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -17,13 +17,7 @@ const (
 	StockRuntimeName = ""
 
 	WindowsV1RuntimeName = "com.docker.hcsshim.v1"
-	WindowsV2RuntimeName = "io.containerd.runhcs.v1"
 )
-
-var builtinRuntimes = map[string]bool{
-	WindowsV1RuntimeName: true,
-	WindowsV2RuntimeName: true,
-}
 
 // BridgeConfig is meant to store all the parameters for both the bridge driver and the default bridge network. On
 // Windows: 1. "bridge" in this context reference the nat driver and the default nat network; 2. the nat driver has no

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -50,6 +50,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/idtools"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/layer"
+	"github.com/moby/moby/v2/daemon/internal/libcontainerd"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
 	pluginexec "github.com/moby/moby/v2/daemon/internal/plugin/executor/containerd"
@@ -1165,7 +1166,8 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	go d.execCommandGC()
 
-	if err := d.initLibcontainerd(ctx, &cfgStore.Config); err != nil {
+	d.containerd, err = libcontainerd.NewClient(ctx, d.containerdClient, filepath.Join(config.ExecRoot, "containerd"), config.ContainerdNamespace, d)
+	if err != nil {
 		return nil, err
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -28,7 +28,6 @@ import (
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/initlayer"
-	"github.com/moby/moby/v2/daemon/internal/libcontainerd/remote"
 	"github.com/moby/moby/v2/daemon/internal/otelutil"
 	"github.com/moby/moby/v2/daemon/internal/usergroup"
 	"github.com/moby/moby/v2/daemon/libnetwork"
@@ -1644,18 +1643,6 @@ func getSysInfo(cfg *config.Config) *sysinfo.SysInfo {
 		}
 	}
 	return sysinfo.New(siOpts...)
-}
-
-func (daemon *Daemon) initLibcontainerd(ctx context.Context, cfg *config.Config) error {
-	var err error
-	daemon.containerd, err = remote.NewClient(
-		ctx,
-		daemon.containerdClient,
-		filepath.Join(cfg.ExecRoot, "containerd"),
-		cfg.ContainerdNamespace,
-		daemon,
-	)
-	return err
 }
 
 func recursiveUnmount(target string) error {

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -16,8 +16,6 @@ import (
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
-	"github.com/moby/moby/v2/daemon/internal/libcontainerd/local"
-	"github.com/moby/moby/v2/daemon/internal/libcontainerd/remote"
 	"github.com/moby/moby/v2/daemon/internal/system"
 	"github.com/moby/moby/v2/daemon/libnetwork"
 	nwconfig "github.com/moby/moby/v2/daemon/libnetwork/config"
@@ -572,37 +570,4 @@ func setupResolvConf(config *config.Config) {}
 
 func getSysInfo(*config.Config) *sysinfo.SysInfo {
 	return sysinfo.New()
-}
-
-func (daemon *Daemon) initLibcontainerd(ctx context.Context, cfg *config.Config) error {
-	var err error
-
-	rt := cfg.DefaultRuntime
-	if rt == "" {
-		if cfg.ContainerdAddr == "" {
-			rt = config.WindowsV1RuntimeName
-		} else {
-			rt = config.WindowsV2RuntimeName
-		}
-	}
-
-	switch rt {
-	case config.WindowsV1RuntimeName:
-		daemon.containerd, err = local.NewClient(ctx, daemon)
-	case config.WindowsV2RuntimeName:
-		if cfg.ContainerdAddr == "" {
-			return fmt.Errorf("cannot use the specified runtime %q without containerd", rt)
-		}
-		daemon.containerd, err = remote.NewClient(
-			ctx,
-			daemon.containerdClient,
-			filepath.Join(cfg.ExecRoot, "containerd"),
-			cfg.ContainerdNamespace,
-			daemon,
-		)
-	default:
-		return fmt.Errorf("unknown windows runtime %s", rt)
-	}
-
-	return err
 }

--- a/daemon/internal/libcontainerd/libcontainerd_windows.go
+++ b/daemon/internal/libcontainerd/libcontainerd_windows.go
@@ -9,14 +9,9 @@ import (
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
 )
 
-// ContainerdRuntimeEnabled determines whether to use containerd for runtime on Windows.
-//
-// TODO(thaJeztah): this value is equivalent to checking whether "cli.Config.ContainerdAddr != """ - do we really need it?
-var ContainerdRuntimeEnabled = false
-
 // NewClient creates a new libcontainerd client from a containerd client
 func NewClient(ctx context.Context, cli *containerd.Client, stateDir, ns string, b libcontainerdtypes.Backend) (libcontainerdtypes.Client, error) {
-	if !ContainerdRuntimeEnabled {
+	if cli == nil {
 		return local.NewClient(ctx, b)
 	}
 	return remote.NewClient(ctx, cli, stateDir, ns, b)

--- a/daemon/start_windows.go
+++ b/daemon/start_windows.go
@@ -1,16 +1,22 @@
 package daemon
 
 import (
-	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
-	"github.com/moby/moby/v2/daemon/config"
+	"context"
+
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/moby/moby/v2/daemon/container"
-	"github.com/moby/moby/v2/daemon/internal/libcontainerd"
 )
 
-func (daemon *Daemon) getLibcontainerdCreateOptions(*configStore, *container.Container) (string, any, error) {
-	if libcontainerd.ContainerdRuntimeEnabled {
-		opts := &options.Options{}
-		return config.WindowsV2RuntimeName, opts, nil
+func (daemon *Daemon) getLibcontainerdCreateOptions(daemonCfg *configStore, container *container.Container) (string, any, error) {
+	if container.HostConfig.Runtime == "" {
+		if daemonCfg.DefaultRuntime != "" {
+			container.HostConfig.Runtime = daemonCfg.DefaultRuntime
+		} else {
+			container.HostConfig.Runtime = defaults.DefaultRuntime
+		}
+
+		container.CheckpointTo(context.WithoutCancel(context.TODO()), daemon.containersReplica)
 	}
-	return "", nil, nil
+
+	return container.HostConfig.Runtime, nil, nil
 }


### PR DESCRIPTION
**- What I did**

This commit gives user full control over container runtimes:

* client-provided runtime is respected when running container
* containerd connection is properly initialized if default runtime is different from `io.containerd.runhcs.v1`
* Managed containerd is started if any default runtime is specified except `com.docker.hcsshim.v1`

This commit partially reverts 7ccf750daad37aa12e790d5f057b7ae6a140e0b8 and 84965c075215de0add8968848e7f93219155be85

Closes #50542

**- How to verify it**

Scenario 1: `docker run --rm -it --runtime <...> <image>` should use custom runtime to run container on Windows.

Scenario 2: change default runtime to any other value than `com.docker.hcsshim.v1` on Windows, and ensure that dockerd properly starts with containerd and runs containers using specified runtime.

Scenario 3: by default, dockerd on Windows doesn't require containerd and uses legacy mode where it directly calls hcsshim.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
- containerd connection is properly initialized if default runtime is different from `io.containerd.runhcs.v1`
-->
```markdown changelog
`docker run --runtime <...>` is now supported on Windows
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="1024" height="680" alt="image" src="https://github.com/user-attachments/assets/d43c67bb-d3d4-4d51-bc96-ba45eb106332" />
