### PR TITLE
api/types/system: move `DiskUsageOptions` to client mod

### DIFF
--- a/api/types/system/disk_usage.go
+++ b/api/types/system/disk_usage.go
@@ -21,13 +21,6 @@ const (
 	BuildCacheObject DiskUsageObject = "build-cache"
 )
 
-// DiskUsageOptions holds parameters for system disk usage query.
-type DiskUsageOptions struct {
-	// Types specifies what object types to include in the response. If empty,
-	// all object types are returned.
-	Types []DiskUsageObject
-}
-
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -189,7 +189,7 @@ type SystemAPIClient interface {
 	Events(ctx context.Context, options EventsListOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
-	DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error)
+	DiskUsage(ctx context.Context, options DiskUsageOptions) (system.DiskUsage, error)
 	Ping(ctx context.Context) (types.Ping, error)
 }
 

--- a/client/system_disk_usage.go
+++ b/client/system_disk_usage.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DiskUsage requests the current data usage from the daemon
-func (cli *Client) DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error) {
+func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (system.DiskUsage, error) {
 	var query url.Values
 	if len(options.Types) > 0 {
 		query = url.Values{}

--- a/client/system_disk_usage_opts.go
+++ b/client/system_disk_usage_opts.go
@@ -1,0 +1,10 @@
+package client
+
+import "github.com/moby/moby/api/types/system"
+
+// DiskUsageOptions holds parameters for system disk usage query.
+type DiskUsageOptions struct {
+	// Types specifies what object types to include in the response. If empty,
+	// all object types are returned.
+	Types []system.DiskUsageObject
+}

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -20,7 +20,7 @@ func TestDiskUsageError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.DiskUsage(context.Background(), system.DiskUsageOptions{})
+	_, err := client.DiskUsage(context.Background(), DiskUsageOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -50,6 +50,6 @@ func TestDiskUsage(t *testing.T) {
 			}, nil
 		}),
 	}
-	_, err := client.DiskUsage(context.Background(), system.DiskUsageOptions{})
+	_, err := client.DiskUsage(context.Background(), DiskUsageOptions{})
 	assert.NilError(t, err)
 }

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/api/types/volume"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/testutil"
 	"github.com/moby/moby/v2/testutil/daemon"
@@ -35,7 +36,7 @@ func TestDiskUsage(t *testing.T) {
 		{
 			doc: "empty",
 			next: func(t *testing.T, _ system.DiskUsage) system.DiskUsage {
-				du, err := apiClient.DiskUsage(ctx, system.DiskUsageOptions{})
+				du, err := apiClient.DiskUsage(ctx, client.DiskUsageOptions{})
 				assert.NilError(t, err)
 
 				expectedLayersSize := int64(0)
@@ -62,7 +63,7 @@ func TestDiskUsage(t *testing.T) {
 			next: func(t *testing.T, _ system.DiskUsage) system.DiskUsage {
 				d.LoadBusybox(ctx, t)
 
-				du, err := apiClient.DiskUsage(ctx, system.DiskUsageOptions{})
+				du, err := apiClient.DiskUsage(ctx, client.DiskUsageOptions{})
 				assert.NilError(t, err)
 				assert.Assert(t, du.LayersSize > 0)
 				assert.Equal(t, len(du.Images), 1)
@@ -80,7 +81,7 @@ func TestDiskUsage(t *testing.T) {
 			next: func(t *testing.T, prev system.DiskUsage) system.DiskUsage {
 				cID := container.Run(ctx, t, apiClient)
 
-				du, err := apiClient.DiskUsage(ctx, system.DiskUsageOptions{})
+				du, err := apiClient.DiskUsage(ctx, client.DiskUsageOptions{})
 				assert.NilError(t, err)
 				assert.Equal(t, len(du.Containers), 1)
 				assert.Equal(t, len(du.Containers[0].Names), 1)
@@ -110,12 +111,12 @@ func TestDiskUsage(t *testing.T) {
 
 			for _, tc := range []struct {
 				doc      string
-				options  system.DiskUsageOptions
+				options  client.DiskUsageOptions
 				expected system.DiskUsage
 			}{
 				{
 					doc: "container types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ContainerObject,
 						},
@@ -126,7 +127,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "image types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ImageObject,
 						},
@@ -138,7 +139,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "volume types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.VolumeObject,
 						},
@@ -149,7 +150,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "build-cache types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.BuildCacheObject,
 						},
@@ -160,7 +161,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "container, volume types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ContainerObject,
 							system.VolumeObject,
@@ -173,7 +174,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "image, build-cache types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ImageObject,
 							system.BuildCacheObject,
@@ -187,7 +188,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "container, volume, build-cache types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ContainerObject,
 							system.VolumeObject,
@@ -202,7 +203,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "image, volume, build-cache types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ImageObject,
 							system.VolumeObject,
@@ -218,7 +219,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "container, image, volume types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ContainerObject,
 							system.ImageObject,
@@ -234,7 +235,7 @@ func TestDiskUsage(t *testing.T) {
 				},
 				{
 					doc: "container, image, volume, build-cache types",
-					options: system.DiskUsageOptions{
+					options: client.DiskUsageOptions{
 						Types: []system.DiskUsageObject{
 							system.ContainerObject,
 							system.ImageObject,

--- a/vendor/github.com/moby/moby/api/types/system/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/system/disk_usage.go
@@ -21,13 +21,6 @@ const (
 	BuildCacheObject DiskUsageObject = "build-cache"
 )
 
-// DiskUsageOptions holds parameters for system disk usage query.
-type DiskUsageOptions struct {
-	// Types specifies what object types to include in the response. If empty,
-	// all object types are returned.
-	Types []DiskUsageObject
-}
-
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -189,7 +189,7 @@ type SystemAPIClient interface {
 	Events(ctx context.Context, options EventsListOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (system.Info, error)
 	RegistryLogin(ctx context.Context, auth registry.AuthConfig) (registry.AuthenticateOKBody, error)
-	DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error)
+	DiskUsage(ctx context.Context, options DiskUsageOptions) (system.DiskUsage, error)
 	Ping(ctx context.Context) (types.Ping, error)
 }
 

--- a/vendor/github.com/moby/moby/client/system_disk_usage.go
+++ b/vendor/github.com/moby/moby/client/system_disk_usage.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DiskUsage requests the current data usage from the daemon
-func (cli *Client) DiskUsage(ctx context.Context, options system.DiskUsageOptions) (system.DiskUsage, error) {
+func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (system.DiskUsage, error) {
 	var query url.Values
 	if len(options.Types) > 0 {
 		query = url.Values{}

--- a/vendor/github.com/moby/moby/client/system_disk_usage_opts.go
+++ b/vendor/github.com/moby/moby/client/system_disk_usage_opts.go
@@ -1,0 +1,10 @@
+package client
+
+import "github.com/moby/moby/api/types/system"
+
+// DiskUsageOptions holds parameters for system disk usage query.
+type DiskUsageOptions struct {
+	// Types specifies what object types to include in the response. If empty,
+	// all object types are returned.
+	Types []system.DiskUsageObject
+}


### PR DESCRIPTION
**- What I did**
Partial of #50740 

This change moves the `system.DiskUsageOptions` type out of the api to the client mod

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/system: move `DiskUsageOptions` to the client
```

**- A picture of a cute animal (not mandatory but encouraged)**

