### PR TITLE
daemon/router/image: initialize default authConfig

### DIFF
--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -166,14 +166,11 @@ func (ir *imageRouter) postImagesPush(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	var authConfig *registry.AuthConfig
-	if authEncoded := r.Header.Get(registry.AuthHeader); authEncoded != "" {
-		// Handle the authConfig as a header, but ignore invalid AuthConfig
-		// to increase compatibility with the existing API.
-		//
-		// TODO(thaJeztah): accept empty values but return an error when failing to decode.
-		authConfig, _ = registry.DecodeAuthConfig(authEncoded)
-	}
+	// Handle the authConfig as a header, but ignore invalid AuthConfig
+	// to increase compatibility with the existing API.
+	//
+	// TODO(thaJeztah): accept empty values but return an error when failing to decode.
+	authConfig, _ := registry.DecodeAuthConfig(r.Header.Get(registry.AuthHeader))
 
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- (possibly) fixes #50729 
- fixes https://github.com/moby/moby/issues/50614

**- What I did**

Initialize `authConfig` to an empty value. This should avoid nil pointer dereferences.

**- How I did it**

Initialize with an empty value.

**- How to verify it**

Invoking an image push without authentication headers (no `X-Registry-Auth`) should not cause a nil pointer dereference panic.

