### PR TITLE
daemon/libnet/drv/bridge: stubPortMapper.UnmapPorts: fix slices.Delete

### DIFF
--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -1015,7 +1015,7 @@ func (pm *stubPortMapper) UnmapPorts(_ context.Context, reqs []portmapperapi.Por
 		if idx == -1 {
 			return fmt.Errorf("stubPortMapper.UnmapPorts: pb doesn't exist %v", req)
 		}
-		pm.mapped = slices.Delete(pm.mapped, idx, idx)
+		pm.mapped = slices.Delete(pm.mapped, idx, idx+1)
 	}
 	return nil
 }


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/50686#discussion_r2267753748
- https://github.com/moby/moby/pull/50382



This stub was introduced in 4e246efcd117ea01526c0c7a1c50846f947bade0, which currently is only in the master branch.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

