### PR TITLE
daemon: Fix forceful switch to containerd image store

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -861,6 +861,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 
 	migrationThreshold := int64(-1)
 	isGraphDriver := func(driver string) (bool, error) {
+		if driver == "" {
+			if graphdriver.HasPriorDriver(config.Root) {
+				return true, nil
+			}
+		}
 		return graphdriver.IsRegistered(driver), nil
 	}
 	if enabled, ok := config.Features["containerd-snapshotter"]; (ok && !enabled) || os.Getenv("TEST_INTEGRATION_USE_GRAPHDRIVER") != "" {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1146,6 +1146,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			return nil, err
 		}
 
+		// NewStoreFromOptions will determine the driver if driverName is empty
+		// so we need to update the driverName to match the driver used.
+		driverName = layerStore.DriverName()
+
 		// Configure and validate the kernels security support. Note this is a Linux/FreeBSD
 		// operation only, so it is safe to pass *just* the runtime OS graphdriver.
 		if err := configureKernelSecuritySupport(&cfgStore.Config, layerStore.DriverName()); err != nil {
@@ -1344,6 +1348,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 
+	if driverName == "" {
+		return nil, errors.New("driverName is empty. Please report it as a bug! As a workaround, please set the storage driver explicitly")
+	}
+
 	driverContainers, ok := containers[driverName]
 	// Log containers which are not loaded with current driver
 	if (!ok && len(containers) > 0) || len(containers) > 1 {
@@ -1352,7 +1360,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 				continue
 			}
 			for id := range all {
-				log.G(ctx).WithField("container", id).Debugf("not restoring container because it was created with another storage driver (%s)", driver)
+				log.G(ctx).WithField("container", id).
+					WithField("driver", driver).
+					WithField("current_driver", driverName).
+					Debugf("not restoring container because it was created with another storage driver (%s)", driver)
 			}
 		}
 	}

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -232,6 +232,12 @@ func New(driverName string, config Options) (Driver, error) {
 	return nil, errors.Errorf("no supported storage driver found")
 }
 
+// HasPriorDriver returns true if any prior driver is found
+func HasPriorDriver(root string) bool {
+	driversMap := scanPriorDrivers(root)
+	return len(driversMap) > 0
+}
+
 // scanPriorDrivers returns an un-ordered scan of directories of prior storage
 // drivers. The 'vfs' storage driver is not taken into account, and ignored.
 func scanPriorDrivers(root string) map[string]bool {

--- a/integration/daemon/default_storage_test.go
+++ b/integration/daemon/default_storage_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/moby/moby/v2/testutil"
+	"github.com/moby/moby/v2/testutil/daemon"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+func TestDefaultStorageDriver(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows does not support running sub-daemons")
+	t.Setenv("DOCKER_DRIVER", "")
+	t.Setenv("DOCKER_GRAPHDRIVER", "")
+	t.Setenv("TEST_INTEGRATION_USE_GRAPHDRIVER", "")
+	_ = testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	defer d.Stop(t)
+
+	d.Start(t, "--iptables=false", "--ip6tables=false")
+
+	info := d.Info(t)
+	assert.Check(t, is.Equal(info.DriverStatus[0][1], "io.containerd.snapshotter.v1"))
+}
+
+// TestGraphDriverPersistence tests that when a daemon starts with graphdrivers,
+// then is restarted without explicit storage configuration, it continues to use
+// graphdrivers instead of migrating to containerd snapshotters automatically.
+func TestGraphDriverPersistence(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Windows does not support running sub-daemons")
+	t.Setenv("DOCKER_DRIVER", "")
+	t.Setenv("DOCKER_GRAPHDRIVER", "")
+	t.Setenv("TEST_INTEGRATION_USE_GRAPHDRIVER", "")
+	ctx := testutil.StartSpan(baseContext, t)
+
+	// Phase 1: Start daemon with explicit graphdriver (overlay2)
+	d := daemon.New(t)
+	t.Cleanup(func() {
+		d.Stop(t)
+	})
+
+	const testImage = "busybox:latest"
+	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false", "--storage-driver=overlay2")
+	c := d.NewClientT(t)
+
+	// Verify we're using graphdriver
+	info := d.Info(t)
+	assert.Check(t, info.DriverStatus[0][1] != "io.containerd.snapshotter.v1")
+	prevDriver := info.Driver
+
+	d.Stop(t)
+
+	// Phase 2: Start daemon again WITHOUT explicit graphdriver configuration
+	d.Start(t, "--iptables=false", "--ip6tables=false")
+
+	// Verify daemon still uses graphdriver (not containerd snapshotter)
+	// Verify we're using graphdriver
+	info = d.Info(t)
+	assert.Check(t, info.DriverStatus[0][1] != "io.containerd.snapshotter.v1")
+	assert.Check(t, is.Equal(info.Driver, prevDriver))
+
+	// Verify our image is still there
+	_, err := c.ImageInspect(ctx, testImage)
+	assert.NilError(t, err, "Test image should still be available after daemon restart")
+}


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/48009

### daemon: Fix forceful switch to containerd image store

When no explicit driver was specified, the containerd store by default was also applied to existing graphdriver setups.  Fix this and add a test. 


### daemon: Fix container restore with automatic driver selection 

Fix a bug causing containers not being loaded when storage driver wasn't chosen explicitly.  


---

Not released yet, so no changelog