### PR TITLE
api: add fields Mapper, ExtraParams to PortBinding

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -69,6 +69,13 @@ keywords: "API, Docker, rcli, REST, documentation"
   of the `Resource` requirements.
 * `GET /tasks/{id}` now  returns `SwapBytes` and `MemorySwappiness` fields as
   part of the `Resource` requirements.
+* Port bindings specified in `POST /containers/create` and returned in
+  `GET /containers/{id}/json` now take two new fields: `Mapper` and `ExtraParams`.
+  The `Mapper` field is a string indicating the port mapper used to create the
+  port binding, and the `ExtraParams` field is a map of additional parameters
+  passed to the mapper.
+  WARNING: These fields are experimental and may change at any time without any
+  backward compatibility.
 
 ## v1.51 API changes
 

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -1629,6 +1629,11 @@ definitions:
           HostPort: "80"
         - HostIp: "0.0.0.0"
           HostPort: "8080"
+        - HostIp: "0.0.0.0"
+          HostPort: ""
+          Mapper: "cloudflare"
+          ExtraParams:
+            hostname: "example.com"
       "80/udp":
         - HostIp: "0.0.0.0"
           HostPort: "80"
@@ -1655,6 +1660,25 @@ definitions:
         description: "Host port number that the container's port is mapped to."
         type: "string"
         example: "4443"
+      Mapper:
+        description: |
+          Mapper is an optional field that defines which portmapper should be
+          used to create this PortBinding. When not specified, an appropriate
+          builtin portmapper will be selected.
+
+          WARNING: This is experimental and may change at any time without any
+          backward compatibility.
+        type: "string"
+      ExtraParams:
+        description: |
+          ExtraParams defines additional parameters passed to the Mapper when
+          it creates or removes this PortBinding.
+
+          WARNING: This is experimental and may change at any time without any
+          backward compatibility.
+        type: object
+        additionalProperties:
+          type: string
 
   DriverData:
     description: |

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1629,6 +1629,11 @@ definitions:
           HostPort: "80"
         - HostIp: "0.0.0.0"
           HostPort: "8080"
+        - HostIp: "0.0.0.0"
+          HostPort: ""
+          Mapper: "cloudflare"
+          ExtraParams:
+            hostname: "example.com"
       "80/udp":
         - HostIp: "0.0.0.0"
           HostPort: "80"
@@ -1655,6 +1660,25 @@ definitions:
         description: "Host port number that the container's port is mapped to."
         type: "string"
         example: "4443"
+      Mapper:
+        description: |
+          Mapper is an optional field that defines which portmapper should be
+          used to create this PortBinding. When not specified, an appropriate
+          builtin portmapper will be selected.
+
+          WARNING: This is experimental and may change at any time without any
+          backward compatibility.
+        type: "string"
+      ExtraParams:
+        description: |
+          ExtraParams defines additional parameters passed to the Mapper when
+          it creates or removes this PortBinding.
+
+          WARNING: This is experimental and may change at any time without any
+          backward compatibility.
+        type: object
+        additionalProperties:
+          type: string
 
   DriverData:
     description: |

--- a/api/types/network/port.go
+++ b/api/types/network/port.go
@@ -152,6 +152,21 @@ type PortBinding struct {
 	HostIP netip.Addr `json:"HostIp"`
 	// HostPort is the host port number
 	HostPort string `json:"HostPort"`
+
+	// Mapper is an optional field that defines which portmapper should be used
+	// to create this PortBinding. When not specified, an appropriate builtin
+	// portmapper will be selected.
+	//
+	// WARNING: This is experimental and may change at any time without any
+	// backward compatibility.
+	Mapper string `json:",omitempty"`
+
+	// ExtraParams defines additional parameters passed to the Mapper when it
+	// creates or removes this PortBinding.
+	//
+	// WARNING: This is experimental and may change at any time without any
+	// backward compatibility.
+	ExtraParams map[string]string `json:",omitempty"`
 }
 
 // PortMap is a collection of [PortBinding] indexed by [Port].

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -137,6 +137,8 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 				HostIP:      binding.HostIP.AsSlice(),
 				HostPort:    portRange.Start(),
 				HostPortEnd: portRange.End(),
+				Mapper:      binding.Mapper,
+				ExtraParams: binding.ExtraParams,
 			})
 		}
 

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1885,6 +1885,8 @@ func parseConnectivityOptions(cOptions map[string]any) (*connectivityConfigurati
 			cc.PortBindings = sliceutil.Map(pbs, func(pb types.PortBinding) portmapperapi.PortBindingReq {
 				return portmapperapi.PortBindingReq{
 					PortBinding: pb.Copy(),
+					Mapper:      pb.Mapper,
+					ExtraParams: pb.ExtraParams,
 				}
 			})
 		} else {

--- a/daemon/libnetwork/portmapperapi/api.go
+++ b/daemon/libnetwork/portmapperapi/api.go
@@ -39,6 +39,9 @@ type PortBindingReq struct {
 	types.PortBinding
 	// Mapper is the name of the port mapper used to process this PortBindingReq.
 	Mapper string
+	// ExtraParams is a map of extra parameters passed to the mapper to map and
+	// unmap this port binding.
+	ExtraParams map[string]string
 	// ChildHostIP is a temporary field used to pass the host IP address as
 	// seen from the daemon. (It'll be removed once the portmapper API is
 	// implemented).

--- a/daemon/libnetwork/types/types.go
+++ b/daemon/libnetwork/types/types.go
@@ -56,6 +56,8 @@ type PortBinding struct {
 	HostIP      net.IP
 	HostPort    uint16
 	HostPortEnd uint16
+	Mapper      string
+	ExtraParams map[string]string
 }
 
 // HostAddr returns the host side transport address

--- a/vendor/github.com/moby/moby/api/types/network/port.go
+++ b/vendor/github.com/moby/moby/api/types/network/port.go
@@ -152,6 +152,21 @@ type PortBinding struct {
 	HostIP netip.Addr `json:"HostIp"`
 	// HostPort is the host port number
 	HostPort string `json:"HostPort"`
+
+	// Mapper is an optional field that defines which portmapper should be used
+	// to create this PortBinding. When not specified, an appropriate builtin
+	// portmapper will be selected.
+	//
+	// WARNING: This is experimental and may change at any time without any
+	// backward compatibility.
+	Mapper string `json:",omitempty"`
+
+	// ExtraParams defines additional parameters passed to the Mapper when it
+	// creates or removes this PortBinding.
+	//
+	// WARNING: This is experimental and may change at any time without any
+	// backward compatibility.
+	ExtraParams map[string]string `json:",omitempty"`
 }
 
 // PortMap is a collection of [PortBinding] indexed by [Port].


### PR DESCRIPTION
- Related to https://github.com/moby/moby/issues/50259
- Stacked on top of https://github.com/moby/moby/pull/50691
- Requires https://github.com/moby/moby/pull/50710

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
- Add new fields Mapper and ExtraParams to API type `PortBindings` to allow API clients to choose which port-mapper should be used.
```
