### PR TITLE
hack: add script to collect file history

### DIFF
--- a/hack/generate-file-history.sh
+++ b/hack/generate-file-history.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script produces a TSV containing the dates and commits at which files
+# were first introduced. It can be used to add copyright headers.
+#
+# Some relevant dates / commits:
+#
+# - Docker Open Sourced as Apache 2 (Feb 18, 2013): https://github.com/moby/moby/commit/a7e9582a53663453d0885b1a0217941ad1fe595f
+# - dotCloud, Inc. -> Docker, Inc. (Oct 29, 2013): https://web.archive.org/web/20210515031439/https://www.businesswire.com/news/home/20131029005746/en/dotCloud-Inc.-is-Now-Docker-Inc.
+# - dotCloud, Inc. -> Docker, Inc. (March 13, 2014): https://github.com/moby/moby/commit/73596b00e053fedbf42f7abb87728e7176e5a95c
+
+command -v parallel > /dev/null 2>&1 || {
+	echo "parallel is not installed"
+	exit 2
+}
+
+# all files, excluding "vendor" (which can be nested, e.g. 'man/vendor') and bundles
+git ls-files -- ':(exclude)vendor/**' ':(exclude)**/vendor/**' ':(exclude)bundles/**' > files.txt
+
+out="file-history.tsv"
+[ -s "$out" ] || printf "filename\tfirst_path\tfirst_date\tfirst_commit\tgenerated\n" > "$out"
+
+# create todo-list, removing already processed paths (first column)
+tmpdone="$(mktemp)"
+trap 'rm -f "$tmpdone" "$worker" todo.txt' EXIT
+tail -n +2 "$out" 2> /dev/null | cut -f1 | LC_ALL=C sort > "$tmpdone" || true
+LC_ALL=C sort files.txt > all-files.txt
+comm -23 all-files.txt "$tmpdone" > todo.txt
+rm -f all-files.txt
+
+worker="$(mktemp)"
+cat > "$worker" <<- 'WORKER'
+	#!/usr/bin/env bash
+	set -euo pipefail
+	f="$1"
+
+	# detect generated files
+	generated=no
+	case "$f" in
+		*.golden|*.pb.go|*.mod|*.sum|*.pem)
+			generated=yes
+			;;
+		*.gotmpl)
+			# template itself is not generated.
+			;;
+		daemon/builder/remotecontext/internal/tarsum/testdata/*)
+			generated=yes
+			;;
+		*)
+			if head -n 10 -- "$f" 2>/dev/null | grep -qi "DO NOT EDIT"; then
+				generated=yes
+			fi
+			;;
+	esac
+
+	# get the first commit and date introducing this file (follow renames) as well
+	# as the original filename.
+	first_commit=$(git -c diff.renameLimit=100000 log --follow --find-renames=40% --diff-filter=A --format=%H -- "$f" | tail -n1)
+	[ -z "$first_commit" ] && exit 0
+
+	first_date=$(git show -s --date=short --format=%ad "$first_commit")
+	first_path=$(git -c diff.renameLimit=100000 log -1 --follow --find-renames=40% --diff-filter=A --name-only --pretty=format: -- "$f")
+	# first_path=$(git show --pretty=format: --name-only "$first_commit" -- "$f" | head -n1)
+
+	# skip (nested) vendor files in history
+	case "$first_path" in vendor/*|*/vendor/*|*/Godeps/_workspace/*) exit 0;; esac
+
+	printf "%s\t%s\t%s\t%s\t%s\n" "$f" "$generated" "$first_path" "$first_date" "$first_commit"
+WORKER
+
+chmod +x "$worker"
+parallel --jobs 8 --no-run-if-empty --bar "$worker" :::: todo.txt >> "$out"


### PR DESCRIPTION
Really work in progress; my intent is to try to trace-back history of files, so that we can add the correct license and copyright headers. Ideally we can use the short (`SPDX`) ones.

The history can be relevant so that we can add the "original" copyright to files that were created by dotCloud / Docker (before open-sourcing in https://github.com/moby/moby/commit/a7e9582a53663453d0885b1a0217941ad1fe595f. Changes after that should (likely) get something like `Copyright The Moby Authors` (or `Copyright The Authors`).

TBD is what to do with the `Copyright 2012-2017 Docker, Inc.` (in NOTICE) and `Copyright 2013-2018 Docker, Inc.` (in LICENSE) claims, because this project never used a CLA, so copyright is with the author / contributor (some of which may have been employed by `Docker, Inc.`).

There's some files where Git had trouble finding the origin; some files were originally in this repository, then moved (to e.g. `github.com/docker/libnetwork` or `github.com/docker/engine-api`), then vendored back, and later moved back again.

Output produced looks something like this (this is the first 100 lines) (it's tab-separated, so `.tsv` is a better file-extension, but github doesn't allow uploading those);

[example.csv](https://github.com/user-attachments/files/21814836/example.csv)




**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

