### PR TITLE
daemon/libnetwork/bitmap: add OnesCount method

### DIFF
--- a/daemon/libnetwork/bitmap/.gitignore
+++ b/daemon/libnetwork/bitmap/.gitignore
@@ -1,0 +1,1 @@
+/testdata/rapid/**

--- a/daemon/libnetwork/bitmap/sequence.go
+++ b/daemon/libnetwork/bitmap/sequence.go
@@ -11,11 +11,11 @@ import (
 // block sequence constants
 // If needed we can think of making these configurable
 const (
-	blockLen      = uint32(32)
-	blockBytes    = uint64(blockLen / 8)
-	blockMAX      = uint32(1<<blockLen - 1)
-	blockFirstBit = uint32(1) << (blockLen - 1)
-	invalidPos    = uint64(0xFFFFFFFFFFFFFFFF)
+	blockLen             = 32
+	blockBytes    uint64 = blockLen / 8
+	blockMAX      uint32 = 1<<blockLen - 1
+	blockFirstBit uint32 = 1 << (blockLen - 1)
+	invalidPos    uint64 = ^uint64(0)
 )
 
 var (
@@ -54,7 +54,7 @@ func New(n uint64) *Bitmap {
 		unselected: n,
 		head: &sequence{
 			block: 0x0,
-			count: getNumBlocks(n),
+			count: (n + blockLen - 1) / blockLen,
 		},
 	}
 }
@@ -573,14 +573,6 @@ func mergeSequences(seq *sequence) {
 		// Move to next
 		mergeSequences(seq.next)
 	}
-}
-
-func getNumBlocks(numBits uint64) uint64 {
-	numBlocks := numBits / uint64(blockLen)
-	if numBits%uint64(blockLen) != 0 {
-		numBlocks++
-	}
-	return numBlocks
 }
 
 func ordinalToPos(ordinal uint64) (uint64, uint64) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a method to bitmap.Bitmap which returns the population count of a slice of the bitmap. The OnesCount method is required for a follow-up PR which will report the number of addresses available for allocation in IPAM pools.

**- How I did it**
Walk the linked list of sequences, summing the popcounts of each block multiplied by the run-length. The blocks containing the start and end ordinals are masked before counting so as to not count bits outside of the slice range.

**- How to verify it**
CI. A property-based test validates that OnesCount always returns the correct count for an arbitrary slice of an arbitrary bitmap.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

