### PR TITLE
dockerfile: download frozen images with regctl 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ ARG BUILDX_VERSION=0.31.1
 # COMPOSE_VERSION is the version of compose to install in the dev container.
 ARG COMPOSE_VERSION=v5.0.2
 
+# REGCTL_VERSION is the version of regctl to install in the dev container.
+ARG REGCTL_VERSION=v0.11.1
+
 ARG SYSTEMD="false"
 ARG FIREWALLD="false"
 ARG DOCKER_STATIC=1
@@ -50,6 +53,9 @@ ARG DELVE_SUPPORTED=${DELVE_SUPPORTED:-"supported"}
 
 # cross compilation helper
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
+
+# regctl is a tool to interact with OCI registries, and is used to export
+FROM --platform=$BUILDPLATFORM regclient/regctl:${REGCTL_VERSION} AS regctl
 
 # dummy stage to make sure the image is built for deps that don't support some
 # architectures
@@ -84,28 +90,21 @@ RUN --mount=type=cache,sharing=locked,id=moby-criu-aptlib,target=/var/lib/apt \
 FROM distribution/distribution:$REGISTRY_VERSION AS registry
 RUN mkdir /build && mv /bin/registry /build/registry
 
-# frozen-images
-# See also frozenImages in "testutil/environment/protect.go" (which needs to
-# be updated when adding images to this list)
-FROM debian:${BASE_DEBIAN_DISTRO} AS frozen-images
-RUN --mount=type=cache,sharing=locked,id=moby-frozen-images-aptlib,target=/var/lib/apt \
-    --mount=type=cache,sharing=locked,id=moby-frozen-images-aptcache,target=/var/cache/apt \
-       apt-get update && apt-get install -y --no-install-recommends \
-           ca-certificates \
-           curl \
-           jq
-# Get useful and necessary Hub images so we can "docker load" locally instead of pulling
-COPY contrib/download-frozen-image-v2.sh /
-ARG TARGETARCH
-ARG TARGETVARIANT
-RUN /download-frozen-image-v2.sh /build \
-        busybox:latest@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209 \
-        busybox:glibc@sha256:1f81263701cddf6402afe9f33fca0266d9fff379e59b1748f33d3072da71ee85 \
-        debian:trixie-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb \
-        hello-world:latest@sha256:d58e752213a51785838f9eed2b7a498ffa1cb3aa7f946dda11af39286c3db9a9 \
-        arm32v7/hello-world:latest@sha256:50b8560ad574c779908da71f7ce370c0a2471c098d44d1c8f6b513c5a55eeeb1 \
-        hello-world:amd64@sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042 \
-        hello-world:arm64@sha256:963612c5503f3f1674f315c67089dee577d8cc6afc18565e0b4183ae355fb343
+# frozen-images gets useful and necessary Hub images so we can "docker load"
+# locally instead of pulling. See also frozenImages in
+# "testutil/environment/protect.go" (which needs to be updated when adding images to this list)
+FROM base AS frozen-images
+RUN --mount=from=regctl,source=/regctl,target=/usr/bin/regctl <<EOT
+  set -ex
+  mkdir /build
+  regctl image export busybox@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209 /build/busybox-latest.tar --name "busybox:latest"
+  regctl image export busybox@sha256:1f81263701cddf6402afe9f33fca0266d9fff379e59b1748f33d3072da71ee85 /build/busybox-glibc.tar --name "busybox:glibc"
+  regctl image export debian@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb /build/debian-trixie-slim.tar --name "debian:trixie-slim"
+  regctl image export hello-world@sha256:d58e752213a51785838f9eed2b7a498ffa1cb3aa7f946dda11af39286c3db9a9 /build/hello-world-latest.tar --name "hello-world:latest"
+  regctl image export arm32v7/hello-world@sha256:50b8560ad574c779908da71f7ce370c0a2471c098d44d1c8f6b513c5a55eeeb1 /build/arm32v7-hello-world-latest.tar --name "arm32v7/hello-world:latest" --platform linux/arm/v7
+  regctl image export hello-world@sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042 /build/hello-world-amd64.tar --name "hello-world:amd64" --platform linux/amd64
+  regctl image export hello-world@sha256:963612c5503f3f1674f315c67089dee577d8cc6afc18565e0b4183ae355fb343 /build/hello-world-arm64.tar --name "hello-world:arm64" --platform linux/arm64
+EOT
 
 # delve
 FROM base AS delve-src

