### PR TITLE
api/types/filters: remove deprecated ToParamWithVersion

### DIFF
--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
-
-	"github.com/moby/moby/api/types/versions"
 )
 
 // Args stores a mapping of keys to a set of multiple values.
@@ -61,24 +59,6 @@ func ToJSON(a Args) (string, error) {
 	}
 	buf, err := json.Marshal(a)
 	return string(buf), err
-}
-
-// ToParamWithVersion encodes Args as a JSON string. If version is less than 1.22
-// then the encoded format will use an older legacy format where the values are a
-// list of strings, instead of a set.
-//
-// Deprecated: do not use in any new code; use ToJSON instead
-func ToParamWithVersion(version string, a Args) (string, error) {
-	if a.Len() == 0 {
-		return "", nil
-	}
-
-	if version != "" && versions.LessThan(version, "1.22") {
-		buf, err := json.Marshal(convertArgsToSlice(a.fields))
-		return string(buf), err
-	}
-
-	return ToJSON(a)
 }
 
 // FromJSON decodes a JSON encoded string into Args
@@ -315,20 +295,6 @@ func deprecatedArgs(d map[string][]string) map[string]map[string]bool {
 		values := map[string]bool{}
 		for _, vv := range v {
 			values[vv] = true
-		}
-		m[k] = values
-	}
-	return m
-}
-
-func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
-	m := map[string][]string{}
-	for k, v := range f {
-		values := []string{}
-		for kk := range v {
-			if v[kk] {
-				values = append(values, kk)
-			}
 		}
 		m[k] = values
 	}

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -43,27 +43,6 @@ func TestToJSON(t *testing.T) {
 	assert.Check(t, is.Equal(s, expected))
 }
 
-func TestToParamWithVersion(t *testing.T) {
-	a := NewArgs(
-		Arg("created", "today"),
-		Arg("image.name", "ubuntu*"),
-		Arg("image.name", "*untu"),
-	)
-
-	str1, err := ToParamWithVersion("1.21", a)
-	assert.Check(t, err)
-	str2, err := ToParamWithVersion("1.22", a)
-	assert.Check(t, err)
-	if str1 != `{"created":["today"],"image.name":["*untu","ubuntu*"]}` &&
-		str1 != `{"created":["today"],"image.name":["ubuntu*","*untu"]}` {
-		t.Errorf("incorrectly marshaled the filters: %s", str1)
-	}
-	if str2 != `{"created":{"today":true},"image.name":{"*untu":true,"ubuntu*":true}}` &&
-		str2 != `{"created":{"today":true},"image.name":{"ubuntu*":true,"*untu":true}}` {
-		t.Errorf("incorrectly marshaled the filters: %s", str2)
-	}
-}
-
 func TestFromJSON(t *testing.T) {
 	invalids := []string{
 		"anything",

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -39,10 +39,16 @@ func (cli *Client) ImageList(ctx context.Context, options image.ListOptions) ([]
 		}
 	}
 	if optionFilters.Len() > 0 {
-		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, optionFilters)
+		filterJSON, err := filters.ToJSON(optionFilters)
 		if err != nil {
 			return images, err
+		}
+		if cli.version != "" && versions.LessThan(cli.version, "1.22") {
+			legacyFormat, err := encodeLegacyFilters(filterJSON)
+			if err != nil {
+				return nil, err
+			}
+			filterJSON = legacyFormat
 		}
 		query.Set("filters", filterJSON)
 	}

--- a/client/utils.go
+++ b/client/utils.go
@@ -81,3 +81,41 @@ func encodePlatform(platform *ocispec.Platform) (string, error) {
 	}
 	return string(p), nil
 }
+
+// encodeLegacyFilters encodes Args in the legacy format as used in API v1.21 and older.
+// where values are a list of strings, instead of a set.
+//
+// Don't use in any new code; use [filters.ToJSON]] instead.
+func encodeLegacyFilters(currentFormat string) (string, error) {
+	// The Args.fields field is not exported, but used to marshal JSON,
+	// so we'll marshal to the new format, then unmarshal to get the
+	// fields, and marshal again.
+	//
+	// This is far from optimal, but this code is only used for deprecated
+	// API versions, so should not be hit commonly.
+	var argsFields map[string]map[string]bool
+	err := json.Unmarshal([]byte(currentFormat), &argsFields)
+	if err != nil {
+		return "", err
+	}
+
+	buf, err := json.Marshal(convertArgsToSlice(argsFields))
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
+	m := map[string][]string{}
+	for k, v := range f {
+		values := []string{}
+		for kk := range v {
+			if v[kk] {
+				values = append(values, kk)
+			}
+		}
+		m[k] = values
+	}
+	return m
+}

