### PR TITLE
libnet/pa: OSAllocator: retry allocations

### DIFF
--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -386,7 +386,7 @@ func TestAddPortMappings(t *testing.T) {
 			},
 			enableProxy:  true,
 			busyPortIPv4: 8081,
-			expErr:       "failed to bind host port 0.0.0.0:8081",
+			expErr:       "failed to bind host port 0.0.0.0:8081/tcp: address already in use",
 		},
 		{
 			name:     "map host ipv6 to ipv4 container with proxy",

--- a/daemon/libnetwork/portallocator/osallocator_linux_test.go
+++ b/daemon/libnetwork/portallocator/osallocator_linux_test.go
@@ -1,12 +1,18 @@
 package portallocator
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"net/netip"
 	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/ishidawataru/sctp"
 	"github.com/moby/moby/v2/daemon/libnetwork/netutils"
@@ -227,4 +233,160 @@ func TestOnlyOneSocketBindsUDPPort(t *testing.T) {
 
 	assert.ErrorContains(t, err, "failed to bind host port")
 	assert.Equal(t, len(socks), 0)
+}
+
+// TestSocketBacklogEqualsSomaxconn verifies that the listen syscall made for
+// TCP / SCTP sockets has a backlog size equal to somaxconn.
+func TestSocketBacklogEqualsSomaxconn(t *testing.T) {
+	// Retrieve and parse sysctl net.core.somaxconn
+	somaxconnSysctl, err := os.ReadFile("/proc/sys/net/core/somaxconn")
+	assert.NilError(t, err)
+	somaxconn, err := strconv.Atoi(strings.TrimSpace(string(somaxconnSysctl)))
+	assert.NilError(t, err)
+
+	// UDP isn't included in the list of protos to test because it doesn't have a backlog, and the ss Send-Q column
+	// reports memory allocation instead of the socket's max backlog size (unlike TCP and SCTP).
+	//
+	// This is where the kernel writes the max backlog size into the sk struct: https://elixir.bootlin.com/linux/v6.16/source/net/ipv4/af_inet.c#L199
+	//
+	// And here's where the kernel writes the 'idiag_wqueue' field used by ss:
+	//
+	// - For TCP: https://elixir.bootlin.com/linux/v6.16/source/net/ipv4/tcp_diag.c#L25
+	// - For UDP: https://elixir.bootlin.com/linux/v6.16/source/net/ipv4/udp_diag.c#L163
+	// - For SCTP: https://elixir.bootlin.com/linux/v6.16/source/net/sctp/diag.c#L414
+	for _, proto := range []types.Protocol{
+		types.TCP,
+		types.SCTP,
+	} {
+		t.Run(proto.String(), func(t *testing.T) {
+			// Allocate an ephemeral port using the OSAllocator.
+			alloc := NewOSAllocator()
+			port, socks, err := alloc.RequestPortsInRange([]net.IP{net.IPv4zero}, proto, 0, 0)
+			assert.NilError(t, err)
+			defer closeSocks(t, socks)
+
+			// 'ss' output looks like that:
+			//
+			//    Netid      State       Recv-Q      Send-Q           Local Address:Port            Peer Address:Port      Process
+			//    tcp        LISTEN      0           4096                   0.0.0.0:32768                0.0.0.0:*
+			//
+			// The max backlog size ('idiag_wqueue' field of 'struct inet_diag_msg' in the kernel) is the 4th field in
+			// the output.
+			out, err := exec.Command("ss", "-Stl", "sport", "=", fmt.Sprintf("inet:%d", port)).Output()
+			assert.NilError(t, err)
+
+			t.Logf("ss output:\n" + string(out))
+
+			lines := strings.Split(string(out), "\n")
+			assert.Assert(t, len(lines) >= 2)
+
+			fields := strings.Fields(lines[1])
+			assert.Equal(t, len(fields), 6)
+
+			backlog, err := strconv.Atoi(fields[3])
+			assert.NilError(t, err)
+
+			assert.Equal(t, fields[4], "0.0.0.0:"+strconv.Itoa(port))
+			assert.Equal(t, backlog, somaxconn, "socket backlog should be equal to net.core.somaxconn")
+		})
+	}
+}
+
+// TestPacketsAreDroppedUntilDetachSocketFilter tests that SYN packets are
+// dropped until DetachSocketFilter is called on the socket.
+func TestPacketsAreDroppedUntilDetachSocketFilter(t *testing.T) {
+	const port = 61100
+	addr := net.ParseIP("127.0.0.1")
+
+	var detached atomic.Bool
+	dialCh, readCh := make(chan error), make(chan error)
+
+	alloc := NewOSAllocator()
+	_, socks, err := alloc.RequestPortsInRange([]net.IP{addr}, types.TCP, port, port)
+	assert.NilError(t, err)
+	assert.Check(t, len(socks) > 0)
+
+	// Start a goroutine that attempts to connect to a listening socket. It'll send SYN packets until
+	// DetachSocketFilter is called. If no filter is attached, the connection will succeed immediately, and it'll send
+	// a payload of 0x0 (or the call to DetachSocketFilter will fail with an error). When the filter is detached, it'll
+	// send a payload of 0x1, which will be read by the other goroutine.
+	go func() {
+		defer close(dialCh)
+
+		c, err := net.Dial("tcp", net.JoinHostPort(addr.String(), strconv.Itoa(port)))
+		if err != nil {
+			dialCh <- fmt.Errorf("net.Dial: %w", err)
+			return
+		}
+		defer c.Close()
+
+		payload := []byte{0x0}
+		if detached.Load() {
+			payload = []byte{0x1}
+		}
+
+		n, err := c.Write(payload)
+		if err != nil {
+			dialCh <- fmt.Errorf("c.Write: %w", err)
+			return
+		}
+		if n != len(payload) {
+			dialCh <- fmt.Errorf("expected to write %d bytes, but wrote %d", len(payload), n)
+		}
+	}()
+
+	// Start a goroutine that accepts a connection on the listening socket created by RequestPortsInRange, and reads
+	// the payload sent by the 1st goroutine. It should not receive any new connection until DetachSocketFilter is
+	// called on the socket.
+	go func() {
+		defer close(readCh)
+
+		// net.FileListener dup's the fd, so DetachSocketFilter will have no effect. Use raw syscalls instead.
+		sd := int(socks[0].Fd())
+
+		var err error
+		connfd, _, err := syscall.Accept(sd)
+		if err != nil {
+			readCh <- fmt.Errorf("syscall.Accept: %w", err)
+			return
+		}
+
+		payload := make([]byte, 1)
+		n, err := syscall.Read(connfd, payload)
+		if err != nil {
+			readCh <- fmt.Errorf("c.Read: %w", err)
+			return
+		}
+		if n != 1 {
+			readCh <- fmt.Errorf("expected to read 1 byte, but read %d", n)
+			return
+		}
+
+		if payload[0] != 0x1 {
+			readCh <- fmt.Errorf("expected payload 0x1, but got %x", payload[0])
+		}
+	}()
+
+	// Sleep for a bit to make sure that both goroutines were scheduled.
+	time.Sleep(500 * time.Millisecond)
+
+	detached.Store(true)
+	err = DetachSocketFilter(socks[0])
+	assert.NilError(t, err)
+
+	var dialStopped, readStopped bool
+	for {
+		if dialStopped && readStopped {
+			return
+		}
+
+		select {
+		case err, ok := <-dialCh:
+			dialStopped = !ok
+			assert.NilError(t, err)
+		case err, ok := <-readCh:
+			readStopped = !ok
+			assert.NilError(t, err)
+		}
+	}
 }

--- a/daemon/libnetwork/portmappers/nat/mapper_linux.go
+++ b/daemon/libnetwork/portmappers/nat/mapper_linux.go
@@ -16,10 +16,7 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
 )
 
