### PR TITLE
[28.x backport] Dockerfile: update runc binary to v1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -261,7 +261,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged. When updating RUNC_VERSION,
 # consider updating runc in vendor.mod accordingly.
-ARG RUNC_VERSION=v1.2.6
+ARG RUNC_VERSION=v1.3.0
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -9,7 +9,7 @@ set -e
 # the containerd project first, and update both after that is merged.
 #
 # When updating RUNC_VERSION, consider updating runc in vendor.mod accordingly
-: "${RUNC_VERSION:=v1.2.6}"
+: "${RUNC_VERSION:=v1.3.0}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50644

- release notes: https://github.com/opencontainers/runc/releases/tag/v1.3.0
- full diff: https://github.com/opencontainers/runc/compare/v1.2.6..v1.3.0

-----

This is the first release of the 1.3.z release branch of runc. It contains a few minor fixes for issues found in 1.3.0-rc.2.

This is the first release of runc that will follow our new release and support policy (see RELEASES.md for more details). This means that, as of this release:

* As of this release, the runc 1.2.z release branch will now only receive security and "significant" bugfixes.
* Users are encouraged to plan migrating to runc 1.3.0 as soon as possible.
* Due to its particular situation, runc 1.1.z is officially no longer supported and will no longer receive any updates (not even for critical security issues). Users are urged (in the strongest possible terms) to upgrade to a supported version of runc.
* Barring any future changes to our release policy, users should expect a runc 1.4.0 release in late October 2025.

Fixed

* Removed pre-emptive "full access to cgroups" warning when calling `runc pause` or `runc unpause` as an unprivileged user without `--systemd-cgroups`. Now the warning is only emitted if an actual permission error was encountered.
* Several fixes to our CI, mainly related to AlmaLinux and CRIU.

Changed

* In runc 1.2, we changed our mount behaviour to correctly handle clearing flags. However, the error messages we returned did not provide as much information to users about what clearing flags were conflicting with locked mount flags. We now provide more diagnostic information if there is an error when in the fallback path to handle locked mount flags.
* Upgrade our CI to use golangci-lint v2.0.
* `runc version` information is now filled in using `//go:embed` rather than being set through `Makefile`. This allows `go install` or other non-`make` builds to contain the correct version information. Note that `make EXTRA_VERSION=...` still works.
* Remove `exclude` directives from our `go.mod` for broken `cilium/ebpf` versions. `v0.17.3` resolved the issue we had, and `exclude` directives are incompatible with `go install`.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update `runc` to [v1.3.0](https://github.com/opencontainers/runc/releases/tag/v1.3.0)
```

**- A picture of a cute animal (not mandatory but encouraged)**

