### PR TITLE
Handle nil pointer in containerd snapshotter integration when containerd address not specified

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1051,6 +1051,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 
 	if d.UsesSnapshotter() {
+		if d.containerdClient == nil {
+			return nil, errors.New("Unable to start with containerd snapshotter integration because containerd address/socket not specified (see --containerd).")
+		}
 		if os.Getenv("TEST_INTEGRATION_USE_SNAPSHOTTER") != "" {
 			log.G(ctx).Warn("Enabling containerd snapshotter through the $TEST_INTEGRATION_USE_SNAPSHOTTER environment variable. This should only be used for testing.")
 		}


### PR DESCRIPTION
This fixes #50543 by returning an error when d.containerdClient == nil, which is expected when `--containerd` is not used to specify containerd socket or address.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Returned an error when containerd snapshotting is requested but `--containerd` socket is not specified.

**- How I did it**

Added a check for `d.containerdClient == nil` during snapshotter initialization.

**- How to verify it**

Start Docker with `--feature containerd-snapshotter` and no `--containerd` flag. It should return a user-friendly error rather than panicking.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
fix: return error when containerd snapshotting requested and no containerd socket is specified
```

