### PR TITLE
router/distribution: fetchManifest; detach from distributionRouter

### DIFF
--- a/daemon/server/router/distribution/distribution_routes.go
+++ b/daemon/server/router/distribution/distribution_routes.go
@@ -64,7 +64,7 @@ func (dr *distributionRouter) getDistributionInfo(ctx context.Context, w http.Re
 	// - https://github.com/moby/moby/blob/12c7411b6b7314bef130cd59f1c7384a7db06d0b/distribution/pull.go#L76-L152
 	var lastErr error
 	for _, repo := range repos {
-		distributionInspect, err := dr.fetchManifest(ctx, repo, namedRef)
+		distributionInspect, err := fetchManifest(ctx, repo, namedRef)
 		if err != nil {
 			lastErr = err
 			continue
@@ -74,7 +74,7 @@ func (dr *distributionRouter) getDistributionInfo(ctx context.Context, w http.Re
 	return lastErr
 }
 
-func (dr *distributionRouter) fetchManifest(ctx context.Context, distrepo distribution.Repository, namedRef reference.Named) (registry.DistributionInspect, error) {
+func fetchManifest(ctx context.Context, distrepo distribution.Repository, namedRef reference.Named) (registry.DistributionInspect, error) {
 	var distributionInspect registry.DistributionInspect
 	if canonicalRef, ok := namedRef.(reference.Canonical); !ok {
 		namedRef = reference.TagNameOnly(namedRef)


### PR DESCRIPTION
The distributionRouter receiver was not used; make it a regular function to make clear it doesn't require the router.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

