### PR TITLE
daemon: make buildSandboxOptions, buildSandboxPlatformOptions more atomic

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -56,10 +56,13 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 		sboxOptions = append(sboxOptions, libnetwork.OptionUseExternalKey())
 	}
 
-	// Add platform-specific Sandbox options.
-	if err := buildSandboxPlatformOptions(ctr, cfg, &sboxOptions); err != nil {
+	// Update the container with platform-specific options, and
+	// add platform-specific Sandbox options.
+	platformOpts, err := buildSandboxPlatformOptions(ctr, cfg)
+	if err != nil {
 		return nil, err
 	}
+	sboxOptions = append(sboxOptions, platformOpts...)
 
 	if len(ctr.HostConfig.DNS) > 0 {
 		sboxOptions = append(sboxOptions, libnetwork.OptionDNS(ctr.HostConfig.DNS))

--- a/daemon/container_operations_windows.go
+++ b/daemon/container_operations_windows.go
@@ -170,8 +170,8 @@ func serviceDiscoveryOnDefaultNetwork() bool {
 	return true
 }
 
-func buildSandboxPlatformOptions(ctr *container.Container, cfg *config.Config, sboxOptions *[]libnetwork.SandboxOption) error {
-	return nil
+func buildSandboxPlatformOptions(ctr *container.Container, cfg *config.Config) ([]libnetwork.SandboxOption, error) {
+	return nil, nil
 }
 
 func (daemon *Daemon) initializeNetworkingPaths(ctr *container.Container, nc *container.Container) error {


### PR DESCRIPTION
The buildSandboxPlatformOptions function was given a pointer to the sboxOptions and modified it in-place.

Similarly, a pointer to the container was passed and `container.HostsPath` and `container.ResolvConfPath` mutated. In cases where either of those failed, we would return an error, but the container (and sboxOptions) would already be modified.

This patch;

- updates the signature of buildSandboxPlatformOptions to return a fresh slice of sandbox options, which can be appended to the sboxOptions by the caller.
- uses intermediate variables for `hostsPath` and `resolvConfPath`, and only mutates the container if both were obtained successfully.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

