### PR TITLE
integration-cli: migrated test TestContainerAPIStop

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -780,29 +780,6 @@ func (s *DockerAPISuite) TestContainerAPIStart(c *testing.T) {
 	// TODO(tibor): figure out why this doesn't work on windows
 }
 
-func (s *DockerAPISuite) TestContainerAPIStop(c *testing.T) {
-	const name = "test-api-stop"
-	runSleepingContainer(c, "-i", "--name", name)
-	timeout := 30
-
-	apiClient, err := client.New(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	_, err = apiClient.ContainerStop(testutil.GetContext(c), name, client.ContainerStopOptions{
-		Timeout: &timeout,
-	})
-	assert.NilError(c, err)
-	assert.NilError(c, waitInspect(name, "{{ .State.Running  }}", "false", 60*time.Second))
-
-	// second call to start should give 304
-	// maybe add ContainerStartWithRaw to test it
-	_, err = apiClient.ContainerStop(testutil.GetContext(c), name, client.ContainerStopOptions{
-		Timeout: &timeout,
-	})
-	assert.NilError(c, err)
-}
-
 func (s *DockerAPISuite) TestContainerAPIWait(c *testing.T) {
 	const name = "test-api-wait"
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Migrated the TestContainerAPIStop from integration-cli to integration/container.
Issue reference: https://github.com/moby/moby/issues/50159

**- How I did it**
Added a test to verify ContainerStop using the API Client.

**- How to verify it**
run the integration test:

TEST_INTEGRATION_DIR=./integration/container TESTFLAGS='-test.run TestContainerAPIStop' ./hack/make.sh dynbinary test-integration


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

