### PR TITLE
d/libnet: remove unused arg from CreateOptionIpam

### DIFF
--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -1033,7 +1033,7 @@ var (
 )
 
 // CreateOptionIpam function returns an option setter for the ipam configuration for this endpoint
-func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP, ipamOptions map[string]string) EndpointOption {
+func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP) EndpointOption {
 	return func(ep *Endpoint) {
 		ep.prefAddress = ipV4
 		ep.prefAddressV6 = ipV6
@@ -1046,7 +1046,6 @@ func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP, ipamOptions map[string]
 				ep.iface.llAddrs = append(ep.iface.llAddrs, nw)
 			}
 		}
-		ep.ipamOptions = ipamOptions
 	}
 }
 

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -1032,8 +1032,8 @@ var (
 	linkLocalMaskIPv6 = net.CIDRMask(64, 128)
 )
 
-// CreateOptionIpam function returns an option setter for the ipam configuration for this endpoint
-func CreateOptionIpam(ipV4, ipV6 net.IP, llIPs []net.IP) EndpointOption {
+// CreateOptionIPAM function returns an option setter for the ipam configuration for this endpoint
+func CreateOptionIPAM(ipV4, ipV6 net.IP, llIPs []net.IP) EndpointOption {
 	return func(ep *Endpoint) {
 		ep.prefAddress = ipV4
 		ep.prefAddressV6 = ipV6

--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -426,7 +426,7 @@ func TestUpdateSvcRecord(t *testing.T) {
 			dnsName := "id-" + tc.epName
 			ep, err := n.CreateEndpoint(context.Background(), tc.epName,
 				CreateOptionDNSNames([]string{tc.epName, dnsName}),
-				CreateOptionIpam(ip4, ip6, nil),
+				CreateOptionIPAM(ip4, ip6, nil),
 			)
 			assert.NilError(t, err)
 

--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -426,7 +426,7 @@ func TestUpdateSvcRecord(t *testing.T) {
 			dnsName := "id-" + tc.epName
 			ep, err := n.CreateEndpoint(context.Background(), tc.epName,
 				CreateOptionDNSNames([]string{tc.epName, dnsName}),
-				CreateOptionIpam(ip4, ip6, nil, nil),
+				CreateOptionIpam(ip4, ip6, nil),
 			)
 			assert.NilError(t, err)
 

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -2106,7 +2106,7 @@ func (n *Network) createLoadBalancerSandbox() (retErr error) {
 
 	endpointName := n.lbEndpointName()
 	epOptions := []EndpointOption{
-		CreateOptionIpam(n.loadBalancerIP, nil, nil, nil),
+		CreateOptionIpam(n.loadBalancerIP, nil, nil),
 		CreateOptionLoadBalancer(),
 	}
 	ep, err := n.createEndpoint(context.TODO(), endpointName, epOptions...)

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -2106,7 +2106,7 @@ func (n *Network) createLoadBalancerSandbox() (retErr error) {
 
 	endpointName := n.lbEndpointName()
 	epOptions := []EndpointOption{
-		CreateOptionIpam(n.loadBalancerIP, nil, nil),
+		CreateOptionIPAM(n.loadBalancerIP, nil, nil),
 		CreateOptionLoadBalancer(),
 	}
 	ep, err := n.createEndpoint(context.TODO(), endpointName, epOptions...)

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -861,7 +861,7 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 				return nil, fmt.Errorf("invalid IPv6 address: %s", ipam.IPv6Address)
 			}
 
-			createOptions = append(createOptions, libnetwork.CreateOptionIpam(ip, ip6, ipList, nil))
+			createOptions = append(createOptions, libnetwork.CreateOptionIpam(ip, ip6, ipList))
 		}
 
 		createOptions = append(createOptions, libnetwork.CreateOptionDNSNames(epConfig.DNSNames))

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -861,7 +861,7 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 				return nil, fmt.Errorf("invalid IPv6 address: %s", ipam.IPv6Address)
 			}
 
-			createOptions = append(createOptions, libnetwork.CreateOptionIpam(ip, ip6, ipList))
+			createOptions = append(createOptions, libnetwork.CreateOptionIPAM(ip, ip6, ipList))
 		}
 
 		createOptions = append(createOptions, libnetwork.CreateOptionDNSNames(epConfig.DNSNames))


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/50586

**- What I did**

CreateOptionIpam takes an `ipamOptions` argument, but all callers are passing nil. So, remove it.