### PR TITLE
hack/test/unit: use empty default values

### DIFF
--- a/hack/test/unit
+++ b/hack/test/unit
@@ -16,6 +16,9 @@ BUILDFLAGS=(-tags 'netgo journald')
 TESTFLAGS+=" -test.timeout=${TIMEOUT:-5m}"
 TESTDIRS="${TESTDIRS:-./...}"
 
+: "${api_pkg_list:=}"
+: "${client_pkg_list:=}"
+
 mkdir -p bundles
 
 case "$TESTDIRS" in


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/50721

**- What I did**

Commit https://github.com/akerouanton/docker/commit/8013d80c24bf9fe5eb0fa20eea19db4f7d299a32 updated the hack/test/unit script to ensure that tests are run against the right module when TESTDIRS is specified. But there's an issue with this commit: the script has `set -u` (i.e. 'nounset'), and some variables are set conditionally, but checked unconditionally, so it fails.

Fix it by defining those vars to empty strings.
