### PR TITLE
[28.x backport] api/types/registry: update deprecation comment for AuthConfig.Email

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2234,6 +2234,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -32,8 +32,8 @@ type AuthConfig struct {
 	Auth     string `json:"auth,omitempty"`
 
 	// Email is an optional value associated with the username.
-	// This field is deprecated and will be removed in a later
-	// version of docker.
+	//
+	// Deprecated: This field is deprecated since docker 1.11 (API v1.23) and will be removed in the next release.
 	Email string `json:"email,omitempty"`
 
 	ServerAddress string `json:"serveraddress,omitempty"`

--- a/docs/api/v1.24.md
+++ b/docs/api/v1.24.md
@@ -1830,8 +1830,7 @@ a base64-encoded AuthConfig object.
         ```
     {
             "username": "jdoe",
-            "password": "secret",
-            "email": "jdoe@acme.com"
+            "password": "secret"
     }
         ```
 
@@ -2066,8 +2065,7 @@ The push is cancelled if the HTTP connection is closed.
         ```
     {
             "username": "jdoe",
-            "password": "secret",
-            "email": "jdoe@acme.com",
+            "password": "secret"
     }
         ```
 

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -984,6 +984,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -984,6 +984,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -989,6 +989,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -1027,6 +1027,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -1033,6 +1033,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -1043,6 +1043,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -1049,6 +1049,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -1308,6 +1308,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -1312,6 +1312,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -1322,6 +1322,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -1319,6 +1319,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -1319,6 +1319,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -1322,6 +1322,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -1333,6 +1333,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -2109,6 +2109,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -2169,6 +2169,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -2200,6 +2200,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -2203,6 +2203,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -2234,6 +2234,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -2261,6 +2261,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -2247,6 +2247,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -2275,6 +2275,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -2288,6 +2288,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.48.yaml
+++ b/docs/api/v1.48.yaml
@@ -2377,6 +2377,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.49.yaml
+++ b/docs/api/v1.49.yaml
@@ -2377,6 +2377,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.50.yaml
+++ b/docs/api/v1.50.yaml
@@ -2235,6 +2235,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/docs/api/v1.51.yaml
+++ b/docs/api/v1.51.yaml
@@ -2234,6 +2234,10 @@ definitions:
       password:
         type: "string"
       email:
+        description: |
+          Email is an optional value associated with the username.
+
+          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/50792

----

relates to:

- https://github.com/moby/moby/issues/6400
- https://github.com/moby/moby/pull/16183
- https://github.com/moby/moby/pull/20565
- https://github.com/docker-archive-public/docker.engine-api/pull/105
- https://github.com/docker-archive-public/docker.engine-api/pull/115

### api/types/registry: update deprecation comment for AuthConfig.Email

The Email field was originally used to create a new Docker Hub account
through the `docker login` command. The `docker login` command could be
used both to log in to an existing account (providing only username and
password), or to create a new account (providing desired username and
password, and an e-mail address to use for the new account).

This functionality was confusing, because it was implemented when Docker
Hub was the only registry, but the same functionality could not be used
for other registries. This functionality was removed in Docker 1.11 (API
version 1.23) through [moby@aee260d], which also removed the Email field
([engine-api@9a9e468]) as it was no longer used.

However, this caused issues when using a new CLI connecting with an old
daemon, as the field would no longer be serialized, and the deprecation
may not yet be picked up by custom registries, so [engine-api@167efc7]
added the field back, deprecated it, and added an "omitempty". There
was no official "deprecated" format yet at the time, so let's make sure
the deprecation follows the proper format to make sure it gets noticed.


[moby@aee260d]: https://github.com/moby/moby/commit/aee260d4eb3aa0fc86ee5038010b7bbc24512ae5
[engine-api@9a9e468]: https://github.com/docker-archive-public/docker.engine-api/commit/9a9e468f503eb731d6fdc9d7f98c122e1b397c86
[engine-api@167efc7]: https://github.com/docker-archive-public/docker.engine-api/commit/167efc72bb24d7ad2bcc91760a9a5d37572e104f


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update deprecation message for `AuthConfig.Email` field
```

**- A picture of a cute animal (not mandatory but encouraged)**

