### PR TITLE
[28.x] api/types/filters: reimplement ToParamWithVersion

### DIFF
--- a/api/types/filters/filters_deprecated.go
+++ b/api/types/filters/filters_deprecated.go
@@ -1,0 +1,61 @@
+package filters
+
+import (
+	"encoding/json"
+
+	"github.com/docker/docker/api/types/versions"
+)
+
+// ToParamWithVersion encodes Args as a JSON string. If version is less than 1.22
+// then the encoded format will use an older legacy format where the values are a
+// list of strings, instead of a set.
+//
+// Deprecated: do not use in any new code; use ToJSON instead
+func ToParamWithVersion(version string, a Args) (string, error) {
+	out, err := ToJSON(a)
+	if out == "" || err != nil {
+		return "", nil
+	}
+	if version != "" && versions.LessThan(version, "1.22") {
+		return encodeLegacyFilters(out)
+	}
+	return out, nil
+}
+
+// encodeLegacyFilters encodes Args in the legacy format as used in API v1.21 and older.
+// where values are a list of strings, instead of a set.
+//
+// Don't use in any new code; use [filters.ToJSON]] instead.
+func encodeLegacyFilters(currentFormat string) (string, error) {
+	// The Args.fields field is not exported, but used to marshal JSON,
+	// so we'll marshal to the new format, then unmarshal to get the
+	// fields, and marshal again.
+	//
+	// This is far from optimal, but this code is only used for deprecated
+	// API versions, so should not be hit commonly.
+	var argsFields map[string]map[string]bool
+	err := json.Unmarshal([]byte(currentFormat), &argsFields)
+	if err != nil {
+		return "", err
+	}
+
+	buf, err := json.Marshal(convertArgsToSlice(argsFields))
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
+	m := map[string][]string{}
+	for k, v := range f {
+		values := []string{}
+		for kk := range v {
+			if v[kk] {
+				values = append(values, kk)
+			}
+		}
+		m[k] = values
+	}
+	return m
+}

--- a/api/types/filters/filters_deprecated_test.go
+++ b/api/types/filters/filters_deprecated_test.go
@@ -1,0 +1,28 @@
+package filters
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestToParamWithVersion(t *testing.T) {
+	a := NewArgs(
+		Arg("created", "today"),
+		Arg("image.name", "ubuntu*"),
+		Arg("image.name", "*untu"),
+	)
+
+	str1, err := ToParamWithVersion("1.21", a)
+	assert.Check(t, err)
+	str2, err := ToParamWithVersion("1.22", a)
+	assert.Check(t, err)
+	if str1 != `{"created":["today"],"image.name":["*untu","ubuntu*"]}` &&
+		str1 != `{"created":["today"],"image.name":["ubuntu*","*untu"]}` {
+		t.Errorf("incorrectly marshaled the filters: %s", str1)
+	}
+	if str2 != `{"created":{"today":true},"image.name":{"*untu":true,"ubuntu*":true}}` &&
+		str2 != `{"created":{"today":true},"image.name":{"ubuntu*":true,"*untu":true}}` {
+		t.Errorf("incorrectly marshaled the filters: %s", str2)
+	}
+}

--- a/api/types/filters/parse.go
+++ b/api/types/filters/parse.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
-
-	"github.com/docker/docker/api/types/versions"
 )
 
 // Args stores a mapping of keys to a set of multiple values.
@@ -61,24 +59,6 @@ func ToJSON(a Args) (string, error) {
 	}
 	buf, err := json.Marshal(a)
 	return string(buf), err
-}
-
-// ToParamWithVersion encodes Args as a JSON string. If version is less than 1.22
-// then the encoded format will use an older legacy format where the values are a
-// list of strings, instead of a set.
-//
-// Deprecated: do not use in any new code; use ToJSON instead
-func ToParamWithVersion(version string, a Args) (string, error) {
-	if a.Len() == 0 {
-		return "", nil
-	}
-
-	if version != "" && versions.LessThan(version, "1.22") {
-		buf, err := json.Marshal(convertArgsToSlice(a.fields))
-		return string(buf), err
-	}
-
-	return ToJSON(a)
 }
 
 // FromJSON decodes a JSON encoded string into Args
@@ -315,20 +295,6 @@ func deprecatedArgs(d map[string][]string) map[string]map[string]bool {
 		values := map[string]bool{}
 		for _, vv := range v {
 			values[vv] = true
-		}
-		m[k] = values
-	}
-	return m
-}
-
-func convertArgsToSlice(f map[string]map[string]bool) map[string][]string {
-	m := map[string][]string{}
-	for k, v := range f {
-		values := []string{}
-		for kk := range v {
-			if v[kk] {
-				values = append(values, kk)
-			}
 		}
 		m[k] = values
 	}

--- a/api/types/filters/parse_test.go
+++ b/api/types/filters/parse_test.go
@@ -43,27 +43,6 @@ func TestToJSON(t *testing.T) {
 	assert.Check(t, is.Equal(s, expected))
 }
 
-func TestToParamWithVersion(t *testing.T) {
-	a := NewArgs(
-		Arg("created", "today"),
-		Arg("image.name", "ubuntu*"),
-		Arg("image.name", "*untu"),
-	)
-
-	str1, err := ToParamWithVersion("1.21", a)
-	assert.Check(t, err)
-	str2, err := ToParamWithVersion("1.22", a)
-	assert.Check(t, err)
-	if str1 != `{"created":["today"],"image.name":["*untu","ubuntu*"]}` &&
-		str1 != `{"created":["today"],"image.name":["ubuntu*","*untu"]}` {
-		t.Errorf("incorrectly marshaled the filters: %s", str1)
-	}
-	if str2 != `{"created":{"today":true},"image.name":{"*untu":true,"ubuntu*":true}}` &&
-		str2 != `{"created":{"today":true},"image.name":{"ubuntu*":true,"*untu":true}}` {
-		t.Errorf("incorrectly marshaled the filters: %s", str2)
-	}
-}
-
 func TestFromJSON(t *testing.T) {
 	invalids := []string{
 		"anything",


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50561
- needed for https://github.com/moby/moby/pull/50475

This function depended on the non-exported `Args.values` field. With the migration of the API to a separate module, we will alias that type, and remove the deprecated `ToParamWithVersion` function.

This means that we cannot alias the function, and aliasing the `Args` type means we can't access the non-exported field.

This patch reimplements `ToParamWithVersion` by unmarshaling the JSON output of the current format, and re-marshaling it to the legacy format.

This is not optimal, but this code-path would only be used for API versions that are deprecated, and is not to be used for any new code.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

