### PR TITLE
api/types/registry: move registry search options to client

### DIFF
--- a/api/types/registry/search.go
+++ b/api/types/registry/search.go
@@ -1,26 +1,5 @@
 package registry
 
-import (
-	"context"
-
-	"github.com/moby/moby/api/types/filters"
-)
-
-// SearchOptions holds parameters to search images with.
-type SearchOptions struct {
-	RegistryAuth string
-
-	// PrivilegeFunc is a function that clients can supply to retry operations
-	// after getting an authorization error. This function returns the registry
-	// authentication header value in base64 encoded format, or an error if the
-	// privilege request fails.
-	//
-	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
-	PrivilegeFunc func(context.Context) (string, error)
-	Filters       filters.Args
-	Limit         int
-}
-
 // SearchResult describes a search result returned from a registry
 type SearchResult struct {
 	// StarCount indicates the number of stars this repository has

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -116,7 +116,7 @@ type ImageAPIClient interface {
 	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
-	ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error)
+	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
 

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -116,7 +116,7 @@ type ImageAPIClient interface {
 	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
-	ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error)
+	ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
 

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -14,7 +14,7 @@ import (
 
 // ImageSearch makes the docker host search by a term in a remote registry.
 // The list of results is not sorted in any fashion.
-func (cli *Client) ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error) {
+func (cli *Client) ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error) {
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)

--- a/client/image_search.go
+++ b/client/image_search.go
@@ -14,7 +14,7 @@ import (
 
 // ImageSearch makes the docker host search by a term in a remote registry.
 // The list of results is not sorted in any fashion.
-func (cli *Client) ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error) {
+func (cli *Client) ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error) {
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)

--- a/client/image_search_opts.go
+++ b/client/image_search_opts.go
@@ -6,8 +6,8 @@ import (
 	"github.com/moby/moby/api/types/filters"
 )
 
-// SearchOptions holds parameters to search images with.
-type SearchOptions struct {
+// ImageSearchOptions holds parameters to search images with.
+type ImageSearchOptions struct {
 	RegistryAuth string
 
 	// PrivilegeFunc is a function that clients can supply to retry operations

--- a/client/image_search_opts.go
+++ b/client/image_search_opts.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+
+	"github.com/moby/moby/api/types/filters"
+)
+
+// SearchOptions holds parameters to search images with.
+type SearchOptions struct {
+	RegistryAuth string
+
+	// PrivilegeFunc is a function that clients can supply to retry operations
+	// after getting an authorization error. This function returns the registry
+	// authentication header value in base64 encoded format, or an error if the
+	// privilege request fails.
+	//
+	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
+	PrivilegeFunc func(context.Context) (string, error)
+	Filters       filters.Args
+	Limit         int
+}

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -22,7 +22,7 @@ func TestImageSearchAnyError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{})
+	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -30,7 +30,7 @@ func TestImageSearchStatusUnauthorizedError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{})
+	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
 }
 
@@ -41,7 +41,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", errors.New("Error requesting privilege")
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
+	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	assert.Check(t, is.Error(err, "Error requesting privilege"))
@@ -54,7 +54,7 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
+	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
@@ -99,7 +99,7 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
-	results, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
+	results, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
@@ -139,7 +139,7 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 			}, nil
 		}),
 	}
-	results, err := client.ImageSearch(context.Background(), "some-image", registry.SearchOptions{
+	results, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("is-automated", "true"),
 			filters.Arg("stars", "3"),

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -22,7 +22,7 @@ func TestImageSearchAnyError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{})
+	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -30,7 +30,7 @@ func TestImageSearchStatusUnauthorizedError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{})
+	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
 }
 
@@ -41,7 +41,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", errors.New("Error requesting privilege")
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
+	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	assert.Check(t, is.Error(err, "Error requesting privilege"))
@@ -54,7 +54,7 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
+	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
@@ -99,7 +99,7 @@ func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
-	results, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
+	results, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
 		RegistryAuth:  "NotValid",
 		PrivilegeFunc: privilegeFunc,
 	})
