### PR TITLE
Restore DOCKER_DRIVER environment variable

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1098,7 +1098,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	// Unix platforms however run a single graphdriver for all containers, and it can
 	// be set through an environment variable, a daemon start parameter, or chosen through
 	// initialization of the layerstore through driver priority order for example.
-	driverName := os.Getenv("DOCKER_GRAPHDRIVER")
+	driverName := os.Getenv("DOCKER_DRIVER")
 	if isWindows {
 		if driverName == "" {
 			driverName = cfgStore.GraphDriver
@@ -1120,7 +1120,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 		}
 	} else if driverName != "" {
-		log.G(ctx).Infof("Setting the storage driver from the $DOCKER_GRAPHDRIVER environment variable (%s)", driverName)
+		log.G(ctx).Infof("Setting the storage driver from the $DOCKER_DRIVER environment variable (%s)", driverName)
 	} else {
 		driverName = cfgStore.GraphDriver
 	}

--- a/integration/daemon/migration_test.go
+++ b/integration/daemon/migration_test.go
@@ -29,7 +29,7 @@ func testMigrateSnapshotter(t *testing.T, graphdriver, snapshotter string) {
 	skip.If(t, runtime.GOOS != "linux")
 
 	t.Setenv("DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD", "200M")
-	t.Setenv("DOCKER_GRAPHDRIVER", "")
+	t.Setenv("DOCKER_DRIVER", "")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -93,7 +93,7 @@ func TestMigrateSaveLoad(t *testing.T) {
 	skip.If(t, runtime.GOOS != "linux")
 
 	t.Setenv("DOCKER_MIGRATE_SNAPSHOTTER_THRESHOLD", "200M")
-	t.Setenv("DOCKER_GRAPHDRIVER", "")
+	t.Setenv("DOCKER_DRIVER", "")
 
 	var (
 		ctx         = testutil.StartSpan(baseContext, t)


### PR DESCRIPTION
**- What I did**

- Addresses #50702 
- relates to, addresses https://github.com/moby/moby/pull/48009#discussion_r2268822719

**- How I did it**
Reverted the changes from DOCKER_GRAPHDRIVER in daemon to DOCKER_DRIVER and also updated the migration integration tests to set the DOCKER_DRIVER environment variable to empty.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

