### PR TITLE
gha: Add conditional skip for jobs with 'ci/validate-only' label

### DIFF
--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -37,6 +37,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
     strategy:
@@ -70,6 +71,7 @@ jobs:
   build-dev:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 120 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
     steps:
@@ -93,6 +95,7 @@ jobs:
   test-unit:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 120 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-dev
     steps:
@@ -150,7 +153,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only'))
     needs:
       - test-unit
     steps:
@@ -179,6 +182,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 120 # guardrails timeout for the whole job
     continue-on-error: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-dev
     steps:
@@ -249,7 +253,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only'))
     needs:
       - test-integration
     steps:

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -42,6 +42,7 @@ jobs:
   prepare:
     runs-on: ubuntu-24.04
     timeout-minutes: 20 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     outputs:
       platforms: ${{ steps.platforms.outputs.matrix }}
     steps:
@@ -96,10 +97,10 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     timeout-minutes: 20 # guardrails timeout for the whole job
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only')) }}
     needs:
       - validate-dco
       - prepare
-    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     strategy:
       fail-fast: false
       matrix:
@@ -172,9 +173,9 @@ jobs:
   merge:
     runs-on: ubuntu-24.04
     timeout-minutes: 40 # guardrails timeout for the whole job
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && github.event_name != 'pull_request' && github.repository == 'moby/moby' }}
     needs:
       - build
-    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && github.event_name != 'pull_request' && github.repository == 'moby/moby'
     steps:
       -
         name: Download meta bake definition

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -35,6 +35,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
     steps:
@@ -62,6 +63,7 @@ jobs:
   test-linux:
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-linux
     env:
@@ -166,6 +168,7 @@ jobs:
   build-windows:
     runs-on: windows-2022
     timeout-minutes: 120
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
     env:
@@ -265,6 +268,7 @@ jobs:
   test-windows:
     runs-on: windows-2022
     timeout-minutes: 120 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-windows
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
   prepare-cross:
     runs-on: ubuntu-24.04
     timeout-minutes: 20 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
     outputs:
@@ -89,6 +90,7 @@ jobs:
   cross:
     runs-on: ubuntu-24.04
     timeout-minutes: 20 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
       - prepare-cross
@@ -128,6 +130,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-24.04
     timeout-minutes: 120 # guardrails timeout for the whole job
+    # Always run security checks, even with 'ci/validate-only' label
     permissions:
       # required to write sarif report
       security-events: write
@@ -157,6 +160,7 @@ jobs:
 
   build-dind:
     runs-on: ubuntu-24.04
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
             *.output=type=cacheonly
 
   test:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-dev
       - validate-dco
@@ -84,6 +85,7 @@ jobs:
       storage: ${{ matrix.storage }}
 
   test-unit:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-dev
       - validate-dco
@@ -153,6 +155,7 @@ jobs:
   smoke-prepare:
     runs-on: ubuntu-24.04
     timeout-minutes: 10 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
     outputs:
@@ -175,6 +178,7 @@ jobs:
   smoke:
     runs-on: ubuntu-24.04
     timeout-minutes: 20 # guardrails timeout for the whole job
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - smoke-prepare
     strategy:

--- a/.github/workflows/windows-2022.yml
+++ b/.github/workflows/windows-2022.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   run:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     uses: ./.github/workflows/.windows.yml
     secrets: inherit
     strategy:

--- a/.github/workflows/windows-2025.yml
+++ b/.github/workflows/windows-2025.yml
@@ -27,6 +27,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   run:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     uses: ./.github/workflows/.windows.yml
     secrets: inherit
     strategy:


### PR DESCRIPTION
This change adds conditional logic to skip build and test jobs when a pull request is labeled with `ci/validate-only`.

The `govulncheck` job in the CI workflow is intentionally excluded from this conditional logic, ensuring security vulnerability checks always run regardless of the label.