### PR TITLE
[28.x] api/types: deprecate disk usage types for build cache, container, ima…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -334,6 +334,11 @@ linters:
         path: "libnetwork/cmd/networkdb-test/dbclient"
         linters:
           - forbidigo
+      
+      # Ignore deprecated disk usage type warnings which will be moved internal to the daemon backend in the next major release.
+      - text: "SA1019: ((buildtypes|build).CacheDiskUsage|(container|containertypes|image|volume|volumetypes).DiskUsage) is deprecated"
+        linters:
+          - staticcheck
 
     # Log a warning if an exclusion rule is unused.
     # Default: false

--- a/api/types/build/disk_usage.go
+++ b/api/types/build/disk_usage.go
@@ -1,6 +1,8 @@
 package build
 
 // CacheDiskUsage contains disk usage for the build cache.
+//
+// Deprecated: this type is no longer used and will be removed in the next release.
 type CacheDiskUsage struct {
 	TotalSize   int64
 	Reclaimable int64

--- a/api/types/container/disk_usage.go
+++ b/api/types/container/disk_usage.go
@@ -1,6 +1,8 @@
 package container
 
 // DiskUsage contains disk usage for containers.
+//
+// Deprecated: this type is no longer used and will be removed in the next release.
 type DiskUsage struct {
 	TotalSize   int64
 	Reclaimable int64

--- a/api/types/image/disk_usage.go
+++ b/api/types/image/disk_usage.go
@@ -1,6 +1,8 @@
 package image
 
 // DiskUsage contains disk usage for images.
+//
+// Deprecated: this type is no longer used and will be removed in the next release.
 type DiskUsage struct {
 	TotalSize   int64
 	Reclaimable int64

--- a/api/types/volume/disk_usage.go
+++ b/api/types/volume/disk_usage.go
@@ -1,6 +1,8 @@
 package volume
 
 // DiskUsage contains disk usage for volumes.
+//
+// Deprecated: this type is no longer used and will be removed in the next release.
 type DiskUsage struct {
 	TotalSize   int64
 	Reclaimable int64


### PR DESCRIPTION
…ges, and volumes


**- What I did**

This change marks the disk usage structs in `api/types/build`, `api/types/container`, `api/types/images`,  and `api/types/volumes` as deprecated.

- related to https://github.com/moby/moby/pull/50764

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
Go SDK: api/types: `build.CacheDiskUsage`,  `container.DiskUsage`, `images.DiskUsage` and `volumes.DiskUsage` are now deprecated and will be removed in the next major release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

