### PR TITLE
libnetwork/types: use stricter types for enums

### DIFF
--- a/daemon/libnetwork/driverapi/driverapi.go
+++ b/daemon/libnetwork/driverapi/driverapi.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/moby/moby/v2/daemon/libnetwork/options"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 )
 
 // NetworkPluginEndpointType represents the Endpoint Type used by Plugin system
@@ -173,7 +174,7 @@ type JoinInfo interface {
 
 	// AddStaticRoute adds a route to the sandbox.
 	// It may be used in addition to or instead of a default gateway (as above).
-	AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error
+	AddStaticRoute(destination *net.IPNet, routeType types.RouteType, nextHop net.IP) error
 
 	// DisableGatewayService tells libnetwork not to provide Default GW for the container
 	DisableGatewayService()

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -772,7 +772,7 @@ func (te *testEndpoint) SetGatewayIPv6(gw6 net.IP) error {
 	return nil
 }
 
-func (te *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
+func (te *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType types.RouteType, nextHop net.IP) error {
 	te.routes = append(te.routes, types.StaticRoute{Destination: destination, RouteType: routeType, NextHop: nextHop})
 	return nil
 }

--- a/daemon/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/daemon/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -20,7 +20,7 @@ import (
 
 type staticRoute struct {
 	Destination *net.IPNet
-	RouteType   int
+	RouteType   types.RouteType
 	NextHop     net.IP
 }
 

--- a/daemon/libnetwork/drivers/remote/api/api.go
+++ b/daemon/libnetwork/drivers/remote/api/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/moby/moby/v2/daemon/libnetwork/discoverapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/driverapi"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 )
 
 // Response is the basic response structure used in all responses.
@@ -186,7 +187,7 @@ type InterfaceName struct {
 // StaticRoute is the plain JSON representation of a static route.
 type StaticRoute struct {
 	Destination string
-	RouteType   int
+	RouteType   types.RouteType
 	NextHop     string
 }
 

--- a/daemon/libnetwork/drivers/remote/driver_test.go
+++ b/daemon/libnetwork/drivers/remote/driver_test.go
@@ -91,7 +91,7 @@ type testEndpoint struct {
 	hostsPath             string
 	nextHop               string
 	destination           string
-	routeType             int
+	routeType             types.RouteType
 	disableGatewayService bool
 }
 
@@ -193,7 +193,7 @@ func (test *testEndpoint) SetNames(srcName, dstPrefix, dstName string) error {
 	return nil
 }
 
-func (test *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
+func (test *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType types.RouteType, nextHop net.IP) error {
 	compareIPNets(test.t, "Destination", test.destination, *destination)
 	compareIPs(test.t, "NextHop", test.nextHop, nextHop)
 
@@ -328,7 +328,7 @@ func TestRemoteDriver(t *testing.T) {
 		resolvConfPath: "/there/goes/the/resolv/conf",
 		destination:    "10.0.0.0/8",
 		nextHop:        "10.0.0.1",
-		routeType:      1,
+		routeType:      types.CONNECTED,
 	}
 
 	mux := http.NewServeMux()
@@ -374,8 +374,8 @@ func TestRemoteDriver(t *testing.T) {
 		}
 	})
 	handle(t, mux, "Join", func(msg map[string]interface{}) interface{} {
-		options := msg["Options"].(map[string]interface{})
-		foo, ok := options["foo"].(string)
+		opts := msg["Options"].(map[string]interface{})
+		foo, ok := opts["foo"].(string)
 		if !ok || foo != "fooValue" {
 			t.Fatalf("Did not receive expected foo string in request options: %+v", msg)
 		}

--- a/daemon/libnetwork/drivers/windows/windows_test.go
+++ b/daemon/libnetwork/drivers/windows/windows_test.go
@@ -138,7 +138,7 @@ func (test *testEndpoint) SetNames(_, _, _ string) error {
 	return nil
 }
 
-func (test *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
+func (test *testEndpoint) AddStaticRoute(destination *net.IPNet, routeType types.RouteType, nextHop net.IP) error {
 	return nil
 }
 

--- a/daemon/libnetwork/endpoint_info.go
+++ b/daemon/libnetwork/endpoint_info.go
@@ -300,7 +300,7 @@ func (ep *Endpoint) InterfaceName() driverapi.InterfaceNameInfo {
 
 // AddStaticRoute adds a route to the sandbox.
 // It may be used in addition to or instead of a default gateway (as above).
-func (ep *Endpoint) AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error {
+func (ep *Endpoint) AddStaticRoute(destination *net.IPNet, routeType types.RouteType, nextHop net.IP) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 	if routeType == types.NEXTHOP {

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -1930,7 +1930,7 @@ func (n *Network) hasLoadBalancerEndpoint() bool {
 // Returns (addresses, true) if req is found, but len(addresses) may be 0 if
 // there are no addresses of ipType. If the name is not found, the bool return
 // will be false.
-func (n *Network) ResolveName(ctx context.Context, req string, ipType int) ([]net.IP, bool) {
+func (n *Network) ResolveName(ctx context.Context, req string, ipType types.IPFamily) ([]net.IP, bool) {
 	c := n.getController()
 	networkID := n.ID()
 

--- a/daemon/libnetwork/resolver.go
+++ b/daemon/libnetwork/resolver.go
@@ -33,7 +33,7 @@ type DNSBackend interface {
 	// the networks the sandbox is connected to. The second return value will be
 	// true if the name exists in docker domain, even if there are no addresses of
 	// the required type. Such queries shouldn't be forwarded to external nameservers.
-	ResolveName(ctx context.Context, name string, ipType int) ([]net.IP, bool)
+	ResolveName(ctx context.Context, name string, ipType types.IPFamily) ([]net.IP, bool)
 	// ResolveIP returns the service name for the passed in IP. IP is in reverse dotted
 	// notation; the format used for DNS PTR records
 	ResolveIP(ctx context.Context, name string) string
@@ -310,7 +310,7 @@ func (r *Resolver) handleMXQuery(ctx context.Context, query *dns.Msg) (*dns.Msg,
 	return resp, nil
 }
 
-func (r *Resolver) handleIPQuery(ctx context.Context, query *dns.Msg, ipType int) (*dns.Msg, error) {
+func (r *Resolver) handleIPQuery(ctx context.Context, query *dns.Msg, ipType types.IPFamily) (*dns.Msg, error) {
 	name := query.Question[0].Name
 	addr, ok := r.backend.ResolveName(ctx, name, ipType)
 	if !ok {

--- a/daemon/libnetwork/resolver_test.go
+++ b/daemon/libnetwork/resolver_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/miekg/dns"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/internal/testutils/netnsutils"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
@@ -246,7 +247,7 @@ func (w tlogWriter) Write(p []byte) (int, error) {
 
 type noopDNSBackend struct{ DNSBackend }
 
-func (noopDNSBackend) ResolveName(_ context.Context, name string, ipType int) ([]net.IP, bool) {
+func (noopDNSBackend) ResolveName(_ context.Context, name string, ipType types.IPFamily) ([]net.IP, bool) {
 	return nil, false
 }
 

--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -395,7 +395,7 @@ func (sb *Sandbox) ResolveService(ctx context.Context, name string) ([]*net.SRV,
 	return nil, nil
 }
 
-func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType int) ([]net.IP, bool) {
+func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType types.IPFamily) ([]net.IP, bool) {
 	// Embedded server owns the docker network domain. Resolution should work
 	// for both container_name and container_name.network_name
 	// We allow '.' in service name and network name. For a name a.b.c.d the
@@ -452,12 +452,12 @@ func (sb *Sandbox) ResolveName(ctx context.Context, name string, ipType int) ([]
 	return nil, false
 }
 
-func (sb *Sandbox) resolveName(ctx context.Context, nameOrAlias string, networkName string, epList []*Endpoint, lookupAlias bool, ipType int) ([]net.IP, bool) {
+func (sb *Sandbox) resolveName(ctx context.Context, nameOrAlias string, networkName string, epList []*Endpoint, lookupAlias bool, ipType types.IPFamily) ([]net.IP, bool) {
 	ctx, span := otel.Tracer("").Start(ctx, "Sandbox.resolveName", trace.WithAttributes(
 		attribute.String("libnet.resolver.name-or-alias", nameOrAlias),
 		attribute.String("libnet.network.name", networkName),
 		attribute.Bool("libnet.resolver.alias-lookup", lookupAlias),
-		attribute.Int("libnet.resolver.ip-family", ipType)))
+		attribute.Int("libnet.resolver.ip-family", int(ipType))))
 	defer span.End()
 
 	for _, ep := range epList {

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/ishidawataru/sctp"
 	"github.com/moby/moby/v2/errdefs"
@@ -16,9 +17,9 @@ import (
 type IPFamily int
 
 const (
-	IP   IPFamily = iota // Either IPv4 or IPv6.
-	IPv4                 // Internet Protocol version 4 (IPv4).
-	IPv6                 // Internet Protocol version 6 (IPv6).
+	IP   IPFamily = syscall.AF_UNSPEC // Either IPv4 or IPv6.
+	IPv4 IPFamily = syscall.AF_INET   // Internet Protocol version 4 (IPv4).
+	IPv6 IPFamily = syscall.AF_INET6  // Internet Protocol version 6 (IPv6).
 )
 
 // EncryptionKey is the libnetwork representation of the key distributed by the lead

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -12,11 +12,13 @@ import (
 	"github.com/moby/moby/v2/errdefs"
 )
 
-// constants for the IP address type.
+// IPFamily specify IP address type(s).
+type IPFamily int
+
 const (
-	IP = iota // IPv4 and IPv6
-	IPv4
-	IPv6
+	IP   IPFamily = iota // Either IPv4 or IPv6.
+	IPv4                 // Internet Protocol version 4 (IPv4).
+	IPv6                 // Internet Protocol version 6 (IPv6).
 )
 
 // EncryptionKey is the libnetwork representation of the key distributed by the lead

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -339,32 +339,26 @@ func ParseCIDR(cidr string) (*net.IPNet, error) {
 	return ipNet, nil
 }
 
-const (
-	// NEXTHOP indicates a StaticRoute with an IP next hop.
-	NEXTHOP = iota
+type RouteType int
 
-	// CONNECTED indicates a StaticRoute with an interface for directly connected peers.
-	CONNECTED
+const (
+	NEXTHOP   RouteType = iota // NEXTHOP indicates a StaticRoute with an IP next hop.
+	CONNECTED                  // CONNECTED indicates a StaticRoute with an interface for directly connected peers.
 )
 
-// StaticRoute is a statically-provisioned IP route.
+// StaticRoute is a statically provisioned IP route.
 type StaticRoute struct {
 	Destination *net.IPNet
-
-	RouteType int // NEXT_HOP or CONNECTED
-
-	// NextHop will be resolved by the kernel (i.e. as a loose hop).
-	NextHop net.IP
+	RouteType   RouteType // NEXTHOP or CONNECTED
+	NextHop     net.IP    // NextHop will be resolved by the kernel (i.e., as a loose hop).
 }
 
 // GetCopy returns a copy of this StaticRoute structure
 func (r *StaticRoute) GetCopy() *StaticRoute {
-	d := GetIPNetCopy(r.Destination)
-	nh := GetIPCopy(r.NextHop)
 	return &StaticRoute{
-		Destination: d,
+		Destination: GetIPNetCopy(r.Destination),
 		RouteType:   r.RouteType,
-		NextHop:     nh,
+		NextHop:     GetIPCopy(r.NextHop),
 	}
 }
 

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -174,14 +174,10 @@ func (p PortBinding) String() string {
 }
 
 const (
-	// ICMP is for the ICMP ip protocol
-	ICMP = 1
-	// TCP is for the TCP ip protocol
-	TCP = 6
-	// UDP is for the UDP ip protocol
-	UDP = 17
-	// SCTP is for the SCTP ip protocol
-	SCTP = 132
+	ICMP Protocol = 1   // ICMP (Internet Control Message Protocol) — [syscall.IPPROTO_ICMP]
+	TCP  Protocol = 6   // TCP (Transmission Control Protocol) — [syscall.IPPROTO_TCP]
+	UDP  Protocol = 17  // UDP (User Datagram Protocol) — [syscall.IPPROTO_UDP]
+	SCTP Protocol = 132 // SCTP (Stream Control Transmission Protocol) — [syscall.IPPROTO_SCTP] (not supported on Windows).
 )
 
 // Protocol represents an IP protocol number


### PR DESCRIPTION
### libnetwork/types: define IPFamily type for IP-family consts

Define a type to help discovery, and update the signatures of `ResolveName`,
`Network.ResolveName`, and `Sandbox.ResolveName` accordingly.

### libnetwork/types: define IPFamily options using syscall.AF_XXX consts

Use the consts defined in syscall that basically match our intent here.

### libnetwork/types: make Protocol consts strong-typed

These use the Linux-specific values as convention, so unfortunately,
the syscall package doesn't define consts for these on Windows, so
keeping our own definition (values are not really relevant here).

### libnetwork/types: define RouteType type

Define a `RouteType` type, type the related consts, and update the
`JoinInfo.AddStaticRoute` signature in the interface.

----

With this patch, available options are listed together in the docs, and helps discoverability in function signatures :

<img width="732" height="292" alt="Screenshot 2025-08-01 at 21 08 24" src="https://github.com/user-attachments/assets/38be64c7-490b-441f-a1df-25f4bd214963" />
<img width="738" height="308" alt="Screenshot 2025-08-01 at 21 08 38" src="https://github.com/user-attachments/assets/88e97ce1-ea21-4901-b4f1-660c9e27cfda" />
<img width="1060" height="425" alt="Screenshot 2025-08-01 at 21 24 46" src="https://github.com/user-attachments/assets/6dc3bac0-8c17-43f4-8e92-6b930079e1cd" />



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

