### PR TITLE
Dockerfile: disable CGO for building utilities, and remove trailing slashes for GOBIN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ FROM base AS gowinres
 ARG GOWINRES_VERSION=v0.3.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build/ go install "github.com/tc-hib/go-winres@${GOWINRES_VERSION}" \
+        GOBIN=/build go install "github.com/tc-hib/go-winres@${GOWINRES_VERSION}" \
      && /build/go-winres --help
 
 # containerd
@@ -194,7 +194,7 @@ FROM base AS golangci_lint
 ARG GOLANGCI_LINT_VERSION=v2.1.5
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build/ go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \
+        GOBIN=/build go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \
      && /build/golangci-lint --version
 
 FROM base AS gotestsum
@@ -202,20 +202,20 @@ FROM base AS gotestsum
 ARG GOTESTSUM_VERSION=v1.12.3
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build/ go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
+        GOBIN=/build go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
      && /build/gotestsum --version
 
 FROM base AS shfmt
 ARG SHFMT_VERSION=v3.8.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build/ go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}" \
+        GOBIN=/build go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}" \
      && /build/shfmt --version
 
 FROM base AS gopls
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build/ go install "golang.org/x/tools/gopls@latest" \
+        GOBIN=/build go install "golang.org/x/tools/gopls@latest" \
      && /build/gopls version
 
 FROM base AS dockercli

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build,id=swagger-build-$TARGETPLAT
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ <<EOT
   set -e
-  GOBIN=/build xx-go install "github.com/go-swagger/go-swagger/cmd/swagger@${GO_SWAGGER_VERSION}"
+  GOBIN=/build CGO_ENABLED=0 xx-go install "github.com/go-swagger/go-swagger/cmd/swagger@${GO_SWAGGER_VERSION}"
   xx-verify /build/swagger
 EOT
 
@@ -149,7 +149,7 @@ FROM base AS gowinres
 ARG GOWINRES_VERSION=v0.3.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build go install "github.com/tc-hib/go-winres@${GOWINRES_VERSION}" \
+        GOBIN=/build CGO_ENABLED=0 go install "github.com/tc-hib/go-winres@${GOWINRES_VERSION}" \
      && /build/go-winres --help
 
 # containerd
@@ -194,7 +194,7 @@ FROM base AS golangci_lint
 ARG GOLANGCI_LINT_VERSION=v2.1.5
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \
+        GOBIN=/build CGO_ENABLED=0 go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}" \
      && /build/golangci-lint --version
 
 FROM base AS gotestsum
@@ -202,20 +202,20 @@ FROM base AS gotestsum
 ARG GOTESTSUM_VERSION=v1.12.3
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
+        GOBIN=/build CGO_ENABLED=0 go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
      && /build/gotestsum --version
 
 FROM base AS shfmt
 ARG SHFMT_VERSION=v3.8.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}" \
+        GOBIN=/build CGO_ENABLED=0 go install "mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}" \
      && /build/shfmt --version
 
 FROM base AS gopls
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        GOBIN=/build go install "golang.org/x/tools/gopls@latest" \
+        GOBIN=/build CGO_ENABLED=0 go install "golang.org/x/tools/gopls@latest" \
      && /build/gopls version
 
 FROM base AS dockercli


### PR DESCRIPTION
- taken from https://github.com/moby/moby/pull/50726

----

### Dockerfile: remove trailing slashes for GOBIN

It should be specified without (but works when included).

### Dockerfile: disable CGO for building utilities

Debian trixie is slimmed down, causing failures, but we probably don't
need CGO at all for these, so just disable it;

    > [swagger 2/2] RUN --mount=type=cache,target=/root/.cache/go-build,id=swagger-build-linux/arm64     --mount=type=cache,target=/go/pkg/mod     --mount=type=tmpfs,target=/go/src/ <<EOT (set -e...):
    12.22 go: downloading github.com/magiconair/properties v1.8.7
    12.29 go: downloading github.com/pelletier/go-toml/v2 v2.1.1
    12.44 go: downloading github.com/mitchellh/reflectwalk v1.0.2
    13.76 go: downloading golang.org/x/mod v0.17.0
    95.08 # github.com/go-swagger/go-swagger/cmd/swagger
    95.08 /usr/local/go/pkg/tool/linux_arm64/link: running aarch64-linux-gnu-gcc failed: exit status 1
    95.08 /usr/bin/aarch64-linux-gnu-gcc -Wl,-z,now -Wl,-z,nocopyreloc -fuse-ld=gold -Wl,--build-id=0xfd69e82d4bb4563abaec0df02ad550f5a6254e10 -o $WORK/b001/exe/a.out -rdynamic /tmp/go-link-2728250351/go.o /tmp/go-link-2728250351/000000.o /tmp/go-link-2728250351/000001.o /tmp/go-link-2728250351/000002.o /tmp/go-link-2728250351/000003.o /tmp/go-link-2728250351/000004.o /tmp/go-link-2728250351/000005.o /tmp/go-link-2728250351/000006.o /tmp/go-link-2728250351/000007.o /tmp/go-link-2728250351/000008.o /tmp/go-link-2728250351/000009.o /tmp/go-link-2728250351/000010.o /tmp/go-link-2728250351/000011.o /tmp/go-link-2728250351/000012.o /tmp/go-link-2728250351/000013.o /tmp/go-link-2728250351/000014.o /tmp/go-link-2728250351/000015.o /tmp/go-link-2728250351/000016.o /tmp/go-link-2728250351/000017.o /tmp/go-link-2728250351/000018.o /tmp/go-link-2728250351/000019.o /tmp/go-link-2728250351/000020.o /tmp/go-link-2728250351/000021.o -O2 -g -lresolv -O2 -g -ldl -O2 -g -lpthread
    95.08 collect2: fatal error: cannot find 'ld'
    95.08 compilation terminated.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

