### PR TITLE
Clarify host vs. container command prompts in development setup docs and fix file path reference

### DIFF
--- a/docs/contributing/set-up-dev-env.md
+++ b/docs/contributing/set-up-dev-env.md
@@ -1,5 +1,7 @@
 ### Work with a development container
 
+> Note: this document contains commands run on your host machine and commands run inside the development container. Host commands are shown with a leading "$" prompt (for example, `$ docker ps -a`). Commands intended to be executed inside the container are shown with a leading "#" prompt (for example, `# docker version`). If a command in a fenced block begins with `$`, run it on your host; if it begins with `#`, run it inside the container.
+
 In this section, you learn to develop like the Moby Engine core team.
 The `moby/moby` repository includes a `Dockerfile` at its root. This file defines
 Moby's development environment. The `Dockerfile` lists the environment's

--- a/docs/contributing/set-up-dev-env.md
+++ b/docs/contributing/set-up-dev-env.md
@@ -1,6 +1,6 @@
 ### Work with a development container
 
-> Note: this document contains commands run on your host machine and commands run inside the development container. Host commands are shown with a leading "$" prompt (for example, `$ docker ps -a`). Commands intended to be executed inside the container are shown with a leading "#" prompt (for example, `# docker version`). If a command in a fenced block begins with `$`, run it on your host; if it begins with `#`, run it inside the container.
+> **Note**: this document contains commands run on your host machine and commands run inside the development container. Host commands are shown with a leading "$" prompt (for example, `$ docker ps -a`). Commands intended to be executed inside the container are shown with a leading "#" prompt (for example, `# docker version`). If a command in a fenced block begins with `$`, run it on your host; if it begins with `#`, run it inside the container.
 
 In this section, you learn to develop like the Moby Engine core team.
 The `moby/moby` repository includes a `Dockerfile` at its root. This file defines

--- a/docs/contributing/set-up-dev-env.md
+++ b/docs/contributing/set-up-dev-env.md
@@ -308,7 +308,7 @@ example, you'll edit the help for the `attach` subcommand.
    Your location should be different because, at least, your username is
    different.
 
-3. Open the `cmd/dockerd/docker.go` file.
+3. Open the `daemon/command/docker.go` file.
 
 4. Edit the command's help message.
 


### PR DESCRIPTION

### PR Template:

Closes #50753 

**- What I did**

Improved clarity in the `set-up-dev-env.md` documentation by:

* Adding a clear explanation of how to distinguish between commands run on the host machine and those inside the development container.
* Corrected an outdated file path reference from `cmd/dockerd/docker.go` to `daemon/command/docker.go`.

**- How I did it**

* Added a descriptive note block at the top of the document explaining the prompt syntax (`$` for host, `#` for container).
* Updated step 3 under the section about editing the help message to reflect the current file structure.

**- How to verify it**

* Open the `set-up-dev-env.md` doc and confirm the note accurately describes the prompt convention.
* Follow the documentation and verify the file path in step 3 matches the actual file structure of the repository.

**- Human readable description for the release notes**

```markdown changelog
Improved development documentation with clearer instructions on command prompt context and updated a file path reference to match the current repository structure.
```

*"Hey there, thanks for improving the docs!"* 🦦✨
