### PR TITLE
api/types: move disk usage structs to daemon backend

### DIFF
--- a/api/types/build/disk_usage.go
+++ b/api/types/build/disk_usage.go
@@ -1,8 +1,0 @@
-package build
-
-// CacheDiskUsage contains disk usage for the build cache.
-type CacheDiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*CacheRecord
-}

--- a/api/types/container/disk_usage.go
+++ b/api/types/container/disk_usage.go
@@ -1,8 +1,0 @@
-package container
-
-// DiskUsage contains disk usage for containers.
-type DiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*Summary
-}

--- a/api/types/image/disk_usage.go
+++ b/api/types/image/disk_usage.go
@@ -1,8 +1,0 @@
-package image
-
-// DiskUsage contains disk usage for images.
-type DiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*Summary
-}

--- a/api/types/volume/disk_usage.go
+++ b/api/types/volume/disk_usage.go
@@ -1,8 +1,0 @@
-package volume
-
-// DiskUsage contains disk usage for volumes.
-type DiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*Volume
-}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -134,7 +134,7 @@ type Daemon struct {
 	seccompProfile     []byte
 	seccompProfilePath string
 
-	usageContainers singleflight.Group[struct{}, *containertypes.DiskUsage]
+	usageContainers singleflight.Group[struct{}, *backend.ContainerDiskUsage]
 	usageImages     singleflight.Group[struct{}, []*imagetypes.Summary]
 	usageVolumes    singleflight.Group[struct{}, *volumetypes.DiskUsage]
 	usageLayer      singleflight.Group[struct{}, int64]

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -38,7 +38,6 @@ import (
 	networktypes "github.com/moby/moby/api/types/network"
 	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/swarm"
-	volumetypes "github.com/moby/moby/api/types/volume"
 	"github.com/moby/sys/user"
 	"github.com/moby/sys/userns"
 	"github.com/pkg/errors"
@@ -136,7 +135,7 @@ type Daemon struct {
 
 	usageContainers singleflight.Group[struct{}, *backend.ContainerDiskUsage]
 	usageImages     singleflight.Group[struct{}, []*imagetypes.Summary]
-	usageVolumes    singleflight.Group[struct{}, *volumetypes.DiskUsage]
+	usageVolumes    singleflight.Group[struct{}, *backend.VolumeDiskUsage]
 	usageLayer      singleflight.Group[struct{}, int64]
 
 	pruneRunning atomic.Bool

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -70,14 +69,14 @@ func (daemon *Daemon) imageDiskUsage(ctx context.Context) ([]*image.Summary, err
 
 // localVolumesSize obtains information about volume disk usage from volumes service
 // and makes sure that only one size calculation is performed at the same time.
-func (daemon *Daemon) localVolumesSize(ctx context.Context) (*volume.DiskUsage, error) {
-	volumes, _, err := daemon.usageVolumes.Do(ctx, struct{}{}, func(ctx context.Context) (*volume.DiskUsage, error) {
+func (daemon *Daemon) localVolumesSize(ctx context.Context) (*backend.VolumeDiskUsage, error) {
+	volumes, _, err := daemon.usageVolumes.Do(ctx, struct{}{}, func(ctx context.Context) (*backend.VolumeDiskUsage, error) {
 		volumes, err := daemon.volumes.LocalVolumesSize(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		du := &volume.DiskUsage{Items: volumes}
+		du := &backend.VolumeDiskUsage{Items: volumes}
 		for _, v := range du.Items {
 			if v.UsageData.Size != -1 {
 				if v.UsageData.RefCount == 0 {

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -150,7 +150,7 @@ func (daemon *Daemon) SystemDiskUsage(ctx context.Context, opts backend.DiskUsag
 			}
 		}
 
-		du.Images = &image.DiskUsage{
+		du.Images = &backend.ImageDiskUsage{
 			TotalSize:   layersSize,
 			Reclaimable: reclaimable,
 			Items:       images,

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -15,8 +15,8 @@ import (
 
 // containerDiskUsage obtains information about container data disk usage
 // and makes sure that only one calculation is performed at the same time.
-func (daemon *Daemon) containerDiskUsage(ctx context.Context) (*container.DiskUsage, error) {
-	res, _, err := daemon.usageContainers.Do(ctx, struct{}{}, func(ctx context.Context) (*container.DiskUsage, error) {
+func (daemon *Daemon) containerDiskUsage(ctx context.Context) (*backend.ContainerDiskUsage, error) {
+	res, _, err := daemon.usageContainers.Do(ctx, struct{}{}, func(ctx context.Context) (*backend.ContainerDiskUsage, error) {
 		// Retrieve container list
 		containers, err := daemon.Containers(ctx, &container.ListOptions{
 			Size: true,
@@ -38,7 +38,7 @@ func (daemon *Daemon) containerDiskUsage(ctx context.Context) (*container.DiskUs
 				ctr.State == container.StateRestarting
 		}
 
-		du := &container.DiskUsage{Items: containers}
+		du := &backend.ContainerDiskUsage{Items: containers}
 		for _, ctr := range du.Items {
 			du.TotalSize += ctr.SizeRw
 			if !isActive(ctr) {

--- a/daemon/server/backend/disk_usage.go
+++ b/daemon/server/backend/disk_usage.go
@@ -22,7 +22,7 @@ type DiskUsageOptions struct {
 // DiskUsage contains the information returned by the backend for the
 // GET "/system/df" endpoint.
 type DiskUsage struct {
-	Images     *image.DiskUsage
+	Images     *ImageDiskUsage
 	Containers *ContainerDiskUsage
 	Volumes    *volume.DiskUsage
 	BuildCache *BuildCacheDiskUsage
@@ -40,4 +40,11 @@ type ContainerDiskUsage struct {
 	TotalSize   int64
 	Reclaimable int64
 	Items       []*container.Summary
+}
+
+// ImageDiskUsage contains disk usage for images.
+type ImageDiskUsage struct {
+	TotalSize   int64
+	Reclaimable int64
+	Items       []*image.Summary
 }

--- a/daemon/server/backend/disk_usage.go
+++ b/daemon/server/backend/disk_usage.go
@@ -23,7 +23,7 @@ type DiskUsageOptions struct {
 // GET "/system/df" endpoint.
 type DiskUsage struct {
 	Images     *image.DiskUsage
-	Containers *container.DiskUsage
+	Containers *ContainerDiskUsage
 	Volumes    *volume.DiskUsage
 	BuildCache *BuildCacheDiskUsage
 }
@@ -33,4 +33,11 @@ type BuildCacheDiskUsage struct {
 	TotalSize   int64
 	Reclaimable int64
 	Items       []*build.CacheRecord
+}
+
+// ContainerDiskUsage contains disk usage for containers.
+type ContainerDiskUsage struct {
+	TotalSize   int64
+	Reclaimable int64
+	Items       []*container.Summary
 }

--- a/daemon/server/backend/disk_usage.go
+++ b/daemon/server/backend/disk_usage.go
@@ -24,7 +24,7 @@ type DiskUsageOptions struct {
 type DiskUsage struct {
 	Images     *ImageDiskUsage
 	Containers *ContainerDiskUsage
-	Volumes    *volume.DiskUsage
+	Volumes    *VolumeDiskUsage
 	BuildCache *BuildCacheDiskUsage
 }
 
@@ -47,4 +47,11 @@ type ImageDiskUsage struct {
 	TotalSize   int64
 	Reclaimable int64
 	Items       []*image.Summary
+}
+
+// VolumeDiskUsage contains disk usage for volumes.
+type VolumeDiskUsage struct {
+	TotalSize   int64
+	Reclaimable int64
+	Items       []*volume.Volume
 }

--- a/daemon/server/backend/disk_usage.go
+++ b/daemon/server/backend/disk_usage.go
@@ -25,5 +25,12 @@ type DiskUsage struct {
 	Images     *image.DiskUsage
 	Containers *container.DiskUsage
 	Volumes    *volume.DiskUsage
-	BuildCache *build.CacheDiskUsage
+	BuildCache *BuildCacheDiskUsage
+}
+
+// BuildCacheDiskUsage contains disk usage for the build cache.
+type BuildCacheDiskUsage struct {
+	TotalSize   int64
+	Reclaimable int64
+	Items       []*build.CacheRecord
 }

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -237,7 +237,7 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 
 	du := backend.DiskUsage{}
 	if getBuildCache {
-		du.BuildCache = &buildtypes.CacheDiskUsage{
+		du.BuildCache = &backend.BuildCacheDiskUsage{
 			TotalSize: builderSize,
 			Items:     buildCache,
 		}

--- a/vendor/github.com/moby/moby/api/types/build/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/build/disk_usage.go
@@ -1,8 +1,0 @@
-package build
-
-// CacheDiskUsage contains disk usage for the build cache.
-type CacheDiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*CacheRecord
-}

--- a/vendor/github.com/moby/moby/api/types/container/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/container/disk_usage.go
@@ -1,8 +1,0 @@
-package container
-
-// DiskUsage contains disk usage for containers.
-type DiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*Summary
-}

--- a/vendor/github.com/moby/moby/api/types/image/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/image/disk_usage.go
@@ -1,8 +1,0 @@
-package image
-
-// DiskUsage contains disk usage for images.
-type DiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*Summary
-}

--- a/vendor/github.com/moby/moby/api/types/volume/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/volume/disk_usage.go
@@ -1,8 +1,0 @@
-package volume
-
-// DiskUsage contains disk usage for volumes.
-type DiskUsage struct {
-	TotalSize   int64
-	Reclaimable int64
-	Items       []*Volume
-}


### PR DESCRIPTION
**- What I did**
Partial for #50740 

This change moves the disk usage structs in `api/types/build`, `api/types/container`, `api/types/images` and `api/types/volumes` to backend server definitions where the code was actually used.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types: daemon: move the disk usage structs to the backend server
```

**- A picture of a cute animal (not mandatory but encouraged)**

