### PR TITLE
api/types/registry: move auth config functions to pkg

### DIFF
--- a/api/pkg/authconfig/authconfig.go
+++ b/api/pkg/authconfig/authconfig.go
@@ -1,0 +1,92 @@
+package authconfig
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/moby/moby/api/types/registry"
+)
+
+// Encode serializes the auth configuration as a base64url encoded
+// ([RFC4648, section 5]) JSON string for sending through the X-Registry-Auth header.
+//
+// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
+func Encode(authConfig registry.AuthConfig) (string, error) {
+	// Older daemons (or registries) may not handle an empty string,
+	// which resulted in an "io.EOF" when unmarshaling or decoding.
+	//
+	// FIXME(thaJeztah): find exactly what code-paths are impacted by this.
+	// if authConfig == (AuthConfig{}) { return "", nil }
+	buf, err := json.Marshal(authConfig)
+	if err != nil {
+		return "", errInvalidParameter{err}
+	}
+	return base64.URLEncoding.EncodeToString(buf), nil
+}
+
+// Decode decodes base64url encoded ([RFC4648, section 5]) JSON
+// authentication information as sent through the X-Registry-Auth header.
+//
+// This function always returns an [AuthConfig], even if an error occurs. It is up
+// to the caller to decide if authentication is required, and if the error can
+// be ignored.
+//
+// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
+func Decode(authEncoded string) (*registry.AuthConfig, error) {
+	if authEncoded == "" {
+		return &registry.AuthConfig{}, nil
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(authEncoded)
+	if err != nil {
+		var e base64.CorruptInputError
+		if errors.As(err, &e) {
+			return &registry.AuthConfig{}, invalid(errors.New("must be a valid base64url-encoded string"))
+		}
+		return &registry.AuthConfig{}, invalid(err)
+	}
+
+	if bytes.Equal(decoded, []byte("{}")) {
+		return &registry.AuthConfig{}, nil
+	}
+
+	return decode(bytes.NewReader(decoded))
+}
+
+// DecodeRequestBody decodes authentication information as sent as JSON in the
+// body of a request. This function is to provide backward compatibility with old
+// clients and API versions. Current clients and API versions expect authentication
+// to be provided through the X-Registry-Auth header.
+//
+// Like [Decode], this function always returns an [AuthConfig], even if an
+// error occurs. It is up to the caller to decide if authentication is required,
+// and if the error can be ignored.
+func DecodeRequestBody(r io.ReadCloser) (*registry.AuthConfig, error) {
+	return decode(r)
+}
+
+func decode(r io.Reader) (*registry.AuthConfig, error) {
+	authConfig := &registry.AuthConfig{}
+	if err := json.NewDecoder(r).Decode(authConfig); err != nil {
+		// always return an (empty) AuthConfig to increase compatibility with
+		// the existing API.
+		return &registry.AuthConfig{}, invalid(fmt.Errorf("invalid JSON: %w", err))
+	}
+	return authConfig, nil
+}
+
+func invalid(err error) error {
+	return errInvalidParameter{fmt.Errorf("invalid X-Registry-Auth header: %w", err)}
+}
+
+type errInvalidParameter struct{ error }
+
+func (errInvalidParameter) InvalidParameter() {}
+
+func (e errInvalidParameter) Cause() error { return e.error }
+
+func (e errInvalidParameter) Unwrap() error { return e.error }

--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -1,14 +1,6 @@
 package registry
 
-import (
-	"bytes"
-	"context"
-	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-)
+import "context"
 
 // AuthHeader is the name of the header used to send encoded registry
 // authorization credentials for registry operations (push/pull).
@@ -46,85 +38,3 @@ type AuthConfig struct {
 	// RegistryToken is a bearer token to be sent to a registry
 	RegistryToken string `json:"registrytoken,omitempty"`
 }
-
-// EncodeAuthConfig serializes the auth configuration as a base64url encoded
-// ([RFC4648, section 5]) JSON string for sending through the X-Registry-Auth header.
-//
-// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
-func EncodeAuthConfig(authConfig AuthConfig) (string, error) {
-	// Older daemons (or registries) may not handle an empty string,
-	// which resulted in an "io.EOF" when unmarshaling or decoding.
-	//
-	// FIXME(thaJeztah): find exactly what code-paths are impacted by this.
-	// if authConfig == (AuthConfig{}) { return "", nil }
-	buf, err := json.Marshal(authConfig)
-	if err != nil {
-		return "", errInvalidParameter{err}
-	}
-	return base64.URLEncoding.EncodeToString(buf), nil
-}
-
-// DecodeAuthConfig decodes base64url encoded ([RFC4648, section 5]) JSON
-// authentication information as sent through the X-Registry-Auth header.
-//
-// This function always returns an [AuthConfig], even if an error occurs. It is up
-// to the caller to decide if authentication is required, and if the error can
-// be ignored.
-//
-// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
-func DecodeAuthConfig(authEncoded string) (*AuthConfig, error) {
-	if authEncoded == "" {
-		return &AuthConfig{}, nil
-	}
-
-	decoded, err := base64.URLEncoding.DecodeString(authEncoded)
-	if err != nil {
-		var e base64.CorruptInputError
-		if errors.As(err, &e) {
-			return &AuthConfig{}, invalid(errors.New("must be a valid base64url-encoded string"))
-		}
-		return &AuthConfig{}, invalid(err)
-	}
-
-	if bytes.Equal(decoded, []byte("{}")) {
-		return &AuthConfig{}, nil
-	}
-
-	return decodeAuthConfigFromReader(bytes.NewReader(decoded))
-}
-
-// DecodeAuthConfigBody decodes authentication information as sent as JSON in the
-// body of a request. This function is to provide backward compatibility with old
-// clients and API versions. Current clients and API versions expect authentication
-// to be provided through the X-Registry-Auth header.
-//
-// Like [DecodeAuthConfig], this function always returns an [AuthConfig], even if an
-// error occurs. It is up to the caller to decide if authentication is required,
-// and if the error can be ignored.
-//
-// Deprecated: this function is no longer used and will be removed in the next release.
-func DecodeAuthConfigBody(rdr io.ReadCloser) (*AuthConfig, error) {
-	return decodeAuthConfigFromReader(rdr)
-}
-
-func decodeAuthConfigFromReader(rdr io.Reader) (*AuthConfig, error) {
-	authConfig := &AuthConfig{}
-	if err := json.NewDecoder(rdr).Decode(authConfig); err != nil {
-		// always return an (empty) AuthConfig to increase compatibility with
-		// the existing API.
-		return &AuthConfig{}, invalid(fmt.Errorf("invalid JSON: %w", err))
-	}
-	return authConfig, nil
-}
-
-func invalid(err error) error {
-	return errInvalidParameter{fmt.Errorf("invalid X-Registry-Auth header: %w", err)}
-}
-
-type errInvalidParameter struct{ error }
-
-func (errInvalidParameter) InvalidParameter() {}
-
-func (e errInvalidParameter) Cause() error { return e.error }
-
-func (e errInvalidParameter) Unwrap() error { return e.error }

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -2,13 +2,10 @@ package cluster
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/containerd/log"
@@ -232,9 +229,9 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 			// retrieve auth config from encoded auth
 			authConfig := &registry.AuthConfig{}
 			if encodedAuth != "" {
-				authReader := strings.NewReader(encodedAuth)
-				dec := json.NewDecoder(base64.NewDecoder(base64.URLEncoding, authReader))
-				if err := dec.Decode(authConfig); err != nil {
+				var err error
+				authConfig, err = registry.DecodeAuthConfig(encodedAuth)
+				if err != nil {
 					log.G(ctx).Warnf("invalid authconfig: %v", err)
 				}
 			}
@@ -350,7 +347,9 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swa
 			// retrieve auth config from encoded auth
 			authConfig := &registry.AuthConfig{}
 			if encodedAuth != "" {
-				if err := json.NewDecoder(base64.NewDecoder(base64.URLEncoding, strings.NewReader(encodedAuth))).Decode(authConfig); err != nil {
+				var err error
+				authConfig, err = registry.DecodeAuthConfig(encodedAuth)
+				if err != nil {
 					log.G(ctx).Warnf("invalid authconfig: %v", err)
 				}
 			}

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/swarm"
@@ -230,7 +231,7 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 			authConfig := &registry.AuthConfig{}
 			if encodedAuth != "" {
 				var err error
-				authConfig, err = registry.DecodeAuthConfig(encodedAuth)
+				authConfig, err = authconfig.Decode(encodedAuth)
 				if err != nil {
 					log.G(ctx).Warnf("invalid authconfig: %v", err)
 				}
@@ -348,7 +349,7 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swa
 			authConfig := &registry.AuthConfig{}
 			if encodedAuth != "" {
 				var err error
-				authConfig, err = registry.DecodeAuthConfig(encodedAuth)
+				authConfig, err = authconfig.Decode(encodedAuth)
 				if err != nil {
 					log.G(ctx).Warnf("invalid authconfig: %v", err)
 				}

--- a/daemon/server/router/distribution/distribution_routes.go
+++ b/daemon/server/router/distribution/distribution_routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/types/registry"
 	distributionpkg "github.com/moby/moby/v2/daemon/internal/distribution"
 	"github.com/moby/moby/v2/daemon/server/httputils"
@@ -42,7 +43,7 @@ func (dr *distributionRouter) getDistributionInfo(ctx context.Context, w http.Re
 
 	// For a search it is not an error if no auth was given. Ignore invalid
 	// AuthConfig to increase compatibility with the existing API.
-	authConfig, _ := registry.DecodeAuthConfig(r.Header.Get(registry.AuthHeader))
+	authConfig, _ := authconfig.Decode(r.Header.Get(registry.AuthHeader))
 	repos, err := dr.backend.GetRepositories(ctx, namedRef, authConfig)
 	if err != nil {
 		return err

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/pkg/progress"
 	"github.com/moby/moby/api/pkg/streamformatter"
 	"github.com/moby/moby/api/types/filters"
@@ -101,7 +102,7 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 		// AuthConfig to increase compatibility with the existing API.
 		//
 		// TODO(thaJeztah): accept empty values but return an error when failing to decode.
-		authConfig, _ := registry.DecodeAuthConfig(r.Header.Get(registry.AuthHeader))
+		authConfig, _ := authconfig.Decode(r.Header.Get(registry.AuthHeader))
 		progressErr = ir.backend.PullImage(ctx, ref, platform, metaHeaders, authConfig, output)
 	} else { // import
 		src := r.Form.Get("fromSrc")
@@ -170,7 +171,7 @@ func (ir *imageRouter) postImagesPush(ctx context.Context, w http.ResponseWriter
 	// to increase compatibility with the existing API.
 	//
 	// TODO(thaJeztah): accept empty values but return an error when failing to decode.
-	authConfig, _ := registry.DecodeAuthConfig(r.Header.Get(registry.AuthHeader))
+	authConfig, _ := authconfig.Decode(r.Header.Get(registry.AuthHeader))
 
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()
@@ -554,7 +555,7 @@ func (ir *imageRouter) getImagesSearch(ctx context.Context, w http.ResponseWrite
 
 	// For a search it is not an error if no auth was given. Ignore invalid
 	// AuthConfig to increase compatibility with the existing API.
-	authConfig, _ := registry.DecodeAuthConfig(r.Header.Get(registry.AuthHeader))
+	authConfig, _ := authconfig.Decode(r.Header.Get(registry.AuthHeader))
 
 	headers := http.Header{}
 	for k, v := range r.Header {

--- a/daemon/server/router/plugin/plugin_routes.go
+++ b/daemon/server/router/plugin/plugin_routes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/pkg/streamformatter"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/plugin"
@@ -26,7 +27,7 @@ func parseHeaders(headers http.Header) (map[string][]string, *registry.AuthConfi
 	}
 
 	// Ignore invalid AuthConfig to increase compatibility with the existing API.
-	authConfig, _ := registry.DecodeAuthConfig(headers.Get(registry.AuthHeader))
+	authConfig, _ := authconfig.Decode(headers.Get(registry.AuthHeader))
 	return metaHeaders, authConfig
 }
 

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/moby/moby/api/pkg/authconfig"
 	buildtypes "github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/filters"
@@ -373,9 +374,7 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 }
 
 func (s *systemRouter) postAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	var config *registry.AuthConfig
-	err := json.NewDecoder(r.Body).Decode(&config)
-	r.Body.Close()
+	config, err := authconfig.DecodeRequestBody(r.Body)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/moby/moby/api/pkg/authconfig/authconfig.go
+++ b/vendor/github.com/moby/moby/api/pkg/authconfig/authconfig.go
@@ -1,0 +1,92 @@
+package authconfig
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/moby/moby/api/types/registry"
+)
+
+// Encode serializes the auth configuration as a base64url encoded
+// ([RFC4648, section 5]) JSON string for sending through the X-Registry-Auth header.
+//
+// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
+func Encode(authConfig registry.AuthConfig) (string, error) {
+	// Older daemons (or registries) may not handle an empty string,
+	// which resulted in an "io.EOF" when unmarshaling or decoding.
+	//
+	// FIXME(thaJeztah): find exactly what code-paths are impacted by this.
+	// if authConfig == (AuthConfig{}) { return "", nil }
+	buf, err := json.Marshal(authConfig)
+	if err != nil {
+		return "", errInvalidParameter{err}
+	}
+	return base64.URLEncoding.EncodeToString(buf), nil
+}
+
+// Decode decodes base64url encoded ([RFC4648, section 5]) JSON
+// authentication information as sent through the X-Registry-Auth header.
+//
+// This function always returns an [AuthConfig], even if an error occurs. It is up
+// to the caller to decide if authentication is required, and if the error can
+// be ignored.
+//
+// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
+func Decode(authEncoded string) (*registry.AuthConfig, error) {
+	if authEncoded == "" {
+		return &registry.AuthConfig{}, nil
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(authEncoded)
+	if err != nil {
+		var e base64.CorruptInputError
+		if errors.As(err, &e) {
+			return &registry.AuthConfig{}, invalid(errors.New("must be a valid base64url-encoded string"))
+		}
+		return &registry.AuthConfig{}, invalid(err)
+	}
+
+	if bytes.Equal(decoded, []byte("{}")) {
+		return &registry.AuthConfig{}, nil
+	}
+
+	return decode(bytes.NewReader(decoded))
+}
+
+// DecodeRequestBody decodes authentication information as sent as JSON in the
+// body of a request. This function is to provide backward compatibility with old
+// clients and API versions. Current clients and API versions expect authentication
+// to be provided through the X-Registry-Auth header.
+//
+// Like [Decode], this function always returns an [AuthConfig], even if an
+// error occurs. It is up to the caller to decide if authentication is required,
+// and if the error can be ignored.
+func DecodeRequestBody(r io.ReadCloser) (*registry.AuthConfig, error) {
+	return decode(r)
+}
+
+func decode(r io.Reader) (*registry.AuthConfig, error) {
+	authConfig := &registry.AuthConfig{}
+	if err := json.NewDecoder(r).Decode(authConfig); err != nil {
+		// always return an (empty) AuthConfig to increase compatibility with
+		// the existing API.
+		return &registry.AuthConfig{}, invalid(fmt.Errorf("invalid JSON: %w", err))
+	}
+	return authConfig, nil
+}
+
+func invalid(err error) error {
+	return errInvalidParameter{fmt.Errorf("invalid X-Registry-Auth header: %w", err)}
+}
+
+type errInvalidParameter struct{ error }
+
+func (errInvalidParameter) InvalidParameter() {}
+
+func (e errInvalidParameter) Cause() error { return e.error }
+
+func (e errInvalidParameter) Unwrap() error { return e.error }

--- a/vendor/github.com/moby/moby/api/types/registry/authconfig.go
+++ b/vendor/github.com/moby/moby/api/types/registry/authconfig.go
@@ -1,14 +1,6 @@
 package registry
 
-import (
-	"bytes"
-	"context"
-	"encoding/base64"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-)
+import "context"
 
 // AuthHeader is the name of the header used to send encoded registry
 // authorization credentials for registry operations (push/pull).
@@ -46,85 +38,3 @@ type AuthConfig struct {
 	// RegistryToken is a bearer token to be sent to a registry
 	RegistryToken string `json:"registrytoken,omitempty"`
 }
-
-// EncodeAuthConfig serializes the auth configuration as a base64url encoded
-// ([RFC4648, section 5]) JSON string for sending through the X-Registry-Auth header.
-//
-// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
-func EncodeAuthConfig(authConfig AuthConfig) (string, error) {
-	// Older daemons (or registries) may not handle an empty string,
-	// which resulted in an "io.EOF" when unmarshaling or decoding.
-	//
-	// FIXME(thaJeztah): find exactly what code-paths are impacted by this.
-	// if authConfig == (AuthConfig{}) { return "", nil }
-	buf, err := json.Marshal(authConfig)
-	if err != nil {
-		return "", errInvalidParameter{err}
-	}
-	return base64.URLEncoding.EncodeToString(buf), nil
-}
-
-// DecodeAuthConfig decodes base64url encoded ([RFC4648, section 5]) JSON
-// authentication information as sent through the X-Registry-Auth header.
-//
-// This function always returns an [AuthConfig], even if an error occurs. It is up
-// to the caller to decide if authentication is required, and if the error can
-// be ignored.
-//
-// [RFC4648, section 5]: https://tools.ietf.org/html/rfc4648#section-5
-func DecodeAuthConfig(authEncoded string) (*AuthConfig, error) {
-	if authEncoded == "" {
-		return &AuthConfig{}, nil
-	}
-
-	decoded, err := base64.URLEncoding.DecodeString(authEncoded)
-	if err != nil {
-		var e base64.CorruptInputError
-		if errors.As(err, &e) {
-			return &AuthConfig{}, invalid(errors.New("must be a valid base64url-encoded string"))
-		}
-		return &AuthConfig{}, invalid(err)
-	}
-
-	if bytes.Equal(decoded, []byte("{}")) {
-		return &AuthConfig{}, nil
-	}
-
-	return decodeAuthConfigFromReader(bytes.NewReader(decoded))
-}
-
-// DecodeAuthConfigBody decodes authentication information as sent as JSON in the
-// body of a request. This function is to provide backward compatibility with old
-// clients and API versions. Current clients and API versions expect authentication
-// to be provided through the X-Registry-Auth header.
-//
-// Like [DecodeAuthConfig], this function always returns an [AuthConfig], even if an
-// error occurs. It is up to the caller to decide if authentication is required,
-// and if the error can be ignored.
-//
-// Deprecated: this function is no longer used and will be removed in the next release.
-func DecodeAuthConfigBody(rdr io.ReadCloser) (*AuthConfig, error) {
-	return decodeAuthConfigFromReader(rdr)
-}
-
-func decodeAuthConfigFromReader(rdr io.Reader) (*AuthConfig, error) {
-	authConfig := &AuthConfig{}
-	if err := json.NewDecoder(rdr).Decode(authConfig); err != nil {
-		// always return an (empty) AuthConfig to increase compatibility with
-		// the existing API.
-		return &AuthConfig{}, invalid(fmt.Errorf("invalid JSON: %w", err))
-	}
-	return authConfig, nil
-}
-
-func invalid(err error) error {
-	return errInvalidParameter{fmt.Errorf("invalid X-Registry-Auth header: %w", err)}
-}
-
-type errInvalidParameter struct{ error }
-
-func (errInvalidParameter) InvalidParameter() {}
-
-func (e errInvalidParameter) Cause() error { return e.error }
-
-func (e errInvalidParameter) Unwrap() error { return e.error }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -944,6 +944,7 @@ github.com/moby/locker
 # github.com/moby/moby/api v1.52.0-alpha.1 => ./api
 ## explicit; go 1.23.0
 github.com/moby/moby/api
+github.com/moby/moby/api/pkg/authconfig
 github.com/moby/moby/api/pkg/progress
 github.com/moby/moby/api/pkg/stdcopy
 github.com/moby/moby/api/pkg/streamformatter


### PR DESCRIPTION
**- What I did**
Partial for #50740 
Alternative to #50765

**- How I did it**
Refactor the encode/decode auth config functions into their own utility package.

Carried forward the daemon touch-ups suggested from #50765

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/registry: moved encode/decode auth config functions into reference utility package
```

**- A picture of a cute animal (not mandatory but encouraged)**

