### PR TITLE
chore: use fmt.Errorf instead of errors.Errorf

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,6 +112,9 @@ linters:
         - pkg: github.com/moby/moby/v2/internal/nlwrap$
           pattern: ^nlwrap.Handle.(BridgeVlanList|ChainList|ClassList|ConntrackDeleteFilter$|DevLinkGetDeviceList|DevLinkGetAllPortList|DevlinkGetDeviceParams|FilterList|FouList|GenlFamilyList|GTPPDPList|LinkByAlias|LinkSubscribeWithOptions|NeighList$|NeighProxyList|NeighListExecute|NeighSubscribeWithOptions|LinkGetProtinfo|QdiscList|RdmaLinkList|RdmaLinkByName|RdmaLinkDel|RouteListFilteredIter|RuleListFiltered$|RouteSubscribeWithOptions|RuleList$|RuleListFiltered|SocketGet|SocketDiagTCPInfo|SocketDiagTCP|SocketDiagUDPInfo|SocketDiagUDP|UnixSocketDiagInfo|UnixSocketDiag|VDPAGetDevConfigList|VDPAGetDevList|VDPAGetMGMTDevList)
           msg: Add a wrapper to nlwrap.Handle for EINTR handling and update the list in .golangci.yml.
+        - pkg: ^github.com/pkg/errors$
+          pattern: ^errors\.Errorf
+          msg: Use fmt.Errorf instead.
       analyze-types: true
 
     gocritic:

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -25,7 +25,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 	if req.DetachKeys != "" {
 		keys, err = term.ToBytes(req.DetachKeys)
 		if err != nil {
-			return errdefs.InvalidParameter(errors.Errorf("Invalid detach keys (%s) provided", req.DetachKeys))
+			return errdefs.InvalidParameter(fmt.Errorf("Invalid detach keys (%s) provided", req.DetachKeys))
 		}
 	}
 

--- a/daemon/builder/backend/backend.go
+++ b/daemon/builder/backend/backend.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
 	"github.com/distribution/reference"
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
@@ -14,8 +17,6 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
 	"github.com/moby/moby/v2/daemon/server/backend"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 )
 
 // ImageComponent provides an interface for working with images
@@ -122,7 +123,7 @@ func squashBuild(build *builder.Result, imageComponent ImageComponent) (string, 
 	}
 	imageID, err := imageComponent.SquashImage(build.ImageID, fromID)
 	if err != nil {
-		return "", errors.Wrap(err, "error squashing image")
+		return "", fmt.Errorf("error squashing image: %w", err)
 	}
 	return imageID, nil
 }

--- a/daemon/builder/dockerfile/builder.go
+++ b/daemon/builder/dockerfile/builder.go
@@ -197,7 +197,7 @@ func (b *Builder) build(ctx context.Context, source builder.Source, dockerfile *
 		targetIx, found := instructions.HasStage(stages, b.options.Target)
 		if !found {
 			buildsFailed.WithValues(metricsBuildTargetNotReachableError).Inc()
-			return nil, errdefs.InvalidParameter(errors.Errorf("target stage %q could not be found", b.options.Target))
+			return nil, errdefs.InvalidParameter(fmt.Errorf("target stage %q could not be found", b.options.Target))
 		}
 		stages = stages[:targetIx+1]
 	}
