### PR TITLE
api/types/swarm: move swarm option types to client

### DIFF
--- a/api/types/swarm/config.go
+++ b/api/types/swarm/config.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"os"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // Config represents a config.
@@ -54,9 +52,4 @@ type ConfigReference struct {
 type ConfigCreateResponse struct {
 	// ID is the id of the created config.
 	ID string
-}
-
-// ConfigListOptions holds parameters to list configs
-type ConfigListOptions struct {
-	Filters filters.Args
 }

--- a/api/types/swarm/node.go
+++ b/api/types/swarm/node.go
@@ -1,7 +1,5 @@
 package swarm
 
-import "github.com/moby/moby/api/types/filters"
-
 // Node represents a node.
 type Node struct {
 	ID string
@@ -138,11 +136,6 @@ const (
 // duplicate it here. See that type for full documentation
 type Topology struct {
 	Segments map[string]string `json:",omitempty"`
-}
-
-// NodeListOptions holds parameters to list nodes with.
-type NodeListOptions struct {
-	Filters filters.Args
 }
 
 // NodeRemoveOptions holds parameters to remove nodes with.

--- a/api/types/swarm/node.go
+++ b/api/types/swarm/node.go
@@ -137,8 +137,3 @@ const (
 type Topology struct {
 	Segments map[string]string `json:",omitempty"`
 }
-
-// NodeRemoveOptions holds parameters to remove nodes with.
-type NodeRemoveOptions struct {
-	Force bool
-}

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"time"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // Service represents a service.
@@ -210,15 +208,6 @@ const (
 	RegistryAuthFromSpec         = "spec"
 	RegistryAuthFromPreviousSpec = "previous-spec"
 )
-
-// ServiceListOptions holds parameters to list services with.
-type ServiceListOptions struct {
-	Filters filters.Args
-
-	// Status indicates whether the server should include the service task
-	// count of running and desired tasks.
-	Status bool
-}
 
 // ServiceInspectOptions holds parameters related to the "service inspect"
 // operation.

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -211,36 +211,6 @@ const (
 	RegistryAuthFromPreviousSpec = "previous-spec"
 )
 
-// ServiceUpdateOptions contains the options to be used for updating services.
-type ServiceUpdateOptions struct {
-	// EncodedRegistryAuth is the encoded registry authorization credentials to
-	// use when updating the service.
-	//
-	// This field follows the format of the X-Registry-Auth header.
-	EncodedRegistryAuth string
-
-	// TODO(stevvooe): Consider moving the version parameter of ServiceUpdate
-	// into this field. While it does open API users up to racy writes, most
-	// users may not need that level of consistency in practice.
-
-	// RegistryAuthFrom specifies where to find the registry authorization
-	// credentials if they are not given in EncodedRegistryAuth. Valid
-	// values are "spec" and "previous-spec".
-	RegistryAuthFrom string
-
-	// Rollback indicates whether a server-side rollback should be
-	// performed. When this is set, the provided spec will be ignored.
-	// The valid values are "previous" and "none". An empty value is the
-	// same as "none".
-	Rollback string
-
-	// QueryRegistry indicates whether the service update requires
-	// contacting a registry. A registry may be contacted to retrieve
-	// the image digest and manifest, which in turn can be used to update
-	// platform or other information about the service.
-	QueryRegistry bool
-}
-
 // ServiceListOptions holds parameters to list services with.
 type ServiceListOptions struct {
 	Filters filters.Args

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -208,9 +208,3 @@ const (
 	RegistryAuthFromSpec         = "spec"
 	RegistryAuthFromPreviousSpec = "previous-spec"
 )
-
-// ServiceInspectOptions holds parameters related to the "service inspect"
-// operation.
-type ServiceInspectOptions struct {
-	InsertDefaults bool
-}

--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -205,21 +205,6 @@ type JobStatus struct {
 	LastExecution time.Time `json:",omitempty"`
 }
 
-// ServiceCreateOptions contains the options to use when creating a service.
-type ServiceCreateOptions struct {
-	// EncodedRegistryAuth is the encoded registry authorization credentials to
-	// use when updating the service.
-	//
-	// This field follows the format of the X-Registry-Auth header.
-	EncodedRegistryAuth string
-
-	// QueryRegistry indicates whether the service update requires
-	// contacting a registry. A registry may be contacted to retrieve
-	// the image digest and manifest, which in turn can be used to update
-	// platform or other information about the service.
-	QueryRegistry bool
-}
-
 // Values for RegistryAuthFrom in ServiceUpdateOptions
 const (
 	RegistryAuthFromSpec         = "spec"

--- a/api/types/swarm/swarm.go
+++ b/api/types/swarm/swarm.go
@@ -229,13 +229,6 @@ type Peer struct {
 	Addr   string
 }
 
-// UpdateFlags contains flags for SwarmUpdate.
-type UpdateFlags struct {
-	RotateWorkerToken      bool
-	RotateManagerToken     bool
-	RotateManagerUnlockKey bool
-}
-
 // UnlockKeyResponse contains the response for Engine API:
 // GET /swarm/unlockkey
 type UnlockKeyResponse struct {

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"time"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // TaskState represents the state of a task.
@@ -222,9 +220,4 @@ type VolumeAttachment struct {
 	// Target, together with Source, indicates the Mount, as specified
 	// in the ContainerSpec, that this volume fulfills.
 	Target string `json:",omitempty"`
-}
-
-// TaskListOptions holds parameters to list tasks with.
-type TaskListOptions struct {
-	Filters filters.Args
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -142,7 +142,7 @@ type NetworkAPIClient interface {
 type NodeAPIClient interface {
 	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
 	NodeList(ctx context.Context, options NodeListOptions) ([]swarm.Node, error)
-	NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error
+	NodeRemove(ctx context.Context, nodeID string, options NodeRemoveOptions) error
 	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
 }
 

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -164,7 +164,7 @@ type PluginAPIClient interface {
 type ServiceAPIClient interface {
 	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
-	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
+	ServiceList(ctx context.Context, options ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
 	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -181,7 +181,7 @@ type SwarmAPIClient interface {
 	SwarmUnlock(ctx context.Context, req swarm.UnlockRequest) error
 	SwarmLeave(ctx context.Context, force bool) error
 	SwarmInspect(ctx context.Context) (swarm.Swarm, error)
-	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error
+	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags SwarmUpdateFlags) error
 }
 
 // SystemAPIClient defines API client methods for the system

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -215,7 +215,7 @@ type SecretAPIClient interface {
 
 // ConfigAPIClient defines API client methods for configs
 type ConfigAPIClient interface {
-	ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error)
+	ConfigList(ctx context.Context, options ConfigListOptions) ([]swarm.Config, error)
 	ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (swarm.ConfigCreateResponse, error)
 	ConfigRemove(ctx context.Context, id string) error
 	ConfigInspectWithRaw(ctx context.Context, name string) (swarm.Config, []byte, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -166,7 +166,7 @@ type ServiceAPIClient interface {
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
-	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options swarm.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskLogs(ctx context.Context, taskID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -162,7 +162,7 @@ type PluginAPIClient interface {
 
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
-	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options swarm.ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -141,7 +141,7 @@ type NetworkAPIClient interface {
 // NodeAPIClient defines API client methods for the nodes
 type NodeAPIClient interface {
 	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
-	NodeList(ctx context.Context, options swarm.NodeListOptions) ([]swarm.Node, error)
+	NodeList(ctx context.Context, options NodeListOptions) ([]swarm.Node, error)
 	NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error
 	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -163,7 +163,7 @@ type PluginAPIClient interface {
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
 	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
-	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
+	ServiceInspectWithRaw(ctx context.Context, serviceID string, options ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
 	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -170,7 +170,7 @@ type ServiceAPIClient interface {
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskLogs(ctx context.Context, taskID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
-	TaskList(ctx context.Context, options swarm.TaskListOptions) ([]swarm.Task, error)
+	TaskList(ctx context.Context, options TaskListOptions) ([]swarm.Task, error)
 }
 
 // SwarmAPIClient defines API client methods for the swarm

--- a/client/config_list.go
+++ b/client/config_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ConfigList returns the list of configs.
-func (cli *Client) ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error) {
+func (cli *Client) ConfigList(ctx context.Context, options ConfigListOptions) ([]swarm.Config, error) {
 	if err := cli.NewVersionError(ctx, "1.30", "config list"); err != nil {
 		return nil, err
 	}

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -22,7 +22,7 @@ func TestConfigListUnsupported(t *testing.T) {
 		version: "1.29",
 		client:  &http.Client{},
 	}
-	_, err := client.ConfigList(context.Background(), swarm.ConfigListOptions{})
+	_, err := client.ConfigList(context.Background(), ConfigListOptions{})
 	assert.Check(t, is.Error(err, `"config list" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
@@ -32,7 +32,7 @@ func TestConfigListError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ConfigList(context.Background(), swarm.ConfigListOptions{})
+	_, err := client.ConfigList(context.Background(), ConfigListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -40,17 +40,17 @@ func TestConfigList(t *testing.T) {
 	expectedURL := "/v1.30/configs"
 
 	listCases := []struct {
-		options             swarm.ConfigListOptions
+		options             ConfigListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: swarm.ConfigListOptions{},
+			options: ConfigListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: swarm.ConfigListOptions{
+			options: ConfigListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NodeList returns the list of nodes.
-func (cli *Client) NodeList(ctx context.Context, options swarm.NodeListOptions) ([]swarm.Node, error) {
+func (cli *Client) NodeList(ctx context.Context, options NodeListOptions) ([]swarm.Node, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -22,7 +22,7 @@ func TestNodeListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NodeList(context.Background(), swarm.NodeListOptions{})
+	_, err := client.NodeList(context.Background(), NodeListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -30,17 +30,17 @@ func TestNodeList(t *testing.T) {
 	const expectedURL = "/nodes"
 
 	listCases := []struct {
-		options             swarm.NodeListOptions
+		options             NodeListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: swarm.NodeListOptions{},
+			options: NodeListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: swarm.NodeListOptions{
+			options: NodeListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/node_remove.go
+++ b/client/node_remove.go
@@ -3,12 +3,10 @@ package client
 import (
 	"context"
 	"net/url"
-
-	"github.com/moby/moby/api/types/swarm"
 )
 
 // NodeRemove removes a Node.
-func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error {
+func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options NodeRemoveOptions) error {
 	nodeID, err := trimID("node", nodeID)
 	if err != nil {
 		return err

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -20,14 +19,14 @@ func TestNodeRemoveError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.NodeRemove(context.Background(), "node_id", swarm.NodeRemoveOptions{Force: false})
+	err := client.NodeRemove(context.Background(), "node_id", NodeRemoveOptions{Force: false})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.NodeRemove(context.Background(), "", swarm.NodeRemoveOptions{Force: false})
+	err = client.NodeRemove(context.Background(), "", NodeRemoveOptions{Force: false})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.NodeRemove(context.Background(), "    ", swarm.NodeRemoveOptions{Force: false})
+	err = client.NodeRemove(context.Background(), "    ", NodeRemoveOptions{Force: false})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -69,7 +68,7 @@ func TestNodeRemove(t *testing.T) {
 			}),
 		}
 
-		err := client.NodeRemove(context.Background(), "node_id", swarm.NodeRemoveOptions{Force: removeCase.force})
+		err := client.NodeRemove(context.Background(), "node_id", NodeRemoveOptions{Force: removeCase.force})
 		assert.NilError(t, err)
 	}
 }

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ServiceCreate creates a new service.
-func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options swarm.ServiceCreateOptions) (swarm.ServiceCreateResponse, error) {
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error) {
 	var response swarm.ServiceCreateResponse
 
 	// Make sure we negotiated (if the client is configured to do so),

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -24,7 +24,7 @@ func TestServiceCreateError(t *testing.T) {
 	client := &Client{
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
-	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, swarm.ServiceCreateOptions{})
+	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, ServiceCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -36,7 +36,7 @@ func TestServiceCreateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, swarm.ServiceCreateOptions{})
+	_, err = client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, ServiceCreateOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
@@ -63,7 +63,7 @@ func TestServiceCreate(t *testing.T) {
 		}),
 	}
 
-	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, swarm.ServiceCreateOptions{})
+	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, ServiceCreateOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(r.ID, "service_id"))
 }
@@ -122,7 +122,7 @@ func TestServiceCreateCompatiblePlatforms(t *testing.T) {
 
 	spec := swarm.ServiceSpec{TaskTemplate: swarm.TaskSpec{ContainerSpec: &swarm.ContainerSpec{Image: "foobar:1.0"}}}
 
-	r, err := client.ServiceCreate(context.Background(), spec, swarm.ServiceCreateOptions{QueryRegistry: true})
+	r, err := client.ServiceCreate(context.Background(), spec, ServiceCreateOptions{QueryRegistry: true})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal("service_linux_amd64", r.ID))
 }
@@ -201,7 +201,7 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 					Image: p.img,
 				},
 			},
-		}, swarm.ServiceCreateOptions{QueryRegistry: true})
+		}, ServiceCreateOptions{QueryRegistry: true})
 		assert.NilError(t, err)
 
 		assert.Check(t, is.Equal(r.ID, "service_id"))

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ServiceInspectWithRaw returns the service information and the raw data.
-func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts swarm.ServiceInspectOptions) (swarm.Service, []byte, error) {
+func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts ServiceInspectOptions) (swarm.Service, []byte, error) {
 	serviceID, err := trimID("service", serviceID)
 	if err != nil {
 		return swarm.Service{}, nil, err

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -22,7 +22,7 @@ func TestServiceInspectError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", swarm.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "nothing", ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -31,7 +31,7 @@ func TestServiceInspectServiceNotFound(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
 	}
 
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", swarm.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "unknown", ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }
 
@@ -41,11 +41,11 @@ func TestServiceInspectWithEmptyID(t *testing.T) {
 			return nil, errors.New("should not make request")
 		}),
 	}
-	_, _, err := client.ServiceInspectWithRaw(context.Background(), "", swarm.ServiceInspectOptions{})
+	_, _, err := client.ServiceInspectWithRaw(context.Background(), "", ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	_, _, err = client.ServiceInspectWithRaw(context.Background(), "    ", swarm.ServiceInspectOptions{})
+	_, _, err = client.ServiceInspectWithRaw(context.Background(), "    ", ServiceInspectOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -70,7 +70,7 @@ func TestServiceInspect(t *testing.T) {
 		}),
 	}
 
-	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id", swarm.ServiceInspectOptions{})
+	serviceInspect, _, err := client.ServiceInspectWithRaw(context.Background(), "service_id", ServiceInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(serviceInspect.ID, "service_id"))
 }

--- a/client/service_list.go
+++ b/client/service_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ServiceList returns the list of services.
-func (cli *Client) ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error) {
+func (cli *Client) ServiceList(ctx context.Context, options ServiceListOptions) ([]swarm.Service, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -22,7 +22,7 @@ func TestServiceListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ServiceList(context.Background(), swarm.ServiceListOptions{})
+	_, err := client.ServiceList(context.Background(), ServiceListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -30,17 +30,17 @@ func TestServiceList(t *testing.T) {
 	const expectedURL = "/services"
 
 	listCases := []struct {
-		options             swarm.ServiceListOptions
+		options             ServiceListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: swarm.ServiceListOptions{},
+			options: ServiceListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: swarm.ServiceListOptions{
+			options: ServiceListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/client/service_update.go
+++ b/client/service_update.go
@@ -15,7 +15,7 @@ import (
 // conflicting writes. It must be the value as set *before* the update.
 // You can find this value in the [swarm.Service.Meta] field, which can
 // be found using [Client.ServiceInspectWithRaw].
-func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options swarm.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
 	serviceID, err := trimID("service", serviceID)
 	if err != nil {
 		return swarm.ServiceUpdateResponse{}, err

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -20,14 +20,14 @@ func TestServiceUpdateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
+	_, err := client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	_, err = client.ServiceUpdate(context.Background(), "", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
+	_, err = client.ServiceUpdate(context.Background(), "", swarm.Version{}, swarm.ServiceSpec{}, ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	_, err = client.ServiceUpdate(context.Background(), "    ", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
+	_, err = client.ServiceUpdate(context.Background(), "    ", swarm.Version{}, swarm.ServiceSpec{}, ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -40,7 +40,7 @@ func TestServiceUpdateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
+	_, err = client.ServiceUpdate(context.Background(), "service_id", swarm.Version{}, swarm.ServiceSpec{}, ServiceUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
@@ -88,7 +88,7 @@ func TestServiceUpdate(t *testing.T) {
 			}),
 		}
 
-		_, err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, swarm.ServiceUpdateOptions{})
+		_, err := client.ServiceUpdate(context.Background(), "service_id", updateCase.swarmVersion, swarm.ServiceSpec{}, ServiceUpdateOptions{})
 		assert.NilError(t, err)
 	}
 }

--- a/client/swarm_config_list_options.go
+++ b/client/swarm_config_list_options.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// ConfigListOptions holds parameters to list configs
+type ConfigListOptions struct {
+	Filters filters.Args
+}

--- a/client/swarm_node_list_opts.go
+++ b/client/swarm_node_list_opts.go
@@ -1,11 +1,8 @@
-package swarmbackend
+package client
 
 import "github.com/moby/moby/api/types/filters"
 
-type ConfigListOptions struct {
-	Filters filters.Args
-}
-
+// NodeListOptions holds parameters to list nodes with.
 type NodeListOptions struct {
 	Filters filters.Args
 }

--- a/client/swarm_node_remove_opts.go
+++ b/client/swarm_node_remove_opts.go
@@ -1,0 +1,6 @@
+package client
+
+// NodeRemoveOptions holds parameters to remove nodes with.
+type NodeRemoveOptions struct {
+	Force bool
+}

--- a/client/swarm_service_create_opts.go
+++ b/client/swarm_service_create_opts.go
@@ -1,0 +1,16 @@
+package client
+
+// ServiceCreateOptions contains the options to use when creating a service.
+type ServiceCreateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
+}

--- a/client/swarm_service_inspect_opts.go
+++ b/client/swarm_service_inspect_opts.go
@@ -1,0 +1,7 @@
+package client
+
+// ServiceInspectOptions holds parameters related to the "service inspect"
+// operation.
+type ServiceInspectOptions struct {
+	InsertDefaults bool
+}

--- a/client/swarm_service_list_opts.go
+++ b/client/swarm_service_list_opts.go
@@ -1,0 +1,12 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// ServiceListOptions holds parameters to list services with.
+type ServiceListOptions struct {
+	Filters filters.Args
+
+	// Status indicates whether the server should include the service task
+	// count of running and desired tasks.
+	Status bool
+}

--- a/client/swarm_service_update_opts.go
+++ b/client/swarm_service_update_opts.go
@@ -1,25 +1,6 @@
-package swarmbackend
+package client
 
-import "github.com/moby/moby/api/types/filters"
-
-type ConfigListOptions struct {
-	Filters filters.Args
-}
-
-type NodeListOptions struct {
-	Filters filters.Args
-}
-
-type TaskListOptions struct {
-	Filters filters.Args
-}
-
-type UpdateFlags struct {
-	RotateWorkerToken      bool
-	RotateManagerToken     bool
-	RotateManagerUnlockKey bool
-}
-
+// ServiceUpdateOptions contains the options to be used for updating services.
 type ServiceUpdateOptions struct {
 	// EncodedRegistryAuth is the encoded registry authorization credentials to
 	// use when updating the service.
@@ -41,4 +22,10 @@ type ServiceUpdateOptions struct {
 	// The valid values are "previous" and "none". An empty value is the
 	// same as "none".
 	Rollback string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
 }

--- a/client/swarm_task_list_opts.go
+++ b/client/swarm_task_list_opts.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// TaskListOptions holds parameters to list tasks with.
+type TaskListOptions struct {
+	Filters filters.Args
+}

--- a/client/swarm_update.go
+++ b/client/swarm_update.go
@@ -9,7 +9,7 @@ import (
 )
 
 // SwarmUpdate updates the swarm.
-func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error {
+func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags SwarmUpdateFlags) error {
 	query := url.Values{}
 	query.Set("version", version.String())
 	query.Set("rotateWorkerToken", strconv.FormatBool(flags.RotateWorkerToken))

--- a/client/swarm_update_flags.go
+++ b/client/swarm_update_flags.go
@@ -1,0 +1,8 @@
+package client
+
+// SwarmUpdateFlags contains flags for SwarmUpdate.
+type SwarmUpdateFlags struct {
+	RotateWorkerToken      bool
+	RotateManagerToken     bool
+	RotateManagerUnlockKey bool
+}

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -20,7 +20,7 @@ func TestSwarmUpdateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
+	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, SwarmUpdateFlags{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -42,6 +42,6 @@ func TestSwarmUpdate(t *testing.T) {
 		}),
 	}
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, swarm.UpdateFlags{})
+	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, SwarmUpdateFlags{})
 	assert.NilError(t, err)
 }

--- a/client/task_list.go
+++ b/client/task_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TaskList returns the list of tasks.
-func (cli *Client) TaskList(ctx context.Context, options swarm.TaskListOptions) ([]swarm.Task, error) {
+func (cli *Client) TaskList(ctx context.Context, options TaskListOptions) ([]swarm.Task, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -22,7 +22,7 @@ func TestTaskListError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.TaskList(context.Background(), swarm.TaskListOptions{})
+	_, err := client.TaskList(context.Background(), TaskListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -30,17 +30,17 @@ func TestTaskList(t *testing.T) {
 	const expectedURL = "/tasks"
 
 	listCases := []struct {
-		options             swarm.TaskListOptions
+		options             TaskListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: swarm.TaskListOptions{},
+			options: TaskListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: swarm.TaskListOptions{
+			options: TaskListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -5,6 +5,7 @@ import (
 
 	types "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/cluster/convert"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"google.golang.org/grpc"
 )
@@ -27,7 +28,7 @@ func (c *Cluster) GetConfig(input string) (types.Config, error) {
 }
 
 // GetConfigs returns all configs of a managed swarm cluster.
-func (c *Cluster) GetConfigs(options types.ConfigListOptions) ([]types.Config, error) {
+func (c *Cluster) GetConfigs(options swarmbackend.ConfigListOptions) ([]types.Config, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/cluster/nodes.go
+++ b/daemon/cluster/nodes.go
@@ -5,13 +5,14 @@ import (
 
 	types "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/cluster/convert"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	"github.com/moby/moby/v2/errdefs"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"google.golang.org/grpc"
 )
 
 // GetNodes returns a list of all nodes known to a cluster.
-func (c *Cluster) GetNodes(options types.NodeListOptions) ([]types.Node, error) {
+func (c *Cluster) GetNodes(options swarmbackend.NodeListOptions) ([]types.Node, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/moby/v2/daemon/cluster/convert"
 	"github.com/moby/moby/v2/daemon/internal/timestamp"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	"github.com/moby/moby/v2/errdefs"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/opencontainers/go-digest"
@@ -282,7 +283,7 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 }
 
 // UpdateService updates existing service to match new properties.
-func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swarm.ServiceSpec, flags swarm.ServiceUpdateOptions, queryRegistry bool) (*swarm.ServiceUpdateResponse, error) {
+func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swarm.ServiceSpec, flags swarmbackend.ServiceUpdateOptions, queryRegistry bool) (*swarm.ServiceUpdateResponse, error) {
 	var resp *swarm.ServiceUpdateResponse
 
 	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -29,7 +29,7 @@ import (
 )
 
 // GetServices returns all services of a managed swarm cluster.
-func (c *Cluster) GetServices(options swarm.ServiceListOptions) ([]swarm.Service, error) {
+func (c *Cluster) GetServices(options swarmbackend.ServiceListOptions) ([]swarm.Service, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/stack"
 	"github.com/moby/moby/v2/daemon/pkg/opts"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	"github.com/moby/moby/v2/errdefs"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/manager/encryption"
@@ -240,7 +241,7 @@ func (c *Cluster) inspect(ctx context.Context, state nodeState) (types.Swarm, er
 }
 
 // Update updates configuration of a managed swarm cluster.
-func (c *Cluster) Update(version uint64, spec types.Spec, flags types.UpdateFlags) error {
+func (c *Cluster) Update(version uint64, spec types.Spec, flags swarmbackend.UpdateFlags) error {
 	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
 		swarm, err := getSwarm(ctx, state.controlClient)
 		if err != nil {

--- a/daemon/cluster/tasks.go
+++ b/daemon/cluster/tasks.go
@@ -6,12 +6,13 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	types "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/cluster/convert"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"google.golang.org/grpc"
 )
 
 // GetTasks returns a list of tasks matching the filter options.
-func (c *Cluster) GetTasks(options types.TaskListOptions) ([]types.Task, error) {
+func (c *Cluster) GetTasks(options swarmbackend.TaskListOptions) ([]types.Task, error) {
 	var r *swarmapi.ListTasksResponse
 
 	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {

--- a/daemon/server/router/swarm/backend.go
+++ b/daemon/server/router/swarm/backend.go
@@ -21,7 +21,7 @@ type Backend interface {
 	GetServices(swarm.ServiceListOptions) ([]swarm.Service, error)
 	GetService(idOrName string, insertDefaults bool) (swarm.Service, error)
 	CreateService(swarm.ServiceSpec, string, bool) (*swarm.ServiceCreateResponse, error)
-	UpdateService(string, uint64, swarm.ServiceSpec, swarm.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)
+	UpdateService(string, uint64, swarm.ServiceSpec, swarmbackend.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)
 	RemoveService(string) error
 	ServiceLogs(context.Context, *backend.LogSelector, *container.LogsOptions) (<-chan *backend.LogMessage, error)
 	GetNodes(swarmbackend.NodeListOptions) ([]swarm.Node, error)

--- a/daemon/server/router/swarm/backend.go
+++ b/daemon/server/router/swarm/backend.go
@@ -6,6 +6,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 )
 
 // Backend abstracts a swarm manager.
@@ -34,7 +35,7 @@ type Backend interface {
 	RemoveSecret(idOrName string) error
 	GetSecret(id string) (swarm.Secret, error)
 	UpdateSecret(idOrName string, version uint64, spec swarm.SecretSpec) error
-	GetConfigs(opts swarm.ConfigListOptions) ([]swarm.Config, error)
+	GetConfigs(opts swarmbackend.ConfigListOptions) ([]swarm.Config, error)
 	CreateConfig(s swarm.ConfigSpec) (string, error)
 	RemoveConfig(id string) error
 	GetConfig(id string) (swarm.Config, error)

--- a/daemon/server/router/swarm/backend.go
+++ b/daemon/server/router/swarm/backend.go
@@ -24,7 +24,7 @@ type Backend interface {
 	UpdateService(string, uint64, swarm.ServiceSpec, swarm.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)
 	RemoveService(string) error
 	ServiceLogs(context.Context, *backend.LogSelector, *container.LogsOptions) (<-chan *backend.LogMessage, error)
-	GetNodes(swarm.NodeListOptions) ([]swarm.Node, error)
+	GetNodes(swarmbackend.NodeListOptions) ([]swarm.Node, error)
 	GetNode(string) (swarm.Node, error)
 	UpdateNode(string, uint64, swarm.NodeSpec) error
 	RemoveNode(string, bool) error

--- a/daemon/server/router/swarm/backend.go
+++ b/daemon/server/router/swarm/backend.go
@@ -15,7 +15,7 @@ type Backend interface {
 	Join(req swarm.JoinRequest) error
 	Leave(ctx context.Context, force bool) error
 	Inspect() (swarm.Swarm, error)
-	Update(uint64, swarm.Spec, swarm.UpdateFlags) error
+	Update(uint64, swarm.Spec, swarmbackend.UpdateFlags) error
 	GetUnlockKey() (string, error)
 	UnlockSwarm(req swarm.UnlockRequest) error
 	GetServices(swarm.ServiceListOptions) ([]swarm.Service, error)

--- a/daemon/server/router/swarm/backend.go
+++ b/daemon/server/router/swarm/backend.go
@@ -28,7 +28,7 @@ type Backend interface {
 	GetNode(string) (swarm.Node, error)
 	UpdateNode(string, uint64, swarm.NodeSpec) error
 	RemoveNode(string, bool) error
-	GetTasks(swarm.TaskListOptions) ([]swarm.Task, error)
+	GetTasks(swarmbackend.TaskListOptions) ([]swarm.Task, error)
 	GetTask(string) (swarm.Task, error)
 	GetSecrets(opts swarm.SecretListOptions) ([]swarm.Secret, error)
 	CreateSecret(s swarm.SecretSpec) (string, error)

--- a/daemon/server/router/swarm/backend.go
+++ b/daemon/server/router/swarm/backend.go
@@ -18,7 +18,7 @@ type Backend interface {
 	Update(uint64, swarm.Spec, swarmbackend.UpdateFlags) error
 	GetUnlockKey() (string, error)
 	UnlockSwarm(req swarm.UnlockRequest) error
-	GetServices(swarm.ServiceListOptions) ([]swarm.Service, error)
+	GetServices(swarmbackend.ServiceListOptions) ([]swarm.Service, error)
 	GetService(idOrName string, insertDefaults bool) (swarm.Service, error)
 	CreateService(swarm.ServiceSpec, string, bool) (*swarm.ServiceCreateResponse, error)
 	UpdateService(string, uint64, swarm.ServiceSpec, swarmbackend.ServiceUpdateOptions, bool) (*swarm.ServiceUpdateResponse, error)

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
 )
@@ -486,7 +487,7 @@ func (sr *swarmRouter) getConfigs(ctx context.Context, w http.ResponseWriter, r 
 		return err
 	}
 
-	configs, err := sr.backend.GetConfigs(types.ConfigListOptions{Filters: filters})
+	configs, err := sr.backend.GetConfigs(swarmbackend.ConfigListOptions{Filters: filters})
 	if err != nil {
 		return err
 	}

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -245,7 +245,7 @@ func (sr *swarmRouter) updateService(ctx context.Context, w http.ResponseWriter,
 		return errdefs.InvalidParameter(err)
 	}
 
-	var flags types.ServiceUpdateOptions
+	var flags swarmbackend.ServiceUpdateOptions
 
 	// Get returns "" if the header does not exist
 	flags.EncodedRegistryAuth = r.Header.Get(registry.AuthHeader)

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -314,7 +314,7 @@ func (sr *swarmRouter) getNodes(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	nodes, err := sr.backend.GetNodes(types.NodeListOptions{Filters: filter})
+	nodes, err := sr.backend.GetNodes(swarmbackend.NodeListOptions{Filters: filter})
 	if err != nil {
 		log.G(ctx).WithContext(ctx).WithError(err).Debug("Error getting nodes")
 		return err

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -82,7 +82,7 @@ func (sr *swarmRouter) updateCluster(ctx context.Context, w http.ResponseWriter,
 		return errdefs.InvalidParameter(err)
 	}
 
-	var flags types.UpdateFlags
+	var flags swarmbackend.UpdateFlags
 
 	if value := r.URL.Query().Get("rotateWorkerToken"); value != "" {
 		rot, err := strconv.ParseBool(value)

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -385,7 +385,7 @@ func (sr *swarmRouter) getTasks(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	tasks, err := sr.backend.GetTasks(types.TaskListOptions{Filters: filter})
+	tasks, err := sr.backend.GetTasks(swarmbackend.TaskListOptions{Filters: filter})
 	if err != nil {
 		log.G(ctx).WithContext(ctx).WithError(err).Debug("Error getting tasks")
 		return err

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -166,7 +166,7 @@ func (sr *swarmRouter) getServices(ctx context.Context, w http.ResponseWriter, r
 		}
 	}
 
-	services, err := sr.backend.GetServices(types.ServiceListOptions{Filters: filter, Status: status})
+	services, err := sr.backend.GetServices(swarmbackend.ServiceListOptions{Filters: filter, Status: status})
 	if err != nil {
 		log.G(ctx).WithContext(ctx).WithError(err).Debug("Error getting services")
 		return err

--- a/daemon/server/swarmbackend/swarm.go
+++ b/daemon/server/swarmbackend/swarm.go
@@ -13,3 +13,9 @@ type NodeListOptions struct {
 type TaskListOptions struct {
 	Filters filters.Args
 }
+
+type UpdateFlags struct {
+	RotateWorkerToken      bool
+	RotateManagerToken     bool
+	RotateManagerUnlockKey bool
+}

--- a/daemon/server/swarmbackend/swarm.go
+++ b/daemon/server/swarmbackend/swarm.go
@@ -1,0 +1,7 @@
+package swarmbackend
+
+import "github.com/moby/moby/api/types/filters"
+
+type ConfigListOptions struct {
+	Filters filters.Args
+}

--- a/daemon/server/swarmbackend/swarm.go
+++ b/daemon/server/swarmbackend/swarm.go
@@ -9,3 +9,7 @@ type ConfigListOptions struct {
 type NodeListOptions struct {
 	Filters filters.Args
 }
+
+type TaskListOptions struct {
+	Filters filters.Args
+}

--- a/daemon/server/swarmbackend/swarm.go
+++ b/daemon/server/swarmbackend/swarm.go
@@ -42,3 +42,11 @@ type ServiceUpdateOptions struct {
 	// same as "none".
 	Rollback string
 }
+
+type ServiceListOptions struct {
+	Filters filters.Args
+
+	// Status indicates whether the server should include the service task
+	// count of running and desired tasks.
+	Status bool
+}

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -104,7 +104,7 @@ func (d *Daemon) CheckRunningTaskNetworks(ctx context.Context) func(t *testing.T
 		cli := d.NewClientT(t)
 		defer cli.Close()
 
-		tasks, err := cli.TaskList(ctx, swarm.TaskListOptions{
+		tasks, err := cli.TaskList(ctx, client.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("desired-state", "running")),
 		})
 		assert.NilError(t, err)
@@ -125,7 +125,7 @@ func (d *Daemon) CheckRunningTaskImages(ctx context.Context) func(t *testing.T) 
 		cli := d.NewClientT(t)
 		defer cli.Close()
 
-		tasks, err := cli.TaskList(ctx, swarm.TaskListOptions{
+		tasks, err := cli.TaskList(ctx, client.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("desired-state", "running")),
 		})
 		assert.NilError(t, err)

--- a/integration-cli/daemon/daemon_swarm.go
+++ b/integration-cli/daemon/daemon_swarm.go
@@ -10,6 +10,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 )
 
@@ -178,7 +179,7 @@ func (d *Daemon) CheckLeader(ctx context.Context) func(t *testing.T) (any, strin
 
 		errList := "could not get node list"
 
-		ls, err := cli.NodeList(ctx, swarm.NodeListOptions{})
+		ls, err := cli.NodeList(ctx, client.NodeListOptions{})
 		if err != nil {
 			return err, errList
 		}

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration-cli/checker"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/integration-cli/cli/build"
@@ -71,19 +72,19 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesCreate(c *testing.T) {
 	id := d.CreateService(ctx, c, simpleTestService, setInstances(instances))
 	poll.WaitOn(c, pollCheck(c, d.CheckActiveContainerCount(ctx), checker.Equals(instances)), poll.WithTimeout(defaultReconciliationTimeout))
 
-	client := d.NewClientT(c)
-	defer client.Close()
+	apiClient := d.NewClientT(c)
+	defer apiClient.Close()
 
-	options := swarm.ServiceInspectOptions{InsertDefaults: true}
+	options := client.ServiceInspectOptions{InsertDefaults: true}
 
 	// insertDefaults inserts UpdateConfig when service is fetched by ID
-	resp, _, err := client.ServiceInspectWithRaw(ctx, id, options)
+	resp, _, err := apiClient.ServiceInspectWithRaw(ctx, id, options)
 	out := fmt.Sprintf("%+v", resp)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Contains(out, "UpdateConfig"))
 
 	// insertDefaults inserts UpdateConfig when service is fetched by ID
-	resp, _, err = client.ServiceInspectWithRaw(ctx, "top", options)
+	resp, _, err = apiClient.ServiceInspectWithRaw(ctx, "top", options)
 	out = fmt.Sprintf("%+v", resp)
 	assert.NilError(c, err)
 	assert.Assert(c, is.Contains(out, "UpdateConfig"))

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -414,7 +414,7 @@ func (s *DockerSwarmSuite) TestAPISwarmRaftQuorum(c *testing.T) {
 
 	// d1 will eventually step down from leader because there is no longer an active quorum, wait for that to happen
 	poll.WaitOn(c, pollCheck(c, func(t *testing.T) (any, string) {
-		_, err := cli.ServiceCreate(testutil.GetContext(t), service.Spec, swarm.ServiceCreateOptions{})
+		_, err := cli.ServiceCreate(testutil.GetContext(t), service.Spec, client.ServiceCreateOptions{})
 		return err.Error(), ""
 	}, checker.Contains("Make sure more than half of the managers are online.")), poll.WithTimeout(defaultReconciliationTimeout*2))
 

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -890,7 +890,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateWithName(c *testing.T) {
 	setInstances(instances)(service)
 	cli := d.NewClientT(c)
 	defer cli.Close()
-	_, err := cli.ServiceUpdate(ctx, service.Spec.Name, service.Version, service.Spec, swarm.ServiceUpdateOptions{})
+	_, err := cli.ServiceUpdate(ctx, service.Spec.Name, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(c, err)
 	poll.WaitOn(c, pollCheck(c, d.CheckActiveContainerCount(ctx), checker.Equals(instances)), poll.WithTimeout(defaultReconciliationTimeout))
 }

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -56,7 +56,7 @@ func TestConfigList(t *testing.T) {
 	defer c.Close()
 
 	// This test case is ported from the original TestConfigsEmptyList
-	configs, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
+	configs, err := c.ConfigList(ctx, client.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(configs), 0))
 
@@ -71,7 +71,7 @@ func TestConfigList(t *testing.T) {
 	config1ID := createConfig(ctx, t, c, testName1, []byte("TESTINGDATA1"), map[string]string{"type": "production"})
 
 	// test by `config ls`
-	entries, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
+	entries, err := c.ConfigList(ctx, client.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(configNamesFromList(entries), testNames))
 
@@ -109,7 +109,7 @@ func TestConfigList(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
-			entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{
+			entries, err = c.ConfigList(ctx, client.ConfigListOptions{
 				Filters: tc.filters,
 			})
 			assert.NilError(t, err)
@@ -356,7 +356,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	fakeName := configID
 	fakeID := createConfig(ctx, t, c, fakeName, []byte("fake foo"), nil)
 
-	entries, err := c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
+	entries, err := c.ConfigList(ctx, client.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Contains(configNamesFromList(entries), configName))
 	assert.Assert(t, is.Contains(configNamesFromList(entries), fakeName))
@@ -365,7 +365,7 @@ func TestConfigCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Fake one will remain
-	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, client.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(configNamesFromList(entries), []string{fakeName}))
 
@@ -377,14 +377,14 @@ func TestConfigCreateResolve(t *testing.T) {
 	// - Partial ID (prefix)
 	err = c.ConfigRemove(ctx, configID[:5])
 	assert.Assert(t, err != nil)
-	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, client.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(configNamesFromList(entries), []string{fakeName}))
 
 	// Remove based on ID prefix of the fake one should succeed
 	err = c.ConfigRemove(ctx, fakeID[:5])
 	assert.NilError(t, err)
-	entries, err = c.ConfigList(ctx, swarmtypes.ConfigListOptions{})
+	entries, err = c.ConfigList(ctx, client.ConfigListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(0, len(entries)))
 }

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -63,7 +63,7 @@ func CreateService(ctx context.Context, t *testing.T, d *daemon.Daemon, opts ...
 	defer apiClient.Close()
 
 	spec := CreateServiceSpec(t, opts...)
-	resp, err := apiClient.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{})
+	resp, err := apiClient.ServiceCreate(ctx, spec, client.ServiceCreateOptions{})
 	assert.NilError(t, err, "error creating service")
 	return resp.ID
 }

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -199,7 +199,7 @@ func ServiceWithPidsLimit(limit int64) ServiceSpecOpt {
 func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClient, serviceID string) []swarmtypes.Task {
 	t.Helper()
 
-	tasks, err := c.TaskList(ctx, swarmtypes.TaskListOptions{
+	tasks, err := c.TaskList(ctx, client.TaskListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("service", serviceID),
 			filters.Arg("desired-state", "running"),

--- a/integration/internal/swarm/states.go
+++ b/integration/internal/swarm/states.go
@@ -11,9 +11,9 @@ import (
 )
 
 // NoTasksForService verifies that there are no more tasks for the given service
-func NoTasksForService(ctx context.Context, client client.ServiceAPIClient, serviceID string) func(log poll.LogT) poll.Result {
+func NoTasksForService(ctx context.Context, apiClient client.ServiceAPIClient, serviceID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
+		tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
 			Filters: filters.NewArgs(
 				filters.Arg("service", serviceID),
 			),
@@ -33,9 +33,9 @@ func NoTasksForService(ctx context.Context, client client.ServiceAPIClient, serv
 }
 
 // NoTasks verifies that all tasks are gone
-func NoTasks(ctx context.Context, client client.ServiceAPIClient) func(log poll.LogT) poll.Result {
+func NoTasks(ctx context.Context, apiClient client.ServiceAPIClient) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{})
+		tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)
@@ -48,11 +48,11 @@ func NoTasks(ctx context.Context, client client.ServiceAPIClient) func(log poll.
 }
 
 // RunningTasksCount verifies there are `instances` tasks running for `serviceID`
-func RunningTasksCount(ctx context.Context, client client.ServiceAPIClient, serviceID string, instances uint64) func(log poll.LogT) poll.Result {
+func RunningTasksCount(ctx context.Context, apiClient client.ServiceAPIClient, serviceID string, instances uint64) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
 		filter := filters.NewArgs()
 		filter.Add("service", serviceID)
-		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
+		tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
 			Filters: filter,
 		})
 		var running int
@@ -88,7 +88,7 @@ func RunningTasksCount(ctx context.Context, client client.ServiceAPIClient, serv
 // JobComplete is a poll function for determining that a ReplicatedJob is
 // completed additionally, while polling, it verifies that the job never
 // exceeds MaxConcurrent running tasks
-func JobComplete(ctx context.Context, client client.ServiceAPIClient, service swarmtypes.Service) func(log poll.LogT) poll.Result {
+func JobComplete(ctx context.Context, apiClient client.ServiceAPIClient, service swarmtypes.Service) func(log poll.LogT) poll.Result {
 	filter := filters.NewArgs(filters.Arg("service", service.ID))
 
 	var jobIteration swarmtypes.Version
@@ -101,7 +101,7 @@ func JobComplete(ctx context.Context, client client.ServiceAPIClient, service sw
 	previousResult := ""
 
 	return func(log poll.LogT) poll.Result {
-		tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
+		tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
 			Filters: filter,
 		})
 		if err != nil {

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -245,7 +245,7 @@ func TestServiceWithPredefinedNetwork(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	err = c.ServiceRemove(ctx, serviceID)
@@ -286,7 +286,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, c, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+	_, _, err := c.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	err = c.ServiceRemove(ctx, serviceID)
@@ -440,7 +440,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, cli, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+	_, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	out, err := cli.NetworkInspect(ctx, overlayID, client.NetworkInspectOptions{Verbose: true})

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -331,9 +331,9 @@ func swarmIngressReady(ctx context.Context, apiClient client.NetworkAPIClient) f
 	}
 }
 
-func noServices(ctx context.Context, client client.ServiceAPIClient) func(log poll.LogT) poll.Result {
+func noServices(ctx context.Context, apiClient client.ServiceAPIClient) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		services, err := client.ServiceList(ctx, swarmtypes.ServiceListOptions{})
+		services, err := apiClient.ServiceList(ctx, client.ServiceListOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -101,7 +101,7 @@ func TestCreateServiceMultipleTimes(t *testing.T) {
 	serviceID := swarm.CreateService(ctx, t, d, serviceSpec...)
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances), swarm.ServicePoll)
 
-	_, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+	_, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	err = apiClient.ServiceRemove(ctx, serviceID)
@@ -186,7 +186,7 @@ func TestCreateServiceMaxReplicas(t *testing.T) {
 	serviceID := swarm.CreateService(ctx, t, d, serviceSpec...)
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, maxReplicas), swarm.ServicePoll)
 
-	_, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+	_, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 }
 
@@ -382,7 +382,7 @@ func TestCreateServiceSysctls(t *testing.T) {
 		assert.DeepEqual(t, tasks[0].Spec.ContainerSpec.Sysctls, expectedSysctls)
 
 		// verify that the service also has the sysctl set in the spec.
-		service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+		service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 		assert.NilError(t, err)
 		assert.DeepEqual(t,
 			service.Spec.TaskTemplate.ContainerSpec.Sysctls, expectedSysctls,
@@ -454,7 +454,7 @@ func TestCreateServiceCapabilities(t *testing.T) {
 	assert.DeepEqual(t, tasks[0].Spec.ContainerSpec.CapabilityDrop, capDrop)
 
 	// verify that the service also has the capabilities set in the spec.
-	service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+	service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd, capAdd)
 	assert.DeepEqual(t, service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop, capDrop)

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -164,7 +164,7 @@ func TestCreateServiceConflict(t *testing.T) {
 	swarm.CreateService(ctx, t, d, serviceSpec...)
 
 	spec := swarm.CreateServiceSpec(t, serviceSpec...)
-	_, err := c.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{})
+	_, err := c.ServiceCreate(ctx, spec, client.ServiceCreateOptions{})
 	assert.Check(t, cerrdefs.IsConflict(err))
 	assert.ErrorContains(t, err, "service "+serviceName+" already exists")
 }

--- a/integration/service/create_test.go
+++ b/integration/service/create_test.go
@@ -367,7 +367,7 @@ func TestCreateServiceSysctls(t *testing.T) {
 		// more complex)
 
 		// get all tasks of the service, so we can get the container
-		tasks, err := apiClient.TaskList(ctx, swarmtypes.TaskListOptions{
+		tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
 			Filters: filters.NewArgs(filters.Arg("service", serviceID)),
 		})
 		assert.NilError(t, err)
@@ -437,7 +437,7 @@ func TestCreateServiceCapabilities(t *testing.T) {
 	// level has been tested elsewhere.
 
 	// get all tasks of the service, so we can get the container
-	tasks, err := apiClient.TaskList(ctx, swarmtypes.TaskListOptions{
+	tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
 		Filters: filters.NewArgs(filters.Arg("service", serviceID)),
 	})
 	assert.NilError(t, err)

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/moby/moby/api/types/container"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -20,22 +21,22 @@ func TestInspect(t *testing.T) {
 	ctx := setupTest(t)
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	now := time.Now()
 	var instances uint64 = 2
 	serviceSpec := fullSwarmServiceSpec("test-service-inspect"+t.Name(), instances)
 
-	resp, err := client.ServiceCreate(ctx, serviceSpec, swarmtypes.ServiceCreateOptions{
+	resp, err := apiClient.ServiceCreate(ctx, serviceSpec, client.ServiceCreateOptions{
 		QueryRegistry: false,
 	})
 	assert.NilError(t, err)
 
 	id := resp.ID
-	poll.WaitOn(t, swarm.RunningTasksCount(ctx, client, id, instances))
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, id, instances))
 
-	service, _, err := client.ServiceInspectWithRaw(ctx, id, swarmtypes.ServiceInspectOptions{})
+	service, _, err := apiClient.ServiceInspectWithRaw(ctx, id, swarmtypes.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	expected := swarmtypes.Service{

--- a/integration/service/inspect_test.go
+++ b/integration/service/inspect_test.go
@@ -36,7 +36,7 @@ func TestInspect(t *testing.T) {
 	id := resp.ID
 	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, id, instances))
 
-	service, _, err := apiClient.ServiceInspectWithRaw(ctx, id, swarmtypes.ServiceInspectOptions{})
+	service, _, err := apiClient.ServiceInspectWithRaw(ctx, id, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 
 	expected := swarmtypes.Service{

--- a/integration/service/jobs_test.go
+++ b/integration/service/jobs_test.go
@@ -60,8 +60,8 @@ func TestReplicatedJob(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	id := swarm.CreateService(ctx, t, d,
 		swarm.ServiceWithMode(swarmtypes.ServiceMode{
@@ -74,12 +74,12 @@ func TestReplicatedJob(t *testing.T) {
 		swarm.ServiceWithCommand([]string{"true"}),
 	)
 
-	service, _, err := client.ServiceInspectWithRaw(
-		ctx, id, swarmtypes.ServiceInspectOptions{},
+	service, _, err := apiClient.ServiceInspectWithRaw(
+		ctx, id, client.ServiceInspectOptions{},
 	)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, swarm.JobComplete(ctx, client, service), swarm.ServicePoll)
+	poll.WaitOn(t, swarm.JobComplete(ctx, apiClient, service), swarm.ServicePoll)
 }
 
 // TestUpdateReplicatedJob tests that a job can be updated, and that it runs with the
@@ -108,7 +108,7 @@ func TestUpdateReplicatedJob(t *testing.T) {
 	)
 
 	service, _, err := apiClient.ServiceInspectWithRaw(
-		ctx, id, swarmtypes.ServiceInspectOptions{},
+		ctx, id, client.ServiceInspectOptions{},
 	)
 	assert.NilError(t, err)
 
@@ -125,7 +125,7 @@ func TestUpdateReplicatedJob(t *testing.T) {
 	assert.NilError(t, err)
 
 	service2, _, err := apiClient.ServiceInspectWithRaw(
-		ctx, id, swarmtypes.ServiceInspectOptions{},
+		ctx, id, client.ServiceInspectOptions{},
 	)
 	assert.NilError(t, err)
 

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -79,7 +79,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 	}
 
 	// now, let's do the list operation with no status arg set.
-	resp, err := apiClient.ServiceList(ctx, swarmtypes.ServiceListOptions{})
+	resp, err := apiClient.ServiceList(ctx, client.ServiceListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(resp, serviceCount))
 	for _, service := range resp {
@@ -87,7 +87,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 	}
 
 	// now try again, but with Status: true. This time, we should have statuses
-	resp, err = apiClient.ServiceList(ctx, swarmtypes.ServiceListOptions{Status: true})
+	resp, err = apiClient.ServiceList(ctx, client.ServiceListOptions{Status: true})
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(resp, serviceCount))
 	for _, service := range resp {

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -44,7 +44,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 		// tasks to fail and exit. instead, we'll just pass no args, which
 		// works.
 		spec.TaskTemplate.ContainerSpec.Args = []string{}
-		resp, err := apiClient.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{
+		resp, err := apiClient.ServiceCreate(ctx, spec, client.ServiceCreateOptions{
 			QueryRegistry: false,
 		})
 		assert.NilError(t, err)

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moby/moby/api/types/filters"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -32,8 +33,8 @@ func TestServiceListWithStatuses(t *testing.T) {
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	serviceCount := 3
 	// create some services.
@@ -43,7 +44,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 		// tasks to fail and exit. instead, we'll just pass no args, which
 		// works.
 		spec.TaskTemplate.ContainerSpec.Args = []string{}
-		resp, err := client.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{
+		resp, err := apiClient.ServiceCreate(ctx, spec, swarmtypes.ServiceCreateOptions{
 			QueryRegistry: false,
 		})
 		assert.NilError(t, err)
@@ -52,7 +53,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 		// serviceContainerCount function does not do. instead, we'll use a
 		// bespoke closure right here.
 		poll.WaitOn(t, func(log poll.LogT) poll.Result {
-			tasks, err := client.TaskList(ctx, swarmtypes.TaskListOptions{
+			tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
 				Filters: filters.NewArgs(filters.Arg("service", id)),
 			})
 
@@ -78,7 +79,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 	}
 
 	// now, let's do the list operation with no status arg set.
-	resp, err := client.ServiceList(ctx, swarmtypes.ServiceListOptions{})
+	resp, err := apiClient.ServiceList(ctx, swarmtypes.ServiceListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(resp, serviceCount))
 	for _, service := range resp {
@@ -86,7 +87,7 @@ func TestServiceListWithStatuses(t *testing.T) {
 	}
 
 	// now try again, but with Status: true. This time, we should have statuses
-	resp, err = client.ServiceList(ctx, swarmtypes.ServiceListOptions{Status: true})
+	resp, err = apiClient.ServiceList(ctx, swarmtypes.ServiceListOptions{Status: true})
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(resp, serviceCount))
 	for _, service := range resp {

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -341,14 +341,14 @@ func getServiceTaskContainer(ctx context.Context, t *testing.T, cli client.APICl
 
 func getService(ctx context.Context, t *testing.T, cli client.ServiceAPIClient, serviceID string) swarmtypes.Service {
 	t.Helper()
-	service, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+	service, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	return service
 }
 
-func serviceIsUpdated(ctx context.Context, client client.ServiceAPIClient, serviceID string) func(log poll.LogT) poll.Result {
+func serviceIsUpdated(ctx context.Context, apiClient client.ServiceAPIClient, serviceID string) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+		service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)
@@ -363,9 +363,9 @@ func serviceIsUpdated(ctx context.Context, client client.ServiceAPIClient, servi
 	}
 }
 
-func serviceSpecIsUpdated(ctx context.Context, client client.ServiceAPIClient, serviceID string, serviceOldVersion uint64) func(log poll.LogT) poll.Result {
+func serviceSpecIsUpdated(ctx context.Context, apiClient client.ServiceAPIClient, serviceID string, serviceOldVersion uint64) func(log poll.LogT) poll.Result {
 	return func(log poll.LogT) poll.Result {
-		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, swarmtypes.ServiceInspectOptions{})
+		service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 		switch {
 		case err != nil:
 			return poll.Error(err)

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -33,7 +33,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 
 	// add label to empty set
 	service.Spec.Labels["foo"] = "bar"
-	_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -41,21 +41,21 @@ func TestServiceUpdateLabel(t *testing.T) {
 
 	// add label to non-empty set
 	service.Spec.Labels["foo2"] = "bar"
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar", "foo2": "bar"}))
 
 	delete(service.Spec.Labels, "foo2")
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
 	delete(service.Spec.Labels, "foo")
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -63,7 +63,7 @@ func TestServiceUpdateLabel(t *testing.T) {
 
 	// now make sure we can add again
 	service.Spec.Labels["foo"] = "bar"
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -110,7 +110,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 			SecretName: secretName,
 		},
 	)
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
@@ -125,7 +125,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 	// remove
 	service.Spec.TaskTemplate.ContainerSpec.Secrets = []*swarmtypes.SecretReference{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -172,7 +172,7 @@ func TestServiceUpdateConfigs(t *testing.T) {
 			ConfigName: configName,
 		},
 	)
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
@@ -187,7 +187,7 @@ func TestServiceUpdateConfigs(t *testing.T) {
 
 	// remove
 	service.Spec.TaskTemplate.ContainerSpec.Configs = []*swarmtypes.ConfigReference{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 	service = getService(ctx, t, cli, serviceID)
@@ -230,7 +230,7 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 	// Remove network from service
 	service.Spec.TaskTemplate.Networks = []swarmtypes.NetworkAttachmentConfig{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 
@@ -298,7 +298,7 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 					service.Spec.TaskTemplate.Resources.Limits = &swarmtypes.Limit{}
 				}
 				service.Spec.TaskTemplate.Resources.Limits.Pids = tc.pidsLimit
-				_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, swarmtypes.ServiceUpdateOptions{})
+				_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 				assert.NilError(t, err)
 				poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
 			}

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -324,7 +324,7 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 
 func getServiceTaskContainer(ctx context.Context, t *testing.T, cli client.APIClient, serviceID string) container.InspectResponse {
 	t.Helper()
-	tasks, err := cli.TaskList(ctx, swarmtypes.TaskListOptions{
+	tasks, err := cli.TaskList(ctx, client.TaskListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("service", serviceID),
 			filters.Arg("desired-state", "running"),

--- a/testutil/daemon/config.go
+++ b/testutil/daemon/config.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 )
 
@@ -28,7 +29,7 @@ func (d *Daemon) ListConfigs(t testing.TB) []swarm.Config {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	configs, err := cli.ConfigList(context.Background(), swarm.ConfigListOptions{})
+	configs, err := cli.ConfigList(context.Background(), client.ConfigListOptions{})
 	assert.NilError(t, err)
 	return configs
 }

--- a/testutil/daemon/node.go
+++ b/testutil/daemon/node.go
@@ -39,7 +39,7 @@ func (d *Daemon) RemoveNode(ctx context.Context, t testing.TB, id string, force 
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	options := swarm.NodeRemoveOptions{
+	options := client.NodeRemoveOptions{
 		Force: force,
 	}
 	err := cli.NodeRemove(ctx, id, options)

--- a/testutil/daemon/node.go
+++ b/testutil/daemon/node.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 )
 
@@ -73,7 +74,7 @@ func (d *Daemon) ListNodes(ctx context.Context, t testing.TB) []swarm.Node {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	nodes, err := cli.NodeList(ctx, swarm.NodeListOptions{})
+	nodes, err := cli.NodeList(ctx, client.NodeListOptions{})
 	assert.NilError(t, err)
 
 	return nodes

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -102,7 +102,7 @@ func (d *Daemon) ListServices(ctx context.Context, t testing.TB) []swarm.Service
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	services, err := cli.ServiceList(ctx, swarm.ServiceListOptions{})
+	services, err := cli.ServiceList(ctx, client.ServiceListOptions{})
 	assert.NilError(t, err)
 	return services
 }

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -44,7 +44,7 @@ func (d *Daemon) GetService(ctx context.Context, t testing.TB, id string) *swarm
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	service, _, err := cli.ServiceInspectWithRaw(ctx, id, swarm.ServiceInspectOptions{})
+	service, _, err := cli.ServiceInspectWithRaw(ctx, id, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	return &service
 }

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -82,7 +82,7 @@ func (d *Daemon) UpdateService(ctx context.Context, t testing.TB, service *swarm
 		fn(service)
 	}
 
-	_, err := cli.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, swarm.ServiceUpdateOptions{})
+	_, err := cli.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
 }
 

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 )
 
@@ -62,7 +63,7 @@ func (d *Daemon) GetServiceTasks(ctx context.Context, t testing.TB, service stri
 		filterArgs.Add(filter.Key, filter.Value)
 	}
 
-	options := swarm.TaskListOptions{
+	options := client.TaskListOptions{
 		Filters: filterArgs,
 	}
 

--- a/testutil/daemon/service.go
+++ b/testutil/daemon/service.go
@@ -14,7 +14,7 @@ import (
 // ServiceConstructor defines a swarm service constructor function
 type ServiceConstructor func(*swarm.Service)
 
-func (d *Daemon) createServiceWithOptions(ctx context.Context, t testing.TB, opts swarm.ServiceCreateOptions, f ...ServiceConstructor) string {
+func (d *Daemon) createServiceWithOptions(ctx context.Context, t testing.TB, opts client.ServiceCreateOptions, f ...ServiceConstructor) string {
 	t.Helper()
 	var service swarm.Service
 	for _, fn := range f {
@@ -35,7 +35,7 @@ func (d *Daemon) createServiceWithOptions(ctx context.Context, t testing.TB, opt
 // CreateService creates a swarm service given the specified service constructor
 func (d *Daemon) CreateService(ctx context.Context, t testing.TB, f ...ServiceConstructor) string {
 	t.Helper()
-	return d.createServiceWithOptions(ctx, t, swarm.ServiceCreateOptions{}, f...)
+	return d.createServiceWithOptions(ctx, t, client.ServiceCreateOptions{}, f...)
 }
 
 // GetService returns the swarm service corresponding to the specified id

--- a/testutil/daemon/swarm.go
+++ b/testutil/daemon/swarm.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
@@ -177,7 +178,7 @@ func (d *Daemon) UpdateSwarm(t testing.TB, f ...SpecConstructor) {
 		fn(&sw.Spec)
 	}
 
-	err := cli.SwarmUpdate(context.Background(), sw.Version, sw.Spec, swarm.UpdateFlags{})
+	err := cli.SwarmUpdate(context.Background(), sw.Version, sw.Spec, client.SwarmUpdateFlags{})
 	assert.NilError(t, err)
 }
 
@@ -190,7 +191,7 @@ func (d *Daemon) RotateTokens(t testing.TB) {
 	sw, err := cli.SwarmInspect(context.Background())
 	assert.NilError(t, err)
 
-	flags := swarm.UpdateFlags{
+	flags := client.SwarmUpdateFlags{
 		RotateManagerToken: true,
 		RotateWorkerToken:  true,
 	}

--- a/vendor/github.com/moby/moby/api/types/swarm/config.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/config.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"os"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // Config represents a config.
@@ -54,9 +52,4 @@ type ConfigReference struct {
 type ConfigCreateResponse struct {
 	// ID is the id of the created config.
 	ID string
-}
-
-// ConfigListOptions holds parameters to list configs
-type ConfigListOptions struct {
-	Filters filters.Args
 }

--- a/vendor/github.com/moby/moby/api/types/swarm/node.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/node.go
@@ -1,7 +1,5 @@
 package swarm
 
-import "github.com/moby/moby/api/types/filters"
-
 // Node represents a node.
 type Node struct {
 	ID string
@@ -138,11 +136,6 @@ const (
 // duplicate it here. See that type for full documentation
 type Topology struct {
 	Segments map[string]string `json:",omitempty"`
-}
-
-// NodeListOptions holds parameters to list nodes with.
-type NodeListOptions struct {
-	Filters filters.Args
 }
 
 // NodeRemoveOptions holds parameters to remove nodes with.

--- a/vendor/github.com/moby/moby/api/types/swarm/node.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/node.go
@@ -137,8 +137,3 @@ const (
 type Topology struct {
 	Segments map[string]string `json:",omitempty"`
 }
-
-// NodeRemoveOptions holds parameters to remove nodes with.
-type NodeRemoveOptions struct {
-	Force bool
-}

--- a/vendor/github.com/moby/moby/api/types/swarm/service.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/service.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"time"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // Service represents a service.
@@ -210,15 +208,6 @@ const (
 	RegistryAuthFromSpec         = "spec"
 	RegistryAuthFromPreviousSpec = "previous-spec"
 )
-
-// ServiceListOptions holds parameters to list services with.
-type ServiceListOptions struct {
-	Filters filters.Args
-
-	// Status indicates whether the server should include the service task
-	// count of running and desired tasks.
-	Status bool
-}
 
 // ServiceInspectOptions holds parameters related to the "service inspect"
 // operation.

--- a/vendor/github.com/moby/moby/api/types/swarm/service.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/service.go
@@ -211,36 +211,6 @@ const (
 	RegistryAuthFromPreviousSpec = "previous-spec"
 )
 
-// ServiceUpdateOptions contains the options to be used for updating services.
-type ServiceUpdateOptions struct {
-	// EncodedRegistryAuth is the encoded registry authorization credentials to
-	// use when updating the service.
-	//
-	// This field follows the format of the X-Registry-Auth header.
-	EncodedRegistryAuth string
-
-	// TODO(stevvooe): Consider moving the version parameter of ServiceUpdate
-	// into this field. While it does open API users up to racy writes, most
-	// users may not need that level of consistency in practice.
-
-	// RegistryAuthFrom specifies where to find the registry authorization
-	// credentials if they are not given in EncodedRegistryAuth. Valid
-	// values are "spec" and "previous-spec".
-	RegistryAuthFrom string
-
-	// Rollback indicates whether a server-side rollback should be
-	// performed. When this is set, the provided spec will be ignored.
-	// The valid values are "previous" and "none". An empty value is the
-	// same as "none".
-	Rollback string
-
-	// QueryRegistry indicates whether the service update requires
-	// contacting a registry. A registry may be contacted to retrieve
-	// the image digest and manifest, which in turn can be used to update
-	// platform or other information about the service.
-	QueryRegistry bool
-}
-
 // ServiceListOptions holds parameters to list services with.
 type ServiceListOptions struct {
 	Filters filters.Args

--- a/vendor/github.com/moby/moby/api/types/swarm/service.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/service.go
@@ -208,9 +208,3 @@ const (
 	RegistryAuthFromSpec         = "spec"
 	RegistryAuthFromPreviousSpec = "previous-spec"
 )
-
-// ServiceInspectOptions holds parameters related to the "service inspect"
-// operation.
-type ServiceInspectOptions struct {
-	InsertDefaults bool
-}

--- a/vendor/github.com/moby/moby/api/types/swarm/service.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/service.go
@@ -205,21 +205,6 @@ type JobStatus struct {
 	LastExecution time.Time `json:",omitempty"`
 }
 
-// ServiceCreateOptions contains the options to use when creating a service.
-type ServiceCreateOptions struct {
-	// EncodedRegistryAuth is the encoded registry authorization credentials to
-	// use when updating the service.
-	//
-	// This field follows the format of the X-Registry-Auth header.
-	EncodedRegistryAuth string
-
-	// QueryRegistry indicates whether the service update requires
-	// contacting a registry. A registry may be contacted to retrieve
-	// the image digest and manifest, which in turn can be used to update
-	// platform or other information about the service.
-	QueryRegistry bool
-}
-
 // Values for RegistryAuthFrom in ServiceUpdateOptions
 const (
 	RegistryAuthFromSpec         = "spec"

--- a/vendor/github.com/moby/moby/api/types/swarm/swarm.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/swarm.go
@@ -229,13 +229,6 @@ type Peer struct {
 	Addr   string
 }
 
-// UpdateFlags contains flags for SwarmUpdate.
-type UpdateFlags struct {
-	RotateWorkerToken      bool
-	RotateManagerToken     bool
-	RotateManagerUnlockKey bool
-}
-
 // UnlockKeyResponse contains the response for Engine API:
 // GET /swarm/unlockkey
 type UnlockKeyResponse struct {

--- a/vendor/github.com/moby/moby/api/types/swarm/task.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/task.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"time"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // TaskState represents the state of a task.
@@ -222,9 +220,4 @@ type VolumeAttachment struct {
 	// Target, together with Source, indicates the Mount, as specified
 	// in the ContainerSpec, that this volume fulfills.
 	Target string `json:",omitempty"`
-}
-
-// TaskListOptions holds parameters to list tasks with.
-type TaskListOptions struct {
-	Filters filters.Args
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -142,7 +142,7 @@ type NetworkAPIClient interface {
 type NodeAPIClient interface {
 	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
 	NodeList(ctx context.Context, options NodeListOptions) ([]swarm.Node, error)
-	NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error
+	NodeRemove(ctx context.Context, nodeID string, options NodeRemoveOptions) error
 	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
 }
 

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -164,7 +164,7 @@ type PluginAPIClient interface {
 type ServiceAPIClient interface {
 	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
-	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
+	ServiceList(ctx context.Context, options ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
 	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -181,7 +181,7 @@ type SwarmAPIClient interface {
 	SwarmUnlock(ctx context.Context, req swarm.UnlockRequest) error
 	SwarmLeave(ctx context.Context, force bool) error
 	SwarmInspect(ctx context.Context) (swarm.Swarm, error)
-	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error
+	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags SwarmUpdateFlags) error
 }
 
 // SystemAPIClient defines API client methods for the system

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -215,7 +215,7 @@ type SecretAPIClient interface {
 
 // ConfigAPIClient defines API client methods for configs
 type ConfigAPIClient interface {
-	ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error)
+	ConfigList(ctx context.Context, options ConfigListOptions) ([]swarm.Config, error)
 	ConfigCreate(ctx context.Context, config swarm.ConfigSpec) (swarm.ConfigCreateResponse, error)
 	ConfigRemove(ctx context.Context, id string) error
 	ConfigInspectWithRaw(ctx context.Context, name string) (swarm.Config, []byte, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -166,7 +166,7 @@ type ServiceAPIClient interface {
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
-	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options swarm.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskLogs(ctx context.Context, taskID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -162,7 +162,7 @@ type PluginAPIClient interface {
 
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
-	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options swarm.ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
 	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -141,7 +141,7 @@ type NetworkAPIClient interface {
 // NodeAPIClient defines API client methods for the nodes
 type NodeAPIClient interface {
 	NodeInspectWithRaw(ctx context.Context, nodeID string) (swarm.Node, []byte, error)
-	NodeList(ctx context.Context, options swarm.NodeListOptions) ([]swarm.Node, error)
+	NodeList(ctx context.Context, options NodeListOptions) ([]swarm.Node, error)
 	NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error
 	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -163,7 +163,7 @@ type PluginAPIClient interface {
 // ServiceAPIClient defines API client methods for the services
 type ServiceAPIClient interface {
 	ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error)
-	ServiceInspectWithRaw(ctx context.Context, serviceID string, options swarm.ServiceInspectOptions) (swarm.Service, []byte, error)
+	ServiceInspectWithRaw(ctx context.Context, serviceID string, options ServiceInspectOptions) (swarm.Service, []byte, error)
 	ServiceList(ctx context.Context, options ServiceListOptions) ([]swarm.Service, error)
 	ServiceRemove(ctx context.Context, serviceID string) error
 	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -170,7 +170,7 @@ type ServiceAPIClient interface {
 	ServiceLogs(ctx context.Context, serviceID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskLogs(ctx context.Context, taskID string, options container.LogsOptions) (io.ReadCloser, error)
 	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
-	TaskList(ctx context.Context, options swarm.TaskListOptions) ([]swarm.Task, error)
+	TaskList(ctx context.Context, options TaskListOptions) ([]swarm.Task, error)
 }
 
 // SwarmAPIClient defines API client methods for the swarm

--- a/vendor/github.com/moby/moby/client/config_list.go
+++ b/vendor/github.com/moby/moby/client/config_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ConfigList returns the list of configs.
-func (cli *Client) ConfigList(ctx context.Context, options swarm.ConfigListOptions) ([]swarm.Config, error) {
+func (cli *Client) ConfigList(ctx context.Context, options ConfigListOptions) ([]swarm.Config, error) {
 	if err := cli.NewVersionError(ctx, "1.30", "config list"); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/moby/moby/client/node_list.go
+++ b/vendor/github.com/moby/moby/client/node_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NodeList returns the list of nodes.
-func (cli *Client) NodeList(ctx context.Context, options swarm.NodeListOptions) ([]swarm.Node, error) {
+func (cli *Client) NodeList(ctx context.Context, options NodeListOptions) ([]swarm.Node, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/vendor/github.com/moby/moby/client/node_remove.go
+++ b/vendor/github.com/moby/moby/client/node_remove.go
@@ -3,12 +3,10 @@ package client
 import (
 	"context"
 	"net/url"
-
-	"github.com/moby/moby/api/types/swarm"
 )
 
 // NodeRemove removes a Node.
-func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options swarm.NodeRemoveOptions) error {
+func (cli *Client) NodeRemove(ctx context.Context, nodeID string, options NodeRemoveOptions) error {
 	nodeID, err := trimID("node", nodeID)
 	if err != nil {
 		return err

--- a/vendor/github.com/moby/moby/client/service_create.go
+++ b/vendor/github.com/moby/moby/client/service_create.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ServiceCreate creates a new service.
-func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options swarm.ServiceCreateOptions) (swarm.ServiceCreateResponse, error) {
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec, options ServiceCreateOptions) (swarm.ServiceCreateResponse, error) {
 	var response swarm.ServiceCreateResponse
 
 	// Make sure we negotiated (if the client is configured to do so),

--- a/vendor/github.com/moby/moby/client/service_inspect.go
+++ b/vendor/github.com/moby/moby/client/service_inspect.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ServiceInspectWithRaw returns the service information and the raw data.
-func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts swarm.ServiceInspectOptions) (swarm.Service, []byte, error) {
+func (cli *Client) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts ServiceInspectOptions) (swarm.Service, []byte, error) {
 	serviceID, err := trimID("service", serviceID)
 	if err != nil {
 		return swarm.Service{}, nil, err

--- a/vendor/github.com/moby/moby/client/service_list.go
+++ b/vendor/github.com/moby/moby/client/service_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ServiceList returns the list of services.
-func (cli *Client) ServiceList(ctx context.Context, options swarm.ServiceListOptions) ([]swarm.Service, error) {
+func (cli *Client) ServiceList(ctx context.Context, options ServiceListOptions) ([]swarm.Service, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {

--- a/vendor/github.com/moby/moby/client/service_update.go
+++ b/vendor/github.com/moby/moby/client/service_update.go
@@ -15,7 +15,7 @@ import (
 // conflicting writes. It must be the value as set *before* the update.
 // You can find this value in the [swarm.Service.Meta] field, which can
 // be found using [Client.ServiceInspectWithRaw].
-func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options swarm.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error) {
 	serviceID, err := trimID("service", serviceID)
 	if err != nil {
 		return swarm.ServiceUpdateResponse{}, err

--- a/vendor/github.com/moby/moby/client/swarm_config_list_options.go
+++ b/vendor/github.com/moby/moby/client/swarm_config_list_options.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// ConfigListOptions holds parameters to list configs
+type ConfigListOptions struct {
+	Filters filters.Args
+}

--- a/vendor/github.com/moby/moby/client/swarm_node_list_opts.go
+++ b/vendor/github.com/moby/moby/client/swarm_node_list_opts.go
@@ -1,11 +1,8 @@
-package swarmbackend
+package client
 
 import "github.com/moby/moby/api/types/filters"
 
-type ConfigListOptions struct {
-	Filters filters.Args
-}
-
+// NodeListOptions holds parameters to list nodes with.
 type NodeListOptions struct {
 	Filters filters.Args
 }

--- a/vendor/github.com/moby/moby/client/swarm_node_remove_opts.go
+++ b/vendor/github.com/moby/moby/client/swarm_node_remove_opts.go
@@ -1,0 +1,6 @@
+package client
+
+// NodeRemoveOptions holds parameters to remove nodes with.
+type NodeRemoveOptions struct {
+	Force bool
+}

--- a/vendor/github.com/moby/moby/client/swarm_service_create_opts.go
+++ b/vendor/github.com/moby/moby/client/swarm_service_create_opts.go
@@ -1,0 +1,16 @@
+package client
+
+// ServiceCreateOptions contains the options to use when creating a service.
+type ServiceCreateOptions struct {
+	// EncodedRegistryAuth is the encoded registry authorization credentials to
+	// use when updating the service.
+	//
+	// This field follows the format of the X-Registry-Auth header.
+	EncodedRegistryAuth string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
+}

--- a/vendor/github.com/moby/moby/client/swarm_service_inspect_opts.go
+++ b/vendor/github.com/moby/moby/client/swarm_service_inspect_opts.go
@@ -1,0 +1,7 @@
+package client
+
+// ServiceInspectOptions holds parameters related to the "service inspect"
+// operation.
+type ServiceInspectOptions struct {
+	InsertDefaults bool
+}

--- a/vendor/github.com/moby/moby/client/swarm_service_list_opts.go
+++ b/vendor/github.com/moby/moby/client/swarm_service_list_opts.go
@@ -1,0 +1,12 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// ServiceListOptions holds parameters to list services with.
+type ServiceListOptions struct {
+	Filters filters.Args
+
+	// Status indicates whether the server should include the service task
+	// count of running and desired tasks.
+	Status bool
+}

--- a/vendor/github.com/moby/moby/client/swarm_service_update_opts.go
+++ b/vendor/github.com/moby/moby/client/swarm_service_update_opts.go
@@ -1,25 +1,6 @@
-package swarmbackend
+package client
 
-import "github.com/moby/moby/api/types/filters"
-
-type ConfigListOptions struct {
-	Filters filters.Args
-}
-
-type NodeListOptions struct {
-	Filters filters.Args
-}
-
-type TaskListOptions struct {
-	Filters filters.Args
-}
-
-type UpdateFlags struct {
-	RotateWorkerToken      bool
-	RotateManagerToken     bool
-	RotateManagerUnlockKey bool
-}
-
+// ServiceUpdateOptions contains the options to be used for updating services.
 type ServiceUpdateOptions struct {
 	// EncodedRegistryAuth is the encoded registry authorization credentials to
 	// use when updating the service.
@@ -41,4 +22,10 @@ type ServiceUpdateOptions struct {
 	// The valid values are "previous" and "none". An empty value is the
 	// same as "none".
 	Rollback string
+
+	// QueryRegistry indicates whether the service update requires
+	// contacting a registry. A registry may be contacted to retrieve
+	// the image digest and manifest, which in turn can be used to update
+	// platform or other information about the service.
+	QueryRegistry bool
 }

--- a/vendor/github.com/moby/moby/client/swarm_task_list_opts.go
+++ b/vendor/github.com/moby/moby/client/swarm_task_list_opts.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// TaskListOptions holds parameters to list tasks with.
+type TaskListOptions struct {
+	Filters filters.Args
+}

--- a/vendor/github.com/moby/moby/client/swarm_update.go
+++ b/vendor/github.com/moby/moby/client/swarm_update.go
@@ -9,7 +9,7 @@ import (
 )
 
 // SwarmUpdate updates the swarm.
-func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error {
+func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags SwarmUpdateFlags) error {
 	query := url.Values{}
 	query.Set("version", version.String())
 	query.Set("rotateWorkerToken", strconv.FormatBool(flags.RotateWorkerToken))

--- a/vendor/github.com/moby/moby/client/swarm_update_flags.go
+++ b/vendor/github.com/moby/moby/client/swarm_update_flags.go
@@ -1,0 +1,8 @@
+package client
+
+// SwarmUpdateFlags contains flags for SwarmUpdate.
+type SwarmUpdateFlags struct {
+	RotateWorkerToken      bool
+	RotateManagerToken     bool
+	RotateManagerUnlockKey bool
+}

--- a/vendor/github.com/moby/moby/client/task_list.go
+++ b/vendor/github.com/moby/moby/client/task_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TaskList returns the list of tasks.
-func (cli *Client) TaskList(ctx context.Context, options swarm.TaskListOptions) ([]swarm.Task, error) {
+func (cli *Client) TaskList(ctx context.Context, options TaskListOptions) ([]swarm.Task, error) {
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {


### PR DESCRIPTION
**- What I did**
Partial of #50740 

This change moves the swarm option types out of the api to the client module. This change also introduces daemon backend types when needed for swarm backend types to decouple the daemon backend from the client module.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/swarm: move option types to the client module
```

**- A picture of a cute animal (not mandatory but encouraged)**

