### PR TITLE
api/docs: sync v1.52 swagger with current version

### DIFF
--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -2950,6 +2950,7 @@ definitions:
 
   PluginMount:
     type: "object"
+    x-go-name: "Mount"
     x-nullable: false
     required: [Name, Description, Settable, Source, Destination, Type, Options]
     properties:
@@ -2986,6 +2987,7 @@ definitions:
 
   PluginDevice:
     type: "object"
+    x-go-name: "Device"
     required: [Name, Description, Settable, Path]
     x-nullable: false
     properties:
@@ -3005,6 +3007,7 @@ definitions:
 
   PluginEnv:
     type: "object"
+    x-go-name: "Env"
     x-nullable: false
     required: [Name, Description, Settable, Value]
     properties:
@@ -3026,7 +3029,7 @@ definitions:
       Describes a permission the user has to accept upon installing
       the plugin.
     type: "object"
-    x-go-name: "PluginPrivilege"
+    x-go-name: "Privilege"
     properties:
       Name:
         type: "string"
@@ -3043,6 +3046,7 @@ definitions:
   Plugin:
     description: "A plugin for the Engine API"
     type: "object"
+    x-go-name: "Plugin"
     required: [Settings, Enabled, Config, Name]
     properties:
       Id:
@@ -3060,8 +3064,9 @@ definitions:
         x-nullable: false
         example: true
       Settings:
-        description: "Settings that can be modified by users."
+        description: "user-configurable settings for the plugin."
         type: "object"
+        x-go-name: "Settings"
         x-nullable: false
         required: [Args, Devices, Env, Mounts]
         properties:
@@ -3086,11 +3091,13 @@ definitions:
       PluginReference:
         description: "plugin remote reference used to push/pull the plugin"
         type: "string"
+        x-go-name: "PluginReference"
         x-nullable: false
         example: "localhost:5000/tiborvass/sample-volume-plugin:latest"
       Config:
         description: "The config of a plugin."
         type: "object"
+        x-go-name: "Config"
         x-nullable: false
         required:
           - Description
@@ -3124,6 +3131,7 @@ definitions:
             description: "The interface between Docker and the plugin"
             x-nullable: false
             type: "object"
+            x-go-name: "Interface"
             required: [Types, Socket]
             properties:
               Types:
@@ -3132,8 +3140,6 @@ definitions:
                   type: "string"
                   x-go-type:
                     type: "CapabilityID"
-                    import:
-                      package: "github.com/moby/moby/api/types/plugin"
                 example:
                   - "docker.volumedriver/1.0"
               Socket:
@@ -3160,6 +3166,7 @@ definitions:
             example: "/bin/"
           User:
             type: "object"
+            x-go-name: "User"
             x-nullable: false
             properties:
               UID:
@@ -3172,6 +3179,7 @@ definitions:
                 example: 1000
           Network:
             type: "object"
+            x-go-name: "NetworkConfig"
             x-nullable: false
             required: [Type]
             properties:
@@ -3181,6 +3189,7 @@ definitions:
                 example: "host"
           Linux:
             type: "object"
+            x-go-name: "LinuxConfig"
             x-nullable: false
             required: [Capabilities, AllowAllDevices, Devices]
             properties:
@@ -3226,6 +3235,7 @@ definitions:
                 Value: "0"
           Args:
             type: "object"
+            x-go-name: "Args"
             x-nullable: false
             required: [Name, Description, Settable, Value]
             properties:
@@ -3247,6 +3257,7 @@ definitions:
                   type: "string"
           rootfs:
             type: "object"
+            x-go-name: "RootFS"
             properties:
               type:
                 type: "string"


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/48114

This includes the changes from c13266d2c0abdf19bcaa4ad11d309a09601d0681 in the versioned swagger, as those changes were made after the v1.52 versioned document was created.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

