### PR TITLE
Match device driver on name and ignore capabilities

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -293,6 +293,11 @@ definitions:
     description: "A request for devices to be sent to device drivers"
     properties:
       Driver:
+        description: |
+          The name of the device driver to use for this request.
+
+          Note that if this is specified the capabilities are ignored when
+          selecting a device driver.
         type: "string"
         example: "nvidia"
       Count:
@@ -309,6 +314,12 @@ definitions:
       Capabilities:
         description: |
           A list of capabilities; an OR list of AND lists of capabilities.
+
+          Note that if a driver is specified the capabilities have no effect on
+          selecting a driver as the driver name is used directly.
+
+          Note that if no driver is specified the capabilities are used to
+          select a driver with the required capabilities.
         type: "array"
         items:
           type: "array"


### PR DESCRIPTION
This change ignores requested capabilities when a driver is explicitly requested. This simplifies the logic for selecting a driver and means that users need not spefify redundant capabilities. This aligns the behaviour for all drivers with the CDI driver.

With the exception of the catch-all "gpu" capability the remaining capabilities are only relevant for the "nvidia" driver.

See also the discussion in [#50099](https://github.com/moby/moby/pull/50099#discussion_r2127591740)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed the logic for selecting a device driver to *ignore* capabilities when selecting a driver by name. If no driver name is specified, the current behaviour remains and an appropriate driver is selected based on the set of required capabilities.

**- How I did it**

Updated the `handleDevice` implementation 

**- How to verify it**

When running a modified daemon in debug mode on a system with `nvidia` devices (and therefore an `nvidia` driver registered):

1. Confirm that the standard flag works as expected:
```
$ docker run --rm -ti --gpus all ubuntu nvidia-smi -L
GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-4cf8db2d-06c0-7d70-1a51-e59b25b2c16c)
GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-4404041a-04cf-1ccf-9e70-f139a9b1e23c)
GPU 2: NVIDIA A100-SXM4-40GB (UUID: GPU-79a2ba02-a537-ccbf-2965-8e9d90c0bd54)
GPU 3: NVIDIA A100-SXM4-40GB (UUID: GPU-662077db-fa3f-0d8f-9502-21ab0ef058a2)
GPU 4: NVIDIA A100-SXM4-40GB (UUID: GPU-ec9d53cc-125d-d4a3-9687-304df8eb4749)
GPU 5: NVIDIA A100-SXM4-40GB (UUID: GPU-3eb87630-93d5-b2b6-b8ff-9b359caf4ee2)
GPU 6: NVIDIA A100-SXM4-40GB (UUID: GPU-8216274a-c05d-def0-af18-c74647300267)
GPU 7: NVIDIA A100-SXM4-40GB (UUID: GPU-b1028956-cfa2-0990-bf4a-5da9abb51763)
```
Check the logs:
```
DEBU[2025-08-13T14:18:46.795782525Z] Selecting device driver by capabilities       capabilities="map[requested:[[gpu]] selected:[gpu]]" driver=nvidia
```

2. Confirm that selecting a driver by name bypasses capabilities:
```
$ docker run --rm -ti --gpus "all,driver=nvidia" ubuntu nvidia-smi -L
GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-4cf8db2d-06c0-7d70-1a51-e59b25b2c16c)
GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-4404041a-04cf-1ccf-9e70-f139a9b1e23c)
GPU 2: NVIDIA A100-SXM4-40GB (UUID: GPU-79a2ba02-a537-ccbf-2965-8e9d90c0bd54)
GPU 3: NVIDIA A100-SXM4-40GB (UUID: GPU-662077db-fa3f-0d8f-9502-21ab0ef058a2)
GPU 4: NVIDIA A100-SXM4-40GB (UUID: GPU-ec9d53cc-125d-d4a3-9687-304df8eb4749)
GPU 5: NVIDIA A100-SXM4-40GB (UUID: GPU-3eb87630-93d5-b2b6-b8ff-9b359caf4ee2)
GPU 6: NVIDIA A100-SXM4-40GB (UUID: GPU-8216274a-c05d-def0-af18-c74647300267)
GPU 7: NVIDIA A100-SXM4-40GB (UUID: GPU-b1028956-cfa2-0990-bf4a-5da9abb51763)
```
Check the logs:
```
DEBU[2025-08-13T14:20:06.294560418Z] Selecting device driver by driver name; possibly ignoring capabilities  capabilities="[[gpu]]" driver=nvidia
```

3. Confirm that a driver that is not fails:
```
$ docker run --rm -ti --gpus "all,driver=amd" ubuntu nvidia-smi -L
docker: Error response from daemon: could not select device driver "amd" with capabilities: [[gpu]]

Run 'docker run --help' for more information
```

```
DEBU[2025-08-13T14:20:44.913657033Z] Selecting device driver by capabilities       capabilities="map[requested:[[gpu]] selected:[gpu]]" driver=nvidia
```

4. Ensure that non-matching capabilities still return an error:
```
$ docker run --rm -ti --gpus "all,capabilities=foo" ubuntu nvidia-smi -L
docker: Error response from daemon: could not select device driver "" with capabilities: [[foo gpu]]

Run 'docker run --help' for more information
```

5. Ensure that non-matching capabilities are ignored when matching by driver:
```
$ docker run --rm -ti --gpus "all,capabilities=foo,driver=nvidia" ubuntu nvidia-smi -L
GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-4cf8db2d-06c0-7d70-1a51-e59b25b2c16c)
GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-4404041a-04cf-1ccf-9e70-f139a9b1e23c)
GPU 2: NVIDIA A100-SXM4-40GB (UUID: GPU-79a2ba02-a537-ccbf-2965-8e9d90c0bd54)
GPU 3: NVIDIA A100-SXM4-40GB (UUID: GPU-662077db-fa3f-0d8f-9502-21ab0ef058a2)
GPU 4: NVIDIA A100-SXM4-40GB (UUID: GPU-ec9d53cc-125d-d4a3-9687-304df8eb4749)
GPU 5: NVIDIA A100-SXM4-40GB (UUID: GPU-3eb87630-93d5-b2b6-b8ff-9b359caf4ee2)
GPU 6: NVIDIA A100-SXM4-40GB (UUID: GPU-8216274a-c05d-def0-af18-c74647300267)
GPU 7: NVIDIA A100-SXM4-40GB (UUID: GPU-b1028956-cfa2-0990-bf4a-5da9abb51763)
```

Check the logs
```
DEBU[2025-08-13T14:27:12.029915404Z] Selecting device driver by driver name; possibly ignoring capabilities  capabilities="[[foo gpu]]" driver=nvidia
```




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Prefer explicit device driver name over GPU capabilities when selecting the device driver with `docker run --gpus`
```

**- A picture of a cute animal (not mandatory but encouraged)**

