### PR TITLE
hack: Fix references to old `docker/docker` module

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,7 +107,7 @@ linters:
         - pkg: github.com/vishvananda/netlink$
           pattern: ^netlink\.(Handle\.)?(AddrList|BridgeVlanList|ChainList|ClassList|ConntrackTableList|ConntrackDeleteFilter$|ConntrackDeleteFilters|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByName|LinkByAlias|LinkList|LinkSubscribeWithOptions|NeighList$|NeighProxyList|NeighListExecute|NeighSubscribeWithOptions|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteList|RouteListFilteredIter|RuleListFiltered$|RouteSubscribeWithOptions|RuleList$|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|VDPAGetDevConfigList|VDPAGetDevList|VDPAGetMGMTDevList|XfrmPolicyList|XfrmStateList)
           msg: Use internal nlwrap package for EINTR handling.
-        - pkg: github.com/docker/docker/internal/nlwrap$
+        - pkg: github.com/moby/moby/v2/internal/nlwrap$
           pattern: ^nlwrap.Handle.(BridgeVlanList|ChainList|ClassList|ConntrackDeleteFilter$|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByAlias|LinkSubscribeWithOptions|NeighList$|NeighProxyList|NeighListExecute|NeighSubscribeWithOptions|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteListFilteredIter|RuleListFiltered$|RouteSubscribeWithOptions|RuleList$|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|VDPAGetDevConfigList|VDPAGetDevList|VDPAGetMGMTDevList)
           msg: Add a wrapper to nlwrap.Handle for EINTR handling and update the list in .golangci.yml.
       analyze-types: true
@@ -190,7 +190,7 @@ linters:
           alias: cerrdefs
         - pkg: github.com/containerd/containerd/images
           alias: c8dimages
-        - pkg: github.com/docker/docker/reference
+        - pkg: github.com/moby/moby/v2/reference
           alias: refstore
         - pkg: github.com/opencontainers/image-spec/specs-go/v1
           alias: ocispec

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -17,7 +17,7 @@ RUN <<EOT
   wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip
   unzip protoc-${PROTOC_VERSION}-${TARGETOS}-${arch}.zip -d /usr/local
 EOT
-WORKDIR /go/src/github.com/docker/docker
+WORKDIR /go/src/github.com/moby/moby
 
 FROM base AS src
 WORKDIR /out

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -5,7 +5,7 @@ ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 
 FROM golang:${GO_VERSION}-alpine AS base
