### PR TITLE
daemon/config: disable the userland proxy by default

### DIFF
--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -36,7 +36,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IPVar(&conf.BridgeConfig.DefaultGatewayIPv6, "default-gateway-v6", nil, "Default gateway IPv6 address for the default bridge network")
 	flags.BoolVar(&conf.BridgeConfig.InterContainerCommunication, "icc", true, "Enable inter-container communication for the default bridge network")
 	flags.IPVar(&conf.BridgeConfig.DefaultIP, "ip", net.IPv4zero, "Host IP for port publishing from the default bridge network")
-	flags.BoolVar(&conf.BridgeConfig.EnableUserlandProxy, "userland-proxy", true, "Use userland proxy for loopback traffic")
+	flags.BoolVar(&conf.BridgeConfig.EnableUserlandProxy, "userland-proxy", false, "Use userland proxy for loopback traffic")
 	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", conf.BridgeConfig.UserlandProxyPath, "Path to the userland proxy binary")
 	flags.BoolVar(&conf.BridgeConfig.AllowDirectRouting, "allow-direct-routing", false, "Allow remote access to published ports on container IP addresses")
 	flags.StringVar(&conf.BridgeConfig.BridgeAcceptFwMark, "bridge-accept-fwmark", "", "In bridge networks, accept packets with this firewall mark/mask")

--- a/daemon/command/daemon_unix_test.go
+++ b/daemon/command/daemon_unix_test.go
@@ -58,7 +58,7 @@ func TestLoadDaemonConfigWithMapOptions(t *testing.T) {
 }
 
 func TestLoadDaemonConfigWithTrueDefaultValues(t *testing.T) {
-	content := `{ "userland-proxy": false }`
+	content := `{ "userland-proxy": true }`
 	tempFile := fs.NewFile(t, "config", fs.WithContent(content))
 
 	opts := defaultOptions(t, tempFile.Path())
@@ -66,12 +66,12 @@ func TestLoadDaemonConfigWithTrueDefaultValues(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
 
-	assert.Check(t, !loadedConfig.EnableUserlandProxy)
+	assert.Check(t, loadedConfig.EnableUserlandProxy)
 
 	// make sure reloading doesn't generate configuration
 	// conflicts after normalizing boolean values.
 	reload := func(reloadedConfig *config.Config) {
-		assert.Check(t, !reloadedConfig.EnableUserlandProxy)
+		assert.Check(t, reloadedConfig.EnableUserlandProxy)
 	}
 	assert.Check(t, config.Reload(opts.configFile, opts.flags, reload))
 }
@@ -84,5 +84,5 @@ func TestLoadDaemonConfigWithTrueDefaultValuesLeaveDefaults(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
 
-	assert.Check(t, loadedConfig.EnableUserlandProxy)
+	assert.Check(t, !loadedConfig.EnableUserlandProxy)
 }


### PR DESCRIPTION
- Closes https://github.com/moby/moby/issues/14856. There were three outstanding issues left in that issue until today. I closed all of them (either marked as 'fixed' or 'won't fix'), so we should be good to go.

**- What I did**

The userland proxy is currently used to handle connections to mapped ports on the loopback address, or from other containers connected to the same network, when they target a host's IP address (e.g. their bridge IP address, or one of the host's 'external' IP addresses).

When the userland proxy is disabled, connections coming from other containers can be DNATed as usual — but the br_netfilter module is required. For loopback connections, IPv4 packets can be DNATed too, but not IPv6 packets (so, it's not possible to map a port to ::1).

As we discovered, there are some special setups where br_netfilter might not be available — commit e7bd60ee added an escape hatch to ignore module loading errors. (Before commit 5c499fc4, br_netfilter was loaded unconditionally, but no loading errors were reported.)

Regarding ::1 mappings, Linux provides no way to disable IPv4 globally. So there are little chances that ::1 is available, but not 127.0.0.1. Mapping a different port to both loopback addresses would be silly. Thus, there are probably no use cases where 127.0.0.1 couldn't be used in place of ::1. But re-enabling the userland proxy is still an option if needed.

The userland proxy also has some drawbacks: it consumes unnecessary resources, and mangles the connection's source address, which can confuse users when they look at their application logs.

I think it'd be best to change this default in v29.0, instead of a minor but let's if it can get enough approval on time.

**- How to verify it**

CI is green.

**- Human readable description for the release notes**

```markdown changelog
- Disable the userland proxy by default
  - The kernel module `br_netfilter` is now required by default. If it's not available on your system, and you don't need to access mapped ports from other containers connected to the same network as the publishing container, you may consider setting `DOCKER_IGNORE_BR_NETFILTER_ERROR=1` to ignore failures to load `br_netfilter`. Otherwise, you need to enable the userland proxy.
  - Mapping ports on `::1` won't work unless you enable the userland proxy. Consider using `127.0.0.1` instead.
```

