### PR TITLE
api/types/network: move network create/connect/disconnect options from api to client

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -45,20 +45,6 @@ type CreateOptions struct {
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
 }
 
-// ConnectOptions represents the data to be used to connect a container to the
-// network.
-type ConnectOptions struct {
-	Container      string
-	EndpointConfig *EndpointSettings `json:",omitempty"`
-}
-
-// DisconnectOptions represents the data to be used to disconnect a container
-// from the network.
-type DisconnectOptions struct {
-	Container string
-	Force     bool
-}
-
 // Inspect is the body of the "get network" http response message.
 type Inspect struct {
 	Name       string                      // Name is the name of the network

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -21,16 +21,7 @@ const (
 
 // CreateRequest is the request message sent to the server for network create call.
 type CreateRequest struct {
-	CreateOptions
-	Name string // Name is the requested name of the network.
-
-	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
-	// package to older daemons.
-	CheckDuplicate *bool `json:",omitempty"`
-}
-
-// CreateOptions holds options to create a network.
-type CreateOptions struct {
+	Name       string            // Name is the requested name of the network.
 	Driver     string            // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
 	Scope      string            // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
 	EnableIPv4 *bool             `json:",omitempty"` // EnableIPv4 represents whether to enable IPv4.
@@ -43,6 +34,10 @@ type CreateOptions struct {
 	ConfigFrom *ConfigReference  // ConfigFrom specifies the source which will provide the configuration for this network. The specified network must be a config-only network; see [CreateOptions.ConfigOnly].
 	Options    map[string]string // Options specifies the network-specific options to use for when creating the network.
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
+
+	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
+	// package to older daemons.
+	CheckDuplicate *bool `json:",omitempty"`
 }
 
 // Inspect is the body of the "get network" http response message.

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -129,7 +129,7 @@ type ImageAPIClient interface {
 // NetworkAPIClient defines API client methods for the networks
 type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, network, container string, config *network.EndpointSettings) error
-	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
+	NetworkCreate(ctx context.Context, name string, options NetworkCreateOptions) (network.CreateResponse, error)
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
 	NetworkInspect(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, error)
 	NetworkInspectWithRaw(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, []byte, error)

--- a/client/network_connect.go
+++ b/client/network_connect.go
@@ -18,7 +18,7 @@ func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID st
 		return err
 	}
 
-	nc := network.ConnectOptions{
+	nc := NetworkConnectOptions{
 		Container:      containerID,
 		EndpointConfig: config,
 	}

--- a/client/network_connect_opts.go
+++ b/client/network_connect_opts.go
@@ -1,0 +1,10 @@
+package client
+
+import "github.com/moby/moby/api/types/network"
+
+// NetworkConnectOptions represents the data to be used to connect a container to the
+// network.
+type NetworkConnectOptions struct {
+	Container      string
+	EndpointConfig *network.EndpointSettings `json:",omitempty"`
+}

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -47,7 +47,7 @@ func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
 				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
 			}
 
-			var connect network.ConnectOptions
+			var connect NetworkConnectOptions
 			if err := json.NewDecoder(req.Body).Decode(&connect); err != nil {
 				return nil, err
 			}
@@ -84,7 +84,7 @@ func TestNetworkConnect(t *testing.T) {
 				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
 			}
 
-			var connect network.ConnectOptions
+			var connect NetworkConnectOptions
 			if err := json.NewDecoder(req.Body).Decode(&connect); err != nil {
 				return nil, err
 			}

--- a/client/network_create.go
+++ b/client/network_create.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NetworkCreate creates a new network in the docker host.
-func (cli *Client) NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error) {
+func (cli *Client) NetworkCreate(ctx context.Context, name string, options NetworkCreateOptions) (network.CreateResponse, error) {
 	// Make sure we negotiated (if the client is configured to do so),
 	// as code below contains API-version specific handling of options.
 	//
@@ -20,8 +20,19 @@ func (cli *Client) NetworkCreate(ctx context.Context, name string, options netwo
 	}
 
 	networkCreateRequest := network.CreateRequest{
-		CreateOptions: options,
-		Name:          name,
+		Name:       name,
+		Driver:     options.Driver,
+		Scope:      options.Scope,
+		EnableIPv4: options.EnableIPv4,
+		EnableIPv6: options.EnableIPv6,
+		IPAM:       options.IPAM,
+		Internal:   options.Internal,
+		Attachable: options.Attachable,
+		Ingress:    options.Ingress,
+		ConfigOnly: options.ConfigOnly,
+		ConfigFrom: options.ConfigFrom,
+		Options:    options.Options,
+		Labels:     options.Labels,
 	}
 	if versions.LessThan(cli.version, "1.44") {
 		enabled := true

--- a/client/network_create_opts.go
+++ b/client/network_create_opts.go
@@ -1,0 +1,19 @@
+package client
+
+import "github.com/moby/moby/api/types/network"
+
+// NetworkCreateOptions holds options to create a network.
+type NetworkCreateOptions struct {
+	Driver     string                   // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
+	Scope      string                   // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
+	EnableIPv4 *bool                    // EnableIPv4 represents whether to enable IPv4.
+	EnableIPv6 *bool                    // EnableIPv6 represents whether to enable IPv6.
+	IPAM       *network.IPAM            // IPAM is the network's IP Address Management.
+	Internal   bool                     // Internal represents if the network is used internal only.
+	Attachable bool                     // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
+	Ingress    bool                     // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
+	ConfigOnly bool                     // ConfigOnly creates a config-only network. Config-only networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
+	ConfigFrom *network.ConfigReference // ConfigFrom specifies the source which will provide the configuration for this network. The specified network must be a config-only network; see [CreateOptions.ConfigOnly].
+	Options    map[string]string        // Options specifies the network-specific options to use for when creating the network.
+	Labels     map[string]string        // Labels holds metadata specific to the network being created.
+}

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -21,7 +21,7 @@ func TestNetworkCreateError(t *testing.T) {
 		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	}
 
-	_, err := client.NetworkCreate(context.Background(), "mynetwork", network.CreateOptions{})
+	_, err := client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -33,7 +33,7 @@ func TestNetworkCreateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.NetworkCreate(context.Background(), "mynetwork", network.CreateOptions{})
+	_, err = client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
@@ -65,7 +65,7 @@ func TestNetworkCreate(t *testing.T) {
 	}
 
 	enableIPv6 := true
-	networkResponse, err := client.NetworkCreate(context.Background(), "mynetwork", network.CreateOptions{
+	networkResponse, err := client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{
 		Driver:     "mydriver",
 		EnableIPv6: &enableIPv6,
 		Internal:   true,

--- a/client/network_disconnect.go
+++ b/client/network_disconnect.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"context"
-
-	"github.com/moby/moby/api/types/network"
 )
 
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
@@ -18,7 +16,7 @@ func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID
 		return err
 	}
 
-	nd := network.DisconnectOptions{
+	nd := NetworkDisconnectOptions{
 		Container: containerID,
 		Force:     force,
 	}

--- a/client/network_disconnect_opts.go
+++ b/client/network_disconnect_opts.go
@@ -1,0 +1,8 @@
+package client
+
+// NetworkDisconnectOptions represents the data to be used to disconnect a container
+// from the network.
+type NetworkDisconnectOptions struct {
+	Container string
+	Force     bool
+}

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types/network"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -47,7 +46,7 @@ func TestNetworkDisconnect(t *testing.T) {
 				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
 			}
 
-			var disconnect network.DisconnectOptions
+			var disconnect NetworkDisconnectOptions
 			if err := json.NewDecoder(req.Body).Decode(&disconnect); err != nil {
 				return nil, err
 			}

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -214,13 +214,14 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 	if ingressNA == nil {
 		e.backend.ReleaseIngress()
 	} else {
-		options := network.CreateOptions{
+		networkCreateRequest := network.CreateRequest{
+			Name:   ingressNA.Network.Spec.Annotations.Name,
 			Driver: ingressNA.Network.DriverState.Name,
 			IPAM: &network.IPAM{
 				Driver: ingressNA.Network.IPAM.Driver.Name,
 			},
-			Options: ingressNA.Network.DriverState.Options,
 			Ingress: true,
+			Options: ingressNA.Network.DriverState.Options,
 		}
 
 		for _, ic := range ingressNA.Network.IPAM.Configs {
@@ -229,15 +230,12 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 				IPRange: ic.Range,
 				Gateway: ic.Gateway,
 			}
-			options.IPAM.Config = append(options.IPAM.Config, c)
+			networkCreateRequest.IPAM.Config = append(networkCreateRequest.IPAM.Config, c)
 		}
 
 		_, err := e.backend.SetupIngress(clustertypes.NetworkCreateRequest{
-			ID: ingressNA.Network.ID,
-			CreateRequest: network.CreateRequest{
-				Name:          ingressNA.Network.Spec.Annotations.Name,
-				CreateOptions: options,
-			},
+			ID:            ingressNA.Network.ID,
+			CreateRequest: networkCreateRequest,
 		}, ingressNA.Addresses[0])
 		if err != nil {
 			return err

--- a/daemon/server/networkbackend/network.go
+++ b/daemon/server/networkbackend/network.go
@@ -1,0 +1,17 @@
+package networkbackend
+
+import "github.com/moby/moby/api/types/network"
+
+// ConnectOptions represents the data to be used to connect a container to the
+// network.
+type ConnectOptions struct {
+	Container      string
+	EndpointConfig *network.EndpointSettings `json:",omitempty"`
+}
+
+// DisconnectOptions represents the data to be used to disconnect a container
+// from the network.
+type DisconnectOptions struct {
+	Container string
+	Force     bool
+}

--- a/daemon/server/router/network/network_routes.go
+++ b/daemon/server/router/network/network_routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/scope"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/daemon/server/networkbackend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
 )
@@ -245,7 +246,7 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 		return err
 	}
 
-	var connect network.ConnectOptions
+	var connect networkbackend.ConnectOptions
 	if err := httputils.ReadJSON(r, &connect); err != nil {
 		return err
 	}
@@ -262,7 +263,7 @@ func (n *networkRouter) postNetworkDisconnect(ctx context.Context, w http.Respon
 		return err
 	}
 
-	var disconnect network.DisconnectOptions
+	var disconnect networkbackend.DisconnectOptions
 	if err := httputils.ReadJSON(r, &disconnect); err != nil {
 		return err
 	}

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/testutil"
 	"github.com/moby/moby/v2/testutil/request"
@@ -289,7 +290,7 @@ func createNetwork(t *testing.T, config network.CreateRequest, expectedStatusCod
 }
 
 func connectNetwork(t *testing.T, nid, cid string) {
-	resp, _, err := request.Post(testutil.GetContext(t), "/networks/"+nid+"/connect", request.JSONBody(network.ConnectOptions{
+	resp, _, err := request.Post(testutil.GetContext(t), "/networks/"+nid+"/connect", request.JSONBody(client.NetworkConnectOptions{
 		Container: cid,
 	}))
 	assert.NilError(t, err)
@@ -297,7 +298,7 @@ func connectNetwork(t *testing.T, nid, cid string) {
 }
 
 func disconnectNetwork(t *testing.T, nid, cid string) {
-	config := network.ConnectOptions{
+	config := client.NetworkDisconnectOptions{
 		Container: cid,
 	}
 

--- a/integration-cli/docker_api_network_test.go
+++ b/integration-cli/docker_api_network_test.go
@@ -67,12 +67,10 @@ func (s *DockerAPISuite) TestAPINetworkInspectUserDefinedNetwork(c *testing.T) {
 		Config: []network.IPAMConfig{{Subnet: "172.28.0.0/16", IPRange: "172.28.5.0/24", Gateway: "172.28.5.254"}},
 	}
 	config := network.CreateRequest{
-		Name: "br0",
-		CreateOptions: network.CreateOptions{
-			Driver:  "bridge",
-			IPAM:    ipam,
-			Options: map[string]string{"foo": "bar", "opts": "dopts"},
-		},
+		Name:    "br0",
+		Driver:  "bridge",
+		IPAM:    ipam,
+		Options: map[string]string{"foo": "bar", "opts": "dopts"},
 	}
 	id0 := createNetwork(c, config, http.StatusCreated)
 	assert.Assert(c, isNetworkAvailable(c, "br0"))
@@ -140,11 +138,9 @@ func (s *DockerAPISuite) TestAPINetworkIPAMMultipleBridgeNetworks(c *testing.T) 
 		Config: []network.IPAMConfig{{Subnet: "192.178.0.0/16", IPRange: "192.178.128.0/17", Gateway: "192.178.138.100"}},
 	}
 	config0 := network.CreateRequest{
-		Name: "test0",
-		CreateOptions: network.CreateOptions{
-			Driver: "bridge",
-			IPAM:   ipam0,
-		},
+		Name:   "test0",
+		Driver: "bridge",
+		IPAM:   ipam0,
 	}
 	id0 := createNetwork(c, config0, http.StatusCreated)
 	assert.Assert(c, isNetworkAvailable(c, "test0"))
@@ -155,11 +151,9 @@ func (s *DockerAPISuite) TestAPINetworkIPAMMultipleBridgeNetworks(c *testing.T) 
 	}
 	// test1 bridge network overlaps with test0
 	config1 := network.CreateRequest{
-		Name: "test1",
-		CreateOptions: network.CreateOptions{
-			Driver: "bridge",
-			IPAM:   ipam1,
-		},
+		Name:   "test1",
+		Driver: "bridge",
+		IPAM:   ipam1,
 	}
 	createNetwork(c, config1, http.StatusForbidden)
 	assert.Assert(c, !isNetworkAvailable(c, "test1"))
@@ -170,11 +164,9 @@ func (s *DockerAPISuite) TestAPINetworkIPAMMultipleBridgeNetworks(c *testing.T) 
 	}
 	// test2 bridge network does not overlap
 	config2 := network.CreateRequest{
-		Name: "test2",
-		CreateOptions: network.CreateOptions{
-			Driver: "bridge",
-			IPAM:   ipam2,
-		},
+		Name:   "test2",
+		Driver: "bridge",
+		IPAM:   ipam2,
 	}
 	createNetwork(c, config2, http.StatusCreated)
 	assert.Assert(c, isNetworkAvailable(c, "test2"))

--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cloudflare/cfssl/initca"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration-cli/checker"
@@ -1023,7 +1022,7 @@ func (s *DockerSwarmSuite) TestAPINetworkInspectWithScope(c *testing.T) {
 	name := "test-scoped-network"
 	apiclient := d.NewClientT(c)
 
-	resp, err := apiclient.NetworkCreate(ctx, name, network.CreateOptions{Driver: "overlay"})
+	resp, err := apiclient.NetworkCreate(ctx, name, client.NetworkCreateOptions{Driver: "overlay"})
 	assert.NilError(c, err)
 
 	nw, err := apiclient.NetworkInspect(ctx, name, client.NetworkInspectOptions{})

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -5,6 +5,7 @@ import (
 
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -113,7 +114,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	networkName := "network1" + t.Name()
-	_, err := apiClient.NetworkCreate(ctx, networkName, network.CreateOptions{})
+	_, err := apiClient.NetworkCreate(ctx, networkName, client.NetworkCreateOptions{})
 
 	assert.NilError(t, err)
 	cID := container.Run(ctx, t, apiClient, func(c *container.TestContainerConfig) {

--- a/integration/internal/network/network.go
+++ b/integration/internal/network/network.go
@@ -4,32 +4,31 @@ import (
 	"context"
 	"testing"
 
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 )
 
-func createNetwork(ctx context.Context, client client.APIClient, name string, ops ...func(*network.CreateOptions)) (string, error) {
-	config := network.CreateOptions{}
+func createNetwork(ctx context.Context, apiClient client.APIClient, name string, ops ...func(*client.NetworkCreateOptions)) (string, error) {
+	config := client.NetworkCreateOptions{}
 
 	for _, op := range ops {
 		op(&config)
 	}
 
-	n, err := client.NetworkCreate(ctx, name, config)
+	n, err := apiClient.NetworkCreate(ctx, name, config)
 	return n.ID, err
 }
 
 // Create creates a network with the specified options
-func Create(ctx context.Context, client client.APIClient, name string, ops ...func(*network.CreateOptions)) (string, error) {
-	return createNetwork(ctx, client, name, ops...)
+func Create(ctx context.Context, apiClient client.APIClient, name string, ops ...func(*client.NetworkCreateOptions)) (string, error) {
+	return createNetwork(ctx, apiClient, name, ops...)
 }
 
 // CreateNoError creates a network with the specified options and verifies there were no errors
-func CreateNoError(ctx context.Context, t *testing.T, client client.APIClient, name string, ops ...func(*network.CreateOptions)) string {
+func CreateNoError(ctx context.Context, t *testing.T, apiClient client.APIClient, name string, ops ...func(*client.NetworkCreateOptions)) string {
 	t.Helper()
 
-	name, err := createNetwork(ctx, client, name, ops...)
+	name, err := createNetwork(ctx, apiClient, name, ops...)
 	assert.NilError(t, err)
 	return name
 }

--- a/integration/internal/network/ops.go
+++ b/integration/internal/network/ops.go
@@ -2,85 +2,86 @@ package network
 
 import (
 	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 )
 
 // WithDriver sets the driver of the network
-func WithDriver(driver string) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithDriver(driver string) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.Driver = driver
 	}
 }
 
 // WithIPv4 enables/disables IPv4 on the network
-func WithIPv4(enable bool) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithIPv4(enable bool) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		enableIPv4 := enable
 		n.EnableIPv4 = &enableIPv4
 	}
 }
 
 // WithIPv6 Enables IPv6 on the network
-func WithIPv6() func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithIPv6() func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		enableIPv6 := true
 		n.EnableIPv6 = &enableIPv6
 	}
 }
 
 // WithIPv4Disabled makes sure IPv4 is disabled on the network.
-func WithIPv4Disabled() func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithIPv4Disabled() func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		enable := false
 		n.EnableIPv4 = &enable
 	}
 }
 
 // WithIPv6Disabled makes sure IPv6 is disabled on the network.
-func WithIPv6Disabled() func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithIPv6Disabled() func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		enable := false
 		n.EnableIPv6 = &enable
 	}
 }
 
 // WithInternal enables Internal flag on the create network request
-func WithInternal() func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithInternal() func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.Internal = true
 	}
 }
 
 // WithConfigOnly sets the ConfigOnly flag in the create network request
-func WithConfigOnly(co bool) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithConfigOnly(co bool) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.ConfigOnly = co
 	}
 }
 
 // WithConfigFrom sets the ConfigOnly flag in the create network request
-func WithConfigFrom(name string) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithConfigFrom(name string) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.ConfigFrom = &network.ConfigReference{Network: name}
 	}
 }
 
 // WithAttachable sets Attachable flag on the create network request
