### PR TITLE
client: check for Digested reference instead of Canonical

### DIFF
--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -24,7 +24,7 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 			return container.CommitResponse{}, err
 		}
 
-		if _, isCanonical := ref.(reference.Canonical); isCanonical {
+		if _, ok := ref.(reference.Digested); ok {
 			return container.CommitResponse{}, errors.New("refusing to create a tag with a digest reference")
 		}
 		ref = reference.TagNameOnly(ref)

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -25,7 +25,7 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options image.Pu
 		return nil, err
 	}
 
-	if _, isCanonical := ref.(reference.Canonical); isCanonical {
+	if _, ok := ref.(reference.Digested); ok {
 		return nil, errors.New("cannot push a digest reference")
 	}
 

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -20,7 +20,7 @@ func (cli *Client) ImageTag(ctx context.Context, source, target string) error {
 		return fmt.Errorf("error parsing reference: %q is not a valid repository/tag: %w", target, err)
 	}
 
-	if _, isCanonical := ref.(reference.Canonical); isCanonical {
+	if _, ok := ref.(reference.Digested); ok {
 		return errors.New("refusing to create a tag with a digest reference")
 	}
 

--- a/client/service_create.go
+++ b/client/service_create.go
@@ -154,7 +154,7 @@ func imageDigestAndPlatforms(ctx context.Context, cli DistributionAPIClient, ima
 func imageWithDigestString(image string, dgst digest.Digest) string {
 	namedRef, err := reference.ParseNormalizedNamed(image)
 	if err == nil {
-		if _, isCanonical := namedRef.(reference.Canonical); !isCanonical {
+		if _, hasDigest := namedRef.(reference.Digested); !hasDigest {
 			// ensure that image gets a default tag if none is provided
 			img, err := reference.WithDigest(namedRef, dgst)
 			if err == nil {


### PR DESCRIPTION
The [Canonical] interface defines images that are both [Named] and [Digested], but in all places where it was used, we were only interested whether the reference contained a digest.

This patch changes those checks to check for [Digested] references, as that's what's relevant for these checks.

[Named]: https://pkg.go.dev/github.com/distribution/reference#Named
[Canonical]: https://pkg.go.dev/github.com/distribution/reference#Canonical
[Digested]: https://pkg.go.dev/github.com/distribution/reference#Digested

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

