### PR TITLE
client: Client.Ping: improve error handling and fallback, and assorted fixes/cleanups

### DIFF
--- a/client/build_cancel.go
+++ b/client/build_cancel.go
@@ -12,6 +12,6 @@ func (cli *Client) BuildCancel(ctx context.Context, id string) error {
 	query.Set("id", id)
 
 	resp, err := cli.post(ctx, "/build/cancel", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_create.go
+++ b/client/checkpoint_create.go
@@ -14,6 +14,6 @@ func (cli *Client) CheckpointCreate(ctx context.Context, containerID string, opt
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/checkpoints", nil, options, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/checkpoint_delete.go
+++ b/client/checkpoint_delete.go
@@ -20,6 +20,6 @@ func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, opt
 	}
 
 	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+options.CheckpointID, query, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/config_update.go
+++ b/client/config_update.go
@@ -19,6 +19,6 @@ func (cli *Client) ConfigUpdate(ctx context.Context, id string, version swarm.Ve
 	query := url.Values{}
 	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/configs/"+id+"/update", query, config, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_exec.go
+++ b/client/container_exec.go
@@ -58,7 +58,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 		config.ConsoleSize = nil
 	}
 	resp, err := cli.post(ctx, "/exec/"+execID+"/start", nil, config, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }
 
@@ -91,13 +91,13 @@ func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, confi
 
 // ContainerExecInspect returns information about a specific exec process on the docker host.
 func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error) {
-	var response container.ExecInspect
 	resp, err := cli.get(ctx, "/exec/"+execID+"/json", nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
-		return response, err
+		return container.ExecInspect{}, err
 	}
 
+	var response container.ExecInspect
 	err = json.NewDecoder(resp.Body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/client/container_kill.go
+++ b/client/container_kill.go
@@ -18,6 +18,6 @@ func (cli *Client) ContainerKill(ctx context.Context, containerID, signal string
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/kill", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_pause.go
+++ b/client/container_pause.go
@@ -10,6 +10,6 @@ func (cli *Client) ContainerPause(ctx context.Context, containerID string) error
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/pause", nil, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_rename.go
+++ b/client/container_rename.go
@@ -15,6 +15,6 @@ func (cli *Client) ContainerRename(ctx context.Context, containerID, newContaine
 	query := url.Values{}
 	query.Set("name", newContainerName)
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/rename", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -33,6 +33,6 @@ func (cli *Client) resize(ctx context.Context, basePath string, height, width ui
 	query.Set("w", strconv.FormatUint(uint64(width), 10))
 
 	resp, err := cli.post(ctx, basePath+"/resize", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_restart.go
+++ b/client/container_restart.go
@@ -36,6 +36,6 @@ func (cli *Client) ContainerRestart(ctx context.Context, containerID string, opt
 		}
 	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_start.go
+++ b/client/container_start.go
@@ -23,6 +23,6 @@ func (cli *Client) ContainerStart(ctx context.Context, containerID string, optio
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_stop.go
+++ b/client/container_stop.go
@@ -40,6 +40,6 @@ func (cli *Client) ContainerStop(ctx context.Context, containerID string, option
 		}
 	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/container_unpause.go
+++ b/client/container_unpause.go
@@ -10,6 +10,6 @@ func (cli *Client) ContainerUnpause(ctx context.Context, containerID string) err
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/unpause", nil, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -33,6 +33,6 @@ func (cli *Client) ImageTag(ctx context.Context, source, target string) error {
 	}
 
 	resp, err := cli.post(ctx, "/images/"+source+"/tag", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_connect.go
+++ b/client/network_connect.go
@@ -23,6 +23,6 @@ func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID st
 		EndpointConfig: config,
 	}
 	resp, err := cli.post(ctx, "/networks/"+networkID+"/connect", nil, nc, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/network_disconnect.go
+++ b/client/network_disconnect.go
@@ -23,6 +23,6 @@ func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID
 		Force:     force,
 	}
 	resp, err := cli.post(ctx, "/networks/"+networkID+"/disconnect", nil, nd, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/node_update.go
+++ b/client/node_update.go
@@ -17,6 +17,6 @@ func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.
 	query := url.Values{}
 	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/ping.go
+++ b/client/ping.go
@@ -39,7 +39,7 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusInternalServerError:
 			// Server handled the request, so parse the response
-			return parsePingResponse(cli, resp)
+			return parsePingResponse(resp)
 		}
 	}
 
@@ -50,17 +50,17 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	if err != nil {
 		return ping, err
 	}
-	return parsePingResponse(cli, resp)
+	return parsePingResponse(resp)
 }
 
-func parsePingResponse(cli *Client, resp *http.Response) (types.Ping, error) {
+func parsePingResponse(resp *http.Response) (types.Ping, error) {
 	if resp == nil {
 		return types.Ping{}, nil
 	}
 
 	var ping types.Ping
 	if resp.Header == nil {
-		return ping, cli.checkResponseErr(resp)
+		return ping, checkResponseErr(resp)
 	}
 	ping.APIVersion = resp.Header.Get("Api-Version")
 	ping.OSType = resp.Header.Get("Ostype")
@@ -77,5 +77,5 @@ func parsePingResponse(cli *Client, resp *http.Response) (types.Ping, error) {
 			ControlAvailable: role == "manager",
 		}
 	}
-	return ping, cli.checkResponseErr(resp)
+	return ping, checkResponseErr(resp)
 }

--- a/client/ping.go
+++ b/client/ping.go
@@ -19,63 +19,56 @@ import (
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
-	var ping types.Ping
-
 	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
 	// because ping requests are used during API version negotiation, so we want
 	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
 	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {
-		return ping, err
+		return types.Ping{}, err
 	}
 	resp, err := cli.doRequest(req)
-	if err != nil {
-		if IsErrConnectionFailed(err) {
-			return ping, err
-		}
-		// We managed to connect, but got some error; continue and try GET request.
-	} else {
-		defer ensureReaderClosed(resp)
-		switch resp.StatusCode {
-		case http.StatusOK, http.StatusInternalServerError:
-			// Server handled the request, so parse the response
-			return parsePingResponse(resp)
-		}
+	defer ensureReaderClosed(resp)
+	if err == nil && resp.StatusCode == http.StatusOK {
+		// Fast-path; successfully connected using a HEAD request and
+		// we got a "OK" (200) status. For non-200 status-codes, we fall
+		// back to doing a GET request, as a HEAD request won't have a
+		// response-body to get error details from.
+		return newPingResponse(resp), nil
 	}
 
-	// HEAD failed; fallback to GET.
+	// HEAD failed or returned a non-OK status; fallback to GET.
 	req.Method = http.MethodGet
 	resp, err = cli.doRequest(req)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return ping, err
+		// Failed to connect.
+		return types.Ping{}, err
 	}
-	return parsePingResponse(resp)
+
+	// GET request succeeded but may have returned a non-200 status.
+	// Return a Ping response, together with any error returned by
+	// the API server.
+	return newPingResponse(resp), checkResponseErr(resp)
 }
 
-func parsePingResponse(resp *http.Response) (types.Ping, error) {
+func newPingResponse(resp *http.Response) types.Ping {
 	if resp == nil {
-		return types.Ping{}, nil
+		return types.Ping{}
 	}
-
-	var ping types.Ping
-	if resp.Header == nil {
-		return ping, checkResponseErr(resp)
-	}
-	ping.APIVersion = resp.Header.Get("Api-Version")
-	ping.OSType = resp.Header.Get("Ostype")
-	if resp.Header.Get("Docker-Experimental") == "true" {
-		ping.Experimental = true
-	}
-	if bv := resp.Header.Get("Builder-Version"); bv != "" {
-		ping.BuilderVersion = build.BuilderVersion(bv)
-	}
+	var swarmStatus *swarm.Status
 	if si := resp.Header.Get("Swarm"); si != "" {
 		state, role, _ := strings.Cut(si, "/")
-		ping.SwarmStatus = &swarm.Status{
+		swarmStatus = &swarm.Status{
 			NodeState:        swarm.LocalNodeState(state),
 			ControlAvailable: role == "manager",
 		}
 	}
-	return ping, checkResponseErr(resp)
+
+	return types.Ping{
+		APIVersion:     resp.Header.Get("Api-Version"),
+		OSType:         resp.Header.Get("Ostype"),
+		Experimental:   resp.Header.Get("Docker-Experimental") == "true",
+		BuilderVersion: build.BuilderVersion(resp.Header.Get("Builder-Version")),
+		SwarmStatus:    swarmStatus,
+	}
 }

--- a/client/plugin_create.go
+++ b/client/plugin_create.go
@@ -21,6 +21,6 @@ func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, cr
 	query.Set("name", createOptions.RepoName)
 
 	resp, err := cli.postRaw(ctx, "/plugins/create", query, createContext, headers)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_disable.go
+++ b/client/plugin_disable.go
@@ -21,6 +21,6 @@ func (cli *Client) PluginDisable(ctx context.Context, name string, options Plugi
 		query.Set("force", "1")
 	}
 	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_enable.go
+++ b/client/plugin_enable.go
@@ -21,6 +21,6 @@ func (cli *Client) PluginEnable(ctx context.Context, name string, options Plugin
 	query.Set("timeout", strconv.Itoa(options.Timeout))
 
 	resp, err := cli.post(ctx, "/plugins/"+name+"/enable", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/plugin_set.go
+++ b/client/plugin_set.go
@@ -12,6 +12,6 @@ func (cli *Client) PluginSet(ctx context.Context, name string, args []string) er
 	}
 
 	resp, err := cli.post(ctx, "/plugins/"+name+"/set", nil, args, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/request.go
+++ b/client/request.go
@@ -127,7 +127,7 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return nil, err
 	case err == nil:
-		return resp, cli.checkResponseErr(resp)
+		return resp, checkResponseErr(resp)
 	default:
 		return resp, err
 	}
@@ -203,7 +203,7 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	return nil, errConnectionFailed{fmt.Errorf("error during connect: %w", err)}
 }
 
-func (cli *Client) checkResponseErr(serverResp *http.Response) (retErr error) {
+func checkResponseErr(serverResp *http.Response) (retErr error) {
 	if serverResp == nil {
 		return nil
 	}

--- a/client/request.go
+++ b/client/request.go
@@ -123,14 +123,14 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	}
 
 	resp, err := cli.doRequest(req)
-	switch {
-	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-		return nil, err
-	case err == nil:
-		return resp, checkResponseErr(resp)
-	default:
+	if err != nil {
+		// Failed to connect or context error.
 		return resp, err
 	}
+
+	// Successfully made a request; return the response and handle any
+	// API HTTP response errors.
+	return resp, checkResponseErr(resp)
 }
 
 // doRequest sends an HTTP request and returns an HTTP response. It is a

--- a/client/request.go
+++ b/client/request.go
@@ -133,6 +133,12 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	}
 }
 
+// doRequest sends an HTTP request and returns an HTTP response. It is a
+// wrapper around [http.Client.Do] with extra handling to decorate errors.
+//
+// Otherwise, it behaves identical to [http.Client.Do]; an error is returned
+// when failing to make a connection, On error, any Response can be ignored.
+// A non-2xx status code doesn't cause an error.
 func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	resp, err := cli.client.Do(req)
 	if err == nil {

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -19,6 +19,6 @@ func (cli *Client) SecretUpdate(ctx context.Context, id string, version swarm.Ve
 	query := url.Values{}
 	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/swarm_join.go
+++ b/client/swarm_join.go
@@ -9,6 +9,6 @@ import (
 // SwarmJoin joins the swarm.
 func (cli *Client) SwarmJoin(ctx context.Context, req swarm.JoinRequest) error {
 	resp, err := cli.post(ctx, "/swarm/join", nil, req, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/swarm_leave.go
+++ b/client/swarm_leave.go
@@ -12,6 +12,6 @@ func (cli *Client) SwarmLeave(ctx context.Context, force bool) error {
 		query.Set("force", "1")
 	}
 	resp, err := cli.post(ctx, "/swarm/leave", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/swarm_unlock.go
+++ b/client/swarm_unlock.go
@@ -9,6 +9,6 @@ import (
 // SwarmUnlock unlocks locked swarm.
 func (cli *Client) SwarmUnlock(ctx context.Context, req swarm.UnlockRequest) error {
 	resp, err := cli.post(ctx, "/swarm/unlock", nil, req, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/swarm_update.go
+++ b/client/swarm_update.go
@@ -16,6 +16,6 @@ func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm
 	query.Set("rotateManagerToken", strconv.FormatBool(flags.RotateManagerToken))
 	query.Set("rotateManagerUnlockKey", strconv.FormatBool(flags.RotateManagerUnlockKey))
 	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/client/volume_update.go
+++ b/client/volume_update.go
@@ -23,6 +23,6 @@ func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version sw
 	query.Set("version", version.String())
 
 	resp, err := cli.put(ctx, "/volumes/"+volumeID, query, options, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/build_cancel.go
+++ b/vendor/github.com/moby/moby/client/build_cancel.go
@@ -12,6 +12,6 @@ func (cli *Client) BuildCancel(ctx context.Context, id string) error {
 	query.Set("id", id)
 
 	resp, err := cli.post(ctx, "/build/cancel", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/checkpoint_create.go
+++ b/vendor/github.com/moby/moby/client/checkpoint_create.go
@@ -14,6 +14,6 @@ func (cli *Client) CheckpointCreate(ctx context.Context, containerID string, opt
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/checkpoints", nil, options, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/checkpoint_delete.go
+++ b/vendor/github.com/moby/moby/client/checkpoint_delete.go
@@ -20,6 +20,6 @@ func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, opt
 	}
 
 	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+options.CheckpointID, query, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/config_update.go
+++ b/vendor/github.com/moby/moby/client/config_update.go
@@ -19,6 +19,6 @@ func (cli *Client) ConfigUpdate(ctx context.Context, id string, version swarm.Ve
 	query := url.Values{}
 	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/configs/"+id+"/update", query, config, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_exec.go
+++ b/vendor/github.com/moby/moby/client/container_exec.go
@@ -58,7 +58,7 @@ func (cli *Client) ContainerExecStart(ctx context.Context, execID string, config
 		config.ConsoleSize = nil
 	}
 	resp, err := cli.post(ctx, "/exec/"+execID+"/start", nil, config, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }
 
@@ -91,13 +91,13 @@ func (cli *Client) ContainerExecAttach(ctx context.Context, execID string, confi
 
 // ContainerExecInspect returns information about a specific exec process on the docker host.
 func (cli *Client) ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error) {
-	var response container.ExecInspect
 	resp, err := cli.get(ctx, "/exec/"+execID+"/json", nil, nil)
+	defer ensureReaderClosed(resp)
 	if err != nil {
-		return response, err
+		return container.ExecInspect{}, err
 	}
 
+	var response container.ExecInspect
 	err = json.NewDecoder(resp.Body).Decode(&response)
-	ensureReaderClosed(resp)
 	return response, err
 }

--- a/vendor/github.com/moby/moby/client/container_kill.go
+++ b/vendor/github.com/moby/moby/client/container_kill.go
@@ -18,6 +18,6 @@ func (cli *Client) ContainerKill(ctx context.Context, containerID, signal string
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/kill", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_pause.go
+++ b/vendor/github.com/moby/moby/client/container_pause.go
@@ -10,6 +10,6 @@ func (cli *Client) ContainerPause(ctx context.Context, containerID string) error
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/pause", nil, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_rename.go
+++ b/vendor/github.com/moby/moby/client/container_rename.go
@@ -15,6 +15,6 @@ func (cli *Client) ContainerRename(ctx context.Context, containerID, newContaine
 	query := url.Values{}
 	query.Set("name", newContainerName)
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/rename", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_resize.go
+++ b/vendor/github.com/moby/moby/client/container_resize.go
@@ -33,6 +33,6 @@ func (cli *Client) resize(ctx context.Context, basePath string, height, width ui
 	query.Set("w", strconv.FormatUint(uint64(width), 10))
 
 	resp, err := cli.post(ctx, basePath+"/resize", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_restart.go
+++ b/vendor/github.com/moby/moby/client/container_restart.go
@@ -36,6 +36,6 @@ func (cli *Client) ContainerRestart(ctx context.Context, containerID string, opt
 		}
 	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_start.go
+++ b/vendor/github.com/moby/moby/client/container_start.go
@@ -23,6 +23,6 @@ func (cli *Client) ContainerStart(ctx context.Context, containerID string, optio
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_stop.go
+++ b/vendor/github.com/moby/moby/client/container_stop.go
@@ -40,6 +40,6 @@ func (cli *Client) ContainerStop(ctx context.Context, containerID string, option
 		}
 	}
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/container_unpause.go
+++ b/vendor/github.com/moby/moby/client/container_unpause.go
@@ -10,6 +10,6 @@ func (cli *Client) ContainerUnpause(ctx context.Context, containerID string) err
 	}
 
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/unpause", nil, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/image_tag.go
+++ b/vendor/github.com/moby/moby/client/image_tag.go
@@ -33,6 +33,6 @@ func (cli *Client) ImageTag(ctx context.Context, source, target string) error {
 	}
 
 	resp, err := cli.post(ctx, "/images/"+source+"/tag", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/network_connect.go
+++ b/vendor/github.com/moby/moby/client/network_connect.go
@@ -23,6 +23,6 @@ func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID st
 		EndpointConfig: config,
 	}
 	resp, err := cli.post(ctx, "/networks/"+networkID+"/connect", nil, nc, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/network_disconnect.go
+++ b/vendor/github.com/moby/moby/client/network_disconnect.go
@@ -23,6 +23,6 @@ func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID
 		Force:     force,
 	}
 	resp, err := cli.post(ctx, "/networks/"+networkID+"/disconnect", nil, nd, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/node_update.go
+++ b/vendor/github.com/moby/moby/client/node_update.go
@@ -17,6 +17,6 @@ func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.
 	query := url.Values{}
 	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/ping.go
+++ b/vendor/github.com/moby/moby/client/ping.go
@@ -39,7 +39,7 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 		switch resp.StatusCode {
 		case http.StatusOK, http.StatusInternalServerError:
 			// Server handled the request, so parse the response
-			return parsePingResponse(cli, resp)
+			return parsePingResponse(resp)
 		}
 	}
 
@@ -50,17 +50,17 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	if err != nil {
 		return ping, err
 	}
-	return parsePingResponse(cli, resp)
+	return parsePingResponse(resp)
 }
 
-func parsePingResponse(cli *Client, resp *http.Response) (types.Ping, error) {
+func parsePingResponse(resp *http.Response) (types.Ping, error) {
 	if resp == nil {
 		return types.Ping{}, nil
 	}
 
 	var ping types.Ping
 	if resp.Header == nil {
-		return ping, cli.checkResponseErr(resp)
+		return ping, checkResponseErr(resp)
 	}
 	ping.APIVersion = resp.Header.Get("Api-Version")
 	ping.OSType = resp.Header.Get("Ostype")
@@ -77,5 +77,5 @@ func parsePingResponse(cli *Client, resp *http.Response) (types.Ping, error) {
 			ControlAvailable: role == "manager",
 		}
 	}
-	return ping, cli.checkResponseErr(resp)
+	return ping, checkResponseErr(resp)
 }

--- a/vendor/github.com/moby/moby/client/ping.go
+++ b/vendor/github.com/moby/moby/client/ping.go
@@ -19,63 +19,56 @@ import (
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
-	var ping types.Ping
-
 	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
 	// because ping requests are used during API version negotiation, so we want
 	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
 	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {
-		return ping, err
+		return types.Ping{}, err
 	}
 	resp, err := cli.doRequest(req)
-	if err != nil {
-		if IsErrConnectionFailed(err) {
-			return ping, err
-		}
-		// We managed to connect, but got some error; continue and try GET request.
-	} else {
-		defer ensureReaderClosed(resp)
-		switch resp.StatusCode {
-		case http.StatusOK, http.StatusInternalServerError:
-			// Server handled the request, so parse the response
-			return parsePingResponse(resp)
-		}
+	defer ensureReaderClosed(resp)
+	if err == nil && resp.StatusCode == http.StatusOK {
+		// Fast-path; successfully connected using a HEAD request and
+		// we got a "OK" (200) status. For non-200 status-codes, we fall
+		// back to doing a GET request, as a HEAD request won't have a
+		// response-body to get error details from.
+		return newPingResponse(resp), nil
 	}
 
-	// HEAD failed; fallback to GET.
+	// HEAD failed or returned a non-OK status; fallback to GET.
 	req.Method = http.MethodGet
 	resp, err = cli.doRequest(req)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return ping, err
+		// Failed to connect.
+		return types.Ping{}, err
 	}
-	return parsePingResponse(resp)
+
+	// GET request succeeded but may have returned a non-200 status.
+	// Return a Ping response, together with any error returned by
+	// the API server.
+	return newPingResponse(resp), checkResponseErr(resp)
 }
 
-func parsePingResponse(resp *http.Response) (types.Ping, error) {
+func newPingResponse(resp *http.Response) types.Ping {
 	if resp == nil {
-		return types.Ping{}, nil
+		return types.Ping{}
 	}
-
-	var ping types.Ping
-	if resp.Header == nil {
-		return ping, checkResponseErr(resp)
-	}
-	ping.APIVersion = resp.Header.Get("Api-Version")
-	ping.OSType = resp.Header.Get("Ostype")
-	if resp.Header.Get("Docker-Experimental") == "true" {
-		ping.Experimental = true
-	}
-	if bv := resp.Header.Get("Builder-Version"); bv != "" {
-		ping.BuilderVersion = build.BuilderVersion(bv)
-	}
+	var swarmStatus *swarm.Status
 	if si := resp.Header.Get("Swarm"); si != "" {
 		state, role, _ := strings.Cut(si, "/")
-		ping.SwarmStatus = &swarm.Status{
+		swarmStatus = &swarm.Status{
 			NodeState:        swarm.LocalNodeState(state),
 			ControlAvailable: role == "manager",
 		}
 	}
-	return ping, checkResponseErr(resp)
+
+	return types.Ping{
+		APIVersion:     resp.Header.Get("Api-Version"),
+		OSType:         resp.Header.Get("Ostype"),
+		Experimental:   resp.Header.Get("Docker-Experimental") == "true",
+		BuilderVersion: build.BuilderVersion(resp.Header.Get("Builder-Version")),
+		SwarmStatus:    swarmStatus,
+	}
 }

--- a/vendor/github.com/moby/moby/client/plugin_create.go
+++ b/vendor/github.com/moby/moby/client/plugin_create.go
@@ -21,6 +21,6 @@ func (cli *Client) PluginCreate(ctx context.Context, createContext io.Reader, cr
 	query.Set("name", createOptions.RepoName)
 
 	resp, err := cli.postRaw(ctx, "/plugins/create", query, createContext, headers)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/plugin_disable.go
+++ b/vendor/github.com/moby/moby/client/plugin_disable.go
@@ -21,6 +21,6 @@ func (cli *Client) PluginDisable(ctx context.Context, name string, options Plugi
 		query.Set("force", "1")
 	}
 	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/plugin_enable.go
+++ b/vendor/github.com/moby/moby/client/plugin_enable.go
@@ -21,6 +21,6 @@ func (cli *Client) PluginEnable(ctx context.Context, name string, options Plugin
 	query.Set("timeout", strconv.Itoa(options.Timeout))
 
 	resp, err := cli.post(ctx, "/plugins/"+name+"/enable", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/plugin_set.go
+++ b/vendor/github.com/moby/moby/client/plugin_set.go
@@ -12,6 +12,6 @@ func (cli *Client) PluginSet(ctx context.Context, name string, args []string) er
 	}
 
 	resp, err := cli.post(ctx, "/plugins/"+name+"/set", nil, args, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -127,7 +127,7 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 		return nil, err
 	case err == nil:
-		return resp, cli.checkResponseErr(resp)
+		return resp, checkResponseErr(resp)
 	default:
 		return resp, err
 	}
@@ -203,7 +203,7 @@ func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	return nil, errConnectionFailed{fmt.Errorf("error during connect: %w", err)}
 }
 
-func (cli *Client) checkResponseErr(serverResp *http.Response) (retErr error) {
+func checkResponseErr(serverResp *http.Response) (retErr error) {
 	if serverResp == nil {
 		return nil
 	}

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -123,14 +123,14 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	}
 
 	resp, err := cli.doRequest(req)
-	switch {
-	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-		return nil, err
-	case err == nil:
-		return resp, checkResponseErr(resp)
-	default:
+	if err != nil {
+		// Failed to connect or context error.
 		return resp, err
 	}
+
+	// Successfully made a request; return the response and handle any
+	// API HTTP response errors.
+	return resp, checkResponseErr(resp)
 }
 
 // doRequest sends an HTTP request and returns an HTTP response. It is a

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -133,6 +133,12 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	}
 }
 
+// doRequest sends an HTTP request and returns an HTTP response. It is a
+// wrapper around [http.Client.Do] with extra handling to decorate errors.
+//
+// Otherwise, it behaves identical to [http.Client.Do]; an error is returned
+// when failing to make a connection, On error, any Response can be ignored.
+// A non-2xx status code doesn't cause an error.
 func (cli *Client) doRequest(req *http.Request) (*http.Response, error) {
 	resp, err := cli.client.Do(req)
 	if err == nil {

--- a/vendor/github.com/moby/moby/client/secret_update.go
+++ b/vendor/github.com/moby/moby/client/secret_update.go
@@ -19,6 +19,6 @@ func (cli *Client) SecretUpdate(ctx context.Context, id string, version swarm.Ve
 	query := url.Values{}
 	query.Set("version", version.String())
 	resp, err := cli.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/swarm_join.go
+++ b/vendor/github.com/moby/moby/client/swarm_join.go
@@ -9,6 +9,6 @@ import (
 // SwarmJoin joins the swarm.
 func (cli *Client) SwarmJoin(ctx context.Context, req swarm.JoinRequest) error {
 	resp, err := cli.post(ctx, "/swarm/join", nil, req, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/swarm_leave.go
+++ b/vendor/github.com/moby/moby/client/swarm_leave.go
@@ -12,6 +12,6 @@ func (cli *Client) SwarmLeave(ctx context.Context, force bool) error {
 		query.Set("force", "1")
 	}
 	resp, err := cli.post(ctx, "/swarm/leave", query, nil, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/swarm_unlock.go
+++ b/vendor/github.com/moby/moby/client/swarm_unlock.go
@@ -9,6 +9,6 @@ import (
 // SwarmUnlock unlocks locked swarm.
 func (cli *Client) SwarmUnlock(ctx context.Context, req swarm.UnlockRequest) error {
 	resp, err := cli.post(ctx, "/swarm/unlock", nil, req, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/swarm_update.go
+++ b/vendor/github.com/moby/moby/client/swarm_update.go
@@ -16,6 +16,6 @@ func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm
 	query.Set("rotateManagerToken", strconv.FormatBool(flags.RotateManagerToken))
 	query.Set("rotateManagerUnlockKey", strconv.FormatBool(flags.RotateManagerUnlockKey))
 	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/moby/moby/client/volume_update.go
+++ b/vendor/github.com/moby/moby/client/volume_update.go
@@ -23,6 +23,6 @@ func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version sw
 	query.Set("version", version.String())
 
 	resp, err := cli.put(ctx, "/volumes/"+volumeID, query, options, nil)
-	ensureReaderClosed(resp)
+	defer ensureReaderClosed(resp)
 	return err
 }


### PR DESCRIPTION
### client: make checkResponseErr a regular function

It was implemented as a method on Client, but the receiver was not used;
make it a regular function to prevent passing around the Client where
not needed.

### client: Client.Ping: improve error handling and fallback

The Ping function first tries to do a HEAD request, but the parsePingResponse
was written with the assumption that a Body could be present in the response
that may include errors returned by the API server.

HEAD responses don't include a body, so there's no response to handle, and
no errors to return by the API, other than a HTTP status code.

This patch:

- Rewrites `parsePingResponse` to a `newPingResponse`, removing the error-
  handling for the response-body. It's also simplified, because a non-nil
  response is guaranteed to have a non-nil Header (but it may not have
  any of the headers set that are used for the Ping).
- Rewrites the `Client.Ping` to only return a Ping-response from the HEAD
  request if no error was returned (i.e., we connected with the API) and
  a successful status-code, otherwise it will fallback to a GET request,
  which allows (for non "OK" (200) status-codes) returning errors from
  the daemon (for example, if the daemon is in an unhealthy state).

### client.doRequest: improve GoDoc to clarify behavior

Outline that any error returned is a connectivity error and a nil-error
requires the response to be handled (including errors returned in the
response).


### client.sendRequest: clean-up logic for error-handling

Only use checkResponseErr if `client.doRequest` did not return an error;
any error returned by `client.doRequest` means there was an error connecting,
so there's no response to handle (including errors in the response).

### client: consistently use defer for ensureReaderClosed

ensureReaderClosed was designed to be usable regardless if a response
was nil (error) or non-nil (success). Some code-paths were optimized to
avoid using a defer (which used to have an overhead), but the overhead
of defer is neglectable in current versions of Go, and some of these
optimizations made the logic more complicated (and err-prone).

This patch switches to use a defer for all places.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

