### PR TITLE
libnet/pa: don't set SO_REUSEADDR on UDP sockets

### DIFF
--- a/daemon/libnetwork/portallocator/osallocator_linux.go
+++ b/daemon/libnetwork/portallocator/osallocator_linux.go
@@ -122,8 +122,10 @@ func bindTCPOrUDP(addr netip.AddrPort, typ int, proto types.Protocol) (_ *os.Fil
 		}
 	}()
 
-	if err := syscall.SetsockoptInt(sd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
-		return nil, fmt.Errorf("failed to setsockopt(SO_REUSEADDR) for %s/%s: %w", addr, proto, err)
+	if proto == syscall.IPPROTO_TCP {
+		if err := syscall.SetsockoptInt(sd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1); err != nil {
+			return nil, fmt.Errorf("failed to setsockopt(SO_REUSEADDR) for %s/%s: %w", addr, proto, err)
+		}
 	}
 
 	if domain == syscall.AF_INET6 {


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/48567
- Related to https://github.com/moby/moby/pull/50054

**- What I did**

The userland proxy uses unconnected UDP sockets to receive packets from anywhere, so enabling SO_REUSEADDR means that multiple sockets can bind the same port. This defeats the purpose of the portallocator, which is supposed to ensure that the port is free and not already in use (either by us, or by another process). So, do not enable SO_REUSEADDR for UDP sockets.

**- How to verify it**

A new unit test is added to make sure that the same UDP port can't be bound more than once.

**- Human readable description for the release notes**

```markdown changelog
- Fix a bug that could cause the Engine and another host process to bind the same UDP port
```
