### PR TITLE
fix: containerd moby archive arbitrary file access during archive extraction

### DIFF
--- a/vendor/github.com/moby/go-archive/archive.go
+++ b/vendor/github.com/moby/go-archive/archive.go
@@ -972,6 +972,10 @@ func createImpliedDirectories(dest string, hdr *tar.Header, options *TarOptions)
 	if !strings.HasSuffix(hdr.Name, string(os.PathSeparator)) {
 		parent := filepath.Dir(hdr.Name)
 		parentPath := filepath.Join(dest, parent)
+		rel, err := filepath.Rel(dest, parentPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("archive: illegal file path: %q", parentPath)
+		}
 		if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
 			// RootPair() is confined inside this loop as most cases will not require a call, so we can spend some
 			// unneeded function calls in the uncommon case to encapsulate logic -- implied directories are a niche


### PR DESCRIPTION
https://github.com/moby/moby/blob/2574c2b2e9174688bb78010a1dd8a02017ca5130/vendor/github.com/moby/go-archive/diff.go#L40-L40

https://github.com/moby/moby/blob/2574c2b2e9174688bb78010a1dd8a02017ca5130/vendor/github.com/moby/go-archive/archive.go#L856-L856

https://github.com/moby/moby/blob/2574c2b2e9174688bb78010a1dd8a02017ca5130/vendor/github.com/containerd/containerd/v2/pkg/archive/tar.go#L224-L224

Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths. zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.



fix the vulnerability, we need to ensure that after cleaning the archive entry name (`hdr.Name`), the resulting path does not escape the intended destination directory. The best way to do this is to construct the full output path using `filepath.Join(dest, hdr.Name)` and then check that the resulting path is within `dest` by comparing the absolute paths. If the resulting path is not within `dest`, we should skip extraction or return an error.

Specifically, in `UnpackLayer`, after cleaning `hdr.Name`, we should check that joining `dest` and `hdr.Name` does not result in a path outside `dest`. This check should be performed before any filesystem operations (including `createImpliedDirectories`). The same check should be applied to all uses of `hdr.Name` that result in filesystem writes. To implement this, we can add a helper function, e.g., `isSubpath(base, target string) (bool, error)`, that checks if `target` is within `base`. We should call this function before proceeding with extraction for each archive entry.

that the `Linkname` field from the tar header does not contain any directory traversal (`..`) or absolute paths before it is used to construct a filesystem path for hard links. The best way to do this is to add explicit validation in the `hardlinkRootPath` function to reject any `linkname` that is absolute or contains `..` path elements. If such a path is detected, the function should return an error and not attempt to create the link. This change should be made in `vendor/github.com/containerd/containerd/v2/pkg/archive/tar.go`, specifically in the `hardlinkRootPath` function (lines 782-794). No changes are needed in `link_default.go`, as the vulnerability is in the construction of the path, not the link operation itself.

To implement this, we need to:
- Add a check in `hardlinkRootPath` to reject absolute paths (`filepath.IsAbs(linkname)`).
- Split `linkname` into its path elements and reject any that are `..`.
- Return an error if validation fails.
- Optionally, define a new error variable (e.g., `errInvalidLinkname`) for clarity.

