### PR TITLE
chore: use errors.Join instead of github.com/hashicorp/go-multierror

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,8 @@ linters:
               desc: Use github.com/moby/sys/userns instead.
             - pkg: "github.com/tonistiigi/fsutil"
               desc: The fsutil module does not have a stable API, so we should not have a direct dependency unless necessary.
+            - pkg: "github.com/hashicorp/go-multierror"
+              desc: "Use errors.Join instead"
 
     dupword:
       ignore:

--- a/daemon/cdi.go
+++ b/daemon/cdi.go
@@ -2,16 +2,15 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/containerd/log"
-	"github.com/hashicorp/go-multierror"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
@@ -118,11 +117,11 @@ func (c *cdiHandler) injectCDIDevices(s *specs.Spec, dev *deviceInstance) error 
 
 // getErrors returns a single error representation of errors that may have occurred while refreshing the CDI registry.
 func (c *cdiHandler) getErrors() error {
-	var err *multierror.Error
-	for _, errs := range c.registry.GetErrors() {
-		err = multierror.Append(err, errs...)
+	var errs []error
+	for _, es := range c.registry.GetErrors() {
+		errs = append(errs, es...)
 	}
-	return err.ErrorOrNil()
+	return errors.Join(errs...)
 }
 
 // listDevices uses the CDI cache to list all discovered CDI devices.

--- a/daemon/libnetwork/drivers/overlay/ov_network.go
+++ b/daemon/libnetwork/drivers/overlay/ov_network.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	"github.com/containerd/log"
-	"github.com/hashicorp/go-multierror"
 	"github.com/moby/moby/v2/daemon/libnetwork/driverapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/overlay/overlayutils"
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/countmap"
@@ -543,7 +542,7 @@ func (n *network) initSubnetSandbox(s *subnet) error {
 	}
 	if err := n.driver.programInput(s.vni, n.secure); err != nil {
 		if n.secure {
-			return multierror.Append(err, n.driver.programMangle(s.vni, false))
+			return errors.Join(err, n.driver.programMangle(s.vni, false))
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/hashicorp/go-memdb v1.3.2
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/memberlist v0.4.0
 	github.com/hashicorp/serf v0.8.5
 	github.com/ishidawataru/sctp v0.0.0-20250708014235-1989182a9425
@@ -180,6 +179,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect


### PR DESCRIPTION
**- What I did**

use errors.Join instead of `github.com/hashicorp/go-multierror`

Closes #50670

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

