### PR TITLE
api/types/container: move container resize options from api to client

### DIFF
--- a/api/types/container/options.go
+++ b/api/types/container/options.go
@@ -2,14 +2,6 @@ package container
 
 import "github.com/moby/moby/api/types/filters"
 
-// ResizeOptions holds parameters to resize a TTY.
-// It can be used to resize container TTYs and
-// exec process TTYs too.
-type ResizeOptions struct {
-	Height uint
-	Width  uint
-}
-
 // AttachOptions holds parameters to attach to a container.
 type AttachOptions struct {
 	Stream     bool

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -72,7 +72,7 @@ type ContainerAPIClient interface {
 	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error
+	ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
@@ -83,7 +83,7 @@ type ContainerAPIClient interface {
 	ContainerPause(ctx context.Context, container string) error
 	ContainerRemove(ctx context.Context, container string, options container.RemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
-	ContainerResize(ctx context.Context, container string, options container.ResizeOptions) error
+	ContainerResize(ctx context.Context, container string, options ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (StatsResponseReader, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -72,7 +72,7 @@ type ContainerAPIClient interface {
 	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error
+	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
@@ -83,7 +83,7 @@ type ContainerAPIClient interface {
 	ContainerPause(ctx context.Context, container string) error
 	ContainerRemove(ctx context.Context, container string, options container.RemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
-	ContainerResize(ctx context.Context, container string, options ResizeOptions) error
+	ContainerResize(ctx context.Context, container string, options ContainerResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (StatsResponseReader, error)

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -6,16 +6,16 @@ import (
 	"strconv"
 )
 
-// ResizeOptions holds parameters to resize a TTY.
+// ContainerResizeOptions holds parameters to resize a TTY.
 // It can be used to resize container TTYs and
 // exec process TTYs too.
-type ResizeOptions struct {
+type ContainerResizeOptions struct {
 	Height uint
 	Width  uint
 }
 
 // ContainerResize changes the size of the pseudo-TTY for a container.
-func (cli *Client) ContainerResize(ctx context.Context, containerID string, options ResizeOptions) error {
+func (cli *Client) ContainerResize(ctx context.Context, containerID string, options ContainerResizeOptions) error {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
 		return err
@@ -24,7 +24,7 @@ func (cli *Client) ContainerResize(ctx context.Context, containerID string, opti
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error {
+func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error {
 	execID, err := trimID("exec", execID)
 	if err != nil {
 		return err

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"net/url"
 	"strconv"
-
-	"github.com/moby/moby/api/types/container"
 )
 
+// ResizeOptions holds parameters to resize a TTY.
+// It can be used to resize container TTYs and
+// exec process TTYs too.
+type ResizeOptions struct {
+	Height uint
+	Width  uint
+}
+
 // ContainerResize changes the size of the pseudo-TTY for a container.
-func (cli *Client) ContainerResize(ctx context.Context, containerID string, options container.ResizeOptions) error {
+func (cli *Client) ContainerResize(ctx context.Context, containerID string, options ResizeOptions) error {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
 		return err
@@ -18,7 +24,7 @@ func (cli *Client) ContainerResize(ctx context.Context, containerID string, opti
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error {
+func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error {
 	execID, err := trimID("exec", execID)
 	if err != nil {
 		return err

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -17,14 +17,14 @@ func TestContainerResizeError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerResize(context.Background(), "container_id", ResizeOptions{})
+	err := client.ContainerResize(context.Background(), "container_id", ContainerResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.ContainerResize(context.Background(), "", ResizeOptions{})
+	err = client.ContainerResize(context.Background(), "", ContainerResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.ContainerResize(context.Background(), "    ", ResizeOptions{})
+	err = client.ContainerResize(context.Background(), "    ", ContainerResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -33,7 +33,7 @@ func TestContainerExecResizeError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerExecResize(context.Background(), "exec_id", ResizeOptions{})
+	err := client.ContainerExecResize(context.Background(), "exec_id", ContainerResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -42,18 +42,18 @@ func TestContainerResize(t *testing.T) {
 
 	tests := []struct {
 		doc                           string
-		opts                          ResizeOptions
+		opts                          ContainerResizeOptions
 		expectedHeight, expectedWidth string
 	}{
 		{
 			doc:            "zero width height", // valid, but not very useful
-			opts:           ResizeOptions{},
+			opts:           ContainerResizeOptions{},
 			expectedWidth:  "0",
 			expectedHeight: "0",
 		},
 		{
 			doc: "valid resize",
-			opts: ResizeOptions{
+			opts: ContainerResizeOptions{
 				Height: 500,
 				Width:  600,
 			},
@@ -62,7 +62,7 @@ func TestContainerResize(t *testing.T) {
 		},
 		{
 			doc: "larger than maxint64",
-			opts: ResizeOptions{
+			opts: ContainerResizeOptions{
 				Height: math.MaxInt64 + 1,
 				Width:  math.MaxInt64 + 2,
 			},
@@ -85,18 +85,18 @@ func TestContainerExecResize(t *testing.T) {
 	const expectedURL = "/exec/exec_id/resize"
 	tests := []struct {
 		doc                           string
-		opts                          ResizeOptions
+		opts                          ContainerResizeOptions
 		expectedHeight, expectedWidth string
 	}{
 		{
 			doc:            "zero width height", // valid, but not very useful
-			opts:           ResizeOptions{},
+			opts:           ContainerResizeOptions{},
 			expectedWidth:  "0",
 			expectedHeight: "0",
 		},
 		{
 			doc: "valid resize",
-			opts: ResizeOptions{
+			opts: ContainerResizeOptions{
 				Height: 500,
 				Width:  600,
 			},
@@ -105,7 +105,7 @@ func TestContainerExecResize(t *testing.T) {
 		},
 		{
 			doc: "larger than maxint64",
-			opts: ResizeOptions{
+			opts: ContainerResizeOptions{
 				Height: math.MaxInt64 + 1,
 				Width:  math.MaxInt64 + 2,
 			},

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -18,14 +17,14 @@ func TestContainerResizeError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerResize(context.Background(), "container_id", container.ResizeOptions{})
+	err := client.ContainerResize(context.Background(), "container_id", ResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.ContainerResize(context.Background(), "", container.ResizeOptions{})
+	err = client.ContainerResize(context.Background(), "", ResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.ContainerResize(context.Background(), "    ", container.ResizeOptions{})
+	err = client.ContainerResize(context.Background(), "    ", ResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -34,7 +33,7 @@ func TestContainerExecResizeError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	err := client.ContainerExecResize(context.Background(), "exec_id", container.ResizeOptions{})
+	err := client.ContainerExecResize(context.Background(), "exec_id", ResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -43,18 +42,18 @@ func TestContainerResize(t *testing.T) {
 
 	tests := []struct {
 		doc                           string
-		opts                          container.ResizeOptions
+		opts                          ResizeOptions
 		expectedHeight, expectedWidth string
 	}{
 		{
 			doc:            "zero width height", // valid, but not very useful
-			opts:           container.ResizeOptions{},
+			opts:           ResizeOptions{},
 			expectedWidth:  "0",
 			expectedHeight: "0",
 		},
 		{
 			doc: "valid resize",
-			opts: container.ResizeOptions{
+			opts: ResizeOptions{
 				Height: 500,
 				Width:  600,
 			},
@@ -63,7 +62,7 @@ func TestContainerResize(t *testing.T) {
 		},
 		{
 			doc: "larger than maxint64",
-			opts: container.ResizeOptions{
+			opts: ResizeOptions{
 				Height: math.MaxInt64 + 1,
 				Width:  math.MaxInt64 + 2,
 			},
@@ -86,18 +85,18 @@ func TestContainerExecResize(t *testing.T) {
 	const expectedURL = "/exec/exec_id/resize"
 	tests := []struct {
 		doc                           string
-		opts                          container.ResizeOptions
+		opts                          ResizeOptions
 		expectedHeight, expectedWidth string
 	}{
 		{
 			doc:            "zero width height", // valid, but not very useful
-			opts:           container.ResizeOptions{},
+			opts:           ResizeOptions{},
 			expectedWidth:  "0",
 			expectedHeight: "0",
 		},
 		{
 			doc: "valid resize",
-			opts: container.ResizeOptions{
+			opts: ResizeOptions{
 				Height: 500,
 				Width:  600,
 			},
@@ -106,7 +105,7 @@ func TestContainerExecResize(t *testing.T) {
 		},
 		{
 			doc: "larger than maxint64",
-			opts: container.ResizeOptions{
+			opts: ResizeOptions{
 				Height: math.MaxInt64 + 1,
 				Width:  math.MaxInt64 + 2,
 			},

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moby/moby/api/types/container"
 	eventtypes "github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/client"
 	eventstestutils "github.com/moby/moby/v2/daemon/events/testutils"
@@ -454,7 +453,7 @@ func (s *DockerCLIEventSuite) TestEventsResize(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	options := container.ResizeOptions{
+	options := client.ResizeOptions{
 		Height: 80,
 		Width:  24,
 	}

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -453,7 +453,7 @@ func (s *DockerCLIEventSuite) TestEventsResize(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	options := client.ResizeOptions{
+	options := client.ContainerResizeOptions{
 		Height: 80,
 		Width:  24,
 	}

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -13,6 +13,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/common"
 	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/testutil/fakecontext"
@@ -137,7 +138,7 @@ func TestExecResize(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("success", func(t *testing.T) {
-		err := apiClient.ContainerExecResize(ctx, execID, containertypes.ResizeOptions{
+		err := apiClient.ContainerExecResize(ctx, execID, client.ResizeOptions{
 			Height: 40,
 			Width:  40,
 		})
@@ -246,7 +247,7 @@ func TestExecResize(t *testing.T) {
 	})
 
 	t.Run("unknown execID", func(t *testing.T) {
-		err = apiClient.ContainerExecResize(ctx, "no-such-exec-id", containertypes.ResizeOptions{
+		err = apiClient.ContainerExecResize(ctx, "no-such-exec-id", client.ResizeOptions{
 			Height: 40,
 			Width:  40,
 		})
@@ -274,7 +275,7 @@ func TestExecResize(t *testing.T) {
 		err := apiClient.ContainerKill(ctx, cID, "SIGKILL")
 		assert.NilError(t, err)
 
-		err = apiClient.ContainerExecResize(ctx, execID, containertypes.ResizeOptions{
+		err = apiClient.ContainerExecResize(ctx, execID, client.ResizeOptions{
 			Height: 40,
 			Width:  40,
 		})

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -138,7 +138,7 @@ func TestExecResize(t *testing.T) {
 	assert.NilError(t, err)
 
 	t.Run("success", func(t *testing.T) {
-		err := apiClient.ContainerExecResize(ctx, execID, client.ResizeOptions{
+		err := apiClient.ContainerExecResize(ctx, execID, client.ContainerResizeOptions{
 			Height: 40,
 			Width:  40,
 		})
@@ -247,7 +247,7 @@ func TestExecResize(t *testing.T) {
 	})
 
 	t.Run("unknown execID", func(t *testing.T) {
-		err = apiClient.ContainerExecResize(ctx, "no-such-exec-id", client.ResizeOptions{
+		err = apiClient.ContainerExecResize(ctx, "no-such-exec-id", client.ContainerResizeOptions{
 			Height: 40,
 			Width:  40,
 		})
@@ -275,7 +275,7 @@ func TestExecResize(t *testing.T) {
 		err := apiClient.ContainerKill(ctx, cID, "SIGKILL")
 		assert.NilError(t, err)
 
-		err = apiClient.ContainerExecResize(ctx, execID, client.ResizeOptions{
+		err = apiClient.ContainerExecResize(ctx, execID, client.ContainerResizeOptions{
 			Height: 40,
 			Width:  40,
 		})

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -23,7 +23,7 @@ func TestResize(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cID := container.Run(ctx, t, apiClient, container.WithTty(true))
 		defer container.Remove(ctx, t, apiClient, cID, containertypes.RemoveOptions{Force: true})
-		err := apiClient.ContainerResize(ctx, cID, client.ResizeOptions{
+		err := apiClient.ContainerResize(ctx, cID, client.ContainerResizeOptions{
 			Height: 40,
 			Width:  40,
 		})
@@ -130,7 +130,7 @@ func TestResize(t *testing.T) {
 	t.Run("invalid state", func(t *testing.T) {
 		cID := container.Create(ctx, t, apiClient, container.WithCmd("echo"))
 		defer container.Remove(ctx, t, apiClient, cID, containertypes.RemoveOptions{Force: true})
-		err := apiClient.ContainerResize(ctx, cID, client.ResizeOptions{
+		err := apiClient.ContainerResize(ctx, cID, client.ContainerResizeOptions{
 			Height: 40,
 			Width:  40,
 		})

--- a/integration/container/resize_test.go
+++ b/integration/container/resize_test.go
@@ -9,6 +9,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/common"
 	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	req "github.com/moby/moby/v2/testutil/request"
 	"gotest.tools/v3/assert"
@@ -22,7 +23,7 @@ func TestResize(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		cID := container.Run(ctx, t, apiClient, container.WithTty(true))
 		defer container.Remove(ctx, t, apiClient, cID, containertypes.RemoveOptions{Force: true})
-		err := apiClient.ContainerResize(ctx, cID, containertypes.ResizeOptions{
+		err := apiClient.ContainerResize(ctx, cID, client.ResizeOptions{
 			Height: 40,
 			Width:  40,
 		})
@@ -129,7 +130,7 @@ func TestResize(t *testing.T) {
 	t.Run("invalid state", func(t *testing.T) {
 		cID := container.Create(ctx, t, apiClient, container.WithCmd("echo"))
 		defer container.Remove(ctx, t, apiClient, cID, containertypes.RemoveOptions{Force: true})
-		err := apiClient.ContainerResize(ctx, cID, containertypes.ResizeOptions{
+		err := apiClient.ContainerResize(ctx, cID, client.ResizeOptions{
 			Height: 40,
 			Width:  40,
 		})

--- a/vendor/github.com/moby/moby/api/types/container/options.go
+++ b/vendor/github.com/moby/moby/api/types/container/options.go
@@ -2,14 +2,6 @@ package container
 
 import "github.com/moby/moby/api/types/filters"
 
-// ResizeOptions holds parameters to resize a TTY.
-// It can be used to resize container TTYs and
-// exec process TTYs too.
-type ResizeOptions struct {
-	Height uint
-	Width  uint
-}
-
 // AttachOptions holds parameters to attach to a container.
 type AttachOptions struct {
 	Stream     bool

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -72,7 +72,7 @@ type ContainerAPIClient interface {
 	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error
+	ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
@@ -83,7 +83,7 @@ type ContainerAPIClient interface {
 	ContainerPause(ctx context.Context, container string) error
 	ContainerRemove(ctx context.Context, container string, options container.RemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
-	ContainerResize(ctx context.Context, container string, options container.ResizeOptions) error
+	ContainerResize(ctx context.Context, container string, options ResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (StatsResponseReader, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -72,7 +72,7 @@ type ContainerAPIClient interface {
 	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error
+	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
@@ -83,7 +83,7 @@ type ContainerAPIClient interface {
 	ContainerPause(ctx context.Context, container string) error
 	ContainerRemove(ctx context.Context, container string, options container.RemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
-	ContainerResize(ctx context.Context, container string, options ResizeOptions) error
+	ContainerResize(ctx context.Context, container string, options ContainerResizeOptions) error
 	ContainerRestart(ctx context.Context, container string, options container.StopOptions) error
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (StatsResponseReader, error)

--- a/vendor/github.com/moby/moby/client/container_resize.go
+++ b/vendor/github.com/moby/moby/client/container_resize.go
@@ -6,16 +6,16 @@ import (
 	"strconv"
 )
 
-// ResizeOptions holds parameters to resize a TTY.
+// ContainerResizeOptions holds parameters to resize a TTY.
 // It can be used to resize container TTYs and
 // exec process TTYs too.
-type ResizeOptions struct {
+type ContainerResizeOptions struct {
 	Height uint
 	Width  uint
 }
 
 // ContainerResize changes the size of the pseudo-TTY for a container.
-func (cli *Client) ContainerResize(ctx context.Context, containerID string, options ResizeOptions) error {
+func (cli *Client) ContainerResize(ctx context.Context, containerID string, options ContainerResizeOptions) error {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
 		return err
@@ -24,7 +24,7 @@ func (cli *Client) ContainerResize(ctx context.Context, containerID string, opti
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error {
+func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error {
 	execID, err := trimID("exec", execID)
 	if err != nil {
 		return err

--- a/vendor/github.com/moby/moby/client/container_resize.go
+++ b/vendor/github.com/moby/moby/client/container_resize.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"net/url"
 	"strconv"
-
-	"github.com/moby/moby/api/types/container"
 )
 
+// ResizeOptions holds parameters to resize a TTY.
+// It can be used to resize container TTYs and
+// exec process TTYs too.
+type ResizeOptions struct {
+	Height uint
+	Width  uint
+}
+
 // ContainerResize changes the size of the pseudo-TTY for a container.
-func (cli *Client) ContainerResize(ctx context.Context, containerID string, options container.ResizeOptions) error {
+func (cli *Client) ContainerResize(ctx context.Context, containerID string, options ResizeOptions) error {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
 		return err
@@ -18,7 +24,7 @@ func (cli *Client) ContainerResize(ctx context.Context, containerID string, opti
 }
 
 // ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options container.ResizeOptions) error {
+func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ResizeOptions) error {
 	execID, err := trimID("exec", execID)
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**
Partial for #50740 

This change moves the container resize options to the client module.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/container: move `ResizeOptions` type to `ContainerResizeOptions` in the client
```

**- A picture of a cute animal (not mandatory but encouraged)**

