### PR TITLE
[28.x backport] Add multierror function to api network

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-
-	"github.com/docker/docker/internal/multierror"
 )
 
 // EndpointSettings stores the network endpoint details
@@ -99,7 +97,7 @@ func (cfg *EndpointIPAMConfig) IsInRange(v4Subnets []NetworkSubnet, v6Subnets []
 		errs = append(errs, err)
 	}
 
-	return multierror.Join(errs...)
+	return errJoin(errs...)
 }
 
 func validateEndpointIPAddress(epAddr string, ipamSubnets []NetworkSubnet) error {
@@ -149,5 +147,5 @@ func (cfg *EndpointIPAMConfig) Validate() error {
 		}
 	}
 
-	return multierror.Join(errs...)
+	return errJoin(errs...)
 }


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/50273

Preserve error formatting without importing internal package from the root package.


(cherry picked from commit 374fa24a53ab9332095894c141922f4d0b33c115)

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

