### PR TITLE
api/types/container: add aliases for go-connections/nat types

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -3,7 +3,6 @@ package container
 import (
 	"time"
 
-	"github.com/docker/go-connections/nat"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/strslice"
 )
@@ -48,7 +47,7 @@ type Config struct {
 	AttachStdin     bool                // Attach the standard input, makes possible user interaction
 	AttachStdout    bool                // Attach the standard output
 	AttachStderr    bool                // Attach the standard error
-	ExposedPorts    nat.PortSet         `json:",omitempty"` // List of exposed ports
+	ExposedPorts    PortSet             `json:",omitempty"` // List of exposed ports
 	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
 	OpenStdin       bool                // Open stdin
 	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/blkiodev"
 	"github.com/moby/moby/api/types/mount"
@@ -427,7 +426,7 @@ type HostConfig struct {
 	ContainerIDFile string            // File (path) where the containerId is written
 	LogConfig       LogConfig         // Configuration of the logs for this container
 	NetworkMode     NetworkMode       // Network mode to use for the container
-	PortBindings    nat.PortMap       // Port mapping between the exposed port (container) and the host
+	PortBindings    PortMap           // Port mapping between the exposed port (container) and the host
 	RestartPolicy   RestartPolicy     // Restart policy to be used for the container
 	AutoRemove      bool              // Automatically remove container when it exits
 	VolumeDriver    string            // Name of the volume driver used to mount volumes

--- a/api/types/container/nat_aliases.go
+++ b/api/types/container/nat_aliases.go
@@ -1,0 +1,24 @@
+package container
+
+import "github.com/docker/go-connections/nat"
+
+// PortRangeProto is a string containing port number and protocol in the format "80/tcp",
+// or a port range and protocol in the format "80-83/tcp".
+//
+// It is currently an alias for [nat.Port] but may become a concrete type in a future release.
+type PortRangeProto = nat.Port
+
+// PortSet is a collection of structs indexed by [HostPort].
+//
+// It is currently an alias for [nat.PortSet] but may become a concrete type in a future release.
+type PortSet = nat.PortSet
+
+// PortBinding represents a binding between a Host IP address and a [HostPort].
+//
+// It is currently an alias for [nat.PortBinding] but may become a concrete type in a future release.
+type PortBinding = nat.PortBinding
+
+// PortMap is a collection of [PortBinding] indexed by [HostPort].
+//
+// It is currently an alias for [nat.PortMap] but may become a concrete type in a future release.
+type PortMap = nat.PortMap

--- a/api/types/container/network_settings.go
+++ b/api/types/container/network_settings.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/network"
 )
 
@@ -14,10 +13,10 @@ type NetworkSettings struct {
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
 type NetworkSettingsBase struct {
-	Bridge     string      // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
-	SandboxID  string      // SandboxID uniquely represents a container's network stack
-	SandboxKey string      // SandboxKey identifies the sandbox
-	Ports      nat.PortMap // Ports is a collection of PortBinding indexed by Port
+	Bridge     string  // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
+	SandboxID  string  // SandboxID uniquely represents a container's network stack
+	SandboxKey string  // SandboxKey identifies the sandbox
+	Ports      PortMap // Ports is a collection of PortBinding indexed by Port
 
 	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
 	//

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -3,7 +3,6 @@ package container
 import (
 	"time"
 
-	"github.com/docker/go-connections/nat"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/strslice"
 )
@@ -48,7 +47,7 @@ type Config struct {
 	AttachStdin     bool                // Attach the standard input, makes possible user interaction
 	AttachStdout    bool                // Attach the standard output
 	AttachStderr    bool                // Attach the standard error
-	ExposedPorts    nat.PortSet         `json:",omitempty"` // List of exposed ports
+	ExposedPorts    PortSet             `json:",omitempty"` // List of exposed ports
 	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
 	OpenStdin       bool                // Open stdin
 	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/blkiodev"
 	"github.com/moby/moby/api/types/mount"
@@ -427,7 +426,7 @@ type HostConfig struct {
 	ContainerIDFile string            // File (path) where the containerId is written
 	LogConfig       LogConfig         // Configuration of the logs for this container
 	NetworkMode     NetworkMode       // Network mode to use for the container
-	PortBindings    nat.PortMap       // Port mapping between the exposed port (container) and the host
+	PortBindings    PortMap           // Port mapping between the exposed port (container) and the host
 	RestartPolicy   RestartPolicy     // Restart policy to be used for the container
 	AutoRemove      bool              // Automatically remove container when it exits
 	VolumeDriver    string            // Name of the volume driver used to mount volumes

--- a/vendor/github.com/moby/moby/api/types/container/nat_aliases.go
+++ b/vendor/github.com/moby/moby/api/types/container/nat_aliases.go
@@ -1,0 +1,24 @@
+package container
+
+import "github.com/docker/go-connections/nat"
+
+// PortRangeProto is a string containing port number and protocol in the format "80/tcp",
+// or a port range and protocol in the format "80-83/tcp".
+//
+// It is currently an alias for [nat.Port] but may become a concrete type in a future release.
+type PortRangeProto = nat.Port
+
+// PortSet is a collection of structs indexed by [HostPort].
+//
+// It is currently an alias for [nat.PortSet] but may become a concrete type in a future release.
+type PortSet = nat.PortSet
+
+// PortBinding represents a binding between a Host IP address and a [HostPort].
+//
+// It is currently an alias for [nat.PortBinding] but may become a concrete type in a future release.
+type PortBinding = nat.PortBinding
+
+// PortMap is a collection of [PortBinding] indexed by [HostPort].
+//
+// It is currently an alias for [nat.PortMap] but may become a concrete type in a future release.
+type PortMap = nat.PortMap

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/network"
 )
 
@@ -14,10 +13,10 @@ type NetworkSettings struct {
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
 type NetworkSettingsBase struct {
-	Bridge     string      // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
-	SandboxID  string      // SandboxID uniquely represents a container's network stack
-	SandboxKey string      // SandboxKey identifies the sandbox
-	Ports      nat.PortMap // Ports is a collection of PortBinding indexed by Port
+	Bridge     string  // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
+	SandboxID  string  // SandboxID uniquely represents a container's network stack
+	SandboxKey string  // SandboxKey identifies the sandbox
+	Ports      PortMap // Ports is a collection of PortBinding indexed by Port
 
 	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
 	//


### PR DESCRIPTION
This allows us to update code to not be attached to go-connections directly (in future we may be able to move the types to be concrete types).


**- A picture of a cute animal (not mandatory but encouraged)**

