### PR TITLE
hack/test/unit: run in the right module when TESTDIRS is used

### DIFF
--- a/hack/test/unit
+++ b/hack/test/unit
@@ -18,87 +18,93 @@ TESTDIRS="${TESTDIRS:-./...}"
 
 mkdir -p bundles
 
-cd api
-api_pkg_list=$(go list $TESTDIRS)
-if [ -n "${api_pkg_list}" ]; then
-	gotestsum --format=standard-quiet --jsonfile=../bundles/api-go-test-report.json --junitfile=../bundles/api-junit-report.xml -- \
-		"${BUILDFLAGS[@]}" \
-		-cover \
-		-coverprofile=../bundles/api-coverage.out \
-		-covermode=atomic \
-		${TESTFLAGS} \
-		${api_pkg_list}
+if [[ ${TESTDIRS} == "./api"* || ${TESTDIRS} == "./..." ]]; then
+	pushd api >/dev/null
+	api_pkg_list=$(go list .${TESTDIRS#./api})
+	if [ -n "${api_pkg_list}" ]; then
+		gotestsum --format=standard-quiet --jsonfile=../bundles/api-go-test-report.json --junitfile=../bundles/api-junit-report.xml -- \
+			"${BUILDFLAGS[@]}" \
+			-cover \
+			-coverprofile=../bundles/api-coverage.out \
+			-covermode=atomic \
+			${TESTFLAGS} \
+			${api_pkg_list}
+	fi
+	popd >/dev/null
 fi
 
-cd ../client
+if [[ ${TESTDIRS} == "./client"* || ${TESTDIRS} == "./..." ]]; then
+	pushd client >/dev/null
 
-client_pkg_list=$(go list $TESTDIRS)
-if [ -n "${client_pkg_list}" ]; then
-	gotestsum --format=standard-quiet --jsonfile=../bundles/client-go-test-report.json --junitfile=../bundles/client-junit-report.xml -- \
-		"${BUILDFLAGS[@]}" \
-		-cover \
-		-coverprofile=../bundles/client-coverage.out \
-		-covermode=atomic \
-		${TESTFLAGS} \
-		${client_pkg_list}
+	client_pkg_list=$(go list .${TESTDIRS#./client})
+	if [ -n "${client_pkg_list}" ]; then
+		gotestsum --format=standard-quiet --jsonfile=../bundles/client-go-test-report.json --junitfile=../bundles/client-junit-report.xml -- \
+			"${BUILDFLAGS[@]}" \
+			-cover \
+			-coverprofile=../bundles/client-coverage.out \
+			-covermode=atomic \
+			${TESTFLAGS} \
+			${client_pkg_list}
+	fi
+	popd >/dev/null
 fi
 
-cd ..
+if [[ ${TESTDIRS} != "./api"* && ${TESTDIRS} != "./client"* ]]; then
+	exclude_paths='/vendor/|/integration'
+	pkgs=$(go list $TESTDIRS | grep -vE "($exclude_paths)")
 
-exclude_paths='/vendor/|/integration'
-pkgs=$(go list $TESTDIRS | grep -vE "($exclude_paths)")
+	pkg_list=$(echo "${pkgs}" | grep --fixed-strings -v "/libnetwork" || :)
+	libnetwork_pkg_list=$(echo "${pkgs}" | grep --fixed-strings "/libnetwork" || :)
 
-pkg_list=$(echo "${pkgs}" | grep --fixed-strings -v "/libnetwork" || :)
-libnetwork_pkg_list=$(echo "${pkgs}" | grep --fixed-strings "/libnetwork" || :)
+	echo "${libnetwork_pkg_list}" | grep --fixed-strings "libnetwork/drivers/bridge" \
+		&& if ! type docker-proxy; then
+			hack/make.sh binary-proxy install-proxy
+		fi
 
-echo "${libnetwork_pkg_list}" | grep --fixed-strings "libnetwork/drivers/bridge" \
-	&& if ! type docker-proxy; then
-		hack/make.sh binary-proxy install-proxy
+	if [ -n "${pkg_list}" ]; then
+		gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report.json --junitfile=bundles/junit-report.xml -- \
+			"${BUILDFLAGS[@]}" \
+			-cover \
+			-coverprofile=bundles/coverage.out \
+			-covermode=atomic \
+			${TESTFLAGS} \
+			${pkg_list}
 	fi
 
-if [ -n "${pkg_list}" ]; then
-	gotestsum --format=standard-quiet --jsonfile=bundles/go-test-report.json --junitfile=bundles/junit-report.xml -- \
-		"${BUILDFLAGS[@]}" \
-		-cover \
-		-coverprofile=bundles/coverage.out \
-		-covermode=atomic \
-		${TESTFLAGS} \
-		${pkg_list}
-fi
+	if [ -n "${libnetwork_pkg_list}" ]; then
+		rerun_flaky=1
 
-if [ -n "${libnetwork_pkg_list}" ]; then
-	rerun_flaky=1
+		gotest_extra_flags="-skip=TestFlaky.*"
+		# Custom -run passed, don't run flaky tests separately.
+		if echo "$TESTFLAGS" | grep -Eq '(-run|-test.run)[= ]'; then
+			rerun_flaky=0
+			gotest_extra_flags=""
+		fi
 
-	gotest_extra_flags="-skip=TestFlaky.*"
-	# Custom -run passed, don't run flaky tests separately.
-	if echo "$TESTFLAGS" | grep -Eq '(-run|-test.run)[= ]'; then
-		rerun_flaky=0
-		gotest_extra_flags=""
-	fi
-
-	# libnetwork tests invoke iptables, and cannot be run in parallel. Execute
-	# tests within /libnetwork with '-p=1' to run them sequentially. See
-	# https://github.com/moby/moby/issues/42458#issuecomment-873216754 for details.
-	gotestsum --format=standard-quiet --jsonfile=bundles/libnetwork-go-test-report.json --junitfile=bundles/libnetwork-junit-report.xml \
-		-- "${BUILDFLAGS[@]}" \
-		-cover \
-		-coverprofile=bundles/libnetwork-coverage.out \
-		-covermode=atomic \
-		-p=1 \
-		${gotest_extra_flags} \
-		${TESTFLAGS} \
-		${libnetwork_pkg_list}
-
-	if [ $rerun_flaky -eq 1 ]; then
-		gotestsum --format=standard-quiet --jsonfile=bundles/libnetwork-flaky-go-test-report.json --junitfile=bundles/libnetwork-flaky-junit-report.xml \
-			--packages "${libnetwork_pkg_list}" \
-			--rerun-fails=4 \
+		# libnetwork tests invoke iptables, and cannot be run in parallel. Execute
+		# tests within /libnetwork with '-p=1' to run them sequentially. See
+		# https://github.com/moby/moby/issues/42458#issuecomment-873216754 for details.
+		gotestsum --format=standard-quiet --jsonfile=bundles/libnetwork-go-test-report.json --junitfile=bundles/libnetwork-junit-report.xml \
 			-- "${BUILDFLAGS[@]}" \
 			-cover \
-			-coverprofile=bundles/libnetwork-flaky-coverage.out \
+			-coverprofile=bundles/libnetwork-coverage.out \
 			-covermode=atomic \
 			-p=1 \
-			-test.run 'TestFlaky.*' \
-			${TESTFLAGS}
+			${gotest_extra_flags} \
+			${TESTFLAGS} \
+			${libnetwork_pkg_list}
+
+		if [ $rerun_flaky -eq 1 ]; then
+			gotestsum --format=standard-quiet --jsonfile=bundles/libnetwork-flaky-go-test-report.json --junitfile=bundles/libnetwork-flaky-junit-report.xml \
+				--packages "${libnetwork_pkg_list}" \
+				--rerun-fails=4 \
+				-- "${BUILDFLAGS[@]}" \
+				-cover \
+				-coverprofile=bundles/libnetwork-flaky-coverage.out \
+				-covermode=atomic \
+				-p=1 \
+				-test.run 'TestFlaky.*' \
+				${TESTFLAGS}
+		fi
 	fi
 fi


### PR DESCRIPTION
**- What I did**

Since 'api/' and 'client/' are separate Go modules, tests need to be run separately in each module. Commit https://github.com/moby/moby/commit/900a0516de7e9261474c67ebd39f8ddd652060fa changed the hack/test/unit script to account for that.

But since that commit, if that script is invoked with TESTDIRS set, it will try every module instead of locating the one containing TESTDIRS.