### PR TITLE
{ip,nf}tablesdoc: ensure format compatibility across Debian versions

### DIFF
--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge/internal/firewaller"
@@ -99,8 +100,9 @@ func testNftabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 			assert.Assert(t, is.Contains(res.Combined(), "No such file or directory"))
 			return
 		}
+		out := strings.ReplaceAll(res.Combined(), "type nat hook output priority -100", "type nat hook output priority dstnat")
 		assert.Assert(t, res.Error)
-		golden.Assert(t, res.Combined(), name+"__"+family+".golden")
+		golden.Assert(t, out, name+"__"+family+".golden")
 	}
 
 	makePB := func(hip string, cip netip.Addr) types.PortBinding {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=false,wsl2mirrored=true__ip.golden
@@ -22,7 +22,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=false__ip.golden
@@ -22,7 +22,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=false__ip6.golden
@@ -22,7 +22,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=true,wsl2mirrored=true__ip.golden
@@ -22,7 +22,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=true__ip.golden
@@ -22,7 +22,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/cleaned,hairpin=true__ip6.golden
@@ -22,7 +22,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip daddr != 127.0.0.0/8 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=true,icc=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		ip6 daddr != ::1 fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=false,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=false__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=false__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=true,wsl2mirrored=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=true__ip.golden
@@ -26,7 +26,7 @@ table ip docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=true,icc=true__ip6.golden
@@ -26,7 +26,7 @@ table ip6 docker-bridges {
 	}
 
 	chain nat-OUTPUT {
-		type nat hook output priority -100; policy accept;
+		type nat hook output priority dstnat; policy accept;
 		fib daddr type local counter packets 0 bytes 0 jump nat-prerouting-and-output
 	}
 

--- a/integration/network/bridge/iptablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/generated/new-daemon.md
@@ -12,30 +12,30 @@ Table `filter`:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -137,18 +137,18 @@ Table nat:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         

--- a/integration/network/bridge/iptablesdoc/generated/swarm-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/swarm-portmap.md
@@ -13,42 +13,42 @@ The filter table is:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DROP       0    --  !docker_gwbridge docker_gwbridge  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    2        0     0 DROP       all  --  !docker_gwbridge docker_gwbridge  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER     0    --  *      docker_gwbridge  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
+    2        0     0 DOCKER     all  --  any    docker_gwbridge  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    2        0     0 ACCEPT     0    --  *      docker_gwbridge  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     all  --  any    docker_gwbridge  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-INGRESS  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    6        0     0 DROP       0    --  docker_gwbridge docker_gwbridge  0.0.0.0/0            0.0.0.0/0           
-    7        0     0 ACCEPT     0    --  docker_gwbridge !docker_gwbridge  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-INGRESS  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    4        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    5        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    6        0     0 DROP       all  --  docker_gwbridge docker_gwbridge  anywhere             anywhere            
+    7        0     0 ACCEPT     all  --  docker_gwbridge !docker_gwbridge  anywhere             anywhere            
     
     Chain DOCKER-INGRESS (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     6    --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8080
-    2        0     0 ACCEPT     6    --  *      *       0.0.0.0/0            0.0.0.0/0            tcp spt:8080 ctstate RELATED,ESTABLISHED
-    3        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     tcp  --  any    any     anywhere             anywhere             tcp dpt:http-alt
+    2        0     0 ACCEPT     tcp  --  any    any     anywhere             anywhere             tcp spt:http-alt ctstate RELATED,ESTABLISHED
+    3        0     0 RETURN     all  --  any    any     anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -103,30 +103,30 @@ And the corresponding nat table:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-INGRESS  0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
-    2        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER-INGRESS  all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
+    2        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-INGRESS  0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
-    2        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER-INGRESS  all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
+    2        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      docker_gwbridge  0.0.0.0/0            0.0.0.0/0            ADDRTYPE match src-type LOCAL
-    2        0     0 MASQUERADE  0    --  *      !docker_gwbridge  172.18.0.0/16        0.0.0.0/0           
-    3        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    docker_gwbridge  anywhere             anywhere             ADDRTYPE match src-type LOCAL
+    2        0     0 MASQUERADE  all  --  any    !docker_gwbridge  172.18.0.0/16        anywhere            
+    3        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER-INGRESS (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DNAT       6    --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8080 to:172.18.0.2:8080
-    2        0     0 RETURN     0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DNAT       tcp  --  any    any     anywhere             anywhere             tcp dpt:http-alt to:172.18.0.2:8080
+    2        0     0 RETURN     all  --  any    any     anywhere             anywhere            
     
 
 <details>

--- a/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
@@ -27,39 +27,39 @@ The filter table is updated as follows:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 ACCEPT     0    --  bridgeICC bridgeICC  0.0.0.0/0            0.0.0.0/0           
-    6        0     0 DROP       0    --  bridgeNoICC bridgeNoICC  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    5        0     0 ACCEPT     all  --  bridgeICC bridgeICC  anywhere             anywhere            
+    6        0     0 DROP       all  --  bridgeNoICC bridgeNoICC  anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       0    --  *      bridgeNoICC !198.51.100.0/24      0.0.0.0/0           
-    2        0     0 DROP       0    --  bridgeNoICC *       0.0.0.0/0           !198.51.100.0/24     
-    3        0     0 DROP       0    --  *      bridgeICC !192.0.2.0/24         0.0.0.0/0           
-    4        0     0 DROP       0    --  bridgeICC *       0.0.0.0/0           !192.0.2.0/24        
+    1        0     0 DROP       all  --  any    bridgeNoICC !198.51.100.0/24      anywhere            
+    2        0     0 DROP       all  --  bridgeNoICC any     anywhere            !198.51.100.0/24     
+    3        0     0 DROP       all  --  any    bridgeICC !192.0.2.0/24         anywhere            
+    4        0     0 DROP       all  --  bridgeICC any     anywhere            !192.0.2.0/24        
     
     Chain DOCKER-USER (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -114,18 +114,18 @@ And the corresponding nat table:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
@@ -19,35 +19,35 @@ The filter and nat tables are identical to [nat mode][0]:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
-    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     tcp  --  !bridge1 bridge1  anywhere             192.0.2.2            tcp dpt:http
+    2        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    3        0     0 DROP       all  --  !bridge1 bridge1  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
+    2        0     0 DOCKER     all  --  any    bridge1  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     all  --  any    bridge1  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    5        0     0 ACCEPT     all  --  bridge1 any     anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -88,23 +88,23 @@ The filter and nat tables are identical to [nat mode][0]:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
-    2        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    !bridge1  192.0.2.0/24         anywhere            
+    2        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DNAT       6    --  !bridge1 *       0.0.0.0/0            127.0.0.1            tcp dpt:8080 to:192.0.2.2:80
+    1        0     0 DNAT       tcp  --  !bridge1 any     anywhere             localhost            tcp dpt:http-alt to:192.0.2.2:80
     
 
     -P PREROUTING ACCEPT
@@ -123,8 +123,8 @@ The filter and nat tables are identical to [nat mode][0]:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       0    --  !bridge1 *       0.0.0.0/0            192.0.2.2           
-    2        0     0 DROP       6    --  !lo    *       0.0.0.0/0            127.0.0.1            tcp dpt:8080
+    1        0     0 DROP       all  --  !bridge1 any     anywhere             192.0.2.2           
+    2        0     0 DROP       tcp  --  !lo    any     anywhere             localhost            tcp dpt:http-alt
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
@@ -17,34 +17,34 @@ The filter table is:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 ACCEPT     0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    2        0     0 ACCEPT     all  --  !bridge1 bridge1  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
+    2        0     0 DOCKER     all  --  any    bridge1  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     all  --  any    bridge1  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    5        0     0 ACCEPT     all  --  bridge1 any     anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -102,23 +102,23 @@ The nat table is identical to [nat mode][400].
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
-    2        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    !bridge1  192.0.2.0/24         anywhere            
+    2        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DNAT       6    --  !bridge1 *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8080 to:192.0.2.2:80
+    1        0     0 DNAT       tcp  --  !bridge1 any     anywhere             anywhere             tcp dpt:http-alt to:192.0.2.2:80
     
 
     -P PREROUTING ACCEPT

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -17,36 +17,36 @@ The filter table is:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
-    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     tcp  --  !bridge1 bridge1  anywhere             192.0.2.2            tcp dpt:http
+    2        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    3        0     0 DROP       all  --  !bridge1 bridge1  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
+    2        0     0 DOCKER     all  --  any    bridge1  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     all  --  any    bridge1  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 DROP       0    --  bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
-    6        0     0 ACCEPT     0    --  bridge1 !bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    5        0     0 DROP       all  --  bridge1 bridge1  anywhere             anywhere            
+    6        0     0 ACCEPT     all  --  bridge1 !bridge1  anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -98,23 +98,23 @@ And the corresponding nat table:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
-    2        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    !bridge1  192.0.2.0/24         anywhere            
+    2        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DNAT       6    --  !bridge1 *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8080 to:192.0.2.2:80
+    1        0     0 DNAT       tcp  --  !bridge1 any     anywhere             anywhere             tcp dpt:http-alt to:192.0.2.2:80
     
 
 <details>

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
@@ -20,35 +20,35 @@ The filter table is the same as with the userland proxy enabled.
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
-    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     tcp  --  !bridge1 bridge1  anywhere             192.0.2.2            tcp dpt:http
+    2        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    3        0     0 DROP       all  --  !bridge1 bridge1  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
+    2        0     0 DOCKER     all  --  any    bridge1  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     all  --  any    bridge1  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    5        0     0 ACCEPT     all  --  bridge1 any     anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -88,26 +88,26 @@ The nat table is:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ADDRTYPE match src-type LOCAL
-    2        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
-    3        0     0 MASQUERADE  0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ADDRTYPE match src-type LOCAL
-    4        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
-    5        0     0 MASQUERADE  6    --  *      *       192.0.2.2            192.0.2.2            tcp dpt:80
+    1        0     0 MASQUERADE  all  --  any    bridge1  anywhere             anywhere             ADDRTYPE match src-type LOCAL
+    2        0     0 MASQUERADE  all  --  any    !bridge1  192.0.2.0/24         anywhere            
+    3        0     0 MASQUERADE  all  --  any    docker0  anywhere             anywhere             ADDRTYPE match src-type LOCAL
+    4        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
+    5        0     0 MASQUERADE  tcp  --  any    any     192.0.2.2            192.0.2.2            tcp dpt:http
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DNAT       6    --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8080 to:192.0.2.2:80
+    1        0     0 DNAT       tcp  --  any    any     anywhere             anywhere             tcp dpt:http-alt to:192.0.2.2:80
     
     
 <details>

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
@@ -17,36 +17,36 @@ The filter table is:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
-    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     1    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     tcp  --  !bridge1 bridge1  anywhere             192.0.2.2            tcp dpt:http
+    2        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    3        0     0 ACCEPT     icmp --  any    bridge1  anywhere             anywhere            
+    4        0     0 DROP       all  --  !bridge1 bridge1  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
+    2        0     0 DOCKER     all  --  any    bridge1  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     all  --  any    bridge1  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    5        0     0 ACCEPT     all  --  bridge1 any     anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -103,15 +103,12 @@ sense used by the RFC. So, Node Information and Router Renumbering messages are
 not discarded, and experimental/unused types are allowed because they may be
 needed._
 
-The ICMP rule, as shown by `iptables -L`, looks alarming until you spot that it's
-for `prot 1`:
-
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
-    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 ACCEPT     1    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
-    4        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     tcp  --  !bridge1 bridge1  anywhere             192.0.2.2            tcp dpt:http
+    2        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    3        0     0 ACCEPT     icmp --  any    bridge1  anywhere             anywhere            
+    4        0     0 DROP       all  --  !bridge1 bridge1  anywhere             anywhere            
     
 
     -N DOCKER
@@ -125,18 +122,18 @@ The nat table is:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -16,35 +16,35 @@ The filter table is updated as follows:
     
     Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-USER  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-FORWARD  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-USER  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-FORWARD  all  --  any    any     anywhere             anywhere            
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     6    --  !bridge1 bridge1  0.0.0.0/0            192.0.2.2            tcp dpt:80
-    2        0     0 DROP       0    --  !docker0 docker0  0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DROP       0    --  !bridge1 bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 ACCEPT     tcp  --  !bridge1 bridge1  anywhere             192.0.2.2            tcp dpt:http
+    2        0     0 DROP       all  --  !docker0 docker0  anywhere             anywhere            
+    3        0     0 DROP       all  --  !bridge1 bridge1  anywhere             anywhere            
     
     Chain DOCKER-BRIDGE (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER     all  --  any    docker0  anywhere             anywhere            
+    2        0     0 DOCKER     all  --  any    bridge1  anywhere             anywhere            
     
     Chain DOCKER-CT (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 ACCEPT     0    --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
-    2        0     0 ACCEPT     0    --  *      bridge1  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
+    1        0     0 ACCEPT     all  --  any    docker0  anywhere             anywhere             ctstate RELATED,ESTABLISHED
+    2        0     0 ACCEPT     all  --  any    bridge1  anywhere             anywhere             ctstate RELATED,ESTABLISHED
     
     Chain DOCKER-FORWARD (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER-CT  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    2        0     0 DOCKER-INTERNAL  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    3        0     0 DOCKER-BRIDGE  0    --  *      *       0.0.0.0/0            0.0.0.0/0           
-    4        0     0 ACCEPT     0    --  docker0 *       0.0.0.0/0            0.0.0.0/0           
-    5        0     0 ACCEPT     0    --  bridge1 *       0.0.0.0/0            0.0.0.0/0           
+    1        0     0 DOCKER-CT  all  --  any    any     anywhere             anywhere            
+    2        0     0 DOCKER-INTERNAL  all  --  any    any     anywhere             anywhere            
+    3        0     0 DOCKER-BRIDGE  all  --  any    any     anywhere             anywhere            
+    4        0     0 ACCEPT     all  --  docker0 any     anywhere             anywhere            
+    5        0     0 ACCEPT     all  --  bridge1 any     anywhere             anywhere            
     
     Chain DOCKER-INTERNAL (1 references)
     num   pkts bytes target     prot opt in     out     source               destination         
@@ -105,23 +105,23 @@ The corresponding nat table:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0            0.0.0.0/0            ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere             anywhere             ADDRTYPE match dst-type LOCAL
     
     Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DOCKER     0    --  *      *       0.0.0.0/0           !127.0.0.0/8          ADDRTYPE match dst-type LOCAL
+    1        0     0 DOCKER     all  --  any    any     anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
     
     Chain POSTROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 MASQUERADE  0    --  *      !bridge1  192.0.2.0/24         0.0.0.0/0           
-    2        0     0 MASQUERADE  0    --  *      !docker0  172.17.0.0/16        0.0.0.0/0           
+    1        0     0 MASQUERADE  all  --  any    !bridge1  192.0.2.0/24         anywhere            
+    2        0     0 MASQUERADE  all  --  any    !docker0  172.17.0.0/16        anywhere            
     
     Chain DOCKER (2 references)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DNAT       6    --  !bridge1 *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8080 to:192.0.2.2:80
+    1        0     0 DNAT       tcp  --  !bridge1 any     anywhere             anywhere             tcp dpt:http-alt to:192.0.2.2:80
     
 
 <details>
@@ -145,7 +145,7 @@ And the raw table:
 
     Chain PREROUTING (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         
-    1        0     0 DROP       0    --  !bridge1 *       0.0.0.0/0            192.0.2.2           
+    1        0     0 DROP       all  --  !bridge1 any     anywhere             192.0.2.2           
     
     Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
     num   pkts bytes target     prot opt in     out     source               destination         

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -202,13 +202,13 @@ const (
 )
 
 var iptCmds = map[iptCmdType][]string{
-	iptCmdLFilter4:       {"iptables", "-nvL", "--line-numbers", "-t", "filter"},
+	iptCmdLFilter4:       {"iptables", "-vL", "--line-numbers", "-t", "filter"},
 	iptCmdSFilter4:       {"iptables", "-S", "-t", "filter"},
-	iptCmdLFilterDocker4: {"iptables", "-nvL", "DOCKER", "--line-numbers", "-t", "filter"},
+	iptCmdLFilterDocker4: {"iptables", "-vL", "DOCKER", "--line-numbers", "-t", "filter"},
 	iptCmdSFilterDocker4: {"iptables", "-S", "DOCKER"},
-	iptCmdLNat4:          {"iptables", "-nvL", "--line-numbers", "-t", "nat"},
+	iptCmdLNat4:          {"iptables", "-vL", "--line-numbers", "-t", "nat"},
 	iptCmdSNat4:          {"iptables", "-S", "-t", "nat"},
-	iptCmdLRaw4:          {"iptables", "-nvL", "--line-numbers", "-t", "raw"},
+	iptCmdLRaw4:          {"iptables", "-vL", "--line-numbers", "-t", "raw"},
 	iptCmdSRaw4:          {"iptables", "-S", "-t", "raw"},
 }
 

--- a/integration/network/bridge/iptablesdoc/templates/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/templates/usernet-portmap-routed.md
@@ -36,9 +36,6 @@ sense used by the RFC. So, Node Information and Router Renumbering messages are
 not discarded, and experimental/unused types are allowed because they may be
 needed._
 
-The ICMP rule, as shown by `iptables -L`, looks alarming until you spot that it's
-for `prot 1`:
-
     {{index . "LFilterDocker4"}}
 
     {{index . "SFilterDocker4"}}

--- a/integration/network/bridge/nftablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/nftablesdoc/generated/new-daemon.md
@@ -35,7 +35,7 @@ are then added.
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		ip daddr != 127.0.0.0/8 fib daddr type local counter jump nat-prerouting-and-output
     	}
     

--- a/integration/network/bridge/nftablesdoc/generated/usernet-internal.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-internal.md
@@ -61,7 +61,7 @@ Most rules are the same as the network with [external access][0]:
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		ip daddr != 127.0.0.0/8 fib daddr type local counter jump nat-prerouting-and-output
     	}
     

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-lo.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-lo.md
@@ -46,7 +46,7 @@ Most rules are the same as for a port published to a regular [host address][0]:
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		ip daddr != 127.0.0.0/8 fib daddr type local counter jump nat-prerouting-and-output
     	}
     

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-natunprot.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-natunprot.md
@@ -47,7 +47,7 @@ Most rules are the same as the [nat mode network][1]:
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		ip daddr != 127.0.0.0/8 fib daddr type local counter jump nat-prerouting-and-output
     	}
     

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noicc.md
@@ -47,7 +47,7 @@ Most rules are the same as the network with [icc enabled][0]:
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		ip daddr != 127.0.0.0/8 fib daddr type local counter jump nat-prerouting-and-output
     	}
     

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noproxy.md
@@ -48,7 +48,7 @@ Most rules are the same as the network with the [proxy enabled][0]:
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		fib daddr type local counter jump nat-prerouting-and-output
     	}
     
@@ -124,7 +124,7 @@ loopback address by a container in another network - there's no proxy to catch
 them ...
 
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		fib daddr type local counter jump nat-prerouting-and-output
     	}
 

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-routed.md
@@ -47,7 +47,7 @@ Most rules are the same as the [nat mode network][1]:
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		ip daddr != 127.0.0.0/8 fib daddr type local counter jump nat-prerouting-and-output
     	}
     

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap.md
@@ -43,7 +43,7 @@ The `ip docker-bridges` table is updated as follows:
     	}
     
     	chain nat-OUTPUT {
-    		type nat hook output priority -100; policy accept;
+    		type nat hook output priority dstnat; policy accept;
     		ip daddr != 127.0.0.0/8 fib daddr type local counter jump nat-prerouting-and-output
     	}
     

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -380,6 +380,7 @@ func pollService(ctx context.Context, t *testing.T, c *client.Client, host netwo
 func runNftables(t *testing.T, host networking.Host) map[string]string {
 	res := map[string]string{}
 	out := host.MustRun(t, "nft", "-s", "list", "table", "ip", "docker-bridges")
+	out = strings.ReplaceAll(out, "type nat hook output priority -100", "type nat hook output priority dstnat")
 	// Indent the result, so that it's treated as preformatted markdown.
 	res["Ruleset4"] = "    " + strings.ReplaceAll(out, "\n", "\n    ")
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Related to https://github.com/moby/moby/pull/50726

**- What I did**

**iptablesdoc: remove -n from iptables -L invocations**

The output of `iptables -nvL` has changed in Debian 13 — the proto column now shows protocol names instead of numbers, even when `-n` is specified. This breaks the iptablesdoc golden files, which expect protocols to be represented numerically.

This change comes from 34f085b1607364f4eaded1140060dcaf965a2649 in repo git.netfilter.org/iptables (see [1]), which is a revert of da8ecc62dd765b15df84c3aa6b83dcb7a81d4ffa (see [2]), and was made to address a bug report (see [3]).

Unfortunately, this means there's a drift between iptables versions. So, remove the `-n` flag altogether to ensure that the iptablesdoc tests pass everywhere.

[1]: https://git.netfilter.org/iptables/commit/?id=da8ecc62dd765b15df84c3aa6b83dcb7a81d4ffa
[2]: https://git.netfilter.org/iptables/commit/?id=34f085b1607364f4eaded1140060dcaf965a2649
[3]: https://bugzilla.netfilter.org/show_bug.cgi?id=1729

**nftablesdoc: stringify numerical dstnat prio**

When nftablesdoc tests dump the state of nftables, the argument '-y' / '--numeric-priority' isn't used, so all priorities should be stringified. However, there's a bug in older versions of nftables that prevents the stringification of the 'dstnat' priority — it's currently dumped as '-100'.

New versions fix that, and thus running these tests on Debian 13 fails because of this discrepancy with golden files.

So, look for 'type nat hook output priority -100' and stringify the priority to ensure compatibility across versions of nft.