### PR TITLE
api/types/events: move events list options from api to client

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -1,7 +1,5 @@
 package events
 
-import "github.com/moby/moby/api/types/filters"
-
 // Type is used for event-types.
 type Type string
 
@@ -129,11 +127,4 @@ type Message struct {
 
 	Time     int64 `json:"time,omitempty"`
 	TimeNano int64 `json:"timeNano,omitempty"`
-}
-
-// ListOptions holds parameters to filter events with.
-type ListOptions struct {
-	Since   string
-	Until   string
-	Filters filters.Args
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -186,7 +186,7 @@ type SwarmAPIClient interface {
 
 // SystemAPIClient defines API client methods for the system
 type SystemAPIClient interface {
-	Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error)
+	Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -186,7 +186,7 @@ type SwarmAPIClient interface {
 
 // SystemAPIClient defines API client methods for the system
 type SystemAPIClient interface {
-	Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error)
+	Events(ctx context.Context, options EventsListOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error)

--- a/client/system_events.go
+++ b/client/system_events.go
@@ -12,8 +12,8 @@ import (
 	"github.com/moby/moby/client/internal/timestamp"
 )
 
-// ListOptions holds parameters to filter events with.
-type ListOptions struct {
+// EventsListOptions holds parameters to filter events with.
+type EventsListOptions struct {
 	Since   string
 	Until   string
 	Filters filters.Args
@@ -23,7 +23,7 @@ type ListOptions struct {
 // by cancelling the context. Once the stream has been completely read an [io.EOF] error is
 // sent over the error channel. If an error is sent, all processing is stopped. It's up
 // to the caller to reopen the stream in the event of an error by reinvoking this method.
-func (cli *Client) Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error) {
+func (cli *Client) Events(ctx context.Context, options EventsListOptions) (<-chan events.Message, <-chan error) {
 	messages := make(chan events.Message)
 	errs := make(chan error, 1)
 
@@ -85,7 +85,7 @@ func (cli *Client) Events(ctx context.Context, options ListOptions) (<-chan even
 	return messages, errs
 }
 
-func buildEventsQueryParams(cliVersion string, options ListOptions) (url.Values, error) {
+func buildEventsQueryParams(cliVersion string, options EventsListOptions) (url.Values, error) {
 	query := url.Values{}
 	ref := time.Now()
 

--- a/client/system_events.go
+++ b/client/system_events.go
@@ -12,11 +12,18 @@ import (
 	"github.com/moby/moby/client/internal/timestamp"
 )
 
+// ListOptions holds parameters to filter events with.
+type ListOptions struct {
+	Since   string
+	Until   string
+	Filters filters.Args
+}
+
 // Events returns a stream of events in the daemon. It's up to the caller to close the stream
 // by cancelling the context. Once the stream has been completely read an [io.EOF] error is
 // sent over the error channel. If an error is sent, all processing is stopped. It's up
 // to the caller to reopen the stream in the event of an error by reinvoking this method.
-func (cli *Client) Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error) {
+func (cli *Client) Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error) {
 	messages := make(chan events.Message)
 	errs := make(chan error, 1)
 
@@ -78,7 +85,7 @@ func (cli *Client) Events(ctx context.Context, options events.ListOptions) (<-ch
 	return messages, errs
 }
 
-func buildEventsQueryParams(cliVersion string, options events.ListOptions) (url.Values, error) {
+func buildEventsQueryParams(cliVersion string, options ListOptions) (url.Values, error) {
 	query := url.Values{}
 	ref := time.Now()
 

--- a/client/system_events_test.go
+++ b/client/system_events_test.go
@@ -20,17 +20,17 @@ import (
 
 func TestEventsErrorInOptions(t *testing.T) {
 	errorCases := []struct {
-		options       ListOptions
+		options       EventsListOptions
 		expectedError string
 	}{
 		{
-			options: ListOptions{
+			options: EventsListOptions{
 				Since: "2006-01-02TZ",
 			},
 			expectedError: `parsing time "2006-01-02TZ"`,
 		},
 		{
-			options: ListOptions{
+			options: EventsListOptions{
 				Until: "2006-01-02TZ",
 			},
 			expectedError: `parsing time "2006-01-02TZ"`,
@@ -50,7 +50,7 @@ func TestEventsErrorFromServer(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, errs := client.Events(context.Background(), ListOptions{})
+	_, errs := client.Events(context.Background(), EventsListOptions{})
 	err := <-errs
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
@@ -62,13 +62,13 @@ func TestEvents(t *testing.T) {
 	expectedFiltersJSON := fmt.Sprintf(`{"type":{%q:true}}`, events.ContainerEventType)
 
 	eventsCases := []struct {
-		options             ListOptions
+		options             EventsListOptions
 		events              []events.Message
 		expectedEvents      map[string]bool
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: ListOptions{
+			options: EventsListOptions{
 				Filters: fltrs,
 			},
 			expectedQueryParams: map[string]string{
@@ -78,7 +78,7 @@ func TestEvents(t *testing.T) {
 			expectedEvents: make(map[string]bool),
 		},
 		{
-			options: ListOptions{
+			options: EventsListOptions{
 				Filters: fltrs,
 			},
 			expectedQueryParams: map[string]string{

--- a/client/system_events_test.go
+++ b/client/system_events_test.go
@@ -20,17 +20,17 @@ import (
 
 func TestEventsErrorInOptions(t *testing.T) {
 	errorCases := []struct {
-		options       events.ListOptions
+		options       ListOptions
 		expectedError string
 	}{
 		{
-			options: events.ListOptions{
+			options: ListOptions{
 				Since: "2006-01-02TZ",
 			},
 			expectedError: `parsing time "2006-01-02TZ"`,
 		},
 		{
-			options: events.ListOptions{
+			options: ListOptions{
 				Until: "2006-01-02TZ",
 			},
 			expectedError: `parsing time "2006-01-02TZ"`,
@@ -50,7 +50,7 @@ func TestEventsErrorFromServer(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, errs := client.Events(context.Background(), events.ListOptions{})
+	_, errs := client.Events(context.Background(), ListOptions{})
 	err := <-errs
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
@@ -62,13 +62,13 @@ func TestEvents(t *testing.T) {
 	expectedFiltersJSON := fmt.Sprintf(`{"type":{%q:true}}`, events.ContainerEventType)
 
 	eventsCases := []struct {
-		options             events.ListOptions
+		options             ListOptions
 		events              []events.Message
 		expectedEvents      map[string]bool
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: events.ListOptions{
+			options: ListOptions{
 				Filters: fltrs,
 			},
 			expectedQueryParams: map[string]string{
@@ -78,7 +78,7 @@ func TestEvents(t *testing.T) {
 			expectedEvents: make(map[string]bool),
 		},
 		{
-			options: events.ListOptions{
+			options: ListOptions{
 				Filters: fltrs,
 			},
 			expectedQueryParams: map[string]string{

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -766,7 +766,7 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 			assert.NilError(t, err)
 			buildLogs := out.String()
 
-			eventsChan, errs := apiClient.Events(ctx, client.ListOptions{
+			eventsChan, errs := apiClient.Events(ctx, client.EventsListOptions{
 				Since: since.Format(time.RFC3339Nano),
 				Until: time.Now().Format(time.RFC3339Nano),
 			})

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/testutil"
 	"github.com/moby/moby/v2/testutil/fakecontext"
@@ -765,7 +766,7 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 			assert.NilError(t, err)
 			buildLogs := out.String()
 
-			eventsChan, errs := apiClient.Events(ctx, events.ListOptions{
+			eventsChan, errs := apiClient.Events(ctx, client.ListOptions{
 				Since: since.Format(time.RFC3339Nano),
 				Until: time.Now().Format(time.RFC3339Nano),
 			})

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -9,6 +9,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/filters"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/testutil/request"
 	"gotest.tools/v3/assert"
@@ -40,7 +41,7 @@ func TestPause(t *testing.T) {
 
 	until := request.DaemonUnixTime(ctx, t, apiClient, testEnv)
 
-	messages, errs := apiClient.Events(ctx, events.ListOptions{
+	messages, errs := apiClient.Events(ctx, client.ListOptions{
 		Since:   since,
 		Until:   until,
 		Filters: filters.NewArgs(filters.Arg(string(events.ContainerEventType), cID)),

--- a/integration/container/pause_test.go
+++ b/integration/container/pause_test.go
@@ -41,7 +41,7 @@ func TestPause(t *testing.T) {
 
 	until := request.DaemonUnixTime(ctx, t, apiClient, testEnv)
 
-	messages, errs := apiClient.Events(ctx, client.ListOptions{
+	messages, errs := apiClient.Events(ctx, client.EventsListOptions{
 		Since:   since,
 		Until:   until,
 		Filters: filters.NewArgs(filters.Arg(string(events.ContainerEventType), cID)),

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -241,7 +241,7 @@ func TestContainerRestartWithCancelledRequest(t *testing.T) {
 	}()
 
 	// Start listening for events.
-	messages, errs := apiClient.Events(ctx, events.ListOptions{
+	messages, errs := apiClient.Events(ctx, client.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("container", cID),
 			filters.Arg("event", string(events.ActionRestart)),

--- a/integration/container/restart_test.go
+++ b/integration/container/restart_test.go
@@ -241,7 +241,7 @@ func TestContainerRestartWithCancelledRequest(t *testing.T) {
 	}()
 
 	// Start listening for events.
-	messages, errs := apiClient.Events(ctx, client.ListOptions{
+	messages, errs := apiClient.Events(ctx, client.EventsListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("container", cID),
 			filters.Arg("event", string(events.ActionRestart)),

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -273,12 +273,12 @@ func TestAuthZPluginAllowEventStream(t *testing.T) {
 	assertURIRecorded(t, ctrl.requestsURIs, fmt.Sprintf("/containers/%s/start", cID))
 }
 
-func systemTime(ctx context.Context, t *testing.T, client client.APIClient, testEnv *environment.Execution) time.Time {
+func systemTime(ctx context.Context, t *testing.T, apiClient client.APIClient, testEnv *environment.Execution) time.Time {
 	if testEnv.IsLocalDaemon() {
 		return time.Now()
 	}
 
-	info, err := client.Info(ctx)
+	info, err := apiClient.Info(ctx)
 	assert.NilError(t, err)
 
 	dt, err := time.Parse(time.RFC3339Nano, info.SystemTime)
@@ -286,12 +286,12 @@ func systemTime(ctx context.Context, t *testing.T, client client.APIClient, test
 	return dt
 }
 
-func systemEventsSince(ctx context.Context, client client.APIClient, since string) (<-chan eventtypes.Message, <-chan error, func()) {
+func systemEventsSince(ctx context.Context, apiClient client.APIClient, since string) (<-chan eventtypes.Message, <-chan error, func()) {
 	eventOptions := eventtypes.ListOptions{
 		Since: since,
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	events, errs := client.Events(ctx, eventOptions)
+	events, errs := apiClient.Events(ctx, eventOptions)
 
 	return events, errs, cancel
 }
@@ -454,7 +454,7 @@ func imageLoad(ctx context.Context, apiClient client.APIClient, path string) err
 	return nil
 }
 
-func imageImport(ctx context.Context, client client.APIClient, path string) error {
+func imageImport(ctx context.Context, apiClient client.APIClient, path string) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err
@@ -466,7 +466,7 @@ func imageImport(ctx context.Context, client client.APIClient, path string) erro
 		Source:     file,
 		SourceName: "-",
 	}
-	responseReader, err := client.ImageImport(ctx, source, ref, options)
+	responseReader, err := apiClient.ImageImport(ctx, source, ref, options)
 	if err != nil {
 		return err
 	}

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -287,7 +287,7 @@ func systemTime(ctx context.Context, t *testing.T, apiClient client.APIClient, t
 }
 
 func systemEventsSince(ctx context.Context, apiClient client.APIClient, since string) (<-chan eventtypes.Message, <-chan error, func()) {
-	eventOptions := eventtypes.ListOptions{
+	eventOptions := client.ListOptions{
 		Since: since,
 	}
 	ctx, cancel := context.WithCancel(ctx)

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -287,7 +287,7 @@ func systemTime(ctx context.Context, t *testing.T, apiClient client.APIClient, t
 }
 
 func systemEventsSince(ctx context.Context, apiClient client.APIClient, since string) (<-chan eventtypes.Message, <-chan error, func()) {
-	eventOptions := client.ListOptions{
+	eventOptions := client.EventsListOptions{
 		Since: since,
 	}
 	ctx, cancel := context.WithCancel(ctx)

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/volume"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/testutil/request"
 	"gotest.tools/v3/assert"
@@ -32,7 +33,7 @@ func TestEventsExecDie(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	msg, errs := apiClient.Events(ctx, events.ListOptions{
+	msg, errs := apiClient.Events(ctx, client.ListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("container", cID),
 			filters.Arg("event", string(events.ActionExecDie)),
@@ -113,7 +114,7 @@ func TestEventsVolumeCreate(t *testing.T) {
 		filters.Arg("event", "create"),
 		filters.Arg("volume", volName),
 	)
-	messages, errs := apiClient.Events(ctx, events.ListOptions{
+	messages, errs := apiClient.Events(ctx, client.ListOptions{
 		Since:   since,
 		Until:   request.DaemonUnixTime(ctx, t, apiClient, testEnv),
 		Filters: filter,
@@ -129,7 +130,7 @@ func TestEventsVolumeCreate(t *testing.T) {
 		Target: "/tmp/foo",
 	}))
 
-	messages, errs = apiClient.Events(ctx, events.ListOptions{
+	messages, errs = apiClient.Events(ctx, client.ListOptions{
 		Since:   since,
 		Until:   request.DaemonUnixTime(ctx, t, apiClient, testEnv),
 		Filters: filter,

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -33,7 +33,7 @@ func TestEventsExecDie(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	msg, errs := apiClient.Events(ctx, client.ListOptions{
+	msg, errs := apiClient.Events(ctx, client.EventsListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("container", cID),
 			filters.Arg("event", string(events.ActionExecDie)),
@@ -114,7 +114,7 @@ func TestEventsVolumeCreate(t *testing.T) {
 		filters.Arg("event", "create"),
 		filters.Arg("volume", volName),
 	)
-	messages, errs := apiClient.Events(ctx, client.ListOptions{
+	messages, errs := apiClient.Events(ctx, client.EventsListOptions{
 		Since:   since,
 		Until:   request.DaemonUnixTime(ctx, t, apiClient, testEnv),
 		Filters: filter,
@@ -130,7 +130,7 @@ func TestEventsVolumeCreate(t *testing.T) {
 		Target: "/tmp/foo",
 	}))
 
-	messages, errs = apiClient.Events(ctx, client.ListOptions{
+	messages, errs = apiClient.Events(ctx, client.EventsListOptions{
 		Since:   since,
 		Until:   request.DaemonUnixTime(ctx, t, apiClient, testEnv),
 		Filters: filter,

--- a/vendor/github.com/moby/moby/api/types/events/events.go
+++ b/vendor/github.com/moby/moby/api/types/events/events.go
@@ -1,7 +1,5 @@
 package events
 
-import "github.com/moby/moby/api/types/filters"
-
 // Type is used for event-types.
 type Type string
 
@@ -129,11 +127,4 @@ type Message struct {
 
 	Time     int64 `json:"time,omitempty"`
 	TimeNano int64 `json:"timeNano,omitempty"`
-}
-
-// ListOptions holds parameters to filter events with.
-type ListOptions struct {
-	Since   string
-	Until   string
-	Filters filters.Args
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -186,7 +186,7 @@ type SwarmAPIClient interface {
 
 // SystemAPIClient defines API client methods for the system
 type SystemAPIClient interface {
-	Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error)
+	Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -186,7 +186,7 @@ type SwarmAPIClient interface {
 
 // SystemAPIClient defines API client methods for the system
 type SystemAPIClient interface {
-	Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error)
+	Events(ctx context.Context, options EventsListOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
 	DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error)

--- a/vendor/github.com/moby/moby/client/system_events.go
+++ b/vendor/github.com/moby/moby/client/system_events.go
@@ -12,8 +12,8 @@ import (
 	"github.com/moby/moby/client/internal/timestamp"
 )
 
-// ListOptions holds parameters to filter events with.
-type ListOptions struct {
+// EventsListOptions holds parameters to filter events with.
+type EventsListOptions struct {
 	Since   string
 	Until   string
 	Filters filters.Args
@@ -23,7 +23,7 @@ type ListOptions struct {
 // by cancelling the context. Once the stream has been completely read an [io.EOF] error is
 // sent over the error channel. If an error is sent, all processing is stopped. It's up
 // to the caller to reopen the stream in the event of an error by reinvoking this method.
-func (cli *Client) Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error) {
+func (cli *Client) Events(ctx context.Context, options EventsListOptions) (<-chan events.Message, <-chan error) {
 	messages := make(chan events.Message)
 	errs := make(chan error, 1)
 
@@ -85,7 +85,7 @@ func (cli *Client) Events(ctx context.Context, options ListOptions) (<-chan even
 	return messages, errs
 }
 
-func buildEventsQueryParams(cliVersion string, options ListOptions) (url.Values, error) {
+func buildEventsQueryParams(cliVersion string, options EventsListOptions) (url.Values, error) {
 	query := url.Values{}
 	ref := time.Now()
 

--- a/vendor/github.com/moby/moby/client/system_events.go
+++ b/vendor/github.com/moby/moby/client/system_events.go
@@ -12,11 +12,18 @@ import (
 	"github.com/moby/moby/client/internal/timestamp"
 )
 
+// ListOptions holds parameters to filter events with.
+type ListOptions struct {
+	Since   string
+	Until   string
+	Filters filters.Args
+}
+
 // Events returns a stream of events in the daemon. It's up to the caller to close the stream
 // by cancelling the context. Once the stream has been completely read an [io.EOF] error is
 // sent over the error channel. If an error is sent, all processing is stopped. It's up
 // to the caller to reopen the stream in the event of an error by reinvoking this method.
-func (cli *Client) Events(ctx context.Context, options events.ListOptions) (<-chan events.Message, <-chan error) {
+func (cli *Client) Events(ctx context.Context, options ListOptions) (<-chan events.Message, <-chan error) {
 	messages := make(chan events.Message)
 	errs := make(chan error, 1)
 
@@ -78,7 +85,7 @@ func (cli *Client) Events(ctx context.Context, options events.ListOptions) (<-ch
 	return messages, errs
 }
 
-func buildEventsQueryParams(cliVersion string, options events.ListOptions) (url.Values, error) {
+func buildEventsQueryParams(cliVersion string, options ListOptions) (url.Values, error) {
 	query := url.Values{}
 	ref := time.Now()
 


### PR DESCRIPTION
**- What I did**
Partial for https://github.com/moby/moby/issues/50740

This change moves events list options into client mod.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/events: move `ListOptions` type to the client `EventsListOptions`
```

**- A picture of a cute animal (not mandatory but encouraged)**

