### PR TITLE
integration/network/bridge: add "generated" header to markdown docs

### DIFF
--- a/integration/network/bridge/iptablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/iptablesdoc/generated/new-daemon.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## iptables for a new Daemon
 
 When the daemon starts, it creates custom chains, and rules for the

--- a/integration/network/bridge/iptablesdoc/generated/swarm-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/swarm-portmap.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Swarm service, with a published port
 
 Equivalent to:

--- a/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-internal.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Containers on user-defined --internal networks
 
 These are the rules for two containers on different `--internal` networks, with and

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-lo.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network, with a port published on a loopback address
 
 Adding a network running a container with a port mapped on a loopback address, equivalent to:

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-natunprot.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a nat-unprotected network, with a published port
 
 Running the daemon with the userland proxy disable then, as before, adding a network running a container with a mapped port, equivalent to:

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noicc.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network with inter-container communication disabled, with a published port
 
 Equivalent to:

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-noproxy.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network, with a published port, no userland proxy
 
 Running the daemon with the userland proxy disabled then, as before, adding a network running a container with a mapped port, equivalent to:

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap-routed.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a routed-mode network, with a published port
 
 Running the daemon with the userland proxy disabled then, as before, adding a network running a container with a mapped port, equivalent to:

--- a/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/iptablesdoc/generated/usernet-portmap.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network, with a published port
 
 Adding a network running a container with a mapped port, equivalent to:

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -417,11 +417,15 @@ func runIptables(t *testing.T, host networking.Host) map[iptCmdType]string {
 	return res
 }
 
+const genHeader = "<!-- This is a generated file; DO NOT EDIT. -->\n\n"
+
 func generate(t *testing.T, name string, data map[iptCmdType]string) string {
 	t.Helper()
 	templ, err := template.New(name).ParseFiles(filepath.Join("templates", name))
 	assert.NilError(t, err)
-	wr := strings.Builder{}
+
+	var wr strings.Builder
+	wr.WriteString(genHeader)
 	err = templ.ExecuteTemplate(&wr, name, data)
 	assert.NilError(t, err)
 	return wr.String()

--- a/integration/network/bridge/nftablesdoc/generated/new-daemon.md
+++ b/integration/network/bridge/nftablesdoc/generated/new-daemon.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## nftables for a new Daemon
 
 When the daemon starts, it creates two tables, `ip docker-bridges` and

--- a/integration/network/bridge/nftablesdoc/generated/usernet-internal.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-internal.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Containers on user-defined --internal networks
 
 These are the rules for two containers on different `--internal` networks, with and

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-lo.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-lo.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network, with a port published on a loopback address
 
 Adding a network running a container with a port mapped on a loopback address, equivalent to:

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-natunprot.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-natunprot.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a nat-unprotected network, with a published port
 
 Running the daemon with the userland proxy disable then, as before, adding a network running a container with a mapped port, equivalent to:

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noicc.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noicc.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network with inter-container communication disabled, with a published port
 
 Equivalent to:

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noproxy.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-noproxy.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network, with a published port, no userland proxy
 
 Running the daemon with the userland proxy disabled then, as before, adding a

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap-routed.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap-routed.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a routed-mode network, with a published port
 
 Running the daemon with the userland proxy disabled then, as before, adding a network running a container with a mapped port, equivalent to:

--- a/integration/network/bridge/nftablesdoc/generated/usernet-portmap.md
+++ b/integration/network/bridge/nftablesdoc/generated/usernet-portmap.md
@@ -1,3 +1,5 @@
+<!-- This is a generated file; DO NOT EDIT. -->
+
 ## Container on a user-defined network, with a published port
 
 Adding a network running a container with a mapped port, equivalent to:

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -447,11 +447,15 @@ func lines(s string) iter.Seq[string] {
 	}
 }
 
+const genHeader = "<!-- This is a generated file; DO NOT EDIT. -->\n\n"
+
 func generate(t *testing.T, name string, data map[string]string) string {
 	t.Helper()
 	templ, err := template.New(name).ParseFiles(filepath.Join("templates", name))
 	assert.NilError(t, err)
-	wr := strings.Builder{}
+
+	var wr strings.Builder
+	wr.WriteString(genHeader)
 	err = templ.ExecuteTemplate(&wr, name, data)
 	assert.NilError(t, err)
 	return wr.String()


### PR DESCRIPTION
We can't add it to the templates, because those are not generated, so adding it in the code that uses the templates, and prepend the header before handling the template.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

