### PR TITLE
hack/make/test-integration: disable firewalld integration

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -119,6 +119,14 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 	(
 		echo "Starting dockerd"
 		[ -n "$TESTDEBUG" ] && set -x
+		if [ -n "${FIREWALLD:-}" ] && [ "${DOCKER_FIREWALL_BACKEND:-}" == "iptables" ]; then
+			# Networking integration tests start their own daemon to have fine control over the configuration of the
+			# daemon-under-test. Two daemons running with firewalld integration enabled would race against each other
+			# when the firewalld reload signal is dispatched, and would result in iptables disappearing unexpectedly
+			# from the point of view of the daemon-under-test. So, disable firewalld integration on this daemon, as it's
+			# only used to load frozen images.
+			export DOCKER_TEST_NO_FIREWALLD="true"
+		fi
 		exec \
 			${dockerd} --debug \
 			--host "$DOCKER_HOST" \

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -368,7 +368,13 @@ func TestFilterForwardPolicy(t *testing.T) {
 // address is reserved for a gateway, because it won't be used).
 func TestPointToPoint(t *testing.T) {
 	ctx := setupTest(t)
-	apiClient := testEnv.APIClient()
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	t.Cleanup(func() { d.Stop(t) })
+
+	apiClient := d.NewClientT(t)
+	t.Cleanup(func() { apiClient.Close() })
 
 	testcases := []struct {
 		name   string
@@ -422,7 +428,13 @@ func TestIsolated(t *testing.T) {
 	skip.If(t, testEnv.IsRootless, "can't inspect bridge addrs in rootless netns")
 
 	ctx := setupTest(t)
-	apiClient := testEnv.APIClient()
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	t.Cleanup(func() { d.Stop(t) })
+
+	apiClient := d.NewClientT(t)
+	t.Cleanup(func() { apiClient.Close() })
 
 	const netName = "testisol"
 	const bridgeName = "br-" + netName

--- a/integration/networking/firewall_linux_test.go
+++ b/integration/networking/firewall_linux_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/testutils/networking"
+	"github.com/moby/moby/v2/testutil/daemon"
 	"github.com/moby/moby/v2/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -15,7 +16,13 @@ const defaultFirewallBackend = "iptables"
 
 func TestInfoFirewallBackend(t *testing.T) {
 	ctx := setupTest(t)
-	c := testEnv.APIClient()
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	t.Cleanup(func() { d.Stop(t) })
+
+	c := d.NewClientT(t)
+	t.Cleanup(func() { c.Close() })
 
 	expDriver := defaultFirewallBackend
 	if val := os.Getenv("DOCKER_FIREWALL_BACKEND"); val != "" {


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/50726
- Possibly a fix for https://github.com/moby/moby/issues/50595

**- What I did**

The daemon started by the test-integration script needs to run without firewalld integration to make sure that daemons started by networking tests will handle firewalld reload without any interference (i.e. without another daemon racing against them to recreate the iptables chains).

This may have been the cause of `TestBridgeICC` flakiness observed so far, although only one testcase is flaky. See https://github.com/moby/moby/issues/50595.

Presumably, this started to fail consistently with Debian Trixie due to quicker signal dispatch across daemons. On https://github.com/moby/moby/pull/50726, following integration tests are broken:

```
--- FAIL: TestBridgeICC (4.27s)
    --- PASS: TestBridgeICC/IPv4_non-internal_network (2.63s)
    --- FAIL: TestBridgeICC/IPv4_internal_network (0.03s)
    --- FAIL: TestBridgeICC/IPv6_ULA_on_non-internal_network (0.10s)
    --- FAIL: TestBridgeICC/IPv6_ULA_on_internal_network (0.03s)
    --- FAIL: TestBridgeICC/IPv6_link-local_address_on_non-internal_network (0.11s)
    --- FAIL: TestBridgeICC/IPv6_link-local_address_on_internal_network (0.04s)
    --- FAIL: TestBridgeICC/IPv6_link-local_address_on_non-internal_network_ping_by_name (0.12s)
    --- FAIL: TestBridgeICC/IPv6_nonstandard_link-local_subnet_on_non-internal_network_ping_by_name (0.10s)
    --- FAIL: TestBridgeICC/IPv6_non-internal_network_with_SLAAC_LL_address (0.11s)
    --- FAIL: TestBridgeICC/IPv6_internal_network_with_SLAAC_LL_address (0.11s)

--- FAIL: TestBridgeINC (6.67s)
    --- PASS: TestBridgeINC/IPv4_non-internal_network (5.77s)
    --- FAIL: TestBridgeINC/IPv4_internal_network (0.03s)
    --- FAIL: TestBridgeINC/IPv6_ULA_on_non-internal_network (0.14s)
    --- FAIL: TestBridgeINC/IPv6_ULA_on_internal_network (0.03s)
```