--- a/internal/testutil/fixtures/load/frozen.go
+++ b/internal/testutil/fixtures/load/frozen.go
@@ -1,31 +1,21 @@
 package load
 
 import (
-	"bufio"
 	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/term"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const frozenImgDir = "/docker-frozen-images"
 
-// FrozenImagesLinux loads the frozen image set for the integration suite
-// If the images are not available locally it will download them
-// TODO: This loads whatever is in the frozen image dir, regardless of what
-// images were passed in. If the images need to be downloaded, then it will respect
-// the passed in images
+// FrozenImagesLinux loads the frozen image set for the integration suite.
 func FrozenImagesLinux(ctx context.Context, apiClient client.APIClient, images ...string) error {
 	ctx, span := otel.Tracer("").Start(ctx, "LoadFrozenImages")
 	defer span.End()
@@ -34,10 +24,7 @@ func FrozenImagesLinux(ctx context.Context, apiClient client.APIClient, images .
 	for _, img := range images {
 		if !imageExists(ctx, apiClient, img) {
 			srcName := img
-			// hello-world:latest gets re-tagged as hello-world:frozen
-			// there are some tests that use hello-world:latest specifically so it pulls
-			// the image and hello-world:frozen is used for when we just want a super
-			// small image
+			// hello-world:latest gets re-tagged as hello-world:frozen.
 			if img == "hello-world:frozen" {
 				srcName = "hello-world:latest"
 			}
@@ -48,23 +35,14 @@ func FrozenImagesLinux(ctx context.Context, apiClient client.APIClient, images .
 		}
 	}
 	if len(loadImages) == 0 {
-		// everything is loaded, we're done
 		return nil
 	}
 
-	fi, err := os.Stat(frozenImgDir)
-	if err != nil || !fi.IsDir() {
-		srcImages := make([]string, 0, len(loadImages))
-		for _, img := range loadImages {
-			srcImages = append(srcImages, img.srcName)
-		}
-		if err := pullImages(ctx, apiClient, srcImages); err != nil {
-			return errors.Wrap(err, "error pulling image list")
-		}
-	} else {
-		if err := loadFrozenImages(ctx, apiClient); err != nil {
-			return err
-		}
+	if fi, err := os.Stat(frozenImgDir); err != nil || !fi.IsDir() {
+		return errors.Wrapf(err, "error checking frozen images directory %s", frozenImgDir)
+	}
+	if err := loadFrozenImages(ctx, apiClient); err != nil {
+		return err
 	}
 
 	for _, img := range loadImages {
@@ -101,7 +79,7 @@ func loadFrozenImages(ctx context.Context, apiClient client.APIClient) error {
 			return err
 		}
 		err = func(tarfile fs.FileInfo) error {
-			reader, err := os.OpenFile(filepath.Join(frozenImgDir, tarfile.Name()), os.O_RDONLY, 0644)
+			reader, err := os.OpenFile(filepath.Join(frozenImgDir, tarfile.Name()), os.O_RDONLY, 0o644)
 			if err != nil {
 				return err
 			}
@@ -121,106 +99,4 @@ func loadFrozenImages(ctx context.Context, apiClient client.APIClient) error {
 		}
 	}
 	return nil
-}
-
-func pullImages(ctx context.Context, client client.APIClient, images []string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "error getting path to dockerfile")
-	}
-	dockerfile := os.Getenv("DOCKERFILE")
-	if dockerfile == "" {
-		dockerfile = "Dockerfile"
-	}
-	dockerfilePath := filepath.Join(filepath.Dir(filepath.Clean(cwd)), dockerfile)
-	pullRefs, err := readFrozenImageList(ctx, dockerfilePath, images)
-	if err != nil {
-		return errors.Wrap(err, "error reading frozen image list")
-	}
-
-	var wg sync.WaitGroup
-	chErr := make(chan error, len(images))
-	for tag, ref := range pullRefs {
-		wg.Add(1)
-		go func(tag, ref string) {
-			defer wg.Done()
-			if err := pullTagAndRemove(ctx, client, ref, tag); err != nil {
-				chErr <- err
-				return
-			}
-		}(tag, ref)
-	}
-	wg.Wait()
-	close(chErr)
-	return <-chErr
-}
-
-func pullTagAndRemove(ctx context.Context, apiClient client.APIClient, ref string, tag string) (retErr error) {
-	ctx, span := otel.Tracer("").Start(ctx, "pull image: "+ref+" with tag: "+tag)
-	defer func() {
-		if retErr != nil {
-			// An error here is a real error for the span, so set the span status
-			span.SetStatus(codes.Error, retErr.Error())
-		}
-		span.End()
-	}()
-
-	resp, err := apiClient.ImagePull(ctx, ref, client.ImagePullOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to pull %s", ref)
-	}
-	defer resp.Close()
-	fd, isTerminal := term.GetFdInfo(os.Stdout)
-	if err := jsonmessage.DisplayJSONMessagesStream(resp, os.Stdout, fd, isTerminal, nil); err != nil {
-		return err
-	}
-
-	if _, err := apiClient.ImageTag(ctx, client.ImageTagOptions{Source: ref, Target: tag}); err != nil {
-		return errors.Wrapf(err, "failed to tag %s as %s", ref, tag)
-	}
-	_, err = apiClient.ImageRemove(ctx, ref, client.ImageRemoveOptions{})
-	return errors.Wrapf(err, "failed to remove %s", ref)
-}
-
-func readFrozenImageList(ctx context.Context, dockerfilePath string, images []string) (map[string]string, error) {
-	f, err := os.Open(dockerfilePath)
-	if err != nil {
-		return nil, errors.Wrap(err, "error reading dockerfile")
-	}
-	defer f.Close()
-	ls := make(map[string]string)
-
-	span := trace.SpanFromContext(ctx)
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.Fields(scanner.Text())
-		if len(line) < 3 {
-			continue
-		}
-		if line[0] != "RUN" || line[1] != "./contrib/download-frozen-image-v2.sh" {
-			continue
-		}
-
-		for scanner.Scan() {
-			img := strings.TrimSpace(scanner.Text())
-			img = strings.TrimSuffix(img, "\\")
-			img = strings.TrimSpace(img)
-			split := strings.Split(img, "@")
-			if len(split) < 2 {
-				break
-			}
-
-			for _, i := range images {
-				if split[0] == i {
-					ls[i] = img
-					if span.IsRecording() {
-						span.AddEvent("found frozen image", trace.WithAttributes(attribute.String("image", i)))
-					}
-					break
-				}
-			}
-		}
-	}
-	return ls, nil
 }

--- a/internal/testutil/fixtures/load/frozen.go
+++ b/internal/testutil/fixtures/load/frozen.go
@@ -2,10 +2,9 @@ package load
 
 import (
 	"bufio"
-	"bytes"
 	"context"
+	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -92,31 +91,36 @@ func imageExists(ctx context.Context, client client.APIClient, name string) bool
 }
 
 func loadFrozenImages(ctx context.Context, apiClient client.APIClient) error {
-	ctx, span := otel.Tracer("").Start(ctx, "load frozen images")
-	defer span.End()
+	frozenImages, _ := os.ReadDir(frozenImgDir)
+	for _, frozenImage := range frozenImages {
+		if frozenImage.IsDir() {
+			continue
+		}
+		fi, err := frozenImage.Info()
+		if err != nil {
+			return err
+		}
+		err = func(tarfile fs.FileInfo) error {
+			reader, err := os.OpenFile(filepath.Join(frozenImgDir, tarfile.Name()), os.O_RDONLY, 0644)
+			if err != nil {
+				return err
+			}
+			defer reader.Close()
 
-	tar, err := exec.LookPath("tar")
-	if err != nil {
-		return errors.Wrap(err, "could not find tar binary")
-	}
-	tarCmd := exec.Command(tar, "-cC", frozenImgDir, ".")
-	out, err := tarCmd.StdoutPipe()
-	if err != nil {
-		return errors.Wrap(err, "error getting stdout pipe for tar command")
-	}
+			resp, err := apiClient.ImageLoad(ctx, reader, client.ImageLoadWithQuiet(true))
+			if err != nil {
+				return errors.Wrap(err, "failed to load frozen images")
+			}
+			defer resp.Close()
 
-	errBuf := bytes.NewBuffer(nil)
-	tarCmd.Stderr = errBuf
-	tarCmd.Start()
-	defer tarCmd.Wait()
-
-	resp, err := apiClient.ImageLoad(ctx, out, client.ImageLoadWithQuiet(true))
-	if err != nil {
-		return errors.Wrap(err, "failed to load frozen images")
+			fd, isTerminal := term.GetFdInfo(os.Stdout)
+			return jsonmessage.DisplayJSONMessagesStream(resp, os.Stdout, fd, isTerminal, nil)
+		}(fi)
+		if err != nil {
+			return err
+		}
 	}
-	defer resp.Close()
-	fd, isTerminal := term.GetFdInfo(os.Stdout)
-	return jsonmessage.DisplayJSONMessagesStream(resp, os.Stdout, fd, isTerminal, nil)
+	return nil
 }
 
 func pullImages(ctx context.Context, client client.APIClient, images []string) error {


### PR DESCRIPTION
alternative to https://github.com/moby/moby/pull/50659

Use regctl to download frozen images instead of our script. About rate limitation that might happen in GHA so I was thinking we could mount docker config of the runner as secret when building on CI. Can be a follow-up if you want. Didn't remove the script yet as it lives in contrib dir so might be used by other projects. From a quick look, [not many](https://grep.app/search?q=download-frozen-image-v2.sh).