### PR TITLE
Dockerfile: add GO_SWAGGER_VERSION build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,11 +84,15 @@ RUN mkdir /build && mv /bin/registry /build/registry
 FROM base AS swagger
 WORKDIR /go/src/github.com/go-swagger/go-swagger
 ARG TARGETPLATFORM
+# GO_SWAGGER_VERSION specifies the version of the go-swagger binary to install.
+# Go-swagger is used in CI for generating types from swagger.yaml in
+# hack/validate/swagger-gen
+ARG GO_SWAGGER_VERSION=v0.32.3
 RUN --mount=type=cache,target=/root/.cache/go-build,id=swagger-build-$TARGETPLATFORM \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ <<EOT
   set -e
-  GOBIN=/build xx-go install github.com/go-swagger/go-swagger/cmd/swagger@v0.32.3
+  GOBIN=/build xx-go install "github.com/go-swagger/go-swagger/cmd/swagger@${GO_SWAGGER_VERSION}"
   xx-verify /build/swagger
 EOT
 


### PR DESCRIPTION
Allow overriding the go-swagger version to install.

With this patch:

    docker build -q --call=outline --target=swagger .

    TARGET: swagger

    BUILD ARG            VALUE                    DESCRIPTION
    GO_VERSION           1.24.5
    BASE_DEBIAN_DISTRO   bookworm
    GOLANG_IMAGE         golang:1.24.5-bookworm
    XX_VERSION           1.6.1
    GO_SWAGGER_VERSION   v0.32.3                  specifies the version of the go-swagger binary to install.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

