### PR TITLE
daemon: deprecate env vars set by legacy links

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -46,15 +46,18 @@ func (daemon *Daemon) setupLinkedContainers(ctr *container.Container) ([]string,
 			return nil, fmt.Errorf("container %s not attached to default bridge network", child.ID)
 		}
 
-		linkEnvVars := links.EnvVars(
-			bridgeSettings.IPAddress,
-			childBridgeSettings.IPAddress,
-			linkAlias,
-			child.Config.Env,
-			child.Config.ExposedPorts,
-		)
-
-		env = append(env, linkEnvVars...)
+		// Environment variables defined when using legacy links are deprecated and will be removed in a future release.
+		// Allow users to restore the old behavior through this escape hatch.
+		if os.Getenv("DOCKER_KEEP_DEPRECATED_LEGACY_LINKS_ENV_VARS") == "1" {
+			linkEnvVars := links.EnvVars(
+				bridgeSettings.IPAddress,
+				childBridgeSettings.IPAddress,
+				linkAlias,
+				child.Config.Env,
+				child.Config.ExposedPorts,
+			)
+			env = append(env, linkEnvVars...)
+		}
 	}
 
 	return env, nil

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -37,6 +37,11 @@ PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/api_image_test.py
 
 # TODO(laurazard): re-enable after https://github.com/docker/docker-py/pull/3290 is included in the DOCKER_PY_COMMIT release.
 PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/models_containers_test.py::ContainerTest::test_exec_run_failed"
+
+# Legacy links are deprecated since a long time, and starting with v29.0, the Engine won't set legacy links env vars
+# automatically in linking containers. Thus, this test is expected to fail — skip it. See https://github.com/moby/moby/pull/50719
+PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_test.py::CreateContainerTest::test_create_with_links"
+
 (
 	bundle .integration-daemon-start
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -532,12 +532,3 @@ func (s *DockerCLIExecSuite) TestExecWindowsPathNotWiped(c *testing.T) {
 	out = strings.ToLower(strings.Trim(out, "\r\n"))
 	assert.Assert(c, is.Contains(out, `windowspowershell\v1.0`))
 }
-
-func (s *DockerCLIExecSuite) TestExecEnvLinksHost(c *testing.T) {
-	testRequires(c, DaemonIsLinux)
-	runSleepingContainer(c, "-d", "--name", "foo")
-	runSleepingContainer(c, "-d", "--link", "foo:db", "--hostname", "myhost", "--name", "bar")
-	out := cli.DockerCmd(c, "exec", "bar", "env").Stdout()
-	assert.Check(c, is.Contains(out, "HOSTNAME=myhost"))
-	assert.Check(c, is.Contains(out, "DB_NAME=/bar/db"))
-}

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -193,15 +193,6 @@ func (s *DockerCLILinksSuite) TestLinksUpdateOnRestart(c *testing.T) {
 	assert.Check(c, is.Equal(ip, realIP))
 }
 
-func (s *DockerCLILinksSuite) TestLinksEnvs(c *testing.T) {
-	testRequires(c, DaemonIsLinux)
-	cli.DockerCmd(c, "run", "-d", "-e", "e1=", "-e", "e2=v2", "-e", "e3=v3=v3", "--name=first", "busybox", "top")
-	out := cli.DockerCmd(c, "run", "--name=second", "--link=first:first", "busybox", "env").Stdout()
-	assert.Assert(c, is.Contains(out, "FIRST_ENV_e1=\n"))
-	assert.Assert(c, is.Contains(out, "FIRST_ENV_e2=v2"))
-	assert.Assert(c, is.Contains(out, "FIRST_ENV_e3=v3=v3"))
-}
-
 func (s *DockerCLILinksSuite) TestLinkShortDefinition(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	cid := cli.DockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top").Stdout()


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/22295

**- What I did**

The environment variables set by legacy links are not particularly useful because you need to know the name of the linked container to use them, or you need to scan all enviornment variables to find them.

Legacy links are deprecated / marked "legacy" since a long time, and we want to replace them with non-legacy links. This will help make the default bridge work like custom networks.

For now, stop setting these environment variables inside of linking containers by default, but provide an escape hatch to allow users who still rely on these to re-enable them.

**- How to verify it**

A new integration test verifies that: 1. no env vars are set when the escape hatch is not used; 2. and they're correctly set when the escape hatch is used.

**- Human readable description for the release notes**

```markdown changelog
- Environment variables set on a container using legacy links are deprecated and aren't added automatically anymore.
  * The daemon can be started with `DOCKER_KEEP_DEPRECATED_LEGACY_LINKS_ENV_VARS=1` to get them back.
  * Users are encouraged to stop relying on these as they're deprecated, and the escape hatch will be removed in a later version.
```
