### PR TITLE
apk/pkg/stdcopy: remove use of `iota`, improve docs, and add example 

### DIFF
--- a/api/pkg/stdcopy/stdcopy.go
+++ b/api/pkg/stdcopy/stdcopy.go
@@ -14,16 +14,13 @@ import (
 type StdType byte
 
 const (
-	// Stdin represents standard input stream type.
-	Stdin StdType = iota
-	// Stdout represents standard output stream type.
-	Stdout
-	// Stderr represents standard error steam type.
-	Stderr
-	// Systemerr represents errors originating from the system that make it
-	// into the multiplexed stream.
-	Systemerr
+	Stdin     StdType = 0 // Stdin represents standard input stream.
+	Stdout    StdType = 1 // Stdout represents standard output stream.
+	Stderr    StdType = 2 // Stderr represents standard error steam.
+	Systemerr StdType = 3 // Systemerr represents errors originating from the system.
+)
 
+const (
 	stdWriterPrefixLen = 8
 	stdWriterFdIndex   = 0
 	stdWriterSizeIndex = 4

--- a/api/pkg/stdcopy/stdcopy_example_test.go
+++ b/api/pkg/stdcopy/stdcopy_example_test.go
@@ -1,0 +1,66 @@
+package stdcopy_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/moby/moby/api/pkg/stdcopy"
+)
+
+func ExampleNewStdWriter() {
+	muxReader, muxStream := io.Pipe()
+	defer func() { _ = muxStream.Close() }()
+
+	// Start demuxing before the daemon starts writing.
+	done := make(chan error, 1)
+	go func() {
+		// using os.Stdout for both, otherwise output doesn't show up in the example.
+		osStdout := os.Stdout
+		osStderr := os.Stdout
+		_, err := stdcopy.StdCopy(osStdout, osStderr, muxReader)
+		done <- err
+	}()
+
+	// daemon writing to stdout, stderr, and systemErr.
+	stdout := stdcopy.NewStdWriter(muxStream, stdcopy.Stdout)
+	stderr := stdcopy.NewStdWriter(muxStream, stdcopy.Stderr)
+	systemErr := stdcopy.NewStdWriter(muxStream, stdcopy.Systemerr)
+
+	for range 10 {
+		_, _ = fmt.Fprintln(stdout, "hello from stdout")
+		_, _ = fmt.Fprintln(stderr, "hello from stderr")
+		time.Sleep(50 * time.Millisecond)
+	}
+	_, _ = fmt.Fprintln(systemErr, errors.New("something went wrong"))
+
+	// Wait for the demuxer to finish.
+	if err := <-done; err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// hello from stdout
+	// hello from stderr
+	// error from daemon in stream: something went wrong
+}

--- a/vendor/github.com/moby/moby/api/pkg/stdcopy/stdcopy.go
+++ b/vendor/github.com/moby/moby/api/pkg/stdcopy/stdcopy.go
@@ -14,16 +14,13 @@ import (
 type StdType byte
 
 const (
-	// Stdin represents standard input stream type.
-	Stdin StdType = iota
-	// Stdout represents standard output stream type.
-	Stdout
-	// Stderr represents standard error steam type.
-	Stderr
-	// Systemerr represents errors originating from the system that make it
-	// into the multiplexed stream.
-	Systemerr
+	Stdin     StdType = 0 // Stdin represents standard input stream.
+	Stdout    StdType = 1 // Stdout represents standard output stream.
+	Stderr    StdType = 2 // Stderr represents standard error steam.
+	Systemerr StdType = 3 // Systemerr represents errors originating from the system.
+)
 
+const (
 	stdWriterPrefixLen = 8
 	stdWriterFdIndex   = 0
 	stdWriterSizeIndex = 4


### PR DESCRIPTION
### api/pkg/stdcopy: don't use iota for consts

iota can be convenient for internal use for cases where the value
doesn't matter. It can be a footgun when using it to define public
values; it's easy to accidentally change values (e.g. by re-ordering
or adding a value), which may go undetected within our code because
both producer and consumer would be updated.

This patch updates these consts to have a concrete value, because it's
part of the API contract and must not be changed.


### api/pkg/stdcopy: improve docs

- Outline the purpose of the Stdin and Systemerr streams and how
  they're used.
- Update docs for StdCopy function
- Touch-up error for unknown stream types

### api/pkg/stdcopy: add example



**- How to verify it**

```bash
go install golang.org/x/pkgsite/cmd/pkgsite@latest
pkgsite -open -http=:6060 ./api
```

Then navigate to http://localhost:6060/github.com/moby/moby/api/pkg/stdcopy

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

