### PR TITLE
pkg/jsonmessage: remove github.com/morikuni/aec dependency

### DIFF
--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -179,10 +179,16 @@ func clearLine(out io.Writer) {
 }
 
 func cursorUp(out io.Writer, l uint) {
+	if l == 0 {
+		return
+	}
 	_, _ = fmt.Fprintf(out, ansiCursorUpFmt, l)
 }
 
 func cursorDown(out io.Writer, l uint) {
+	if l == 0 {
+		return
+	}
 	_, _ = fmt.Fprintf(out, ansiCursorDownFmt, l)
 }
 
@@ -197,29 +203,29 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	if isTerminal && jm.Stream == "" && jm.Progress != nil {
 		clearLine(out)
 		endl = "\r"
-		fmt.Fprint(out, endl)
+		_, _ = fmt.Fprint(out, endl)
 	} else if jm.Progress != nil && jm.Progress.String() != "" { // disable progressbar in non-terminal
 		return nil
 	}
 	if jm.TimeNano != 0 {
-		fmt.Fprintf(out, "%s ", time.Unix(0, jm.TimeNano).Format(RFC3339NanoFixed))
+		_, _ = fmt.Fprintf(out, "%s ", time.Unix(0, jm.TimeNano).Format(RFC3339NanoFixed))
 	} else if jm.Time != 0 {
-		fmt.Fprintf(out, "%s ", time.Unix(jm.Time, 0).Format(RFC3339NanoFixed))
+		_, _ = fmt.Fprintf(out, "%s ", time.Unix(jm.Time, 0).Format(RFC3339NanoFixed))
 	}
 	if jm.ID != "" {
-		fmt.Fprintf(out, "%s: ", jm.ID)
+		_, _ = fmt.Fprintf(out, "%s: ", jm.ID)
 	}
 	if jm.From != "" {
-		fmt.Fprintf(out, "(from %s) ", jm.From)
+		_, _ = fmt.Fprintf(out, "(from %s) ", jm.From)
 	}
 	if jm.Progress != nil && isTerminal {
-		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)
+		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)
 	} else if jm.ProgressMessage != "" { // deprecated
-		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.ProgressMessage, endl)
+		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.ProgressMessage, endl)
 	} else if jm.Stream != "" {
-		fmt.Fprintf(out, "%s%s", jm.Stream, endl)
+		_, _ = fmt.Fprintf(out, "%s%s", jm.Stream, endl)
 	} else {
-		fmt.Fprintf(out, "%s%s\n", jm.Status, endl)
+		_, _ = fmt.Fprintf(out, "%s%s\n", jm.Status, endl)
 	}
 	return nil
 }
@@ -278,7 +284,7 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 				line = uint(len(ids))
 				ids[jm.ID] = line
 				if isTerminal {
-					fmt.Fprintf(out, "\n")
+					_, _ = fmt.Fprintf(out, "\n")
 				}
 			}
 			diff = uint(len(ids)) - line

--- a/vendor.mod
+++ b/vendor.mod
@@ -83,7 +83,6 @@ require (
 	github.com/moby/sys/userns v0.1.0
 	github.com/moby/term v0.5.2
 	github.com/montanaflynn/stats v0.7.1
-	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/cgroups v0.0.4
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -194,6 +193,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/moby/api v0.0.0
 	github.com/moby/moby/client v0.0.0
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 // indirect
 	github.com/package-url/packageurl-go v0.1.1 // indirect


### PR DESCRIPTION
We can probably use [aec.EmptyBuilder] for managing the output, but
currently we're doing it all manually, so defining some consts for
the basics we use.

[aec.EmptyBuilder]: https://pkg.go.dev/github.com/morikuni/aec#EmptyBuilder


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

