### PR TITLE
[28.x] pkg/jsonmessage: JSONMessage: deprecate From, Time, and TimeNano fields

### DIFF
--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -151,9 +151,9 @@ type JSONMessage struct {
 	// Deprecated: this field is deprecated since docker v0.7.1 / API v1.8. Use the information in [Progress] instead. This field will be omitted in a future release.
 	ProgressMessage string     `json:"progress,omitempty"`
 	ID              string     `json:"id,omitempty"`
-	From            string     `json:"from,omitempty"`
-	Time            int64      `json:"time,omitempty"`
-	TimeNano        int64      `json:"timeNano,omitempty"`
+	From            string     `json:"from,omitempty"`     // Deprecated: this field is no longer set in stream responses and should not be used.
+	Time            int64      `json:"time,omitempty"`     // Deprecated: this field is no longer set in stream responses and should not be used.
+	TimeNano        int64      `json:"timeNano,omitempty"` // Deprecated: this field is no longer set in stream responses and should not be used.
 	Error           *JSONError `json:"errorDetail,omitempty"`
 
 	// ErrorMessage contains errors encountered during the operation.


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/50759
- https://github.com/moby/moby/pull/18888


On API version v1.22 and older, the `JSONMessage` was used to produce the `/events` response. However, commit 72f1881df102fce9ad31e98045b91c204dd44513 introduced an `events.Message` type that replaced the use of `JSONMessage` for that purpose.

The `JSONMessage` is no longer used to unmarshal these messages, and users of this package should not depend on these fields, and use the `events.Message` type instead for unmarshaling the `/events` response.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: pkg/jsonmessage: deprecate the `JSONMessage.From`, `JSONMessage.Time`, and `JSONMessage.TimeNano` fields, as they are no longer returned by the API for progress messages. Use the `events.Message` type instead to unmarshal the `/events` response.
```

**- A picture of a cute animal (not mandatory but encouraged)**

