### PR TITLE
[28.x backport] api: swagger: Tweak type of ForceUpdate to uint64

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4392,6 +4392,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -1975,6 +1975,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Networks:
         type: "array"
         items:

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -1979,6 +1979,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Networks:
         type: "array"
         items:

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -2051,6 +2051,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Networks:
         type: "array"
         items:

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -2104,6 +2104,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Networks:
         type: "array"
         items:

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -2125,6 +2125,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Networks:
         type: "array"
         items:

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -2303,6 +2303,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -2332,6 +2332,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -2783,6 +2783,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -2787,6 +2787,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -2797,6 +2797,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -2801,6 +2801,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -2814,6 +2814,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -2817,6 +2817,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -2871,6 +2871,7 @@ definitions:
       ForceUpdate:
         description: "A counter that triggers an update even if no relevant parameters have been changed."
         type: "integer"
+        format: "uint64"
       Runtime:
         description: "Runtime is the type of runtime specified for the task executor."
         type: "string"

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -3913,6 +3913,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -4039,6 +4039,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -4204,6 +4204,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -4223,6 +4223,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -4254,6 +4254,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -4322,6 +4322,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -4308,6 +4308,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -4361,6 +4361,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -4379,6 +4379,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.48.yaml
+++ b/docs/api/v1.48.yaml
@@ -4518,6 +4518,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.49.yaml
+++ b/docs/api/v1.49.yaml
@@ -4518,6 +4518,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.50.yaml
+++ b/docs/api/v1.50.yaml
@@ -4393,6 +4393,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.

--- a/docs/api/v1.51.yaml
+++ b/docs/api/v1.51.yaml
@@ -4392,6 +4392,7 @@ definitions:
           A counter that triggers an update even if no relevant parameters have
           been changed.
         type: "integer"
+        format: "uint64"
       Runtime:
         description: |
           Runtime is the type of runtime specified for the task executor.


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50679

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes: https://github.com/moby/moby/issues/50676

**- What I did**

Tweak the ForceUpdate type format to uint64 across the docs.

**- How I did it**

Modified all API documents in ./docs/api that contain a ForceUpdate to be of format uint64. Added a separate commit to modify ./api/swagger.yaml with the same change.

**- How to verify it**

Generated the types based on the API and verified that ForceUpdate is an uint64.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

