### PR TITLE
Add separate const for daemon httputils to avoid jsonmessage import

### DIFF
--- a/daemon/server/httputils/write_log_stream.go
+++ b/daemon/server/httputils/write_log_stream.go
@@ -10,10 +10,13 @@ import (
 
 	"github.com/docker/docker/daemon/server/backend"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/moby/api/stdcopy"
 	"github.com/moby/moby/api/types/container"
 )
+
+// rfc3339NanoFixed is time.RFC3339Nano with nanoseconds padded using zeros to
+// ensure the formatted time isalways the same number of characters.
+const rfc3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
 
 // WriteLogStream writes an encoded byte stream of log messages from the
 // messages channel, multiplexing them with a stdcopy.Writer if mux is true
@@ -53,7 +56,7 @@ func WriteLogStream(_ context.Context, w http.ResponseWriter, msgs <-chan *backe
 			logLine = append(logLine, msg.Line...)
 		}
 		if config.Timestamps {
-			logLine = append([]byte(msg.Timestamp.Format(jsonmessage.RFC3339NanoFixed)+" "), logLine...)
+			logLine = append([]byte(msg.Timestamp.Format(rfc3339NanoFixed)+" "), logLine...)
 		}
 		if msg.Source == "stdout" && config.ShowStdout {
 			_, _ = outStream.Write(logLine)


### PR DESCRIPTION
- taken from https://github.com/moby/moby/pull/50565

(we may need this in the 28.x branch)

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

