### PR TITLE
Allow default-address-pools option in Windows

### DIFF
--- a/daemon/command/config.go
+++ b/daemon/command/config.go
@@ -72,6 +72,7 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.StringVar(&conf.NoProxy, "no-proxy", "", "Comma-separated list of hosts or IP addresses for which the proxy is skipped")
 
 	flags.Var(opts.NewNamedListOptsRef("cdi-spec-dirs", &conf.CDISpecDirs, nil), "cdi-spec-dir", "CDI specification directories to use")
+	flags.Var(&conf.NetworkConfig.DefaultAddressPools, "default-address-pool", "Default address pools for node specific local networks")
 
 	// Deprecated flags / options
 	allowNonDistributable := opts.NewNamedListOptsRef("allow-nondistributable-artifacts", &([]string{}), registry.ValidateIndexName)

--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -51,7 +51,6 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Var(&conf.ShmSize, "default-shm-size", "Default shm size for containers")
 	flags.BoolVar(&conf.NoNewPrivileges, "no-new-privileges", false, "Set no-new-privileges by default for new containers")
 	flags.StringVar(&conf.IpcMode, "default-ipc-mode", conf.IpcMode, `Default mode for containers ipc ("shareable" | "private")`)
-	flags.Var(&conf.NetworkConfig.DefaultAddressPools, "default-address-pool", "Default address pools for node specific local networks")
 	flags.StringVar(&conf.NetworkConfig.FirewallBackend, "firewall-backend", "", "Firewall backend to use, iptables or nftables")
 	// rootless needs to be explicitly specified for running "rootful" dockerd in rootless dockerd (#38702)
 	// Note that conf.BridgeConfig.UserlandProxyPath and honorXDG are configured according to the value of rootless.RunningWithRootlessKit, not the value of --rootless.


### PR DESCRIPTION
**- What I did**
Revisited #36396 and noticed that this option was not enabled for Windows because it was failing in RS1 (Windows Server 2016) but for me it looks that potentially it was just CI failure or that contributor didn't know Windows well enough.

Closes #50805

**- How I did it**
Copy & paste

**- How to verify it**
~Enabled one test which needed smallest amount of Windows specific modifications which should cover this use case.~
EDIT: Oh, that was Swarm test which would need more work. Then I don't actually see any test(s) which can be easily activated in Windows side and don't have time to write new a the moment.

Feel free to take over this PR if test case is needed for this.