### PR TITLE
nftables: never enable IP forwarding on the host

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -128,6 +128,16 @@ check_device() {
 	fi
 }
 
+check_sysctl() {
+	val=$(sysctl -n $1)
+	want=$2
+	if [ "$val" = "$want" ]; then
+		wrap_good "sysctl $1" "enabled"
+	else
+		wrap_bad "sysctl $1" "disabled"
+	fi
+}
+
 if [ ! -e "$CONFIG" ]; then
 	wrap_warning "warning: $CONFIG does not exist, searching other paths for kernel config ..."
 	for tryConfig in $possibleConfigs; do
@@ -343,6 +353,10 @@ if ! is_set EXT4_FS || ! is_set EXT4_FS_POSIX_ACL || ! is_set EXT4_FS_SECURITY; 
 fi
 
 echo '- Network Drivers:'
+echo "  - \"$(wrap_color 'bridge' blue)\":"
+check_sysctl net.ipv4.ip_forward 1 | sed 's/^/    - /'
+check_sysctl net.ipv6.conf.all.forwarding 1 | sed 's/^/    - /'
+check_sysctl net.ipv6.conf.default.forwarding 1 | sed 's/^/    - /'
 echo "  - \"$(wrap_color 'overlay' blue)\":"
 check_flags VXLAN BRIDGE_VLAN_FILTERING | sed 's/^/    /'
 echo '      Optional (for encrypted networks):'

--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -199,5 +199,12 @@ else
 		mount_directory /etc/ssl "--rbind"
 	fi
 
+	# When running with --firewall-backend=nftables, IP forwarding needs to be enabled
+	# because the daemon won't enable it. IP forwarding is harmless in the rootless
+	# netns, there's only a single external interface and only Docker uses the netns.
+	# So, always enable IPv4 and IPv6 forwarding.
+	sysctl -w net.ipv4.ip_forward=1
+	sysctl -w net.ipv6.conf.all.forwarding=1
+
 	exec "$dockerd" "$@"
 fi

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -556,7 +556,7 @@ var newFirewaller = func(ctx context.Context, config firewaller.Config) (firewal
 		// cleaner can't clean up network or port-specific rules that may have been added
 		// to iptables built-in chains. So, if cleanup is needed, give the cleaner to
 		// the nftabler. Then, it'll use it to delete old rules as networks are restored.
-		fw.(firewaller.FirewallCleanerSetter).SetFirewallCleaner(iptabler.NewCleaner(ctx, config))
+		fw.SetFirewallCleaner(iptabler.NewCleaner(ctx, config))
 		return fw, nil
 	}
 

--- a/daemon/libnetwork/drivers/bridge/bridge_store.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_store.go
@@ -13,7 +13,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/internal/otelutil"
 	"github.com/moby/moby/v2/daemon/libnetwork/datastore"
-	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge/internal/firewaller"
+	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge/internal/nftabler"
 	"github.com/moby/moby/v2/daemon/libnetwork/portmapperapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"go.opentelemetry.io/otel"
