### PR TITLE
nftables: preserve filter-FORWARD drop policy on restart/upgrade

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -882,14 +882,14 @@ func (d *driver) createNetwork(ctx context.Context, config *networkConfiguration
 			config.EnableIPv4 && d.config.EnableIPForwarding,
 			"setupIPv4Forwarding",
 			func(*networkConfiguration, *bridgeInterface) error {
-				return setupIPv4Forwarding(d.firewaller, d.config.EnableIPTables && !d.config.DisableFilterForwardDrop)
+				return d.setupIPv4Forwarding(ctx)
 			},
 		},
 		{
 			config.EnableIPv6 && d.config.EnableIPForwarding,
 			"setupIPv6Forwarding",
 			func(*networkConfiguration, *bridgeInterface) error {
-				return setupIPv6Forwarding(d.firewaller, d.config.EnableIP6Tables && !d.config.DisableFilterForwardDrop)
+				return d.setupIPv6Forwarding(ctx)
 			},
 		},
 

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1337,8 +1337,8 @@ func TestCreateParallel(t *testing.T) {
 
 func useStubFirewaller(t *testing.T) {
 	origNewFirewaller := newFirewaller
-	newFirewaller = func(_ context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
-		return firewaller.NewStubFirewaller(config), nil
+	newFirewaller = func(_ context.Context, config firewaller.Config) (firewaller.Firewaller, firewaller.FirewallCleaner, error) {
+		return firewaller.NewStubFirewaller(config), nil, nil
 	}
 	t.Cleanup(func() { newFirewaller = origNewFirewaller })
 }

--- a/daemon/libnetwork/drivers/bridge/bridge_store.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_store.go
@@ -47,6 +47,7 @@ func (d *driver) initStore() error {
 
 	// If there's a firewall cleaner, it's done its job by cleaning up rules
 	// belonging to the restored networks. So, drop it.
+	d.firewallCleaner = nil
 	if fcs, ok := d.firewaller.(firewaller.FirewallCleanerSetter); ok {
 		fcs.SetFirewallCleaner(nil)
 	}
@@ -126,7 +127,7 @@ func (d *driver) storeUpdate(ctx context.Context, kvObject datastore.KVObject) e
 	}
 
 	if err := d.store.PutObjectAtomic(kvObject); err != nil {
-		return fmt.Errorf("failed to update bridge store for object type %T: %v", kvObject, err)
+		return fmt.Errorf("failed to update bridge store for object type %T: %w", kvObject, err)
 	}
 
 	return nil

--- a/daemon/libnetwork/drivers/bridge/bridge_store.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_store.go
@@ -31,6 +31,10 @@ const (
 )
 
 func (d *driver) initStore() error {
+	if err := d.initForwardingPolicy(context.TODO()); err != nil {
+		return err
+	}
+
 	err := d.populateNetworks()
 	if err != nil {
 		return err

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
@@ -122,6 +122,11 @@ type FirewallCleanerSetter interface {
 // a FirewallCleaner from the old Firewaller and pass it to the new/current
 // Firewaller's SetFirewallCleaner.
 type FirewallCleaner interface {
+	// HadFilterForwardDrop returns true if the default policy for forwarded packets
+	// was set to 'drop' in the rules that are being cleaned.
+	HadFilterForwardDrop(ipv IPVersion) bool
+	// SetFilterForwardAccept sets the policy of filter chain FORWARD to "ACCEPT".
+	SetFilterForwardAccept(ipv IPVersion) error
 	// DelNetwork removes all firewall rules related to the specified network configuration.
 	// It should be called by the new Firewaller when adding a new network.
 	DelNetwork(ctx context.Context, nc NetworkConfig)

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -97,7 +97,10 @@ func (nft *nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVer
 	if err := table.Chain(ctx, forwardChain).SetPolicy("drop"); err != nil {
 		return err
 	}
-	return nftApply(ctx, table)
+	if err := nftApply(ctx, table); err != nil {
+		return err
+	}
+	return nil
 }
 
 // init creates the bridge driver's nftables table for IPv4 or IPv6.

--- a/daemon/libnetwork/drivers/bridge/setup_ip_forwarding.go
+++ b/daemon/libnetwork/drivers/bridge/setup_ip_forwarding.go
@@ -4,10 +4,13 @@ package bridge
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/containerd/log"
+	"github.com/docker/docker/daemon/libnetwork/datastore"
 	"github.com/docker/docker/daemon/libnetwork/drivers/bridge/internal/firewaller"
 )
 
@@ -17,7 +20,7 @@ const (
 	ipv6ForwardConfAll     = "/proc/sys/net/ipv6/conf/all/forwarding"
 )
 
-func setupIPv4Forwarding(fw firewaller.Firewaller, wantFilterForwardDrop bool) (retErr error) {
+func (d *driver) setupIPv4Forwarding(ctx context.Context) (retErr error) {
 	changed, err := configureIPForwarding(ipv4ForwardConf, '1')
 	if err != nil {
 		return err
@@ -26,24 +29,20 @@ func setupIPv4Forwarding(fw firewaller.Firewaller, wantFilterForwardDrop bool) (
 		defer func() {
 			if retErr != nil {
 				if _, err := configureIPForwarding(ipv4ForwardConf, '0'); err != nil {
-					log.G(context.TODO()).WithError(err).Error("Cannot disable IPv4 forwarding")
+					log.G(ctx).WithError(err).Error("Cannot disable IPv4 forwarding")
 				}
 			}
 		}()
-	}
 
-	// When enabling ip_forward set the default policy on forward chain to drop.
-	if changed && wantFilterForwardDrop {
-		if err := fw.FilterForwardDrop(context.TODO(), firewaller.IPv4); err != nil {
+		if err := d.setFilterForwardDrop(ctx, firewaller.IPv4); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func setupIPv6Forwarding(fw firewaller.Firewaller, wantFilterForwardDrop bool) (retErr error) {
+func (d *driver) setupIPv6Forwarding(ctx context.Context) (retErr error) {
 	// Set IPv6 default.forwarding, if needed.
-	// FIXME(robmry) - is it necessary to set this, setting "all" (below) does the job?
 	changedDef, err := configureIPForwarding(ipv6ForwardConfDefault, '1')
 	if err != nil {
 		return err
@@ -52,7 +51,7 @@ func setupIPv6Forwarding(fw firewaller.Firewaller, wantFilterForwardDrop bool) (
 		defer func() {
 			if retErr != nil {
 				if _, err := configureIPForwarding(ipv6ForwardConfDefault, '0'); err != nil {
-					log.G(context.TODO()).WithError(err).Error("Cannot disable IPv6 default.forwarding")
+					log.G(ctx).WithError(err).Error("Cannot disable IPv6 default.forwarding")
 				}
 			}
 		}()
@@ -67,14 +66,14 @@ func setupIPv6Forwarding(fw firewaller.Firewaller, wantFilterForwardDrop bool) (
 		defer func() {
 			if retErr != nil {
 				if _, err := configureIPForwarding(ipv6ForwardConfAll, '0'); err != nil {
-					log.G(context.TODO()).WithError(err).Error("Cannot disable IPv6 all.forwarding")
+					log.G(ctx).WithError(err).Error("Cannot disable IPv6 all.forwarding")
 				}
 			}
 		}()
 	}
 
-	if (changedAll || changedDef) && wantFilterForwardDrop {
-		if err := fw.FilterForwardDrop(context.TODO(), firewaller.IPv6); err != nil {
+	if changedAll || changedDef {
+		if err := d.setFilterForwardDrop(ctx, firewaller.IPv6); err != nil {
 			return err
 		}
 	}
@@ -97,4 +96,138 @@ func configureIPForwarding(file string, val byte) (changed bool, _ error) {
 		return false, fmt.Errorf("failed to set IP forwarding '%s' = '%c': %w", file, val, err)
 	}
 	return true, nil
+}
+
+const (
+	ipForwardingEnabledKeyPrefix = "ip_forwarding_enabled"
+	ipForwarding4                = "ipv4"
+	ipForwarding6                = "ipv6"
+)
+
+// filterForwardDrop being present in the store for a given IP version
+// indicates that the filter-FORWARD policy has been set to drop by the
+// daemon. So, future incarnations of the daemon should also set it.
+type filterForwardDrop struct {
+	ipv string
+
+	// For the datastore...
+	dbIndex  uint64
+	dbExists bool
+}
+
+// setFilterForwardDrop tells the firewaller to set the filter-FORWARD policy to
+// "drop", and remembers that in the store so that future incarnations of the
+// daemon will also set it.
+func (d *driver) setFilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
+	ipvKey := ipForwarding4
+	if ipv == firewaller.IPv6 {
+		ipvKey = ipForwarding6
+	}
+	if err := d.storeUpdate(ctx, &filterForwardDrop{ipv: ipvKey}); err != nil && !errors.Is(err, datastore.ErrKeyModified) {
+		log.G(ctx).WithError(err).Error("Cannot persist IP forwarding enabled flag")
+	}
+
+	if d.config.DisableFilterForwardDrop {
+		return nil
+	}
+	if ipv == firewaller.IPv4 && !d.config.EnableIPTables {
+		return nil
+	}
+	if ipv == firewaller.IPv6 && !d.config.EnableIP6Tables {
+		return nil
+	}
+	if err := d.firewaller.FilterForwardDrop(ctx, ipv); err != nil {
+		return err
+	}
+	log.G(ctx).WithField("ipv", ipv).Warn("IP forwarding policy set to 'drop', use '--ip-forward-no-drop' to disable")
+	return nil
+}
+
+// initForwardingPolicy checks whether an earlier incarnation of the daemon has set
+// the filter-FORWARD policy to "drop". If it has, it also sets the policy to drop.
+//
+// (The policy is set when IP forwarding is enabled. But is only likely to happen when
+// the daemon is first started. On restarts with nftables, the policy is lost when
+// the nftables table is reconstructed. So, it needs to be re-set here.)
+func (d *driver) initForwardingPolicy(ctx context.Context) error {
+	ffds, err := d.store.List(&filterForwardDrop{})
+	if err != nil {
+		if errors.Is(err, datastore.ErrKeyNotFound) {
+			return nil
+		}
+		return err
+	}
+	for _, i := range ffds {
+		ffd := i.(*filterForwardDrop)
+		ipv := firewaller.IPv4
+		if ffd.ipv == ipForwarding6 {
+			ipv = firewaller.IPv6
+		}
+		if err := d.setFilterForwardDrop(ctx, ipv); err != nil {
+			return fmt.Errorf("setting %s forwarding policy to drop: %w", ffd.ipv, err)
+		}
+	}
+	return nil
+}
+
+func (ife *filterForwardDrop) Key() []string {
+	return []string{ipForwardingEnabledKeyPrefix, ife.ipv}
+}
+
+func (ife *filterForwardDrop) KeyPrefix() []string {
+	return []string{ipForwardingEnabledKeyPrefix}
+}
+
+func (ife *filterForwardDrop) Value() []byte {
+	b, err := json.Marshal(ife)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func (ife *filterForwardDrop) SetValue(value []byte) error {
+	return json.Unmarshal(value, ife)
+}
+
+func (ife *filterForwardDrop) Index() uint64 {
+	return ife.dbIndex
+}
+
+func (ife *filterForwardDrop) SetIndex(index uint64) {
+	ife.dbIndex = index
+	ife.dbExists = true
+}
+
+func (ife *filterForwardDrop) Exists() bool {
+	return ife.dbExists
+}
+
+func (ife *filterForwardDrop) Skip() bool {
+	return false
+}
+
+func (ife *filterForwardDrop) New() datastore.KVObject {
+	return &filterForwardDrop{}
+}
+
+func (ife *filterForwardDrop) CopyTo(o datastore.KVObject) error {
+	dstNcfg := o.(*filterForwardDrop)
+	*dstNcfg = *ife
+	return nil
+}
+
+func (ife *filterForwardDrop) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"ID": ife.ipv,
+	})
+}
+
+func (ife *filterForwardDrop) UnmarshalJSON(b []byte) error {
+	m := map[string]any{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+	ife.ipv = m["ID"].(string)
+	return nil
 }

--- a/daemon/libnetwork/drivers/bridge/setup_ip_forwarding_test.go
+++ b/daemon/libnetwork/drivers/bridge/setup_ip_forwarding_test.go
@@ -35,13 +35,23 @@ func TestSetupIPForwarding(t *testing.T) {
 
 	for _, wantFFD := range []bool{true, false} {
 		t.Run(fmt.Sprintf("wantFFD=%v", wantFFD), func(t *testing.T) {
+			fw := &ffdTestFirewaller{}
+			d := &driver{
+				config: configuration{
+					EnableIPForwarding:       true,
+					DisableFilterForwardDrop: !wantFFD,
+					EnableIPTables:           true,
+					EnableIP6Tables:          true,
+				},
+				firewaller: fw,
+			}
+
 			// Disable IP Forwarding if enabled
 			_, err := configureIPForwarding(ipv4ForwardConf, '0')
 			assert.NilError(t, err)
 
 			// Set IP Forwarding
-			fw := &ffdTestFirewaller{}
-			err = setupIPv4Forwarding(fw, wantFFD)
+			err = d.setupIPv4Forwarding(context.Background())
 			assert.NilError(t, err)
 
 			// Check what the firewaller was told.
@@ -65,14 +75,24 @@ func TestSetupIP6Forwarding(t *testing.T) {
 
 	for _, wantFFD := range []bool{true, false} {
 		t.Run(fmt.Sprintf("wantFFD=%v", wantFFD), func(t *testing.T) {
+			fw := &ffdTestFirewaller{}
+			d := &driver{
+				config: configuration{
+					EnableIPForwarding:       true,
+					DisableFilterForwardDrop: !wantFFD,
+					EnableIPTables:           true,
+					EnableIP6Tables:          true,
+				},
+				firewaller: fw,
+			}
+
 			_, err := configureIPForwarding(ipv6ForwardConfDefault, '0')
 			assert.NilError(t, err)
 			_, err = configureIPForwarding(ipv6ForwardConfAll, '0')
 			assert.NilError(t, err)
 
 			// Set IP Forwarding
-			fw := &ffdTestFirewaller{}
-			err = setupIPv6Forwarding(fw, wantFFD)
+			err = d.setupIPv6Forwarding(context.Background())
 			assert.NilError(t, err)
 
 			// Check what the firewaller was told.

--- a/daemon/libnetwork/iptables/iptables.go
+++ b/daemon/libnetwork/iptables/iptables.go
@@ -4,6 +4,7 @@
 package iptables
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -410,6 +411,16 @@ func (iptable IPTable) SetDefaultPolicy(table Table, chain string, policy Policy
 		return fmt.Errorf("setting default policy to %v in %v chain failed: %v", policy, chain, err)
 	}
 	return nil
+}
+
+// HasPolicy returns true if the chain exists and has the given policy.
+func (iptable IPTable) HasPolicy(table Table, chain string, policy Policy) bool {
+	out, err := iptable.Raw("-t", string(table), "-L", chain)
+	if err != nil {
+		return false
+	}
+	firstLine, _, _ := bytes.Cut(out, []byte("\n"))
+	return strings.Contains(string(firstLine), "policy "+string(policy))
 }
 
 // AddReturnRule adds a return rule for the chain in the filter table


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/50566

See the linked issue for a description of the problems.

One option would be to always set the filter-FORWARD policy to "drop" for nftables - treating the introduction of nftables support as an opportunity to make a significant change. But, it's been [tried before](https://github.com/moby/libnetwork/pull/2450) and [reverted](https://github.com/moby/libnetwork/pull/2460) due to fallout including this [issue](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=865975) in the Debian tracker. Before https://github.com/moby/moby/pull/48594, when ip6tables was enabled, the policy for IPv6 was always set to DROP - and that caused [problems](https://github.com/moby/moby/issues/48365) when we enabled ip6tables by default. So, that PR aligned the IPv6 behaviour with the long standing IPv4 behaviour. (However, https://github.com/moby/moby/pull/48594 also added daemon option `--ip-forward-no-drop`, which could now be used to deal with those problems. So, a new install of Docker would potentially break things on the host but, after some debugging, that problem could be fixed by manually setting policy back to accept, adding daemon option `--ip-forward-no-drop`, and restarting it. (But, I think Docker might be in the bin before then in many cases!)

Alternatively, go the other way - there's certainly a case to be made that Docker shouldn't enable IP forwarding on the host, or change the firewall policy to drop, unless it's told to. So, the daemon could error out if configured with ip forwarding enabled (the default), but forwarding isn't enabled in the kernel. It could then offer separate options for the user to tell it to enable forwarding, and set the firewall's forwarding policy to "drop". But, that's quite a significant change for existing users, on a host where the daemon had previously been enabling forwarding, it would appear to be fine after upgrade, then just fail to run after a reboot. So, this needs more consideration, but it's probably where we should be heading.

For the time being at least - try to preserve the existing behaviour ... only set the firewall policy to drop after enabling IP forwarding, and don't set the policy if forwarding was already enabled. But, when setting the policy to drop, remember that for the next daemon restart - it'll then be set to drop on each subsequent daemon restart (including after a reboot, even if IP forwarding was enabled by something else before dockerd started that time). That deals with the nftables restart case, and makes it less susceptible to changes in startup ordering... if Docker's messing with the policy and that's unwanted, it'll always do that so problems should be easier to track down. To stop it from setting the policy to drop on subsequent restarts, option `--ip-forward-no-drop` will be needed.

**- How I did it**

_**First commit ...**_

_Set filter-FORWARD drop on restart after enabling IP forwarding_

The daemon sets the host's filter-FORWARD firewall chain policy to DROP if it enables IP forwarding.

With iptables, that policy is preserved over a daemon restart (the chain is not deleted, it's a built-in chain). But, with nftables, the daemon's table is re-created on restart, so the filter-FORWARD drop policy is lost.

So, when setting the policy to "drop" after enabling IP forwarding, record that in the datastore. Every subsequent daemon restart will then set the policy to drop (for iptables or nftables).

To stop the daemon from setting the policy, it must be started with option '--ip-forward-no-drop'.

_**Second commit ...**_

_Migrate iptables filter-FORWARD policy on upgrade_

When a pre-29.0 daemon has been running, and it set the iptables filter-FORWARD policy to DROP because it enabled IP forwarding, if the daemon is stopped, upgraded to >=29.0 and nftables is enabled...

The iptables policy will still be DROP. The newly started daemon won't need to enable IP forwarding, and there won't be a record in the datastore indicating that it needs to be set.

So, when migrating from iptables to nftables, check the iptables filter-FORWARD policy. If it's DROP, set the nftables policy to drop, and note that in the datastore for future restarts. Then, set the iptables policy to ACCEPT, so that it doesn't drop packets for published ports (because the allow rules for them will only be in the nftables chain).

**- How to verify it**

Manual test:
- Run a pre-29.0 daemon with IPv6 enabled on the default bridge, and IPv4 and IPv6 forwarding disabled in the kernel. Make sure the filter-FORWARD chains' policies are both set to DROP (`iptables -L FORWARD`, `ip6tables -L FORWARD`).
- Stop that daemon, start a 29.0 daemon, check that the iptables filter-FORWARD policy is still DROP.
- Restart that daemon, with firewall-backend nftables. Check that the iptables DROP policies have been removed, and the nftables policy for both `filter-FORWARD` chains is "drop" (`nft list ruleset`).

Updated unit and integration tests.

**- Human readable description for the release notes**
```markdown changelog
- If Docker enables IP forwarding on the host, it sets the default forwarding policy to "drop" in the firewall. Now, in addition it will remember that it's set the policy and do so on each subsequent restart (including following reboots where it did not enable IP forwarding). To prevent the daemon from setting the firewall's forwarding policy, use option `--ip-forward-no-drop`.
```
