### PR TITLE
docs/contributing: remove GIT_BRANCH image tag references

### DIFF
--- a/docs/contributing/set-up-dev-env.md
+++ b/docs/contributing/set-up-dev-env.md
@@ -129,8 +129,7 @@ can take over 15 minutes to complete.
 
    ```none
    Successfully built 3d872560918e
-   Successfully tagged docker-dev:dry-run-test
-   docker run --rm -i --privileged -e BUILDFLAGS -e KEEPBUNDLE -e DOCKER_BUILD_GOGC -e DOCKER_BUILD_PKGS -e DOCKER_CLIENTONLY -e DOCKER_DEBUG -e DOCKER_EXPERIMENTAL -e DOCKER_GITCOMMIT -e DOCKER_GRAPHDRIVER=vfs -e DOCKER_REMAP_ROOT -e DOCKER_STORAGE_OPTS -e DOCKER_USERLANDPROXY -e TESTDIRS -e TESTFLAGS -e TIMEOUT -v "home/ubuntu/repos/docker/bundles:/go/src/github.com/docker/docker/bundles" -t "docker-dev:dry-run-test" bash
+   docker run --rm -i --privileged -e BUILDFLAGS -e KEEPBUNDLE -e DOCKER_BUILD_GOGC -e DOCKER_BUILD_PKGS -e DOCKER_CLIENTONLY -e DOCKER_DEBUG -e DOCKER_EXPERIMENTAL -e DOCKER_GITCOMMIT -e DOCKER_GRAPHDRIVER=vfs -e DOCKER_REMAP_ROOT -e DOCKER_STORAGE_OPTS -e DOCKER_USERLANDPROXY -e TESTDIRS -e TESTFLAGS -e TIMEOUT -v "home/ubuntu/repos/docker/bundles:/go/src/github.com/docker/docker/bundles" -t "docker-dev" bash
    #
    ```
 
@@ -267,12 +266,9 @@ can take over 15 minutes to complete.
 
     ```none
     ubuntu@ubuntu1404:~$ docker ps
-    CONTAINER ID        IMAGE                     COMMAND             CREATED             STATUS              PORTS               NAMES
-    a8b2885ab900        docker-dev:dry-run-test   "hack/dind bash"    43 minutes ago      Up 43 minutes                           hungry_payne
+    CONTAINER ID   IMAGE        COMMAND            CREATED          STATUS          PORTS     NAMES
+    a8b2885ab900   docker-dev   "hack/dind bash"   43 minutes ago   Up 43 minutes             hungry_payne
     ```
-
-    Notice that the tag on the container is marked with the `dry-run-test` branch name.
-
 
 ## Task 3. Make a code change
 

--- a/docs/contributing/test.md
+++ b/docs/contributing/test.md
@@ -108,10 +108,10 @@ Try this now.
 2.  Start a Moby development image.
 
     If you are following along with this guide, you should have a
-    `docker-dev:dry-run-test` image.
+    `docker-dev:latest` image.
 
     ```bash
-    $ docker run --privileged --rm -ti -v `pwd`:/go/src/github.com/docker/docker docker-dev:dry-run-test /bin/bash
+    $ docker run --privileged --rm -ti -v `pwd`:/go/src/github.com/docker/docker docker-dev:latest /bin/bash
     ```
 
 3.  Run the unit tests using the `hack/test/unit` script.


### PR DESCRIPTION
**- What I did**
When creating development containers currently, `Makefile` doesn't use the GIT_BRANCH variable to tag `docker-dev` image. But in some documentation files for contributing, references remain for image tags with the `git branch` name.

This PR simply removes those references. Correct image tag names are important for newcomers, especially for copy-pasteable commands.

- Related PR: #42652

**- A picture of a cute animal (not mandatory but encouraged)**