@@ -43,8 +43,8 @@ func (d *driver) initStore() error {
 
 	// If there's a firewall cleaner, it's done its job by cleaning up rules
 	// belonging to the restored networks. So, drop it.
-	if fcs, ok := d.firewaller.(firewaller.FirewallCleanerSetter); ok {
-		fcs.SetFirewallCleaner(nil)
+	if nft, ok := d.firewaller.(*nftabler.Nftabler); ok {
+		nft.SetFirewallCleaner(nil)
 	}
 
 	return nil

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
@@ -76,9 +76,6 @@ type Firewaller interface {
 	// NewNetwork returns an object that can be used to add published ports and legacy
 	// links for a bridge network.
 	NewNetwork(ctx context.Context, nc NetworkConfig) (Network, error)
-	// FilterForwardDrop sets the default policy of the FORWARD chain in the filter
-	// table to DROP.
-	FilterForwardDrop(ctx context.Context, ipv IPVersion) error
 }
 
 // Network can be used to manipulate firewall rules for a bridge network.

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/firewaller.go
@@ -110,12 +110,6 @@ type Network interface {
 	DelLink(ctx context.Context, parentIP, childIP netip.Addr, ports []types.TransportPort)
 }
 
-// FirewallCleanerSetter is an optional interface for a Firewaller.
-type FirewallCleanerSetter interface {
-	// SetFirewallCleaner replaces the FirewallCleaner (possibly with 'nil').
-	SetFirewallCleaner(FirewallCleaner)
-}
-
 // FirewallCleaner is used to delete rules created by previous incarnations of
 // the daemon. On startup, once a Firewaller implementation has been selected, if
 // rules may have been left behind by a different Firewaller implementation, get

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
@@ -15,7 +15,6 @@ import (
 type StubFirewaller struct {
 	Config
 	Networks map[string]*StubFirewallerNetwork
-	FFD      map[IPVersion]bool // filter forward drop
 }
 
 func NewStubFirewaller(config Config) *StubFirewaller {
@@ -24,7 +23,6 @@ func NewStubFirewaller(config Config) *StubFirewaller {
 		// A real Firewaller shouldn't hold on to its own networks, the bridge driver is doing that.
 		// But, for unit tests cross-checking the driver, this is useful.
 		Networks: make(map[string]*StubFirewallerNetwork),
-		FFD:      make(map[IPVersion]bool),
 	}
 }
 
@@ -39,11 +37,6 @@ func (fw *StubFirewaller) NewNetwork(_ context.Context, nc NetworkConfig) (Netwo
 	}
 	fw.Networks[nc.IfName] = nw
 	return nw, nil
-}
-
-func (fw *StubFirewaller) FilterForwardDrop(_ context.Context, ipv IPVersion) error {
-	fw.FFD[ipv] = true
-	return nil
 }
 
 type stubFirewallerLink struct {

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
@@ -17,7 +17,7 @@ type iptablesCleaner struct {
 }
 
 // NewCleaner checks for iptables rules left behind by an old daemon that was using
-// the iptabler.
+// the Iptabler.
 //
 // If there are old rules present, it deletes as much as possible straight away
 // (user-defined chains and jumps from the built-in chains).
@@ -62,7 +62,7 @@ func (ic iptablesCleaner) DelNetwork(ctx context.Context, nc firewaller.NetworkC
 	}
 	n := network{
 		config: nc,
-		ipt:    &iptabler{config: ic.config},
+		ipt:    &Iptabler{config: ic.config},
 	}
 	if ic.config.IPv4 && nc.Config4.Prefix.IsValid() {
 		_ = deleteLegacyFilterRules(iptables.IPv4, nc.IfName)
@@ -77,7 +77,7 @@ func (ic iptablesCleaner) DelNetwork(ctx context.Context, nc firewaller.NetworkC
 func (ic iptablesCleaner) DelEndpoint(ctx context.Context, nc firewaller.NetworkConfig, epIPv4, epIPv6 netip.Addr) {
 	n := network{
 		config: nc,
-		ipt:    &iptabler{config: ic.config},
+		ipt:    &Iptabler{config: ic.config},
 	}
 	if n.ipt.config.IPv4 && epIPv4.IsValid() {
 		_ = n.filterDirectAccess(ctx, iptables.IPv4, n.config.Config4, epIPv4, false)
@@ -90,7 +90,7 @@ func (ic iptablesCleaner) DelEndpoint(ctx context.Context, nc firewaller.Network
 func (ic iptablesCleaner) DelPorts(ctx context.Context, nc firewaller.NetworkConfig, pbs []types.PortBinding) {
 	n := network{
 		config: nc,
-		ipt:    &iptabler{config: ic.config},
+		ipt:    &Iptabler{config: ic.config},
 	}
 	_ = n.DelPorts(ctx, pbs)
 }

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
@@ -91,6 +91,7 @@ func NewIptabler(ctx context.Context, config firewaller.Config) (*Iptabler, erro
 	return ipt, nil
 }
 
+// FilterForwardDrop sets the default policy of the FORWARD chain in the filter table to DROP.
 func (ipt *Iptabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
 	var iptv iptables.IPVersion
 	switch ipv {

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/iptabler.go
@@ -35,12 +35,12 @@ const (
 	isolationChain2 = "DOCKER-ISOLATION-STAGE-2"
 )
 
-type iptabler struct {
+type Iptabler struct {
 	config firewaller.Config
 }
 
-func NewIptabler(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
-	ipt := &iptabler{config: config}
+func NewIptabler(ctx context.Context, config firewaller.Config) (*Iptabler, error) {
+	ipt := &Iptabler{config: config}
 
 	if ipt.config.IPv4 {
 		removeIPChains(ctx, iptables.IPv4)
@@ -91,7 +91,7 @@ func NewIptabler(ctx context.Context, config firewaller.Config) (firewaller.Fire
 	return ipt, nil
 }
 
-func (ipt *iptabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
+func (ipt *Iptabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
 	var iptv iptables.IPVersion
 	switch ipv {
 	case firewaller.IPv4:

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/network.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/network.go
@@ -22,11 +22,11 @@ type (
 
 type network struct {
 	config     firewaller.NetworkConfig
-	ipt        *iptabler
+	ipt        *Iptabler
 	cleanFuncs iptablesCleanFuncs
 }
 
-func (ipt *iptabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig) (_ firewaller.Network, retErr error) {
+func (ipt *Iptabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig) (_ firewaller.Network, retErr error) {
 	n := &network{
 		ipt:    ipt,
 		config: nc,

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/cleaner.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/cleaner.go
@@ -11,7 +11,7 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
 )
 
-// Cleanup deletes all rules created by nftabler; it's intended to be used
+// Cleanup deletes all rules created by Nftabler; it's intended to be used
 // during startup, to clean up rules created by an old incarnation of the daemon
 // after switching to a different Firewaller implementation.
 func Cleanup(ctx context.Context, config firewaller.Config) {
@@ -31,6 +31,6 @@ func Cleanup(ctx context.Context, config firewaller.Config) {
 	}
 }
 
-func (nft *nftabler) SetFirewallCleaner(fc firewaller.FirewallCleaner) {
+func (nft *Nftabler) SetFirewallCleaner(fc firewaller.FirewallCleaner) {
 	nft.cleaner = fc
 }

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/network.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/network.go
@@ -18,10 +18,10 @@ import (
 type network struct {
 	config  firewaller.NetworkConfig
 	cleaner func(ctx context.Context) error
-	fw      *nftabler
+	fw      *Nftabler
 }
 
-func (nft *nftabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig) (_ firewaller.Network, retErr error) {
+func (nft *Nftabler) NewNetwork(ctx context.Context, nc firewaller.NetworkConfig) (_ firewaller.Network, retErr error) {
 	n := &network{
 		fw:     nft,
 		config: nc,

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -85,21 +85,6 @@ func NewNftabler(ctx context.Context, config firewaller.Config) (*Nftabler, erro
 	return nft, nil
 }
 
-func (nft *Nftabler) getTable(ipv firewaller.IPVersion) nftables.TableRef {
-	if ipv == firewaller.IPv4 {
-		return nft.table4
-	}
-	return nft.table6
-}
-
-func (nft *Nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
-	table := nft.getTable(ipv)
-	if err := table.Chain(ctx, forwardChain).SetPolicy("drop"); err != nil {
-		return err
-	}
-	return nftApply(ctx, table)
-}
-
 // init creates the bridge driver's nftables table for IPv4 or IPv6.
 func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (nftables.TableRef, error) {
 	// Instantiate the table.

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -45,15 +45,15 @@ const (
 	rawPreroutingPortsRuleGroup = iota + initialRuleGroup + 1
 )
 
-type nftabler struct {
+type Nftabler struct {
 	config  firewaller.Config
 	cleaner firewaller.FirewallCleaner
 	table4  nftables.TableRef
 	table6  nftables.TableRef
 }
 
-func NewNftabler(ctx context.Context, config firewaller.Config) (firewaller.Firewaller, error) {
-	nft := &nftabler{config: config}
+func NewNftabler(ctx context.Context, config firewaller.Config) (*Nftabler, error) {
+	nft := &Nftabler{config: config}
 
 	if nft.config.IPv4 {
 		var err error
@@ -85,14 +85,14 @@ func NewNftabler(ctx context.Context, config firewaller.Config) (firewaller.Fire
 	return nft, nil
 }
 
-func (nft *nftabler) getTable(ipv firewaller.IPVersion) nftables.TableRef {
+func (nft *Nftabler) getTable(ipv firewaller.IPVersion) nftables.TableRef {
 	if ipv == firewaller.IPv4 {
 		return nft.table4
 	}
 	return nft.table6
 }
 
-func (nft *nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
+func (nft *Nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVersion) error {
 	table := nft.getTable(ipv)
 	if err := table.Chain(ctx, forwardChain).SetPolicy("drop"); err != nil {
 		return err
@@ -101,7 +101,7 @@ func (nft *nftabler) FilterForwardDrop(ctx context.Context, ipv firewaller.IPVer
 }
 
 // init creates the bridge driver's nftables table for IPv4 or IPv6.
-func (nft *nftabler) init(ctx context.Context, family nftables.Family) (nftables.TableRef, error) {
+func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (nftables.TableRef, error) {
 	// Instantiate the table.
 	table, err := nftables.NewTable(family, dockerTable)
 	if err != nil {

--- a/daemon/libnetwork/iptables/iptables.go
+++ b/daemon/libnetwork/iptables/iptables.go
@@ -3,6 +3,7 @@
 package iptables
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -409,6 +410,16 @@ func (iptable IPTable) SetDefaultPolicy(table Table, chain string, policy Policy
 		return fmt.Errorf("setting default policy to %v in %v chain failed: %v", policy, chain, err)
 	}
 	return nil
+}
+
+// HasPolicy returns true if the chain exists and has the given policy.
+func (iptable IPTable) HasPolicy(table Table, chain string, policy Policy) bool {
+	out, err := iptable.Raw("-t", string(table), "-L", chain)
+	if err != nil {
+		return false
+	}
+	firstLine, _, _ := bytes.Cut(out, []byte("\n"))
+	return strings.Contains(string(firstLine), "policy "+string(policy))
 }
 
 // AddReturnRule adds a return rule for the chain in the filter table

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -67,6 +67,13 @@ fi
 
 dockerd="dockerd"
 
+# When running with the nftables backend, dockerd will not enable IP forwarding (by default, it
+# will error on network creation if forwarding is not enabled).
+if [ "$DOCKER_FIREWALL_BACKEND" = "nftables" ]; then
+	sysctl -w net.ipv4.ip_forward=1 > /dev/null
+	sysctl -w net.ipv6.conf.all.forwarding=1 > /dev/null
+fi
+
 if [ -n "$DOCKER_ROOTLESS" ]; then
 	if [ -z "$TEST_SKIP_INTEGRATION_CLI" ]; then
 		echo >&2 '# DOCKER_ROOTLESS requires TEST_SKIP_INTEGRATION_CLI to be set'

--- a/integration/internal/testutils/networking/firewall.go
+++ b/integration/internal/testutils/networking/firewall.go
@@ -1,7 +1,6 @@
 package networking
 
 import (
-	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -9,45 +8,29 @@ import (
 
 	"github.com/moby/moby/v2/testutil/daemon"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
-)
-
-const (
-	// The name of the bridge driver's nftables tables.
-	nftTable = "docker-bridges"
-	// The name of the filter-FORWARD chain in nftTable.
-	nftFFChain = "filter-FORWARD"
 )
 
 // Find the policy in, for example "Chain FORWARD (policy ACCEPT)".
 var rePolicy = regexp.MustCompile("policy ([A-Za-z]+)")
 
 // SetFilterForwardPolicies sets the default policy for the FORWARD chain in
-// the filter tables for both IPv4 and IPv6. The original policy is restored
-// using t.Cleanup().
+// the iptables filter tables for both IPv4 and IPv6. The original policy is
+// restored using t.Cleanup().
 //
 // There's only one filter-FORWARD policy, so this won't behave well if used by
 // tests running in parallel in a single network namespace that expect different
 // behaviour.
-func SetFilterForwardPolicies(t *testing.T, firewallBackend string, policy string) {
-	t.Helper()
-	if strings.HasPrefix(firewallBackend, "iptables") {
-		setIptablesFFP(t, policy)
-		return
-	}
-	if strings.HasPrefix(firewallBackend, "nftables") {
-		setNftablesFFP(t, policy)
-		return
-	}
-	t.Fatalf("unknown firewall backend %s", firewallBackend)
-}
-
-func setIptablesFFP(t *testing.T, policy string) {
+func SetFilterForwardPolicies(t *testing.T, policy string) {
 	t.Helper()
 	for _, iptablesCmd := range []string{"iptables", "ip6tables"} {
-		origPolicy, err := getChainPolicy(t, exec.Command(iptablesCmd, "-L", "FORWARD"))
-		assert.NilError(t, err, "failed to get iptables policy")
+		out, err := exec.Command(iptablesCmd, "-L", "FORWARD").Output()
+		assert.NilError(t, err, "failed to get %s policy", iptablesCmd)
+		opMatch := rePolicy.FindSubmatch(out)
+		assert.Assert(t, is.Len(opMatch, 2), "searching for policy: %w", err)
+		origPolicy := string(opMatch[1])
 		if origPolicy == policy {
 			continue
 		}
@@ -60,42 +43,6 @@ func setIptablesFFP(t *testing.T, policy string) {
 			}
 		})
 	}
-}
-
-func setNftablesFFP(t *testing.T, policy string) {
-	t.Helper()
-	policy = strings.ToLower(policy)
-	for _, family := range []string{"ip", "ip6"} {
-		origPolicy, err := getChainPolicy(t, exec.Command("nft", "list", "chain", family, nftTable, nftFFChain))
-		assert.NilError(t, err, "failed to get nftables policy")
-		if origPolicy == policy {
-			continue
-		}
-		cmd := func(p string) *exec.Cmd {
-			return exec.Command("nft", "add", "chain", family, nftTable, nftFFChain, "{", "policy", p, ";", "}")
-		}
-		if err := cmd(policy).Run(); err != nil {
-			t.Fatalf("Failed to set %s filter-FORWARD policy: %v", family, err)
-		}
-		t.Cleanup(func() {
-			if err := cmd(origPolicy).Run(); err != nil {
-				t.Logf("Failed to restore %s filter-FORWARD policy: %v", family, err)
-			}
-		})
-	}
-}
-
-func getChainPolicy(t *testing.T, cmd *exec.Cmd) (string, error) {
-	t.Helper()
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("getting policy: %w", err)
-	}
-	opMatch := rePolicy.FindSubmatch(out)
-	if len(opMatch) != 2 {
-		return "", fmt.Errorf("searching for policy: %w", err)
-	}
-	return string(opMatch[1]), nil
 }
 
 // FirewalldRunning returns true if "firewall-cmd --state" reports "running".

--- a/integration/internal/testutils/networking/l3_segment_linux.go
+++ b/integration/internal/testutils/networking/l3_segment_linux.go
@@ -77,6 +77,8 @@ func (l3 *L3Segment) AddHost(t *testing.T, hostname, nsName, ifname string, addr
 	l3.bridge.MustRun(t, "ip", "link", "set", hostname, "up", "master", l3.bridge.Iface)
 	host.MustRun(t, "ip", "link", "set", host.Iface, "up")
 	host.MustRun(t, "ip", "link", "set", "lo", "up")
+	host.MustRun(t, "sysctl", "-w", "net.ipv4.ip_forward=1")
+	host.MustRun(t, "sysctl", "-w", "net.ipv6.conf.all.forwarding=1")
 
 	for _, addr := range addrs {
 		host.MustRun(t, "ip", "addr", "add", addr.String(), "dev", host.Iface, "nodad")


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/50566
- replaces https://github.com/moby/moby/pull/50576
- replaces https://github.com/moby/moby/pull/50634

When Docker is using iptables and it enables IP forwarding, unless daemon option `--ip-forward-no-drop` is true, it sets the iptables filter-FORWARD policy to DROP.

When running with nftables - don't do that, raise an error if forwarding is needed but not enabled, unless `--ip-forward=false`.

On a host without IPv4 forwarding enabled, nftables firewall backend, and other settings at defaults - the daemon will fail to start when it tries to create the default bridge. It will fail to restore other networks, but those errors are only logged, not sure why. In other cases, for example `--bridge=none` or creating an IPv6 network when IPv6 global forwarding is disabled, network creation will fail with an error.

Log a warning when migrating from iptables to nftables when the iptables policy is DROP, because it'll drop packets that have been accepted by nftables rules (so, for example, published ports won't work).

_In 29.0, nftables is opt-in, and will be documented as "experimental". So, if we get push-back on this or come up with better ideas, we'll be able to change it._

_Docs will need an update to say it's the user's responsibility to update their firewall rules to block unwanted forwarding between non-Docker network interfaces._

**- How I did it**

- The first two commits are tidy-up - only nftabler needs an iptables cleaner, and only the iptabler (now) needs a method to set the filter-FORWARD policy. So, use those types directly in the bridge driver when needed.
- Raise the error when using nftables and forwarding is not enabled, and update tests.
- Log a warning about the iptables policy on migration to nftables.
- Enable IP forwarding in rootlesskit's netns, before starting the daemon.
- Update `check-config.sh` to report on the IP forwarding sysctls.

**- How to verify it**

- Start Docker with IP forwarding disabled and --firewall-backend=iptables - check the filter-FORWARD policies are DROP.
- Start Docker again with --firewall-backend=nftables, check logs for a warning about the iptables policy, for example ...
```
WARN[2025-08-06T13:26:03.383667797Z] Network traffic for published ports may be dropped, iptables chain FORWARD has policy DROP.  ipv=ipv4
```
- Disable IP forwarding, restart with nftables, check the daemon fails with an error ...
```
failed to start daemon: Error initializing network controller: error creating default "bridge" network: IPv4 forwarding is disabled: check your host's firewalling and set sysctl net.ipv4.ip_forward=1, or disable this check using daemon option --ip-forward=false
```
- With rootless Docker, checked a dual-stack bridge network was created ok with nftables (and wasn't without the sysctls in this PR), and that port publishing worked.

And, updated tests.

**- Human readable description for the release notes**
```markdown changelog
- nftables: Docker will not enable IP forwarding on the host. If forwarding is needed by a bridge network, but not enabled, daemon startup or network creation will fail with an error. You must either enable forwarding and ensure firewall rules are in place to prevent unwanted forwarding between non-Docker interfaces. Or, use daemon option `--ip-forward=false` to disable the check, but some bridge network functionality including port forwarding may not work. See [Engine Docs](https://docs.docker.com/engine/network/firewall-nftables) for more information about migration from iptables to nftables.
```