### PR TITLE
api/types/network: modernize EndpointIPAMConfig.Copy, EndpointSettings.Copy

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -3,7 +3,9 @@ package network
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net"
+	"slices"
 )
 
 // EndpointSettings stores the network endpoint details
@@ -39,25 +41,16 @@ type EndpointSettings struct {
 
 // Copy makes a deep copy of `EndpointSettings`
 func (es *EndpointSettings) Copy() *EndpointSettings {
+	if es == nil {
+		return nil
+	}
+
 	epCopy := *es
-	if es.IPAMConfig != nil {
-		epCopy.IPAMConfig = es.IPAMConfig.Copy()
-	}
-
-	if es.Links != nil {
-		links := make([]string, 0, len(es.Links))
-		epCopy.Links = append(links, es.Links...)
-	}
-
-	if es.Aliases != nil {
-		aliases := make([]string, 0, len(es.Aliases))
-		epCopy.Aliases = append(aliases, es.Aliases...)
-	}
-
-	if len(es.DNSNames) > 0 {
-		epCopy.DNSNames = make([]string, len(es.DNSNames))
-		copy(epCopy.DNSNames, es.DNSNames)
-	}
+	epCopy.IPAMConfig = es.IPAMConfig.Copy()
+	epCopy.Links = slices.Clone(es.Links)
+	epCopy.Aliases = slices.Clone(es.Aliases)
+	epCopy.DNSNames = slices.Clone(es.DNSNames)
+	epCopy.DriverOpts = maps.Clone(es.DriverOpts)
 
 	return &epCopy
 }
@@ -71,9 +64,11 @@ type EndpointIPAMConfig struct {
 
 // Copy makes a copy of the endpoint ipam config
 func (cfg *EndpointIPAMConfig) Copy() *EndpointIPAMConfig {
+	if cfg == nil {
+		return nil
+	}
 	cfgCopy := *cfg
-	cfgCopy.LinkLocalIPs = make([]string, 0, len(cfg.LinkLocalIPs))
-	cfgCopy.LinkLocalIPs = append(cfgCopy.LinkLocalIPs, cfg.LinkLocalIPs...)
+	cfgCopy.LinkLocalIPs = slices.Clone(cfg.LinkLocalIPs)
 	return &cfgCopy
 }
 

--- a/vendor/github.com/moby/moby/api/types/network/endpoint.go
+++ b/vendor/github.com/moby/moby/api/types/network/endpoint.go
@@ -3,7 +3,9 @@ package network
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net"
+	"slices"
 )
 
 // EndpointSettings stores the network endpoint details
@@ -39,25 +41,16 @@ type EndpointSettings struct {
 
 // Copy makes a deep copy of `EndpointSettings`
 func (es *EndpointSettings) Copy() *EndpointSettings {
+	if es == nil {
+		return nil
+	}
+
 	epCopy := *es
-	if es.IPAMConfig != nil {
-		epCopy.IPAMConfig = es.IPAMConfig.Copy()
-	}
-
-	if es.Links != nil {
-		links := make([]string, 0, len(es.Links))
-		epCopy.Links = append(links, es.Links...)
-	}
-
-	if es.Aliases != nil {
-		aliases := make([]string, 0, len(es.Aliases))
-		epCopy.Aliases = append(aliases, es.Aliases...)
-	}
-
-	if len(es.DNSNames) > 0 {
-		epCopy.DNSNames = make([]string, len(es.DNSNames))
-		copy(epCopy.DNSNames, es.DNSNames)
-	}
+	epCopy.IPAMConfig = es.IPAMConfig.Copy()
+	epCopy.Links = slices.Clone(es.Links)
+	epCopy.Aliases = slices.Clone(es.Aliases)
+	epCopy.DNSNames = slices.Clone(es.DNSNames)
+	epCopy.DriverOpts = maps.Clone(es.DriverOpts)
 
 	return &epCopy
 }
@@ -71,9 +64,11 @@ type EndpointIPAMConfig struct {
 
 // Copy makes a copy of the endpoint ipam config
 func (cfg *EndpointIPAMConfig) Copy() *EndpointIPAMConfig {
+	if cfg == nil {
+		return nil
+	}
 	cfgCopy := *cfg
-	cfgCopy.LinkLocalIPs = make([]string, 0, len(cfg.LinkLocalIPs))
-	cfgCopy.LinkLocalIPs = append(cfgCopy.LinkLocalIPs, cfg.LinkLocalIPs...)
+	cfgCopy.LinkLocalIPs = slices.Clone(cfg.LinkLocalIPs)
 	return &cfgCopy
 }
 


### PR DESCRIPTION
- taken from (first commit) https://github.com/moby/moby/pull/50684

----

- Use slices.Clone where suitable.
- Handle `nil` values so that callers don't have to check for `nil`.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

