### PR TITLE
daemon/libnetwork/types: use Errorf methods

### DIFF
--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -11,9 +11,9 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/stream"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/server/backend"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/term"
 	"github.com/pkg/errors"
 )
@@ -25,7 +25,7 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 	if req.DetachKeys != "" {
 		keys, err = term.ToBytes(req.DetachKeys)
 		if err != nil {
-			return errdefs.InvalidParameter(errors.Errorf("Invalid detach keys (%s) provided", req.DetachKeys))
+			return types.InvalidParameterErrorf("Invalid detach keys (%s) provided", req.DetachKeys)
 		}
 	}
 
@@ -34,10 +34,10 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 		return err
 	}
 	if ctr.IsPaused() {
-		return errdefs.Conflict(fmt.Errorf("container %s is paused, unpause the container before attach", prefixOrName))
+		return types.ConflictErrorf("container %s is paused, unpause the container before attach", prefixOrName)
 	}
 	if ctr.IsRestarting() {
-		return errdefs.Conflict(fmt.Errorf("container %s is restarting, wait until the container is running", prefixOrName))
+		return types.ConflictErrorf("container %s is restarting, wait until the container is running", prefixOrName)
 	}
 
 	cfg := stream.AttachConfig{

--- a/daemon/builder/dockerfile/builder.go
+++ b/daemon/builder/dockerfile/builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/moby/v2/daemon/builder"
 	"github.com/moby/moby/v2/daemon/builder/remotecontext"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/user"
@@ -197,7 +198,7 @@ func (b *Builder) build(ctx context.Context, source builder.Source, dockerfile *
 		targetIx, found := instructions.HasStage(stages, b.options.Target)
 		if !found {
 			buildsFailed.WithValues(metricsBuildTargetNotReachableError).Inc()
-			return nil, errdefs.InvalidParameter(errors.Errorf("target stage %q could not be found", b.options.Target))
+			return nil, types.InvalidParameterErrorf("target stage %q could not be found", b.options.Target)
 		}
 		stages = stages[:targetIx+1]
 	}
@@ -333,7 +334,7 @@ func BuildFromConfig(ctx context.Context, config *container.Config, changes []st
 	var commands []instructions.Command
 	for _, n := range dockerfile.AST.Children {
 		if !validCommitCommands[strings.ToLower(n.Value)] {
-			return nil, errdefs.InvalidParameter(errors.Errorf("%s is not a valid change command", n.Value))
+			return nil, types.InvalidParameterErrorf("%s is not a valid change command", n.Value)
 		}
 		cmd, err := instructions.ParseCommand(n)
 		if err != nil {

--- a/daemon/builder/remotecontext/detect.go
+++ b/daemon/builder/remotecontext/detect.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/moby/v2/daemon/builder"
 	"github.com/moby/moby/v2/daemon/builder/remotecontext/urlutil"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/patternmatcher"
@@ -143,14 +144,14 @@ func readAndParseDockerfile(name string, rc io.Reader) (*parser.Result, error) {
 	br := bufio.NewReader(rc)
 	if _, err := br.Peek(1); err != nil {
 		if err == io.EOF {
-			return nil, errdefs.InvalidParameter(errors.Errorf("the Dockerfile (%s) cannot be empty", name))
+			return nil, types.InvalidParameterErrorf("the Dockerfile (%s) cannot be empty", name)
 		}
 		return nil, errors.Wrap(err, "unexpected error reading Dockerfile")
 	}
 
 	dockerfile, err := parser.Parse(br)
 	if err != nil {
-		return nil, errdefs.InvalidParameter(errors.Wrapf(err, "failed to parse %s", name))
+		return nil, types.InvalidParameterErrorf("failed to parse %s: %w", name, err)
 	}
 
 	return dockerfile, nil

--- a/daemon/cluster/helpers.go
+++ b/daemon/cluster/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/pkg/errors"
@@ -53,7 +54,7 @@ func getNode(ctx context.Context, c swarmapi.ControlClient, input string) (*swar
 	}
 
 	if l := len(rl.Nodes); l > 1 {
-		return nil, errdefs.InvalidParameter(fmt.Errorf("node %s is ambiguous (%d matches found)", input, l))
+		return nil, types.InvalidParameterErrorf("node %s is ambiguous (%d matches found)", input, l)
 	}
 
 	return rl.Nodes[0], nil
@@ -89,7 +90,7 @@ func getService(ctx context.Context, c swarmapi.ControlClient, input string, ins
 	}
 
 	if l := len(rl.Services); l > 1 {
-		return nil, errdefs.InvalidParameter(fmt.Errorf("service %s is ambiguous (%d matches found)", input, l))
+		return nil, types.InvalidParameterErrorf("service %s is ambiguous (%d matches found)", input, l)
 	}
 
 	if !insertDefaults {
@@ -133,7 +134,7 @@ func getTask(ctx context.Context, c swarmapi.ControlClient, input string) (*swar
 	}
 
 	if l := len(rl.Tasks); l > 1 {
-		return nil, errdefs.InvalidParameter(fmt.Errorf("task %s is ambiguous (%d matches found)", input, l))
+		return nil, types.InvalidParameterErrorf("task %s is ambiguous (%d matches found)", input, l)
 	}
 
 	return rl.Tasks[0], nil
@@ -169,7 +170,7 @@ func getSecret(ctx context.Context, c swarmapi.ControlClient, input string) (*sw
 	}
 
 	if l := len(rl.Secrets); l > 1 {
-		return nil, errdefs.InvalidParameter(fmt.Errorf("secret %s is ambiguous (%d matches found)", input, l))
+		return nil, types.InvalidParameterErrorf("secret %s is ambiguous (%d matches found)", input, l)
 	}
 
 	return rl.Secrets[0], nil
@@ -205,7 +206,7 @@ func getConfig(ctx context.Context, c swarmapi.ControlClient, input string) (*sw
 	}
 
 	if l := len(rl.Configs); l > 1 {
-		return nil, errdefs.InvalidParameter(fmt.Errorf("config %s is ambiguous (%d matches found)", input, l))
+		return nil, types.InvalidParameterErrorf("config %s is ambiguous (%d matches found)", input, l)
 	}
 
 	return rl.Configs[0], nil
@@ -239,7 +240,7 @@ func getNetwork(ctx context.Context, c swarmapi.ControlClient, input string) (*s
 	}
 
 	if l := len(rl.Networks); l > 1 {
-		return nil, errdefs.InvalidParameter(fmt.Errorf("network %s is ambiguous (%d matches found)", input, l))
+		return nil, types.InvalidParameterErrorf("network %s is ambiguous (%d matches found)", input, l)
 	}
 
 	return rl.Networks[0], nil
@@ -271,11 +272,11 @@ func getVolume(ctx context.Context, c swarmapi.ControlClient, input string) (*sw
 	}
 
 	if len(resp.Volumes) == 0 {
-		return nil, errdefs.NotFound(fmt.Errorf("volume %s not found", input))
+		return nil, types.NotFoundErrorf("volume %s not found", input)
 	}
 
 	if l := len(resp.Volumes); l > 1 {
-		return nil, errdefs.InvalidParameter(fmt.Errorf("volume %s is ambiguous (%d matches found)", input, l))
+		return nil, types.InvalidParameterErrorf("volume %s is ambiguous (%d matches found)", input, l)
 	}
 
 	return resp.Volumes[0], nil

--- a/daemon/cluster/volumes.go
+++ b/daemon/cluster/volumes.go
@@ -2,12 +2,11 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 
 	cerrdefs "github.com/containerd/errdefs"
 	volumetypes "github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/v2/daemon/cluster/convert"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"google.golang.org/grpc"
 )
@@ -81,7 +80,7 @@ func (c *Cluster) CreateVolume(v volumetypes.CreateOptions) (*volumetypes.Volume
 		// very helpful at all. Instead, before returning the error, add some
 		// context, and change this to a system-type error, because it's
 		// nothing the user did wrong.
-		return nil, errdefs.System(fmt.Errorf("unable to retrieve created volume: %w", err))
+		return nil, types.SystemErrorf("unable to retrieve created volume: %w", err)
 	}
 	return &createdVol, nil
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"runtime"
 	"strings"
 	"time"
@@ -12,8 +11,8 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/builder/dockerfile"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -137,11 +136,11 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 	}
 
 	if container.IsDead() {
-		return "", errdefs.Conflict(fmt.Errorf("You cannot commit container %s which is Dead", container.ID))
+		return "", types.ConflictErrorf("You cannot commit container %s which is Dead", container.ID)
 	}
 
 	if container.IsRemovalInProgress() {
-		return "", errdefs.Conflict(fmt.Errorf("You cannot commit container %s which is being removed", container.ID))
+		return "", types.ConflictErrorf("You cannot commit container %s which is being removed", container.ID)
 	}
 
 	if c.Pause && !container.IsPaused() {

--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -26,6 +26,7 @@ import (
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
 	"github.com/moby/moby/v2/daemon/internal/restartmanager"
 	"github.com/moby/moby/v2/daemon/internal/stream"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/jsonfilelog"
 	"github.com/moby/moby/v2/daemon/logger/local"
@@ -468,7 +469,7 @@ func (container *Container) StartLogger() (logger.Logger, error) {
 			return nil, err
 		}
 		if err := os.MkdirAll(logDir, 0o700); err != nil {
-			return nil, errdefs.System(errors.Wrap(err, "error creating local logs dir"))
+			return nil, types.SystemErrorf("error creating local logs dir: %w", err)
 		}
 		info.LogPath = filepath.Join(logDir, "container.log")
 	}
@@ -831,7 +832,7 @@ func (container *Container) RestoreTask(ctx context.Context, client libcontainer
 // The container lock must be held when calling this method.
 func (container *Container) GetRunningTask() (libcontainerdtypes.Task, error) {
 	if !container.Running {
-		return nil, errdefs.Conflict(fmt.Errorf("container %s is not running", container.ID))
+		return nil, types.ConflictErrorf("container %s is not running", container.ID)
 	}
 	tsk, ok := container.Task()
 	if !ok {

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -922,7 +922,7 @@ func (daemon *Daemon) getNetworkedContainer(containerID, connectedContainerPrefi
 		return nil, errdefs.System(errdefs.InvalidParameter(errors.New("cannot join own network namespace")))
 	}
 	if !nc.IsRunning() {
-		return nil, errdefs.Conflict(fmt.Errorf("cannot join network namespace of a non running container: container %s is %s", strings.TrimPrefix(nc.Name, "/"), nc.StateString()))
+		return nil, types.ConflictErrorf("cannot join network namespace of a non running container: container %s is %s", strings.TrimPrefix(nc.Name, "/"), nc.StateString())
 	}
 	if nc.IsRestarting() {
 		return nil, fmt.Errorf("cannot join network namespace of container: %w", errContainerIsRestarting(connectedContainerPrefixOrName))

--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/stringid"
 	"github.com/moby/moby/v2/daemon/libnetwork"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/links"
 	"github.com/moby/moby/v2/daemon/network"
 	"github.com/moby/moby/v2/errdefs"
@@ -166,7 +167,7 @@ func (daemon *Daemon) getIPCContainer(id string) (*container.Container, error) {
 			return nil, errdefs.InvalidParameter(errors.New("container " + id + ": non-shareable IPC (hint: use IpcMode:shareable for the donor container)"))
 		}
 		// stat() failed?
-		return nil, errdefs.System(errors.Wrap(err, "container "+id))
+		return nil, types.SystemErrorf("container %s: %w", id, err)
 	}
 
 	return ctr, nil
@@ -490,7 +491,7 @@ func killProcessDirectly(ctr *container.Container) error {
 			return err
 		}
 		if isZombie {
-			return errdefs.System(errors.Errorf("container %s PID %d is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes", stringid.TruncateID(ctr.ID), pid))
+			return types.SystemErrorf("container %s PID %d is zombie and can not be killed. Use the --init option when creating containers to run an init inside the container that forwards signals and reaps processes", stringid.TruncateID(ctr.ID), pid)
 		}
 	}
 	return nil

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -15,6 +15,7 @@ import (
 	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/v2/daemon/images"
 	"github.com/moby/moby/v2/daemon/internal/image"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/go-digest"
@@ -239,7 +240,7 @@ func (i *ImageService) getImageLabelByDigest(ctx context.Context, target digest.
 	for _, img := range imgs {
 		if v, ok := img.Labels[labelKey]; ok {
 			if value != "" && value != v {
-				return value, errdefs.Conflict(fmt.Errorf("conflicting label value %q and %q", value, v))
+				return value, types.ConflictErrorf("conflicting label value %q and %q", value, v)
 			}
 			value = v
 		}

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -32,8 +32,8 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/opencontainers/image-spec/specs-go"
@@ -213,7 +213,7 @@ func newROLayerForImage(ctx context.Context, imgDesc *ocispec.Descriptor, i *Ima
 	snapshotter := i.StorageDriver()
 	_, lease, err := createLease(ctx, i.client.LeasesService())
 	if err != nil {
-		return nil, errdefs.System(fmt.Errorf("failed to lease image snapshot %s: %w", imageSnapshotID, err))
+		return nil, types.SystemErrorf("failed to lease image snapshot %s: %w", imageSnapshotID, err)
 	}
 
 	return &rolayer{

--- a/daemon/containerd/image_children.go
+++ b/daemon/containerd/image_children.go
@@ -5,7 +5,7 @@ import (
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/moby/moby/v2/daemon/internal/image"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
@@ -14,7 +14,7 @@ import (
 func (i *ImageService) getImagesWithLabel(ctx context.Context, labelKey string, labelValue string) ([]image.ID, error) {
 	imgs, err := i.images.List(ctx, "labels."+labelKey+"=="+labelValue)
 	if err != nil {
-		return []image.ID{}, errdefs.System(errors.Wrap(err, "failed to list all images"))
+		return []image.ID{}, types.SystemErrorf("failed to list all images: %w", err)
 	}
 
 	var children []image.ID

--- a/daemon/containerd/image_manifest.go
+++ b/daemon/containerd/image_manifest.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/util/attestation"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -158,7 +159,7 @@ func (im *ImageManifest) IsPseudoImage(ctx context.Context) (bool, error) {
 	mfst, err := im.Manifest(ctx)
 	if err != nil {
 		if cerrdefs.IsNotFound(err) {
-			return false, errdefs.NotFound(errors.Wrapf(err, "failed to read manifest %v", im.Target().Digest))
+			return false, types.NotFoundErrorf("failed to read manifest %v: %w", im.Target().Digest, err)
 		}
 		return true, err
 	}

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -23,7 +23,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/distribution"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -96,7 +96,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	if oldImage.Target.Digest != "" {
 		err = i.leaseContent(ctx, i.content, oldImage.Target)
 		if err != nil {
-			return errdefs.System(fmt.Errorf("failed to lease content: %w", err))
+			return types.SystemErrorf("failed to lease content: %w", err)
 		}
 
 		// If the pulled image is different than the old image, we will keep the old image as a dangling image.
@@ -214,7 +214,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 			if strings.Contains(err.Error(), "no basic auth credentials") {
 				return err
 			}
-			return errdefs.NotFound(fmt.Errorf("pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(ref)))
+			return types.NotFoundErrorf("pull access denied for %s, repository does not exist or may require 'docker login'", reference.FamiliarName(ref))
 		}
 		if cerrdefs.IsNotFound(err) {
 			// Transform "no match for platform in manifest" error returned by containerd into
@@ -225,7 +225,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 				if platform != nil {
 					platformStr = platforms.FormatAll(*platform)
 				}
-				return errdefs.NotFound(fmt.Errorf("no matching manifest for %s in the manifest list entries: %w", platformStr, err))
+				return types.NotFoundErrorf("no matching manifest for %s in the manifest list entries: %w", platformStr, err)
 			}
 		}
 		return translateRegistryError(ctx, err)

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -2,7 +2,6 @@ package containerd
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -18,6 +17,7 @@ import (
 	daemonevents "github.com/moby/moby/v2/daemon/events"
 	dimages "github.com/moby/moby/v2/daemon/images"
 	"github.com/moby/moby/v2/daemon/internal/distribution"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/snapshotter"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/user"
@@ -202,9 +202,9 @@ func (i *ImageService) GetContainerLayerSize(ctx context.Context, containerID st
 	rwLayerUsage, err := snapshotter.Usage(ctx, containerID)
 	if err != nil {
 		if cerrdefs.IsNotFound(err) {
-			return 0, 0, errdefs.NotFound(fmt.Errorf("rw layer snapshot not found for container %s", containerID))
+			return 0, 0, types.NotFoundErrorf("rw layer snapshot not found for container %s", containerID)
 		}
-		return 0, 0, errdefs.System(errors.Wrapf(err, "snapshotter.Usage failed for %s", containerID))
+		return 0, 0, types.SystemErrorf("snapshotter.Usage failed for %s: %w", containerID, err)
 	}
 
 	unpackedUsage, err := calculateSnapshotParentUsage(ctx, snapshotter, containerID)

--- a/daemon/containerd/soft_delete.go
+++ b/daemon/containerd/soft_delete.go
@@ -5,10 +5,9 @@ import (
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 const imageNameDanglingPrefix = "moby-dangling@"
@@ -25,8 +24,8 @@ func (i *ImageService) softImageDelete(ctx context.Context, img c8dimages.Image,
 		err := i.ensureDanglingImage(context.WithoutCancel(ctx), img)
 		// Error out in case we couldn't persist the old image.
 		if err != nil {
-			return errdefs.System(errors.Wrapf(err, "failed to create a dangling image for the replaced image %s with digest %s",
-				img.Name, img.Target.Digest.String()))
+			return types.SystemErrorf("failed to create a dangling image for the replaced image %s with digest %s: %w",
+				img.Name, img.Target.Digest.String(), err)
 		}
 	}
 
@@ -35,7 +34,7 @@ func (i *ImageService) softImageDelete(ctx context.Context, img c8dimages.Image,
 	err := i.images.Delete(context.WithoutCancel(ctx), img.Name)
 	if err != nil {
 		if !cerrdefs.IsNotFound(err) {
-			return errdefs.System(errors.Wrapf(err, "failed to delete image %s which existed a moment before", img.Name))
+			return types.SystemErrorf("failed to delete image %s which existed a moment before: %w", img.Name, err)
 		}
 	}
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/containerfs"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -93,7 +94,7 @@ func (daemon *Daemon) cleanupContainer(ctr *container.Container, config backend.
 			if ctr.Paused {
 				return errdefs.Conflict(errors.New("container is paused and must be unpaused first"))
 			} else {
-				return errdefs.Conflict(fmt.Errorf("container is %s: stop the container before removing or force remove", ctr.StateString()))
+				return types.ConflictErrorf("container is %s: stop the container before removing or force remove", ctr.StateString())
 			}
 		}
 		if err := daemon.Kill(ctr); err != nil && !isNotRunning(err) {

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moby/moby/v2/daemon/graphdriver"
 	"github.com/moby/moby/v2/daemon/internal/containerfs"
 	"github.com/moby/moby/v2/daemon/internal/quota"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/user"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -116,15 +117,15 @@ func (d *Driver) parseOptions(options []string) error {
 				return errdefs.InvalidParameter(err)
 			}
 			if err = d.setQuotaOpt(uint64(size)); err != nil {
-				return errdefs.InvalidParameter(errors.Wrap(err, "failed to set option size for vfs"))
+				return types.InvalidParameterErrorf("failed to set option size for vfs: %w", err)
 			}
 		case xattrsStorageOpt:
 			if val != bestEffortXattrsOptValue {
-				return errdefs.InvalidParameter(errors.Errorf("do not set the " + xattrsStorageOpt + " option unless you are willing to accept the consequences"))
+				return types.InvalidParameterErrorf("do not set the " + xattrsStorageOpt + " option unless you are willing to accept the consequences")
 			}
 			d.bestEffortXattrs = true
 		default:
-			return errdefs.InvalidParameter(errors.Errorf("unknown option %s for vfs", key))
+			return types.InvalidParameterErrorf("unknown option %s for vfs", key)
 		}
 	}
 	return nil
@@ -148,7 +149,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 				}
 				quotaSize = uint64(size)
 			default:
-				return errdefs.InvalidParameter(errors.Errorf("Storage opt %s not supported", key))
+				return types.InvalidParameterErrorf("Storage opt %s not supported", key)
 			}
 		}
 	}

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -14,11 +14,11 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/moby/moby/v2/daemon/internal/image"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ErrImageDoesNotExist is error returned when no image can be found for a reference.
@@ -195,7 +195,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options bac
 		if ref, err := reference.ParseNamed(refOrID); err == nil {
 			imgName = reference.FamiliarString(ref)
 		}
-		retErr = errdefs.NotFound(errors.Errorf("image with reference %s was found but its platform (%s) does not match the specified platform (%s)", imgName, platforms.FormatAll(imgPlat), platforms.FormatAll(p)))
+		retErr = types.NotFoundErrorf("image with reference %s was found but its platform (%s) does not match the specified platform (%s)", imgName, platforms.FormatAll(imgPlat), platforms.FormatAll(p))
 	}()
 	ref, err := reference.ParseAnyReference(refOrID)
 	if err != nil {

--- a/daemon/internal/libcontainerd/local/local_windows.go
+++ b/daemon/internal/libcontainerd/local/local_windows.go
@@ -22,6 +22,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/internal/libcontainerd/queue"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -1044,7 +1045,7 @@ func (*task) CreateCheckpoint(context.Context, string, bool) error {
 // assertIsCurrentTask returns a non-nil error if the task has been deleted.
 func (t *task) assertIsCurrentTask() error {
 	if t.ctr.task != t {
-		return errors.WithStack(errdefs.NotFound(fmt.Errorf("task %q not found", t.id)))
+		return errors.WithStack(types.NotFoundErrorf("task %q not found", t.id))
 	}
 	return nil
 }
@@ -1062,7 +1063,7 @@ func (t *task) getHCSContainer() (hcsshim.Container, error) {
 	}
 	hc := t.ctr.hcsContainer
 	if hc == nil {
-		return nil, errors.WithStack(errdefs.NotFound(fmt.Errorf("container %q not found", t.ctr.id)))
+		return nil, errors.WithStack(types.NotFoundErrorf("container %q not found", t.ctr.id))
 	}
 	return hc, nil
 }
@@ -1197,7 +1198,7 @@ func (ctr *container) Delete(context.Context) error {
 	defer ctr.mu.Unlock()
 
 	if ctr.hcsContainer == nil {
-		return errors.WithStack(errdefs.NotFound(fmt.Errorf("container %q not found", ctr.id)))
+		return errors.WithStack(types.NotFoundErrorf("container %q not found", ctr.id))
 	}
 
 	// Check that there is no task currently running.

--- a/daemon/internal/plugin/executor/containerd/containerd.go
+++ b/daemon/internal/plugin/executor/containerd/containerd.go
@@ -2,7 +2,6 @@ package containerd
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sync"
 	"syscall"
@@ -13,7 +12,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/internal/libcontainerd"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -142,7 +141,7 @@ func (e *Executor) IsRunning(id string) (bool, error) {
 	p := e.plugins[id]
 	e.mu.Unlock()
 	if p == nil {
-		return false, errdefs.NotFound(fmt.Errorf("unknown plugin %q", id))
+		return false, types.NotFoundErrorf("unknown plugin %q", id)
 	}
 	status, err := p.tsk.Status(context.Background())
 	return status.Status == containerd.Running, err
@@ -154,7 +153,7 @@ func (e *Executor) Signal(id string, signal syscall.Signal) error {
 	p := e.plugins[id]
 	e.mu.Unlock()
 	if p == nil {
-		return errdefs.NotFound(fmt.Errorf("unknown plugin %q", id))
+		return types.NotFoundErrorf("unknown plugin %q", id)
 	}
 	return p.tsk.Kill(context.Background(), signal)
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -13,6 +13,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	containerpkg "github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/signal"
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ func (daemon *Daemon) ContainerKill(name, stopSignal string) error {
 			return errdefs.InvalidParameter(err)
 		}
 		if !signal.ValidSignalForPlatform(sig) {
-			return errdefs.InvalidParameter(errors.Errorf("the %s daemon does not support signal %d", runtime.GOOS, sig))
+			return types.InvalidParameterErrorf("the %s daemon does not support signal %d", runtime.GOOS, sig)
 		}
 	}
 	container, err := daemon.GetContainer(name)

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -236,14 +236,17 @@ func ValidateFixedCIDRV6(val string) error {
 	if err == nil {
 		err = validateIPv6Subnet(prefix)
 	}
-	return errdefs.InvalidParameter(errors.Wrap(err, "invalid fixed-cidr-v6"))
+	if err != nil {
+		return types.InvalidParameterErrorf("invalid fixed-cidr-v6: %w", err)
+	}
+	return nil
 }
 
 // Validate performs a static validation on the network configuration parameters.
 // Whatever can be assessed a priori before attempting any programming.
 func (ncfg *networkConfiguration) Validate() error {
 	if ncfg.Mtu < 0 {
-		return errdefs.InvalidParameter(fmt.Errorf("invalid MTU number: %d", ncfg.Mtu))
+		return types.InvalidParameterErrorf("invalid MTU number: %d", ncfg.Mtu)
 	}
 
 	if ncfg.EnableIPv4 {
@@ -267,7 +270,7 @@ func (ncfg *networkConfiguration) Validate() error {
 		// AddressIPv6 must be IPv6, and not overlap with the LL subnet prefix.
 		addr, ok := netiputil.ToPrefix(ncfg.AddressIPv6)
 		if !ok {
-			return errdefs.InvalidParameter(fmt.Errorf("invalid IPv6 address '%s'", ncfg.AddressIPv6))
+			return types.InvalidParameterErrorf("invalid IPv6 address '%s'", ncfg.AddressIPv6)
 		}
 		if err := validateIPv6Subnet(addr); err != nil {
 			return errdefs.InvalidParameter(err)
@@ -518,7 +521,7 @@ func (d *driver) configure(option map[string]any) error {
 	case nil:
 		// No GenericData option set. Use defaults.
 	default:
-		return errdefs.InvalidParameter(fmt.Errorf("invalid configuration type (%T) passed", opt))
+		return types.InvalidParameterErrorf("invalid configuration type (%T) passed", opt)
 	}
 
 	var err error

--- a/daemon/libnetwork/drivers/bridge/interface_linux.go
+++ b/daemon/libnetwork/drivers/bridge/interface_linux.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/internal/netiputil"
 	"github.com/moby/moby/v2/daemon/libnetwork/nlwrap"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/vishvananda/netlink"
 )
@@ -139,7 +140,7 @@ func (i *bridgeInterface) programIPv6Addresses(config *networkConfiguration) err
 		IPNet: netiputil.ToIPNet(addrPrefix),
 		Flags: syscall.IFA_F_NODAD,
 	}); err != nil {
-		return errdefs.System(fmt.Errorf("failed to add IPv6 address %s to bridge: %v", i.bridgeIPv6, err))
+		return types.SystemErrorf("failed to add IPv6 address %s to bridge: %v", i.bridgeIPv6, err)
 	}
 	return nil
 }

--- a/daemon/libnetwork/drivers/bridge/setup_device_linux.go
+++ b/daemon/libnetwork/drivers/bridge/setup_device_linux.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/netutils"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/vishvananda/netlink"
 )
 
@@ -16,7 +16,7 @@ import (
 func setupDevice(config *networkConfiguration, i *bridgeInterface) error {
 	if config.BridgeName != DefaultBridgeName && config.DefaultBridge {
 		// TODO(thaJeztah): should this be an [errdefs.ErrInvalidParameter], not an [errdefs.ErrForbidden]?
-		return errdefs.Forbidden(fmt.Errorf("bridge device with non default name %s must be created manually", config.BridgeName))
+		return types.ForbiddenErrorf("bridge device with non default name %s must be created manually", config.BridgeName)
 	}
 
 	// Set the bridgeInterface netlink.Bridge.

--- a/daemon/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/daemon/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/netlabel"
 	"github.com/moby/moby/v2/daemon/libnetwork/ns"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
-	"github.com/moby/moby/v2/errdefs"
 )
 
 // CreateEndpoint assigns the mac, ip and endpoint id for the new container
@@ -22,7 +21,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	}
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return errdefs.System(fmt.Errorf("network id %q not found", nid))
+		return types.SystemErrorf("network id %q not found", nid)
 	}
 	if ifInfo.MacAddress() != nil {
 		return errors.New("ipvlan interfaces do not support custom mac address assignment")

--- a/daemon/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/daemon/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/netutils"
 	"github.com/moby/moby/v2/daemon/libnetwork/ns"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
-	"github.com/moby/moby/v2/errdefs"
 )
 
 // CreateEndpoint assigns the mac, ip and endpoint id for the new container
@@ -22,7 +21,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	}
 	n, err := d.getNetwork(nid)
 	if err != nil {
-		return errdefs.System(fmt.Errorf("network id %q not found", nid))
+		return types.SystemErrorf("network id %q not found", nid)
 	}
 	ep := &endpoint{
 		id:     eid,

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -29,7 +29,6 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/options"
 	"github.com/moby/moby/v2/daemon/libnetwork/scope"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
-	"github.com/moby/moby/v2/errdefs"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -1011,7 +1010,7 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 
 	n, err := c.getNetworkFromStore(id)
 	if err != nil {
-		return errdefs.NotFound(fmt.Errorf("unknown network %s id %s", name, id))
+		return types.NotFoundErrorf("unknown network %s id %s", name, id)
 	}
 
 	// Only remove ingress on force removal or explicit LB endpoint removal
@@ -1311,7 +1310,7 @@ func (n *Network) EndpointByName(name string) (*Endpoint, error) {
 	n.WalkEndpoints(s)
 
 	if e == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("endpoint %s not found", name))
+		return nil, types.NotFoundErrorf("endpoint %s not found", name)
 	}
 
 	return e, nil

--- a/daemon/libnetwork/sandbox_dns_unix.go
+++ b/daemon/libnetwork/sandbox_dns_unix.go
@@ -4,7 +4,6 @@ package libnetwork
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"net/netip"
 	"os"
@@ -144,7 +143,7 @@ func (sb *Sandbox) buildHostsFile(ctx context.Context, ifaceIPs []netip.Addr) er
 	for _, host := range sb.config.extraHosts {
 		addr, err := netip.ParseAddr(host.IP)
 		if err != nil {
-			return errdefs.InvalidParameter(fmt.Errorf("could not parse extra host IP %s: %v", host.IP, err))
+			return types.InvalidParameterErrorf("could not parse extra host IP %s: %v", host.IP, err)
 		}
 		extraContent = append(extraContent, etchosts.Record{Hosts: host.name, IP: addr})
 	}

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -367,14 +367,29 @@ func NotFoundErrorf(format string, params ...any) error {
 	return errdefs.NotFound(fmt.Errorf(format, params...))
 }
 
+// ConflictErrorf creates an instance of [errdefs.ErrConflict].
+func ConflictErrorf(format string, params ...any) error {
+	return errdefs.Conflict(fmt.Errorf(format, params...))
+}
+
 // ForbiddenErrorf creates an instance of [errdefs.ErrForbidden].
 func ForbiddenErrorf(format string, params ...any) error {
 	return errdefs.Forbidden(fmt.Errorf(format, params...))
 }
 
-// UnavailableErrorf creates an instance of [errdefs.ErrUnavailable]
+// SystemErrorf creates an instance of [errdefs.ErrSystem].
+func SystemErrorf(format string, params ...any) error {
+	return errdefs.System(fmt.Errorf(format, params...))
+}
+
+// UnavailableErrorf creates an instance of [errdefs.ErrUnavailable].
 func UnavailableErrorf(format string, params ...any) error {
 	return errdefs.Unavailable(fmt.Errorf(format, params...))
+}
+
+// UnknownErrorf creates an instance of [errdefs.ErrUnknown].
+func UnknownErrorf(format string, params ...any) error {
+	return errdefs.Unknown(fmt.Errorf(format, params...))
 }
 
 // NotImplementedErrorf creates an instance of [errdefs.ErrNotImplemented].

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -16,8 +16,8 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/image"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -270,7 +270,7 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view *container.View, conf
 	err := psFilters.WalkValues("exited", func(value string) error {
 		code, err := strconv.Atoi(value)
 		if err != nil {
-			return errdefs.InvalidParameter(errors.Wrapf(err, "invalid filter 'exited=%s'", value))
+			return types.InvalidParameterErrorf("invalid filter 'exited=%s': %w", value, err)
 		}
 		filtExited = append(filtExited, code)
 		return nil
@@ -281,7 +281,7 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view *container.View, conf
 
 	err = psFilters.WalkValues("status", func(value string) error {
 		if err := containertypes.ValidateContainerState(value); err != nil {
-			return errdefs.InvalidParameter(fmt.Errorf("invalid filter 'status=%s': %w", value, err))
+			return types.InvalidParameterErrorf("invalid filter 'status=%s': %w", value, err)
 		}
 		config.All = true
 		return nil
@@ -298,7 +298,7 @@ func (daemon *Daemon) foldFilter(ctx context.Context, view *container.View, conf
 
 	err = psFilters.WalkValues("health", func(value string) error {
 		if err := containertypes.ValidateHealthStatus(value); err != nil {
-			return errdefs.InvalidParameter(fmt.Errorf("invalid filter 'health=%s': %w", value, err))
+			return types.InvalidParameterErrorf("invalid filter 'health=%s': %w", value, err)
 		}
 		return nil
 	})

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/internal/logdriver"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
@@ -77,7 +78,7 @@ func New(info logger.Info) (logger.Logger, error) {
 		var err error
 		cfg.MaxFileSize, err = units.FromHumanSize(capacity)
 		if err != nil {
-			return nil, errdefs.InvalidParameter(errors.Wrapf(err, "invalid value for max-size: %s", capacity))
+			return nil, types.InvalidParameterErrorf("invalid value for max-size: %s: %w", capacity, err)
 		}
 	}
 
@@ -85,14 +86,14 @@ func New(info logger.Info) (logger.Logger, error) {
 		var err error
 		cfg.MaxFileCount, err = strconv.Atoi(userMaxFileCount)
 		if err != nil {
-			return nil, errdefs.InvalidParameter(errors.Wrapf(err, "invalid value for max-file: %s", userMaxFileCount))
+			return nil, types.InvalidParameterErrorf("invalid value for max-file: %s: %w", userMaxFileCount, err)
 		}
 	}
 
 	if userCompress, ok := info.Config["compress"]; ok {
 		compressLogs, err := strconv.ParseBool(userCompress)
 		if err != nil {
-			return nil, errdefs.InvalidParameter(errors.Wrap(err, "error reading compress log option"))
+			return nil, types.InvalidParameterErrorf("error reading compress log option: %w", err)
 		}
 		cfg.DisableCompression = !compressLogs
 	}

--- a/daemon/logger/local/read.go
+++ b/daemon/logger/local/read.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/internal/logdriver"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
@@ -25,7 +26,7 @@ func (d *driver) ReadLogs(ctx context.Context, config logger.ReadConfig) *logger
 func getTailReader(ctx context.Context, r loggerutils.SizeReaderAt, req int) (loggerutils.SizeReaderAt, int, error) {
 	size := r.Size()
 	if req < 0 {
-		return nil, 0, errdefs.InvalidParameter(errors.Errorf("invalid number of lines to tail: %d", req))
+		return nil, 0, types.InvalidParameterErrorf("invalid number of lines to tail: %d", req)
 	}
 
 	if size < (encodeBinaryLen*2)+1 {

--- a/daemon/logger/plugin.go
+++ b/daemon/logger/plugin.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 
 	"github.com/moby/moby/v2/daemon/internal/stringid"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/logger/internal/logdriver"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/plugingetter"
 	"github.com/moby/moby/v2/pkg/plugins"
 	"github.com/pkg/errors"
@@ -52,7 +52,7 @@ func makePluginClient(p plugingetter.CompatPlugin) (logPlugin, error) {
 	}
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin type %T", p))
+		return nil, types.SystemErrorf("got unknown plugin type %T", p)
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {

--- a/daemon/names.go
+++ b/daemon/names.go
@@ -8,8 +8,8 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/names"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/namesgenerator"
 	"github.com/pkg/errors"
 )
@@ -61,7 +61,7 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 
 func (daemon *Daemon) reserveName(id, name string) (string, error) {
 	if !validContainerNamePattern.MatchString(strings.TrimPrefix(name, "/")) {
-		return "", errdefs.InvalidParameter(errors.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars))
+		return "", types.InvalidParameterErrorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars)
 	}
 	if name[0] != '/' {
 		name = "/" + name

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -77,11 +77,11 @@ func (daemon *Daemon) FindNetwork(term string) (*libnetwork.Network, error) {
 	case len(listByFullName) == 1:
 		return listByFullName[0], nil
 	case len(listByFullName) > 1:
-		return nil, errdefs.InvalidParameter(fmt.Errorf("network %s is ambiguous (%d matches found on name)", term, len(listByFullName)))
+		return nil, lntypes.InvalidParameterErrorf("network %s is ambiguous (%d matches found on name)", term, len(listByFullName))
 	case len(listByPartialID) == 1:
 		return listByPartialID[0], nil
 	case len(listByPartialID) > 1:
-		return nil, errdefs.InvalidParameter(fmt.Errorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID)))
+		return nil, lntypes.InvalidParameterErrorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID))
 	}
 
 	// Be very careful to change the error type here, the
@@ -323,7 +323,7 @@ func (daemon *Daemon) createNetwork(ctx context.Context, cfg *config.Config, cre
 	} else if v, ok := networkOptions[netlabel.EnableIPv4]; ok {
 		var err error
 		if enableIPv4, err = strconv.ParseBool(v); err != nil {
-			return nil, errdefs.InvalidParameter(fmt.Errorf("driver-opt %q is not a valid bool", netlabel.EnableIPv4))
+			return nil, lntypes.InvalidParameterErrorf("driver-opt %q is not a valid bool", netlabel.EnableIPv4)
 		}
 	}
 
@@ -336,7 +336,7 @@ func (daemon *Daemon) createNetwork(ctx context.Context, cfg *config.Config, cre
 	} else if v, ok := networkOptions[netlabel.EnableIPv6]; ok {
 		var err error
 		if enableIPv6, err = strconv.ParseBool(v); err != nil {
-			return nil, errdefs.InvalidParameter(fmt.Errorf("driver-opt %q is not a valid bool", netlabel.EnableIPv6))
+			return nil, lntypes.InvalidParameterErrorf("driver-opt %q is not a valid bool", netlabel.EnableIPv6)
 		}
 	}
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -18,10 +18,10 @@ import (
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/rootless/mountopts"
 	"github.com/moby/moby/v2/daemon/internal/rootless/specconv"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/pkg/oci"
 	"github.com/moby/moby/v2/daemon/pkg/oci/caps"
 	volumemounts "github.com/moby/moby/v2/daemon/volume/mounts"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
 	"github.com/moby/sys/user"
@@ -272,7 +272,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// ipc
 		ipcMode := c.HostConfig.IpcMode
 		if !ipcMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid IPC mode: %v", ipcMode))
+			return types.InvalidParameterErrorf("invalid IPC mode: %v", ipcMode)
 		}
 		switch {
 		case ipcMode.IsContainer():
@@ -308,7 +308,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		// pid
 		pidMode := c.HostConfig.PidMode
 		if !pidMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid PID mode: %v", pidMode))
+			return types.InvalidParameterErrorf("invalid PID mode: %v", pidMode)
 		}
 		switch {
 		case pidMode.IsContainer():
@@ -339,7 +339,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// uts
 		if !c.HostConfig.UTSMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid UTS mode: %v", c.HostConfig.UTSMode))
+			return types.InvalidParameterErrorf("invalid UTS mode: %v", c.HostConfig.UTSMode)
 		}
 		if c.HostConfig.UTSMode.IsHost() {
 			oci.RemoveNamespace(s, specs.UTSNamespace)
@@ -348,7 +348,7 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 
 		// cgroup
 		if !c.HostConfig.CgroupnsMode.Valid() {
-			return errdefs.InvalidParameter(errors.Errorf("invalid cgroup namespace mode: %v", c.HostConfig.CgroupnsMode))
+			return types.InvalidParameterErrorf("invalid cgroup namespace mode: %v", c.HostConfig.CgroupnsMode)
 		}
 		if c.HostConfig.CgroupnsMode.IsPrivate() {
 			setNamespace(s, specs.LinuxNamespace{

--- a/daemon/oci_windows.go
+++ b/daemon/oci_windows.go
@@ -16,6 +16,7 @@ import (
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/image"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/pkg/oci"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
@@ -345,7 +346,7 @@ func getBackingDeviceForContainerdMount(mountPoint string) (string, error) {
 	return backingDevice, nil
 }
 
-var errInvalidCredentialSpecSecOpt = errdefs.InvalidParameter(fmt.Errorf("invalid credential spec security option - value must be prefixed by 'file://', 'registry://', or 'raw://' followed by a non-empty value"))
+var errInvalidCredentialSpecSecOpt = types.InvalidParameterErrorf("invalid credential spec security option - value must be prefixed by 'file://', 'registry://', or 'raw://' followed by a non-empty value")
 
 // setWindowsCredentialSpec sets the spec's `Windows.CredentialSpec`
 // field if relevant
@@ -363,11 +364,11 @@ func (daemon *Daemon) setWindowsCredentialSpec(c *container.Container, s *specs.
 	for _, secOpt := range c.HostConfig.SecurityOpt {
 		k, v, ok := strings.Cut(secOpt, "=")
 		if !ok {
-			return errdefs.InvalidParameter(fmt.Errorf("invalid security option: no equals sign in supplied value %s", secOpt))
+			return types.InvalidParameterErrorf("invalid security option: no equals sign in supplied value %s", secOpt)
 		}
 		// FIXME(thaJeztah): options should not be case-insensitive
 		if !strings.EqualFold(k, "credentialspec") {
-			return errdefs.InvalidParameter(fmt.Errorf("security option not supported: %s", k))
+			return types.InvalidParameterErrorf("security option not supported: %s", k)
 		}
 
 		scheme, value, ok := strings.Cut(v, "://")
@@ -397,7 +398,7 @@ func (daemon *Daemon) setWindowsCredentialSpec(c *container.Container, s *specs.
 
 			csConfig, err := c.DependencyStore.Configs().Get(value)
 			if err != nil {
-				return errdefs.System(errors.Wrap(err, "error getting value from config store"))
+				return types.SystemErrorf("error getting value from config store: %w", err)
 			}
 			// stuff the resulting secret data into a string to use as the
 			// CredentialSpec

--- a/daemon/pkg/oci/caps/utils.go
+++ b/daemon/pkg/oci/caps/utils.go
@@ -1,10 +1,9 @@
 package caps
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 )
 
 var (
@@ -69,9 +68,9 @@ func NormalizeLegacyCapabilities(caps []string) ([]string, error) {
 			c = "CAP_" + c
 		}
 		if v, ok := capabilityList[c]; !ok {
-			return nil, errdefs.InvalidParameter(fmt.Errorf("unknown capability: %q", c))
+			return nil, types.InvalidParameterErrorf("unknown capability: %q", c)
 		} else if v == nil {
-			return nil, errdefs.InvalidParameter(fmt.Errorf("capability not supported by your kernel or not available in the current environment: %q", c))
+			return nil, types.InvalidParameterErrorf("capability not supported by your kernel or not available in the current environment: %q", c)
 		}
 		normalized = append(normalized, c)
 	}

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/libnetwork"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/network"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
@@ -40,7 +41,7 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
 	links := map[string]*container.Container{}
 	for k, v := range daemon.linkIndex.children(ctr) {
 		if !strings.HasPrefix(k, ctr.Name) {
-			return errdefs.InvalidParameter(errors.Errorf("Linked container %s does not match parent %s", k, ctr.Name))
+			return types.InvalidParameterErrorf("Linked container %s does not match parent %s", k, ctr.Name)
 		}
 		links[strings.TrimPrefix(k, ctr.Name)] = v
 	}

--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -20,7 +20,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/internal/libcontainerd/shimopts"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/sys/atomicwriter"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
 	"github.com/pkg/errors"
@@ -216,7 +216,7 @@ func (r *runtimes) Get(name string) (string, any, error) {
 	}
 
 	if !isPermissibleC8dRuntimeName(name) {
-		return "", nil, errdefs.InvalidParameter(errors.Errorf("unknown or invalid runtime name: %s", name))
+		return "", nil, types.InvalidParameterErrorf("unknown or invalid runtime name: %s", name)
 	}
 	return name, nil, nil
 }

--- a/daemon/server/httputils/form.go
+++ b/daemon/server/httputils/form.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/distribution/reference"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
 
@@ -147,7 +148,7 @@ func DecodePlatform(platformJSON string) (*ocispec.Platform, error) {
 	var p ocispec.Platform
 
 	if err := json.Unmarshal([]byte(platformJSON), &p); err != nil {
-		return nil, errdefs.InvalidParameter(errors.Wrap(err, "failed to parse platform"))
+		return nil, types.InvalidParameterErrorf("failed to parse platform: %w", err)
 	}
 
 	hasAnyOptional := (p.Variant != "" || p.OSVersion != "" || len(p.OSFeatures) > 0)

--- a/daemon/server/httputils/httputils.go
+++ b/daemon/server/httputils/httputils.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
 )
@@ -77,7 +78,7 @@ func ReadJSON(r *http.Request, out any) error {
 		if errors.Is(err, io.EOF) {
 			return errdefs.InvalidParameter(errors.New("invalid JSON: got EOF while reading request body"))
 		}
-		return errdefs.InvalidParameter(errors.Wrap(err, "invalid JSON"))
+		return types.InvalidParameterErrorf("invalid JSON: %w", err)
 	}
 
 	if dec.More() {
@@ -125,10 +126,10 @@ func VersionFromContext(ctx context.Context) string {
 func matchesContentType(contentType, expectedType string) error {
 	mimetype, _, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		return errdefs.InvalidParameter(errors.Wrapf(err, "malformed Content-Type header (%s)", contentType))
+		return types.InvalidParameterErrorf("malformed Content-Type header (%s): %w", contentType, err)
 	}
 	if mimetype != expectedType {
-		return errdefs.InvalidParameter(errors.Errorf("unsupported Content-Type header (%s): must be '%s'", contentType, expectedType))
+		return types.InvalidParameterErrorf("unsupported Content-Type header (%s): must be '%s'", contentType, expectedType)
 	}
 	return nil
 }

--- a/daemon/server/router/container/exec.go
+++ b/daemon/server/router/container/exec.go
@@ -11,10 +11,9 @@ import (
 	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/versions"
+	lntypes "github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
-	"github.com/moby/moby/v2/errdefs"
-	"github.com/pkg/errors"
 )
 
 func (c *containerRouter) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -160,11 +159,11 @@ func (c *containerRouter) postContainerExecResize(ctx context.Context, w http.Re
 	}
 	height, err := httputils.Uint32Value(r, "h")
 	if err != nil {
-		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize height %q", r.Form.Get("h")))
+		return lntypes.InvalidParameterErrorf("invalid resize height %q: %w", r.Form.Get("h"), err)
 	}
 	width, err := httputils.Uint32Value(r, "w")
 	if err != nil {
-		return errdefs.InvalidParameter(errors.Wrapf(err, "invalid resize width %q", r.Form.Get("w")))
+		return lntypes.InvalidParameterErrorf("invalid resize width %q: %w", r.Form.Get("w"), err)
 	}
 
 	return c.backend.ContainerExecResize(ctx, vars["name"], height, width)

--- a/daemon/server/router/distribution/distribution_routes.go
+++ b/daemon/server/router/distribution/distribution_routes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/moby/moby/api/types/registry"
 	distributionpkg "github.com/moby/moby/v2/daemon/internal/distribution"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/httputils"
 	"github.com/moby/moby/v2/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -37,7 +38,7 @@ func (dr *distributionRouter) getDistributionInfo(ctx context.Context, w http.Re
 			// full image ID
 			return errors.Errorf("no manifest found for full image ID")
 		}
-		return errdefs.InvalidParameter(errors.Errorf("unknown image reference format: %s", imgName))
+		return types.InvalidParameterErrorf("unknown image reference format: %s", imgName)
 	}
 
 	// For a search it is not an error if no auth was given. Ignore invalid
@@ -81,7 +82,7 @@ func fetchManifest(ctx context.Context, distrepo distribution.Repository, namedR
 
 		taggedRef, ok := namedRef.(reference.NamedTagged)
 		if !ok {
-			return registry.DistributionInspect{}, errdefs.InvalidParameter(errors.Errorf("image reference not tagged: %s", namedRef))
+			return registry.DistributionInspect{}, types.InvalidParameterErrorf("image reference not tagged: %s", namedRef)
 		}
 
 		descriptor, err := distrepo.Tags(ctx).Get(ctx, taggedRef.Tag())

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/v2/daemon/builder/remotecontext"
 	"github.com/moby/moby/v2/daemon/internal/image"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
 	"github.com/moby/moby/v2/dockerversion"
@@ -544,7 +545,7 @@ func (ir *imageRouter) getImagesSearch(ctx context.Context, w http.ResponseWrite
 		var err error
 		limit, err = strconv.Atoi(r.Form.Get("limit"))
 		if err != nil || limit < 0 {
-			return errdefs.InvalidParameter(errors.Wrap(err, "invalid limit specified"))
+			return types.InvalidParameterErrorf("invalid limit specified: %w", err)
 		}
 	}
 	searchFilters, err := filters.FromJSON(r.Form.Get("filters"))

--- a/daemon/server/router/network/network_routes.go
+++ b/daemon/server/router/network/network_routes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/v2/daemon/libnetwork"
 	"github.com/moby/moby/v2/daemon/libnetwork/scope"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
 	"github.com/moby/moby/v2/errdefs"
@@ -369,7 +370,7 @@ func (n *networkRouter) findUniqueNetwork(term string) (network.Inspect, error) 
 		}
 	}
 	if len(listByFullName) > 1 {
-		return network.Inspect{}, errdefs.InvalidParameter(errors.Errorf("network %s is ambiguous (%d matches found based on name)", term, len(listByFullName)))
+		return network.Inspect{}, types.InvalidParameterErrorf("network %s is ambiguous (%d matches found based on name)", term, len(listByFullName))
 	}
 
 	// Find based on partial ID, returns true only if no duplicates
@@ -379,7 +380,7 @@ func (n *networkRouter) findUniqueNetwork(term string) (network.Inspect, error) 
 		}
 	}
 	if len(listByPartialID) > 1 {
-		return network.Inspect{}, errdefs.InvalidParameter(errors.Errorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID)))
+		return network.Inspect{}, types.InvalidParameterErrorf("network %s is ambiguous (%d matches found based on ID prefix)", term, len(listByPartialID))
 	}
 
 	return network.Inspect{}, errdefs.NotFound(libnetwork.ErrNoSuchNetwork(term))

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/moby/api/types/registry"
 	types "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/api/types/versions"
+	lntypes "github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
 	"github.com/moby/moby/v2/errdefs"
@@ -106,7 +107,7 @@ func (sr *swarmRouter) updateCluster(ctx context.Context, w http.ResponseWriter,
 	if value := r.URL.Query().Get("rotateManagerUnlockKey"); value != "" {
 		rot, err := strconv.ParseBool(value)
 		if err != nil {
-			return errdefs.InvalidParameter(fmt.Errorf("invalid value for rotateManagerUnlockKey: %s", value))
+			return lntypes.InvalidParameterErrorf("invalid value for rotateManagerUnlockKey: %s", value)
 		}
 
 		flags.RotateManagerUnlockKey = rot
@@ -430,7 +431,7 @@ func (sr *swarmRouter) createSecret(ctx context.Context, w http.ResponseWriter, 
 	}
 	version := httputils.VersionFromContext(ctx)
 	if secret.Templating != nil && versions.LessThan(version, "1.37") {
-		return errdefs.InvalidParameter(errors.Errorf("secret templating is not supported on the specified API version: %s", version))
+		return lntypes.InvalidParameterErrorf("secret templating is not supported on the specified API version: %s", version)
 	}
 
 	id, err := sr.backend.CreateSecret(secret)
@@ -502,7 +503,7 @@ func (sr *swarmRouter) createConfig(ctx context.Context, w http.ResponseWriter, 
 
 	version := httputils.VersionFromContext(ctx)
 	if config.Templating != nil && versions.LessThan(version, "1.37") {
-		return errdefs.InvalidParameter(errors.Errorf("config templating is not supported on the specified API version: %s", version))
+		return lntypes.InvalidParameterErrorf("config templating is not supported on the specified API version: %s", version)
 	}
 
 	id, err := sr.backend.CreateConfig(config)

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -8,6 +8,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/signal"
 	"github.com/pkg/errors"
@@ -36,7 +37,7 @@ func (daemon *Daemon) ContainerStop(ctx context.Context, name string, options co
 	}
 	err = daemon.containerStop(ctx, ctr, options)
 	if err != nil {
-		return errdefs.System(errors.Wrapf(err, "cannot stop container: %s", name))
+		return types.SystemErrorf("cannot stop container: %s: %w", name, err)
 	}
 	return nil
 }

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -14,7 +14,7 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/internal/lazyregexp"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
-	"github.com/moby/moby/v2/errdefs"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/pkg/errors"
 )
 
@@ -192,7 +192,7 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.TopRe
 					err = errors.New(string(line[0]))
 				}
 			}
-			return nil, errdefs.System(errors.Wrap(err, "ps"))
+			return nil, types.SystemErrorf("ps: %w", err)
 		}
 	}
 	procList, err := parsePSOutput(output, procs)

--- a/daemon/volume/drivers/extpoint.go
+++ b/daemon/volume/drivers/extpoint.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/moby/locker"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/volume"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/plugingetter"
@@ -228,7 +229,7 @@ func makePluginAdapter(p plugingetter.CompatPlugin) (*volumeDriverAdapter, error
 
 	pa, ok := p.(plugingetter.PluginAddr)
 	if !ok {
-		return nil, errdefs.System(errors.Errorf("got unknown plugin instance %T", p))
+		return nil, types.SystemErrorf("got unknown plugin instance %T", p)
 	}
 
 	if pa.Protocol() != plugins.ProtocolSchemeHTTPV1 {

--- a/daemon/volume/local/local_unix.go
+++ b/daemon/volume/local/local_unix.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/moby/moby/v2/daemon/internal/quota"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/mount"
 	"github.com/moby/sys/mountinfo"
@@ -53,13 +54,13 @@ func (r *Root) validateOpts(opts map[string]string) error {
 	}
 	for opt := range opts {
 		if _, ok := validOpts[opt]; !ok {
-			return errdefs.InvalidParameter(errors.Errorf("invalid option: %q", opt))
+			return types.InvalidParameterErrorf("invalid option: %q", opt)
 		}
 	}
 	if typeOpt, deviceOpt := opts["type"], opts["device"]; typeOpt == "cifs" && deviceOpt != "" {
 		deviceURL, err := url.Parse(deviceOpt)
 		if err != nil {
-			return errdefs.InvalidParameter(errors.Wrapf(err, "error parsing mount device url"))
+			return types.InvalidParameterErrorf("error parsing mount device url: %w", err)
 		}
 		if deviceURL.Port() != "" {
 			return errdefs.InvalidParameter(errors.New("port not allowed in CIFS device URL, include 'port' in 'o='"))
@@ -78,7 +79,7 @@ func (r *Root) validateOpts(opts map[string]string) error {
 		if _, ok := opts[opt]; ok {
 			for _, reqopt := range reqopts {
 				if _, ok := opts[reqopt]; !ok {
-					return errdefs.InvalidParameter(errors.Errorf("missing required option: %q", reqopt))
+					return types.InvalidParameterErrorf("missing required option: %q", reqopt)
 				}
 			}
 		}

--- a/daemon/volume/service/convert.go
+++ b/daemon/volume/service/convert.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -10,8 +9,8 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	volumetypes "github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/v2/daemon/internal/directory"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/volume"
-	"github.com/moby/moby/v2/errdefs"
 )
 
 // convertOpts are used to pass options to `volumeToAPI`
@@ -136,11 +135,11 @@ func withPrune(filter filters.Args) error {
 	all := filter.Get("all")
 	switch {
 	case len(all) > 1:
-		return errdefs.InvalidParameter(fmt.Errorf("invalid filter 'all=%s': only one value is expected", all))
+		return types.InvalidParameterErrorf("invalid filter 'all=%s': only one value is expected", all)
 	case len(all) == 1:
 		ok, err := strconv.ParseBool(all[0])
 		if err != nil {
-			return errdefs.InvalidParameter(fmt.Errorf("invalid filter 'all': %w", err))
+			return types.InvalidParameterErrorf("invalid filter 'all': %w", err)
 		}
 		if ok {
 			return nil

--- a/daemon/volume/service/store.go
+++ b/daemon/volume/service/store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/locker"
 	"github.com/moby/moby/api/types/events"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 	"github.com/moby/moby/v2/daemon/volume"
 	"github.com/moby/moby/v2/daemon/volume/drivers"
 	volumemounts "github.com/moby/moby/v2/daemon/volume/mounts"
@@ -327,7 +328,7 @@ func (s *VolumeStore) filter(ctx context.Context, vols *[]volume.Volume, by By) 
 		}
 		filter(vols, filterFunc(f))
 	default:
-		return nil, errdefs.InvalidParameter(errors.Errorf("unsupported filter: %T", f))
+		return nil, types.InvalidParameterErrorf("unsupported filter: %T", f)
 	}
 	return warnings, nil
 }
@@ -355,7 +356,7 @@ func (s *VolumeStore) Find(ctx context.Context, by By) (vols []volume.Volume, wa
 		warnings, err = s.filter(ctx, f.ls, f.by)
 	default:
 		// Really shouldn't be possible, but makes sure that any new By's are added to this check.
-		err = errdefs.InvalidParameter(errors.Errorf("unsupported filter type: %T", f))
+		err = types.InvalidParameterErrorf("unsupported filter type: %T", f)
 	}
 	if err != nil {
 		return nil, nil, &OpErr{Err: err, Op: "list"}

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -4,8 +4,7 @@ import (
 	"strings"
 
 	"github.com/moby/moby/api/types/mount"
-	"github.com/moby/moby/v2/errdefs"
-	"github.com/pkg/errors"
+	"github.com/moby/moby/v2/daemon/libnetwork/types"
 )
 
 // validateBindDaemonRoot ensures that if a given mountpoint's source is within
@@ -32,5 +31,5 @@ func (daemon *Daemon) validateBindDaemonRoot(m mount.Mount) (bool, error) {
 	default:
 	}
 
-	return false, errdefs.InvalidParameter(errors.Errorf(`invalid mount config: must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: %q, bind mount source: %q, propagation: %q`, daemon.root, m.Source, m.BindOptions.Propagation))
+	return false, types.InvalidParameterErrorf(`invalid mount config: must use either propagation mode "rslave" or "rshared" when mount source is within the daemon root, daemon root: %q, bind mount source: %q, propagation: %q`, daemon.root, m.Source, m.BindOptions.Propagation)
 }


### PR DESCRIPTION
**- What I did**

Use `github.com/moby/moby/v2/daemon/libnetwork/types`.*Errorf( methods in daemon packages instead their implementations to avoid repetitions.

Also add `ConflictErrorf`, `SystemErrorf` and `UnknownErrorf`.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

