### PR TITLE
libnet/d/bridge: handleFirewalldReloadNw: fix deadlock

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1697,17 +1697,17 @@ func (d *driver) handleFirewalldReload() {
 }
 
 func (d *driver) handleFirewalldReloadNw(nid string) {
+	// Make sure the network isn't being deleted, and ProgramExternalConnectivity
+	// isn't modifying iptables rules, while restoring the rules.
+	d.configNetwork.Lock()
+	defer d.configNetwork.Unlock()
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if !d.config.EnableIPTables && !d.config.EnableIP6Tables {
 		return
 	}
-
-	// Make sure the network isn't being deleted, and ProgramExternalConnectivity
-	// isn't modifying iptables rules, while restoring the rules.
-	d.configNetwork.Lock()
-	defer d.configNetwork.Unlock()
 
 	nw, ok := d.networks[nid]
 	if !ok {


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/issues/50619
- Bug introduced in https://github.com/moby/moby/pull/49728 (commit https://github.com/moby/moby/commit/a527e5a546526117a0f3d7a33f3fcb8f4cd87c72)

**- What I did**

**1st commit: libnet/d/bridge: driver: un-embed mutex**

The bridge driver was embedding `sync.Mutex` which is unconventional and makes it harder to analyze locks ordering.

**2nd commit: libnet/d/bridge: handleFirewalldReloadNw: fix deadlock**

handleFirewalldReloadNw locks `d.mu` and then `d.configNetworks`. However, the rest of the driver locks `d.configNetworks` first and then `d.mu`.

This could result in deadlocks if `handleFirewalldReloadNw` is called while the bridge driver is already holding `d.configNetworks` lock.

Other code paths were checked to ensure that they all follow the same locking order.

<details>
<summary>Locks ordering analysis</summary>

d.configNetwork:

- `(*driver).configure()` locks `d.configNetwork` — `d.mu` not acquired
- `(*driver).CreateNetwork()` locks `d.configNetwork` - `d.mu` not acquired
- `(*driver).DeleteNetwork()` locks `d.configNetwork` - `d.mu` not acquired
- **`(*driver).handleFirewalldReloadNw` locks `d.configNetwork` - `d.mu` IS acquired**
- `(*driver).ProgramExternalConnectivity` locks `d.configNetwork` - `d.mu` not acquired

d.mu.Lock:

- `(*driver).configure()` locks `d.mu` - `d.configNetwork` not acquired
- `(*driver).CreateEndpoint()` locks `d.mu` - `d.configNetwork` not acquired
- **`(*driver).createNetwork()` locks `d.mu` - `d.configNetwork` IS acquired by callers:**
  - **`(*driver).CreateNetwork()` LOCKS `d.configNetwork` -> `(*driver).createNetwork()`**
  - **`(*driver).configure()` LOCKS `d.configNetwork` -> `(*driver).initStore()` -> `(*driver).populateNetworks()` -> `(*driver).createNetwork()`**
- `(*driver).CreateNetwork()` locks `d.mu` - `d.configNetwork` not acquired
- `(*driver).DeleteEndpoint()` locks `d.mu` - `d.configNetwork` not acquired
- **`(*driver).deleteNetwork()` locks `d.mu` - `d.configNetwork` IS acquired by caller:**
  - **`(*driver).DeleteNetwork()` LOCKS `d.configNetwork` -> `(*driver).deleteNetwork()`**
- `(*driver).EndpointOperInfo()` locks `d.mu` - `d.configNetwork` not acquired
- **`(*driver).getNetwork()` locks `d.mu` — `d.configNetwork` IS acquired by caller:**
  - `(*driver).Join()` doesn't lock `d.configNetwork` -> `(*driver).getNetwork()`
  - `(*driver).Leave()` doesn't lock `d.configNetwork` -> `(*driver).getNetwork()`
  - **`(*driver).ProgramExternalConnectivity()` LOCKS `d.configNetwork` -> `(*driver).getNetwork()`**
- **`(*driver).getNetworks()` locks `d.mu` — `d.configNetwork` IS acquired by caller:**
  - **`(*driver).CreateNetwork()` LOCKS `d.configNetwork` -> `(*driver).checkConflict()` -> `(*driver).getNetworks()`**
- `(*driver).handleFirewalldReload()` locks `d.mu` — `d.configNetwork` not acquired
- **`(*driver).handleFirewalldReloadNw()` locks `d.mu` - `d.configNetwork` locked _after_ `d.mu`**
</details>

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Fix a deadlock that could happen if a firewalld reload was processed while the bridge networking driver was starting up, or creating or deleting a network, or creating port-mappings
```