### PR TITLE
api/types/network: modernize some implementations

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -101,18 +101,18 @@ func validateEndpointIPAddress(epAddr string, ipamSubnets []NetworkSubnet) error
 		return nil
 	}
 
-	var staticSubnet bool
-	parsedAddr := net.ParseIP(epAddr)
-	for _, subnet := range ipamSubnets {
-		if subnet.IsStatic() {
-			staticSubnet = true
-			if subnet.Contains(parsedAddr) {
-				return nil
-			}
-		}
+	addr, err := netip.ParseAddr(epAddr)
+	if err != nil {
+		return fmt.Errorf("invalid IP address: %s", epAddr)
 	}
 
-	if staticSubnet {
+	for _, subnet := range ipamSubnets {
+		if !subnet.IsStatic() {
+			continue
+		}
+		if subnet.Contains(addr.AsSlice()) {
+			return nil
+		}
 		return fmt.Errorf("no configured subnet or ip-range contain the IP address %s", epAddr)
 	}
 

--- a/api/types/network/endpoint_test.go
+++ b/api/types/network/endpoint_test.go
@@ -172,7 +172,7 @@ func TestEndpointIPAMConfigWithInvalidConfig(t *testing.T) {
 			}
 
 			if _, ok := err.(interface{ Unwrap() []error }); !ok {
-				t.Fatal("returned error isn't a multierror")
+				t.Fatalf("returned error isn't a multierror: %[1]v (%[1]T)", err)
 			}
 			errs := err.(interface{ Unwrap() []error }).Unwrap()
 			assert.Check(t, len(errs) == len(tc.expectedErrors), "errs: %+v", errs)

--- a/vendor/github.com/moby/moby/api/types/network/endpoint.go
+++ b/vendor/github.com/moby/moby/api/types/network/endpoint.go
@@ -101,18 +101,18 @@ func validateEndpointIPAddress(epAddr string, ipamSubnets []NetworkSubnet) error
 		return nil
 	}
 
-	var staticSubnet bool
-	parsedAddr := net.ParseIP(epAddr)
-	for _, subnet := range ipamSubnets {
-		if subnet.IsStatic() {
-			staticSubnet = true
-			if subnet.Contains(parsedAddr) {
-				return nil
-			}
-		}
+	addr, err := netip.ParseAddr(epAddr)
+	if err != nil {
+		return fmt.Errorf("invalid IP address: %s", epAddr)
 	}
 
-	if staticSubnet {
+	for _, subnet := range ipamSubnets {
+		if !subnet.IsStatic() {
+			continue
+		}
+		if subnet.Contains(addr.AsSlice()) {
+			return nil
+		}
 		return fmt.Errorf("no configured subnet or ip-range contain the IP address %s", epAddr)
 	}
 


### PR DESCRIPTION
- [x] stacked on https://github.com/moby/moby/pull/50690

### api/types/network: modernize EndpointIPAMConfig.Copy, EndpointSettings.Copy

- Use slices.Clone where suitable.
- Handle `nil` values so that callers don't have to check for `nil`.


### api/types/network: use netip for EndpointIPAMConfig.Validate

Use `netip.ParseAddr`, which doesn't allocate, and is more strict when
parsing IPv4/IPv6 addresses.


### api/types/network: use netip for validateEndpointIPAddress

- Use `netip.ParseAddr`, which doesn't allocate, and is more strict when
  parsing IPv4/IPv6 addresses.
- Remove the `staticSubnet` bool and use an early return.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