@@ -333,7 +333,7 @@ func BuildFromConfig(ctx context.Context, config *container.Config, changes []st
 	var commands []instructions.Command
 	for _, n := range dockerfile.AST.Children {
 		if !validCommitCommands[strings.ToLower(n.Value)] {
-			return nil, errdefs.InvalidParameter(errors.Errorf("%s is not a valid change command", n.Value))
+			return nil, errdefs.InvalidParameter(fmt.Errorf("%s is not a valid change command", n.Value))
 		}
 		cmd, err := instructions.ParseCommand(n)
 		if err != nil {

--- a/daemon/builder/dockerfile/copy.go
+++ b/daemon/builder/dockerfile/copy.go
@@ -105,7 +105,7 @@ func (o *copier) createCopyInstruction(sourcesAndDest instructions.SourcesAndDes
 		return inst, errors.Wrapf(err, "%s failed", cmdName)
 	}
 	if len(infos) > 1 && !strings.HasSuffix(inst.dest, string(os.PathSeparator)) {
-		return inst, errors.Errorf("When using %s with more than one source file, the destination must be a directory and end with a /", cmdName)
+		return inst, fmt.Errorf("When using %s with more than one source file, the destination must be a directory and end with a /", cmdName)
 	}
 	inst.infos = infos
 	return inst, nil
@@ -143,7 +143,7 @@ func (o *copier) getCopyInfoForSourcePath(orig, dest string) ([]copyInfo, error)
 	// We have to make sure dest is available
 	if path == "" {
 		if strings.HasSuffix(dest, "/") {
-			return nil, errors.Errorf("cannot determine filename for source %s", orig)
+			return nil, fmt.Errorf("cannot determine filename for source %s", orig)
 		}
 		path = unnamedFilename
 	}
@@ -195,7 +195,7 @@ func (o *copier) calcCopyInfo(origPath string, allowWildcards bool) ([]copyInfo,
 	}
 
 	if o.source == nil {
-		return nil, errors.Errorf("missing build context")
+		return nil, errors.New("missing build context")
 	}
 
 	// Work in daemon-specific OS filepath semantics

--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -276,7 +276,7 @@ func (d *dispatchRequest) getFromImage(ctx context.Context, shlex *shell.Lex, ba
 	// Empty string is interpreted to FROM scratch by images.GetImageAndReleasableLayer,
 	// so validate expanded result is not empty.
 	if name == "" {
-		return nil, errors.Errorf("base name (%s) should not be blank", basename)
+		return nil, fmt.Errorf("base name (%s) should not be blank", basename)
 	}
 
 	return d.getImageOrStage(ctx, name, platform)
@@ -339,7 +339,7 @@ func dispatchRun(ctx context.Context, d dispatchRequest, c *instructions.RunComm
 
 	if len(c.FlagsUsed) > 0 {
 		// classic builder RUN currently does not support any flags, so fail on the first one
-		return errors.Errorf("the --%s option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled", c.FlagsUsed[0])
+		return fmt.Errorf("the --%s option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled", c.FlagsUsed[0])
 	}
 
 	stateRunConfig := d.state.runConfig

--- a/daemon/builder/dockerfile/evaluator.go
+++ b/daemon/builder/dockerfile/evaluator.go
@@ -21,6 +21,7 @@ package dockerfile
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -101,7 +102,7 @@ func dispatch(ctx context.Context, d dispatchRequest, cmd instructions.Command) 
 	case *instructions.ShellCommand:
 		return dispatchShell(ctx, d, c)
 	}
-	return errors.Errorf("unsupported command type: %v", reflect.TypeOf(cmd))
+	return fmt.Errorf("unsupported command type: %v", reflect.TypeOf(cmd))
 }
 
 // dispatchState is a data object which is modified by dispatchers
@@ -165,7 +166,7 @@ func (r *stagesBuildResults) get(nameOrIndex string) (*container.Config, error) 
 func (r *stagesBuildResults) checkStageNameAvailable(name string) error {
 	if name != "" {
 		if _, ok := r.getByName(name); ok {
-			return errors.Errorf("%s stage name already used", name)
+			return fmt.Errorf("%s stage name already used", name)
 		}
 	}
 	return nil
@@ -174,7 +175,7 @@ func (r *stagesBuildResults) checkStageNameAvailable(name string) error {
 func (r *stagesBuildResults) commitStage(name string, config *container.Config) error {
 	if name != "" {
 		if _, ok := r.getByName(name); ok {
-			return errors.Errorf("%s stage name already used", name)
+			return fmt.Errorf("%s stage name already used", name)
 		}
 		r.indexed[strings.ToLower(name)] = config
 	}

--- a/daemon/builder/dockerfile/internals.go
+++ b/daemon/builder/dockerfile/internals.go
@@ -75,7 +75,7 @@ func (b *Builder) exportImage(ctx context.Context, state *dispatchState, layer b
 
 	parentImage, ok := parent.(*image.Image)
 	if !ok {
-		return errors.Errorf("unexpected image type")
+		return errors.New("unexpected image type")
 	}
 
 	platform := &ocispec.Platform{

--- a/daemon/builder/remotecontext/detect.go
+++ b/daemon/builder/remotecontext/detect.go
@@ -64,7 +64,7 @@ func withDockerfileFromContext(c modifiableContext, dockerfilePath string) (buil
 					return withDockerfileFromContext(c, lowercase)
 				}
 			}
-			return nil, nil, errors.Errorf("Cannot locate specified Dockerfile: %s", dockerfilePath) // backwards compatible error
+			return nil, nil, fmt.Errorf("Cannot locate specified Dockerfile: %s", dockerfilePath) // backwards compatible error
 		}
 		c.Close()
 		return nil, nil, err
@@ -143,7 +143,7 @@ func readAndParseDockerfile(name string, rc io.Reader) (*parser.Result, error) {
 	br := bufio.NewReader(rc)
 	if _, err := br.Peek(1); err != nil {
 		if err == io.EOF {
-			return nil, errdefs.InvalidParameter(errors.Errorf("the Dockerfile (%s) cannot be empty", name))
+			return nil, errdefs.InvalidParameter(fmt.Errorf("the Dockerfile (%s) cannot be empty", name))
 		}
 		return nil, errors.Wrap(err, "unexpected error reading Dockerfile")
 	}

--- a/daemon/builder/remotecontext/git/gitutils.go
+++ b/daemon/builder/remotecontext/git/gitutils.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -113,7 +114,7 @@ func parseRemoteURL(remoteURL string) (gitRepo, error) {
 	}
 
 	if strings.HasPrefix(repo.ref, "-") {
-		return gitRepo{}, errors.Errorf("invalid refspec: %s", repo.ref)
+		return gitRepo{}, fmt.Errorf("invalid refspec: %s", repo.ref)
 	}
 
 	return repo, nil
@@ -193,7 +194,7 @@ func (repo gitRepo) checkout(root string) (string, error) {
 			return "", err
 		}
 		if !fi.IsDir() {
-			return "", errors.Errorf("error setting git context, not a directory: %s", newCtx)
+			return "", fmt.Errorf("error setting git context, not a directory: %s", newCtx)
 		}
 		root = newCtx
 	}

--- a/daemon/cluster/controllers/plugin/controller.go
+++ b/daemon/cluster/controllers/plugin/controller.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -114,7 +115,7 @@ func (p *Controller) Prepare(ctx context.Context) (retErr error) {
 
 	if err == nil && pl != nil {
 		if pl.SwarmServiceID != p.serviceID {
-			return errors.Errorf("plugin already exists: %s", p.spec.Name)
+			return fmt.Errorf("plugin already exists: %s", p.spec.Name)
 		}
 		if pl.IsEnabled() {
 			if err := p.backend.Disable(pl.GetID(), &backend.PluginDisableConfig{ForceDisable: true}); err != nil {

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -624,7 +624,7 @@ func (c *Cluster) imageWithDigestString(ctx context.Context, image string, authC
 		if _, ok := ref.(reference.Digested); ok {
 			return image, nil
 		}
-		return "", errors.Errorf("unknown image reference format: %s", image)
+		return "", fmt.Errorf("unknown image reference format: %s", image)
 	}
 	// only query registry if not a canonical reference (i.e. with digest)
 	if _, ok := namedRef.(reference.Canonical); !ok {
@@ -632,7 +632,7 @@ func (c *Cluster) imageWithDigestString(ctx context.Context, image string, authC
 
 		taggedRef, ok := namedRef.(reference.NamedTagged)
 		if !ok {
-			return "", errors.Errorf("image reference not tagged: %s", image)
+			return "", fmt.Errorf("image reference not tagged: %s", image)
 		}
 
 		// Fetch the image manifest's digest; if a mirror is configured, try the

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -351,7 +351,7 @@ func (c *Cluster) UnlockSwarm(req types.UnlockRequest) error {
 		if errors.Is(err, errSwarmLocked) {
 			return invalidUnlockKey{}
 		}
-		return errors.Errorf("swarm component could not be started: %v", err)
+		return fmt.Errorf("swarm component could not be started: %v", err)
 	}
 	return nil
 }

--- a/daemon/command/daemon_unix.go
+++ b/daemon/command/daemon_unix.go
@@ -4,6 +4,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -47,7 +48,7 @@ func setDefaultUmask() error {
 	desiredUmask := 0o022
 	unix.Umask(desiredUmask)
 	if umask := unix.Umask(desiredUmask); umask != desiredUmask {
-		return errors.Errorf("failed to set umask: expected %#o, got %#o", desiredUmask, umask)
+		return fmt.Errorf("failed to set umask: expected %#o, got %#o", desiredUmask, umask)
 	}
 
 	return nil
@@ -87,13 +88,13 @@ func allocateDaemonPort(addr string) error {
 	if parsedIP := net.ParseIP(host); parsedIP != nil {
 		hostIPs = append(hostIPs, parsedIP)
 	} else if hostIPs, err = net.LookupIP(host); err != nil {
-		return errors.Errorf("failed to lookup %s address in host specification", host)
+		return fmt.Errorf("failed to lookup %s address in host specification", host)
 	}
 
 	pa := portallocator.Get()
 	for _, hostIP := range hostIPs {
 		if _, err := pa.RequestPort(hostIP, "tcp", intPort); err != nil {
-			return errors.Errorf("failed to allocate daemon listening port %d (err: %v)", intPort, err)
+			return fmt.Errorf("failed to allocate daemon listening port %d (err: %v)", intPort, err)
 		}
 	}
 	return nil

--- a/daemon/command/required.go
+++ b/daemon/command/required.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -17,7 +18,7 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 		return errors.New("\n" + strings.TrimRight(cmd.UsageString(), "\n"))
 	}
 
-	return errors.Errorf(
+	return fmt.Errorf(
 		"\"%s\" accepts no argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 		cmd.CommandPath(),
 		cmd.CommandPath(),

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -14,7 +14,6 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/metrics"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
-	"github.com/pkg/errors"
 )
 
 // merge merges two Config, the image container configuration (defaults values),
@@ -133,7 +132,7 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 
 	// It is not possible to commit a running container on Windows
 	if isWindows && container.IsRunning() {
-		return "", errors.Errorf("%+v does not support commit of a running container", runtime.GOOS)
+		return "", fmt.Errorf("%+v does not support commit of a running container", runtime.GOOS)
 	}
 
 	if container.IsDead() {

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -375,7 +375,7 @@ func GetConflictFreeLabels(labels []string) ([]string, error) {
 		if ok {
 			// If there is a conflict we will return an error
 			if v, ok := labelMap[key]; ok && v != val {
-				return nil, errors.Errorf("conflict labels for %s=%s and %s=%s", key, val, key, v)
+				return nil, fmt.Errorf("conflict labels for %s=%s and %s=%s", key, val, key, v)
 			}
 			labelMap[key] = val
 		}
@@ -611,7 +611,7 @@ func findConfigurationConflicts(config map[string]any, flags *pflag.FlagSet) err
 		for key := range unknownKeys {
 			unknown = append(unknown, key)
 		}
-		return errors.Errorf("the following directives don't match any configuration option: %s", strings.Join(unknown, ", "))
+		return fmt.Errorf("the following directives don't match any configuration option: %s", strings.Join(unknown, ", "))
 	}
 
 	// 3. Search keys that are present as a flag and as a file option.
@@ -661,7 +661,7 @@ func findConfigurationConflicts(config map[string]any, flags *pflag.FlagSet) err
 	}
 
 	if len(conflicts) > 0 {
-		errs = append(errs, errors.Errorf("the following directives are specified both as a flag and in the configuration file: %s", strings.Join(conflicts, ", ")))
+		errs = append(errs, fmt.Errorf("the following directives are specified both as a flag and in the configuration file: %s", strings.Join(conflicts, ", ")))
 	}
 	return stderrors.Join(errs...)
 }
@@ -677,10 +677,10 @@ func ValidateMinAPIVersion(ver string) error {
 		return errors.New(`API version must be provided without "v" prefix`)
 	}
 	if versions.LessThan(ver, defaultMinAPIVersion) {
-		return errors.Errorf(`minimum supported API version is %s: %s`, defaultMinAPIVersion, ver)
+		return fmt.Errorf(`minimum supported API version is %s: %s`, defaultMinAPIVersion, ver)
 	}
 	if versions.GreaterThan(ver, DefaultAPIVersion) {
-		return errors.Errorf(`maximum supported API version is %s: %s`, DefaultAPIVersion, ver)
+		return fmt.Errorf(`maximum supported API version is %s: %s`, DefaultAPIVersion, ver)
 	}
 	return nil
 }
@@ -697,7 +697,7 @@ func Validate(config *Config) error {
 		case "panic", "fatal", "error", "warn", "info", "debug", "trace":
 			// These are valid. See [log.SetLevel] for a list of accepted levels.
 		default:
-			return errors.Errorf("invalid logging level: %s", config.LogLevel)
+			return fmt.Errorf("invalid logging level: %s", config.LogLevel)
 		}
 	}
 
@@ -707,7 +707,7 @@ func Validate(config *Config) error {
 		case log.TextFormat, log.JSONFormat:
 			// These are valid
 		default:
-			return errors.Errorf("invalid log format: %s", logFormat)
+			return fmt.Errorf("invalid log format: %s", logFormat)
 		}
 	}
 
@@ -732,19 +732,19 @@ func Validate(config *Config) error {
 
 	// TODO(thaJeztah) Validations below should not accept "0" to be valid; see Validate() for a more in-depth description of this problem
 	if config.MTU < 0 {
-		return errors.Errorf("invalid default MTU: %d", config.MTU)
+		return fmt.Errorf("invalid default MTU: %d", config.MTU)
 	}
 	if config.MaxConcurrentDownloads < 0 {
-		return errors.Errorf("invalid max concurrent downloads: %d", config.MaxConcurrentDownloads)
+		return fmt.Errorf("invalid max concurrent downloads: %d", config.MaxConcurrentDownloads)
 	}
 	if config.MaxConcurrentUploads < 0 {
-		return errors.Errorf("invalid max concurrent uploads: %d", config.MaxConcurrentUploads)
+		return fmt.Errorf("invalid max concurrent uploads: %d", config.MaxConcurrentUploads)
 	}
 	if config.MaxDownloadAttempts < 0 {
-		return errors.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
+		return fmt.Errorf("invalid max download attempts: %d", config.MaxDownloadAttempts)
 	}
 	if config.NetworkDiagnosticPort < 0 || config.NetworkDiagnosticPort > 65535 {
-		return errors.Errorf("invalid network-diagnostic-port (%d): value must be between 0 and 65535", config.NetworkDiagnosticPort)
+		return fmt.Errorf("invalid network-diagnostic-port (%d): value must be between 0 and 65535", config.NetworkDiagnosticPort)
 	}
 
 	if _, err := ParseGenericResources(config.NodeGenericResources); err != nil {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -299,7 +299,7 @@ func validateHostConfig(hostConfig *containertypes.HostConfig) (warnings []strin
 	}
 
 	if hostConfig.AutoRemove && !hostConfig.RestartPolicy.IsNone() {
-		return warnings, errors.Errorf("can't create 'AutoRemove' container with restart policy")
+		return warnings, errors.New("can't create 'AutoRemove' container with restart policy")
 	}
 	// Validate mounts; check if host directories still exist
 	parser := volumemounts.NewParser()
@@ -329,11 +329,11 @@ func validateHostConfig(hostConfig *containertypes.HostConfig) (warnings []strin
 		return warnings, err
 	}
 	if !hostConfig.Isolation.IsValid() {
-		return warnings, errors.Errorf("invalid isolation '%s' on %s", hostConfig.Isolation, runtime.GOOS)
+		return warnings, fmt.Errorf("invalid isolation '%s' on %s", hostConfig.Isolation, runtime.GOOS)
 	}
 	for k := range hostConfig.Annotations {
 		if k == "" {
-			return warnings, errors.Errorf("invalid Annotations: the empty string is not permitted as an annotation key")
+			return warnings, errors.New("invalid Annotations: the empty string is not permitted as an annotation key")
 		}
 	}
 	return warnings, nil
@@ -356,19 +356,19 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 		return nil
 	}
 	if healthConfig.Interval != 0 && healthConfig.Interval < containertypes.MinimumDuration {
-		return errors.Errorf("Interval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("Interval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	if healthConfig.Timeout != 0 && healthConfig.Timeout < containertypes.MinimumDuration {
-		return errors.Errorf("Timeout in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("Timeout in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	if healthConfig.Retries < 0 {
-		return errors.Errorf("Retries in Healthcheck cannot be negative")
+		return errors.New("Retries in Healthcheck cannot be negative")
 	}
 	if healthConfig.StartPeriod != 0 && healthConfig.StartPeriod < containertypes.MinimumDuration {
-		return errors.Errorf("StartPeriod in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("StartPeriod in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	if healthConfig.StartInterval != 0 && healthConfig.StartInterval < containertypes.MinimumDuration {
-		return errors.Errorf("StartInterval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
+		return fmt.Errorf("StartInterval in Healthcheck cannot be less than %s", containertypes.MinimumDuration)
 	}
 	return nil
 }
@@ -377,12 +377,12 @@ func validatePortBindings(ports containertypes.PortMap) error {
 	for port := range ports {
 		_, portStr := nat.SplitProtoPort(string(port))
 		if _, err := nat.ParsePort(portStr); err != nil {
-			return errors.Errorf("invalid port specification: %q", portStr)
+			return fmt.Errorf("invalid port specification: %q", portStr)
 		}
 		for _, pb := range ports[port] {
 			_, err := nat.NewPort(nat.SplitProtoPort(pb.HostPort))
 			if err != nil {
-				return errors.Errorf("invalid port specification: %q", pb.HostPort)
+				return fmt.Errorf("invalid port specification: %q", pb.HostPort)
 			}
 		}
 	}

--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -335,7 +335,7 @@ func (container *Container) SetupWorkingDirectory(uid int, gid int) error {
 	if err := user.MkdirAllAndChown(pth, 0o755, uid, gid, user.WithOnlyNew); err != nil {
 		pthInfo, err2 := os.Stat(pth)
 		if err2 == nil && pthInfo != nil && !pthInfo.IsDir() {
-			return errors.Errorf("Cannot mkdir: %s is not a directory", container.Config.WorkingDir)
+			return fmt.Errorf("Cannot mkdir: %s is not a directory", container.Config.WorkingDir)
 		}
 
 		return err

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -490,7 +490,7 @@ func killProcessDirectly(ctr *container.Container) error {
 			return err
 		}
 		if isZombie {
-			return errdefs.System(errors.Errorf("container %s PID %d is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes", stringid.TruncateID(ctr.ID), pid))
+			return errdefs.System(fmt.Errorf("container %s PID %d is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes", stringid.TruncateID(ctr.ID), pid))
 		}
 	}
 	return nil

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -299,10 +299,10 @@ func (i *ImageService) getPushDescriptor(ctx context.Context, img c8dimages.Imag
 				return bestMatch.Target(), nil
 			}
 
-			return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple matching manifests found but no specific platform requested"))
+			return ocispec.Descriptor{}, errdefs.Conflict(errors.New("multiple matching manifests found but no specific platform requested"))
 		}
 
-		return ocispec.Descriptor{}, errdefs.Conflict(errors.Errorf("multiple manifests found for platform %s", platforms.FormatAll(*platform)))
+		return ocispec.Descriptor{}, errdefs.Conflict(fmt.Errorf("multiple manifests found for platform %s", platforms.FormatAll(*platform)))
 	}
 }
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -663,16 +663,16 @@ func verifyPlatformContainerSettings(daemon *Daemon, daemonCfg *configStore, hos
 	}
 
 	if !hostConfig.IpcMode.Valid() {
-		return warnings, errors.Errorf("invalid IPC mode: %v", hostConfig.IpcMode)
+		return warnings, fmt.Errorf("invalid IPC mode: %v", hostConfig.IpcMode)
 	}
 	if !hostConfig.PidMode.Valid() {
-		return warnings, errors.Errorf("invalid PID mode: %v", hostConfig.PidMode)
+		return warnings, fmt.Errorf("invalid PID mode: %v", hostConfig.PidMode)
 	}
 	if hostConfig.ShmSize < 0 {
 		return warnings, errors.New("SHM size can not be less than 0")
 	}
 	if !hostConfig.UTSMode.Valid() {
-		return warnings, errors.Errorf("invalid UTS mode: %v", hostConfig.UTSMode)
+		return warnings, fmt.Errorf("invalid UTS mode: %v", hostConfig.UTSMode)
 	}
 
 	if hostConfig.OomScoreAdj < -1000 || hostConfig.OomScoreAdj > 1000 {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -16,7 +16,7 @@ func isNotRunning(err error) bool {
 }
 
 func errNotRunning(id string) error {
-	return &containerNotRunningError{errors.Errorf("container %s is not running", id)}
+	return &containerNotRunningError{fmt.Errorf("container %s is not running", id)}
 }
 
 type containerNotRunningError struct {
@@ -41,7 +41,7 @@ func (e objNotFoundError) Error() string {
 func (e objNotFoundError) NotFound() {}
 
 func errContainerIsRestarting(containerID string) error {
-	cause := errors.Errorf("Container %s is restarting, wait until the container is running", containerID)
+	cause := fmt.Errorf("Container %s is restarting, wait until the container is running", containerID)
 	return errdefs.Conflict(cause)
 }
 
@@ -50,12 +50,12 @@ func errExecNotFound(id string) error {
 }
 
 func errExecPaused(id string) error {
-	cause := errors.Errorf("Container %s is paused, unpause the container before exec", id)
+	cause := fmt.Errorf("Container %s is paused, unpause the container before exec", id)
 	return errdefs.Conflict(cause)
 }
 
 func errNotPaused(id string) error {
-	cause := errors.Errorf("Container %s is already paused", id)
+	cause := fmt.Errorf("Container %s is already paused", id)
 	return errdefs.Conflict(cause)
 }
 

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -114,7 +114,7 @@ type FileGetCloser interface {
 // Register registers an InitFunc for the driver.
 func Register(name string, initFunc InitFunc) error {
 	if _, exists := drivers[name]; exists {
-		return errors.Errorf("name already registered %s", name)
+		return fmt.Errorf("name already registered %s", name)
 	}
 	drivers[name] = initFunc
 
@@ -194,7 +194,7 @@ func New(driverName string, config Options) (Driver, error) {
 					driversSlice = append(driversSlice, d)
 				}
 
-				err = errors.Errorf("%s contains several valid graphdrivers: %s; cleanup or explicitly choose storage driver (-s <DRIVER>)", config.Root, strings.Join(driversSlice, ", "))
+				err = fmt.Errorf("%s contains several valid graphdrivers: %s; cleanup or explicitly choose storage driver (-s <DRIVER>)", config.Root, strings.Join(driversSlice, ", "))
 				log.G(ctx).Errorf("[graphdriver] %v", err)
 				return nil, err
 			}
@@ -229,7 +229,7 @@ func New(driverName string, config Options) (Driver, error) {
 		return driver, nil
 	}
 
-	return nil, errors.Errorf("no supported storage driver found")
+	return nil, errors.New("no supported storage driver found")
 }
 
 // scanPriorDrivers returns an un-ordered scan of directories of prior storage

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -120,11 +120,11 @@ func (d *Driver) parseOptions(options []string) error {
 			}
 		case xattrsStorageOpt:
 			if val != bestEffortXattrsOptValue {
-				return errdefs.InvalidParameter(errors.Errorf("do not set the " + xattrsStorageOpt + " option unless you are willing to accept the consequences"))
+				return errdefs.InvalidParameter(fmt.Errorf("do not set the %s option unless you are willing to accept the consequences", xattrsStorageOpt))
 			}
 			d.bestEffortXattrs = true
 		default:
-			return errdefs.InvalidParameter(errors.Errorf("unknown option %s for vfs", key))
+			return errdefs.InvalidParameter(fmt.Errorf("unknown option %s for vfs", key))
 		}
 	}
 	return nil
@@ -148,7 +148,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 				}
 				quotaSize = uint64(size)
 			default:
-				return errdefs.InvalidParameter(errors.Errorf("Storage opt %s not supported", key))
+				return errdefs.InvalidParameter(fmt.Errorf("Storage opt %s not supported", key))
 			}
 		}
 	}

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -18,7 +18,6 @@ import (
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ErrImageDoesNotExist is error returned when no image can be found for a reference.
@@ -195,7 +194,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 		if ref, err := reference.ParseNamed(refOrID); err == nil {
 			imgName = reference.FamiliarString(ref)
 		}
-		retErr = errdefs.NotFound(errors.Errorf("image with reference %s was found but its platform (%s) does not match the specified platform (%s)", imgName, platforms.FormatAll(imgPlat), platforms.FormatAll(p)))
+		retErr = errdefs.NotFound(fmt.Errorf("image with reference %s was found but its platform (%s) does not match the specified platform (%s)", imgName, platforms.FormatAll(imgPlat), platforms.FormatAll(p)))
 	}()
 	ref, err := reference.ParseAnyReference(refOrID)
 	if err != nil {

--- a/daemon/images/image_commit.go
+++ b/daemon/images/image_commit.go
@@ -3,6 +3,7 @@ package images
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/moby/moby/api/types/events"
@@ -10,7 +11,6 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/pkg/ioutils"
-	"github.com/pkg/errors"
 )
 
 // CommitImage creates a new image from a commit config
@@ -123,7 +123,7 @@ func (i *ImageService) CommitBuildStep(ctx context.Context, c backend.CommitConf
 	ctr := i.containers.Get(c.ContainerID)
 	if ctr == nil {
 		// TODO: use typed error
-		return "", errors.Errorf("container not found: %s", c.ContainerID)
+		return "", fmt.Errorf("container not found: %s", c.ContainerID)
 	}
 	c.ContainerMountLabel = ctr.MountLabel
 	c.ContainerOS = ctr.ImagePlatform.OS

--- a/daemon/images/image_delete.go
+++ b/daemon/images/image_delete.go
@@ -114,7 +114,7 @@ func (i *ImageService) ImageDelete(ctx context.Context, imageRef string, options
 				// this image would remain "dangling" and since
 				// we really want to avoid that the client must
 				// explicitly force its removal.
-				err := errors.Errorf("conflict: unable to remove repository reference %q (must force) - container %s is using its referenced image %s", imageRef, stringid.TruncateID(ctr.ID), stringid.TruncateID(imgID.String()))
+				err := fmt.Errorf("conflict: unable to remove repository reference %q (must force) - container %s is using its referenced image %s", imageRef, stringid.TruncateID(ctr.ID), stringid.TruncateID(imgID.String()))
 				return nil, errdefs.Conflict(err)
 			}
 		}

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -352,7 +352,7 @@ func parseInitVersion(v string) (version string, commit string, _ error) {
 		version = strings.TrimPrefix(parts[0], "tini version ")
 	}
 	if version == "" && commit == "" {
-		return "", "", errors.Errorf("unknown output format: %s", v)
+		return "", "", fmt.Errorf("unknown output format: %s", v)
 	}
 	return version, commit, nil
 }
@@ -380,7 +380,7 @@ func parseRuntimeVersion(v string) (runtime, version, commit string, _ error) {
 		}
 	}
 	if version == "" && commit == "" {
-		return runtime, "", "", errors.Errorf("unknown output format: %s", v)
+		return runtime, "", "", fmt.Errorf("unknown output format: %s", v)
 	}
 	return runtime, version, commit, nil
 }

--- a/daemon/internal/builder-next/adapters/containerimage/pull.go
+++ b/daemon/internal/builder-next/adapters/containerimage/pull.go
@@ -128,7 +128,7 @@ func (is *Source) registryIdentifier(ref string, attrs map[string]string, platfo
 				return nil, errors.Wrapf(err, "invalid layer limit %s", v)
 			}
 			if l <= 0 {
-				return nil, errors.Errorf("invalid layer limit %s", v)
+				return nil, fmt.Errorf("invalid layer limit %s", v)
 			}
 			id.LayerLimit = &l
 		}
@@ -146,7 +146,7 @@ func parseImageRecordType(v string) (client.UsageRecordType, error) {
 	case client.UsageRecordTypeFrontend:
 		return client.UsageRecordTypeFrontend, nil
 	default:
-		return "", errors.Errorf("invalid record type %s", v)
+		return "", fmt.Errorf("invalid record type %s", v)
 	}
 }
 
@@ -246,7 +246,7 @@ func (is *Source) ResolveImageConfig(ctx context.Context, ref string, opt source
 func (is *Source) Resolve(ctx context.Context, id source.Identifier, sm *session.Manager, vtx solver.Vertex) (source.SourceInstance, error) {
 	imageIdentifier, ok := id.(*containerimage.ImageIdentifier)
 	if !ok {
-		return nil, errors.Errorf("invalid image identifier %v", id)
+		return nil, fmt.Errorf("invalid image identifier %v", id)
 	}
 
 	platform := platforms.DefaultSpec()
@@ -419,7 +419,7 @@ func (p *puller) CacheKey(ctx context.Context, g session.Group, index int) (stri
 	}
 
 	if len(p.config) == 0 && p.desc.MediaType != c8dimages.MediaTypeDockerSchema1Manifest {
-		return "", "", nil, false, errors.Errorf("invalid empty config file resolved for %s", p.src.Reference.String())
+		return "", "", nil, false, fmt.Errorf("invalid empty config file resolved for %s", p.src.Reference.String())
 	}
 
 	k := cacheKeyFromConfig(p.config).String()
@@ -582,7 +582,7 @@ func (p *puller) Snapshot(ctx context.Context, g session.Group) (cache.Immutable
 	}
 
 	if len(mfst.Layers) != len(img.RootFS.DiffIDs) {
-		return nil, errors.Errorf("invalid config for manifest")
+		return nil, errors.New("invalid config for manifest")
 	}
 
 	pchan := make(chan pkgprogress.Progress, 10)
@@ -943,7 +943,7 @@ func applySourcePolicies(ctx context.Context, str string, spls []*spb.Policy) (s
 	if mut {
 		t, newRef, ok := strings.Cut(op.GetIdentifier(), "://")
 		if !ok {
-			return "", errors.Errorf("could not parse ref: %s", op.GetIdentifier())
+			return "", fmt.Errorf("could not parse ref: %s", op.GetIdentifier())
 		}
 		if t != srctypes.DockerImageScheme {
 			return "", &imageutil.ResolveToNonImageError{Ref: str, Updated: newRef}

--- a/daemon/internal/builder-next/adapters/localinlinecache/inlinecache.go
+++ b/daemon/internal/builder-next/adapters/localinlinecache/inlinecache.go
@@ -3,6 +3,7 @@ package localinlinecache
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -19,7 +20,6 @@ import (
 	refstore "github.com/moby/moby/v2/daemon/internal/refstore"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ResolveCacheImporterFunc returns a resolver function for local inline cache
@@ -157,5 +157,5 @@ func parseCreatedLayerInfo(img image) ([]string, []string, error) {
 type emptyProvider struct{}
 
 func (p *emptyProvider) ReaderAt(ctx context.Context, dec ocispec.Descriptor) (content.ReaderAt, error) {
-	return nil, errors.Errorf("ReaderAt not implemented for empty provider")
+	return nil, errors.New("ReaderAt not implemented for empty provider")
 }

--- a/daemon/internal/builder-next/adapters/snapshot/layer.go
+++ b/daemon/internal/builder-next/adapters/snapshot/layer.go
@@ -2,13 +2,13 @@ package snapshot
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/moby/moby/v2/pkg/longpath"
 	"github.com/opencontainers/image-spec/identity"
-	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sync/errgroup"
 )
@@ -34,7 +34,7 @@ func (s *snapshotter) EnsureLayer(ctx context.Context, key string) ([]layer.Diff
 
 	id, committed := s.getGraphDriverID(key)
 	if !committed {
-		return nil, errors.Errorf("can not convert active %s to layer", key)
+		return nil, fmt.Errorf("can not convert active %s to layer", key)
 	}
 
 	info, err := s.Stat(ctx, key)
@@ -122,5 +122,5 @@ func getGraphID(l layer.Layer) (string, error) {
 	}); ok {
 		return l.CacheID(), nil
 	}
-	return "", errors.Errorf("couldn't access cacheID for %s", l.ChainID())
+	return "", fmt.Errorf("couldn't access cacheID for %s", l.ChainID())
 }

--- a/daemon/internal/builder-next/adapters/snapshot/snapshot.go
+++ b/daemon/internal/builder-next/adapters/snapshot/snapshot.go
@@ -69,7 +69,7 @@ func NewSnapshotter(opt Opt, prevLM leases.Manager, ns string) (snapshot.Snapsho
 
 	reg, ok := opt.LayerStore.(graphIDRegistrar)
 	if !ok {
-		return nil, nil, errors.Errorf("layerstore doesn't support graphID registration")
+		return nil, nil, errors.New("layerstore doesn't support graphID registration")
 	}
 
 	s := &snapshotter{
@@ -330,7 +330,7 @@ func (s *snapshotter) Mounts(ctx context.Context, key string) (snapshot.Mountabl
 }
 
 func (s *snapshotter) Remove(ctx context.Context, key string) error {
-	return errors.Errorf("calling snapshot.remove is forbidden")
+	return errors.New("calling snapshot.remove is forbidden")
 }
 
 func (s *snapshotter) remove(ctx context.Context, key string) error {

--- a/daemon/internal/builder-next/builder.go
+++ b/daemon/internal/builder-next/builder.go
@@ -244,7 +244,7 @@ func (b *Builder) Prune(ctx context.Context, opts build.CachePruneOptions) (int6
 // Build executes a build request
 func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.Result, error) {
 	if len(opt.Options.Outputs) > 1 {
-		return nil, errors.Errorf("multiple outputs not supported")
+		return nil, errors.New("multiple outputs not supported")
 	}
 
 	rc := opt.Source
@@ -353,7 +353,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		frontendAttrs["force-network-mode"] = opt.Options.NetworkMode
 	case "", network.NetworkDefault:
 	default:
-		return nil, errors.Errorf("network mode %q not supported by buildkit", opt.Options.NetworkMode)
+		return nil, fmt.Errorf("network mode %q not supported by buildkit", opt.Options.NetworkMode)
 	}
 
 	extraHosts, err := toBuildkitExtraHosts(opt.Options.ExtraHosts, b.dnsconfig.HostGatewayIPs)
@@ -435,7 +435,7 @@ func (b *Builder) Build(ctx context.Context, opt backend.BuildConfig) (*builder.
 		}
 		imgID, ok := resp.ExporterResponse["containerimage.digest"]
 		if !ok {
-			return errors.Errorf("missing image id")
+			return errors.New("missing image id")
 		}
 		out.ImageID = imgID
 		return aux.Emit("moby.image.id", build.Result{ID: imgID})
@@ -611,7 +611,7 @@ func toBuildkitExtraHosts(inp []string, hostGatewayIPs []netip.Addr) (string, er
 	for _, h := range inp {
 		host, ip, ok := strings.Cut(h, ":")
 		if !ok || host == "" || ip == "" {
-			return "", errors.Errorf("invalid host %s", h)
+			return "", fmt.Errorf("invalid host %s", h)
 		}
 		// If the IP Address is a "host-gateway", replace this value with the
 		// IP address(es) stored in the daemon level HostGatewayIPs config variable.

--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -259,7 +259,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 	}); ok {
 		driver = ls.Driver()
 	} else {
-		return nil, errors.Errorf("could not access graphdriver")
+		return nil, errors.New("could not access graphdriver")
 	}
 
 	innerStore, err := local.NewStore(filepath.Join(root, "content"))
@@ -297,7 +297,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 	layerGetter, ok := snapshotter.(imagerefchecker.LayerGetter)
 	if !ok {
-		return nil, errors.Errorf("snapshotter does not implement layergetter")
+		return nil, errors.New("snapshotter does not implement layergetter")
 	}
 
 	refChecker := imagerefchecker.New(imagerefchecker.Opt{
@@ -359,7 +359,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 	differ, ok := snapshotter.(mobyexporter.Differ)
 	if !ok {
-		return nil, errors.Errorf("snapshotter doesn't support differ")
+		return nil, errors.New("snapshotter doesn't support differ")
 	}
 
 	exp, err := mobyexporter.New(mobyexporter.Opt{
@@ -392,7 +392,7 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 
 	layers, ok := snapshotter.(mobyworker.LayerAccess)
 	if !ok {
-		return nil, errors.Errorf("snapshotter doesn't support differ")
+		return nil, errors.New("snapshotter doesn't support differ")
 	}
 
 	leases, err := lm.List(ctx, `labels."buildkit/lease.temporary"`)

--- a/daemon/internal/builder-next/exporter/mobyexporter/export.go
+++ b/daemon/internal/builder-next/exporter/mobyexporter/export.go
@@ -130,7 +130,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp *exporter.Source
 			return nil, nil, fmt.Errorf("cannot export image, failed to parse platforms: %w", err)
 		}
 		if len(ps.Platforms) != len(inp.Refs) {
-			return nil, nil, errors.Errorf("number of platforms does not match references %d %d", len(ps.Platforms), len(inp.Refs))
+			return nil, nil, fmt.Errorf("number of platforms does not match references %d %d", len(ps.Platforms), len(inp.Refs))
 		}
 		config = inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, ps.Platforms[0].ID)]
 	}

--- a/daemon/internal/builder-next/reqbodyhandler.go
+++ b/daemon/internal/builder-next/reqbodyhandler.go
@@ -43,7 +43,7 @@ func (h *reqBodyHandler) RoundTrip(req *http.Request) (*http.Response, error) {
 	host := req.URL.Host
 	if strings.HasPrefix(host, urlPrefix) {
 		if req.Method != http.MethodGet {
-			return nil, errors.Errorf("invalid request")
+			return nil, errors.New("invalid request")
 		}
 		id := strings.TrimPrefix(host, urlPrefix)
 		h.mu.Lock()
@@ -52,7 +52,7 @@ func (h *reqBodyHandler) RoundTrip(req *http.Request) (*http.Response, error) {
 		h.mu.Unlock()
 
 		if !ok {
-			return nil, errors.Errorf("context not found")
+			return nil, errors.New("context not found")
 		}
 
 		resp := &http.Response{

--- a/daemon/internal/builder-next/worker/worker.go
+++ b/daemon/internal/builder-next/worker/worker.go
@@ -304,7 +304,7 @@ func (w *Worker) ResolveOp(v solver.Vertex, s frontend.FrontendLLBBridge, sm *se
 			return ops.NewDiffOp(v, op, w)
 		}
 	}
-	return nil, errors.Errorf("could not resolve %v", v)
+	return nil, fmt.Errorf("could not resolve %v", v)
 }
 
 // ResolveImageConfig returns image config for an image
@@ -336,7 +336,7 @@ func (w *Worker) Exporter(name string, sm *session.Manager) (exporter.Exporter, 
 			SessionManager: sm,
 		})
 	default:
-		return nil, errors.Errorf("exporter %q could not be found", name)
+		return nil, fmt.Errorf("exporter %q could not be found", name)
 	}
 }
 
@@ -459,7 +459,7 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (cache.I
 	defer release()
 
 	if len(rootFS.DiffIDs) != len(layers) {
-		return nil, errors.Errorf("invalid layer count mismatch %d vs %d", len(rootFS.DiffIDs), len(layers))
+		return nil, fmt.Errorf("invalid layer count mismatch %d vs %d", len(rootFS.DiffIDs), len(layers))
 	}
 
 	for i := range rootFS.DiffIDs {
@@ -483,7 +483,7 @@ func (w *Worker) FromRemote(ctx context.Context, remote *solver.Remote) (cache.I
 		defer ref.Release(context.TODO())
 	}
 
-	return nil, errors.Errorf("unreachable")
+	return nil, errors.New("unreachable")
 }
 
 // Executor returns executor.Executor for running processes
@@ -560,7 +560,7 @@ func getLayers(ctx context.Context, descs []ocispec.Descriptor) ([]rootfs.Layer,
 	for i, desc := range descs {
 		diffIDStr := desc.Annotations["containerd.io/uncompressed"]
 		if diffIDStr == "" {
-			return nil, errors.Errorf("%s missing uncompressed digest", desc.Digest)
+			return nil, fmt.Errorf("%s missing uncompressed digest", desc.Digest)
 		}
 		diffID, err := digest.Parse(diffIDStr)
 		if err != nil {
@@ -599,7 +599,7 @@ func oneOffProgress(ctx context.Context, id string) func(err error) error {
 type emptyProvider struct{}
 
 func (p *emptyProvider) ReaderAt(ctx context.Context, dec ocispec.Descriptor) (content.ReaderAt, error) {
-	return nil, errors.Errorf("ReaderAt not implemented for empty provider")
+	return nil, errors.New("ReaderAt not implemented for empty provider")
 }
 
 func (p *emptyProvider) Info(ctx context.Context, d digest.Digest) (content.Info, error) {

--- a/daemon/internal/image/tarexport/save.go
+++ b/daemon/internal/image/tarexport/save.go
@@ -114,7 +114,7 @@ func (l *tarexporter) parseNames(ctx context.Context, names []string) (desc map[
 				}
 				continue
 			}
-			return nil, errors.Errorf("invalid reference: %v", name)
+			return nil, fmt.Errorf("invalid reference: %v", name)
 		}
 
 		if reference.FamiliarName(namedRef) == string(digest.Canonical) {

--- a/daemon/internal/layer/filestore.go
+++ b/daemon/internal/layer/filestore.go
@@ -189,7 +189,7 @@ func (fms *fileMetadataStore) GetCacheID(layer ChainID) (string, error) {
 	content := strings.TrimSpace(string(contentBytes))
 
 	if content == "" {
-		return "", errors.Errorf("invalid cache id value")
+		return "", errors.New("invalid cache id value")
 	}
 
 	return content, nil

--- a/daemon/internal/libcontainerd/local/local_windows.go
+++ b/daemon/internal/libcontainerd/local/local_windows.go
@@ -318,7 +318,7 @@ func (c *client) createWindows(id string, spec *specs.Spec) (*container, error) 
 			// Per https://github.com/microsoft/hcsshim/blob/v0.9.2/internal/uvm/virtual_device.go#L17-L18,
 			// these represent an Interface Class GUID.
 			if d.IDType != "class" && d.IDType != "vpci-class-guid" {
-				return nil, errors.Errorf("device assignment of type '%s' is not supported", d.IDType)
+				return nil, fmt.Errorf("device assignment of type '%s' is not supported", d.IDType)
 			}
 			configuration.AssignedDevices = append(configuration.AssignedDevices, hcsshim.AssignedDevice{InterfaceClassGUID: d.ID})
 		}

--- a/daemon/internal/libcontainerd/remote/client.go
+++ b/daemon/internal/libcontainerd/remote/client.go
@@ -132,7 +132,7 @@ func (c *client) NewContainer(ctx context.Context, id string, ociSpec *specs.Spe
 	ctr, err := c.client.NewContainer(ctx, id, opts...)
 	if err != nil {
 		if cerrdefs.IsAlreadyExists(err) {
-			return nil, pkgerrors.WithStack(errdefs.Conflict(errors.New("id already in use")))
+			return nil, pkgerrors.WithStack(errdefs.Conflict(pkgerrors.New("id already in use")))
 		}
 		return nil, wrapError(err)
 	}
@@ -289,7 +289,7 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 	if err != nil {
 		close(stdinCloseSync)
 		if cerrdefs.IsAlreadyExists(err) {
-			return nil, pkgerrors.WithStack(errdefs.Conflict(errors.New("id already in use")))
+			return nil, pkgerrors.WithStack(errdefs.Conflict(pkgerrors.New("id already in use")))
 		}
 		return nil, wrapError(err)
 	}
@@ -476,7 +476,7 @@ func (c *client) LoadContainer(ctx context.Context, id string) (libcontainerdtyp
 	ctr, err := c.client.LoadContainer(ctx, id)
 	if err != nil {
 		if cerrdefs.IsNotFound(err) {
-			return nil, pkgerrors.WithStack(errdefs.NotFound(errors.New("no such container")))
+			return nil, pkgerrors.WithStack(errdefs.NotFound(pkgerrors.New("no such container")))
 		}
 		return nil, wrapError(err)
 	}
@@ -580,7 +580,7 @@ func (c *client) waitServe(ctx context.Context) bool {
 	for {
 		serving, err := c.client.IsServing(ctx)
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			if pkgerrors.Is(err, context.DeadlineExceeded) || pkgerrors.Is(err, context.Canceled) {
 				return false
 			}
 			log.G(ctx).WithError(err).Warn("Error while testing if containerd API is ready")

--- a/daemon/internal/libcontainerd/remote/client_windows.go
+++ b/daemon/internal/libcontainerd/remote/client_windows.go
@@ -13,7 +13,6 @@ import (
 	"github.com/containerd/log"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 )
 
 func summaryFromInterface(i any) (*libcontainerdtypes.Summary, error) {
@@ -31,7 +30,7 @@ func summaryFromInterface(i any) (*libcontainerdtypes.Summary, error) {
 			ExecID:                       pd.ExecID,
 		}, nil
 	default:
-		return nil, errors.Errorf("Unknown process details type %T", pd)
+		return nil, fmt.Errorf("Unknown process details type %T", pd)
 	}
 }
 

--- a/daemon/internal/libcontainerd/supervisor/remote_daemon_options.go
+++ b/daemon/internal/libcontainerd/supervisor/remote_daemon_options.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -57,7 +58,7 @@ func WithDetectLocalBinary() DaemonOpt {
 			return nil
 		}
 		if fi.IsDir() {
-			return errors.Errorf("local containerd path found (%s), but is a directory", localBinary)
+			return fmt.Errorf("local containerd path found (%s), but is a directory", localBinary)
 		}
 		r.daemonPath = localBinary
 		r.logger.WithField("daemon path", r.daemonPath).Debug("Local containerd daemon found.")

--- a/daemon/internal/quota/projectquota.go
+++ b/daemon/internal/quota/projectquota.go
@@ -54,6 +54,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -253,7 +254,7 @@ func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	projectID, ok := q.quotas[targetPath]
 	q.RUnlock()
 	if !ok {
-		return errors.Errorf("quota not found for path: %s", targetPath)
+		return fmt.Errorf("quota not found for path: %s", targetPath)
 	}
 
 	//
@@ -342,7 +343,7 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 
 	files, err := os.ReadDir(home)
 	if err != nil {
-		return errors.Errorf("read directory failed: %s", home)
+		return fmt.Errorf("read directory failed: %s", home)
 	}
 	for _, file := range files {
 		if !file.IsDir() {
@@ -358,7 +359,7 @@ func (q *Control) findNextProjectID(home string, baseID uint32) error {
 		}
 		subfiles, err := os.ReadDir(path)
 		if err != nil {
-			return errors.Errorf("read directory failed: %s", path)
+			return fmt.Errorf("read directory failed: %s", path)
 		}
 		for _, subfile := range subfiles {
 			if !subfile.IsDir() {
@@ -385,7 +386,7 @@ func openDir(path string) (*C.DIR, error) {
 
 	dir := C.opendir(Cpath)
 	if dir == nil {
-		return nil, errors.Errorf("failed to open dir: %s", path)
+		return nil, fmt.Errorf("failed to open dir: %s", path)
 	}
 	return dir, nil
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -44,7 +44,7 @@ func (daemon *Daemon) ContainerKill(name, stopSignal string) error {
 			return errdefs.InvalidParameter(err)
 		}
 		if !signal.ValidSignalForPlatform(sig) {
-			return errdefs.InvalidParameter(errors.Errorf("the %s daemon does not support signal %d", runtime.GOOS, sig))
+			return errdefs.InvalidParameter(fmt.Errorf("the %s daemon does not support signal %d", runtime.GOOS, sig))
 		}
 	}
 	container, err := daemon.GetContainer(name)

--- a/daemon/libnetwork/drivers/remote/driver.go
+++ b/daemon/libnetwork/drivers/remote/driver.go
@@ -91,11 +91,11 @@ func getPluginClient(p plugingetter.CompatPlugin) (*plugins.Client, error) {
 
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errors.Errorf("unknown plugin type %T", p)
+		return nil, fmt.Errorf("unknown plugin type %T", p)
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("unsupported plugin protocol %s", pa.Protocol())
+		return nil, fmt.Errorf("unsupported plugin protocol %s", pa.Protocol())
 	}
 
 	addr := pa.Addr()

--- a/daemon/libnetwork/ipams/remote/remote.go
+++ b/daemon/libnetwork/ipams/remote/remote.go
@@ -72,11 +72,11 @@ func getPluginClient(p plugingetter.CompatPlugin) (*plugins.Client, error) {
 
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errors.Errorf("unknown plugin type %T", p)
+		return nil, fmt.Errorf("unknown plugin type %T", p)
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("unsupported plugin protocol %s", pa.Protocol())
+		return nil, fmt.Errorf("unsupported plugin protocol %s", pa.Protocol())
 	}
 
 	addr := pa.Addr()

--- a/daemon/listeners/listeners_linux.go
+++ b/daemon/listeners/listeners_linux.go
@@ -3,6 +3,7 @@ package listeners
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -53,7 +54,7 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]net.Listene
 		}
 		ls = append(ls, l)
 	default:
-		return nil, errors.Errorf("invalid protocol format: %q", proto)
+		return nil, fmt.Errorf("invalid protocol format: %q", proto)
 	}
 
 	return ls, nil
@@ -87,14 +88,14 @@ func listenFD(addr string, tlsConfig *tls.Config) ([]net.Listener, error) {
 
 	fdNum, err := strconv.Atoi(addr)
 	if err != nil {
-		return nil, errors.Errorf("failed to parse systemd fd address: should be a number: %v", addr)
+		return nil, fmt.Errorf("failed to parse systemd fd address: should be a number: %v", addr)
 	}
 	fdOffset := fdNum - 3
 	if len(listeners) < fdOffset+1 {
 		return nil, errors.New("too few socket activated files passed in by systemd")
 	}
 	if listeners[fdOffset] == nil {
-		return nil, errors.Errorf("failed to listen on systemd activated file: fd %d", fdOffset+3)
+		return nil, fmt.Errorf("failed to listen on systemd activated file: fd %d", fdOffset+3)
 	}
 	for i, ls := range listeners {
 		if i == fdOffset || ls == nil {

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -4,6 +4,7 @@ package fluentd
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"net/url"
 	"strconv"
@@ -164,7 +165,7 @@ func ValidateLogOpt(cfg map[string]string) error {
 		case writeTimeoutKey:
 			// Accepted
 		default:
-			return errors.Errorf("unknown log opt '%s' for fluentd log driver", key)
+			return fmt.Errorf("unknown log opt '%s' for fluentd log driver", key)
 		}
 	}
 
@@ -228,7 +229,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		}
 		if interval != 0 {
 			if interval < minReconnectInterval || interval > maxReconnectInterval {
-				return config, errors.Errorf("invalid value for %s: value (%q) must be between %s and %s",
+				return config, fmt.Errorf("invalid value for %s: value (%q) must be between %s and %s",
 					asyncReconnectIntervalKey, interval, minReconnectInterval, maxReconnectInterval)
 			}
 			asyncReconnectInterval = int(interval.Milliseconds())
@@ -254,7 +255,7 @@ func parseConfig(cfg map[string]string) (fluent.Config, error) {
 		if d, err := time.ParseDuration(cfg[writeTimeoutKey]); err != nil {
 			return config, errors.Wrapf(err, "invalid value for %s: value must be a duration", writeTimeoutKey)
 		} else if d < 0 {
-			return config, errors.Errorf("invalid value for %s: value must be a duration that is non-negative", writeTimeoutKey)
+			return config, fmt.Errorf("invalid value for %s: value must be a duration that is non-negative", writeTimeoutKey)
 		} else {
 			writeTimeout = d
 		}
@@ -307,7 +308,7 @@ func parseAddress(address string) (*location, error) {
 	case "tcp", "tls":
 		// continue processing below
 	default:
-		return nil, errors.Errorf("unsupported scheme: '%s'", addr.Scheme)
+		return nil, fmt.Errorf("unsupported scheme: '%s'", addr.Scheme)
 	}
 
 	if addr.Path != "" {

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math/bits"
 	"strconv"
@@ -46,7 +47,7 @@ var LogOptKeys = map[string]bool{
 func ValidateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		if !LogOptKeys[key] {
-			return errors.Errorf("unknown log opt '%s' for log driver %s", key, Name)
+			return fmt.Errorf("unknown log opt '%s' for log driver %s", key, Name)
 		}
 	}
 	return nil

--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -25,7 +25,7 @@ func (d *driver) ReadLogs(ctx context.Context, config logger.ReadConfig) *logger
 func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (loggerutils.SizeReaderAt, int, error) {
 	size := r.Size()
 	if req < 0 {
-		return nil, 0, errdefs.InvalidParameter(errors.Errorf("invalid number of lines to tail: %d", req))
+		return nil, 0, errdefs.InvalidParameter(fmt.Errorf("invalid number of lines to tail: %d", req))
 	}
 
 	if size < (encodeBinaryLen*2)+1 {

--- a/daemon/logger/loggerutils/cache/validate.go
+++ b/daemon/logger/loggerutils/cache/validate.go
@@ -1,11 +1,11 @@
 package cache
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/local"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -20,7 +20,7 @@ func validateLogCacheOpts(cfg map[string]string) error {
 	if v := cfg[cacheDisabledKey]; v != "" {
 		_, err := strconv.ParseBool(v)
 		if err != nil {
-			return errors.Errorf("invalid value for option %s: %s", cacheDisabledKey, cfg[cacheDisabledKey])
+			return fmt.Errorf("invalid value for option %s: %s", cacheDisabledKey, cfg[cacheDisabledKey])
 		}
 	}
 	return nil

--- a/daemon/logger/plugin.go
+++ b/daemon/logger/plugin.go
@@ -52,11 +52,11 @@ func makePluginClient(p plugingetter.CompatPlugin) (logPlugin, error) {
 	}
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin type %T", p))
+		return nil, errdefs.System(fmt.Errorf("got unknown plugin type %T", p))
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("plugin protocol not supported: %s", p)
+		return nil, fmt.Errorf("plugin protocol not supported: %s", p)
 	}
 
 	addr := pa.Addr()

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -61,7 +62,7 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 
 func (daemon *Daemon) reserveName(id, name string) (string, error) {
 	if !validContainerNamePattern.MatchString(strings.TrimPrefix(name, "/")) {
-		return "", errdefs.InvalidParameter(errors.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars))
+		return "", errdefs.InvalidParameter(fmt.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars))
 	}
 	if name[0] != '/' {
 		name = "/" + name

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"fmt"
+
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/errdefs"
@@ -123,7 +125,7 @@ func filterNetworkByType(nws []network.Inspect, netType string) ([]network.Inspe
 			}
 		}
 	default:
-		return nil, errors.Errorf("invalid filter: 'type'='%s'", netType)
+		return nil, fmt.Errorf("invalid filter: 'type'='%s'", netType)
 	}
 	return retNws, nil
 }

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -272,7 +272,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// ipc
 		ipcMode := c.HostConfig.IpcMode
 		if !ipcMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid IPC mode: %v", ipcMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid IPC mode: %v", ipcMode))
 		}
 		switch {
 		case ipcMode.IsContainer():
@@ -308,7 +308,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// pid
 		pidMode := c.HostConfig.PidMode
 		if !pidMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid PID mode: %v", pidMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid PID mode: %v", pidMode))
 		}
 		switch {
 		case pidMode.IsContainer():
@@ -339,7 +339,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// uts
 		if !c.HostConfig.UTSMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid UTS mode: %v", c.HostConfig.UTSMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid UTS mode: %v", c.HostConfig.UTSMode))
 		}
 		if c.HostConfig.UTSMode.IsHost() {
 			oci.RemoveNamespace(s, specs.UTSNamespace)
@@ -348,7 +348,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// cgroup
 		if !c.HostConfig.CgroupnsMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid cgroup namespace mode: %v", c.HostConfig.CgroupnsMode))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid cgroup namespace mode: %v", c.HostConfig.CgroupnsMode))
 		}
 		if c.HostConfig.CgroupnsMode.IsPrivate() {
 			setNamespace(s, specs.LinuxNamespace{
@@ -426,7 +426,7 @@ func ensureShared(path string) error {
 	}
 	// Make sure source mount point is shared.
 	if !hasMountInfoOption(optionalOpts, sharedPropagationOption) {
-		return errors.Errorf("path %s is mounted on %s but it is not a shared mount", path, sourceMount)
+		return fmt.Errorf("path %s is mounted on %s but it is not a shared mount", path, sourceMount)
 	}
 	return nil
 }
@@ -439,7 +439,7 @@ func ensureSharedOrSlave(path string) error {
 	}
 
 	if !hasMountInfoOption(optionalOpts, sharedPropagationOption, slavePropagationOption) {
-		return errors.Errorf("path %s is mounted on %s but it is not a shared or slave mount", path, sourceMount)
+		return fmt.Errorf("path %s is mounted on %s but it is not a shared or slave mount", path, sourceMount)
 	}
 	return nil
 }

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -546,10 +546,10 @@ func setupWindowsDevices(devices []containertypes.DeviceMapping) ([]specs.Window
 		} else {
 			idType, id, ok := strings.Cut(deviceMapping.PathOnHost, "://")
 			if !ok {
-				return nil, errors.Errorf("invalid device assignment path: '%s', must be 'class/ID' or 'IDType://ID'", deviceMapping.PathOnHost)
+				return nil, fmt.Errorf("invalid device assignment path: '%s', must be 'class/ID' or 'IDType://ID'", deviceMapping.PathOnHost)
 			}
 			if idType == "" {
-				return nil, errors.Errorf("invalid device assignment path: '%s', IDType cannot be empty", deviceMapping.PathOnHost)
+				return nil, fmt.Errorf("invalid device assignment path: '%s', IDType cannot be empty", deviceMapping.PathOnHost)
 			}
 			specDevices = append(specDevices, specs.WindowsDevice{
 				ID:     id,

--- a/daemon/pkg/opts/hosts.go
+++ b/daemon/pkg/opts/hosts.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"path/filepath"
@@ -101,7 +102,7 @@ func parseDaemonHost(address string) (string, error) {
 	case "fd":
 		return address, nil
 	default:
-		return "", errors.Errorf("invalid bind address (%s): unsupported proto '%s'", address, proto)
+		return "", fmt.Errorf("invalid bind address (%s): unsupported proto '%s'", address, proto)
 	}
 }
 
@@ -111,7 +112,7 @@ func parseDaemonHost(address string) (string, error) {
 // defaultAddr if addr is a blank string.
 func parseSimpleProtoAddr(proto, addr, defaultAddr string) (string, error) {
 	if strings.Contains(addr, "://") {
-		return "", errors.Errorf("invalid %s address: %s", proto, addr)
+		return "", fmt.Errorf("invalid %s address: %s", proto, addr)
 	}
 	if addr == "" {
 		addr = defaultAddr
@@ -159,7 +160,7 @@ func parseTCPAddr(address string, strict bool) (*url.URL, error) {
 		return nil, err
 	}
 	if parsedURL.Scheme != "tcp" {
-		return nil, errors.Errorf("unsupported proto '%s'", parsedURL.Scheme)
+		return nil, fmt.Errorf("unsupported proto '%s'", parsedURL.Scheme)
 	}
 	if parsedURL.Path != "" {
 		return nil, errors.New("should not contain a path element")
@@ -169,7 +170,7 @@ func parseTCPAddr(address string, strict bool) (*url.URL, error) {
 	}
 	if parsedURL.Port() != "" || strict {
 		if p, err := strconv.Atoi(parsedURL.Port()); err != nil || p == 0 {
-			return nil, errors.Errorf("invalid port: %s", parsedURL.Port())
+			return nil, fmt.Errorf("invalid port: %s", parsedURL.Port())
 		}
 	}
 	return parsedURL, nil
@@ -181,12 +182,12 @@ func ValidateExtraHost(val string) (string, error) {
 	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
 	name, ip, ok := strings.Cut(val, ":")
 	if !ok || name == "" {
-		return "", errors.Errorf("bad format for add-host: %q", val)
+		return "", fmt.Errorf("bad format for add-host: %q", val)
 	}
 	// Skip IPaddr validation for special "host-gateway" string
 	if ip != HostGatewayName {
 		if _, err := ValidateIPAddress(ip); err != nil {
-			return "", errors.Errorf("invalid IP address in add-host: %q", ip)
+			return "", fmt.Errorf("invalid IP address in add-host: %q", ip)
 		}
 	}
 	return val, nil

--- a/daemon/pkg/plugin/backend_linux.go
+++ b/daemon/pkg/plugin/backend_linux.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -207,7 +208,7 @@ func (pm *Manager) Privileges(ctx context.Context, ref reference.Named, metaHead
 	}
 
 	if !configSeen {
-		return plugin.Privileges{}, errors.Errorf("did not find plugin config for specified reference %s", ref)
+		return plugin.Privileges{}, fmt.Errorf("did not find plugin config for specified reference %s", ref)
 	}
 
 	return computePrivileges(config), nil
@@ -636,7 +637,7 @@ func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, 
 		return errors.Wrapf(err, "failed to parse reference %v", options.RepoName)
 	}
 	if _, ok := ref.(reference.Canonical); ok {
-		return errors.Errorf("canonical references are not permitted")
+		return errors.New("canonical references are not permitted")
 	}
 	name := reference.FamiliarString(reference.TagNameOnly(ref))
 

--- a/daemon/pkg/registry/auth.go
+++ b/daemon/pkg/registry/auth.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/moby/moby/api/types/registry"
-	"github.com/pkg/errors"
 )
 
 // AuthClientID is used the ClientID used for the token server
@@ -96,7 +96,7 @@ func loginV2(ctx context.Context, authConfig *registry.AuthConfig, endpoint APIE
 
 	if resp.StatusCode != http.StatusOK {
 		// TODO(dmcgowan): Attempt to further interpret result, status code and error code string
-		return "", errors.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
+		return "", fmt.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	return credentialAuthConfig.IdentityToken, nil

--- a/daemon/pkg/registry/errors.go
+++ b/daemon/pkg/registry/errors.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/docker/distribution/registry/api/errcode"
@@ -23,7 +24,7 @@ func invalidParam(err error) error {
 }
 
 func invalidParamf(format string, args ...any) error {
-	return invalidParameterErr{errors.Errorf(format, args...)}
+	return invalidParameterErr{fmt.Errorf(format, args...)}
 }
 
 func invalidParamWrapf(err error, format string, args ...any) error {

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -40,7 +40,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 	links := map[string]*container.Container{}
 	for k, v := range daemon.linkIndex.children(ctr) {
 		if !strings.HasPrefix(k, ctr.Name) {
-			return errdefs.InvalidParameter(errors.Errorf("Linked container %s does not match parent %s", k, ctr.Name))
+			return errdefs.InvalidParameter(fmt.Errorf("Linked container %s does not match parent %s", k, ctr.Name))
 		}
 		links[strings.TrimPrefix(k, ctr.Name)] = v
 	}

--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -98,7 +98,7 @@ func initRuntimesDir(cfg *config.Config) error {
 
 func setupRuntimes(cfg *config.Config) (runtimes, error) {
 	if _, ok := cfg.Runtimes[config.StockRuntimeName]; ok {
-		return runtimes{}, errors.Errorf("runtime name '%s' is reserved", config.StockRuntimeName)
+		return runtimes{}, fmt.Errorf("runtime name '%s' is reserved", config.StockRuntimeName)
 	}
 
 	newrt := runtimes{
@@ -113,7 +113,7 @@ func setupRuntimes(cfg *config.Config) (runtimes, error) {
 		_, isStock := newrt.configured[newrt.Default]
 		_, isConfigured := cfg.Runtimes[newrt.Default]
 		if !isStock && !isConfigured && !isPermissibleC8dRuntimeName(newrt.Default) {
-			return runtimes{}, errors.Errorf("specified default runtime '%s' does not exist", newrt.Default)
+			return runtimes{}, fmt.Errorf("specified default runtime '%s' does not exist", newrt.Default)
 		}
 	} else {
 		newrt.Default = config.StockRuntimeName
@@ -123,14 +123,14 @@ func setupRuntimes(cfg *config.Config) (runtimes, error) {
 	for name, rt := range cfg.Runtimes {
 		var c *shimConfig
 		if rt.Path == "" && rt.Type == "" {
-			return runtimes{}, errors.Errorf("runtime %s: either a runtimeType or a path must be configured", name)
+			return runtimes{}, fmt.Errorf("runtime %s: either a runtimeType or a path must be configured", name)
 		}
 		if rt.Path != "" {
 			if rt.Type != "" {
-				return runtimes{}, errors.Errorf("runtime %s: cannot configure both path and runtimeType for the same runtime", name)
+				return runtimes{}, fmt.Errorf("runtime %s: cannot configure both path and runtimeType for the same runtime", name)
 			}
 			if len(rt.Options) > 0 {
-				return runtimes{}, errors.Errorf("runtime %s: options cannot be used with a path runtime", name)
+				return runtimes{}, fmt.Errorf("runtime %s: options cannot be used with a path runtime", name)
 			}
 
 			binaryName := rt.Path
@@ -153,7 +153,7 @@ func setupRuntimes(cfg *config.Config) (runtimes, error) {
 			}
 		} else {
 			if len(rt.Args) > 0 {
-				return runtimes{}, errors.Errorf("runtime %s: args cannot be used with a runtimeType runtime", name)
+				return runtimes{}, fmt.Errorf("runtime %s: args cannot be used with a runtimeType runtime", name)
 			}
 			// Unlike implicit runtimes, there is no restriction on configuring a shim by path.
 			c = &shimConfig{Shim: rt.Type}
@@ -216,7 +216,7 @@ func (r *runtimes) Get(name string) (string, any, error) {
 	}
 
 	if !isPermissibleC8dRuntimeName(name) {
-		return "", nil, errdefs.InvalidParameter(errors.Errorf("unknown or invalid runtime name: %s", name))
+		return "", nil, errdefs.InvalidParameter(fmt.Errorf("unknown or invalid runtime name: %s", name))
 	}
 	return name, nil, nil
 }

--- a/daemon/server/httputils/httputils.go
+++ b/daemon/server/httputils/httputils.go
@@ -3,6 +3,7 @@ package httputils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -128,7 +129,7 @@ func matchesContentType(contentType, expectedType string) error {
 		return errdefs.InvalidParameter(errors.Wrapf(err, "malformed Content-Type header (%s)", contentType))
 	}
 	if mimetype != expectedType {
-		return errdefs.InvalidParameter(errors.Errorf("unsupported Content-Type header (%s): must be '%s'", contentType, expectedType))
+		return errdefs.InvalidParameter(fmt.Errorf("unsupported Content-Type header (%s): must be '%s'", contentType, expectedType))
 	}
 	return nil
 }

--- a/daemon/server/router/build/build_routes.go
+++ b/daemon/server/router/build/build_routes.go
@@ -100,7 +100,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*build.ImageBui
 	if i := r.FormValue("isolation"); i != "" {
 		options.Isolation = container.Isolation(i)
 		if !options.Isolation.IsValid() {
-			return nil, invalidParam{errors.Errorf("unsupported isolation: %q", i)}
+			return nil, invalidParam{fmt.Errorf("unsupported isolation: %q", i)}
 		}
 	}
 
@@ -166,7 +166,7 @@ func parseVersion(s string) (build.BuilderVersion, error) {
 	case build.BuilderBuildKit:
 		return build.BuilderBuildKit, nil
 	default:
-		return "", invalidParam{errors.Errorf("invalid version %q", s)}
+		return "", invalidParam{fmt.Errorf("invalid version %q", s)}
 	}
 }
 

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -369,7 +369,7 @@ func (c *containerRouter) postContainersWait(ctx context.Context, w http.Respons
 				waitCondition = container.WaitConditionRemoved
 				legacyRemovalWaitPre134 = versions.LessThan(version, "1.34")
 			default:
-				return errdefs.InvalidParameter(errors.Errorf("invalid condition: %q", v))
+				return errdefs.InvalidParameter(fmt.Errorf("invalid condition: %q", v))
 			}
 		}
 	}
@@ -643,7 +643,7 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 			for k := range networkingConfig.EndpointsConfig {
 				l = append(l, k)
 			}
-			return errdefs.InvalidParameter(errors.Errorf("Container cannot be created with multiple network endpoints: %s", strings.Join(l, ", ")))
+			return errdefs.InvalidParameter(fmt.Errorf("Container cannot be created with multiple network endpoints: %s", strings.Join(l, ", ")))
 		}
 	}
 
@@ -971,7 +971,7 @@ func (c *containerRouter) postContainersAttach(ctx context.Context, w http.Respo
 	containerName := vars["name"]
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		return errdefs.InvalidParameter(errors.Errorf("error attaching to container %s, hijack connection missing", containerName))
+		return errdefs.InvalidParameter(fmt.Errorf("error attaching to container %s, hijack connection missing", containerName))
 	}
 
 	contentType := types.MediaTypeRawStream

--- a/daemon/server/router/distribution/distribution_routes.go
+++ b/daemon/server/router/distribution/distribution_routes.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/distribution/reference"
@@ -35,9 +36,9 @@ func (dr *distributionRouter) getDistributionInfo(ctx context.Context, w http.Re
 	if !ok {
 		if _, ok := ref.(reference.Digested); ok {
 			// full image ID
-			return errors.Errorf("no manifest found for full image ID")
+			return errors.New("no manifest found for full image ID")
 		}
-		return errdefs.InvalidParameter(errors.Errorf("unknown image reference format: %s", imgName))
+		return errdefs.InvalidParameter(fmt.Errorf("unknown image reference format: %s", imgName))
 	}
 
 	// For a search it is not an error if no auth was given. Ignore invalid
@@ -81,7 +82,7 @@ func fetchManifest(ctx context.Context, distrepo distribution.Repository, namedR
 
 		taggedRef, ok := namedRef.(reference.NamedTagged)
 		if !ok {
-			return registry.DistributionInspect{}, errdefs.InvalidParameter(errors.Errorf("image reference not tagged: %s", namedRef))
+			return registry.DistributionInspect{}, errdefs.InvalidParameter(fmt.Errorf("image reference not tagged: %s", namedRef))
 		}
 
 		descriptor, err := distrepo.Tags(ctx).Get(ctx, taggedRef.Tag())

--- a/daemon/server/router/grpc/grpc_routes.go
+++ b/daemon/server/router/grpc/grpc_routes.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -18,7 +19,7 @@ func (gr *grpcRouter) serveGRPC(ctx context.Context, w http.ResponseWriter, r *h
 		return errors.New("no upgrade proto in request")
 	}
 	if proto != "h2c" {
-		return errors.Errorf("protocol %s not supported", proto)
+		return fmt.Errorf("protocol %s not supported", proto)
 	}
 
 	conn, _, err := h.Hijack()

--- a/daemon/server/router/network/network_routes.go
+++ b/daemon/server/router/network/network_routes.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -369,7 +370,7 @@ func (n *networkRouter) findUniqueNetwork(term string) (network.Inspect, error) 
 		}
 	}
 	if len(listByFullName) > 1 {
-		return network.Inspect{}, errdefs.InvalidParameter(errors.Errorf("network %s is ambiguous (%d matches found based on name)", term, len(listByFullName)))
+		return network.Inspect{}, errdefs.InvalidParameter(fmt.Errorf("network %s is ambiguous (%d matches found based on name)", term, len(listByFullName)))
 	}
 
 	// Find based on partial ID, returns true only if no duplicates
@@ -379,7 +380,7 @@ func (n *networkRouter) findUniqueNetwork(term string) (network.Inspect, error) 
 		}
 	}
 	if len(listByPartialID) > 1 {
-		return network.Inspect{}, errdefs.InvalidParameter(errors.Errorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID)))
+		return network.Inspect{}, errdefs.InvalidParameter(fmt.Errorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID)))
 	}
 
 	return network.Inspect{}, errdefs.NotFound(libnetwork.ErrNoSuchNetwork(term))

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -430,7 +430,7 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 	}
 	version := httputils.VersionFromContext(ctx)
 	if secret.Templating != nil && versions.LessThan(version, "1.37") {
-		return errdefs.InvalidParameter(errors.Errorf("secret templating is not supported on the specified API version: %s", version))
+		return errdefs.InvalidParameter(fmt.Errorf("secret templating is not supported on the specified API version: %s", version))
 	}
 
 	id, err := sr.backend.CreateSecret(secret)
@@ -502,7 +502,7 @@ func (sr *swarmRouter) createConfig(ctx context.Context, w http.ResponseWriter, 
 
 	version := httputils.VersionFromContext(ctx)
 	if config.Templating != nil && versions.LessThan(version, "1.37") {
-		return errdefs.InvalidParameter(errors.Errorf("config templating is not supported on the specified API version: %s", version))
+		return errdefs.InvalidParameter(fmt.Errorf("config templating is not supported on the specified API version: %s", version))
 	}
 
 	id, err := sr.backend.CreateConfig(config)

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -55,7 +55,7 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 	case *statsV2.Metrics:
 		return daemon.statsV2(s, t)
 	default:
-		return nil, errors.Errorf("unexpected type of metrics %+v", t)
+		return nil, fmt.Errorf("unexpected type of metrics %+v", t)
 	}
 }
 

--- a/daemon/volume/drivers/extpoint.go
+++ b/daemon/volume/drivers/extpoint.go
@@ -228,11 +228,11 @@ func makePluginAdapter(p plugingetter.CompatPlugin) (*volumeDriverAdapter, error
 
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin instance %T", p))
+		return nil, errdefs.System(fmt.Errorf("got unknown plugin instance %T", p))
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {
-		return nil, errors.Errorf("plugin protocol not supported: %s", p)
+		return nil, fmt.Errorf("plugin protocol not supported: %s", p)
 	}
 
 	addr := pa.Addr()

--- a/daemon/volume/local/local.go
+++ b/daemon/volume/local/local.go
@@ -6,6 +6,7 @@ package local
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -194,7 +195,7 @@ func (r *Root) Remove(v volume.Volume) error {
 
 	lv, ok := v.(*localVolume)
 	if !ok {
-		return errdefs.System(errors.Errorf("unknown volume type %T", v))
+		return errdefs.System(fmt.Errorf("unknown volume type %T", v))
 	}
 
 	if lv.active.count > 0 {
@@ -217,7 +218,7 @@ func (r *Root) Remove(v volume.Volume) error {
 	}
 
 	if realPath == r.path || !strings.HasPrefix(realPath, r.path) {
-		return errdefs.System(errors.Errorf("unable to remove a directory outside of the local volume root %s: %s", r.path, realPath))
+		return errdefs.System(fmt.Errorf("unable to remove a directory outside of the local volume root %s: %s", r.path, realPath))
 	}
 
 	if err := removePath(realPath); err != nil {
@@ -259,7 +260,7 @@ func (r *Root) validateName(name string) error {
 		return errdefs.InvalidParameter(errors.New("volume name is too short, names should be at least two alphanumeric characters"))
 	}
 	if !volumeNameRegex.MatchString(name) {
-		return errdefs.InvalidParameter(errors.Errorf("%q includes invalid characters for a local volume name, only %q are allowed. If you intended to pass a host directory, use absolute path", name, names.RestrictedNameChars))
+		return errdefs.InvalidParameter(fmt.Errorf("%q includes invalid characters for a local volume name, only %q are allowed. If you intended to pass a host directory, use absolute path", name, names.RestrictedNameChars))
 	}
 	return nil
 }

--- a/daemon/volume/local/local_unix.go
+++ b/daemon/volume/local/local_unix.go
@@ -53,7 +53,7 @@ func (r *Root) validateOpts(opts map[string]string) error {
 	}
 	for opt := range opts {
 		if _, ok := validOpts[opt]; !ok {
-			return errdefs.InvalidParameter(errors.Errorf("invalid option: %q", opt))
+			return errdefs.InvalidParameter(fmt.Errorf("invalid option: %q", opt))
 		}
 	}
 	if typeOpt, deviceOpt := opts["type"], opts["device"]; typeOpt == "cifs" && deviceOpt != "" {
@@ -78,7 +78,7 @@ func (r *Root) validateOpts(opts map[string]string) error {
 		if _, ok := opts[opt]; ok {
 			for _, reqopt := range reqopts {
 				if _, ok := opts[reqopt]; !ok {
-					return errdefs.InvalidParameter(errors.Errorf("missing required option: %q", reqopt))
+					return errdefs.InvalidParameter(fmt.Errorf("missing required option: %q", reqopt))
 				}
 			}
 		}

--- a/daemon/volume/mounts/mounts.go
+++ b/daemon/volume/mounts/mounts.go
@@ -2,6 +2,7 @@ package mounts
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"runtime/debug"
 	"syscall"
@@ -300,11 +301,11 @@ func (m *MountPoint) Path() string {
 }
 
 func errInvalidMode(mode string) error {
-	return errors.Errorf("invalid mode: %v", mode)
+	return fmt.Errorf("invalid mode: %v", mode)
 }
 
 func errInvalidSpec(spec string) error {
-	return errors.Errorf("invalid volume specification: '%s'", spec)
+	return fmt.Errorf("invalid volume specification: '%s'", spec)
 }
 
 // noCleanup is a no-op cleanup function.

--- a/daemon/volume/mounts/validate.go
+++ b/daemon/volume/mounts/validate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/moby/moby/api/types/mount"
-	"github.com/pkg/errors"
 )
 
 type errMountConfig struct {
@@ -17,13 +16,13 @@ func (e *errMountConfig) Error() string {
 }
 
 func errBindSourceDoesNotExist(path string) error {
-	return errors.Errorf("bind source path does not exist: %s", path)
+	return fmt.Errorf("bind source path does not exist: %s", path)
 }
 
 func errExtraField(name string) error {
-	return errors.Errorf("field %s must not be specified", name)
+	return fmt.Errorf("field %s must not be specified", name)
 }
 
 func errMissingField(name string) error {
-	return errors.Errorf("field %s must not be empty", name)
+	return fmt.Errorf("field %s must not be empty", name)
 }

--- a/daemon/volume/service/store.go
+++ b/daemon/volume/service/store.go
@@ -327,7 +327,7 @@ func (s *VolumeStore) filter(ctx context.Context, vols *[]volume.Volume, by By) 
 		}
 		filter(vols, filterFunc(f))
 	default:
-		return nil, errdefs.InvalidParameter(errors.Errorf("unsupported filter: %T", f))
+		return nil, errdefs.InvalidParameter(fmt.Errorf("unsupported filter: %T", f))
 	}
 	return warnings, nil
 }
@@ -355,7 +355,7 @@ func (s *VolumeStore) Find(ctx context.Context, by By) (vols []volume.Volume, wa
 		warnings, err = s.filter(ctx, f.ls, f.by)
 	default:
 		// Really shouldn't be possible, but makes sure that any new By's are added to this check.
-		err = errdefs.InvalidParameter(errors.Errorf("unsupported filter type: %T", f))
+		err = errdefs.InvalidParameter(fmt.Errorf("unsupported filter type: %T", f))
 	}
 	if err != nil {
 		return nil, nil, &OpErr{Err: err, Op: "list"}

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -1,11 +1,11 @@
 package daemon
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/v2/errdefs"
-	"github.com/pkg/errors"
 )
 
 // validateBindDaemonRoot ensures that if a given mountpoint's source is within
@@ -32,5 +32,5 @@ func (daemon *Daemon) validateBindDaemonRoot(m mount.Mount) (bool, error) {
 	default:
 	}
 
-	return false, errdefs.InvalidParameter(errors.Errorf(`invalid mount config: must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: %q, bind mount source: %q, propagation: %q`, daemon.root, m.Source, m.BindOptions.Propagation))
+	return false, errdefs.InvalidParameter(fmt.Errorf(`invalid mount config: must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: %q, bind mount source: %q, propagation: %q`, daemon.root, m.Source, m.BindOptions.Propagation))
 }

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/stringid"
 	"github.com/moby/moby/v2/testutil/daemon"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
@@ -72,7 +71,7 @@ func (d *Daemon) inspectFilter(name, filter string) (string, error) {
 	format := fmt.Sprintf("{{%s}}", filter)
 	out, err := d.Cmd("inspect", "-f", format, name)
 	if err != nil {
-		return "", errors.Errorf("failed to inspect %s: %s", name, out)
+		return "", fmt.Errorf("failed to inspect %s: %s", name, out)
 	}
 	return strings.TrimSpace(out), nil
 }
@@ -116,7 +115,7 @@ func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time
 		result := icmd.RunCommand(dockerBinary, args...)
 		if result.Error != nil {
 			if !strings.Contains(strings.ToLower(result.Stderr()), "no such") {
-				return errors.Errorf("error executing docker inspect: %v\n%s",
+				return fmt.Errorf("error executing docker inspect: %v\n%s",
 					result.Stderr(), result.Stdout())
 			}
 			select {
@@ -135,7 +134,7 @@ func WaitInspectWithArgs(dockerBinary, name, expr, expected string, timeout time
 
 		select {
 		case <-after:
-			return errors.Errorf("condition \"%q == %q\" not true in time (%v)", out, expected, timeout)
+			return fmt.Errorf("condition \"%q == %q\" not true in time (%v)", out, expected, timeout)
 		default:
 		}
 

--- a/integration-cli/docker_api_containers_windows_test.go
+++ b/integration-cli/docker_api_containers_windows_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/v2/testutil"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -75,5 +74,5 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsBindNamedPipe(c *testing.T
 
 func mountWrapper(t *testing.T, device, target, mType, options string) error {
 	// This should never be called.
-	return errors.Errorf("there is no implementation of Mount on this platform")
+	return fmt.Errorf("there is no implementation of Mount on this platform")
 }

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -44,7 +44,7 @@ func (s *DockerAPISuite) TestExecResizeImmediatelyAfterExecStart(c *testing.T) {
 			return err
 		}
 		if res.StatusCode != http.StatusCreated {
-			return errors.Errorf("POST %s is expected to return %d, got %d", uri, http.StatusCreated, res.StatusCode)
+			return fmt.Errorf("POST %s is expected to return %d, got %d", uri, http.StatusCreated, res.StatusCode)
 		}
 
 		buf, err := request.ReadBody(body)

--- a/integration/internal/container/states.go
+++ b/integration/internal/container/states.go
@@ -2,12 +2,12 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/poll"
 )
 
@@ -63,7 +63,7 @@ func IsSuccessful(ctx context.Context, apiClient client.APIClient, containerID s
 			if inspect.State.ExitCode == 0 {
 				return poll.Success()
 			}
-			return poll.Error(errors.Errorf("expected exit code 0, got %d", inspect.State.ExitCode))
+			return poll.Error(fmt.Errorf("expected exit code 0, got %d", inspect.State.ExitCode))
 		}
 		return poll.Continue("waiting for container to be %q, currently %s", container.StateExited, inspect.State.Status)
 	}

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -460,7 +460,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 	d.args = []string{}
 	if d.rootlessUser != nil {
 		if d.dockerdBinary != defaultDockerdBinary {
-			return errors.Errorf("[%s] DOCKER_ROOTLESS doesn't support non-default dockerd binary path %q", d.id, d.dockerdBinary)
+			return fmt.Errorf("[%s] DOCKER_ROOTLESS doesn't support non-default dockerd binary path %q", d.id, d.dockerdBinary)
 		}
 		dockerdBinary = "sudo"
 		d.args = append(d.args,
@@ -845,7 +845,7 @@ func (d *Daemon) ReloadConfig() error {
 			return errors.Wrapf(err, "[%s] error waiting for daemon reload event", d.id)
 		}
 	case <-time.After(30 * time.Second):
-		return errors.Errorf("[%s] daemon reload event timed out after 30 seconds", d.id)
+		return fmt.Errorf("[%s] daemon reload event timed out after 30 seconds", d.id)
 	}
 	return nil
 }

--- a/testutil/request/request.go
+++ b/testutil/request/request.go
@@ -219,6 +219,6 @@ func SockConn(timeout time.Duration, daemon string) (net.Conn, error) {
 		}
 		return net.DialTimeout(daemonURL.Scheme, daemonURL.Host, timeout)
 	default:
-		return c, errors.Errorf("unknown scheme %v (%s)", daemonURL.Scheme, daemon)
+		return c, fmt.Errorf("unknown scheme %v (%s)", daemonURL.Scheme, daemon)
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

use fmt.Errorf instead of errors.Errorf to use standard fmt instead of archived `github.com/stretchr/errors` in a progressive way

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

