### PR TITLE
api/types/container: remove `PortSet`, `PortMap`

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -40,25 +40,25 @@ type HealthConfig = dockerspec.HealthcheckConfig
 // All fields added to this struct must be marked `omitempty` to keep getting
 // predictable hashes from the old `v1Compatibility` configuration.
 type Config struct {
-	Hostname        string                      // Hostname
-	Domainname      string                      // Domainname
-	User            string                      // User that will run the command(s) inside the container, also support user:group
-	AttachStdin     bool                        // Attach the standard input, makes possible user interaction
-	AttachStdout    bool                        // Attach the standard output
-	AttachStderr    bool                        // Attach the standard error
-	ExposedPorts    map[PortRangeProto]struct{} `json:",omitempty"` // List of exposed ports
-	Tty             bool                        // Attach standard streams to a tty, including stdin if it is not closed.
-	OpenStdin       bool                        // Open stdin
-	StdinOnce       bool                        // If true, close stdin after the 1 attached client disconnects.
-	Env             []string                    // List of environment variable to set in the container
-	Cmd             []string                    // Command to run when starting the container
-	Healthcheck     *HealthConfig               `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped     bool                        `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
-	Image           string                      // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Volumes         map[string]struct{}         // List of volumes (mounts) used for the container
-	WorkingDir      string                      // Current directory (PWD) in the command will be launched
-	Entrypoint      []string                    // Entrypoint to run when starting the container
-	NetworkDisabled bool                        `json:",omitempty"` // Is network disabled
+	Hostname        string                 // Hostname
+	Domainname      string                 // Domainname
+	User            string                 // User that will run the command(s) inside the container, also support user:group
+	AttachStdin     bool                   // Attach the standard input, makes possible user interaction
+	AttachStdout    bool                   // Attach the standard output
+	AttachStderr    bool                   // Attach the standard error
+	ExposedPorts    map[PortProto]struct{} `json:",omitempty"` // List of exposed ports
+	Tty             bool                   // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool                   // Open stdin
+	StdinOnce       bool                   // If true, close stdin after the 1 attached client disconnects.
+	Env             []string               // List of environment variable to set in the container
+	Cmd             []string               // Command to run when starting the container
+	Healthcheck     *HealthConfig          `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped     bool                   `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
+	Image           string                 // Name of the image as it was passed by the operator (e.g. could be symbolic)
+	Volumes         map[string]struct{}    // List of volumes (mounts) used for the container
+	WorkingDir      string                 // Current directory (PWD) in the command will be launched
+	Entrypoint      []string               // Entrypoint to run when starting the container
+	NetworkDisabled bool                   `json:",omitempty"` // Is network disabled
 	// Mac Address of the container.
 	//
 	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -40,25 +40,25 @@ type HealthConfig = dockerspec.HealthcheckConfig
 // All fields added to this struct must be marked `omitempty` to keep getting
 // predictable hashes from the old `v1Compatibility` configuration.
 type Config struct {
-	Hostname        string              // Hostname
-	Domainname      string              // Domainname
-	User            string              // User that will run the command(s) inside the container, also support user:group
-	AttachStdin     bool                // Attach the standard input, makes possible user interaction
-	AttachStdout    bool                // Attach the standard output
-	AttachStderr    bool                // Attach the standard error
-	ExposedPorts    PortSet             `json:",omitempty"` // List of exposed ports
-	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
-	OpenStdin       bool                // Open stdin
-	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.
-	Env             []string            // List of environment variable to set in the container
-	Cmd             []string            // Command to run when starting the container
-	Healthcheck     *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
-	Image           string              // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Volumes         map[string]struct{} // List of volumes (mounts) used for the container
-	WorkingDir      string              // Current directory (PWD) in the command will be launched
-	Entrypoint      []string            // Entrypoint to run when starting the container
-	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
+	Hostname        string                      // Hostname
+	Domainname      string                      // Domainname
+	User            string                      // User that will run the command(s) inside the container, also support user:group
+	AttachStdin     bool                        // Attach the standard input, makes possible user interaction
+	AttachStdout    bool                        // Attach the standard output
+	AttachStderr    bool                        // Attach the standard error
+	ExposedPorts    map[PortRangeProto]struct{} `json:",omitempty"` // List of exposed ports
+	Tty             bool                        // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool                        // Open stdin
+	StdinOnce       bool                        // If true, close stdin after the 1 attached client disconnects.
+	Env             []string                    // List of environment variable to set in the container
+	Cmd             []string                    // Command to run when starting the container
+	Healthcheck     *HealthConfig               `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped     bool                        `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
+	Image           string                      // Name of the image as it was passed by the operator (e.g. could be symbolic)
+	Volumes         map[string]struct{}         // List of volumes (mounts) used for the container
+	WorkingDir      string                      // Current directory (PWD) in the command will be launched
+	Entrypoint      []string                    // Entrypoint to run when starting the container
+	NetworkDisabled bool                        `json:",omitempty"` // Is network disabled
 	// Mac Address of the container.
 	//
 	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -421,17 +421,17 @@ type UpdateConfig struct {
 // Portable information *should* appear in Config.
 type HostConfig struct {
 	// Applicable to all platforms
-	Binds           []string          // List of volume bindings for this container
-	ContainerIDFile string            // File (path) where the containerId is written
-	LogConfig       LogConfig         // Configuration of the logs for this container
-	NetworkMode     NetworkMode       // Network mode to use for the container
-	PortBindings    PortMap           // Port mapping between the exposed port (container) and the host
-	RestartPolicy   RestartPolicy     // Restart policy to be used for the container
-	AutoRemove      bool              // Automatically remove container when it exits
-	VolumeDriver    string            // Name of the volume driver used to mount volumes
-	VolumesFrom     []string          // List of volumes to take from other container
-	ConsoleSize     [2]uint           // Initial console size (height,width)
-	Annotations     map[string]string `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
+	Binds           []string                         // List of volume bindings for this container
+	ContainerIDFile string                           // File (path) where the containerId is written
+	LogConfig       LogConfig                        // Configuration of the logs for this container
+	NetworkMode     NetworkMode                      // Network mode to use for the container
+	PortBindings    map[PortRangeProto][]PortBinding // Port mapping between the exposed port (container) and the host
+	RestartPolicy   RestartPolicy                    // Restart policy to be used for the container
+	AutoRemove      bool                             // Automatically remove container when it exits
+	VolumeDriver    string                           // Name of the volume driver used to mount volumes
+	VolumesFrom     []string                         // List of volumes to take from other container
+	ConsoleSize     [2]uint                          // Initial console size (height,width)
+	Annotations     map[string]string                `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
 
 	// Applicable to UNIX platforms
 	CapAdd          []string          // List of kernel capabilities to add to the container

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -421,17 +421,17 @@ type UpdateConfig struct {
 // Portable information *should* appear in Config.
 type HostConfig struct {
 	// Applicable to all platforms
-	Binds           []string                         // List of volume bindings for this container
-	ContainerIDFile string                           // File (path) where the containerId is written
-	LogConfig       LogConfig                        // Configuration of the logs for this container
-	NetworkMode     NetworkMode                      // Network mode to use for the container
-	PortBindings    map[PortRangeProto][]PortBinding // Port mapping between the exposed port (container) and the host
-	RestartPolicy   RestartPolicy                    // Restart policy to be used for the container
-	AutoRemove      bool                             // Automatically remove container when it exits
-	VolumeDriver    string                           // Name of the volume driver used to mount volumes
-	VolumesFrom     []string                         // List of volumes to take from other container
-	ConsoleSize     [2]uint                          // Initial console size (height,width)
-	Annotations     map[string]string                `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
+	Binds           []string                    // List of volume bindings for this container
+	ContainerIDFile string                      // File (path) where the containerId is written
+	LogConfig       LogConfig                   // Configuration of the logs for this container
+	NetworkMode     NetworkMode                 // Network mode to use for the container
+	PortBindings    map[PortProto][]PortBinding // Port mapping between the exposed port (container) and the host
+	RestartPolicy   RestartPolicy               // Restart policy to be used for the container
+	AutoRemove      bool                        // Automatically remove container when it exits
+	VolumeDriver    string                      // Name of the volume driver used to mount volumes
+	VolumesFrom     []string                    // List of volumes to take from other container
+	ConsoleSize     [2]uint                     // Initial console size (height,width)
+	Annotations     map[string]string           `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
 
 	// Applicable to UNIX platforms
 	CapAdd          []string          // List of kernel capabilities to add to the container

--- a/api/types/container/nat_aliases.go
+++ b/api/types/container/nat_aliases.go
@@ -2,19 +2,27 @@ package container
 
 import "github.com/docker/go-connections/nat"
 
-// PortRangeProto is a string containing port number and protocol in the format "80/tcp",
-// or a port range and protocol in the format "80-83/tcp".
+// PortProto is a string containing port number and protocol in the format "80/tcp".
+// It is the same as [PortRangeProto], but used in places where we only expect
+// a single port to be used (not a range).
+//
+// It is currently an alias for [nat.Port] but may become a concrete type in a future release.
+type PortProto = nat.Port
+
+// PortRangeProto is a string containing a range of port numbers and protocol in
+// the format "80-90/tcp". It the same as [PortProto], but used in places where
+// we expect a port-range to be used.
 //
 // It is currently an alias for [nat.Port] but may become a concrete type in a future release.
 type PortRangeProto = nat.Port
 
-// PortSet is a collection of structs indexed by [PortRangeProto].
-type PortSet = map[PortRangeProto]struct{}
+// PortSet is a collection of structs indexed by [PortProto].
+type PortSet = map[PortProto]struct{}
 
 // PortBinding represents a binding between a Host IP address and a [HostPort].
 //
 // It is currently an alias for [nat.PortBinding] but may become a concrete type in a future release.
 type PortBinding = nat.PortBinding
 
-// PortMap is a collection of [PortBinding] indexed by [PortRangeProto].
-type PortMap = map[PortRangeProto][]PortBinding
+// PortMap is a collection of [PortBinding] indexed by [PortProto].
+type PortMap = map[PortProto][]PortBinding

--- a/api/types/container/nat_aliases.go
+++ b/api/types/container/nat_aliases.go
@@ -8,17 +8,13 @@ import "github.com/docker/go-connections/nat"
 // It is currently an alias for [nat.Port] but may become a concrete type in a future release.
 type PortRangeProto = nat.Port
 
-// PortSet is a collection of structs indexed by [HostPort].
-//
-// It is currently an alias for [nat.PortSet] but may become a concrete type in a future release.
-type PortSet = nat.PortSet
+// PortSet is a collection of structs indexed by [PortRangeProto].
+type PortSet = map[PortRangeProto]struct{}
 
 // PortBinding represents a binding between a Host IP address and a [HostPort].
 //
 // It is currently an alias for [nat.PortBinding] but may become a concrete type in a future release.
 type PortBinding = nat.PortBinding
 
-// PortMap is a collection of [PortBinding] indexed by [HostPort].
-//
-// It is currently an alias for [nat.PortMap] but may become a concrete type in a future release.
-type PortMap = nat.PortMap
+// PortMap is a collection of [PortBinding] indexed by [PortRangeProto].
+type PortMap = map[PortRangeProto][]PortBinding

--- a/api/types/container/network_settings.go
+++ b/api/types/container/network_settings.go
@@ -18,7 +18,7 @@ type NetworkSettingsBase struct {
 	SandboxKey string // SandboxKey identifies the sandbox
 
 	// Ports is a collection of PortBinding indexed by "port/proto".
-	Ports map[PortRangeProto][]PortBinding
+	Ports map[PortProto][]PortBinding
 
 	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
 	//

--- a/api/types/container/network_settings.go
+++ b/api/types/container/network_settings.go
@@ -13,10 +13,12 @@ type NetworkSettings struct {
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
 type NetworkSettingsBase struct {
-	Bridge     string  // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
-	SandboxID  string  // SandboxID uniquely represents a container's network stack
-	SandboxKey string  // SandboxKey identifies the sandbox
-	Ports      PortMap // Ports is a collection of PortBinding indexed by Port
+	Bridge     string // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
+	SandboxID  string // SandboxID uniquely represents a container's network stack
+	SandboxKey string // SandboxKey identifies the sandbox
+
+	// Ports is a collection of PortBinding indexed by "port/proto".
+	Ports map[PortRangeProto][]PortBinding
 
 	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
 	//

--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -531,7 +531,7 @@ func dispatchExpose(ctx context.Context, d dispatchRequest, c *instructions.Expo
 	}
 
 	if d.state.runConfig.ExposedPorts == nil {
-		d.state.runConfig.ExposedPorts = make(map[container.PortRangeProto]struct{})
+		d.state.runConfig.ExposedPorts = make(map[container.PortProto]struct{})
 	}
 	for p := range ps {
 		d.state.runConfig.ExposedPorts[p] = struct{}{}

--- a/daemon/builder/dockerfile/dispatchers.go
+++ b/daemon/builder/dockerfile/dispatchers.go
@@ -531,7 +531,7 @@ func dispatchExpose(ctx context.Context, d dispatchRequest, c *instructions.Expo
 	}
 
 	if d.state.runConfig.ExposedPorts == nil {
-		d.state.runConfig.ExposedPorts = make(container.PortSet)
+		d.state.runConfig.ExposedPorts = make(map[container.PortRangeProto]struct{})
 	}
 	for p := range ps {
 		d.state.runConfig.ExposedPorts[p] = struct{}{}

--- a/daemon/builder/dockerfile/dispatchers_test.go
+++ b/daemon/builder/dockerfile/dispatchers_test.go
@@ -336,7 +336,7 @@ func TestExpose(t *testing.T) {
 	assert.Assert(t, sb.state.runConfig.ExposedPorts != nil)
 	assert.Assert(t, is.Len(sb.state.runConfig.ExposedPorts, 1))
 
-	assert.Check(t, is.Contains(sb.state.runConfig.ExposedPorts, container.PortRangeProto("80/tcp")))
+	assert.Check(t, is.Contains(sb.state.runConfig.ExposedPorts, container.PortProto("80/tcp")))
 }
 
 func TestUser(t *testing.T) {

--- a/daemon/builder/dockerfile/internals_test.go
+++ b/daemon/builder/dockerfile/internals_test.go
@@ -137,7 +137,7 @@ func fullMutableRunConfig() *container.Config {
 	return &container.Config{
 		Cmd: []string{"command", "arg1"},
 		Env: []string{"env1=foo", "env2=bar"},
-		ExposedPorts: container.PortSet{
+		ExposedPorts: map[container.PortRangeProto]struct{}{
 			"1000/tcp": {},
 			"1001/tcp": {},
 		},

--- a/daemon/builder/dockerfile/internals_test.go
+++ b/daemon/builder/dockerfile/internals_test.go
@@ -137,7 +137,7 @@ func fullMutableRunConfig() *container.Config {
 	return &container.Config{
 		Cmd: []string{"command", "arg1"},
 		Env: []string{"env1=foo", "env2=bar"},
-		ExposedPorts: map[container.PortRangeProto]struct{}{
+		ExposedPorts: map[container.PortProto]struct{}{
 			"1000/tcp": {},
 			"1001/tcp": {},
 		},

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -139,8 +139,8 @@ func (c *containerConfig) image() string {
 	return reference.FamiliarString(reference.TagNameOnly(ref))
 }
 
-func (c *containerConfig) portBindings() container.PortMap {
-	portBindings := container.PortMap{}
+func (c *containerConfig) portBindings() map[container.PortProto][]container.PortBinding {
+	portBindings := map[container.PortProto][]container.PortBinding{}
 	if c.task.Endpoint == nil {
 		return portBindings
 	}

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -150,7 +150,7 @@ func (c *containerConfig) portBindings() container.PortMap {
 			continue
 		}
 
-		port := container.PortRangeProto(fmt.Sprintf("%d/%s", portConfig.TargetPort, strings.ToLower(portConfig.Protocol.String())))
+		port := container.PortProto(fmt.Sprintf("%d/%s", portConfig.TargetPort, strings.ToLower(portConfig.Protocol.String())))
 		binding := []container.PortBinding{
 			{},
 		}
@@ -176,8 +176,8 @@ func (c *containerConfig) init() *bool {
 	return &init
 }
 
-func (c *containerConfig) exposedPorts() map[container.PortRangeProto]struct{} {
-	exposedPorts := make(map[container.PortRangeProto]struct{})
+func (c *containerConfig) exposedPorts() map[container.PortProto]struct{} {
+	exposedPorts := make(map[container.PortProto]struct{})
 	if c.task.Endpoint == nil {
 		return exposedPorts
 	}
@@ -187,7 +187,7 @@ func (c *containerConfig) exposedPorts() map[container.PortRangeProto]struct{} {
 			continue
 		}
 
-		port := container.PortRangeProto(fmt.Sprintf("%d/%s", portConfig.TargetPort, strings.ToLower(portConfig.Protocol.String())))
+		port := container.PortProto(fmt.Sprintf("%d/%s", portConfig.TargetPort, strings.ToLower(portConfig.Protocol.String())))
 		exposedPorts[port] = struct{}{}
 	}
 

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -640,7 +640,7 @@ func parsePortStatus(ctnr container.InspectResponse) (*api.PortStatus, error) {
 	return status, nil
 }
 
-func parsePortMap(portMap container.PortMap) ([]*api.PortConfig, error) {
+func parsePortMap(portMap map[container.PortProto][]container.PortBinding) ([]*api.PortConfig, error) {
 	exposedPorts := make([]*api.PortConfig, 0, len(portMap))
 
 	for portProtocol, mapping := range portMap {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -373,7 +373,7 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 	return nil
 }
 
-func validatePortBindings(ports containertypes.PortMap) error {
+func validatePortBindings(ports map[containertypes.PortProto][]containertypes.PortBinding) error {
 	for port := range ports {
 		_, portStr := nat.SplitProtoPort(string(port))
 		if _, err := nat.ParsePort(portStr); err != nil {

--- a/daemon/container/view.go
+++ b/daemon/container/view.go
@@ -40,8 +40,8 @@ type Snapshot struct {
 	Running      bool
 	Paused       bool
 	Managed      bool
-	ExposedPorts container.PortSet
-	PortBindings container.PortSet
+	ExposedPorts map[container.PortRangeProto]struct{}
+	PortBindings map[container.PortRangeProto]struct{} // FIXME(thaJeztah): should this have been a PortMap? https://github.com/moby/moby/commit/edad52707c536116363031002e6633e3fec16af5
 	Health       container.HealthStatus
 	HostConfig   struct {
 		Isolation string
@@ -321,8 +321,8 @@ func (v *View) transform(ctr *Container) *Snapshot {
 		Name:         ctr.Name,
 		Pid:          ctr.Pid,
 		Managed:      ctr.Managed,
-		ExposedPorts: make(container.PortSet),
-		PortBindings: make(container.PortSet),
+		ExposedPorts: make(map[container.PortRangeProto]struct{}),
+		PortBindings: make(map[container.PortRangeProto]struct{}),
 		Health:       health,
 		Running:      ctr.Running,
 		Paused:       ctr.Paused,

--- a/daemon/container/view.go
+++ b/daemon/container/view.go
@@ -40,8 +40,8 @@ type Snapshot struct {
 	Running      bool
 	Paused       bool
 	Managed      bool
-	ExposedPorts map[container.PortRangeProto]struct{}
-	PortBindings map[container.PortRangeProto]struct{} // FIXME(thaJeztah): should this have been a PortMap? https://github.com/moby/moby/commit/edad52707c536116363031002e6633e3fec16af5
+	ExposedPorts map[container.PortProto]struct{}
+	PortBindings map[container.PortProto]struct{} // FIXME(thaJeztah): should this have been a PortMap? https://github.com/moby/moby/commit/edad52707c536116363031002e6633e3fec16af5
 	Health       container.HealthStatus
 	HostConfig   struct {
 		Isolation string
@@ -321,8 +321,8 @@ func (v *View) transform(ctr *Container) *Snapshot {
 		Name:         ctr.Name,
 		Pid:          ctr.Pid,
 		Managed:      ctr.Managed,
-		ExposedPorts: make(map[container.PortRangeProto]struct{}),
-		PortBindings: make(map[container.PortRangeProto]struct{}),
+		ExposedPorts: make(map[container.PortProto]struct{}),
+		PortBindings: make(map[container.PortProto]struct{}),
 		Health:       health,
 		Running:      ctr.Running,
 		Paused:       ctr.Paused,

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -115,7 +115,7 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 	// Create a deep copy (as [nat.SortPortMap] mutates the map).
 	// Not using a maps.Clone here, as that won't dereference the
 	// slice (PortMap is a map[Port][]PortBinding).
-	bindings := make(containertypes.PortMap)
+	bindings := make(map[containertypes.PortProto][]containertypes.PortBinding, len(ctr.HostConfig.PortBindings))
 	for p, b := range ctr.HostConfig.PortBindings {
 		bindings[p] = slices.Clone(b)
 	}

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -14,12 +14,12 @@ import (
 // This should not be tested on Windows because Windows doesn't support "host" network mode.
 func TestContainerWarningHostAndPublishPorts(t *testing.T) {
 	testCases := []struct {
-		ports    containertypes.PortMap
+		ports    map[containertypes.PortProto][]containertypes.PortBinding
 		warnings []string
 	}{
-		{ports: containertypes.PortMap{}},
-		{ports: containertypes.PortMap{
-			"8080": []containertypes.PortBinding{{HostPort: "8989"}},
+		{ports: map[containertypes.PortProto][]containertypes.PortBinding{}},
+		{ports: map[containertypes.PortProto][]containertypes.PortBinding{
+			"8080": {{HostPort: "8989"}},
 		}, warnings: []string{"Published ports are discarded when using host network mode"}},
 	}
 	muteLogs(t)

--- a/daemon/containerd/image_import_test.go
+++ b/daemon/containerd/image_import_test.go
@@ -11,8 +11,8 @@ import (
 // regression test for https://github.com/moby/moby/issues/45904
 func TestContainerConfigToDockerImageConfig(t *testing.T) {
 	ociCFG := containerConfigToDockerOCIImageConfig(&container.Config{
-		ExposedPorts: container.PortSet{
-			"80/tcp": struct{}{},
+		ExposedPorts: map[container.PortRangeProto]struct{}{
+			"80/tcp": {},
 		},
 	})
 

--- a/daemon/containerd/image_import_test.go
+++ b/daemon/containerd/image_import_test.go
@@ -11,7 +11,7 @@ import (
 // regression test for https://github.com/moby/moby/issues/45904
 func TestContainerConfigToDockerImageConfig(t *testing.T) {
 	ociCFG := containerConfigToDockerOCIImageConfig(&container.Config{
-		ExposedPorts: map[container.PortRangeProto]struct{}{
+		ExposedPorts: map[container.PortProto]struct{}{
 			"80/tcp": {},
 		},
 	})

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -97,7 +97,7 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *container.Config {
 	exposedPorts := make(container.PortSet, len(cfg.ExposedPorts))
 	for k := range cfg.ExposedPorts {
-		exposedPorts[container.PortRangeProto(k)] = struct{}{}
+		exposedPorts[container.PortProto(k)] = struct{}{}
 	}
 
 	return &container.Config{

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -95,7 +95,7 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 }
 
 func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *container.Config {
-	exposedPorts := make(map[container.PortRangeProto]struct{}, len(cfg.ExposedPorts))
+	exposedPorts := make(map[container.PortProto]struct{}, len(cfg.ExposedPorts))
 	for k := range cfg.ExposedPorts {
 		exposedPorts[container.PortProto(k)] = struct{}{}
 	}

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -95,7 +95,7 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 }
 
 func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *container.Config {
-	exposedPorts := make(container.PortSet, len(cfg.ExposedPorts))
+	exposedPorts := make(map[container.PortRangeProto]struct{}, len(cfg.ExposedPorts))
 	for k := range cfg.ExposedPorts {
 		exposedPorts[container.PortProto(k)] = struct{}{}
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -273,7 +273,7 @@ func TestMerge(t *testing.T) {
 	}
 
 	configImage2 := &containertypes.Config{
-		ExposedPorts: map[containertypes.PortRangeProto]struct{}{"0/tcp": {}},
+		ExposedPorts: map[containertypes.PortProto]struct{}{"0/tcp": {}},
 	}
 
 	if err := merge(configUser, configImage2); err != nil {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -220,7 +220,7 @@ func TestContainerInitDNS(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	configImage := &containertypes.Config{
-		ExposedPorts: map[containertypes.PortRangeProto]struct{}{
+		ExposedPorts: map[containertypes.PortProto]struct{}{
 			"1111/tcp": {},
 			"2222/tcp": {},
 		},
@@ -232,7 +232,7 @@ func TestMerge(t *testing.T) {
 	}
 
 	configUser := &containertypes.Config{
-		ExposedPorts: map[containertypes.PortRangeProto]struct{}{
+		ExposedPorts: map[containertypes.PortProto]struct{}{
 			"2222/tcp": {},
 			"3333/tcp": {},
 		},

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -220,9 +220,9 @@ func TestContainerInitDNS(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	configImage := &containertypes.Config{
-		ExposedPorts: containertypes.PortSet{
-			"1111/tcp": struct{}{},
-			"2222/tcp": struct{}{},
+		ExposedPorts: map[containertypes.PortRangeProto]struct{}{
+			"1111/tcp": {},
+			"2222/tcp": {},
 		},
 		Env: []string{"VAR1=1", "VAR2=2"},
 		Volumes: map[string]struct{}{
@@ -232,9 +232,9 @@ func TestMerge(t *testing.T) {
 	}
 
 	configUser := &containertypes.Config{
-		ExposedPorts: containertypes.PortSet{
-			"2222/tcp": struct{}{},
-			"3333/tcp": struct{}{},
+		ExposedPorts: map[containertypes.PortRangeProto]struct{}{
+			"2222/tcp": {},
+			"3333/tcp": {},
 		},
 		Env: []string{"VAR2=3", "VAR3=3"},
 		Volumes: map[string]struct{}{

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -34,7 +34,7 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 	}
 
 	// TODO(thaJeztah): do we need a deep copy here? Otherwise we could use maps.Clone (see https://github.com/moby/moby/commit/7917a36cc787ada58987320e67cc6d96858f3b55)
-	ports := make(containertypes.PortMap, len(ctr.NetworkSettings.Ports))
+	ports := make(map[containertypes.PortProto][]containertypes.PortBinding, len(ctr.NetworkSettings.Ports))
 	for k, pm := range ctr.NetworkSettings.Ports {
 		ports[k] = pm
 	}

--- a/daemon/internal/image/cache/compare_test.go
+++ b/daemon/internal/image/cache/compare_test.go
@@ -11,18 +11,18 @@ import (
 )
 
 func TestCompare(t *testing.T) {
-	ports1 := container.PortSet{
-		"1111/tcp": struct{}{},
-		"2222/tcp": struct{}{},
+	ports1 := map[container.PortRangeProto]struct{}{
+		"1111/tcp": {},
+		"2222/tcp": {},
 	}
-	ports2 := container.PortSet{
-		"3333/tcp": struct{}{},
-		"4444/tcp": struct{}{},
+	ports2 := map[container.PortRangeProto]struct{}{
+		"3333/tcp": {},
+		"4444/tcp": {},
 	}
-	ports3 := container.PortSet{
-		"1111/tcp": struct{}{},
-		"2222/tcp": struct{}{},
-		"5555/tcp": struct{}{},
+	ports3 := map[container.PortRangeProto]struct{}{
+		"1111/tcp": {},
+		"2222/tcp": {},
+		"5555/tcp": {},
 	}
 	volumes1 := map[string]struct{}{
 		"/test1": {},

--- a/daemon/internal/image/cache/compare_test.go
+++ b/daemon/internal/image/cache/compare_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 func TestCompare(t *testing.T) {
-	ports1 := map[container.PortRangeProto]struct{}{
+	ports1 := map[container.PortProto]struct{}{
 		"1111/tcp": {},
 		"2222/tcp": {},
 	}
-	ports2 := map[container.PortRangeProto]struct{}{
+	ports2 := map[container.PortProto]struct{}{
 		"3333/tcp": {},
 		"4444/tcp": {},
 	}
-	ports3 := map[container.PortRangeProto]struct{}{
+	ports3 := map[container.PortProto]struct{}{
 		"1111/tcp": {},
 		"2222/tcp": {},
 		"5555/tcp": {},

--- a/daemon/links/links.go
+++ b/daemon/links/links.go
@@ -20,18 +20,18 @@ type Link struct {
 	// Child environments variables
 	ChildEnvironment []string
 	// Child exposed ports
-	Ports []container.PortRangeProto // TODO(thaJeztah): can we use []string here, or do we need the features of nat.Port?
+	Ports []container.PortProto // TODO(thaJeztah): can we use []string here, or do we need the features of nat.Port?
 }
 
 // EnvVars generates environment variables for the linked container
 // for the Link with the given options.
-func EnvVars(parentIP, childIP, name string, env []string, exposedPorts map[container.PortRangeProto]struct{}) []string {
+func EnvVars(parentIP, childIP, name string, env []string, exposedPorts map[container.PortProto]struct{}) []string {
 	return NewLink(parentIP, childIP, name, env, exposedPorts).ToEnv()
 }
 
 // NewLink initializes a new Link struct with the provided options.
-func NewLink(parentIP, childIP, name string, env []string, exposedPorts map[container.PortRangeProto]struct{}) *Link {
-	ports := make([]container.PortRangeProto, 0, len(exposedPorts))
+func NewLink(parentIP, childIP, name string, env []string, exposedPorts map[container.PortProto]struct{}) *Link {
+	ports := make([]container.PortProto, 0, len(exposedPorts))
 	for p := range exposedPorts {
 		ports = append(ports, p)
 	}
@@ -55,7 +55,7 @@ func (l *Link) ToEnv() []string {
 	// sort the ports so that we can bulk the continuous ports together
 	nat.Sort(l.Ports, withTCPPriority)
 
-	var pStart, pEnd container.PortRangeProto
+	var pStart, pEnd container.PortProto
 	env := make([]string, 0, 1+len(l.Ports)*4)
 	for i, p := range l.Ports {
 		if i == 0 {
@@ -113,7 +113,7 @@ func (l *Link) ToEnv() []string {
 
 // withTCPPriority prioritizes ports using TCP over other protocols before
 // comparing port-number and protocol.
-func withTCPPriority(ip, jp container.PortRangeProto) bool {
+func withTCPPriority(ip, jp container.PortProto) bool {
 	if strings.EqualFold(ip.Proto(), jp.Proto()) {
 		return ip.Int() < jp.Int()
 	}

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -36,7 +36,7 @@ func TestLinkNew(t *testing.T) {
 		Name:     "/db/docker",
 		ParentIP: "172.0.17.3",
 		ChildIP:  "172.0.17.2",
-		Ports:    []container.PortRangeProto{"6379/tcp"},
+		Ports:    []container.PortProto{"6379/tcp"},
 	}
 
 	assert.DeepEqual(t, expected, link)
@@ -64,7 +64,7 @@ func TestLinkEnv(t *testing.T) {
 // TestSortPorts verifies that ports are sorted with TCP taking priority,
 // and ports with the same protocol to be sorted by port.
 func TestSortPorts(t *testing.T) {
-	ports := []container.PortRangeProto{
+	ports := []container.PortProto{
 		"6379/tcp",
 		"6376/udp",
 		"6380/tcp",
@@ -75,7 +75,7 @@ func TestSortPorts(t *testing.T) {
 		"6375/sctp",
 	}
 
-	expected := []container.PortRangeProto{
+	expected := []container.PortProto{
 		"6379/tcp",
 		"6380/tcp",
 		"6381/tcp",

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestLinkNaming(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, container.PortSet{
-		"6379/tcp": struct{}{},
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, map[container.PortRangeProto]struct{}{
+		"6379/tcp": {},
 	})
 
 	expectedEnv := []string{
@@ -28,8 +28,8 @@ func TestLinkNaming(t *testing.T) {
 }
 
 func TestLinkNew(t *testing.T) {
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, container.PortSet{
-		"6379/tcp": struct{}{},
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, map[container.PortRangeProto]struct{}{
+		"6379/tcp": {},
 	})
 
 	expected := &Link{
@@ -43,8 +43,8 @@ func TestLinkNew(t *testing.T) {
 }
 
 func TestLinkEnv(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, container.PortSet{
-		"6379/tcp": struct{}{},
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortRangeProto]struct{}{
+		"6379/tcp": {},
 	})
 
 	expectedEnv := []string{
@@ -91,12 +91,12 @@ func TestSortPorts(t *testing.T) {
 }
 
 func TestLinkMultipleEnv(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, container.PortSet{
-		"6300/udp": struct{}{},
-		"6379/tcp": struct{}{},
-		"6380/tcp": struct{}{},
-		"6381/tcp": struct{}{},
-		"6382/udp": struct{}{},
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortRangeProto]struct{}{
+		"6300/udp": {},
+		"6379/tcp": {},
+		"6380/tcp": {},
+		"6381/tcp": {},
+		"6382/udp": {},
 	})
 
 	expectedEnv := []string{
@@ -142,12 +142,12 @@ func BenchmarkLinkMultipleEnv(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, container.PortSet{
-			"6300/udp": struct{}{},
-			"6379/tcp": struct{}{},
-			"6380/tcp": struct{}{},
-			"6381/tcp": struct{}{},
-			"6382/udp": struct{}{},
+		_ = EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortRangeProto]struct{}{
+			"6300/udp": {},
+			"6379/tcp": {},
+			"6380/tcp": {},
+			"6381/tcp": {},
+			"6382/udp": {},
 		})
 	}
 }

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLinkNaming(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, map[container.PortRangeProto]struct{}{
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, map[container.PortProto]struct{}{
 		"6379/tcp": {},
 	})
 
@@ -28,7 +28,7 @@ func TestLinkNaming(t *testing.T) {
 }
 
 func TestLinkNew(t *testing.T) {
-	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, map[container.PortRangeProto]struct{}{
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, map[container.PortProto]struct{}{
 		"6379/tcp": {},
 	})
 
@@ -43,7 +43,7 @@ func TestLinkNew(t *testing.T) {
 }
 
 func TestLinkEnv(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortRangeProto]struct{}{
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortProto]struct{}{
 		"6379/tcp": {},
 	})
 
@@ -91,7 +91,7 @@ func TestSortPorts(t *testing.T) {
 }
 
 func TestLinkMultipleEnv(t *testing.T) {
-	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortRangeProto]struct{}{
+	actual := EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortProto]struct{}{
 		"6300/udp": {},
 		"6379/tcp": {},
 		"6380/tcp": {},
@@ -142,7 +142,7 @@ func BenchmarkLinkMultipleEnv(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortRangeProto]struct{}{
+		_ = EnvVars("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, map[container.PortProto]struct{}{
 			"6300/udp": {},
 			"6379/tcp": {},
 			"6380/tcp": {},

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -84,9 +84,9 @@ type listContext struct {
 	isTask bool
 
 	// publish is a list of published ports to filter with
-	publish map[containertypes.PortRangeProto]bool // TODO(thaJeztah): could this be a straight map[string]bool?
+	publish map[containertypes.PortProto]bool // TODO(thaJeztah): could this be a straight map[string]bool?
 	// expose is a list of exposed ports to filter with
-	expose map[containertypes.PortRangeProto]bool // TODO(thaJeztah): could this be a straight map[string]bool?
+	expose map[containertypes.PortProto]bool // TODO(thaJeztah): could this be a straight map[string]bool?
 
 	// ListOptions is the filters set by the user
 	*containertypes.ListOptions
@@ -346,13 +346,13 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view *container.View, conf
 		}
 	}
 
-	publishFilter := map[containertypes.PortRangeProto]bool{}
+	publishFilter := map[containertypes.PortProto]bool{}
 	err = psFilters.WalkValues("publish", portOp("publish", publishFilter))
 	if err != nil {
 		return nil, err
 	}
 
-	exposeFilter := map[containertypes.PortRangeProto]bool{}
+	exposeFilter := map[containertypes.PortProto]bool{}
 	err = psFilters.WalkValues("expose", portOp("expose", exposeFilter))
 	if err != nil {
 		return nil, err
@@ -397,7 +397,7 @@ func idOrNameFilter(view *container.View, value string) (*container.Snapshot, er
 	return filter, err
 }
 
-func portOp(key string, filter map[containertypes.PortRangeProto]bool) func(value string) error {
+func portOp(key string, filter map[containertypes.PortProto]bool) func(value string) error {
 	return func(value string) error {
 		if strings.Contains(value, ":") {
 			return fmt.Errorf("filter for '%s' should not contain ':': %s", key, value)
@@ -568,12 +568,12 @@ func includeContainerInList(container *container.Snapshot, filter *listContext) 
 	if len(filter.expose) > 0 || len(filter.publish) > 0 {
 		var (
 			shouldSkip    = true
-			publishedPort containertypes.PortRangeProto
-			exposedPort   containertypes.PortRangeProto
+			publishedPort containertypes.PortProto
+			exposedPort   containertypes.PortProto
 		)
 		for _, port := range container.Ports {
-			publishedPort = containertypes.PortRangeProto(fmt.Sprintf("%d/%s", port.PublicPort, port.Type))
-			exposedPort = containertypes.PortRangeProto(fmt.Sprintf("%d/%s", port.PrivatePort, port.Type))
+			publishedPort = containertypes.PortProto(fmt.Sprintf("%d/%s", port.PublicPort, port.Type))
+			exposedPort = containertypes.PortProto(fmt.Sprintf("%d/%s", port.PrivatePort, port.Type))
 			if ok := filter.publish[publishedPort]; ok {
 				shouldSkip = false
 				break

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -21,7 +21,7 @@ type Settings struct {
 	LinkLocalIPv6PrefixLen int
 	Networks               map[string]*EndpointSettings
 	Service                *clustertypes.ServiceConfig
-	Ports                  container.PortMap
+	Ports                  map[container.PortProto][]container.PortBinding
 	SecondaryIPAddresses   []networktypes.Address
 	SecondaryIPv6Addresses []networktypes.Address
 	HasSwarmEndpoint       bool

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -504,8 +504,8 @@ func (s *DockerAPISuite) TestContainerAPIBadPort(c *testing.T) {
 	}
 
 	hostConfig := container.HostConfig{
-		PortBindings: container.PortMap{
-			"8080/tcp": []container.PortBinding{
+		PortBindings: map[container.PortProto][]container.PortBinding{
+			"8080/tcp": {
 				{
 					HostIP:   "",
 					HostPort: "aa80",

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -92,7 +92,7 @@ func (s *DockerCLICreateSuite) TestCreateWithPortRange(c *testing.T) {
 
 	var containers []struct {
 		HostConfig *struct {
-			PortBindings map[containertypes.PortRangeProto][]containertypes.PortBinding
+			PortBindings map[containertypes.PortProto][]containertypes.PortBinding
 		}
 	}
 	err := json.Unmarshal([]byte(out), &containers)
@@ -118,7 +118,7 @@ func (s *DockerCLICreateSuite) TestCreateWithLargePortRange(c *testing.T) {
 
 	var containers []struct {
 		HostConfig *struct {
-			PortBindings map[containertypes.PortRangeProto][]containertypes.PortBinding
+			PortBindings map[containertypes.PortProto][]containertypes.PortBinding
 		}
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2169,7 +2169,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughExpose(c *testing.T) {
 	id = strings.TrimSpace(id)
 
 	portstr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
-	var ports container.PortMap
+	var ports map[container.PortProto][]container.PortBinding
 	if err := json.Unmarshal([]byte(portstr), &ports); err != nil {
 		c.Fatal(err)
 	}
@@ -2502,7 +2502,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughPublish(c *testing.T) {
 	id = strings.TrimSpace(id)
 	portStr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
 
-	var ports container.PortMap
+	var ports map[container.PortProto][]container.PortBinding
 	err := json.Unmarshal([]byte(portStr), &ports)
 	assert.NilError(c, err, "failed to unmarshal: %v", portStr)
 	for port, binding := range ports {

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -75,7 +75,7 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 	// Sadly this means the test will take longer, but at least this test can be parallelized.
 	cid := container.Run(ctx, t, apiClient,
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(containertypes.PortMap{"80/tcp": {{}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{}}}),
 		container.WithCmd("/bin/sh", "-c", "while true; do echo hello; sleep 1; done"))
 	defer func() {
 		err := apiClient.ContainerRemove(ctx, cid, containertypes.RemoveOptions{Force: true})

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -122,7 +122,7 @@ func startServerContainer(ctx context.Context, t *testing.T, msg string, port in
 		container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)),
 		func(c *container.TestContainerConfig) {
 			c.HostConfig.PortBindings = containertypes.PortMap{
-				containertypes.PortRangeProto(fmt.Sprintf("%d/tcp", port)): []containertypes.PortBinding{
+				containertypes.PortProto(fmt.Sprintf("%d/tcp", port)): []containertypes.PortBinding{
 					{
 						HostPort: fmt.Sprintf("%d", port),
 					},

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -121,12 +121,10 @@ func startServerContainer(ctx context.Context, t *testing.T, msg string, port in
 		container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)),
 		container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)),
 		func(c *container.TestContainerConfig) {
-			c.HostConfig.PortBindings = containertypes.PortMap{
-				containertypes.PortProto(fmt.Sprintf("%d/tcp", port)): []containertypes.PortBinding{
-					{
-						HostPort: fmt.Sprintf("%d", port),
-					},
-				},
+			c.HostConfig.PortBindings = map[containertypes.PortProto][]containertypes.PortBinding{
+				containertypes.PortProto(fmt.Sprintf("%d/tcp", port)): {{
+					HostPort: fmt.Sprintf("%d", port),
+				}},
 			}
 		},
 	)

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -81,9 +81,9 @@ func WithExposedPorts(ports ...string) func(*TestContainerConfig) {
 }
 
 // WithPortMap sets/replaces port mappings.
-func WithPortMap(pm container.PortMap) func(*TestContainerConfig) {
+func WithPortMap(pm map[container.PortProto][]container.PortBinding) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.HostConfig.PortBindings = container.PortMap{}
+		c.HostConfig.PortBindings = map[container.PortProto][]container.PortBinding{}
 		for p, b := range pm {
 			c.HostConfig.PortBindings[p] = slices.Clone(b)
 		}

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -73,9 +73,9 @@ func WithSysctls(sysctls map[string]string) func(*TestContainerConfig) {
 // WithExposedPorts sets the exposed ports of the container
 func WithExposedPorts(ports ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.Config.ExposedPorts = map[container.PortRangeProto]struct{}{}
+		c.Config.ExposedPorts = map[container.PortProto]struct{}{}
 		for _, port := range ports {
-			c.Config.ExposedPorts[container.PortRangeProto(port)] = struct{}{}
+			c.Config.ExposedPorts[container.PortProto(port)] = struct{}{}
 		}
 	}
 }

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -506,14 +506,14 @@ func TestPublishedPortAlreadyInUse(t *testing.T) {
 	ctr1 := ctr.Run(ctx, t, apiClient,
 		ctr.WithCmd("top"),
 		ctr.WithExposedPorts("80/tcp"),
-		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}))
+		ctr.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8000"}}}))
 	defer ctr.Remove(ctx, t, apiClient, ctr1, containertypes.RemoveOptions{Force: true})
 
 	ctr2 := ctr.Create(ctx, t, apiClient,
 		ctr.WithCmd("top"),
 		ctr.WithRestartPolicy(containertypes.RestartPolicyAlways),
 		ctr.WithExposedPorts("80/tcp"),
-		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}))
+		ctr.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8000"}}}))
 	defer ctr.Remove(ctx, t, apiClient, ctr2, containertypes.RemoveOptions{Force: true})
 
 	err := apiClient.ContainerStart(ctx, ctr2, containertypes.StartOptions{})
@@ -548,14 +548,14 @@ func TestAllPortMappingsAreReturned(t *testing.T) {
 
 	ctrID := ctr.Run(ctx, t, apiClient,
 		ctr.WithExposedPorts("80/tcp", "81/tcp"),
-		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}),
+		ctr.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8000"}}}),
 		ctr.WithEndpointSettings("testnetv4", &networktypes.EndpointSettings{}),
 		ctr.WithEndpointSettings("testnetv6", &networktypes.EndpointSettings{}))
 	defer ctr.Remove(ctx, t, apiClient, ctrID, containertypes.RemoveOptions{Force: true})
 
 	inspect := ctr.Inspect(ctx, t, apiClient, ctrID)
-	assert.DeepEqual(t, inspect.NetworkSettings.Ports, containertypes.PortMap{
-		"80/tcp": []containertypes.PortBinding{
+	assert.DeepEqual(t, inspect.NetworkSettings.Ports, map[containertypes.PortProto][]containertypes.PortBinding{
+		"80/tcp": {
 			{HostIP: "0.0.0.0", HostPort: "8000"},
 			{HostIP: "::", HostPort: "8000"},
 		},
@@ -587,7 +587,7 @@ func TestFirewalldReloadNoZombies(t *testing.T) {
 
 	cid := ctr.Run(ctx, t, c,
 		ctr.WithExposedPorts("80/tcp", "81/tcp"),
-		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8000"}}}))
+		ctr.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8000"}}}))
 	defer func() {
 		if !removed {
 			ctr.Remove(ctx, t, c, cid, containertypes.RemoveOptions{Force: true})
@@ -777,7 +777,7 @@ func TestPortMappingRestore(t *testing.T) {
 	const svrName = "svr"
 	cid := ctr.Run(ctx, t, c,
 		ctr.WithExposedPorts("80/tcp"),
-		ctr.WithPortMap(containertypes.PortMap{"80/tcp": {}}),
+		ctr.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {}}),
 		ctr.WithName(svrName),
 		ctr.WithRestartPolicy(containertypes.RestartPolicyUnlessStopped),
 		ctr.WithCmd("httpd", "-f"),

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -788,7 +788,7 @@ func TestPortMappingRestore(t *testing.T) {
 		t.Helper()
 		insp := ctr.Inspect(ctx, t, c, cid)
 		assert.Check(t, is.Equal(insp.State.Running, true))
-		if assert.Check(t, is.Contains(insp.NetworkSettings.Ports, containertypes.PortRangeProto("80/tcp"))) &&
+		if assert.Check(t, is.Contains(insp.NetworkSettings.Ports, containertypes.PortProto("80/tcp"))) &&
 			assert.Check(t, is.Len(insp.NetworkSettings.Ports["80/tcp"], 2)) {
 			hostPort := insp.NetworkSettings.Ports["80/tcp"][0].HostPort
 			res := ctr.RunAttach(ctx, t, c,

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -54,7 +54,7 @@ var (
 
 type ctrDesc struct {
 	name         string
-	portMappings containertypes.PortMap
+	portMappings map[containertypes.PortProto][]containertypes.PortBinding
 }
 
 type networkDesc struct {
@@ -83,7 +83,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -96,7 +96,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -109,7 +109,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -143,7 +143,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -156,7 +156,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -168,7 +168,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -180,7 +180,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
 				},
 			},
 		}},

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -50,7 +50,7 @@ var (
 
 type ctrDesc struct {
 	name         string
-	portMappings containertypes.PortMap
+	portMappings map[containertypes.PortProto][]containertypes.PortBinding
 }
 
 type networkDesc struct {
@@ -79,7 +79,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -92,7 +92,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -105,7 +105,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -139,7 +139,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -152,7 +152,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -165,7 +165,7 @@ var index = []section{
 				containers: []ctrDesc{
 					{
 						name:         "c1",
-						portMappings: containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}},
+						portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}},
 					},
 				},
 			}},
@@ -178,7 +178,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
+					portMappings: map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}}},
 				},
 			},
 		}},

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -387,7 +387,7 @@ func TestBridgeINCRouted(t *testing.T) {
 			container.WithNetworkMode(netName),
 			container.WithName("ctr-"+gwMode),
 			container.WithExposedPorts("80/tcp"),
-			container.WithPortMap(containertypes.PortMap{"80/tcp": {}}),
+			container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {}}),
 		)
 		t.Cleanup(func() {
 			c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -564,7 +564,7 @@ func TestAccessToPublishedPort(t *testing.T) {
 				container.WithNetworkMode(serverNetName),
 				container.WithName("ctr-server"),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(containertypes.PortMap{"80/tcp": {containertypes.PortBinding{HostPort: "8080"}}}),
+				container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -687,7 +687,7 @@ func TestInterNetworkDirectRouting(t *testing.T) {
 				container.WithNetworkMode(serverNetName),
 				container.WithName("ctr-pub"),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(containertypes.PortMap{"80/tcp": {containertypes.PortBinding{HostPort: "8080"}}}),
+				container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {containertypes.PortBinding{HostPort: "8080"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, ctrPubId, containertypes.RemoveOptions{Force: true})
@@ -1428,7 +1428,7 @@ func TestGatewaySelection(t *testing.T) {
 		container.WithName(ctrName),
 		container.WithNetworkMode(netName4),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(containertypes.PortMap{"80": {{HostPort: "8080"}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80": {{HostPort: "8080"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -1877,7 +1877,7 @@ func TestDropInForwardChain(t *testing.T) {
 		ctrId := container.Run(ctx, t, c,
 			container.WithNetworkMode(netName46),
 			container.WithExposedPorts("80"),
-			container.WithPortMap(containertypes.PortMap{"80": {{HostPort: hostPort}}}),
+			container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80": {{HostPort: hostPort}}}),
 			container.WithCmd("httpd", "-f"),
 		)
 		defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -96,7 +96,7 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80": {{HostIP: "0.0.0.0"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -1559,9 +1559,9 @@ func TestMixAnyWithSpecificHostAddrs(t *testing.T) {
 			ctrId := container.Run(ctx, t, c,
 				container.WithExposedPorts("80/"+proto, "81/"+proto, "82/"+proto),
 				container.WithPortMap(containertypes.PortMap{
-					containertypes.PortRangeProto("81/" + proto): {{}},
-					containertypes.PortRangeProto("82/" + proto): {{}},
-					containertypes.PortRangeProto("80/" + proto): {{HostIP: "127.0.0.1"}},
+					containertypes.PortProto("81/" + proto): {{}},
+					containertypes.PortProto("82/" + proto): {{}},
+					containertypes.PortProto("80/" + proto): {{HostIP: "127.0.0.1"}},
 				}),
 			)
 			defer c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -68,12 +68,12 @@ func TestDisableNAT(t *testing.T) {
 		name       string
 		gwMode4    string
 		gwMode6    string
-		expPortMap containertypes.PortMap
+		expPortMap map[containertypes.PortProto][]containertypes.PortBinding
 	}{
 		{
 			name: "defaults",
-			expPortMap: containertypes.PortMap{
-				"80/tcp": []containertypes.PortBinding{
+			expPortMap: map[containertypes.PortProto][]containertypes.PortBinding{
+				"80/tcp": {
 					{HostIP: "0.0.0.0", HostPort: "8080"},
 					{HostIP: "::", HostPort: "8080"},
 				},
@@ -83,8 +83,8 @@ func TestDisableNAT(t *testing.T) {
 			name:    "nat4 routed6",
 			gwMode4: "nat",
 			gwMode6: "routed",
-			expPortMap: containertypes.PortMap{
-				"80/tcp": []containertypes.PortBinding{
+			expPortMap: map[containertypes.PortProto][]containertypes.PortBinding{
+				"80/tcp": {
 					{HostIP: "0.0.0.0", HostPort: "8080"},
 					{HostIP: "::", HostPort: ""},
 				},
@@ -94,8 +94,8 @@ func TestDisableNAT(t *testing.T) {
 			name:    "nat6 routed4",
 			gwMode4: "routed",
 			gwMode6: "nat",
-			expPortMap: containertypes.PortMap{
-				"80/tcp": []containertypes.PortBinding{
+			expPortMap: map[containertypes.PortProto][]containertypes.PortBinding{
+				"80/tcp": {
 					{HostIP: "::", HostPort: "8080"},
 					{HostIP: "0.0.0.0", HostPort: ""},
 				},
@@ -124,7 +124,7 @@ func TestDisableNAT(t *testing.T) {
 			id := container.Run(ctx, t, c,
 				container.WithNetworkMode(netName),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}}),
+				container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}}),
 			)
 			defer c.ContainerRemove(ctx, id, containertypes.RemoveOptions{Force: true})
 
@@ -162,7 +162,7 @@ func TestPortMappedHairpinTCP(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80": {{HostIP: "0.0.0.0"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -209,7 +209,7 @@ func TestPortMappedHairpinUDP(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("54/udp"),
-		container.WithPortMap(containertypes.PortMap{"54/udp": {{HostIP: "0.0.0.0"}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"54/udp": {{HostIP: "0.0.0.0"}}}),
 		container.WithCmd("/bin/sh", "-c", "echo 'foobar.internal 192.168.155.23' | dnsd -c - -p 54"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -251,7 +251,7 @@ func TestProxy4To6(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(netName),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "::1"}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80": {{HostIP: "::1"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -375,7 +375,7 @@ func TestAccessPublishedPortFromHost(t *testing.T) {
 			serverID := container.Run(ctx, t, c,
 				container.WithName(sanitizeCtrName(t.Name()+"-server")),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: hostPort}}}),
+				container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: hostPort}}}),
 				container.WithCmd("httpd", "-f"),
 				container.WithNetworkMode(bridgeName))
 			defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
@@ -455,7 +455,7 @@ func TestAccessPublishedPortFromRemoteHost(t *testing.T) {
 	serverID := container.Run(ctx, t, c,
 		container.WithName(sanitizeCtrName(t.Name()+"-server")),
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: hostPort}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: hostPort}}}),
 		container.WithCmd("httpd", "-f"),
 		container.WithNetworkMode(bridgeName))
 	defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
@@ -553,7 +553,7 @@ func TestAccessPublishedPortFromCtr(t *testing.T) {
 			serverId := container.Run(ctx, t, c,
 				container.WithNetworkMode(netName),
 				container.WithExposedPorts("80"),
-				container.WithPortMap(containertypes.PortMap{"80": {{HostIP: "0.0.0.0"}}}),
+				container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80": {{HostIP: "0.0.0.0"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, serverId, containertypes.RemoveOptions{Force: true})
@@ -603,7 +603,7 @@ func TestRestartUserlandProxyUnder2MSL(t *testing.T) {
 	ctrOpts := []func(*container.TestContainerConfig){
 		container.WithName(ctrName),
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "1780"}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "1780"}}}),
 		container.WithCmd("httpd", "-f"),
 		container.WithNetworkMode(netName),
 	}
@@ -700,7 +700,7 @@ func TestDirectRoutingOpenPorts(t *testing.T) {
 			container.WithNetworkMode(netName),
 			container.WithName("ctr-"+gwMode),
 			container.WithExposedPorts("80/tcp"),
-			container.WithPortMap(containertypes.PortMap{"80/tcp": {}}),
+			container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {}}),
 		)
 		t.Cleanup(func() {
 			c.ContainerRemove(ctx, ctrId, containertypes.RemoveOptions{Force: true})
@@ -979,7 +979,7 @@ func TestRoutedNonGateway(t *testing.T) {
 	ctrId := container.Run(ctx, t, c,
 		container.WithCmd("httpd", "-f"),
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(containertypes.PortMap{"80/tcp": {{HostPort: "8080"}}}),
+		container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {{HostPort: "8080"}}}),
 		container.WithNetworkMode(natNetName),
 		container.WithNetworkMode(routedNetName),
 		container.WithEndpointSettings(natNetName, &networktypes.EndpointSettings{GwPriority: 1}),
@@ -1133,7 +1133,7 @@ func TestAccessPublishedPortFromAnotherNetwork(t *testing.T) {
 					container.WithName("server"),
 					container.WithCmd("nc", "-lp", "5000"),
 					container.WithExposedPorts("5000/tcp"),
-					container.WithPortMap(containertypes.PortMap{"5000/tcp": {{HostPort: "5000"}}}),
+					container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"5000/tcp": {{HostPort: "5000"}}}),
 					container.WithNetworkMode(servnet))
 				defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
 
@@ -1329,7 +1329,7 @@ func testDirectRemoteAccessOnExposedPort(t *testing.T, ctx context.Context, d *d
 					container.WithName(sanitizeCtrName(t.Name()+"-server")),
 					container.WithCmd("nc", "-lup", "5000"),
 					container.WithExposedPorts("5000/udp"),
-					container.WithPortMap(containertypes.PortMap{"5000/udp": {{HostPort: hostPort}}}),
+					container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"5000/udp": {{HostPort: hostPort}}}),
 					container.WithNetworkMode(bridgeName),
 					container.WithEndpointSettings(bridgeName, &networktypes.EndpointSettings{
 						IPAddress:   ctrIP.String(),
@@ -1415,7 +1415,7 @@ func TestAccessPortPublishedOnLoopbackAddress(t *testing.T) {
 			container.WithCmd("nc", "-lup", "5000"),
 			container.WithExposedPorts("5000/udp"),
 			// This port is mapped on 127.0.0.2, so it should not be remotely accessible.
-			container.WithPortMap(containertypes.PortMap{"5000/udp": {{HostIP: loIP, HostPort: hostPort}}}),
+			container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"5000/udp": {{HostIP: loIP, HostPort: hostPort}}}),
 			container.WithNetworkMode(bridgeName))
 		defer c.ContainerRemove(ctx, serverID, containertypes.RemoveOptions{Force: true})
 
@@ -1526,7 +1526,7 @@ func TestSkipRawRules(t *testing.T) {
 
 				ctrId := container.Run(ctx, t, c,
 					container.WithExposedPorts("80/tcp"),
-					container.WithPortMap(containertypes.PortMap{"80/tcp": {
+					container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{"80/tcp": {
 						{HostIP: "127.0.0.1", HostPort: "8080"},
 						{HostPort: "8081"},
 					}}),
@@ -1558,7 +1558,7 @@ func TestMixAnyWithSpecificHostAddrs(t *testing.T) {
 
 			ctrId := container.Run(ctx, t, c,
 				container.WithExposedPorts("80/"+proto, "81/"+proto, "82/"+proto),
-				container.WithPortMap(containertypes.PortMap{
+				container.WithPortMap(map[containertypes.PortProto][]containertypes.PortBinding{
 					containertypes.PortProto("81/" + proto): {{}},
 					containertypes.PortProto("82/" + proto): {{}},
 					containertypes.PortProto("80/" + proto): {{HostIP: "127.0.0.1"}},

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -40,25 +40,25 @@ type HealthConfig = dockerspec.HealthcheckConfig
 // All fields added to this struct must be marked `omitempty` to keep getting
 // predictable hashes from the old `v1Compatibility` configuration.
 type Config struct {
-	Hostname        string                      // Hostname
-	Domainname      string                      // Domainname
-	User            string                      // User that will run the command(s) inside the container, also support user:group
-	AttachStdin     bool                        // Attach the standard input, makes possible user interaction
-	AttachStdout    bool                        // Attach the standard output
-	AttachStderr    bool                        // Attach the standard error
-	ExposedPorts    map[PortRangeProto]struct{} `json:",omitempty"` // List of exposed ports
-	Tty             bool                        // Attach standard streams to a tty, including stdin if it is not closed.
-	OpenStdin       bool                        // Open stdin
-	StdinOnce       bool                        // If true, close stdin after the 1 attached client disconnects.
-	Env             []string                    // List of environment variable to set in the container
-	Cmd             []string                    // Command to run when starting the container
-	Healthcheck     *HealthConfig               `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped     bool                        `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
-	Image           string                      // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Volumes         map[string]struct{}         // List of volumes (mounts) used for the container
-	WorkingDir      string                      // Current directory (PWD) in the command will be launched
-	Entrypoint      []string                    // Entrypoint to run when starting the container
-	NetworkDisabled bool                        `json:",omitempty"` // Is network disabled
+	Hostname        string                 // Hostname
+	Domainname      string                 // Domainname
+	User            string                 // User that will run the command(s) inside the container, also support user:group
+	AttachStdin     bool                   // Attach the standard input, makes possible user interaction
+	AttachStdout    bool                   // Attach the standard output
+	AttachStderr    bool                   // Attach the standard error
+	ExposedPorts    map[PortProto]struct{} `json:",omitempty"` // List of exposed ports
+	Tty             bool                   // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool                   // Open stdin
+	StdinOnce       bool                   // If true, close stdin after the 1 attached client disconnects.
+	Env             []string               // List of environment variable to set in the container
+	Cmd             []string               // Command to run when starting the container
+	Healthcheck     *HealthConfig          `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped     bool                   `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
+	Image           string                 // Name of the image as it was passed by the operator (e.g. could be symbolic)
+	Volumes         map[string]struct{}    // List of volumes (mounts) used for the container
+	WorkingDir      string                 // Current directory (PWD) in the command will be launched
+	Entrypoint      []string               // Entrypoint to run when starting the container
+	NetworkDisabled bool                   `json:",omitempty"` // Is network disabled
 	// Mac Address of the container.
 	//
 	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -40,25 +40,25 @@ type HealthConfig = dockerspec.HealthcheckConfig
 // All fields added to this struct must be marked `omitempty` to keep getting
 // predictable hashes from the old `v1Compatibility` configuration.
 type Config struct {
-	Hostname        string              // Hostname
-	Domainname      string              // Domainname
-	User            string              // User that will run the command(s) inside the container, also support user:group
-	AttachStdin     bool                // Attach the standard input, makes possible user interaction
-	AttachStdout    bool                // Attach the standard output
-	AttachStderr    bool                // Attach the standard error
-	ExposedPorts    PortSet             `json:",omitempty"` // List of exposed ports
-	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
-	OpenStdin       bool                // Open stdin
-	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.
-	Env             []string            // List of environment variable to set in the container
-	Cmd             []string            // Command to run when starting the container
-	Healthcheck     *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
-	Image           string              // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Volumes         map[string]struct{} // List of volumes (mounts) used for the container
-	WorkingDir      string              // Current directory (PWD) in the command will be launched
-	Entrypoint      []string            // Entrypoint to run when starting the container
-	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
+	Hostname        string                      // Hostname
+	Domainname      string                      // Domainname
+	User            string                      // User that will run the command(s) inside the container, also support user:group
+	AttachStdin     bool                        // Attach the standard input, makes possible user interaction
+	AttachStdout    bool                        // Attach the standard output
+	AttachStderr    bool                        // Attach the standard error
+	ExposedPorts    map[PortRangeProto]struct{} `json:",omitempty"` // List of exposed ports
+	Tty             bool                        // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool                        // Open stdin
+	StdinOnce       bool                        // If true, close stdin after the 1 attached client disconnects.
+	Env             []string                    // List of environment variable to set in the container
+	Cmd             []string                    // Command to run when starting the container
+	Healthcheck     *HealthConfig               `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped     bool                        `json:",omitempty"` // True if command is already escaped (meaning treat as a command line) (Windows specific).
+	Image           string                      // Name of the image as it was passed by the operator (e.g. could be symbolic)
+	Volumes         map[string]struct{}         // List of volumes (mounts) used for the container
+	WorkingDir      string                      // Current directory (PWD) in the command will be launched
+	Entrypoint      []string                    // Entrypoint to run when starting the container
+	NetworkDisabled bool                        `json:",omitempty"` // Is network disabled
 	// Mac Address of the container.
 	//
 	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -421,17 +421,17 @@ type UpdateConfig struct {
 // Portable information *should* appear in Config.
 type HostConfig struct {
 	// Applicable to all platforms
-	Binds           []string          // List of volume bindings for this container
-	ContainerIDFile string            // File (path) where the containerId is written
-	LogConfig       LogConfig         // Configuration of the logs for this container
-	NetworkMode     NetworkMode       // Network mode to use for the container
-	PortBindings    PortMap           // Port mapping between the exposed port (container) and the host
-	RestartPolicy   RestartPolicy     // Restart policy to be used for the container
-	AutoRemove      bool              // Automatically remove container when it exits
-	VolumeDriver    string            // Name of the volume driver used to mount volumes
-	VolumesFrom     []string          // List of volumes to take from other container
-	ConsoleSize     [2]uint           // Initial console size (height,width)
-	Annotations     map[string]string `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
+	Binds           []string                         // List of volume bindings for this container
+	ContainerIDFile string                           // File (path) where the containerId is written
+	LogConfig       LogConfig                        // Configuration of the logs for this container
+	NetworkMode     NetworkMode                      // Network mode to use for the container
+	PortBindings    map[PortRangeProto][]PortBinding // Port mapping between the exposed port (container) and the host
+	RestartPolicy   RestartPolicy                    // Restart policy to be used for the container
+	AutoRemove      bool                             // Automatically remove container when it exits
+	VolumeDriver    string                           // Name of the volume driver used to mount volumes
+	VolumesFrom     []string                         // List of volumes to take from other container
+	ConsoleSize     [2]uint                          // Initial console size (height,width)
+	Annotations     map[string]string                `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
 
 	// Applicable to UNIX platforms
 	CapAdd          []string          // List of kernel capabilities to add to the container

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -421,17 +421,17 @@ type UpdateConfig struct {
 // Portable information *should* appear in Config.
 type HostConfig struct {
 	// Applicable to all platforms
-	Binds           []string                         // List of volume bindings for this container
-	ContainerIDFile string                           // File (path) where the containerId is written
-	LogConfig       LogConfig                        // Configuration of the logs for this container
-	NetworkMode     NetworkMode                      // Network mode to use for the container
-	PortBindings    map[PortRangeProto][]PortBinding // Port mapping between the exposed port (container) and the host
-	RestartPolicy   RestartPolicy                    // Restart policy to be used for the container
-	AutoRemove      bool                             // Automatically remove container when it exits
-	VolumeDriver    string                           // Name of the volume driver used to mount volumes
-	VolumesFrom     []string                         // List of volumes to take from other container
-	ConsoleSize     [2]uint                          // Initial console size (height,width)
-	Annotations     map[string]string                `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
+	Binds           []string                    // List of volume bindings for this container
+	ContainerIDFile string                      // File (path) where the containerId is written
+	LogConfig       LogConfig                   // Configuration of the logs for this container
+	NetworkMode     NetworkMode                 // Network mode to use for the container
+	PortBindings    map[PortProto][]PortBinding // Port mapping between the exposed port (container) and the host
+	RestartPolicy   RestartPolicy               // Restart policy to be used for the container
+	AutoRemove      bool                        // Automatically remove container when it exits
+	VolumeDriver    string                      // Name of the volume driver used to mount volumes
+	VolumesFrom     []string                    // List of volumes to take from other container
+	ConsoleSize     [2]uint                     // Initial console size (height,width)
+	Annotations     map[string]string           `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
 
 	// Applicable to UNIX platforms
 	CapAdd          []string          // List of kernel capabilities to add to the container

--- a/vendor/github.com/moby/moby/api/types/container/nat_aliases.go
+++ b/vendor/github.com/moby/moby/api/types/container/nat_aliases.go
@@ -2,19 +2,27 @@ package container
 
 import "github.com/docker/go-connections/nat"
 
-// PortRangeProto is a string containing port number and protocol in the format "80/tcp",
-// or a port range and protocol in the format "80-83/tcp".
+// PortProto is a string containing port number and protocol in the format "80/tcp".
+// It is the same as [PortRangeProto], but used in places where we only expect
+// a single port to be used (not a range).
+//
+// It is currently an alias for [nat.Port] but may become a concrete type in a future release.
+type PortProto = nat.Port
+
+// PortRangeProto is a string containing a range of port numbers and protocol in
+// the format "80-90/tcp". It the same as [PortProto], but used in places where
+// we expect a port-range to be used.
 //
 // It is currently an alias for [nat.Port] but may become a concrete type in a future release.
 type PortRangeProto = nat.Port
 
-// PortSet is a collection of structs indexed by [PortRangeProto].
-type PortSet = map[PortRangeProto]struct{}
+// PortSet is a collection of structs indexed by [PortProto].
+type PortSet = map[PortProto]struct{}
 
 // PortBinding represents a binding between a Host IP address and a [HostPort].
 //
 // It is currently an alias for [nat.PortBinding] but may become a concrete type in a future release.
 type PortBinding = nat.PortBinding
 
-// PortMap is a collection of [PortBinding] indexed by [PortRangeProto].
-type PortMap = map[PortRangeProto][]PortBinding
+// PortMap is a collection of [PortBinding] indexed by [PortProto].
+type PortMap = map[PortProto][]PortBinding

--- a/vendor/github.com/moby/moby/api/types/container/nat_aliases.go
+++ b/vendor/github.com/moby/moby/api/types/container/nat_aliases.go
@@ -8,17 +8,13 @@ import "github.com/docker/go-connections/nat"
 // It is currently an alias for [nat.Port] but may become a concrete type in a future release.
 type PortRangeProto = nat.Port
 
-// PortSet is a collection of structs indexed by [HostPort].
-//
-// It is currently an alias for [nat.PortSet] but may become a concrete type in a future release.
-type PortSet = nat.PortSet
+// PortSet is a collection of structs indexed by [PortRangeProto].
+type PortSet = map[PortRangeProto]struct{}
 
 // PortBinding represents a binding between a Host IP address and a [HostPort].
 //
 // It is currently an alias for [nat.PortBinding] but may become a concrete type in a future release.
 type PortBinding = nat.PortBinding
 
-// PortMap is a collection of [PortBinding] indexed by [HostPort].
-//
-// It is currently an alias for [nat.PortMap] but may become a concrete type in a future release.
-type PortMap = nat.PortMap
+// PortMap is a collection of [PortBinding] indexed by [PortRangeProto].
+type PortMap = map[PortRangeProto][]PortBinding

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -18,7 +18,7 @@ type NetworkSettingsBase struct {
 	SandboxKey string // SandboxKey identifies the sandbox
 
 	// Ports is a collection of PortBinding indexed by "port/proto".
-	Ports map[PortRangeProto][]PortBinding
+	Ports map[PortProto][]PortBinding
 
 	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
 	//

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -13,10 +13,12 @@ type NetworkSettings struct {
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
 type NetworkSettingsBase struct {
-	Bridge     string  // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
-	SandboxID  string  // SandboxID uniquely represents a container's network stack
-	SandboxKey string  // SandboxKey identifies the sandbox
-	Ports      PortMap // Ports is a collection of PortBinding indexed by Port
+	Bridge     string // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
+	SandboxID  string // SandboxID uniquely represents a container's network stack
+	SandboxKey string // SandboxKey identifies the sandbox
+
+	// Ports is a collection of PortBinding indexed by "port/proto".
+	Ports map[PortRangeProto][]PortBinding
 
 	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
 	//


### PR DESCRIPTION
The `PortSet` and `PortMap` types don't carry a real meaning on their own. Their purpose is defined at locations where they're used, such as `Container.ExposedPorts` or `Container.PortBindings`.

Their documentation also shows this;

    // PortSet is a collection of structs indexed by [PortRangeProto].
    // PortMap is a collection of [PortBinding] indexed by [PortRangeProto].

Which, almost literally, describes what a map is. Substituting the types for their implementation doesn't lose any meaning;

    // map[PortRangeProto]struct{} is a collection of structs indexed by [PortRangeProto].
    // map[PortRangeProto][]PortBinding is a collection of [PortBinding] indexed by [PortRangeProto].

Neither type has any special handling connected to them (no methods or otherwise), so they are just maps with a fancy name attached. Worse, using the extra indirect induces cognitive load; it's not clear from the type that it's "just" a map, indexed by `PortBinding`, and it's not clear what (kind of) values are in the map.

There are cases where having a type defined can add value to provide a more in-depth description of their intent, but (as shown above) even that is not the case here.

I'm considering these types to be premature abstraction with no good value. As they are a "straight" copy of a map with the same signature, replacing these types preserves backward compatibility; existing code can assign either a `PortSet` or `PortMap`, or a `map[PortRangeProto]..` with the same signature, but we can deprecate the types to give users a nudge to use a regular map instead. The following shows that they are interchangeable;

```go
type config1 struct {
    ExposedPorts container.PortSet
    PortBindings container.PortMap
}
type config2 struct {
    ExposedPorts map[container.PortRangeProto]struct{}
    PortBindings map[container.PortRangeProto][]container.PortBinding
}

var (
    ports         map[container.PortRangeProto]struct{}
    portBindings  map[container.PortRangeProto][]container.PortBinding
    ports2        container.PortSet
    portBindings2 container.PortMap
)
_ = config1{
    ExposedPorts: ports,
    PortBindings: portBindings,
}
_ = config1{
    ExposedPorts: ports2,
    PortBindings: portBindings2,
}
_ = config2{
    ExposedPorts: ports,
    PortBindings: portBindings,
}
_ = config2{
    ExposedPorts: ports2,
    PortBindings: portBindings2,
}
```

### api/types/container: inline PortSet, PortMap in types

- relates to https://github.com/moby/moby/pull/12927

Use the underlying definition in types, instead of the `PortSet` and `PortMap`
types as intermediates.

This also shows that there's ambiguity in these definitions, because `nat.Port`
(`container.PortRangeProto`) allows either a individual port ("8080/tcp")
or a range of ports ("8080-8090/tcp"). The latter unlikely is supported
by our code.

That behavior was introduced in [moby@47272f9], which changed `nat.Port` to
either be a Port, or a range of ports. However, it's debatable if that should
have modified the existing type or introduced a new type that's only used
for places where a range is expected.

To reduce ambiguity, we need to evaluate where the `nat.Port` / `PortRangeProto`
type is used, and if there's any places where it SHOULD accept a range.
For other places, we should consider having an alias with a more suitable
name (`PortProto`) - at least to be clearer on intent.

[moby@47272f9]: https://github.com/moby/moby/commit/47272f9cc563ea90d1f86df044f5429d15a37e4f

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