@@ -139,7 +139,7 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 			}, nil
 		}),
 	}
-	results, err := client.ImageSearch(context.Background(), "some-image", SearchOptions{
+	results, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("is-automated", "true"),
 			filters.Arg("stars", "3"),

--- a/vendor/github.com/moby/moby/api/types/registry/search.go
+++ b/vendor/github.com/moby/moby/api/types/registry/search.go
@@ -1,26 +1,5 @@
 package registry
 
-import (
-	"context"
-
-	"github.com/moby/moby/api/types/filters"
-)
-
-// SearchOptions holds parameters to search images with.
-type SearchOptions struct {
-	RegistryAuth string
-
-	// PrivilegeFunc is a function that clients can supply to retry operations
-	// after getting an authorization error. This function returns the registry
-	// authentication header value in base64 encoded format, or an error if the
-	// privilege request fails.
-	//
-	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
-	PrivilegeFunc func(context.Context) (string, error)
-	Filters       filters.Args
-	Limit         int
-}
-
 // SearchResult describes a search result returned from a registry
 type SearchResult struct {
 	// StarCount indicates the number of stars this repository has

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -116,7 +116,7 @@ type ImageAPIClient interface {
 	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
-	ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error)
+	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
 

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -116,7 +116,7 @@ type ImageAPIClient interface {
 	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
-	ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error)
+	ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)
 

--- a/vendor/github.com/moby/moby/client/image_search.go
+++ b/vendor/github.com/moby/moby/client/image_search.go
@@ -14,7 +14,7 @@ import (
 
 // ImageSearch makes the docker host search by a term in a remote registry.
 // The list of results is not sorted in any fashion.
-func (cli *Client) ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error) {
+func (cli *Client) ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error) {
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)

--- a/vendor/github.com/moby/moby/client/image_search.go
+++ b/vendor/github.com/moby/moby/client/image_search.go
@@ -14,7 +14,7 @@ import (
 
 // ImageSearch makes the docker host search by a term in a remote registry.
 // The list of results is not sorted in any fashion.
-func (cli *Client) ImageSearch(ctx context.Context, term string, options registry.SearchOptions) ([]registry.SearchResult, error) {
+func (cli *Client) ImageSearch(ctx context.Context, term string, options SearchOptions) ([]registry.SearchResult, error) {
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)

--- a/vendor/github.com/moby/moby/client/image_search_opts.go
+++ b/vendor/github.com/moby/moby/client/image_search_opts.go
@@ -6,8 +6,8 @@ import (
 	"github.com/moby/moby/api/types/filters"
 )
 
-// SearchOptions holds parameters to search images with.
-type SearchOptions struct {
+// ImageSearchOptions holds parameters to search images with.
+type ImageSearchOptions struct {
 	RegistryAuth string
 
 	// PrivilegeFunc is a function that clients can supply to retry operations

--- a/vendor/github.com/moby/moby/client/image_search_opts.go
+++ b/vendor/github.com/moby/moby/client/image_search_opts.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+
+	"github.com/moby/moby/api/types/filters"
+)
+
+// SearchOptions holds parameters to search images with.
+type SearchOptions struct {
+	RegistryAuth string
+
+	// PrivilegeFunc is a function that clients can supply to retry operations
+	// after getting an authorization error. This function returns the registry
+	// authentication header value in base64 encoded format, or an error if the
+	// privilege request fails.
+	//
+	// For details, refer to [github.com/moby/moby/api/types/registry.RequestAuthConfig].
+	PrivilegeFunc func(context.Context) (string, error)
+	Filters       filters.Args
+	Limit         int
+}


### PR DESCRIPTION
**- What I did**
Partial for #50740

This change moves the `registry.SearchOptions` from the api to `ImageSearchOptions` in the client mod

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/registry: move `SearchOptions` to `ImageSearchOptions` in the client
```

**- A picture of a cute animal (not mandatory but encouraged)**