-func WithAttachable() func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithAttachable() func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.Attachable = true
 	}
 }
 
 // WithScope sets the network scope.
-func WithScope(s string) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithScope(s string) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.Scope = s
 	}
 }
 
 // WithMacvlan sets the network as macvlan with the specified parent
-func WithMacvlan(parent string) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithMacvlan(parent string) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.Driver = "macvlan"
 		if parent != "" {
 			n.Options = map[string]string{
@@ -91,8 +92,8 @@ func WithMacvlan(parent string) func(*network.CreateOptions) {
 }
 
 // WithMacvlanPassthru sets the network as macvlan with the specified parent in passthru mode
-func WithMacvlanPassthru(parent string) func(options *network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithMacvlanPassthru(parent string) func(options *client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.Driver = "macvlan"
 		n.Options = map[string]string{
 			"macvlan_mode": "passthru",
@@ -104,8 +105,8 @@ func WithMacvlanPassthru(parent string) func(options *network.CreateOptions) {
 }
 
 // WithIPvlan sets the network as ipvlan with the specified parent and mode
-func WithIPvlan(parent, mode string) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithIPvlan(parent, mode string) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		n.Driver = "ipvlan"
 		if n.Options == nil {
 			n.Options = map[string]string{}
@@ -120,8 +121,8 @@ func WithIPvlan(parent, mode string) func(*network.CreateOptions) {
 }
 
 // WithOption adds the specified key/value pair to network's options
-func WithOption(key, value string) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithOption(key, value string) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		if n.Options == nil {
 			n.Options = map[string]string{}
 		}
@@ -130,13 +131,13 @@ func WithOption(key, value string) func(*network.CreateOptions) {
 }
 
 // WithIPAM adds an IPAM with the specified Subnet and Gateway to the network
-func WithIPAM(subnet, gateway string) func(*network.CreateOptions) {
+func WithIPAM(subnet, gateway string) func(*client.NetworkCreateOptions) {
 	return WithIPAMRange(subnet, "", gateway)
 }
 
 // WithIPAMRange adds an IPAM with the specified Subnet, IPRange and Gateway to the network
-func WithIPAMRange(subnet, iprange, gateway string) func(*network.CreateOptions) {
-	return func(n *network.CreateOptions) {
+func WithIPAMRange(subnet, iprange, gateway string) func(*client.NetworkCreateOptions) {
+	return func(n *client.NetworkCreateOptions) {
 		if n.IPAM == nil {
 			n.IPAM = &network.IPAM{}
 		}

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -127,7 +127,7 @@ func TestDefaultIPvOptOverride(t *testing.T) {
 				t.Run(fmt.Sprintf("override4=%v,override6=%v", override4, override6), func(t *testing.T) {
 					t.Parallel()
 					netName := fmt.Sprintf("tdioo-%v-%v", override4, override6)
-					var nopts []func(*networktypes.CreateOptions)
+					var nopts []func(*client.NetworkCreateOptions)
 					if override4 {
 						nopts = append(nopts, network.WithIPv4(true))
 					}
@@ -373,7 +373,7 @@ func TestPointToPoint(t *testing.T) {
 
 	testcases := []struct {
 		name   string
-		netOpt func(*networktypes.CreateOptions)
+		netOpt func(*client.NetworkCreateOptions)
 	}{
 		{
 			name:   "inhibit_ipv4",

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	containertypes "github.com/moby/moby/api/types/container"
-	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
@@ -311,7 +310,7 @@ func createBridgeNetworks(ctx context.Context, t *testing.T, d *daemon.Daemon, s
 		if gwMode == "" {
 			gwMode = "nat"
 		}
-		netOpts := []func(*networktypes.CreateOptions){
+		netOpts := []func(*client.NetworkCreateOptions){
 			network.WithIPAM(docNetworks[i], docGateways[i]),
 			network.WithOption(bridge.BridgeName, nw.name),
 			network.WithOption(bridge.IPv4GatewayMode, gwMode),

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -29,8 +29,8 @@ import (
 	"text/template"
 
 	containertypes "github.com/moby/moby/api/types/container"
-	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/integration/internal/network"
@@ -283,7 +283,7 @@ func createBridgeNetworks(ctx context.Context, t *testing.T, d *daemon.Daemon, s
 		if gwMode == "" {
 			gwMode = "nat"
 		}
-		netOpts := []func(*networktypes.CreateOptions){
+		netOpts := []func(*client.NetworkCreateOptions){
 			network.WithIPAM(docNetworks[i], docGateways[i]),
 			network.WithOption(bridge.BridgeName, nw.name),
 			network.WithOption(bridge.IPv4GatewayMode, gwMode),

--- a/integration/network/ipvlan/ipvlan_test.go
+++ b/integration/network/ipvlan/ipvlan_test.go
@@ -490,7 +490,7 @@ func TestIpvlanIPAM(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			c := d.NewClientT(t, dclient.WithVersion(tc.apiVersion))
 
-			netOpts := []func(*network.CreateOptions){
+			netOpts := []func(*dclient.NetworkCreateOptions){
 				net.WithIPvlan("", "l3"),
 				net.WithIPv4(tc.enableIPv4),
 			}
@@ -591,7 +591,7 @@ func TestIPVlanDNS(t *testing.T) {
 			name := fmt.Sprintf("Mode=%v/HasParent=%v/Internal=%v", mode, tc.parent != "", tc.internal)
 			t.Run(name, func(t *testing.T) {
 				ctx := testutil.StartSpan(ctx, t)
-				createOpts := []func(*network.CreateOptions){
+				createOpts := []func(*dclient.NetworkCreateOptions){
 					net.WithIPvlan(tc.parent, mode),
 				}
 				if tc.internal {

--- a/integration/network/macvlan/macvlan_test.go
+++ b/integration/network/macvlan/macvlan_test.go
@@ -487,7 +487,7 @@ func TestMacvlanIPAM(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 			c := d.NewClientT(t, client.WithVersion(tc.apiVersion))
 
-			netOpts := []func(*network.CreateOptions){
+			netOpts := []func(*client.NetworkCreateOptions){
 				net.WithMacvlan(""),
 				net.WithOption("macvlan_mode", "bridge"),
 				net.WithIPv4(tc.enableIPv4),
@@ -587,7 +587,7 @@ func TestMACVlanDNS(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
-			createOpts := []func(*network.CreateOptions){
+			createOpts := []func(*client.NetworkCreateOptions){
 				net.WithMacvlan(tc.parent),
 			}
 			if tc.internal {

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -143,7 +143,7 @@ func TestDefaultNetworkOpts(t *testing.T) {
 
 			if tc.configFrom {
 				// Create a new network config
-				network.CreateNoError(ctx, t, c, "from-net", func(create *networktypes.CreateOptions) {
+				network.CreateNoError(ctx, t, c, "from-net", func(create *client.NetworkCreateOptions) {
 					create.ConfigOnly = true
 					create.Options = map[string]string{
 						"com.docker.network.driver.mtu": fmt.Sprint(tc.mtu),
@@ -154,7 +154,7 @@ func TestDefaultNetworkOpts(t *testing.T) {
 
 			// Create a new network
 			networkName := "testnet"
-			networkId := network.CreateNoError(ctx, t, c, networkName, func(create *networktypes.CreateOptions) {
+			networkId := network.CreateNoError(ctx, t, c, networkName, func(create *client.NetworkCreateOptions) {
 				if tc.configFrom {
 					create.ConfigFrom = &networktypes.ConfigReference{
 						Network: "from-net",
@@ -196,7 +196,7 @@ func TestForbidDuplicateNetworkNames(t *testing.T) {
 	network.CreateNoError(ctx, t, c, "testnet")
 	defer network.RemoveNoError(ctx, t, c, "testnet")
 
-	_, err := c.NetworkCreate(ctx, "testnet", networktypes.CreateOptions{})
+	_, err := c.NetworkCreate(ctx, "testnet", client.NetworkCreateOptions{})
 	assert.Error(t, err, "Error response from daemon: network with name testnet already exists", "2nd NetworkCreate call should have failed")
 }
 

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -49,7 +49,7 @@ func TestBridgeICC(t *testing.T) {
 
 	testcases := []struct {
 		name           string
-		bridgeOpts     []func(*networktypes.CreateOptions)
+		bridgeOpts     []func(*client.NetworkCreateOptions)
 		ctr1MacAddress string
 		isIPv6         bool
 		isLinkLocal    bool
@@ -57,17 +57,17 @@ func TestBridgeICC(t *testing.T) {
 	}{
 		{
 			name:       "IPv4 non-internal network",
-			bridgeOpts: []func(*networktypes.CreateOptions){},
+			bridgeOpts: []func(*client.NetworkCreateOptions){},
 		},
 		{
 			name: "IPv4 internal network",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithInternal(),
 			},
 		},
 		{
 			name: "IPv6 ULA on non-internal network",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithIPAM("fdf1:a844:380c:b200::/64", "fdf1:a844:380c:b200::1"),
 			},
@@ -75,7 +75,7 @@ func TestBridgeICC(t *testing.T) {
 		},
 		{
 			name: "IPv6 ULA on internal network",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithInternal(),
 				network.WithIPAM("fdf1:a844:380c:b247::/64", "fdf1:a844:380c:b247::1"),
@@ -84,7 +84,7 @@ func TestBridgeICC(t *testing.T) {
 		},
 		{
 			name: "IPv6 link-local address on non-internal network",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				// There's no real way to specify an IPv6 network is only used with SLAAC link-local IPv6 addresses.
 				// What we can do instead, is to tell the IPAM driver to assign addresses from the link-local prefix.
@@ -97,7 +97,7 @@ func TestBridgeICC(t *testing.T) {
 		},
 		{
 			name: "IPv6 link-local address on internal network",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithInternal(),
 				// See the note above about link-local addresses.
@@ -115,7 +115,7 @@ func TestBridgeICC(t *testing.T) {
 			//   addresses need not be qualified with a zone index."
 			// So, for this common case, LL addresses should be included in DNS config.
 			name: "IPv6 link-local address on non-internal network ping by name",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithIPAM("fe80::/64", "fe80::1"),
 			},
@@ -128,7 +128,7 @@ func TestBridgeICC(t *testing.T) {
 			// configure two networks with the same LL subnet, although perhaps it should
 			// be). So, again, no zone index is required and the LL address should be
 			// included in DNS config.
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithIPAM("fe80:1234::/64", "fe80:1234::1"),
 			},
@@ -136,7 +136,7 @@ func TestBridgeICC(t *testing.T) {
 		},
 		{
 			name: "IPv6 non-internal network with SLAAC LL address",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithIPAM("fdf1:a844:380c:b247::/64", "fdf1:a844:380c:b247::1"),
 			},
@@ -148,7 +148,7 @@ func TestBridgeICC(t *testing.T) {
 		},
 		{
 			name: "IPv6 internal network with SLAAC LL address",
-			bridgeOpts: []func(*networktypes.CreateOptions){
+			bridgeOpts: []func(*client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithIPAM("fdf1:a844:380c:b247::/64", "fdf1:a844:380c:b247::1"),
 			},
@@ -234,8 +234,8 @@ func TestBridgeINC(t *testing.T) {
 	defer c.Close()
 
 	type bridgesOpts struct {
-		bridge1Opts []func(*networktypes.CreateOptions)
-		bridge2Opts []func(*networktypes.CreateOptions)
+		bridge1Opts []func(*client.NetworkCreateOptions)
+		bridge2Opts []func(*client.NetworkCreateOptions)
 	}
 
 	testcases := []struct {
@@ -248,27 +248,27 @@ func TestBridgeINC(t *testing.T) {
 		{
 			name: "IPv4 non-internal network",
 			bridges: bridgesOpts{
-				bridge1Opts: []func(*networktypes.CreateOptions){},
-				bridge2Opts: []func(*networktypes.CreateOptions){},
+				bridge1Opts: []func(*client.NetworkCreateOptions){},
+				bridge2Opts: []func(*client.NetworkCreateOptions){},
 			},
 			stdout: "1 packets transmitted, 0 packets received",
 		},
 		{
 			name: "IPv4 internal network",
 			bridges: bridgesOpts{
-				bridge1Opts: []func(*networktypes.CreateOptions){network.WithInternal()},
-				bridge2Opts: []func(*networktypes.CreateOptions){network.WithInternal()},
+				bridge1Opts: []func(*client.NetworkCreateOptions){network.WithInternal()},
+				bridge2Opts: []func(*client.NetworkCreateOptions){network.WithInternal()},
 			},
 			stderr: "sendto: Network is unreachable",
 		},
 		{
 			name: "IPv6 ULA on non-internal network",
 			bridges: bridgesOpts{
-				bridge1Opts: []func(*networktypes.CreateOptions){
+				bridge1Opts: []func(*client.NetworkCreateOptions){
 					network.WithIPv6(),
 					network.WithIPAM("fdf1:a844:380c:b200::/64", "fdf1:a844:380c:b200::1"),
 				},
-				bridge2Opts: []func(*networktypes.CreateOptions){
+				bridge2Opts: []func(*client.NetworkCreateOptions){
 					network.WithIPv6(),
 					network.WithIPAM("fdf1:a844:380c:b247::/64", "fdf1:a844:380c:b247::1"),
 				},
@@ -279,12 +279,12 @@ func TestBridgeINC(t *testing.T) {
 		{
 			name: "IPv6 ULA on internal network",
 			bridges: bridgesOpts{
-				bridge1Opts: []func(*networktypes.CreateOptions){
+				bridge1Opts: []func(*client.NetworkCreateOptions){
 					network.WithIPv6(),
 					network.WithInternal(),
 					network.WithIPAM("fdf1:a844:390c:b200::/64", "fdf1:a844:390c:b200::1"),
 				},
-				bridge2Opts: []func(*networktypes.CreateOptions){
+				bridge2Opts: []func(*client.NetworkCreateOptions){
 					network.WithIPv6(),
 					network.WithInternal(),
 					network.WithIPAM("fdf1:a844:390c:b247::/64", "fdf1:a844:390c:b247::1"),
@@ -1543,7 +1543,7 @@ func TestAdvertiseAddresses(t *testing.T) {
 
 	testcases := []struct {
 		name            string
-		netOpts         []func(*networktypes.CreateOptions)
+		netOpts         []func(*client.NetworkCreateOptions)
 		ipv6LinkLocal   bool
 		stopCtr2After   time.Duration
 		expNetCreateErr string
@@ -1558,21 +1558,21 @@ func TestAdvertiseAddresses(t *testing.T) {
 		},
 		{
 			name: "disable advertise addrs",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrNMsgs, "0"),
 			},
 			expNoMACUpdate: true,
 		},
 		{
 			name: "single message",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrNMsgs, "1"),
 			},
 			expNMsgs: 1,
 		},
 		{
 			name: "min interval",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "100"),
 			},
 			expNMsgs:    3,
@@ -1580,7 +1580,7 @@ func TestAdvertiseAddresses(t *testing.T) {
 		},
 		{
 			name: "cancel",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "2000"),
 			},
 			stopCtr2After: 200 * time.Millisecond,
@@ -1594,42 +1594,42 @@ func TestAdvertiseAddresses(t *testing.T) {
 		},
 		{
 			name: "interval too short",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "99"),
 			},
 			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_ms must be in the range 100 to 2000",
 		},
 		{
 			name: "interval too long",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "2001"),
 			},
 			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_ms must be in the range 100 to 2000",
 		},
 		{
 			name: "nonsense interval",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrIntervalMs, "nonsense"),
 			},
 			expNetCreateErr: `Error response from daemon: value for option com.docker.network.advertise_addr_ms "nonsense" must be integer milliseconds`,
 		},
 		{
 			name: "negative msg count",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrNMsgs, "-1"),
 			},
 			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_nmsgs must be in the range 0 to 3",
 		},
 		{
 			name: "too many msgs",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrNMsgs, "4"),
 			},
 			expNetCreateErr: "Error response from daemon: com.docker.network.advertise_addr_nmsgs must be in the range 0 to 3",
 		},
 		{
 			name: "nonsense msg count",
-			netOpts: []func(*networktypes.CreateOptions){
+			netOpts: []func(*client.NetworkCreateOptions){
 				network.WithOption(netlabel.AdvertiseAddrNMsgs, "nonsense"),
 			},
 			expNetCreateErr: `Error response from daemon: value for option com.docker.network.advertise_addr_nmsgs "nonsense" must be an integer`,
@@ -1642,7 +1642,7 @@ func TestAdvertiseAddresses(t *testing.T) {
 
 			const netName = "dsnet"
 			const brName = "br-advaddr"
-			netOpts := append([]func(*networktypes.CreateOptions){
+			netOpts := append([]func(*client.NetworkCreateOptions){
 				network.WithOption(bridge.BridgeName, brName),
 				network.WithIPv6(),
 				network.WithIPAM("172.22.22.0/24", "172.22.22.1"),

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -108,7 +108,7 @@ func TestDisableNAT(t *testing.T) {
 			ctx := testutil.StartSpan(ctx, t)
 
 			const netName = "testnet"
-			nwOpts := []func(options *networktypes.CreateOptions){
+			nwOpts := []func(options *client.NetworkCreateOptions){
 				network.WithIPv6(),
 				network.WithIPAM("fd2a:a2c3:4448::/64", "fd2a:a2c3:4448::1"),
 			}
@@ -358,7 +358,7 @@ func TestAccessPublishedPortFromHost(t *testing.T) {
 			defer c.Close()
 
 			bridgeName := fmt.Sprintf("nat-from-host-%d", tcID)
-			bridgeOpts := []func(options *networktypes.CreateOptions){
+			bridgeOpts := []func(options *client.NetworkCreateOptions){
 				network.WithDriver("bridge"),
 				network.WithOption(bridge.BridgeName, bridgeName),
 			}
@@ -1290,7 +1290,7 @@ func testDirectRemoteAccessOnExposedPort(t *testing.T, ctx context.Context, d *d
 
 			testutil.StartSpan(ctx, t)
 
-			nwOpts := []func(*networktypes.CreateOptions){
+			nwOpts := []func(*client.NetworkCreateOptions){
 				network.WithIPAM(tc.gwAddr.Masked().String(), tc.gwAddr.Addr().String()),
 				network.WithOption(bridge.IPv4GatewayMode, tc.gwMode),
 				network.WithOption(bridge.IPv6GatewayMode, tc.gwMode),

--- a/vendor/github.com/moby/moby/api/types/network/network.go
+++ b/vendor/github.com/moby/moby/api/types/network/network.go
@@ -45,20 +45,6 @@ type CreateOptions struct {
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
 }
 
-// ConnectOptions represents the data to be used to connect a container to the
-// network.
-type ConnectOptions struct {
-	Container      string
-	EndpointConfig *EndpointSettings `json:",omitempty"`
-}
-
-// DisconnectOptions represents the data to be used to disconnect a container
-// from the network.
-type DisconnectOptions struct {
-	Container string
-	Force     bool
-}
-
 // Inspect is the body of the "get network" http response message.
 type Inspect struct {
 	Name       string                      // Name is the name of the network

--- a/vendor/github.com/moby/moby/api/types/network/network.go
+++ b/vendor/github.com/moby/moby/api/types/network/network.go
@@ -21,16 +21,7 @@ const (
 
 // CreateRequest is the request message sent to the server for network create call.
 type CreateRequest struct {
-	CreateOptions
-	Name string // Name is the requested name of the network.
-
-	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
-	// package to older daemons.
-	CheckDuplicate *bool `json:",omitempty"`
-}
-
-// CreateOptions holds options to create a network.
-type CreateOptions struct {
+	Name       string            // Name is the requested name of the network.
 	Driver     string            // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
 	Scope      string            // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
 	EnableIPv4 *bool             `json:",omitempty"` // EnableIPv4 represents whether to enable IPv4.
@@ -43,6 +34,10 @@ type CreateOptions struct {
 	ConfigFrom *ConfigReference  // ConfigFrom specifies the source which will provide the configuration for this network. The specified network must be a config-only network; see [CreateOptions.ConfigOnly].
 	Options    map[string]string // Options specifies the network-specific options to use for when creating the network.
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
+
+	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
+	// package to older daemons.
+	CheckDuplicate *bool `json:",omitempty"`
 }
 
 // Inspect is the body of the "get network" http response message.

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -129,7 +129,7 @@ type ImageAPIClient interface {
 // NetworkAPIClient defines API client methods for the networks
 type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, network, container string, config *network.EndpointSettings) error
-	NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
+	NetworkCreate(ctx context.Context, name string, options NetworkCreateOptions) (network.CreateResponse, error)
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
 	NetworkInspect(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, error)
 	NetworkInspectWithRaw(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, []byte, error)

--- a/vendor/github.com/moby/moby/client/network_connect.go
+++ b/vendor/github.com/moby/moby/client/network_connect.go
@@ -18,7 +18,7 @@ func (cli *Client) NetworkConnect(ctx context.Context, networkID, containerID st
 		return err
 	}
 
-	nc := network.ConnectOptions{
+	nc := NetworkConnectOptions{
 		Container:      containerID,
 		EndpointConfig: config,
 	}

--- a/vendor/github.com/moby/moby/client/network_connect_opts.go
+++ b/vendor/github.com/moby/moby/client/network_connect_opts.go
@@ -1,0 +1,10 @@
+package client
+
+import "github.com/moby/moby/api/types/network"
+
+// NetworkConnectOptions represents the data to be used to connect a container to the
+// network.
+type NetworkConnectOptions struct {
+	Container      string
+	EndpointConfig *network.EndpointSettings `json:",omitempty"`
+}

--- a/vendor/github.com/moby/moby/client/network_create.go
+++ b/vendor/github.com/moby/moby/client/network_create.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NetworkCreate creates a new network in the docker host.
-func (cli *Client) NetworkCreate(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error) {
+func (cli *Client) NetworkCreate(ctx context.Context, name string, options NetworkCreateOptions) (network.CreateResponse, error) {
 	// Make sure we negotiated (if the client is configured to do so),
 	// as code below contains API-version specific handling of options.
 	//
@@ -20,8 +20,19 @@ func (cli *Client) NetworkCreate(ctx context.Context, name string, options netwo
 	}
 
 	networkCreateRequest := network.CreateRequest{
-		CreateOptions: options,
-		Name:          name,
+		Name:       name,
+		Driver:     options.Driver,
+		Scope:      options.Scope,
+		EnableIPv4: options.EnableIPv4,
+		EnableIPv6: options.EnableIPv6,
+		IPAM:       options.IPAM,
+		Internal:   options.Internal,
+		Attachable: options.Attachable,
+		Ingress:    options.Ingress,
+		ConfigOnly: options.ConfigOnly,
+		ConfigFrom: options.ConfigFrom,
+		Options:    options.Options,
+		Labels:     options.Labels,
 	}
 	if versions.LessThan(cli.version, "1.44") {
 		enabled := true

--- a/vendor/github.com/moby/moby/client/network_create_opts.go
+++ b/vendor/github.com/moby/moby/client/network_create_opts.go
@@ -1,0 +1,19 @@
+package client
+
+import "github.com/moby/moby/api/types/network"
+
+// NetworkCreateOptions holds options to create a network.
+type NetworkCreateOptions struct {
+	Driver     string                   // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
+	Scope      string                   // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
+	EnableIPv4 *bool                    // EnableIPv4 represents whether to enable IPv4.
+	EnableIPv6 *bool                    // EnableIPv6 represents whether to enable IPv6.
+	IPAM       *network.IPAM            // IPAM is the network's IP Address Management.
+	Internal   bool                     // Internal represents if the network is used internal only.
+	Attachable bool                     // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
+	Ingress    bool                     // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
+	ConfigOnly bool                     // ConfigOnly creates a config-only network. Config-only networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
+	ConfigFrom *network.ConfigReference // ConfigFrom specifies the source which will provide the configuration for this network. The specified network must be a config-only network; see [CreateOptions.ConfigOnly].
+	Options    map[string]string        // Options specifies the network-specific options to use for when creating the network.
+	Labels     map[string]string        // Labels holds metadata specific to the network being created.
+}

--- a/vendor/github.com/moby/moby/client/network_disconnect.go
+++ b/vendor/github.com/moby/moby/client/network_disconnect.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"context"
-
-	"github.com/moby/moby/api/types/network"
 )
 
 // NetworkDisconnect disconnects a container from an existent network in the docker host.
@@ -18,7 +16,7 @@ func (cli *Client) NetworkDisconnect(ctx context.Context, networkID, containerID
 		return err
 	}
 
-	nd := network.DisconnectOptions{
+	nd := NetworkDisconnectOptions{
 		Container: containerID,
 		Force:     force,
 	}

--- a/vendor/github.com/moby/moby/client/network_disconnect_opts.go
+++ b/vendor/github.com/moby/moby/client/network_disconnect_opts.go
@@ -1,0 +1,8 @@
+package client
+
+// NetworkDisconnectOptions represents the data to be used to disconnect a container
+// from the network.
+type NetworkDisconnectOptions struct {
+	Container string
+	Force     bool
+}


### PR DESCRIPTION
**- What I did**
Partial for #50740 
Related to https://github.com/moby/moby/pull/50786

This change moves `network.CreateOptions`, `network.ConnectOptions`, and `network.DisconnectOptions` out of the api to the client module.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/network: move `CreateOptions`, `ConnectOptions` and `DisconnectOptions` to the client module
```

**- A picture of a cute animal (not mandatory but encouraged)**

