### PR TITLE
api: remove deprecated NoBaseImageSpecifier

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -13,10 +13,4 @@ const (
 	// API requests for API versions lower than the configured version produce
 	// an error.
 	MinSupportedAPIVersion = "1.24"
-
-	// NoBaseImageSpecifier is the symbol used by the FROM
-	// command to specify that no base image is to be used.
-	//
-	// Deprecated: this const is no longer used and will be removed in the next release.
-	NoBaseImageSpecifier = "scratch"
 )

--- a/vendor/github.com/moby/moby/api/common.go
+++ b/vendor/github.com/moby/moby/api/common.go
@@ -13,10 +13,4 @@ const (
 	// API requests for API versions lower than the configured version produce
 	// an error.
 	MinSupportedAPIVersion = "1.24"
-
-	// NoBaseImageSpecifier is the symbol used by the FROM
-	// command to specify that no base image is to be used.
-	//
-	// Deprecated: this const is no longer used and will be removed in the next release.
-	NoBaseImageSpecifier = "scratch"
 )


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46464#discussion_r2240915387

It was deprecated in 7b9bd987bfd22a0db817a378ba233f2a46c55024, but won't be carried in the API module.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api: remove `NoBaseImageSpecifier`
```

**- A picture of a cute animal (not mandatory but encouraged)**