-const (
-	driverName              = "nat"
-	maxAllocatePortAttempts = 10
-)
+const driverName = "nat"
 
 type PortDriverClient interface {
 	ChildHostIP(hostIP netip.Addr) netip.Addr
@@ -57,9 +54,9 @@ func NewPortMapper(cfg Config) PortMapper {
 }
 
 // MapPorts allocates and binds host ports for the given cfg. The caller is
-// responsible for ensuring that all entries in cfg map the same proto,
+// responsible for ensuring that all entries in cfg have the same proto,
 // container port, and host port range (their host addresses must differ).
-func (pm PortMapper) MapPorts(ctx context.Context, cfg []portmapperapi.PortBindingReq, fwn portmapperapi.Firewaller) ([]portmapperapi.PortBinding, error) {
+func (pm PortMapper) MapPorts(ctx context.Context, cfg []portmapperapi.PortBindingReq, fwn portmapperapi.Firewaller) (_ []portmapperapi.PortBinding, retErr error) {
 	if len(cfg) == 0 {
 		return nil, nil
 	}
@@ -73,28 +70,45 @@ func (pm PortMapper) MapPorts(ctx context.Context, cfg []portmapperapi.PortBindi
 		}
 	}
 
-	// Try up to maxAllocatePortAttempts times to get a port that's not already allocated.
-	var bindings []portmapperapi.PortBinding
-	var err error
-	for i := 0; i < maxAllocatePortAttempts; i++ {
-		bindings, err = pm.attemptBindHostPorts(ctx, cfg, proto, hostPort, hostPortEnd, fwn)
-		if err == nil {
-			break
+	bindings := make([]portmapperapi.PortBinding, 0, len(cfg))
+	defer func() {
+		if retErr != nil {
+			if err := pm.UnmapPorts(ctx, bindings, fwn); err != nil {
+				log.G(ctx).WithFields(log.Fields{
+					"pbs":   bindings,
+					"error": err,
+				}).Warn("Failed to release port bindings")
+			}
 		}
-		// There is no point in immediately retrying to map an explicitly chosen port.
-		if hostPort != 0 && hostPort == hostPortEnd {
-			log.G(ctx).WithError(err).Warnf("Failed to allocate and map port")
-			return nil, err
-		}
-		log.G(ctx).WithFields(log.Fields{
-			"error":   err,
-			"attempt": i + 1,
-		}).Warn("Failed to allocate and map port")
+	}()
+
+	addrs := make([]net.IP, 0, len(cfg))
+	for i := range cfg {
+		cfg[i] = setChildHostIP(pm.pdc, cfg[i])
+		addrs = append(addrs, cfg[i].ChildHostIP)
 	}
 
+	pa := portallocator.NewOSAllocator()
+	allocatedPort, socks, err := pa.RequestPortsInRange(addrs, proto, int(hostPort), int(hostPortEnd))
 	if err != nil {
-		// If the retry budget is exhausted and no free port could be found, return
-		// the latest error.
+		return nil, err
+	}
+
+	for i := range cfg {
+		pb := portmapperapi.PortBinding{
+			PortBinding: cfg[i].PortBinding.Copy(),
+			BoundSocket: socks[i],
+			ChildHostIP: cfg[i].ChildHostIP,
+		}
+		pb.PortBinding.HostPort = uint16(allocatedPort)
+		pb.PortBinding.HostPortEnd = pb.HostPort
+		bindings = append(bindings, pb)
+	}
+
+	if err := configPortDriver(ctx, bindings, pm.pdc); err != nil {
+		return nil, err
+	}
+	if err := fwn.AddPorts(ctx, mergeChildHostIPs(bindings)); err != nil {
 		return nil, err
 	}
 
@@ -154,81 +168,6 @@ func (pm PortMapper) UnmapPorts(ctx context.Context, pbs []portmapperapi.PortBin
 		portallocator.Get().ReleasePort(pb.ChildHostIP, pb.Proto.String(), int(pb.HostPort))
 	}
 	return errors.Join(errs...)
-}
-
-// attemptBindHostPorts allocates host ports for each NAT port mapping, and
-// reserves those ports by binding them.
-//
-// If the allocator doesn't have an available port in the required range, or the
-// port can't be bound (perhaps because another process has already bound it),
-// all resources are released and an error is returned. When ports are
-// successfully reserved, a PortBinding is returned for each mapping.
-func (pm PortMapper) attemptBindHostPorts(
-	ctx context.Context,
-	cfg []portmapperapi.PortBindingReq,
-	proto types.Protocol,
-	hostPortStart, hostPortEnd uint16,
-	fwn portmapperapi.Firewaller,
-) (_ []portmapperapi.PortBinding, retErr error) {
-	var err error
-	var port int
-
-	addrs := make([]net.IP, 0, len(cfg))
-	for i := range cfg {
-		cfg[i] = setChildHostIP(pm.pdc, cfg[i])
-		addrs = append(addrs, cfg[i].ChildHostIP)
-	}
-
-	pa := portallocator.NewOSAllocator()
-	port, socks, err := pa.RequestPortsInRange(addrs, proto, int(hostPortStart), int(hostPortEnd))
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if retErr != nil {
-			pa.ReleasePorts(addrs, proto, port)
-		}
-	}()
-
-	if len(socks) != len(cfg) {
-		for _, sock := range socks {
-			if err := sock.Close(); err != nil {
-				log.G(ctx).WithError(err).Warn("Failed to close socket")
-			}
-		}
-		return nil, types.InternalErrorf("port allocator returned %d sockets for %d port bindings", len(socks), len(cfg))
-	}
-
-	res := make([]portmapperapi.PortBinding, 0, len(cfg))
-	defer func() {
-		if retErr != nil {
-			if err := pm.UnmapPorts(ctx, res, fwn); err != nil {
-				log.G(ctx).WithFields(log.Fields{
-					"pbs":   res,
-					"error": err,
-				}).Warn("Failed to release port bindings")
-			}
-		}
-	}()
-
-	for i := range cfg {
-		pb := portmapperapi.PortBinding{
-			PortBinding: cfg[i].PortBinding.Copy(),
-			BoundSocket: socks[i],
-			ChildHostIP: cfg[i].ChildHostIP,
-		}
-		pb.PortBinding.HostPort = uint16(port)
-		pb.PortBinding.HostPortEnd = pb.HostPort
-		res = append(res, pb)
-	}
-
-	if err := configPortDriver(ctx, res, pm.pdc); err != nil {
-		return nil, err
-	}
-	if err := fwn.AddPorts(ctx, mergeChildHostIPs(res)); err != nil {
-		return nil, err
-	}
-	return res, nil
 }
 
 func setChildHostIP(pdc PortDriverClient, req portmapperapi.PortBindingReq) portmapperapi.PortBindingReq {


### PR DESCRIPTION
- Related to https://github.com/moby/moby/issues/50259
- Partially addresses concerns about code duplication raised in https://github.com/moby/moby/pull/50419#issuecomment-3124260773

**- What I did**

**libnet/pa: OSAllocator: listen after bind**

Move the listen syscall to the `OSAllocator` such that when `RequestPortsInRange` returns, callers are guaranteed that the allocated port isn't used by another process.

Bind and listen syscalls were previously split because listening before inserting DNAT rules could cause connections to be accepted by the kernel, so packets would never be forwarded to the container.

But, pulling them apart has an undesirable drawback: if another process is racing against the Engine, and starts listening on the same port, the conflict wouldn't be detected until OSAllocator's callers issue a 'listen' syscall. This means that callers need to implement their own retry logic.

To overcome both drawbacks, set a cBPF socket filter on the socket before it's bound, and let callers call `DetachSocketFilter` to remove it. Now, callers are guaranteed that the port is free to use, and no connections will be accepted prematurely.

For TCP / SCTP clients, this means that they'll send the first handshake packet (e.g. SYN), but the kernel won't reply (e.g. SYN-ACK), and they will retry until DNAT rules are configured or the socket filter is removed.

**libnet/pa: OSAllocator: retry allocations**

Previous commit changed the OSAllocator to listen after binding a port, such that we're 100% sure that the port is free. We can now make the OSAllocator responsible for retrying port allocations when it tries to find an ephemeral port, or a free port in a range.

Move the retry logic from the 'nat' portmapper to the OSAllocator.

**- How I did it**

**- How to verify it**

