### PR TITLE
daemon/internal/image: remove image-spec markdown

### DIFF
--- a/daemon/internal/image/spec/README.md
+++ b/daemon/internal/image/spec/README.md
@@ -1,4 +1,0 @@
-# Docker Image Specification v1.
-
-This specification moved to a separate repository:
-https://github.com/moby/docker-image-spec

--- a/daemon/internal/image/spec/spec.md
+++ b/daemon/internal/image/spec/spec.md
@@ -1,4 +1,0 @@
-# Docker Image Specification v1.3.0
-
-This specification moved to a separate repository:
-https://github.com/moby/docker-image-spec

--- a/daemon/internal/image/spec/v1.1.md
+++ b/daemon/internal/image/spec/v1.1.md
@@ -1,4 +1,0 @@
-# Docker Image Specification v1.1.0
-
-This specification moved to a separate repository:
-https://github.com/moby/docker-image-spec

--- a/daemon/internal/image/spec/v1.2.md
+++ b/daemon/internal/image/spec/v1.2.md
@@ -1,4 +1,0 @@
-# Docker Image Specification v1.2.0
-
-This specification moved to a separate repository:
-https://github.com/moby/docker-image-spec

--- a/daemon/internal/image/spec/v1.md
+++ b/daemon/internal/image/spec/v1.md
@@ -1,4 +1,0 @@
-# Docker Image Specification v1.0.0
-
-This specification moved to a separate repository:
-https://github.com/moby/docker-image-spec


### PR DESCRIPTION
- addresses https://github.com/moby/moby/pull/50446#discussion_r2218757908
- relates to https://github.com/moby/moby/pull/47362

The image spec was moved to the github.com/moby/docker-image-spec repository, and 03a17a2887ce9a07768e6982a8ccae9b35bc86c6 removed the files from the moby repository, but left markdown files in place to point people to the new location.

As these files were now moved internally, they no longer serve that purpose, so we can remove them.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

