### PR TITLE
api/types/network: move network options from api to client

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -45,11 +45,6 @@ type CreateOptions struct {
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
 }
 
-// ListOptions holds parameters to filter the list of networks with.
-type ListOptions struct {
-	Filters filters.Args
-}
-
 // InspectOptions holds parameters to inspect network.
 type InspectOptions struct {
 	Scope   string

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -45,12 +45,6 @@ type CreateOptions struct {
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
 }
 
-// InspectOptions holds parameters to inspect network.
-type InspectOptions struct {
-	Scope   string
-	Verbose bool
-}
-
 // ConnectOptions represents the data to be used to connect a container to the
 // network.
 type ConnectOptions struct {

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -133,7 +133,7 @@ type NetworkAPIClient interface {
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
 	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, error)
 	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, []byte, error)
-	NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
+	NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -131,8 +131,8 @@ type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, network, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
-	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, error)
-	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, []byte, error)
+	NetworkInspect(ctx context.Context, network string, options InspectOptions) (network.Inspect, error)
+	NetworkInspectWithRaw(ctx context.Context, network string, options InspectOptions) (network.Inspect, []byte, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -133,7 +133,7 @@ type NetworkAPIClient interface {
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
 	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, error)
 	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, []byte, error)
-	NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error)
+	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -131,8 +131,8 @@ type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, network, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
-	NetworkInspect(ctx context.Context, network string, options InspectOptions) (network.Inspect, error)
-	NetworkInspectWithRaw(ctx context.Context, network string, options InspectOptions) (network.Inspect, []byte, error)
+	NetworkInspect(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, error)
+	NetworkInspectWithRaw(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, []byte, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -11,13 +11,13 @@ import (
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, error) {
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options NetworkInspectOptions) (network.Inspect, error) {
 	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID, options)
 	return networkResource, err
 }
 
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
-func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, []byte, error) {
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options NetworkInspectOptions) (network.Inspect, []byte, error) {
 	networkID, err := trimID("network", networkID)
 	if err != nil {
 		return network.Inspect{}, nil, err

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -11,13 +11,13 @@ import (
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, error) {
 	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID, options)
 	return networkResource, err
 }
 
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
-func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, []byte, error) {
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, []byte, error) {
 	networkID, err := trimID("network", networkID)
 	if err != nil {
 		return network.Inspect{}, nil, err

--- a/client/network_inspect_opts.go
+++ b/client/network_inspect_opts.go
@@ -1,0 +1,7 @@
+package client
+
+// InspectOptions holds parameters to inspect network.
+type InspectOptions struct {
+	Scope   string
+	Verbose bool
+}

--- a/client/network_inspect_opts.go
+++ b/client/network_inspect_opts.go
@@ -1,7 +1,7 @@
 package client
 
-// InspectOptions holds parameters to inspect network.
-type InspectOptions struct {
+// NetworkInspectOptions holds parameters to inspect network.
+type NetworkInspectOptions struct {
 	Scope   string
 	Verbose bool
 }

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -68,39 +68,39 @@ func TestNetworkInspect(t *testing.T) {
 
 	t.Run("empty ID", func(t *testing.T) {
 		// verify that the client does not create a request if the network-ID/name is empty.
-		_, err := client.NetworkInspect(context.Background(), "", network.InspectOptions{})
+		_, err := client.NetworkInspect(context.Background(), "", InspectOptions{})
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 		assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-		_, err = client.NetworkInspect(context.Background(), "    ", network.InspectOptions{})
+		_, err = client.NetworkInspect(context.Background(), "    ", InspectOptions{})
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 		assert.Check(t, is.ErrorContains(err, "value is empty"))
 	})
 	t.Run("no options", func(t *testing.T) {
-		r, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{})
+		r, err := client.NetworkInspect(context.Background(), "network_id", InspectOptions{})
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 	})
 	t.Run("verbose", func(t *testing.T) {
-		r, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{Verbose: true})
+		r, err := client.NetworkInspect(context.Background(), "network_id", InspectOptions{Verbose: true})
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 		_, ok := r.Services["web"]
 		assert.Check(t, ok, "expected service `web` missing in the verbose output")
 	})
 	t.Run("global scope", func(t *testing.T) {
-		_, err := client.NetworkInspect(context.Background(), "network_id", network.InspectOptions{Scope: "global"})
+		_, err := client.NetworkInspect(context.Background(), "network_id", InspectOptions{Scope: "global"})
 		assert.Check(t, is.ErrorContains(err, "Error: No such network: network_id"))
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 	t.Run("unknown network", func(t *testing.T) {
-		_, err := client.NetworkInspect(context.Background(), "unknown", network.InspectOptions{})
+		_, err := client.NetworkInspect(context.Background(), "unknown", InspectOptions{})
 		assert.Check(t, is.ErrorContains(err, "Error: No such network: unknown"))
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 	t.Run("server error", func(t *testing.T) {
 		// Just testing that an internal server error is converted correctly by the client
-		_, err := client.NetworkInspect(context.Background(), "test-500-response", network.InspectOptions{})
+		_, err := client.NetworkInspect(context.Background(), "test-500-response", InspectOptions{})
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 	})
 }

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -68,39 +68,39 @@ func TestNetworkInspect(t *testing.T) {
 
 	t.Run("empty ID", func(t *testing.T) {
 		// verify that the client does not create a request if the network-ID/name is empty.
-		_, err := client.NetworkInspect(context.Background(), "", InspectOptions{})
+		_, err := client.NetworkInspect(context.Background(), "", NetworkInspectOptions{})
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 		assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-		_, err = client.NetworkInspect(context.Background(), "    ", InspectOptions{})
+		_, err = client.NetworkInspect(context.Background(), "    ", NetworkInspectOptions{})
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 		assert.Check(t, is.ErrorContains(err, "value is empty"))
 	})
 	t.Run("no options", func(t *testing.T) {
-		r, err := client.NetworkInspect(context.Background(), "network_id", InspectOptions{})
+		r, err := client.NetworkInspect(context.Background(), "network_id", NetworkInspectOptions{})
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 	})
 	t.Run("verbose", func(t *testing.T) {
-		r, err := client.NetworkInspect(context.Background(), "network_id", InspectOptions{Verbose: true})
+		r, err := client.NetworkInspect(context.Background(), "network_id", NetworkInspectOptions{Verbose: true})
 		assert.NilError(t, err)
 		assert.Check(t, is.Equal(r.Name, "mynetwork"))
 		_, ok := r.Services["web"]
 		assert.Check(t, ok, "expected service `web` missing in the verbose output")
 	})
 	t.Run("global scope", func(t *testing.T) {
-		_, err := client.NetworkInspect(context.Background(), "network_id", InspectOptions{Scope: "global"})
+		_, err := client.NetworkInspect(context.Background(), "network_id", NetworkInspectOptions{Scope: "global"})
 		assert.Check(t, is.ErrorContains(err, "Error: No such network: network_id"))
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 	t.Run("unknown network", func(t *testing.T) {
-		_, err := client.NetworkInspect(context.Background(), "unknown", InspectOptions{})
+		_, err := client.NetworkInspect(context.Background(), "unknown", NetworkInspectOptions{})
 		assert.Check(t, is.ErrorContains(err, "Error: No such network: unknown"))
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 	})
 	t.Run("server error", func(t *testing.T) {
 		// Just testing that an internal server error is converted correctly by the client
-		_, err := client.NetworkInspect(context.Background(), "test-500-response", InspectOptions{})
+		_, err := client.NetworkInspect(context.Background(), "test-500-response", NetworkInspectOptions{})
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 	})
 }

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error) {
+func (cli *Client) NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToJSON(options.Filters)

--- a/client/network_list.go
+++ b/client/network_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
+func (cli *Client) NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToJSON(options.Filters)

--- a/client/network_list_opts.go
+++ b/client/network_list_opts.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// ListOptions holds parameters to filter the list of networks with.
+type ListOptions struct {
+	Filters filters.Args
+}

--- a/client/network_list_opts.go
+++ b/client/network_list_opts.go
@@ -2,7 +2,7 @@ package client
 
 import "github.com/moby/moby/api/types/filters"
 
-// ListOptions holds parameters to filter the list of networks with.
-type ListOptions struct {
+// NetworkListOptions holds parameters to filter the list of networks with.
+type NetworkListOptions struct {
 	Filters filters.Args
 }

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -22,7 +22,7 @@ func TestNetworkListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NetworkList(context.Background(), network.ListOptions{})
+	_, err := client.NetworkList(context.Background(), ListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -30,27 +30,27 @@ func TestNetworkList(t *testing.T) {
 	const expectedURL = "/networks"
 
 	listCases := []struct {
-		options         network.ListOptions
+		options         ListOptions
 		expectedFilters string
 	}{
 		{
-			options:         network.ListOptions{},
+			options:         ListOptions{},
 			expectedFilters: "",
 		},
 		{
-			options: network.ListOptions{
+			options: ListOptions{
 				Filters: filters.NewArgs(filters.Arg("dangling", "false")),
 			},
 			expectedFilters: `{"dangling":{"false":true}}`,
 		},
 		{
-			options: network.ListOptions{
+			options: ListOptions{
 				Filters: filters.NewArgs(filters.Arg("dangling", "true")),
 			},
 			expectedFilters: `{"dangling":{"true":true}}`,
 		},
 		{
-			options: network.ListOptions{
+			options: ListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -22,7 +22,7 @@ func TestNetworkListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NetworkList(context.Background(), ListOptions{})
+	_, err := client.NetworkList(context.Background(), NetworkListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -30,27 +30,27 @@ func TestNetworkList(t *testing.T) {
 	const expectedURL = "/networks"
 
 	listCases := []struct {
-		options         ListOptions
+		options         NetworkListOptions
 		expectedFilters string
 	}{
 		{
-			options:         ListOptions{},
+			options:         NetworkListOptions{},
 			expectedFilters: "",
 		},
 		{
-			options: ListOptions{
+			options: NetworkListOptions{
 				Filters: filters.NewArgs(filters.Arg("dangling", "false")),
 			},
 			expectedFilters: `{"dangling":{"false":true}}`,
 		},
 		{
-			options: ListOptions{
+			options: NetworkListOptions{
 				Filters: filters.NewArgs(filters.Arg("dangling", "true")),
 			},
 			expectedFilters: `{"dangling":{"true":true}}`,
 		},
 		{
-			options: ListOptions{
+			options: NetworkListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -1026,11 +1026,11 @@ func (s *DockerSwarmSuite) TestAPINetworkInspectWithScope(c *testing.T) {
 	resp, err := apiclient.NetworkCreate(ctx, name, network.CreateOptions{Driver: "overlay"})
 	assert.NilError(c, err)
 
-	nw, err := apiclient.NetworkInspect(ctx, name, client.InspectOptions{})
+	nw, err := apiclient.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(c, err)
 	assert.Check(c, is.Equal("swarm", nw.Scope))
 	assert.Check(c, is.Equal(resp.ID, nw.ID))
 
-	_, err = apiclient.NetworkInspect(ctx, name, client.InspectOptions{Scope: "local"})
+	_, err = apiclient.NetworkInspect(ctx, name, client.NetworkInspectOptions{Scope: "local"})
 	assert.Check(c, is.ErrorType(err, cerrdefs.IsNotFound))
 }

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration-cli/checker"
 	"github.com/moby/moby/v2/integration-cli/daemon"
 	"github.com/moby/moby/v2/testutil"
@@ -1025,11 +1026,11 @@ func (s *DockerSwarmSuite) TestAPINetworkInspectWithScope(c *testing.T) {
 	resp, err := apiclient.NetworkCreate(ctx, name, network.CreateOptions{Driver: "overlay"})
 	assert.NilError(c, err)
 
-	nw, err := apiclient.NetworkInspect(ctx, name, network.InspectOptions{})
+	nw, err := apiclient.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(c, err)
 	assert.Check(c, is.Equal("swarm", nw.Scope))
 	assert.Check(c, is.Equal(resp.ID, nw.ID))
 
-	_, err = apiclient.NetworkInspect(ctx, name, network.InspectOptions{Scope: "local"})
+	_, err = apiclient.NetworkInspect(ctx, name, client.InspectOptions{Scope: "local"})
 	assert.Check(c, is.ErrorType(err, cerrdefs.IsNotFound))
 }

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -35,7 +35,7 @@ func OnlyDefaultNetworks(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	networks, err := apiClient.NetworkList(ctx, client.ListOptions{})
+	networks, err := apiClient.NetworkList(ctx, client.NetworkListOptions{})
 	if err != nil || len(networks) > 0 {
 		return false
 	}

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/v2/plugins"
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration-cli/cli"
@@ -36,7 +35,7 @@ func OnlyDefaultNetworks(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	networks, err := apiClient.NetworkList(ctx, network.ListOptions{})
+	networks, err := apiClient.NetworkList(ctx, client.ListOptions{})
 	if err != nil || len(networks) > 0 {
 		return false
 	}

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -153,7 +153,7 @@ func TestDaemonHostGatewayIP(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
 	assert.Equal(t, 0, res.ExitCode)
-	inspect, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
+	inspect, err := c.NetworkInspect(ctx, "bridge", client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(res.Stdout(), inspect.IPAM.Config[0].Gateway))
 	c.ContainerRemove(ctx, cID, containertypes.RemoveOptions{Force: true})

--- a/integration/container/daemon_linux_test.go
+++ b/integration/container/daemon_linux_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	containertypes "github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	realcontainer "github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/testutil"
@@ -153,7 +153,7 @@ func TestDaemonHostGatewayIP(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, is.Len(res.Stderr(), 0))
 	assert.Equal(t, 0, res.ExitCode)
-	inspect, err := c.NetworkInspect(ctx, "bridge", network.InspectOptions{})
+	inspect, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(res.Stdout(), inspect.IPAM.Config[0].Gateway))
 	c.ContainerRemove(ctx, cID, containertypes.RemoveOptions{Force: true})

--- a/integration/daemon/daemon_linux_test.go
+++ b/integration/daemon/daemon_linux_test.go
@@ -419,7 +419,7 @@ func testDefaultBridgeIPAM(ctx context.Context, t *testing.T, tc defaultBridgeIP
 			c := d.NewClientT(t)
 			defer c.Close()
 
-			insp, err := c.NetworkInspect(ctx, network.NetworkBridge, client.InspectOptions{})
+			insp, err := c.NetworkInspect(ctx, network.NetworkBridge, client.NetworkInspectOptions{})
 			assert.NilError(t, err)
 			expIPAMConfig := slices.Clone(tc.expIPAMConfig)
 			for i := range expIPAMConfig {

--- a/integration/daemon/daemon_linux_test.go
+++ b/integration/daemon/daemon_linux_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/nlwrap"
 	"github.com/moby/moby/v2/integration/internal/testutils/networking"
 	"github.com/moby/moby/v2/testutil"
@@ -418,7 +419,7 @@ func testDefaultBridgeIPAM(ctx context.Context, t *testing.T, tc defaultBridgeIP
 			c := d.NewClientT(t)
 			defer c.Close()
 
-			insp, err := c.NetworkInspect(ctx, network.NetworkBridge, network.InspectOptions{})
+			insp, err := c.NetworkInspect(ctx, network.NetworkBridge, client.InspectOptions{})
 			assert.NilError(t, err)
 			expIPAMConfig := slices.Clone(tc.expIPAMConfig)
 			for i := range expIPAMConfig {

--- a/integration/internal/network/states.go
+++ b/integration/internal/network/states.go
@@ -10,7 +10,7 @@ import (
 // IsRemoved verifies the network is removed.
 func IsRemoved(ctx context.Context, apiClient client.NetworkAPIClient, networkID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		_, err := apiClient.NetworkInspect(ctx, networkID, client.InspectOptions{})
+		_, err := apiClient.NetworkInspect(ctx, networkID, client.NetworkInspectOptions{})
 		if err == nil {
 			return poll.Continue("waiting for network %s to be removed", networkID)
 		}

--- a/integration/internal/network/states.go
+++ b/integration/internal/network/states.go
@@ -3,15 +3,14 @@ package network
 import (
 	"context"
 
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"gotest.tools/v3/poll"
 )
 
 // IsRemoved verifies the network is removed.
-func IsRemoved(ctx context.Context, client client.NetworkAPIClient, networkID string) func(log poll.LogT) poll.Result {
+func IsRemoved(ctx context.Context, apiClient client.NetworkAPIClient, networkID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		_, err := client.NetworkInspect(ctx, networkID, network.InspectOptions{})
+		_, err := apiClient.NetworkInspect(ctx, networkID, client.InspectOptions{})
 		if err == nil {
 			return poll.Continue("waiting for network %s to be removed", networkID)
 		}

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -65,7 +65,7 @@ func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
 	network.CreateNoError(ctx, t, apiClient, nwName, network.WithIPv6())
 	defer network.RemoveNoError(ctx, t, apiClient, nwName)
 
-	nw, err := apiClient.NetworkInspect(ctx, "testnetula", client.InspectOptions{})
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 
 	for _, ipam := range nw.IPAM.Config {
@@ -92,7 +92,7 @@ func TestCreateWithIPv6WithoutEnableIPv6Flag(t *testing.T) {
 	network.CreateNoError(ctx, t, apiClient, nwName)
 	defer network.RemoveNoError(ctx, t, apiClient, nwName)
 
-	nw, err := apiClient.NetworkInspect(ctx, "testnetula", client.InspectOptions{})
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 
 	for _, ipam := range nw.IPAM.Config {
@@ -137,7 +137,7 @@ func TestDefaultIPvOptOverride(t *testing.T) {
 					network.CreateNoError(ctx, t, c, netName, nopts...)
 					defer network.RemoveNoError(ctx, t, c, netName)
 
-					insp, err := c.NetworkInspect(ctx, netName, client.InspectOptions{})
+					insp, err := c.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
 					assert.NilError(t, err)
 					t.Log("override4", override4, "override6", override6, "->", insp.Options)
 

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -12,6 +12,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/versions"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
 	"github.com/moby/moby/v2/daemon/libnetwork/netlabel"
 	"github.com/moby/moby/v2/daemon/libnetwork/nlwrap"
@@ -64,7 +65,7 @@ func TestCreateWithIPv6DefaultsToULAPrefix(t *testing.T) {
 	network.CreateNoError(ctx, t, apiClient, nwName, network.WithIPv6())
 	defer network.RemoveNoError(ctx, t, apiClient, nwName)
 
-	nw, err := apiClient.NetworkInspect(ctx, "testnetula", networktypes.InspectOptions{})
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", client.InspectOptions{})
 	assert.NilError(t, err)
 
 	for _, ipam := range nw.IPAM.Config {
@@ -91,7 +92,7 @@ func TestCreateWithIPv6WithoutEnableIPv6Flag(t *testing.T) {
 	network.CreateNoError(ctx, t, apiClient, nwName)
 	defer network.RemoveNoError(ctx, t, apiClient, nwName)
 
-	nw, err := apiClient.NetworkInspect(ctx, "testnetula", networktypes.InspectOptions{})
+	nw, err := apiClient.NetworkInspect(ctx, "testnetula", client.InspectOptions{})
 	assert.NilError(t, err)
 
 	for _, ipam := range nw.IPAM.Config {
@@ -136,7 +137,7 @@ func TestDefaultIPvOptOverride(t *testing.T) {
 					network.CreateNoError(ctx, t, c, netName, nopts...)
 					defer network.RemoveNoError(ctx, t, c, netName)
 
-					insp, err := c.NetworkInspect(ctx, netName, networktypes.InspectOptions{})
+					insp, err := c.NetworkInspect(ctx, netName, client.InspectOptions{})
 					assert.NilError(t, err)
 					t.Log("override4", override4, "override6", override6, "->", insp.Options)
 

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -31,7 +31,7 @@ func createAmbiguousNetworks(ctx context.Context, t *testing.T, apiClient client
 	idPrefixNet := network.CreateNoError(ctx, t, apiClient, testNet[:12])
 	fullIDNet := network.CreateNoError(ctx, t, apiClient, testNet)
 
-	nws, err := apiClient.NetworkList(ctx, client.ListOptions{})
+	nws, err := apiClient.NetworkList(ctx, client.NetworkListOptions{})
 	assert.NilError(t, err)
 
 	assert.Check(t, is.Equal(true, containsNetwork(nws, testNet)), "failed to create network testNet")
@@ -79,7 +79,7 @@ func TestDockerNetworkDeletePreferID(t *testing.T) {
 	assert.NilError(t, err)
 
 	// networks "testNet" and "idPrefixNet" should be removed, but "fullIDNet" should still exist
-	nws, err := apiClient.NetworkList(ctx, client.ListOptions{})
+	nws, err := apiClient.NetworkList(ctx, client.NetworkListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(false, containsNetwork(nws, testNet)), "Network testNet not removed")
 	assert.Check(t, is.Equal(false, containsNetwork(nws, idPrefixNet)), "Network idPrefixNet not removed")

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -31,7 +31,7 @@ func createAmbiguousNetworks(ctx context.Context, t *testing.T, apiClient client
 	idPrefixNet := network.CreateNoError(ctx, t, apiClient, testNet[:12])
 	fullIDNet := network.CreateNoError(ctx, t, apiClient, testNet)
 
-	nws, err := apiClient.NetworkList(ctx, networktypes.ListOptions{})
+	nws, err := apiClient.NetworkList(ctx, client.ListOptions{})
 	assert.NilError(t, err)
 
 	assert.Check(t, is.Equal(true, containsNetwork(nws, testNet)), "failed to create network testNet")
@@ -79,7 +79,7 @@ func TestDockerNetworkDeletePreferID(t *testing.T) {
 	assert.NilError(t, err)
 
 	// networks "testNet" and "idPrefixNet" should be removed, but "fullIDNet" should still exist
-	nws, err := apiClient.NetworkList(ctx, networktypes.ListOptions{})
+	nws, err := apiClient.NetworkList(ctx, client.ListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(false, containsNetwork(nws, testNet)), "Network testNet not removed")
 	assert.Check(t, is.Equal(false, containsNetwork(nws, idPrefixNet)), "Network idPrefixNet not removed")

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -53,7 +53,7 @@ func LinkDoesntExist(ctx context.Context, t *testing.T, master string) {
 // IsNetworkAvailable provides a comparison to check if a docker network is available
 func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) is.Comparison {
 	return func() is.Result {
-		networks, err := c.NetworkList(ctx, client.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.NetworkListOptions{})
 		if err != nil {
 			return is.ResultFromError(err)
 		}
@@ -69,7 +69,7 @@ func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name str
 // IsNetworkNotAvailable provides a comparison to check if a docker network is not available
 func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) is.Comparison {
 	return func() is.Result {
-		networks, err := c.NetworkList(ctx, client.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.NetworkListOptions{})
 		if err != nil {
 			return is.ResultFromError(err)
 		}

--- a/integration/network/helpers.go
+++ b/integration/network/helpers.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/testutil"
 	is "gotest.tools/v3/assert/cmp"
@@ -54,7 +53,7 @@ func LinkDoesntExist(ctx context.Context, t *testing.T, master string) {
 // IsNetworkAvailable provides a comparison to check if a docker network is available
 func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) is.Comparison {
 	return func() is.Result {
-		networks, err := c.NetworkList(ctx, network.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.ListOptions{})
 		if err != nil {
 			return is.ResultFromError(err)
 		}
@@ -70,7 +69,7 @@ func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name str
 // IsNetworkNotAvailable provides a comparison to check if a docker network is not available
 func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) is.Comparison {
 	return func() is.Result {
-		networks, err := c.NetworkList(ctx, network.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.ListOptions{})
 		if err != nil {
 			return is.ResultFromError(err)
 		}

--- a/integration/network/helpers_windows.go
+++ b/integration/network/helpers_windows.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert/cmp"
 )
@@ -12,7 +11,7 @@ import (
 // IsNetworkAvailable provides a comparison to check if a docker network is available
 func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, network.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.ListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}
@@ -28,7 +27,7 @@ func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name str
 // IsNetworkNotAvailable provides a comparison to check if a docker network is not available
 func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, network.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.ListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}

--- a/integration/network/helpers_windows.go
+++ b/integration/network/helpers_windows.go
@@ -11,7 +11,7 @@ import (
 // IsNetworkAvailable provides a comparison to check if a docker network is available
 func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, client.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.NetworkListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}
@@ -27,7 +27,7 @@ func IsNetworkAvailable(ctx context.Context, c client.NetworkAPIClient, name str
 // IsNetworkNotAvailable provides a comparison to check if a docker network is not available
 func IsNetworkNotAvailable(ctx context.Context, c client.NetworkAPIClient, name string) cmp.Comparison {
 	return func() cmp.Result {
-		networks, err := c.NetworkList(ctx, client.ListOptions{})
+		networks, err := c.NetworkList(ctx, client.NetworkListOptions{})
 		if err != nil {
 			return cmp.ResultFromError(err)
 		}

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -41,33 +41,33 @@ func TestInspectNetwork(t *testing.T) {
 	tests := []struct {
 		name    string
 		network string
-		opts    client.InspectOptions
+		opts    client.NetworkInspectOptions
 	}{
 		{
 			name:    "full network id",
 			network: overlayID,
-			opts: client.InspectOptions{
+			opts: client.NetworkInspectOptions{
 				Verbose: true,
 			},
 		},
 		{
 			name:    "partial network id",
 			network: overlayID[0:11],
-			opts: client.InspectOptions{
+			opts: client.NetworkInspectOptions{
 				Verbose: true,
 			},
 		},
 		{
 			name:    "network name",
 			network: networkName,
-			opts: client.InspectOptions{
+			opts: client.NetworkInspectOptions{
 				Verbose: true,
 			},
 		},
 		{
 			name:    "network name and swarm scope",
 			network: networkName,
-			opts: client.InspectOptions{
+			opts: client.NetworkInspectOptions{
 				Verbose: true,
 				Scope:   "swarm",
 			},

--- a/integration/network/inspect_test.go
+++ b/integration/network/inspect_test.go
@@ -3,7 +3,7 @@ package network
 import (
 	"testing"
 
-	networktypes "github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/network"
 	"github.com/moby/moby/v2/integration/internal/swarm"
 	"github.com/moby/moby/v2/testutil"
@@ -41,33 +41,33 @@ func TestInspectNetwork(t *testing.T) {
 	tests := []struct {
 		name    string
 		network string
-		opts    networktypes.InspectOptions
+		opts    client.InspectOptions
 	}{
 		{
 			name:    "full network id",
 			network: overlayID,
-			opts: networktypes.InspectOptions{
+			opts: client.InspectOptions{
 				Verbose: true,
 			},
 		},
 		{
 			name:    "partial network id",
 			network: overlayID[0:11],
-			opts: networktypes.InspectOptions{
+			opts: client.InspectOptions{
 				Verbose: true,
 			},
 		},
 		{
 			name:    "network name",
 			network: networkName,
-			opts: networktypes.InspectOptions{
+			opts: client.InspectOptions{
 				Verbose: true,
 			},
 		},
 		{
 			name:    "network name and swarm scope",
 			network: networkName,
-			opts: networktypes.InspectOptions{
+			opts: client.InspectOptions{
 				Verbose: true,
 				Scope:   "swarm",
 			},

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -89,7 +89,7 @@ func TestHostIPv4BridgeLabel(t *testing.T) {
 		network.WithOption("com.docker.network.bridge.name", bridgeName),
 	)
 	defer network.RemoveNoError(ctx, t, c, bridgeName)
-	out, err := c.NetworkInspect(ctx, bridgeName, networktypes.InspectOptions{Verbose: true})
+	out, err := c.NetworkInspect(ctx, bridgeName, client.InspectOptions{Verbose: true})
 	assert.NilError(t, err)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
 	// Make sure the SNAT rule exists

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -89,7 +89,7 @@ func TestHostIPv4BridgeLabel(t *testing.T) {
 		network.WithOption("com.docker.network.bridge.name", bridgeName),
 	)
 	defer network.RemoveNoError(ctx, t, c, bridgeName)
-	out, err := c.NetworkInspect(ctx, bridgeName, client.InspectOptions{Verbose: true})
+	out, err := c.NetworkInspect(ctx, bridgeName, client.NetworkInspectOptions{Verbose: true})
 	assert.NilError(t, err)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
 	// Make sure the SNAT rule exists

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -45,7 +45,7 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 	defer c.Close()
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, "bridge", networktypes.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
 	assert.NilError(t, err)
 	subnet := out.IPAM.Config[0].Subnet
 
@@ -55,7 +55,7 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 		"--default-address-pool", "base=175.33.0.0/16,size=24",
 	)
 
-	out1, err := c.NetworkInspect(ctx, "bridge", networktypes.InspectOptions{})
+	out1, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
 	assert.NilError(t, err)
 	// Make sure docker0 doesn't get override with new IP in live restore case
 	assert.Equal(t, out1.IPAM.Config[0].Subnet, subnet)
@@ -82,7 +82,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 	defer c.Close()
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, "bridge", networktypes.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "175.30.0.0/16")
 
@@ -92,7 +92,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out, err = c.NetworkInspect(ctx, name, networktypes.InspectOptions{})
+	out, err = c.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(out.IPAM.Config[0].Subnet, "175.33.0.0/24"))
 
@@ -102,7 +102,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out, err = c.NetworkInspect(ctx, name, networktypes.InspectOptions{})
+	out, err = c.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(out.IPAM.Config[0].Subnet, "175.33.1.0/24"))
 }
@@ -127,7 +127,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 	defer network.RemoveNoError(ctx, t, c, name)
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, name, networktypes.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(t, err)
 	networkip := out.IPAM.Config[0].Subnet
 
@@ -137,7 +137,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 		"--default-address-pool", "base=175.33.0.0/16,size=24")
 	defer delInterface(ctx, t, "docker0")
 
-	out1, err := c.NetworkInspect(ctx, name, networktypes.InspectOptions{})
+	out1, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, out1.IPAM.Config[0].Subnet, networkip)
 }
@@ -163,7 +163,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 	defer network.RemoveNoError(ctx, t, c, name)
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, name, networktypes.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(t, err)
 	networkip := out.IPAM.Config[0].Subnet
 
@@ -173,7 +173,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out, err = c.NetworkInspect(ctx, name, networktypes.InspectOptions{})
+	out, err = c.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(t, err)
 	networkip2 := out.IPAM.Config[0].Subnet
 
@@ -190,7 +190,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out1, err := c.NetworkInspect(ctx, name, networktypes.InspectOptions{})
+	out1, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
 	assert.NilError(t, err)
 
 	assert.Check(t, out1.IPAM.Config[0].Subnet != networkip)
@@ -217,7 +217,7 @@ func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
 	defer c.Close()
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, "bridge", networktypes.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
 	assert.NilError(t, err)
 	// Make sure BIP IP doesn't get override with new default address pool .
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "172.60.0.0/16")
@@ -297,7 +297,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 
 	// Ensure that "ingress" is not removed or corrupted
 	time.Sleep(10 * time.Second)
-	netInfo, err := c.NetworkInspect(ctx, ingressNet, networktypes.InspectOptions{
+	netInfo, err := c.NetworkInspect(ctx, ingressNet, client.InspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})
@@ -309,9 +309,9 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 }
 
 //nolint:unused // for some reason, the "unused" linter marks this function as "unused"
-func swarmIngressReady(ctx context.Context, client client.NetworkAPIClient) func(log poll.LogT) poll.Result {
+func swarmIngressReady(ctx context.Context, apiClient client.NetworkAPIClient) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		netInfo, err := client.NetworkInspect(ctx, ingressNet, networktypes.InspectOptions{
+		netInfo, err := apiClient.NetworkInspect(ctx, ingressNet, client.InspectOptions{
 			Verbose: true,
 			Scope:   "swarm",
 		})
@@ -443,7 +443,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	_, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
-	out, err := cli.NetworkInspect(ctx, overlayID, networktypes.InspectOptions{Verbose: true})
+	out, err := cli.NetworkInspect(ctx, overlayID, client.InspectOptions{Verbose: true})
 	assert.NilError(t, err)
 	t.Logf("%s: NetworkInspect: %+v", t.Name(), out)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
@@ -454,7 +454,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.1.0/24")
 
 	// Also inspect ingress network and make sure its in the same subnet
-	out, err = cli.NetworkInspect(ctx, "ingress", networktypes.InspectOptions{Verbose: true})
+	out, err = cli.NetworkInspect(ctx, "ingress", client.InspectOptions{Verbose: true})
 	assert.NilError(t, err)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.0.0/24")

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -45,7 +45,7 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 	defer c.Close()
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, "bridge", client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	subnet := out.IPAM.Config[0].Subnet
 
@@ -55,7 +55,7 @@ func TestDaemonRestartWithLiveRestore(t *testing.T) {
 		"--default-address-pool", "base=175.33.0.0/16,size=24",
 	)
 
-	out1, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
+	out1, err := c.NetworkInspect(ctx, "bridge", client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	// Make sure docker0 doesn't get override with new IP in live restore case
 	assert.Equal(t, out1.IPAM.Config[0].Subnet, subnet)
@@ -82,7 +82,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 	defer c.Close()
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, "bridge", client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "175.30.0.0/16")
 
@@ -92,7 +92,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out, err = c.NetworkInspect(ctx, name, client.InspectOptions{})
+	out, err = c.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(out.IPAM.Config[0].Subnet, "175.33.0.0/24"))
 
@@ -102,7 +102,7 @@ func TestDaemonDefaultNetworkPools(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out, err = c.NetworkInspect(ctx, name, client.InspectOptions{})
+	out, err = c.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(out.IPAM.Config[0].Subnet, "175.33.1.0/24"))
 }
@@ -127,7 +127,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 	defer network.RemoveNoError(ctx, t, c, name)
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	networkip := out.IPAM.Config[0].Subnet
 
@@ -137,7 +137,7 @@ func TestDaemonRestartWithExistingNetwork(t *testing.T) {
 		"--default-address-pool", "base=175.33.0.0/16,size=24")
 	defer delInterface(ctx, t, "docker0")
 
-	out1, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
+	out1, err := c.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, out1.IPAM.Config[0].Subnet, networkip)
 }
@@ -163,7 +163,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 	defer network.RemoveNoError(ctx, t, c, name)
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	networkip := out.IPAM.Config[0].Subnet
 
@@ -173,7 +173,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out, err = c.NetworkInspect(ctx, name, client.InspectOptions{})
+	out, err = c.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	networkip2 := out.IPAM.Config[0].Subnet
 
@@ -190,7 +190,7 @@ func TestDaemonRestartWithExistingNetworkWithDefaultPoolRange(t *testing.T) {
 		network.WithDriver("bridge"),
 	)
 	defer network.RemoveNoError(ctx, t, c, name)
-	out1, err := c.NetworkInspect(ctx, name, client.InspectOptions{})
+	out1, err := c.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 
 	assert.Check(t, out1.IPAM.Config[0].Subnet != networkip)
@@ -217,7 +217,7 @@ func TestDaemonWithBipAndDefaultNetworkPool(t *testing.T) {
 	defer c.Close()
 
 	// Verify bridge network's subnet
-	out, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
+	out, err := c.NetworkInspect(ctx, "bridge", client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	// Make sure BIP IP doesn't get override with new default address pool .
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "172.60.0.0/16")
@@ -297,7 +297,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 
 	// Ensure that "ingress" is not removed or corrupted
 	time.Sleep(10 * time.Second)
-	netInfo, err := c.NetworkInspect(ctx, ingressNet, client.InspectOptions{
+	netInfo, err := c.NetworkInspect(ctx, ingressNet, client.NetworkInspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})
@@ -311,7 +311,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 //nolint:unused // for some reason, the "unused" linter marks this function as "unused"
 func swarmIngressReady(ctx context.Context, apiClient client.NetworkAPIClient) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		netInfo, err := apiClient.NetworkInspect(ctx, ingressNet, client.InspectOptions{
+		netInfo, err := apiClient.NetworkInspect(ctx, ingressNet, client.NetworkInspectOptions{
 			Verbose: true,
 			Scope:   "swarm",
 		})
@@ -443,7 +443,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	_, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
-	out, err := cli.NetworkInspect(ctx, overlayID, client.InspectOptions{Verbose: true})
+	out, err := cli.NetworkInspect(ctx, overlayID, client.NetworkInspectOptions{Verbose: true})
 	assert.NilError(t, err)
 	t.Logf("%s: NetworkInspect: %+v", t.Name(), out)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
@@ -454,7 +454,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.1.0/24")
 
 	// Also inspect ingress network and make sure its in the same subnet
-	out, err = cli.NetworkInspect(ctx, "ingress", client.InspectOptions{Verbose: true})
+	out, err = cli.NetworkInspect(ctx, "ingress", client.NetworkInspectOptions{Verbose: true})
 	assert.NilError(t, err)
 	assert.Assert(t, len(out.IPAM.Config) > 0)
 	assert.Equal(t, out.IPAM.Config[0].Subnet, "20.20.0.0/24")

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -584,7 +584,7 @@ func TestAccessToPublishedPort(t *testing.T) {
 			// Use the default bridge addresses as host addresses (like "host-gateway", but
 			// there's no way to tell wget to prefer ipv4/ipv6 transport, so just use the
 			// addresses directly).
-			insp, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
+			insp, err := c.NetworkInspect(ctx, "bridge", client.NetworkInspectOptions{})
 			assert.NilError(t, err)
 			for _, ipamCfg := range insp.IPAM.Config {
 				ipv := "ipv4"
@@ -1821,7 +1821,7 @@ func TestNetworkInspectGateway(t *testing.T) {
 	assert.NilError(t, err)
 	defer network.RemoveNoError(ctx, t, c, netName)
 
-	insp, err := c.NetworkInspect(ctx, nid, client.InspectOptions{})
+	insp, err := c.NetworkInspect(ctx, nid, client.NetworkInspectOptions{})
 	assert.NilError(t, err)
 	for _, ipamCfg := range insp.IPAM.Config {
 		_, err := netip.ParseAddr(ipamCfg.Gateway)

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -584,7 +584,7 @@ func TestAccessToPublishedPort(t *testing.T) {
 			// Use the default bridge addresses as host addresses (like "host-gateway", but
 			// there's no way to tell wget to prefer ipv4/ipv6 transport, so just use the
 			// addresses directly).
-			insp, err := c.NetworkInspect(ctx, "bridge", networktypes.InspectOptions{})
+			insp, err := c.NetworkInspect(ctx, "bridge", client.InspectOptions{})
 			assert.NilError(t, err)
 			for _, ipamCfg := range insp.IPAM.Config {
 				ipv := "ipv4"
@@ -1821,7 +1821,7 @@ func TestNetworkInspectGateway(t *testing.T) {
 	assert.NilError(t, err)
 	defer network.RemoveNoError(ctx, t, c, netName)
 
-	insp, err := c.NetworkInspect(ctx, nid, networktypes.InspectOptions{})
+	insp, err := c.NetworkInspect(ctx, nid, client.InspectOptions{})
 	assert.NilError(t, err)
 	for _, ipamCfg := range insp.IPAM.Config {
 		_, err := netip.ParseAddr(ipamCfg.Gateway)

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
-	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/network"
@@ -222,7 +221,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, cli, serviceID, instances), swarm.ServicePoll)
 	service := getService(ctx, t, cli, serviceID)
-	netInfo, err := cli.NetworkInspect(ctx, testNet, networktypes.InspectOptions{
+	netInfo, err := cli.NetworkInspect(ctx, testNet, client.InspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})
@@ -235,7 +234,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
-	netInfo, err = cli.NetworkInspect(ctx, testNet, networktypes.InspectOptions{
+	netInfo, err = cli.NetworkInspect(ctx, testNet, client.InspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -221,7 +221,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, cli, serviceID, instances), swarm.ServicePoll)
 	service := getService(ctx, t, cli, serviceID)
-	netInfo, err := cli.NetworkInspect(ctx, testNet, client.InspectOptions{
+	netInfo, err := cli.NetworkInspect(ctx, testNet, client.NetworkInspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})
@@ -234,7 +234,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
-	netInfo, err = cli.NetworkInspect(ctx, testNet, client.InspectOptions{
+	netInfo, err = cli.NetworkInspect(ctx, testNet, client.NetworkInspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -143,7 +143,7 @@ func deleteAllVolumes(ctx context.Context, t testing.TB, c client.VolumeAPIClien
 
 func deleteAllNetworks(ctx context.Context, t testing.TB, c client.NetworkAPIClient, daemonPlatform string, protectedNetworks map[string]struct{}) {
 	t.Helper()
-	networks, err := c.NetworkList(ctx, network.ListOptions{})
+	networks, err := c.NetworkList(ctx, client.ListOptions{})
 	assert.Check(t, err, "failed to list networks")
 
 	for _, n := range networks {

--- a/testutil/environment/clean.go
+++ b/testutil/environment/clean.go
@@ -143,7 +143,7 @@ func deleteAllVolumes(ctx context.Context, t testing.TB, c client.VolumeAPIClien
 
 func deleteAllNetworks(ctx context.Context, t testing.TB, c client.NetworkAPIClient, daemonPlatform string, protectedNetworks map[string]struct{}) {
 	t.Helper()
-	networks, err := c.NetworkList(ctx, client.ListOptions{})
+	networks, err := c.NetworkList(ctx, client.NetworkListOptions{})
 	assert.Check(t, err, "failed to list networks")
 
 	for _, n := range networks {

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -168,7 +168,7 @@ func ProtectNetworks(ctx context.Context, t testing.TB, testEnv *Execution) {
 func getExistingNetworks(ctx context.Context, t testing.TB, testEnv *Execution) []string {
 	t.Helper()
 	apiClient := testEnv.APIClient()
-	networkList, err := apiClient.NetworkList(ctx, client.ListOptions{})
+	networkList, err := apiClient.NetworkList(ctx, client.NetworkListOptions{})
 	assert.NilError(t, err, "failed to list networks")
 
 	var networks []string

--- a/testutil/environment/protect.go
+++ b/testutil/environment/protect.go
@@ -8,7 +8,6 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/testutil"
 	"go.opentelemetry.io/otel"
@@ -168,8 +167,8 @@ func ProtectNetworks(ctx context.Context, t testing.TB, testEnv *Execution) {
 
 func getExistingNetworks(ctx context.Context, t testing.TB, testEnv *Execution) []string {
 	t.Helper()
-	client := testEnv.APIClient()
-	networkList, err := client.NetworkList(ctx, network.ListOptions{})
+	apiClient := testEnv.APIClient()
+	networkList, err := apiClient.NetworkList(ctx, client.ListOptions{})
 	assert.NilError(t, err, "failed to list networks")
 
 	var networks []string

--- a/vendor/github.com/moby/moby/api/types/network/network.go
+++ b/vendor/github.com/moby/moby/api/types/network/network.go
@@ -45,11 +45,6 @@ type CreateOptions struct {
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
 }
 
-// ListOptions holds parameters to filter the list of networks with.
-type ListOptions struct {
-	Filters filters.Args
-}
-
 // InspectOptions holds parameters to inspect network.
 type InspectOptions struct {
 	Scope   string

--- a/vendor/github.com/moby/moby/api/types/network/network.go
+++ b/vendor/github.com/moby/moby/api/types/network/network.go
@@ -45,12 +45,6 @@ type CreateOptions struct {
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
 }
 
-// InspectOptions holds parameters to inspect network.
-type InspectOptions struct {
-	Scope   string
-	Verbose bool
-}
-
 // ConnectOptions represents the data to be used to connect a container to the
 // network.
 type ConnectOptions struct {

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -133,7 +133,7 @@ type NetworkAPIClient interface {
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
 	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, error)
 	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, []byte, error)
-	NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
+	NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -131,8 +131,8 @@ type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, network, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
-	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, error)
-	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, []byte, error)
+	NetworkInspect(ctx context.Context, network string, options InspectOptions) (network.Inspect, error)
+	NetworkInspectWithRaw(ctx context.Context, network string, options InspectOptions) (network.Inspect, []byte, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -133,7 +133,7 @@ type NetworkAPIClient interface {
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
 	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, error)
 	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, []byte, error)
-	NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error)
+	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -131,8 +131,8 @@ type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, network, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
-	NetworkInspect(ctx context.Context, network string, options InspectOptions) (network.Inspect, error)
-	NetworkInspectWithRaw(ctx context.Context, network string, options InspectOptions) (network.Inspect, []byte, error)
+	NetworkInspect(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, error)
+	NetworkInspectWithRaw(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, []byte, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (network.PruneReport, error)

--- a/vendor/github.com/moby/moby/client/network_inspect.go
+++ b/vendor/github.com/moby/moby/client/network_inspect.go
@@ -11,13 +11,13 @@ import (
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, error) {
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options NetworkInspectOptions) (network.Inspect, error) {
 	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID, options)
 	return networkResource, err
 }
 
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
-func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, []byte, error) {
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options NetworkInspectOptions) (network.Inspect, []byte, error) {
 	networkID, err := trimID("network", networkID)
 	if err != nil {
 		return network.Inspect{}, nil, err

--- a/vendor/github.com/moby/moby/client/network_inspect.go
+++ b/vendor/github.com/moby/moby/client/network_inspect.go
@@ -11,13 +11,13 @@ import (
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, error) {
 	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID, options)
 	return networkResource, err
 }
 
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
-func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, []byte, error) {
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options InspectOptions) (network.Inspect, []byte, error) {
 	networkID, err := trimID("network", networkID)
 	if err != nil {
 		return network.Inspect{}, nil, err

--- a/vendor/github.com/moby/moby/client/network_inspect_opts.go
+++ b/vendor/github.com/moby/moby/client/network_inspect_opts.go
@@ -1,0 +1,7 @@
+package client
+
+// InspectOptions holds parameters to inspect network.
+type InspectOptions struct {
+	Scope   string
+	Verbose bool
+}

--- a/vendor/github.com/moby/moby/client/network_inspect_opts.go
+++ b/vendor/github.com/moby/moby/client/network_inspect_opts.go
@@ -1,7 +1,7 @@
 package client
 
-// InspectOptions holds parameters to inspect network.
-type InspectOptions struct {
+// NetworkInspectOptions holds parameters to inspect network.
+type NetworkInspectOptions struct {
 	Scope   string
 	Verbose bool
 }

--- a/vendor/github.com/moby/moby/client/network_list.go
+++ b/vendor/github.com/moby/moby/client/network_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error) {
+func (cli *Client) NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToJSON(options.Filters)

--- a/vendor/github.com/moby/moby/client/network_list.go
+++ b/vendor/github.com/moby/moby/client/network_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
+func (cli *Client) NetworkList(ctx context.Context, options ListOptions) ([]network.Summary, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToJSON(options.Filters)

--- a/vendor/github.com/moby/moby/client/network_list_opts.go
+++ b/vendor/github.com/moby/moby/client/network_list_opts.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// ListOptions holds parameters to filter the list of networks with.
+type ListOptions struct {
+	Filters filters.Args
+}

--- a/vendor/github.com/moby/moby/client/network_list_opts.go
+++ b/vendor/github.com/moby/moby/client/network_list_opts.go
@@ -2,7 +2,7 @@ package client
 
 import "github.com/moby/moby/api/types/filters"
 
-// ListOptions holds parameters to filter the list of networks with.
-type ListOptions struct {
+// NetworkListOptions holds parameters to filter the list of networks with.
+type NetworkListOptions struct {
 	Filters filters.Args
 }


### PR DESCRIPTION
**- What I did**
Partial of #50740

**- How I did it**
Moves the `network.ListOptions` and `network.InspectOptions` types to the client mod

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/network: move the `ListOptions` and `InspectOptions` types to the client
```

**- A picture of a cute animal (not mandatory but encouraged)**

