### PR TITLE
libn/d/overlay: don't deref nil PeerRecord on error

### DIFF
--- a/daemon/libnetwork/drivers/overlay/joinleave.go
+++ b/daemon/libnetwork/drivers/overlay/joinleave.go
@@ -174,8 +174,7 @@ func (d *driver) EventNotify(nid, tableName, key string, prev, value []byte) {
 		prevPeer, err = UnmarshalPeerRecord(prev)
 		if err != nil {
 			log.G(context.TODO()).WithError(err).Error("Failed to unmarshal previous peer record")
-		}
-		if prevPeer.TunnelEndpointIP == d.advertiseAddress {
+		} else if prevPeer.TunnelEndpointIP == d.advertiseAddress {
 			// Ignore local peers. We don't add them to the VXLAN
 			// FDB so don't need to remove them.
 			prevPeer = nil
@@ -186,8 +185,7 @@ func (d *driver) EventNotify(nid, tableName, key string, prev, value []byte) {
 		newPeer, err = UnmarshalPeerRecord(value)
 		if err != nil {
 			log.G(context.TODO()).WithError(err).Error("Failed to unmarshal peer record")
-		}
-		if newPeer.TunnelEndpointIP == d.advertiseAddress {
+		} else if newPeer.TunnelEndpointIP == d.advertiseAddress {
 			newPeer = nil
 		}
 	}

--- a/daemon/libnetwork/drivers/windows/overlay/joinleave_windows.go
+++ b/daemon/libnetwork/drivers/windows/overlay/joinleave_windows.go
@@ -74,8 +74,7 @@ func (d *driver) EventNotify(nid, tableName, key string, prev, value []byte) {
 		prevPeer, err = overlay.UnmarshalPeerRecord(prev)
 		if err != nil {
 			log.G(context.TODO()).WithError(err).Error("Failed to unmarshal previous peer record")
-		}
-		if prevPeer.TunnelEndpointIP.String() == n.providerAddress {
+		} else if prevPeer.TunnelEndpointIP.String() == n.providerAddress {
 			// Ignore local peers. We don't add them to the VXLAN
 			// FDB so don't need to remove them.
 			prevPeer = nil
@@ -86,8 +85,7 @@ func (d *driver) EventNotify(nid, tableName, key string, prev, value []byte) {
 		newPeer, err = overlay.UnmarshalPeerRecord(value)
 		if err != nil {
 			log.G(context.TODO()).WithError(err).Error("Failed to unmarshal peer record")
-		}
-		if prevPeer.TunnelEndpointIP.String() == n.providerAddress {
+		} else if newPeer.TunnelEndpointIP.String() == n.providerAddress {
 			newPeer = nil
 		}
 	}


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/50393

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
**- How I did it**
Copilot(!!) caught a couple mistakes in the recent overlay changes when reviewing the backport PR #50551. (It only caught the mistakes in the Windows overlay driver, not the Linux one, though.)

If unmarshaling the peer record fails, there is no need to check if it's a record for a local peer. Attempting to do so anyway will result in a nil-dereference panic. Don't do that.

The Windows overlay driver has a typo: prevPeer is being checked twice for whether it was a local-peer record. Check prevPeer once and newPeer once each, as intended.

**- How to verify it**
By inspection.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

