### PR TITLE
api/types/swarm: move `SecretListOptions` type to client

### DIFF
--- a/api/types/swarm/secret.go
+++ b/api/types/swarm/secret.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"os"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // Secret represents a secret.
@@ -58,9 +56,4 @@ type SecretReference struct {
 type SecretCreateResponse struct {
 	// ID is the id of the created secret.
 	ID string
-}
-
-// SecretListOptions holds parameters to list secrets
-type SecretListOptions struct {
-	Filters filters.Args
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -206,7 +206,7 @@ type VolumeAPIClient interface {
 
 // SecretAPIClient defines API client methods for secrets
 type SecretAPIClient interface {
-	SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error)
+	SecretList(ctx context.Context, options SecretListOptions) ([]swarm.Secret, error)
 	SecretCreate(ctx context.Context, secret swarm.SecretSpec) (swarm.SecretCreateResponse, error)
 	SecretRemove(ctx context.Context, id string) error
 	SecretInspectWithRaw(ctx context.Context, name string) (swarm.Secret, []byte, error)

--- a/client/secret_list.go
+++ b/client/secret_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SecretList returns the list of secrets.
-func (cli *Client) SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error) {
+func (cli *Client) SecretList(ctx context.Context, options SecretListOptions) ([]swarm.Secret, error) {
 	if err := cli.NewVersionError(ctx, "1.25", "secret list"); err != nil {
 		return nil, err
 	}

--- a/client/secret_list_opts.go
+++ b/client/secret_list_opts.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// SecretListOptions holds parameters to list secrets
+type SecretListOptions struct {
+	Filters filters.Args
+}

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -22,7 +22,7 @@ func TestSecretListUnsupported(t *testing.T) {
 		version: "1.24",
 		client:  &http.Client{},
 	}
-	_, err := client.SecretList(context.Background(), swarm.SecretListOptions{})
+	_, err := client.SecretList(context.Background(), SecretListOptions{})
 	assert.Check(t, is.Error(err, `"secret list" requires API version 1.25, but the Docker daemon API version is 1.24`))
 }
 
@@ -32,7 +32,7 @@ func TestSecretListError(t *testing.T) {
 		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.SecretList(context.Background(), swarm.SecretListOptions{})
+	_, err := client.SecretList(context.Background(), SecretListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -40,17 +40,17 @@ func TestSecretList(t *testing.T) {
 	const expectedURL = "/v1.25/secrets"
 
 	listCases := []struct {
-		options             swarm.SecretListOptions
+		options             SecretListOptions
 		expectedQueryParams map[string]string
 	}{
 		{
-			options: swarm.SecretListOptions{},
+			options: SecretListOptions{},
 			expectedQueryParams: map[string]string{
 				"filters": "",
 			},
 		},
 		{
-			options: swarm.SecretListOptions{
+			options: SecretListOptions{
 				Filters: filters.NewArgs(
 					filters.Arg("label", "label1"),
 					filters.Arg("label", "label2"),

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -5,6 +5,7 @@ import (
 
 	types "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/cluster/convert"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"google.golang.org/grpc"
 )
@@ -27,7 +28,7 @@ func (c *Cluster) GetSecret(input string) (types.Secret, error) {
 }
 
 // GetSecrets returns all secrets of a managed swarm cluster.
-func (c *Cluster) GetSecrets(options types.SecretListOptions) ([]types.Secret, error) {
+func (c *Cluster) GetSecrets(options swarmbackend.SecretListOptions) ([]types.Secret, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/daemon/server/router/swarm/backend.go
+++ b/daemon/server/router/swarm/backend.go
@@ -30,7 +30,7 @@ type Backend interface {
 	RemoveNode(string, bool) error
 	GetTasks(swarmbackend.TaskListOptions) ([]swarm.Task, error)
 	GetTask(string) (swarm.Task, error)
-	GetSecrets(opts swarm.SecretListOptions) ([]swarm.Secret, error)
+	GetSecrets(opts swarmbackend.SecretListOptions) ([]swarm.Secret, error)
 	CreateSecret(s swarm.SecretSpec) (string, error)
 	RemoveSecret(idOrName string) error
 	GetSecret(id string) (swarm.Secret, error)

--- a/daemon/server/router/swarm/cluster_routes.go
+++ b/daemon/server/router/swarm/cluster_routes.go
@@ -416,7 +416,7 @@ func (sr *swarmRouter) getSecrets(ctx context.Context, w http.ResponseWriter, r 
 		return err
 	}
 
-	secrets, err := sr.backend.GetSecrets(types.SecretListOptions{Filters: filters})
+	secrets, err := sr.backend.GetSecrets(swarmbackend.SecretListOptions{Filters: filters})
 	if err != nil {
 		return err
 	}

--- a/daemon/server/swarmbackend/swarm.go
+++ b/daemon/server/swarmbackend/swarm.go
@@ -50,3 +50,8 @@ type ServiceListOptions struct {
 	// count of running and desired tasks.
 	Status bool
 }
+
+// SecretListOptions holds parameters to list secrets
+type SecretListOptions struct {
+	Filters filters.Args
+}

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -53,7 +53,7 @@ func TestSecretList(t *testing.T) {
 	c := d.NewClientT(t)
 	defer c.Close()
 
-	configs, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
+	configs, err := c.SecretList(ctx, client.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(configs), 0))
 
@@ -69,7 +69,7 @@ func TestSecretList(t *testing.T) {
 	secret1ID := createSecret(ctx, t, c, testName1, []byte("TESTINGDATA1"), map[string]string{"type": "production"})
 
 	// test by `secret ls`
-	entries, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
+	entries, err := c.SecretList(ctx, client.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(secretNamesFromList(entries), testNames))
 
@@ -102,7 +102,7 @@ func TestSecretList(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{
+		entries, err = c.SecretList(ctx, client.SecretListOptions{
 			Filters: tc.filters,
 		})
 		assert.NilError(t, err)
@@ -356,7 +356,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	fakeName := secretID
 	fakeID := createSecret(ctx, t, c, fakeName, []byte("fake foo"), nil)
 
-	entries, err := c.SecretList(ctx, swarmtypes.SecretListOptions{})
+	entries, err := c.SecretList(ctx, client.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(secretNamesFromList(entries), testName))
 	assert.Check(t, is.Contains(secretNamesFromList(entries), fakeName))
@@ -365,7 +365,7 @@ func TestSecretCreateResolve(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Fake one will remain
-	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
+	entries, err = c.SecretList(ctx, client.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(secretNamesFromList(entries), []string{fakeName}))
 
@@ -376,14 +376,14 @@ func TestSecretCreateResolve(t *testing.T) {
 	// - Partial ID (prefix)
 	err = c.SecretRemove(ctx, fakeName[:5])
 	assert.Assert(t, err != nil)
-	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
+	entries, err = c.SecretList(ctx, client.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.DeepEqual(secretNamesFromList(entries), []string{fakeName}))
 
 	// Remove based on ID prefix of the fake one should succeed
 	err = c.SecretRemove(ctx, fakeID[:5])
 	assert.NilError(t, err)
-	entries, err = c.SecretList(ctx, swarmtypes.SecretListOptions{})
+	entries, err = c.SecretList(ctx, client.SecretListOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Equal(0, len(entries)))
 }

--- a/testutil/daemon/secret.go
+++ b/testutil/daemon/secret.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 )
 
@@ -29,7 +30,7 @@ func (d *Daemon) ListSecrets(t testing.TB) []swarm.Secret {
 	cli := d.NewClientT(t)
 	defer cli.Close()
 
-	secrets, err := cli.SecretList(context.Background(), swarm.SecretListOptions{})
+	secrets, err := cli.SecretList(context.Background(), client.SecretListOptions{})
 	assert.NilError(t, err)
 	return secrets
 }

--- a/vendor/github.com/moby/moby/api/types/swarm/secret.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/secret.go
@@ -2,8 +2,6 @@ package swarm
 
 import (
 	"os"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 // Secret represents a secret.
@@ -58,9 +56,4 @@ type SecretReference struct {
 type SecretCreateResponse struct {
 	// ID is the id of the created secret.
 	ID string
-}
-
-// SecretListOptions holds parameters to list secrets
-type SecretListOptions struct {
-	Filters filters.Args
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -206,7 +206,7 @@ type VolumeAPIClient interface {
 
 // SecretAPIClient defines API client methods for secrets
 type SecretAPIClient interface {
-	SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error)
+	SecretList(ctx context.Context, options SecretListOptions) ([]swarm.Secret, error)
 	SecretCreate(ctx context.Context, secret swarm.SecretSpec) (swarm.SecretCreateResponse, error)
 	SecretRemove(ctx context.Context, id string) error
 	SecretInspectWithRaw(ctx context.Context, name string) (swarm.Secret, []byte, error)

--- a/vendor/github.com/moby/moby/client/secret_list.go
+++ b/vendor/github.com/moby/moby/client/secret_list.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SecretList returns the list of secrets.
-func (cli *Client) SecretList(ctx context.Context, options swarm.SecretListOptions) ([]swarm.Secret, error) {
+func (cli *Client) SecretList(ctx context.Context, options SecretListOptions) ([]swarm.Secret, error) {
 	if err := cli.NewVersionError(ctx, "1.25", "secret list"); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/moby/moby/client/secret_list_opts.go
+++ b/vendor/github.com/moby/moby/client/secret_list_opts.go
@@ -1,0 +1,8 @@
+package client
+
+import "github.com/moby/moby/api/types/filters"
+
+// SecretListOptions holds parameters to list secrets
+type SecretListOptions struct {
+	Filters filters.Args
+}


### PR DESCRIPTION
**- What I did**
Partial part of #50740 
Related to https://github.com/moby/moby/pull/50794

This change moves the `swarm.SecretListOptions` type to the client module and introduces a new backend type to decouple the daemon from client usage.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/swarm: move the `SecretListOptions` type to the client module
```

**- A picture of a cute animal (not mandatory but encouraged)**

