### PR TITLE
libnetwork: provide endpoint name for IPAM drivers

### DIFF
--- a/daemon/libnetwork/netlabel/labels.go
+++ b/daemon/libnetwork/netlabel/labels.go
@@ -26,6 +26,9 @@ const (
 	// DNSServers A list of DNS servers associated with the endpoint
 	DNSServers = Prefix + ".endpoint.dnsservers"
 
+	// EndpointName constant represents the container's Name
+	EndpointName = Prefix + ".endpoint.name"
+
 	// EndpointSysctls is a comma separated list interface-specific sysctls
 	// where the interface name is represented by the string "IFNAME".
 	EndpointSysctls = Prefix + ".endpoint.sysctls"

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -1217,12 +1217,10 @@ func (n *Network) createEndpoint(ctx context.Context, name string, options ...En
 		return nil, err
 	}
 
+	ep.ipamOptions = map[string]string{netlabel.EndpointName: name}
 	if capability.RequiresMACAddress {
 		if ep.iface.mac == nil {
 			ep.iface.mac = netutils.GenerateRandomMAC()
-		}
-		if ep.ipamOptions == nil {
-			ep.ipamOptions = make(map[string]string)
 		}
 		ep.ipamOptions[netlabel.MacAddress] = ep.iface.mac.String()
 	}


### PR DESCRIPTION
**- What I did**
I'm building IPAM driver which integrates Docker and HashiCorp Nomad in way that it is possible dynamically allocate sub ranges (like can do manually with `--ip-range`) by utilizing Nomad namespace metadata.

So for example I would create network to Windows nodes like this:
```powershell
docker network create `
  --driver transparent `
  --subnet 10.0.0.0/16 `
  --gateway 10.0.0.1 `
  containers
```
and to Linux nodes like this:
```bash
docker network create \
  -d ipvlan \
  --subnet 10.0.0.0/16 \
  --gateway 10.0.0.1 \
  --opt parent=eth0 \
  --opt ipvlan_mode=l2 \
  containers
```

And then create application environments with Nomad namespace configuration like this:
```hcl
name = "example"
meta {
  subnet = "10.0.1.0/24"
}
name = "foobar"
meta {
  subnet = "10.0.2.0/24"
}
```

But it requires that IPAM driver knows that to which Nomad namespace container sending `RequestAddress` belongs to.

Initially I tried to solve that by enabling `RequiresMACAddress` capability and using that to find correct container and it's labels but it turns out that `ContainerInspect` cannot be called inside of `RequestAddress` function because libnetwork has locks enabled in that point.

So this PR provides minimal change to libnetwork allowing this to be done in IPAM drivers.

**- How I did it**
Added logic which will always send `com.docker.network.endpoint.name` label to IPAM driver containing name of the endpoint (=> name of the container).

That solves issue for me because containers naming is [hardcoded in Nomad](https://github.com/hashicorp/nomad/blob/fde0bf26a7db35fc63ceb50b5b694478034392c6/drivers/docker/driver.go#L1430) so I can simply parse allocation ID from it and call [Read Allocation API](https://developer.hashicorp.com/nomad/api-docs/allocations#read-allocation)

**- How to verify it**
In current form it it should not need anything more than pass CI. If maintainers want, this can be also put behind of capability flag but I don't think that it is necessary as it is just extra label. 

EDIT: Plugin described above is now available in [here](https://github.com/olljanat/nomad-simplified/tree/main/ipam-plugin) and seems to be working fine with this.

**- A picture of a cute animal (not mandatory but encouraged)**
![nomad-docker](https://github.com/user-attachments/assets/b9d585ec-e3d6-4068-9b63-14fd0158f76a)

