### PR TITLE
api/types/strslice: use slices.Equal

### DIFF
--- a/api/types/strslice/strslice_test.go
+++ b/api/types/strslice/strslice_test.go
@@ -2,7 +2,7 @@ package strslice
 
 import (
 	"encoding/json"
-	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -14,8 +14,8 @@ func TestStrSliceMarshalJSON(t *testing.T) {
 		// MADNESS(stevvooe): No clue why nil would be "" but empty would be
 		// "null". Had to make a change here that may affect compatibility.
 		{input: nil, expected: "null"},
-		{StrSlice{}, "[]"},
-		{StrSlice{"/bin/sh", "-c", "echo"}, `["/bin/sh","-c","echo"]`},
+		{input: StrSlice{}, expected: "[]"},
+		{input: StrSlice{"/bin/sh", "-c", "echo"}, expected: `["/bin/sh","-c","echo"]`},
 	} {
 		data, err := json.Marshal(testcase.input)
 		if err != nil {
@@ -39,47 +39,41 @@ func TestStrSliceUnmarshalJSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		actualParts := []string(strs)
-		if !reflect.DeepEqual(actualParts, expected) {
-			t.Fatalf("%#v: expected %v, got %v", input, expected, actualParts)
+		actual := []string(strs)
+		if !slices.Equal(actual, expected) {
+			t.Fatalf("%#v: expected %#v, got %#v", input, expected, actual)
 		}
 	}
 }
 
 func TestStrSliceUnmarshalString(t *testing.T) {
-	var e StrSlice
+	var actual StrSlice
 	echo, err := json.Marshal("echo")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := json.Unmarshal(echo, &e); err != nil {
+	if err := json.Unmarshal(echo, &actual); err != nil {
 		t.Fatal(err)
 	}
 
-	if len(e) != 1 {
-		t.Fatalf("expected 1 element after unmarshal: %q", e)
-	}
-
-	if e[0] != "echo" {
-		t.Fatalf("expected `echo`, got: %q", e[0])
+	expected := []string{"echo"}
+	if !slices.Equal(actual, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, actual)
 	}
 }
 
 func TestStrSliceUnmarshalSlice(t *testing.T) {
-	var e StrSlice
+	var actual StrSlice
 	echo, err := json.Marshal([]string{"echo"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := json.Unmarshal(echo, &e); err != nil {
+	if err := json.Unmarshal(echo, &actual); err != nil {
 		t.Fatal(err)
 	}
 
-	if len(e) != 1 {
-		t.Fatalf("expected 1 element after unmarshal: %q", e)
-	}
-
-	if e[0] != "echo" {
-		t.Fatalf("expected `echo`, got: %q", e[0])
+	expected := []string{"echo"}
+	if !slices.Equal(actual, expected) {
+		t.Fatalf("expected %#v, got %#v", expected, actual)
 	}
 }


### PR DESCRIPTION
[Open Source Insights], which is linked from [pkg.go.dev] flagged the API module to have [CAPABILITY_REFLECT], because it detected "reflect" to be imported.

Let's use the slices package, which should do the job for these tests.

[Open Source Insights]: https://deps.dev/go/github.com%2Fmoby%2Fmoby%2Fapi/v0.0.0-20250801143505-5f121ce46324/analysis
[pkg.go.dev]: https://pkg.go.dev/github.com/moby/moby/api@v0.0.0-20250801143505-5f121ce46324
[CAPABILITY_REFLECT]: https://github.com/google/capslock/blob/3166f9ba9d15790c9e39bc08607cb574556e994e/docs/capabilities.md#capability_reflect


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

