### PR TITLE
Revert "api/types/registry: EncodeAuthConfig: use empty string for zero value"

### DIFF
--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -52,6 +52,11 @@ type AuthConfig struct {
 //
 // [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
 func EncodeAuthConfig(authConfig AuthConfig) (string, error) {
+	// Older daemons (or registries) may not handle an empty string,
+	// which resulted in an "io.EOF" when unmarshaling or decoding.
+	//
+	// FIXME(thaJeztah): find exactly what code-paths are impacted by this.
+	// if authConfig == (AuthConfig{}) { return "", nil }
 	buf, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", errInvalidParameter{err}

--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -52,9 +52,6 @@ type AuthConfig struct {
 //
 // [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
 func EncodeAuthConfig(authConfig AuthConfig) (string, error) {
-	if authConfig == (AuthConfig{}) {
-		return "", nil
-	}
 	buf, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", errInvalidParameter{err}

--- a/api/types/registry/authconfig_test.go
+++ b/api/types/registry/authconfig_test.go
@@ -109,6 +109,10 @@ func TestEncodeAuthConfig(t *testing.T) {
 		outPlain  string
 	}{
 		{
+			// Older daemons (or registries) may not handle an empty string,
+			// which resulted in an "io.EOF" when unmarshaling or decoding.
+			//
+			// FIXME(thaJeztah): find exactly what code-paths are impacted by this.
 			doc:       "empty",
 			input:     AuthConfig{},
 			outBase64: `e30=`,

--- a/api/types/registry/authconfig_test.go
+++ b/api/types/registry/authconfig_test.go
@@ -111,8 +111,8 @@ func TestEncodeAuthConfig(t *testing.T) {
 		{
 			doc:       "empty",
 			input:     AuthConfig{},
-			outBase64: ``,
-			outPlain:  ``,
+			outBase64: `e30=`,
+			outPlain:  `{}`,
 		},
 		{
 			doc: "test authConfig",


### PR DESCRIPTION
- reverts https://github.com/moby/moby/pull/50426

This reverts commit 3a447bc0794ff3c90a2fb88d23e89372d8c11426.

Some daemon versions don't handle empty values well, which resulted in
an io.EOF error when sending an empty X-Registry-Auth during decoding
or unmarshaling.

We should investigate what code-paths are hit to trigger this, but
in the meantime, let's revert this patch.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