-WORKDIR /go/src/github.com/docker/docker
+WORKDIR /go/src/github.com/moby/moby
 RUN apk add --no-cache jq moreutils
 ARG GOVULNCHECK_VERSION
 RUN --mount=type=cache,target=/root/.cache \

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -162,7 +162,7 @@ Function Get-HeadCommit() {
 
 # Utility function to get the commit for upstream
 Function Get-UpstreamCommit() {
-    Invoke-Expression "git fetch -q https://github.com/docker/docker.git refs/heads/master"
+    Invoke-Expression "git fetch -q https://github.com/moby/moby.git refs/heads/master"
     if ($LASTEXITCODE -ne 0) { Throw "Failed fetching" }
 
     $upstream = Invoke-Expression "git rev-parse --verify FETCH_HEAD"
@@ -243,7 +243,7 @@ Function Validate-DCO($headCommit, $upstreamCommit) {
         $badCommits | %{ $e+=" - $_`n"}
         $e += "`nPlease amend each commit to include a properly formatted DCO marker.`n`n"
         $e += "Visit the following URL for information about the Docker DCO:`n"
-        $e += "https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work`n"
+        $e += "https://github.com/moby/moby/blob/master/CONTRIBUTING.md#sign-your-work`n"
         Throw $e
     }
 }
@@ -261,10 +261,10 @@ Function Validate-PkgImports($headCommit, $upstreamCommit) {
         if ($LASTEXITCODE -ne 0) { Throw "Failed go list for dependencies on $file" }
         $imports = $imports -Replace "\[" -Replace "\]", "" -Split(" ") | Sort-Object | Get-Unique
         # Filter out what we are looking for
-        $imports = @() + $imports -NotMatch "^github.com/docker/docker/pkg/" `
-                                  -NotMatch "^github.com/docker/docker/vendor" `
-                                  -NotMatch "^github.com/docker/docker/internal" `
-                                  -Match "^github.com/docker/docker" `
+        $imports = @() + $imports -NotMatch "^github.com/moby/moby/v2/pkg/" `
+                                  -NotMatch "^github.com/moby/moby/v2/vendor" `
+                                  -NotMatch "^github.com/moby/moby/v2/internal" `
+                                  -Match    "^github.com/moby/moby/v2" `
                                   -Replace "`n", ""
         $imports | ForEach-Object{ $badFiles+="$file imports $_`n" }
     }
@@ -482,12 +482,12 @@ Try {
         Catch [Exception] { Throw $_ }
     }
 
-    $ldflags = "-X 'github.com/docker/docker/dockerversion.Version="+$dockerVersion+"'"
-    $ldflags += " -X 'github.com/docker/docker/dockerversion.GitCommit="+$gitCommit+"'"
-    $ldflags += " -X 'github.com/docker/docker/dockerversion.BuildTime="+$env:BUILDTIME+"'"
-    $ldflags += " -X 'github.com/docker/docker/dockerversion.PlatformName="+$env:PLATFORM+"'"
-    $ldflags += " -X 'github.com/docker/docker/dockerversion.ProductName="+$env:PRODUCT+"'"
-    $ldflags += " -X 'github.com/docker/docker/dockerversion.DefaultProductLicense="+$env:DEFAULT_PRODUCT_LICENSE+"'"
+    $ldflags = "-X 'github.com/moby/moby/v2/dockerversion.Version="+$dockerVersion+"'"
+    $ldflags += " -X 'github.com/moby/moby/v2/dockerversion.GitCommit="+$gitCommit+"'"
+    $ldflags += " -X 'github.com/moby/moby/v2/dockerversion.BuildTime="+$env:BUILDTIME+"'"
+    $ldflags += " -X 'github.com/moby/moby/v2/dockerversion.PlatformName="+$env:PLATFORM+"'"
+    $ldflags += " -X 'github.com/moby/moby/v2/dockerversion.ProductName="+$env:PRODUCT+"'"
+    $ldflags += " -X 'github.com/moby/moby/v2/dockerversion.DefaultProductLicense="+$env:DEFAULT_PRODUCT_LICENSE+"'"
 
     # DCO, Package import and Go formatting tests.
     if ($DCO -or $PkgImports -or $GoFormat) {

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -23,7 +23,7 @@ set -e
 
 set -o pipefail
 
-export DOCKER_PKG='github.com/docker/docker'
+export DOCKER_PKG='github.com/moby/moby'
 export SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MAKEDIR="$SCRIPTDIR/make"
 export PKG_CONFIG=${PKG_CONFIG:-pkg-config}

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 LDFLAGS="${LDFLAGS} \
--X \"github.com/docker/docker/dockerversion.Version=${VERSION}\" \
--X \"github.com/docker/docker/dockerversion.GitCommit=${GITCOMMIT}\" \
--X \"github.com/docker/docker/dockerversion.BuildTime=${BUILDTIME}\" \
--X \"github.com/docker/docker/dockerversion.PlatformName=${PLATFORM}\" \
--X \"github.com/docker/docker/dockerversion.ProductName=${PRODUCT}\" \
--X \"github.com/docker/docker/dockerversion.DefaultProductLicense=${DEFAULT_PRODUCT_LICENSE}\" "
+-X \"github.com/moby/moby/v2/dockerversion.Version=${VERSION}\" \
+-X \"github.com/moby/moby/v2/dockerversion.GitCommit=${GITCOMMIT}\" \
+-X \"github.com/moby/moby/v2/dockerversion.BuildTime=${BUILDTIME}\" \
+-X \"github.com/moby/moby/v2/dockerversion.PlatformName=${PLATFORM}\" \
+-X \"github.com/moby/moby/v2/dockerversion.ProductName=${PRODUCT}\" \
+-X \"github.com/moby/moby/v2/dockerversion.DefaultProductLicense=${DEFAULT_PRODUCT_LICENSE}\" "
 
 # Compile the Windows resources into the sources
 if [ "$(go env GOOS)" = "windows" ]; then

--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -91,7 +91,7 @@ run_test_integration_suites() {
 		if ! (
 			cd "$dir"
 			# Create a useful package name based on the tests's $dir. We need to take
-			# into account that  "$dir" can be either an absolute (/go/src/github.com/docker/docker/integration/foo)
+			# into account that  "$dir" can be either an absolute (/go/src/github.com/moby/moby/integration/foo)
 			# or relative (./integration/foo) path. To account for both, first we strip
 			# the absolute path, then remove any leading periods and slashes.
 			pkgname="${dir}"

--- a/hack/validate/.validate
+++ b/hack/validate/.validate
@@ -6,7 +6,7 @@ if [ -z "$VALIDATE_UPSTREAM" ]; then
 	# this is kind of an expensive check, so let's not do this twice if we
 	# are running more than one validate bundlescript
 
-	VALIDATE_REPO="${VALIDATE_REPO:-https://github.com/docker/docker.git}"
+	VALIDATE_REPO="${VALIDATE_REPO:-https://github.com/moby/moby.git}"
 	VALIDATE_BRANCH="${VALIDATE_BRANCH:-master}"
 
 	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"

--- a/hack/validate/dco
+++ b/hack/validate/dco
@@ -13,7 +13,7 @@ dels=$(validate_diff --numstat | awk '{ s += $2 } END { print s }')
 # "Username may only contain alphanumeric characters or dashes and cannot begin with a dash"
 githubUsernameRegex='[a-zA-Z0-9][a-zA-Z0-9-]+'
 
-# https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work
+# https://github.com/moby/moby/blob/master/CONTRIBUTING.md#sign-your-work
 dcoPrefix='Signed-off-by:'
 dcoRegex="^(Docker-DCO-1.1-)?$dcoPrefix ([^<]+) <([^<>@]+@[^<>]+)>( \\(github: ($githubUsernameRegex)\\))?$"
 

--- a/hack/validate/pkg-imports
+++ b/hack/validate/pkg-imports
@@ -12,10 +12,10 @@ badFiles=()
 for f in "${files[@]}"; do
 	IFS=$'\n'
 	badImports=($(go list -e -f '{{ join .Deps "\n" }}' "$f" | sort -u \
-		| grep -vE '^github.com/docker/docker/pkg/' \
-		| grep -vE '^github.com/docker/docker/vendor' \
-		| grep -vE '^github.com/docker/docker/internal' \
-		| grep -E '^github.com/docker/docker' \
+		| grep -vE '^github.com/moby/moby/v2/pkg/' \
+		| grep -vE '^github.com/moby/moby/v2/vendor' \
+		| grep -vE '^github.com/moby/moby/v2/internal' \
+		| grep -E '^github.com/moby/moby' \
 		|| true))
 	unset IFS
 


### PR DESCRIPTION
Fixes some validation steps and setting the correct version values in https://github.com/moby/moby/tree/master/dockerversion.
