### PR TITLE
Natively support gRPC on the docker socket

### DIFF
--- a/daemon/command/httphandler.go
+++ b/daemon/command/httphandler.go
@@ -1,0 +1,70 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/containerd/containerd/v2/defaults"
+	"github.com/containerd/log"
+	"github.com/moby/buildkit/util/grpcerrors"
+	"github.com/moby/buildkit/util/stack"
+	"github.com/moby/buildkit/util/tracing"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+
+	"github.com/moby/moby/v2/daemon/internal/otelutil"
+)
+
+type httpHandler struct {
+	ctx        context.Context
+	grpcServer *grpc.Server
+	apiServer  http.Handler
+}
+
+func newHTTPHandler(ctx context.Context, gs *grpc.Server, apiServer http.Handler) http.Handler {
+	return &httpHandler{
+		ctx:        ctx,
+		grpcServer: gs,
+		apiServer:  apiServer,
+	}
+}
+
+func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+		h.grpcServer.ServeHTTP(w, r)
+	} else {
+		h.apiServer.ServeHTTP(w, r)
+	}
+}
+
+func newGRPCServer(ctx context.Context) *grpc.Server {
+	tp, _ := otelutil.NewTracerProvider(ctx, false)
+	return grpc.NewServer(
+		grpc.StatsHandler(tracing.ServerStatsHandler(otelgrpc.WithTracerProvider(tp))),
+		grpc.ChainUnaryInterceptor(unaryInterceptor, grpcerrors.UnaryServerInterceptor),
+		grpc.StreamInterceptor(grpcerrors.StreamServerInterceptor),
+		grpc.MaxRecvMsgSize(defaults.DefaultMaxRecvMsgSize),
+		grpc.MaxSendMsgSize(defaults.DefaultMaxSendMsgSize),
+	)
+}
+
+func unaryInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, _ error) {
+	// This method is used by the clients to send their traces to buildkit so they can be included
+	// in the daemon trace and stored in the build history record. This method can not be traced because
+	// it would cause an infinite loop.
+	if strings.HasSuffix(info.FullMethod, "opentelemetry.proto.collector.trace.v1.TraceService/Export") {
+		return handler(ctx, req)
+	}
+
+	resp, err := handler(ctx, req)
+	if err != nil {
+		log.G(ctx).WithError(err).Error(info.FullMethod)
+		if log.GetLevel() >= log.DebugLevel {
+			_, _ = fmt.Fprintf(os.Stderr, "%+v", stack.Formatter(grpcerrors.FromGRPC(err)))
+		}
+	}
+	return resp, err
+}

--- a/integration/build/build_traces_test.go
+++ b/integration/build/build_traces_test.go
@@ -3,7 +3,6 @@ package build
 import (
 	"context"
 	"errors"
-	"net"
 	"testing"
 	"time"
 
@@ -34,15 +33,8 @@ func TestBuildkitHistoryTracePropagation(t *testing.T) {
 	ctx := testutil.StartSpan(baseContext, t)
 
 	c := testEnv.APIClient()
-	opts := []client.ClientOpt{
-		client.WithSessionDialer(func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
-			return c.DialHijack(ctx, "/session", proto, meta)
-		}),
-		client.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			return c.DialHijack(ctx, "/grpc", "h2c", nil)
-		}),
-	}
-	bc, err := client.New(ctx, "", opts...)
+	bc, err := client.New(ctx, c.DaemonHost())
+
 	assert.NilError(t, err)
 	defer bc.Close()
 


### PR DESCRIPTION
- relates to / addresses https://github.com/moby/moby/issues/49836
- relates to https://github.com/moby/buildkit/issues/5927

Adds support for directly serving the gRPC server on the Docker socket. The requests can be easily detected from the content-type and use of HTTP 2.  Explicitly adds the HTTP 2 protocol when using tcp+tls or unencrypted HTTP 2 when using a unix socket.

Only registers the buildkit service, which will allow deprecating the hijacking `/session` and `/grpc` endpoints. In the future, we can register more services using containerd style plugins.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Natively support gRPC on the listening socket
```
