### PR TITLE
replace direct uses of nat types for api/types/container aliases

### DIFF
--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/sys/signal"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -530,7 +531,7 @@ func dispatchExpose(ctx context.Context, d dispatchRequest, c *instructions.Expo
 	}
 
 	if d.state.runConfig.ExposedPorts == nil {
-		d.state.runConfig.ExposedPorts = make(nat.PortSet)
+		d.state.runConfig.ExposedPorts = make(container.PortSet)
 	}
 	for p := range ps {
 		d.state.runConfig.ExposedPorts[p] = struct{}{}

--- a/daemon/builder/dockerfile/dispatchers_test.go
+++ b/daemon/builder/dockerfile/dispatchers_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/daemon/internal/image"
 	"github.com/docker/docker/daemon/pkg/oci"
 	"github.com/docker/docker/daemon/server/backend"
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
@@ -337,9 +336,7 @@ func TestExpose(t *testing.T) {
 	assert.Assert(t, sb.state.runConfig.ExposedPorts != nil)
 	assert.Assert(t, is.Len(sb.state.runConfig.ExposedPorts, 1))
 
-	portsMapping, err := nat.ParsePortSpec(exposedPort)
-	assert.NilError(t, err)
-	assert.Check(t, is.Contains(sb.state.runConfig.ExposedPorts, portsMapping[0].Port))
+	assert.Check(t, is.Contains(sb.state.runConfig.ExposedPorts, container.PortRangeProto("80/tcp")))
 }
 
 func TestUser(t *testing.T) {

--- a/daemon/builder/dockerfile/internals.go
+++ b/daemon/builder/dockerfile/internals.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/daemon/internal/stringid"
 	networkSettings "github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/daemon/server/backend"
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/go-archive"
 	"github.com/moby/go-archive/chrootarchive"
 	"github.com/moby/moby/api/types/build"
@@ -294,7 +293,7 @@ func copyRunConfig(runConfig *container.Config, modifiers ...runConfigModifier) 
 	}
 
 	if cfgCopy.ExposedPorts != nil {
-		cfgCopy.ExposedPorts = make(nat.PortSet, len(runConfig.ExposedPorts))
+		cfgCopy.ExposedPorts = make(container.PortSet, len(runConfig.ExposedPorts))
 		for k, v := range runConfig.ExposedPorts {
 			cfgCopy.ExposedPorts[k] = v
 		}

--- a/daemon/builder/dockerfile/internals_test.go
+++ b/daemon/builder/dockerfile/internals_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/docker/daemon/internal/image"
 	"github.com/docker/docker/daemon/internal/layer"
 	"github.com/docker/docker/daemon/server/backend"
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/container"
@@ -138,7 +137,7 @@ func fullMutableRunConfig() *container.Config {
 	return &container.Config{
 		Cmd: []string{"command", "arg1"},
 		Env: []string{"env1=foo", "env2=bar"},
-		ExposedPorts: nat.PortSet{
+		ExposedPorts: container.PortSet{
 			"1000/tcp": {},
 			"1001/tcp": {},
 		},

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -11,7 +11,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	executorpkg "github.com/docker/docker/daemon/cluster/executor"
 	"github.com/docker/docker/daemon/libnetwork"
-	"github.com/docker/go-connections/nat"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
@@ -641,7 +640,7 @@ func parsePortStatus(ctnr container.InspectResponse) (*api.PortStatus, error) {
 	return status, nil
 }
 
-func parsePortMap(portMap nat.PortMap) ([]*api.PortConfig, error) {
+func parsePortMap(portMap container.PortMap) ([]*api.PortConfig, error) {
 	exposedPorts := make([]*api.PortConfig, 0, len(portMap))
 
 	for portProtocol, mapping := range portMap {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -376,7 +376,7 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 	return nil
 }
 
-func validatePortBindings(ports nat.PortMap) error {
+func validatePortBindings(ports containertypes.PortMap) error {
 	for port := range ports {
 		_, portStr := nat.SplitProtoPort(string(port))
 		if _, err := nat.ParsePort(portStr); err != nil {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -101,17 +101,14 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 		}
 	}
 
+	// Create a deep copy (as [nat.SortPortMap] mutates the map).
+	// Not using a maps.Clone here, as that won't dereference the
+	// slice (PortMap is a map[Port][]PortBinding).
 	bindings := make(containertypes.PortMap)
-	if ctr.HostConfig.PortBindings != nil {
-		for p, b := range ctr.HostConfig.PortBindings {
-			bindings[p] = []containertypes.PortBinding{}
-			for _, bb := range b {
-				bindings[p] = append(bindings[p], containertypes.PortBinding{
-					HostIP:   bb.HostIP,
-					HostPort: bb.HostPort,
-				})
-			}
-		}
+	for p, b := range ctr.HostConfig.PortBindings {
+		copied := make([]containertypes.PortBinding, len(b))
+		copy(copied, b)
+		bindings[p] = copied
 	}
 
 	// TODO(thaJeztah): Move this code to a method on nat.PortSet.

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -101,12 +101,12 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 		}
 	}
 
-	bindings := make(nat.PortMap)
+	bindings := make(containertypes.PortMap)
 	if ctr.HostConfig.PortBindings != nil {
 		for p, b := range ctr.HostConfig.PortBindings {
-			bindings[p] = []nat.PortBinding{}
+			bindings[p] = []containertypes.PortBinding{}
 			for _, bb := range b {
-				bindings[p] = append(bindings[p], nat.PortBinding{
+				bindings[p] = append(bindings[p], containertypes.PortBinding{
 					HostIP:   bb.HostIP,
 					HostPort: bb.HostPort,
 				})
@@ -115,7 +115,7 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 	}
 
 	// TODO(thaJeztah): Move this code to a method on nat.PortSet.
-	ports := make([]nat.Port, 0, len(ctr.Config.ExposedPorts))
+	ports := make([]containertypes.PortRangeProto, 0, len(ctr.Config.ExposedPorts))
 	for p := range ctr.Config.ExposedPorts {
 		ports = append(ports, p)
 	}

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/daemon/config"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 )
@@ -15,12 +14,12 @@ import (
 // This should not be tested on Windows because Windows doesn't support "host" network mode.
 func TestContainerWarningHostAndPublishPorts(t *testing.T) {
 	testCases := []struct {
-		ports    nat.PortMap
+		ports    containertypes.PortMap
 		warnings []string
 	}{
-		{ports: nat.PortMap{}},
-		{ports: nat.PortMap{
-			"8080": []nat.PortBinding{{HostPort: "8989"}},
+		{ports: containertypes.PortMap{}},
+		{ports: containertypes.PortMap{
+			"8080": []containertypes.PortBinding{{HostPort: "8989"}},
 		}, warnings: []string{"Published ports are discarded when using host network mode"}},
 	}
 	muteLogs(t)
@@ -34,9 +33,9 @@ func TestContainerWarningHostAndPublishPorts(t *testing.T) {
 		d := &Daemon{}
 		cfg, err := config.New()
 		assert.NilError(t, err)
-		runtimes, err := setupRuntimes(cfg)
+		rts, err := setupRuntimes(cfg)
 		assert.NilError(t, err)
-		daemonCfg := &configStore{Config: *cfg, Runtimes: runtimes}
+		daemonCfg := &configStore{Config: *cfg, Runtimes: rts}
 		wrns, err := d.verifyContainerSettings(daemonCfg, hostConfig, &containertypes.Config{}, false)
 		assert.NilError(t, err)
 		assert.DeepEqual(t, tc.warnings, wrns)

--- a/daemon/containerd/image_import_test.go
+++ b/daemon/containerd/image_import_test.go
@@ -3,7 +3,6 @@ package containerd
 import (
 	"testing"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -12,7 +11,7 @@ import (
 // regression test for https://github.com/moby/moby/issues/45904
 func TestContainerConfigToDockerImageConfig(t *testing.T) {
 	ociCFG := containerConfigToDockerOCIImageConfig(&container.Config{
-		ExposedPorts: nat.PortSet{
+		ExposedPorts: container.PortSet{
 			"80/tcp": struct{}{},
 		},
 	})

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/daemon/internal/image"
 	"github.com/docker/docker/dockerversion"
-	"github.com/docker/go-connections/nat"
 	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -83,8 +82,8 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 
 		if len(cfg.ExposedPorts) > 0 {
 			ociCfg.ExposedPorts = map[string]struct{}{}
-			for k, v := range cfg.ExposedPorts {
-				ociCfg.ExposedPorts[string(k)] = v
+			for k := range cfg.ExposedPorts {
+				ociCfg.ExposedPorts[string(k)] = struct{}{}
 			}
 		}
 		ext.Healthcheck = cfg.Healthcheck
@@ -99,9 +98,9 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 }
 
 func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *container.Config {
-	exposedPorts := make(nat.PortSet, len(cfg.ExposedPorts))
-	for k, v := range cfg.ExposedPorts {
-		exposedPorts[nat.Port(k)] = v
+	exposedPorts := make(container.PortSet, len(cfg.ExposedPorts))
+	for k := range cfg.ExposedPorts {
+		exposedPorts[container.PortRangeProto(k)] = struct{}{}
 	}
 
 	return &container.Config{

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/daemon/server/backend"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 )
@@ -60,7 +59,7 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 		Networks:               apiNetworks,
 	}
 
-	ports := make(nat.PortMap, len(ctr.NetworkSettings.Ports))
+	ports := make(containertypes.PortMap, len(ctr.NetworkSettings.Ports))
 	for k, pm := range ctr.NetworkSettings.Ports {
 		ports[k] = pm
 	}

--- a/daemon/internal/image/cache/compare_test.go
+++ b/daemon/internal/image/cache/compare_test.go
@@ -4,37 +4,36 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/container"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
-// Just to make life easier
-func newPortNoError(proto, port string) nat.Port {
-	p, _ := nat.NewPort(proto, port)
-	return p
-}
-
 func TestCompare(t *testing.T) {
-	ports1 := make(nat.PortSet)
-	ports1[newPortNoError("tcp", "1111")] = struct{}{}
-	ports1[newPortNoError("tcp", "2222")] = struct{}{}
-	ports2 := make(nat.PortSet)
-	ports2[newPortNoError("tcp", "3333")] = struct{}{}
-	ports2[newPortNoError("tcp", "4444")] = struct{}{}
-	ports3 := make(nat.PortSet)
-	ports3[newPortNoError("tcp", "1111")] = struct{}{}
-	ports3[newPortNoError("tcp", "2222")] = struct{}{}
-	ports3[newPortNoError("tcp", "5555")] = struct{}{}
-	volumes1 := make(map[string]struct{})
-	volumes1["/test1"] = struct{}{}
-	volumes2 := make(map[string]struct{})
-	volumes2["/test2"] = struct{}{}
-	volumes3 := make(map[string]struct{})
-	volumes3["/test1"] = struct{}{}
-	volumes3["/test3"] = struct{}{}
+	ports1 := container.PortSet{
+		"1111/tcp": struct{}{},
+		"2222/tcp": struct{}{},
+	}
+	ports2 := container.PortSet{
+		"3333/tcp": struct{}{},
+		"4444/tcp": struct{}{},
+	}
+	ports3 := container.PortSet{
+		"1111/tcp": struct{}{},
+		"2222/tcp": struct{}{},
+		"5555/tcp": struct{}{},
+	}
+	volumes1 := map[string]struct{}{
+		"/test1": {},
+	}
+	volumes2 := map[string]struct{}{
+		"/test2": {},
+	}
+	volumes3 := map[string]struct{}{
+		"/test1": {},
+		"/test3": {},
+	}
 	envs1 := []string{"ENV1=value1", "ENV2=value2"}
 	envs2 := []string{"ENV1=value1", "ENV3=value3"}
 	entrypoint1 := []string{"/bin/sh", "-c"}

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 )
 
 func TestLinkNaming(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, nat.PortSet{
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, container.PortSet{
 		"6379/tcp": struct{}{},
 	})
 
@@ -27,7 +28,7 @@ func TestLinkNaming(t *testing.T) {
 }
 
 func TestLinkNew(t *testing.T) {
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, nat.PortSet{
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, container.PortSet{
 		"6379/tcp": struct{}{},
 	})
 
@@ -35,14 +36,14 @@ func TestLinkNew(t *testing.T) {
 		Name:     "/db/docker",
 		ParentIP: "172.0.17.3",
 		ChildIP:  "172.0.17.2",
-		Ports:    []nat.Port{"6379/tcp"},
+		Ports:    []container.PortRangeProto{"6379/tcp"},
 	}
 
 	assert.DeepEqual(t, expected, link)
 }
 
 func TestLinkEnv(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, nat.PortSet{
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, container.PortSet{
 		"6379/tcp": struct{}{},
 	})
 
@@ -63,7 +64,7 @@ func TestLinkEnv(t *testing.T) {
 // TestSortPorts verifies that ports are sorted with TCP taking priority,
 // and ports with the same protocol to be sorted by port.
 func TestSortPorts(t *testing.T) {
-	ports := []nat.Port{
+	ports := []container.PortRangeProto{
 		"6379/tcp",
 		"6376/udp",
 		"6380/tcp",
@@ -74,7 +75,7 @@ func TestSortPorts(t *testing.T) {
 		"6375/sctp",
 	}
 
-	expected := []nat.Port{
+	expected := []container.PortRangeProto{
 		"6379/tcp",
 		"6380/tcp",
 		"6381/tcp",
@@ -90,7 +91,7 @@ func TestSortPorts(t *testing.T) {
 }
 
 func TestLinkMultipleEnv(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, nat.PortSet{
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, container.PortSet{
 		"6300/udp": struct{}{},
 		"6379/tcp": struct{}{},
 		"6380/tcp": struct{}{},
@@ -141,7 +142,7 @@ func BenchmarkLinkMultipleEnv(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, nat.PortSet{
+		_ = EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, container.PortSet{
 			"6300/udp": struct{}{},
 			"6379/tcp": struct{}{},
 			"6380/tcp": struct{}{},

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -944,12 +944,12 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 		return nil, nil
 	}
 
-	bindings := make(nat.PortMap)
+	bindings := make(containertypes.PortMap)
 	if c.HostConfig.PortBindings != nil {
 		for p, b := range c.HostConfig.PortBindings {
-			bindings[p] = []nat.PortBinding{}
+			bindings[p] = []containertypes.PortBinding{}
 			for _, bb := range b {
-				bindings[p] = append(bindings[p], nat.PortBinding{
+				bindings[p] = append(bindings[p], containertypes.PortBinding{
 					HostIP:   bb.HostIP,
 					HostPort: bb.HostPort,
 				})
@@ -958,7 +958,7 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 	}
 
 	// TODO(thaJeztah): Move this code to a method on nat.PortSet.
-	ports := make([]nat.Port, 0, len(c.Config.ExposedPorts))
+	ports := make([]containertypes.PortRangeProto, 0, len(c.Config.ExposedPorts))
 	for p := range c.Config.ExposedPorts {
 		ports = append(ports, p)
 	}
@@ -1009,8 +1009,8 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 }
 
 // getPortMapInfo retrieves the current port-mapping programmed for the given sandbox
-func getPortMapInfo(sb *libnetwork.Sandbox) nat.PortMap {
-	pm := nat.PortMap{}
+func getPortMapInfo(sb *libnetwork.Sandbox) containertypes.PortMap {
+	pm := containertypes.PortMap{}
 	if sb == nil {
 		return pm
 	}
@@ -1021,7 +1021,7 @@ func getPortMapInfo(sb *libnetwork.Sandbox) nat.PortMap {
 	return pm
 }
 
-func getEndpointPortMapInfo(pm nat.PortMap, ep *libnetwork.Endpoint) {
+func getEndpointPortMapInfo(pm containertypes.PortMap, ep *libnetwork.Endpoint) {
 	driverInfo, _ := ep.DriverInfo()
 	if driverInfo == nil {
 		// It is not an error for epInfo to be nil
@@ -1060,7 +1060,7 @@ func getEndpointPortMapInfo(pm nat.PortMap, ep *libnetwork.Endpoint) {
 			if pp.HostPort > 0 {
 				hp = strconv.Itoa(int(pp.HostPort))
 			}
-			natBndg := nat.PortBinding{HostIP: pp.HostIP.String(), HostPort: hp}
+			natBndg := containertypes.PortBinding{HostIP: pp.HostIP.String(), HostPort: hp}
 			pm[natPort] = append(pm[natPort], natBndg)
 		}
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -944,17 +944,14 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 		return nil, nil
 	}
 
+	// Create a deep copy (as [nat.SortPortMap] mutates the map).
+	// Not using a maps.Clone here, as that won't dereference the
+	// slice (PortMap is a map[Port][]PortBinding).
 	bindings := make(containertypes.PortMap)
-	if c.HostConfig.PortBindings != nil {
-		for p, b := range c.HostConfig.PortBindings {
-			bindings[p] = []containertypes.PortBinding{}
-			for _, bb := range b {
-				bindings[p] = append(bindings[p], containertypes.PortBinding{
-					HostIP:   bb.HostIP,
-					HostPort: bb.HostPort,
-				})
-			}
-		}
+	for p, b := range c.HostConfig.PortBindings {
+		copied := make([]containertypes.PortBinding, len(b))
+		copy(copied, b)
+		bindings[p] = copied
 	}
 
 	// TODO(thaJeztah): Move this code to a method on nat.PortSet.

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	clustertypes "github.com/docker/docker/daemon/cluster/provider"
-	"github.com/docker/go-connections/nat"
+	"github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/pkg/errors"
 )
@@ -21,7 +21,7 @@ type Settings struct {
 	LinkLocalIPv6PrefixLen int
 	Networks               map[string]*EndpointSettings
 	Service                *clustertypes.ServiceConfig
-	Ports                  nat.PortMap
+	Ports                  container.PortMap
 	SecondaryIPAddresses   []networktypes.Address
 	SecondaryIPv6Addresses []networktypes.Address
 	HasSwarmEndpoint       bool

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/request"
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
@@ -505,8 +504,8 @@ func (s *DockerAPISuite) TestContainerAPIBadPort(c *testing.T) {
 	}
 
 	hostConfig := container.HostConfig{
-		PortBindings: nat.PortMap{
-			"8080/tcp": []nat.PortBinding{
+		PortBindings: container.PortMap{
+			"8080/tcp": []container.PortBinding{
 				{
 					HostIP:   "",
 					HostPort: "aa80",

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/integration-cli/cli"
 	"github.com/docker/docker/integration-cli/cli/build"
 	"github.com/docker/docker/testutil/fakecontext"
-	"github.com/docker/go-connections/nat"
+	containertypes "github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -92,7 +92,7 @@ func (s *DockerCLICreateSuite) TestCreateWithPortRange(c *testing.T) {
 
 	var containers []struct {
 		HostConfig *struct {
-			PortBindings map[nat.Port][]nat.PortBinding
+			PortBindings map[containertypes.PortRangeProto][]containertypes.PortBinding
 		}
 	}
 	err := json.Unmarshal([]byte(out), &containers)
@@ -118,7 +118,7 @@ func (s *DockerCLICreateSuite) TestCreateWithLargePortRange(c *testing.T) {
 
 	var containers []struct {
 		HostConfig *struct {
-			PortBindings map[nat.Port][]nat.PortBinding
+			PortBindings map[containertypes.PortRangeProto][]containertypes.PortBinding
 		}
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/docker/docker/testutil"
 	testdaemon "github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fakecontext"
-	"github.com/docker/go-connections/nat"
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/stringid"
 	"github.com/moby/sys/mountinfo"
@@ -2169,7 +2169,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughExpose(c *testing.T) {
 	id = strings.TrimSpace(id)
 
 	portstr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
-	var ports nat.PortMap
+	var ports container.PortMap
 	if err := json.Unmarshal([]byte(portstr), &ports); err != nil {
 		c.Fatal(err)
 	}
@@ -2502,7 +2502,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughPublish(c *testing.T) {
 	id = strings.TrimSpace(id)
 	portStr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
 
-	var ports nat.PortMap
+	var ports container.PortMap
 	err := json.Unmarshal([]byte(portStr), &ports)
 	assert.NilError(c, err, "failed to unmarshal: %v", portStr)
 	for port, binding := range ports {

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -76,7 +75,7 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 	// Sadly this means the test will take longer, but at least this test can be parallelized.
 	cid := container.Run(ctx, t, apiClient,
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(nat.PortMap{"80/tcp": {{}}}),
+		container.WithPortMap(containertypes.PortMap{"80/tcp": {{}}}),
 		container.WithCmd("/bin/sh", "-c", "while true; do echo hello; sleep 1; done"))
 	defer func() {
 		err := apiClient.ContainerRemove(ctx, cid, containertypes.RemoveOptions{Force: true})

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/docker/docker/integration/internal/container"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -122,8 +121,8 @@ func startServerContainer(ctx context.Context, t *testing.T, msg string, port in
 		container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)),
 		container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)),
 		func(c *container.TestContainerConfig) {
-			c.HostConfig.PortBindings = nat.PortMap{
-				nat.Port(fmt.Sprintf("%d/tcp", port)): []nat.PortBinding{
+			c.HostConfig.PortBindings = containertypes.PortMap{
+				containertypes.PortRangeProto(fmt.Sprintf("%d/tcp", port)): []containertypes.PortBinding{
 					{
 						HostPort: fmt.Sprintf("%d", port),
 					},

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
@@ -74,17 +73,17 @@ func WithSysctls(sysctls map[string]string) func(*TestContainerConfig) {
 // WithExposedPorts sets the exposed ports of the container
 func WithExposedPorts(ports ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.Config.ExposedPorts = map[nat.Port]struct{}{}
+		c.Config.ExposedPorts = map[container.PortRangeProto]struct{}{}
 		for _, port := range ports {
-			c.Config.ExposedPorts[nat.Port(port)] = struct{}{}
+			c.Config.ExposedPorts[container.PortRangeProto(port)] = struct{}{}
 		}
 	}
 }
 
 // WithPortMap sets/replaces port mappings.
-func WithPortMap(pm nat.PortMap) func(*TestContainerConfig) {
+func WithPortMap(pm container.PortMap) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.HostConfig.PortBindings = nat.PortMap{}
+		c.HostConfig.PortBindings = container.PortMap{}
 		for p, b := range pm {
 			c.HostConfig.PortBindings[p] = slices.Clone(b)
 		}

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/integration/internal/testutils/networking"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/versions"
@@ -519,14 +518,14 @@ func TestPublishedPortAlreadyInUse(t *testing.T) {
 	ctr1 := ctr.Run(ctx, t, apiClient,
 		ctr.WithCmd("top"),
 		ctr.WithExposedPorts("80/tcp"),
-		ctr.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8000"}}}))
+		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}))
 	defer ctr.Remove(ctx, t, apiClient, ctr1, containertypes.RemoveOptions{Force: true})
 
 	ctr2 := ctr.Create(ctx, t, apiClient,
 		ctr.WithCmd("top"),
 		ctr.WithRestartPolicy(containertypes.RestartPolicyAlways),
 		ctr.WithExposedPorts("80/tcp"),
-		ctr.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8000"}}}))
+		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}))
 	defer ctr.Remove(ctx, t, apiClient, ctr2, containertypes.RemoveOptions{Force: true})
 
 	err := apiClient.ContainerStart(ctx, ctr2, containertypes.StartOptions{})
@@ -561,14 +560,14 @@ func TestAllPortMappingsAreReturned(t *testing.T) {
 
 	ctrID := ctr.Run(ctx, t, apiClient,
 		ctr.WithExposedPorts("80/tcp", "81/tcp"),
-		ctr.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8000"}}}),
+		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}),
 		ctr.WithEndpointSettings("testnetv4", &networktypes.EndpointSettings{}),
 		ctr.WithEndpointSettings("testnetv6", &networktypes.EndpointSettings{}))
 	defer ctr.Remove(ctx, t, apiClient, ctrID, containertypes.RemoveOptions{Force: true})
 
 	inspect := ctr.Inspect(ctx, t, apiClient, ctrID)
-	assert.DeepEqual(t, inspect.NetworkSettings.Ports, nat.PortMap{
-		"80/tcp": []nat.PortBinding{
+	assert.DeepEqual(t, inspect.NetworkSettings.Ports, containertypes.PortMap{
+		"80/tcp": []containertypes.PortBinding{
 			{HostIP: "0.0.0.0", HostPort: "8000"},
 			{HostIP: "::", HostPort: "8000"},
 		},
@@ -600,7 +599,7 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 
 	cid := ctr.Run(ctx, t, c,
 		ctr.WithExposedPorts("80/tcp", "81/tcp"),
-		ctr.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8000"}}}))
+		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}))
 	defer func() {
 		if !removed {
 			ctr.Remove(ctx, t, c, cid, containertypes.RemoveOptions{Force: true})
@@ -790,7 +789,7 @@ func TestPortMappingRestore(t *testing.T) {
 	const svrName = "svr"
 	cid := ctr.Run(ctx, t, c,
 		ctr.WithExposedPorts("80/tcp"),
-		ctr.WithPortMap(nat.PortMap{"80/tcp": {}}),
+		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {}}),
 		ctr.WithName(svrName),
 		ctr.WithRestartPolicy(containertypes.RestartPolicyUnlessStopped),
 		ctr.WithCmd("httpd", "-f"),
@@ -801,7 +800,7 @@ func TestPortMappingRestore(t *testing.T) {
 		t.Helper()
 		insp := ctr.Inspect(ctx, t, c, cid)
 		assert.Check(t, is.Equal(insp.State.Running, true))
-		if assert.Check(t, is.Contains(insp.NetworkSettings.Ports, nat.Port("80/tcp"))) &&
+		if assert.Check(t, is.Contains(insp.NetworkSettings.Ports, containertypes.PortRangeProto("80/tcp"))) &&
 			assert.Check(t, is.Len(insp.NetworkSettings.Ports["80/tcp"], 2)) {
 			hostPort := insp.NetworkSettings.Ports["80/tcp"][0].HostPort
 			res := ctr.RunAttach(ctx, t, c,

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/docker/docker/integration/internal/testutils/networking"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
@@ -55,7 +54,7 @@ var (
 
 type ctrDesc struct {
 	name         string
-	portMappings nat.PortMap
+	portMappings containertypes.PortMap
 }
 
 type networkDesc struct {
@@ -84,7 +83,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -97,7 +96,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -110,7 +109,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -144,7 +143,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -157,7 +156,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -169,7 +168,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -181,7 +180,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
 				},
 			},
 		}},

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/docker/docker/integration/internal/testutils/networking"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
@@ -50,7 +49,7 @@ var (
 
 type ctrDesc struct {
 	name         string
-	portMappings nat.PortMap
+	portMappings containertypes.PortMap
 }
 
 type networkDesc struct {
@@ -79,7 +78,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -92,7 +91,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -105,7 +104,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -139,7 +138,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -152,7 +151,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -165,7 +164,7 @@ var index = []section{
 				containers: []ctrDesc{
 					{
 						name:         "c1",
-						portMappings: nat.PortMap{"80/tcp": {{HostPort: "8080"}}},
+						portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
 					},
 				},
 			}},
@@ -178,7 +177,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: nat.PortMap{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
+					portMappings: containertypes.PortMap{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
 				},
 			},
 		}},

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -25,7 +25,6 @@ import (
 	n "github.com/docker/docker/integration/network"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/go-connections/nat"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
@@ -389,7 +388,7 @@ func TestBridgeINCRouted(t *testing.T) {
 			container.WithNetworkMode(netName),
 			container.WithName("ctr-"+gwMode),
 			container.WithExposedPorts("80/tcp"),
-			container.WithPortMap(nat.PortMap{"80/tcp": {}}),
+			container.WithPortMap(containertypes.PortMap{"80/tcp": {}}),
 		)
 		t.Cleanup(func() {
 			c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -557,7 +556,7 @@ func TestAccessToPublishedPort(t *testing.T) {
 				container.WithNetworkMode(serverNetName),
 				container.WithName("ctr-server"),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(nat.PortMap{"80/tcp": {nat.PortBinding{HostPort: "8080"}}}),
+				container.WithPortMap(containertypes.PortMap{"80/tcp": {containertypes.PortBinding{HostPort: "8080"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -680,7 +679,7 @@ func TestInterNetworkDirectRouting(t *testing.T) {
 				container.WithNetworkMode(serverNetName),
 				container.WithName("ctr-pub"),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(nat.PortMap{"80/tcp": {nat.PortBinding{HostPort: "8080"}}}),
+				container.WithPortMap(containertypes.PortMap{"80/tcp": {containertypes.PortBinding{HostPort: "8080"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, ctrPubId, containertypes.RemoveOptions{Force: true})
@@ -1421,7 +1420,7 @@ func TestGatewaySelection(t *testing.T) {
 		container.WithName(ctrName),
 		container.WithNetworkMode(netName4),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(nat.PortMap{"80": {{HostPort: "8080"}}}),
+		container.WithPortMap(containertypes.PortMap{"80": {{HostPort: "8080"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -1870,7 +1869,7 @@ func TestDropInForwardChain(t *testing.T) {
 		ctrId := container.Run(ctx, t, c,
 			container.WithNetworkMode(netName46),
 			container.WithExposedPorts("80"),
-			container.WithPortMap(nat.PortMap{"80": {{HostPort: hostPort}}}),
+			container.WithPortMap(containertypes.PortMap{"80": {{HostPort: hostPort}}}),
 			container.WithCmd("httpd", "-f"),
 		)
 		defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/docker/integration/internal/container"
 	"github.com/docker/docker/integration/internal/network"
 	"github.com/docker/docker/testutil"
-	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -97,7 +96,7 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(nat.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+		container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/integration/internal/testutils/networking"
 	"github.com/docker/docker/testutil"
 	"github.com/docker/docker/testutil/daemon"
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
@@ -69,12 +68,12 @@ func TestDisableNAT(t *testing.T) {
 		name       string
 		gwMode4    string
 		gwMode6    string
-		expPortMap nat.PortMap
+		expPortMap containertypes.PortMap
 	}{
 		{
 			name: "defaults",
-			expPortMap: nat.PortMap{
-				"80/tcp": []nat.PortBinding{
+			expPortMap: containertypes.PortMap{
+				"80/tcp": []containertypes.PortBinding{
 					{HostIP: "0.0.0.0", HostPort: "8080"},
 					{HostIP: "::", HostPort: "8080"},
 				},
@@ -84,8 +83,8 @@ func TestDisableNAT(t *testing.T) {
 			name:    "nat4 routed6",
 			gwMode4: "nat",
 			gwMode6: "routed",
-			expPortMap: nat.PortMap{
-				"80/tcp": []nat.PortBinding{
+			expPortMap: containertypes.PortMap{
+				"80/tcp": []containertypes.PortBinding{
 					{HostIP: "0.0.0.0", HostPort: "8080"},
 					{HostIP: "::", HostPort: ""},
 				},
@@ -95,8 +94,8 @@ func TestDisableNAT(t *testing.T) {
 			name:    "nat6 routed4",
 			gwMode4: "routed",
 			gwMode6: "nat",
-			expPortMap: nat.PortMap{
-				"80/tcp": []nat.PortBinding{
+			expPortMap: containertypes.PortMap{
+				"80/tcp": []containertypes.PortBinding{
 					{HostIP: "::", HostPort: "8080"},
 					{HostIP: "0.0.0.0", HostPort: ""},
 				},
@@ -125,7 +124,7 @@ func TestDisableNAT(t *testing.T) {
 			id := container.Run(ctx, t, c,
 				container.WithNetworkMode(netName),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8080"}}}),
+				container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}}),
 			)
 			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
 
@@ -163,7 +162,7 @@ func TestPortMappedHairpinTCP(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(nat.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+		container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -210,7 +209,7 @@ func TestPortMappedHairpinUDP(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("54/udp"),
-		container.WithPortMap(nat.PortMap{"54/udp": {{HostIP: "0.0.0.0"}}}),
+		container.WithPortMap(containertypes.PortMap{"54/udp": {{HostIP: "0.0.0.0"}}}),
 		container.WithCmd("/bin/sh", "-c", "echo 'foobar.internal 192.168.155.23' | dnsd -c - -p 54"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -252,7 +251,7 @@ func TestProxy4To6(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(netName),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(nat.PortMap{"80": {{HostIP: "::1"}}}),
+		container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "::1"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -376,7 +375,7 @@ func TestAccessPublishedPortFromHost(t *testing.T) {
 			serverID := container.Run(ctx, t, c,
 				container.WithName(sanitizeCtrName(t.Name()+"-server")),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: hostPort}}}),
+				container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: hostPort}}}),
 				container.WithCmd("httpd", "-f"),
 				container.WithNetworkMode(bridgeName))
 			defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
@@ -456,7 +455,7 @@ func TestAccessPublishedPortFromRemoteHost(t *testing.T) {
 	serverID := container.Run(ctx, t, c,
 		container.WithName(sanitizeCtrName(t.Name()+"-server")),
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: hostPort}}}),
+		container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: hostPort}}}),
 		container.WithCmd("httpd", "-f"),
 		container.WithNetworkMode(bridgeName))
 	defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
@@ -554,7 +553,7 @@ func TestAccessPublishedPortFromCtr(t *testing.T) {
 			serverId := container.Run(ctx, t, c,
 				container.WithNetworkMode(netName),
 				container.WithExposedPorts("80"),
-				container.WithPortMap(nat.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+				container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -604,7 +603,7 @@ func TestRestartUserlandProxyUnder2MSL(t *testing.T) {
 	ctrOpts := []func(*container.TestContainerConfig){
 		container.WithName(ctrName),
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "1780"}}}),
+		container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "1780"}}}),
 		container.WithCmd("httpd", "-f"),
 		container.WithNetworkMode(netName),
 	}
@@ -702,7 +701,7 @@ func TestDirectRoutingOpenPorts(t *testing.T) {
 			container.WithNetworkMode(netName),
 			container.WithName("ctr-"+gwMode),
 			container.WithExposedPorts("80/tcp"),
-			container.WithPortMap(nat.PortMap{"80/tcp": {}}),
+			container.WithPortMap(containertypes.PortMap{"80/tcp": {}}),
 		)
 		t.Cleanup(func() {
 			c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -972,7 +971,7 @@ func TestRoutedNonGateway(t *testing.T) {
 	ctrId := container.Run(ctx, t, c,
 		container.WithCmd("httpd", "-f"),
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(nat.PortMap{"80/tcp": {{HostPort: "8080"}}}),
+		container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}}),
 		container.WithNetworkMode(natNetName),
 		container.WithNetworkMode(routedNetName),
 		container.WithEndpointSettings(natNetName, &networktypes.EndpointSettings{GwPriority: 1}),
@@ -1126,7 +1125,7 @@ func TestAccessPublishedPortFromAnotherNetwork(t *testing.T) {
 					container.WithName("server"),
 					container.WithCmd("nc", "-lp", "5000"),
 					container.WithExposedPorts("5000/tcp"),
-					container.WithPortMap(nat.PortMap{"5000/tcp": {{HostPort: "5000"}}}),
+					container.WithPortMap(containertypes.PortMap{"5000/tcp": {{HostPort: "5000"}}}),
 					container.WithNetworkMode(servnet))
 				defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
 
@@ -1322,7 +1321,7 @@ func testDirectRemoteAccessOnExposedPort(t *testing.T, ctx context.Context, d *d
 					container.WithName(sanitizeCtrName(t.Name()+"-server")),
 					container.WithCmd("nc", "-lup", "5000"),
 					container.WithExposedPorts("5000/udp"),
-					container.WithPortMap(nat.PortMap{"5000/udp": {{HostPort: hostPort}}}),
+					container.WithPortMap(containertypes.PortMap{"5000/udp": {{HostPort: hostPort}}}),
 					container.WithNetworkMode(bridgeName),
 					container.WithEndpointSettings(bridgeName, &networktypes.EndpointSettings{
 						IPAddress:   ctrIP.String(),
@@ -1408,7 +1407,7 @@ func TestAccessPortPublishedOnLoopbackAddress(t *testing.T) {
 			container.WithCmd("nc", "-lup", "5000"),
 			container.WithExposedPorts("5000/udp"),
 			// This port is mapped on 127.0.0.2, so it should not be remotely accessible.
-			container.WithPortMap(nat.PortMap{"5000/udp": {{HostIP: loIP, HostPort: hostPort}}}),
+			container.WithPortMap(containertypes.PortMap{"5000/udp": {{HostIP: loIP, HostPort: hostPort}}}),
 			container.WithNetworkMode(bridgeName))
 		defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
 
@@ -1519,7 +1518,7 @@ func TestSkipRawRules(t *testing.T) {
 
 				ctrId := container.Run(ctx, t, c,
 					container.WithExposedPorts("80/tcp"),
-					container.WithPortMap(nat.PortMap{"80/tcp": {
+					container.WithPortMap(containertypes.PortMap{"80/tcp": {
 						{HostIP: "127.0.0.1", HostPort: "8080"},
 						{HostPort: "8081"},
 					}}),
@@ -1551,10 +1550,10 @@ func TestMixAnyWithSpecificHostAddrs(t *testing.T) {
 
 			ctrId := container.Run(ctx, t, c,
 				container.WithExposedPorts("80/"+proto, "81/"+proto, "82/"+proto),
-				container.WithPortMap(nat.PortMap{
-					nat.Port("81/" + proto): {{}},
-					nat.Port("82/" + proto): {{}},
-					nat.Port("80/" + proto): {{HostIP: "127.0.0.1"}},
+				container.WithPortMap(containertypes.PortMap{
+					containertypes.PortRangeProto("81/" + proto): {{}},
+					containertypes.PortRangeProto("82/" + proto): {{}},
+					containertypes.PortRangeProto("80/" + proto): {{HostIP: "127.0.0.1"}},
 				}),
 			)
 			defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})

--- a/testutil/fakestorage/storage.go
+++ b/testutil/fakestorage/storage.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/testutil/environment"
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/docker/docker/testutil/request"
-	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/build"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/image"
@@ -164,9 +163,7 @@ COPY . /static`); err != nil {
 	// Find out the system assigned port
 	i, err := c.ContainerInspect(context.Background(), b.ID)
 	assert.NilError(t, err)
-	newP, err := nat.NewPort("tcp", "80")
-	assert.NilError(t, err)
-	ports, exists := i.NetworkSettings.Ports[newP]
+	ports, exists := i.NetworkSettings.Ports["80/tcp"]
 	if !exists || len(ports) != 1 {
 		t.Fatalf("unable to find port 80/tcp for %s", container)
 	}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/50573

Follow-up to 494677f93f04ab3ad4c295c0e92ac05bfe0a546a, which added the aliases, but did not yet replace our own use of the nat types.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

