### PR TITLE
Fix image prune events for containerd backend

### DIFF
--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -12,12 +12,14 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/v2/daemon/container"
-	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/errdefs"
 )
 
 var imagesAcceptedFilters = map[string]bool{
@@ -243,24 +245,33 @@ func (i *ImageService) pruneAll(ctx context.Context, imagesToPrune map[string]c8
 			continue
 		}
 
+		familiarName := imageFamiliarName(img)
+		i.logImageEvent(img, familiarName, events.ActionUnTag)
 		report.ImagesDeleted = append(report.ImagesDeleted,
 			image.DeleteResponse{
-				Untagged: imageFamiliarName(img),
+				Untagged: familiarName,
 			},
 		)
 
+		var deleted bool
 		// Check which blobs have been deleted and sum their sizes
 		for _, blob := range blobs {
 			_, err := i.content.ReaderAt(ctx, blob)
 
 			if cerrdefs.IsNotFound(err) {
-				report.ImagesDeleted = append(report.ImagesDeleted,
-					image.DeleteResponse{
-						Deleted: blob.Digest.String(),
-					},
-				)
+				if c8dimages.IsManifestType(blob.MediaType) || c8dimages.IsIndexType(blob.MediaType) {
+					deleted = true
+					report.ImagesDeleted = append(report.ImagesDeleted,
+						image.DeleteResponse{
+							Deleted: blob.Digest.String(),
+						},
+					)
+				}
 				report.SpaceReclaimed += uint64(blob.Size)
 			}
+		}
+		if deleted {
+			i.logImageEvent(img, familiarName, events.ActionDelete)
 		}
 	}
 


### PR DESCRIPTION
Ensure events for containerd backend are properly sent when deleted via image prune. Fix prune output to only show deleted images rather than the deletion of each blob.

We should backport this to 28 as well.

```markdown changelog
containerd image store: Fix `docker image prune` to emit correct `untag` and `delete` events and list only the deleted images root digests instead of every blob.
```