### PR TITLE
[28.x backport] daemon/router/image: initialize default authConfig

### DIFF
--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -167,14 +167,11 @@ func (ir *imageRouter) postImagesPush(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	var authConfig *registry.AuthConfig
-	if authEncoded := r.Header.Get(registry.AuthHeader); authEncoded != "" {
-		// Handle the authConfig as a header, but ignore invalid AuthConfig
-		// to increase compatibility with the existing API.
-		//
-		// TODO(thaJeztah): accept empty values but return an error when failing to decode.
-		authConfig, _ = registry.DecodeAuthConfig(authEncoded)
-	}
+	// Handle the authConfig as a header, but ignore invalid AuthConfig
+	// to increase compatibility with the existing API.
+	//
+	// TODO(thaJeztah): accept empty values but return an error when failing to decode.
+	authConfig, _ := registry.DecodeAuthConfig(r.Header.Get(registry.AuthHeader))
 
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/50730
- fixes https://github.com/moby/moby/issues/50729
- fixes https://github.com/moby/moby/issues/50614

(cherry picked from commit 033ec8be44b4b43e5e9d0da1f906cfea08f0b561)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix a regression in v28.3.3 that could cause a panic on `docker push` if the client did not send an `X-Registry-Auth` header.
```

**- A picture of a cute animal (not mandatory but encouraged)**

