### PR TITLE
contrib/check-config: fix MEMCG_SWAP checking

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -247,7 +247,7 @@ echo 'Optional Features:'
 }
 {
 	# Kernel v5.8+ removes MEMCG_SWAP_ENABLED and deprecates MEMCG_SWAP.
-	if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 8 ]; then
+	if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -lt 8 ]; then
 		CODE=${EXITCODE}
 		check_flags MEMCG_SWAP MEMCG_SWAP_ENABLED
 		# FIXME this check is cgroupv1-specific

--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -246,11 +246,10 @@ echo 'Optional Features:'
 	check_flags CGROUP_PIDS
 }
 {
-	check_flags MEMCG_SWAP
-	# Kernel v5.8+ removes MEMCG_SWAP_ENABLED.
+	# Kernel v5.8+ removes MEMCG_SWAP_ENABLED and deprecates MEMCG_SWAP.
 	if [ "$kernelMajor" -lt 5 ] || [ "$kernelMajor" -eq 5 -a "$kernelMinor" -le 8 ]; then
 		CODE=${EXITCODE}
-		check_flags MEMCG_SWAP_ENABLED
+		check_flags MEMCG_SWAP MEMCG_SWAP_ENABLED
 		# FIXME this check is cgroupv1-specific
 		if [ -e /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes ]; then
 			echo "    $(wrap_color '(cgroup swap accounting is currently enabled)' bold black)"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

CONFIG_MEMCG_SWAP has been deprecated since kernel v5.8-rc1 (commit 2d1c498) and removed since kernel v6.1-rc1 (commit e55b9f9).

Since kernel v5.8-rc1, swap tracking has been an integral part of memory control. CONFIG_MEMCG_SWAP becomes invisible to user and simply means CONFIG_MEMCG && CONFIG_SWAP. 

This PR disables the check for kernel v5.8+, and fixes a tiny bug in kernel version range check.

Closes [#49231](https://github.com/moby/moby/issues/49231).


**- A picture of a cute animal (not mandatory but encouraged)**
 ฅ^•ﻌ•^ฅ