### PR TITLE
daemon/libnetwork: refactor, modernize various `CopyTo` functions, remove redundant utilities

### DIFF
--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1411,7 +1411,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]any, error) {
 		// Return a copy of the operational data
 		pmc := make([]types.PortBinding, 0, len(ep.portMapping))
 		for _, pm := range ep.portMapping {
-			pmc = append(pmc, pm.PortBinding.GetCopy())
+			pmc = append(pmc, pm.PortBinding.Copy())
 		}
 		m[netlabel.PortMap] = pmc
 	}
@@ -1643,7 +1643,7 @@ func (ep *bridgeEndpoint) trimPortBindings(ctx context.Context, n *bridgeNetwork
 	undo := func() []portmapperapi.PortBinding {
 		pbReq := make([]portmapperapi.PortBindingReq, 0, len(toDrop))
 		for _, pb := range toDrop {
-			pbReq = append(pbReq, portmapperapi.PortBindingReq{PortBinding: pb.GetCopy()})
+			pbReq = append(pbReq, portmapperapi.PortBindingReq{PortBinding: pb.Copy()})
 		}
 		pbs, err := n.addPortMappings(ctx, ep, pbReq, n.config.DefaultBindingIP, ep.portBindingState)
 		if err != nil {
@@ -1895,7 +1895,7 @@ func parseConnectivityOptions(cOptions map[string]any) (*connectivityConfigurati
 		if pbs, ok := opt.([]types.PortBinding); ok {
 			cc.PortBindings = sliceutil.Map(pbs, func(pb types.PortBinding) portmapperapi.PortBindingReq {
 				return portmapperapi.PortBindingReq{
-					PortBinding: pb.GetCopy(),
+					PortBinding: pb.Copy(),
 				}
 			})
 		} else {

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1399,12 +1399,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]any, error) {
 	m := make(map[string]any)
 
 	if ep.extConnConfig != nil && ep.extConnConfig.ExposedPorts != nil {
-		// Return a copy of the config data
-		epc := make([]types.TransportPort, 0, len(ep.extConnConfig.ExposedPorts))
-		for _, tp := range ep.extConnConfig.ExposedPorts {
-			epc = append(epc, tp.GetCopy())
-		}
-		m[netlabel.ExposedPorts] = epc
+		m[netlabel.ExposedPorts] = slices.Clone(ep.extConnConfig.ExposedPorts)
 	}
 
 	if ep.portMapping != nil {

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -1181,10 +1181,10 @@ func TestSetDefaultGw(t *testing.T) {
 	}
 
 	ipam4 := getIPv4Data(t)
-	gw4 := types.GetIPCopy(ipam4[0].Pool.IP).To4()
+	gw4 := slices.Clone(ipam4[0].Pool.IP).To4()
 	gw4[3] = 254
 	ipam6 := getIPv6Data(t)
-	gw6 := types.GetIPCopy(ipam6[0].Pool.IP)
+	gw6 := slices.Clone(ipam6[0].Pool.IP)
 	gw6[15] = 0x42
 
 	option := map[string]any{

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -158,14 +158,8 @@ func compareConnConfig(a, b *connectivityConfiguration) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	if len(a.ExposedPorts) != len(b.ExposedPorts) ||
-		len(a.PortBindings) != len(b.PortBindings) {
+	if !slices.Equal(a.ExposedPorts, b.ExposedPorts) {
 		return false
-	}
-	for i := 0; i < len(a.ExposedPorts); i++ {
-		if !a.ExposedPorts[i].Equal(&b.ExposedPorts[i]) {
-			return false
-		}
 	}
 	for i := 0; i < len(a.PortBindings); i++ {
 		if !comparePortBinding(&a.PortBindings[i].PortBinding, &b.PortBindings[i].PortBinding) {

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -718,7 +718,7 @@ func (i *testInterface) SetMacAddress(mac net.HardwareAddr) error {
 	if mac == nil {
 		return types.InvalidParameterErrorf("tried to set nil MAC address to endpoint interface")
 	}
-	i.mac = types.GetMacCopy(mac)
+	i.mac = slices.Clone(mac)
 	return nil
 }
 

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
@@ -116,9 +116,7 @@ func (nw *StubFirewallerNetwork) AddPorts(_ context.Context, pbs []types.PortBin
 
 func (nw *StubFirewallerNetwork) DelPorts(_ context.Context, pbs []types.PortBinding) error {
 	for _, pb := range pbs {
-		nw.Ports = slices.DeleteFunc(nw.Ports, func(p types.PortBinding) bool {
-			return p.Equal(&pb)
-		})
+		nw.Ports = slices.DeleteFunc(nw.Ports, pb.Equal)
 	}
 	return nil
 }
@@ -148,9 +146,7 @@ func (nw *StubFirewallerNetwork) DelLink(_ context.Context, parentIP, childIP ne
 }
 
 func (nw *StubFirewallerNetwork) PortExists(pb types.PortBinding) bool {
-	return slices.ContainsFunc(nw.Ports, func(p types.PortBinding) bool {
-		return p.Equal(&pb)
-	})
+	return slices.ContainsFunc(nw.Ports, pb.Equal)
 }
 
 func (nw *StubFirewallerNetwork) LinkExists(parentIP, childIP netip.Addr, ports []types.TransportPort) bool {

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
@@ -128,13 +128,7 @@ func (nw *StubFirewallerNetwork) AddLink(_ context.Context, parentIP, childIP ne
 	nw.Links = append(nw.Links, stubFirewallerLink{
 		parentIP: parentIP,
 		childIP:  childIP,
-		ports: func() []types.TransportPort {
-			res := make([]types.TransportPort, 0, len(ports))
-			for _, p := range ports {
-				res = append(res, p.GetCopy())
-			}
-			return res
-		}(),
+		ports:    slices.Clone(ports),
 	})
 	return nil
 }

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
@@ -154,7 +154,7 @@ func matchLink(l stubFirewallerLink, parentIP, childIP netip.Addr, ports []types
 		return false
 	}
 	for i, p := range l.ports {
-		if !p.Equal(&ports[i]) {
+		if p != ports[i] {
 			return false
 		}
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
+++ b/daemon/libnetwork/drivers/bridge/internal/firewaller/stub.go
@@ -109,7 +109,7 @@ func (nw *StubFirewallerNetwork) AddPorts(_ context.Context, pbs []types.PortBin
 		if nw.PortExists(pb) {
 			return nil
 		}
-		nw.Ports = append(nw.Ports, pb.GetCopy())
+		nw.Ports = append(nw.Ports, pb.Copy())
 	}
 	return nil
 }

--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -1009,8 +1009,10 @@ func (pm *stubPortMapper) MapPorts(_ context.Context, reqs []portmapperapi.PortB
 
 func (pm *stubPortMapper) UnmapPorts(_ context.Context, reqs []portmapperapi.PortBinding, _ portmapperapi.Firewaller) error {
 	for _, req := range reqs {
+		// We're only checking for the PortBinding here, not any other
+		// property of [portmapperapi.PortBinding].
 		idx := slices.IndexFunc(pm.mapped, func(pb portmapperapi.PortBinding) bool {
-			return pb.Equal(&req.PortBinding)
+			return pb.Equal(req.PortBinding)
 		})
 		if idx == -1 {
 			return fmt.Errorf("stubPortMapper.UnmapPorts: pb doesn't exist %v", req)

--- a/daemon/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/daemon/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -262,7 +262,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]any, error) {
 		// Return a copy of the operational data
 		pmc := make([]types.PortBinding, 0, len(ep.portMapping))
 		for _, pm := range ep.portMapping {
-			pmc = append(pmc, pm.GetCopy())
+			pmc = append(pmc, pm.Copy())
 		}
 		data[netlabel.PortMap] = pmc
 	}

--- a/daemon/libnetwork/drivers/windows/port_mapping.go
+++ b/daemon/libnetwork/drivers/windows/port_mapping.go
@@ -21,7 +21,7 @@ const maxAllocatePortAttempts = 10
 func AllocatePorts(portMapper *portmapper.PortMapper, bindings []types.PortBinding, containerIP net.IP) ([]types.PortBinding, error) {
 	bs := make([]types.PortBinding, 0, len(bindings))
 	for _, c := range bindings {
-		b := c.GetCopy()
+		b := c.Copy()
 		if err := allocatePort(portMapper, &b, containerIP); err != nil {
 			// On allocation failure, release previously allocated ports. On cleanup error, just log a warning message
 			if cuErr := ReleasePorts(portMapper, bs); cuErr != nil {

--- a/daemon/libnetwork/drivers/windows/windows.go
+++ b/daemon/libnetwork/drivers/windows/windows.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -863,12 +864,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]any, error) {
 
 	data["hnsid"] = ep.profileID
 	if ep.epConnectivity.ExposedPorts != nil {
-		// Return a copy of the config data
-		epc := make([]types.TransportPort, 0, len(ep.epConnectivity.ExposedPorts))
-		for _, tp := range ep.epConnectivity.ExposedPorts {
-			epc = append(epc, tp.GetCopy())
-		}
-		data[netlabel.ExposedPorts] = epc
+		data[netlabel.ExposedPorts] = slices.Clone(ep.epConnectivity.ExposedPorts)
 	}
 
 	if ep.portMapping != nil {

--- a/daemon/libnetwork/drivers/windows/windows.go
+++ b/daemon/libnetwork/drivers/windows/windows.go
@@ -875,7 +875,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]any, error) {
 		// Return a copy of the operational data
 		pmc := make([]types.PortBinding, 0, len(ep.portMapping))
 		for _, pm := range ep.portMapping {
-			pmc = append(pmc, pm.GetCopy())
+			pmc = append(pmc, pm.Copy())
 		}
 		data[netlabel.PortMap] = pmc
 	}

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -295,12 +295,7 @@ func (ep *Endpoint) CopyTo(o datastore.KVObject) error {
 	dstEp.ingressPorts = make([]*PortConfig, len(ep.ingressPorts))
 	copy(dstEp.ingressPorts, ep.ingressPorts)
 
-	if ep.iface != nil {
-		dstEp.iface = &EndpointInterface{}
-		if err := ep.iface.CopyTo(dstEp.iface); err != nil {
-			return err
-		}
-	}
+	dstEp.iface = ep.iface.Copy()
 
 	if ep.joinInfo != nil {
 		dstEp.joinInfo = &endpointJoinInfo{}

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -296,13 +296,7 @@ func (ep *Endpoint) CopyTo(o datastore.KVObject) error {
 	copy(dstEp.ingressPorts, ep.ingressPorts)
 
 	dstEp.iface = ep.iface.Copy()
-
-	if ep.joinInfo != nil {
-		dstEp.joinInfo = &endpointJoinInfo{}
-		if err := ep.joinInfo.CopyTo(dstEp.joinInfo); err != nil {
-			return err
-		}
-	}
+	dstEp.joinInfo = ep.joinInfo.Copy()
 
 	dstEp.exposedPorts = make([]types.TransportPort, len(ep.exposedPorts))
 	copy(dstEp.exposedPorts, ep.exposedPorts)

--- a/daemon/libnetwork/endpoint_info.go
+++ b/daemon/libnetwork/endpoint_info.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 
 	"github.com/moby/moby/v2/daemon/libnetwork/driverapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
@@ -143,7 +144,7 @@ func (epi *EndpointInterface) UnmarshalJSON(b []byte) error {
 }
 
 func (epi *EndpointInterface) CopyTo(dstEpi *EndpointInterface) error {
-	dstEpi.mac = types.GetMacCopy(epi.mac)
+	dstEpi.mac = slices.Clone(epi.mac)
 	dstEpi.addr = types.GetIPNetCopy(epi.addr)
 	dstEpi.addrv6 = types.GetIPNetCopy(epi.addrv6)
 	dstEpi.srcName = epi.srcName
@@ -224,7 +225,7 @@ func (epi *EndpointInterface) SetMacAddress(mac net.HardwareAddr) error {
 	if mac == nil {
 		return types.InvalidParameterErrorf("tried to set nil MAC address to endpoint interface")
 	}
-	epi.mac = types.GetMacCopy(mac)
+	epi.mac = slices.Clone(mac)
 	return nil
 }
 
@@ -248,7 +249,7 @@ func setAddress(ifaceAddr **net.IPNet, address *net.IPNet) error {
 
 // MacAddress returns the MAC address assigned to the endpoint.
 func (epi *EndpointInterface) MacAddress() net.HardwareAddr {
-	return types.GetMacCopy(epi.mac)
+	return slices.Clone(epi.mac)
 }
 
 // Address returns the IPv4 address assigned to the endpoint.

--- a/daemon/libnetwork/endpoint_info.go
+++ b/daemon/libnetwork/endpoint_info.go
@@ -143,26 +143,32 @@ func (epi *EndpointInterface) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (epi *EndpointInterface) CopyTo(dstEpi *EndpointInterface) error {
-	dstEpi.mac = slices.Clone(epi.mac)
-	dstEpi.addr = types.GetIPNetCopy(epi.addr)
-	dstEpi.addrv6 = types.GetIPNetCopy(epi.addrv6)
-	dstEpi.srcName = epi.srcName
-	dstEpi.dstPrefix = epi.dstPrefix
-	dstEpi.dstName = epi.dstName
-	dstEpi.v4PoolID = epi.v4PoolID
-	dstEpi.v6PoolID = epi.v6PoolID
-	dstEpi.createdInContainer = epi.createdInContainer
-	if len(epi.llAddrs) != 0 {
-		dstEpi.llAddrs = make([]*net.IPNet, 0, len(epi.llAddrs))
-		dstEpi.llAddrs = append(dstEpi.llAddrs, epi.llAddrs...)
+// Copy returns a deep copy of [EndpointInterface]. If the receiver is nil,
+// Copy returns nil.
+func (epi *EndpointInterface) Copy() *EndpointInterface {
+	if epi == nil {
+		return nil
 	}
 
+	var routes []*net.IPNet
 	for _, route := range epi.routes {
-		dstEpi.routes = append(dstEpi.routes, types.GetIPNetCopy(route))
+		routes = append(routes, types.GetIPNetCopy(route))
 	}
 
-	return nil
+	return &EndpointInterface{
+		mac:                slices.Clone(epi.mac),
+		addr:               types.GetIPNetCopy(epi.addr),
+		addrv6:             types.GetIPNetCopy(epi.addrv6),
+		llAddrs:            slices.Clone(epi.llAddrs),
+		srcName:            epi.srcName,
+		dstPrefix:          epi.dstPrefix,
+		dstName:            epi.dstName,
+		routes:             routes,
+		v4PoolID:           epi.v4PoolID,
+		v6PoolID:           epi.v6PoolID,
+		netnsPath:          epi.netnsPath,
+		createdInContainer: epi.createdInContainer,
+	}
 }
 
 type endpointJoinInfo struct {

--- a/daemon/libnetwork/endpoint_info.go
+++ b/daemon/libnetwork/endpoint_info.go
@@ -372,7 +372,7 @@ func (ep *Endpoint) Gateway() net.IP {
 		return net.IP{}
 	}
 
-	return types.GetIPCopy(ep.joinInfo.gw)
+	return slices.Clone(ep.joinInfo.gw)
 }
 
 // GatewayIPv6 returns the IPv6 gateway assigned by the driver.
@@ -385,7 +385,7 @@ func (ep *Endpoint) GatewayIPv6() net.IP {
 		return net.IP{}
 	}
 
-	return types.GetIPCopy(ep.joinInfo.gw6)
+	return slices.Clone(ep.joinInfo.gw6)
 }
 
 // SetGateway sets the default IPv4 gateway when a container joins the endpoint.
@@ -393,7 +393,7 @@ func (ep *Endpoint) SetGateway(gw net.IP) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
-	ep.joinInfo.gw = types.GetIPCopy(gw)
+	ep.joinInfo.gw = slices.Clone(gw)
 	return nil
 }
 
@@ -402,7 +402,7 @@ func (ep *Endpoint) SetGatewayIPv6(gw6 net.IP) error {
 	ep.mu.Lock()
 	defer ep.mu.Unlock()
 
-	ep.joinInfo.gw6 = types.GetIPCopy(gw6)
+	ep.joinInfo.gw6 = slices.Clone(gw6)
 	return nil
 }
 
@@ -510,7 +510,7 @@ func (epj *endpointJoinInfo) CopyTo(dstEpj *endpointJoinInfo) error {
 	copy(dstEpj.StaticRoutes, epj.StaticRoutes)
 	dstEpj.driverTableEntries = make([]*tableEntry, len(epj.driverTableEntries))
 	copy(dstEpj.driverTableEntries, epj.driverTableEntries)
-	dstEpj.gw = types.GetIPCopy(epj.gw)
-	dstEpj.gw6 = types.GetIPCopy(epj.gw6)
+	dstEpj.gw = slices.Clone(epj.gw)
+	dstEpj.gw6 = slices.Clone(epj.gw6)
 	return nil
 }

--- a/daemon/libnetwork/endpoint_info.go
+++ b/daemon/libnetwork/endpoint_info.go
@@ -510,13 +510,16 @@ func (epj *endpointJoinInfo) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (epj *endpointJoinInfo) CopyTo(dstEpj *endpointJoinInfo) error {
-	dstEpj.disableGatewayService = epj.disableGatewayService
-	dstEpj.StaticRoutes = make([]*types.StaticRoute, len(epj.StaticRoutes))
-	copy(dstEpj.StaticRoutes, epj.StaticRoutes)
-	dstEpj.driverTableEntries = make([]*tableEntry, len(epj.driverTableEntries))
-	copy(dstEpj.driverTableEntries, epj.driverTableEntries)
-	dstEpj.gw = slices.Clone(epj.gw)
-	dstEpj.gw6 = slices.Clone(epj.gw6)
-	return nil
+func (epj *endpointJoinInfo) Copy() *endpointJoinInfo {
+	if epj == nil {
+		return nil
+	}
+
+	return &endpointJoinInfo{
+		gw:                    slices.Clone(epj.gw),
+		gw6:                   slices.Clone(epj.gw6),
+		StaticRoutes:          slices.Clone(epj.StaticRoutes),
+		driverTableEntries:    slices.Clone(epj.driverTableEntries),
+		disableGatewayService: epj.disableGatewayService,
+	}
 }

--- a/daemon/libnetwork/osl/interface_linux.go
+++ b/daemon/libnetwork/osl/interface_linux.go
@@ -136,7 +136,7 @@ func (i *Interface) Bridge() bool {
 }
 
 func (i *Interface) MacAddress() net.HardwareAddr {
-	return types.GetMacCopy(i.mac)
+	return slices.Clone(i.mac)
 }
 
 // Address returns the IPv4 address for the interface.

--- a/daemon/libnetwork/osl/route_linux.go
+++ b/daemon/libnetwork/osl/route_linux.go
@@ -37,8 +37,7 @@ func (n *Namespace) StaticRoutes() []*types.StaticRoute {
 
 	routes := make([]*types.StaticRoute, len(n.staticRoutes))
 	for i, route := range n.staticRoutes {
-		r := route.GetCopy()
-		routes[i] = r
+		routes[i] = route.Copy()
 	}
 
 	return routes

--- a/daemon/libnetwork/portmappers/nat/mapper_linux.go
+++ b/daemon/libnetwork/portmappers/nat/mapper_linux.go
@@ -211,7 +211,7 @@ func (pm PortMapper) attemptBindHostPorts(
 
 	for i := range cfg {
 		pb := portmapperapi.PortBinding{
-			PortBinding: cfg[i].PortBinding.GetCopy(),
+			PortBinding: cfg[i].PortBinding.Copy(),
 			BoundSocket: socks[i],
 			ChildHostIP: cfg[i].ChildHostIP,
 		}

--- a/daemon/libnetwork/portmappers/routed/mapper_linux.go
+++ b/daemon/libnetwork/portmappers/routed/mapper_linux.go
@@ -31,7 +31,7 @@ func (pm PortMapper) MapPorts(ctx context.Context, reqs []portmapperapi.PortBind
 	res := make([]portmapperapi.PortBinding, 0, len(reqs))
 	bindings := make([]types.PortBinding, 0, len(reqs))
 	for _, c := range reqs {
-		pb := portmapperapi.PortBinding{PortBinding: c.GetCopy()}
+		pb := portmapperapi.PortBinding{PortBinding: c.Copy()}
 		if pb.HostPort != 0 || pb.HostPortEnd != 0 {
 			log.G(ctx).WithFields(log.Fields{"mapping": pb}).Infof(
 				"Host port ignored, because NAT is disabled")

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -251,12 +251,6 @@ func CompareIPNet(a, b *net.IPNet) bool {
 	return a.IP.Equal(b.IP) && bytes.Equal(a.Mask, b.Mask)
 }
 
-// IsIPNetValid returns true if the ipnet is a valid network/mask
-// combination. Otherwise returns false.
-func IsIPNetValid(nw *net.IPNet) bool {
-	return nw.String() != "0.0.0.0/0"
-}
-
 var v4inV6MaskPrefix = []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 
 // compareIPMask checks if the passed ip and mask are semantically compatible.

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -214,16 +214,6 @@ func ParseProtocol(s string) Protocol {
 	}
 }
 
-// GetMacCopy returns a copy of the passed MAC address
-func GetMacCopy(from net.HardwareAddr) net.HardwareAddr {
-	if from == nil {
-		return nil
-	}
-	to := make(net.HardwareAddr, len(from))
-	copy(to, from)
-	return to
-}
-
 // GetIPCopy returns a copy of the passed IP address
 func GetIPCopy(from net.IP) net.IP {
 	if from == nil {

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -111,9 +112,9 @@ func (p PortBinding) ContainerAddr() (net.Addr, error) {
 func (p *PortBinding) GetCopy() PortBinding {
 	return PortBinding{
 		Proto:       p.Proto,
-		IP:          GetIPCopy(p.IP),
+		IP:          slices.Clone(p.IP),
 		Port:        p.Port,
-		HostIP:      GetIPCopy(p.HostIP),
+		HostIP:      slices.Clone(p.HostIP),
 		HostPort:    p.HostPort,
 		HostPortEnd: p.HostPortEnd,
 	}
@@ -214,16 +215,6 @@ func ParseProtocol(s string) Protocol {
 	}
 }
 
-// GetIPCopy returns a copy of the passed IP address
-func GetIPCopy(from net.IP) net.IP {
-	if from == nil {
-		return nil
-	}
-	to := make(net.IP, len(from))
-	copy(to, from)
-	return to
-}
-
 // GetIPNetCopy returns a copy of the passed IP Network
 func GetIPNetCopy(from *net.IPNet) *net.IPNet {
 	if from == nil {
@@ -231,7 +222,7 @@ func GetIPNetCopy(from *net.IPNet) *net.IPNet {
 	}
 	bm := make(net.IPMask, len(from.Mask))
 	copy(bm, from.Mask)
-	return &net.IPNet{IP: GetIPCopy(from.IP), Mask: bm}
+	return &net.IPNet{IP: slices.Clone(from.IP), Mask: bm}
 }
 
 // GetIPNetCanonical returns the canonical form for the passed network
@@ -292,7 +283,7 @@ func GetHostPartIP(ip net.IP, mask net.IPMask) (net.IP, error) {
 	}
 
 	// Compute host portion
-	out := GetIPCopy(ip)
+	out := slices.Clone(ip)
 	for i := 0; i < len(mask[ms:]); i++ {
 		out[is+i] &= ^mask[ms+i]
 	}
@@ -311,7 +302,7 @@ func GetBroadcastIP(ip net.IP, mask net.IPMask) (net.IP, error) {
 	}
 
 	// Compute broadcast address
-	out := GetIPCopy(ip)
+	out := slices.Clone(ip)
 	for i := 0; i < len(mask[ms:]); i++ {
 		out[is+i] |= ^mask[ms+i]
 	}
@@ -348,7 +339,7 @@ func (r *StaticRoute) GetCopy() *StaticRoute {
 	return &StaticRoute{
 		Destination: GetIPNetCopy(r.Destination),
 		RouteType:   r.RouteType,
-		NextHop:     GetIPCopy(r.NextHop),
+		NextHop:     slices.Clone(r.NextHop),
 	}
 }
 

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -43,23 +43,6 @@ type TransportPort struct {
 	Port  uint16
 }
 
-// Equal checks if this instance of TransportPort is equal to the passed one
-func (t *TransportPort) Equal(o *TransportPort) bool {
-	if t == o {
-		return true
-	}
-
-	if o == nil {
-		return false
-	}
-
-	if t.Proto != o.Proto || t.Port != o.Port {
-		return false
-	}
-
-	return true
-}
-
 // String returns the TransportPort structure in string form
 func (t *TransportPort) String() string {
 	return fmt.Sprintf("%s/%d", t.Proto.String(), t.Port)

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -311,8 +311,8 @@ type StaticRoute struct {
 	NextHop     net.IP    // NextHop will be resolved by the kernel (i.e., as a loose hop).
 }
 
-// GetCopy returns a copy of this StaticRoute structure
-func (r *StaticRoute) GetCopy() *StaticRoute {
+// Copy returns a copy of this StaticRoute structure
+func (r *StaticRoute) Copy() *StaticRoute {
 	return &StaticRoute{
 		Destination: GetIPNetCopy(r.Destination),
 		RouteType:   r.RouteType,

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -108,8 +108,8 @@ func (p PortBinding) ContainerAddr() (net.Addr, error) {
 	}
 }
 
-// GetCopy returns a copy of this PortBinding structure instance
-func (p *PortBinding) GetCopy() PortBinding {
+// Copy returns a deep copy of the PortBinding.
+func (p PortBinding) Copy() PortBinding {
 	return PortBinding{
 		Proto:       p.Proto,
 		IP:          slices.Clone(p.IP),

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -121,7 +121,7 @@ func (p PortBinding) Copy() PortBinding {
 }
 
 // Equal returns true if o has the same values as p, else false.
-func (p *PortBinding) Equal(o *PortBinding) bool {
+func (p PortBinding) Equal(o PortBinding) bool {
 	return p.Proto == o.Proto &&
 		p.IP.Equal(o.IP) &&
 		p.Port == o.Port &&

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -60,11 +60,6 @@ func (t *TransportPort) Equal(o *TransportPort) bool {
 	return true
 }
 
-// GetCopy returns a copy of this TransportPort structure instance
-func (t *TransportPort) GetCopy() TransportPort {
-	return TransportPort{Proto: t.Proto, Port: t.Port}
-}
-
 // String returns the TransportPort structure in string form
 func (t *TransportPort) String() string {
 	return fmt.Sprintf("%s/%d", t.Proto.String(), t.Port)

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -215,24 +215,29 @@ func ParseProtocol(s string) Protocol {
 	}
 }
 
-// GetIPNetCopy returns a copy of the passed IP Network
+// GetIPNetCopy returns a copy of the passed IP Network. If the input is nil,
+// it returns nil.
 func GetIPNetCopy(from *net.IPNet) *net.IPNet {
 	if from == nil {
 		return nil
 	}
-	bm := make(net.IPMask, len(from.Mask))
-	copy(bm, from.Mask)
-	return &net.IPNet{IP: slices.Clone(from.IP), Mask: bm}
+	return &net.IPNet{
+		IP:   slices.Clone(from.IP),
+		Mask: slices.Clone(from.Mask),
+	}
 }
 
-// GetIPNetCanonical returns the canonical form for the passed network
+// GetIPNetCanonical returns the canonical form of the given IP network,
+// where the IP is masked with the subnet mask. If the input is nil,
+// it returns nil.
 func GetIPNetCanonical(nw *net.IPNet) *net.IPNet {
 	if nw == nil {
 		return nil
 	}
-	c := GetIPNetCopy(nw)
-	c.IP = c.IP.Mask(nw.Mask)
-	return c
+	return &net.IPNet{
+		IP:   slices.Clone(nw.IP.Mask(nw.Mask)),
+		Mask: slices.Clone(nw.Mask),
+	}
 }
 
 // CompareIPNet returns equal if the two IP Networks are equal


### PR DESCRIPTION
### daemon/libnetwork: replace IpamConf.CopyTo with IpamConf.Copy()

The IpamConf.CopyTo function expected the caller to construct an
IpamConf to copy to, but all callsites created an empty struct.
In addition, `CopyTo` would never return an error, so the error
return was redundant.

Replace it with a `Copy()` function, which makes it easier to
consume.


### daemon/libnetwork: replace IpamInfo.CopyTo with IpamInfo.Copy()

The IpamInfo.CopyTo function expected the caller to construct an
IpamInfo to copy to, but all callsites created an empty struct.
In addition, `CopyTo` would never return an error, so the error
return was redundant.

Replace it with a `Copy()` function, which makes it easier to
consume.

### daemon/libnetwork/types: remove GetMacCopy; use slices.Clone

We can replace this utility with slices.Clone, which provides the
same functionality.

### daemon/libnetwork/types: remove GetIPCopy; use slices.Clone

We can replace this utility with slices.Clone, which provides the
same functionality.


### daemon/libnetwork/types: cleanup GetIPNetCopy, GetIPNetCanonical

Rewrite both to use slices.Clone, and GetIPNetCanonical to not depend
on GetIPNetCopy. GetIPNetCopy only has a single consumer, so we should
consider moving it local to where it's used.

### daemon/libnetwork/types: rename PortBinding.GetCopy to Copy and non-pointer

- Rename `PortBinding.GetCopy()` to `PortBinding.Copy()`, which is more
  idiomatic, and aligns with other similar methods.
- Change it to a non-pointer receiver; `Copy` does not mutate state, and
  the type should still be reasonably small.


### daemon/libnetwork/types: PortBinding.Equal: use non-pointer receiver

Change `PortBinding.Equal` to use a value receiver and parameter, this
allows us to use it directly with `slices.IndexFunc`, `DeleteFunc`,
without having to add a wrapper func.

The only exception currently is the `UnmapPorts` function (stub), which
takes portmapperapi.PortBinding as argument; the portmapperapi.PortBinding
type embeds `types.PortBinding`, and it's the only field that's compared
as part of `UnmapPorts`


### daemon/libnetwork: replace EndpointInterface.CopyTo with Copy()

The EndpointInterface.CopyTo function expected the caller to construct an
EndpointInterface to copy to, but all callsites created an empty struct.
In addition, `CopyTo` would never return an error, so the error return
was redundant.

Replace it with a `Copy()` function, which makes it easier to
consume.

### daemon/libnetwork: replace endpointJoinInfo.CopyTo with Copy()

The endpointJoinInfo.CopyTo function expected the caller to construct an
EndpointInterface to copy to, but all callsites created an empty struct.
In addition, `CopyTo` would never return an error, so the error return
was redundant.

Replace it with a `Copy()` function, which makes it easier to
consume.

### daemon/libnetwork: Endpoint.CopyTo: use maps/slices.Clone

Modernize using maps.Clone, slices.Clone. This method is needed to
satisfy the datastore.KVObject interface, so also assert it does.

### daemon/libnetwork/types: remove unused IsIPNetValid utility


### daemon/libnetwork/types: remove TransportPort.GetCopy()

The `GetCopy()` function doesn't de-reference anything, as it's
all a straight copy. We can remove it as it's only making things
more complicated than needed.

### daemon/libnetwork/types: remove TransportPort.Equal()

The `TransporPort` type is comparable; it doesn't have fields that
require special handling. It's defined as;

    // TransportPort represents a local Layer 4 endpoint
    type TransportPort struct {
        Proto Protocol
        Port  uint16
    }

where `Protocol` is an int (with a stringer interface);

    type Protocol uint8

So we can remove the `Equal` method, and simplify places where it's
compared.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

