### PR TITLE
docs: fix URI fragment by changing it to the existing subheading

### DIFF
--- a/docs/contributing/who-written-for.md
+++ b/docs/contributing/who-written-for.md
@@ -3,7 +3,7 @@
 This section of the documentation contains a guide for Moby project users who want to
 contribute code or documentation to the Moby Engine project. As a community, we
 share rules of behavior and interaction. Make sure you are familiar with the <a
-href="https://github.com/moby/moby/blob/master/CONTRIBUTING.md#docker-community-guidelines"
+href="https://github.com/moby/moby/blob/master/CONTRIBUTING.md#moby-community-guidelines"
 target="_blank">community guidelines</a> before continuing.
 
 ## Where and what you can contribute


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Markdown subheading name was changed in `CONTRIBUTING.md` in the past, so this commit fixes the link by changing it from `docker` to `moby`.

**- A picture of a cute animal (not mandatory but encouraged)**

