### PR TITLE
client/pkg/jsonmessage: remove unused fields

### DIFF
--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -126,9 +126,6 @@ type JSONMessage struct {
 	Status   string            `json:"status,omitempty"`
 	Progress *JSONProgress     `json:"progressDetail,omitempty"`
 	ID       string            `json:"id,omitempty"`
-	From     string            `json:"from,omitempty"`
-	Time     int64             `json:"time,omitempty"`
-	TimeNano int64             `json:"timeNano,omitempty"`
 	Error    *jsonstream.Error `json:"errorDetail,omitempty"`
 	Aux      *json.RawMessage  `json:"aux,omitempty"` // Aux contains out-of-band data, such as digests for push signing and image id after building.
 }
@@ -177,16 +174,8 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	} else if jm.Progress != nil && jm.Progress.String() != "" { // disable progressbar in non-terminal
 		return nil
 	}
-	if jm.TimeNano != 0 {
-		_, _ = fmt.Fprintf(out, "%s ", time.Unix(0, jm.TimeNano).Format(RFC3339NanoFixed))
-	} else if jm.Time != 0 {
-		_, _ = fmt.Fprintf(out, "%s ", time.Unix(jm.Time, 0).Format(RFC3339NanoFixed))
-	}
 	if jm.ID != "" {
 		_, _ = fmt.Fprintf(out, "%s: ", jm.ID)
-	}
-	if jm.From != "" {
-		_, _ = fmt.Fprintf(out, "(from %s) ", jm.From)
 	}
 	if jm.Progress != nil && isTerminal {
 		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)

--- a/client/pkg/jsonmessage/jsonmessage_test.go
+++ b/client/pkg/jsonmessage/jsonmessage_test.go
@@ -112,7 +112,6 @@ func TestProgressString(t *testing.T) {
 }
 
 func TestJSONMessageDisplay(t *testing.T) {
-	now := time.Now()
 	messages := map[JSONMessage][]string{
 		// Empty
 		{}: {"\n", "\n"},
@@ -125,34 +124,11 @@ func TestJSONMessageDisplay(t *testing.T) {
 		},
 		// General
 		{
-			Time:   now.Unix(),
 			ID:     "ID",
-			From:   "From",
 			Status: "status",
 		}: {
-			fmt.Sprintf("%v ID: (from From) status\n", time.Unix(now.Unix(), 0).Format(RFC3339NanoFixed)),
-			fmt.Sprintf("%v ID: (from From) status\n", time.Unix(now.Unix(), 0).Format(RFC3339NanoFixed)),
-		},
-		// General, with nano precision time
-		{
-			TimeNano: now.UnixNano(),
-			ID:       "ID",
-			From:     "From",
-			Status:   "status",
-		}: {
-			fmt.Sprintf("%v ID: (from From) status\n", time.Unix(0, now.UnixNano()).Format(RFC3339NanoFixed)),
-			fmt.Sprintf("%v ID: (from From) status\n", time.Unix(0, now.UnixNano()).Format(RFC3339NanoFixed)),
-		},
-		// General, with both times Nano is preferred
-		{
-			Time:     now.Unix(),
-			TimeNano: now.UnixNano(),
-			ID:       "ID",
-			From:     "From",
-			Status:   "status",
-		}: {
-			fmt.Sprintf("%v ID: (from From) status\n", time.Unix(0, now.UnixNano()).Format(RFC3339NanoFixed)),
-			fmt.Sprintf("%v ID: (from From) status\n", time.Unix(0, now.UnixNano()).Format(RFC3339NanoFixed)),
+			"ID: status\n",
+			"ID: status\n",
 		},
 		// Stream over status
 		{

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -126,9 +126,6 @@ type JSONMessage struct {
 	Status   string            `json:"status,omitempty"`
 	Progress *JSONProgress     `json:"progressDetail,omitempty"`
 	ID       string            `json:"id,omitempty"`
-	From     string            `json:"from,omitempty"`
-	Time     int64             `json:"time,omitempty"`
-	TimeNano int64             `json:"timeNano,omitempty"`
 	Error    *jsonstream.Error `json:"errorDetail,omitempty"`
 	Aux      *json.RawMessage  `json:"aux,omitempty"` // Aux contains out-of-band data, such as digests for push signing and image id after building.
 }
@@ -177,16 +174,8 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	} else if jm.Progress != nil && jm.Progress.String() != "" { // disable progressbar in non-terminal
 		return nil
 	}
-	if jm.TimeNano != 0 {
-		_, _ = fmt.Fprintf(out, "%s ", time.Unix(0, jm.TimeNano).Format(RFC3339NanoFixed))
-	} else if jm.Time != 0 {
-		_, _ = fmt.Fprintf(out, "%s ", time.Unix(jm.Time, 0).Format(RFC3339NanoFixed))
-	}
 	if jm.ID != "" {
 		_, _ = fmt.Fprintf(out, "%s: ", jm.ID)
-	}
-	if jm.From != "" {
-		_, _ = fmt.Fprintf(out, "(from %s) ", jm.From)
 	}
 	if jm.Progress != nil && isTerminal {
 		_, _ = fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/pull/18888
- [x] depends on https://github.com/moby/moby/pull/48733
- https://github.com/moby/moby/issues/50575


The JSONMessage struct contained fields that were previously used to produce the `/events` response. However, commit 72f1881df102fce9ad31e98045b91c204dd44513 introduced an events.Message type that replaced the use of JSONMessage for that purpose, and clients no longer use the JSONMessage struct to unmarshal those responses.


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

