### PR TITLE
api/types/container: merge InspectResponse and ContainerJSONBase

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -119,16 +119,9 @@ type Summary struct {
 	Mounts          []MountPoint
 }
 
-// ContainerJSONBase contains response of Engine API GET "/containers/{name:.*}/json"
-// for API version 1.18 and older.
-//
-// TODO(thaJeztah): combine ContainerJSONBase and InspectResponse into a single struct.
-// The split between ContainerJSONBase (ContainerJSONBase) and InspectResponse (InspectResponse)
-// was done in commit 6deaa58ba5f051039643cedceee97c8695e2af74 (https://github.com/moby/moby/pull/13675).
-// ContainerJSONBase contained all fields for API < 1.19, and InspectResponse
-// held fields that were added in API 1.19 and up. Given that the minimum
-// supported API version is now 1.24, we no longer use the separate type.
-type ContainerJSONBase struct {
+// InspectResponse is the response for the GET "/containers/{name:.*}/json"
+// endpoint.
+type InspectResponse struct {
 	ID              string `json:"Id"`
 	Created         string
 	Path            string
@@ -151,12 +144,6 @@ type ContainerJSONBase struct {
 	GraphDriver     storage.DriverData
 	SizeRw          *int64 `json:",omitempty"`
 	SizeRootFs      *int64 `json:",omitempty"`
-}
-
-// InspectResponse is the response for the GET "/containers/{name:.*}/json"
-// endpoint.
-type InspectResponse struct {
-	*ContainerJSONBase
 	Mounts          []MountPoint
 	Config          *Config
 	NetworkSettings *NetworkSettings

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -75,11 +75,9 @@ func TestContainerInspect(t *testing.T) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
 			content, err := json.Marshal(container.InspectResponse{
-				ContainerJSONBase: &container.ContainerJSONBase{
-					ID:    "container_id",
-					Image: "image",
-					Name:  "name",
-				},
+				ID:    "container_id",
+				Image: "image",
+				Name:  "name",
 			})
 			if err != nil {
 				return nil, err

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -86,16 +86,15 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 		imageManifest.Platform = &ctr.ImagePlatform
 	}
 
-	return &containertypes.InspectResponse{
-		ContainerJSONBase:       base,
-		Mounts:                  mountPoints,
-		Config:                  ctr.Config,
-		NetworkSettings:         networkSettings,
-		ImageManifestDescriptor: imageManifest,
-	}, nil
+	base.Mounts = mountPoints
+	base.Config = ctr.Config
+	base.NetworkSettings = networkSettings
+	base.ImageManifestDescriptor = imageManifest
+
+	return base, nil
 }
 
-func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Container) (*containertypes.ContainerJSONBase, error) {
+func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Container) (*containertypes.InspectResponse, error) {
 	// make a copy to play with
 	hostConfig := *ctr.HostConfig
 
@@ -130,7 +129,7 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Co
 		}
 	}
 
-	inspectResponse := &containertypes.ContainerJSONBase{
+	inspectResponse := &containertypes.InspectResponse{
 		ID:      ctr.ID,
 		Created: ctr.Created.Format(time.RFC3339Nano),
 		Path:    ctr.Path,

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -87,7 +87,6 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 	}
 
 	base.Mounts = mountPoints
-	base.Config = ctr.Config
 	base.NetworkSettings = networkSettings
 	base.ImageManifestDescriptor = imageManifest
 
@@ -161,6 +160,7 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Co
 		GraphDriver: storage.DriverData{
 			Name: ctr.Driver,
 		},
+		Config: ctr.Config,
 	}
 
 	// Now set any platform-specific fields

--- a/daemon/inspect_linux.go
+++ b/daemon/inspect_linux.go
@@ -6,7 +6,7 @@ import (
 )
 
 // This sets platform-specific fields
-func setPlatformSpecificContainerFields(ctr *containerpkg.Container, resp *container.ContainerJSONBase) *container.ContainerJSONBase {
+func setPlatformSpecificContainerFields(ctr *containerpkg.Container, resp *container.InspectResponse) *container.InspectResponse {
 	resp.AppArmorProfile = ctr.AppArmorProfile
 	resp.ResolvConfPath = ctr.ResolvConfPath
 	resp.HostnamePath = ctr.HostnamePath

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -6,6 +6,6 @@ import (
 )
 
 // This sets platform-specific fields
-func setPlatformSpecificContainerFields(ctr *containerpkg.Container, resp *container.ContainerJSONBase) *container.ContainerJSONBase {
+func setPlatformSpecificContainerFields(ctr *containerpkg.Container, resp *container.InspectResponse) *container.InspectResponse {
 	return resp
 }

--- a/vendor/github.com/moby/moby/api/types/container/container.go
+++ b/vendor/github.com/moby/moby/api/types/container/container.go
@@ -119,16 +119,9 @@ type Summary struct {
 	Mounts          []MountPoint
 }
 
-// ContainerJSONBase contains response of Engine API GET "/containers/{name:.*}/json"
-// for API version 1.18 and older.
-//
-// TODO(thaJeztah): combine ContainerJSONBase and InspectResponse into a single struct.
-// The split between ContainerJSONBase (ContainerJSONBase) and InspectResponse (InspectResponse)
-// was done in commit 6deaa58ba5f051039643cedceee97c8695e2af74 (https://github.com/moby/moby/pull/13675).
-// ContainerJSONBase contained all fields for API < 1.19, and InspectResponse
-// held fields that were added in API 1.19 and up. Given that the minimum
-// supported API version is now 1.24, we no longer use the separate type.
-type ContainerJSONBase struct {
+// InspectResponse is the response for the GET "/containers/{name:.*}/json"
+// endpoint.
+type InspectResponse struct {
 	ID              string `json:"Id"`
 	Created         string
 	Path            string
@@ -151,12 +144,6 @@ type ContainerJSONBase struct {
 	GraphDriver     storage.DriverData
 	SizeRw          *int64 `json:",omitempty"`
 	SizeRootFs      *int64 `json:",omitempty"`
-}
-
-// InspectResponse is the response for the GET "/containers/{name:.*}/json"
-// endpoint.
-type InspectResponse struct {
-	*ContainerJSONBase
 	Mounts          []MountPoint
 	Config          *Config
 	NetworkSettings *NetworkSettings


### PR DESCRIPTION
Merge the two types instead of embedding the ContainerJSONBase. This should have no impact on the API response, but users constructing a response through struct literals will need to update their code.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