--- a/vendor/github.com/moby/moby/api/types/filters/parse.go
+++ b/vendor/github.com/moby/moby/api/types/filters/parse.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
-
-	"github.com/moby/moby/api/types/versions"
 )
 
 // Args stores a mapping of keys to a set of multiple values.
@@ -61,24 +59,6 @@ func ToJSON(a Args) (string, error) {
 	}
 	buf, err := json.Marshal(a)
 	return string(buf), err
-}
-
-// ToParamWithVersion encodes Args as a JSON string. If version is less than 1.22
-// then the encoded format will use an older legacy format where the values are a
-// list of strings, instead of a set.
-//
-// Deprecated: do not use in any new code; use ToJSON instead
-func ToParamWithVersion(version string, a Args) (string, error) {
-	if a.Len() == 0 {
-		return "", nil
-	}
-
-	if version != "" && versions.LessThan(version, "1.22") {
-		buf, err := json.Marshal(convertArgsToSlice(a.fields))
-		return string(buf), err
-	}
-
-	return ToJSON(a)
 }
 
 // FromJSON decodes a JSON encoded string into Args
@@ -315,20 +295,6 @@ func deprecatedArgs(d map[string][]string) map[string]map[string]bool {
 		values := map[string]bool{}
 		for _, vv := range v {
 			values[vv] = true
-		}
-		m[k] = values
-	}
-	return m
-}
-
-func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
-	m := map[string][]string{}
-	for k, v := range f {
-		values := []string{}
-		for kk := range v {
-			if v[kk] {
-				values = append(values, kk)
-			}
 		}
 		m[k] = values
 	}

--- a/vendor/github.com/moby/moby/client/image_list.go
+++ b/vendor/github.com/moby/moby/client/image_list.go
@@ -39,10 +39,16 @@ func (cli *Client) ImageList(ctx context.Context, options image.ListOptions) ([]
 		}
 	}
 	if optionFilters.Len() > 0 {
-		//nolint:staticcheck // ignore SA1019 for old code
-		filterJSON, err := filters.ToParamWithVersion(cli.version, optionFilters)
+		filterJSON, err := filters.ToJSON(optionFilters)
 		if err != nil {
 			return images, err
+		}
+		if cli.version != "" && versions.LessThan(cli.version, "1.22") {
+			legacyFormat, err := encodeLegacyFilters(filterJSON)
+			if err != nil {
+				return nil, err
+			}
+			filterJSON = legacyFormat
 		}
 		query.Set("filters", filterJSON)
 	}

--- a/vendor/github.com/moby/moby/client/utils.go
+++ b/vendor/github.com/moby/moby/client/utils.go
@@ -81,3 +81,41 @@ func encodePlatform(platform *ocispec.Platform) (string, error) {
 	}
 	return string(p), nil
 }
+
+// encodeLegacyFilters encodes Args in the legacy format as used in API v1.21 and older.
+// where values are a list of strings, instead of a set.
+//
+// Don't use in any new code; use [filters.ToJSON]] instead.
+func encodeLegacyFilters(currentFormat string) (string, error) {
+	// The Args.fields field is not exported, but used to marshal JSON,
+	// so we'll marshal to the new format, then unmarshal to get the
+	// fields, and marshal again.
+	//
+	// This is far from optimal, but this code is only used for deprecated
+	// API versions, so should not be hit commonly.
+	var argsFields map[string]map[string]bool
+	err := json.Unmarshal([]byte(currentFormat), &argsFields)
+	if err != nil {
+		return "", err
+	}
+
+	buf, err := json.Marshal(convertArgsToSlice(argsFields))
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
+	m := map[string][]string{}
+	for k, v := range f {
+		values := []string{}
+		for kk := range v {
+			if v[kk] {
+				values = append(values, kk)
+			}
+		}
+		m[k] = values
+	}
+	return m
+}


### PR DESCRIPTION
It's only used by the client to support API versions older than v1.22. Make it an internal utility that doesn't depend on internal fields of `filter.Args`.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go-SDK: api/types/filters: remove deprecated `ToParamWithVersion`
```


**- A picture of a cute animal (not mandatory but encouraged)**

