### PR TITLE
[28.x] testutil/fixtures/plugin: makePluginBundle: fix invalid spec

### DIFF
--- a/testutil/fixtures/plugin/plugin.go
+++ b/testutil/fixtures/plugin/plugin.go
@@ -142,7 +142,7 @@ func makePluginBundle(inPath string, opts ...CreateOpt) (io.ReadCloser, error) {
 	p := &types.PluginConfig{
 		Interface: types.PluginConfigInterface{
 			Socket: "basic.sock",
-			Types:  []types.PluginInterfaceType{{Capability: "docker.dummy/1.0"}},
+			Types:  []types.PluginInterfaceType{{Prefix: "docker", Capability: "dummy", Version: "1.0"}},
 		},
 		Entrypoint: []string{"/basic"},
 	}


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/50519
- https://github.com/docker/cli/pull/6333
- needed for https://github.com/moby/moby/pull/50475


The fixture was using an invalid formatted Capability, which wasn't detected in the old API code, but fails with the API module, for example:

    === RUN   TestPluginsWithRuntimes
        plugin_test.go:269: assertion failed: error is not nil: json: error calling MarshalText for type plugin.CapabilityID: capability "docker.dummy/1.0" cannot contain a dot
    --- FAIL: TestPluginsWithRuntimes (0.63s)
    === RUN   TestPluginBackCompatMediaTypes
        plugin_test.go:331: assertion failed: error is not nil: json: error calling MarshalText for type plugin.CapabilityID: capability "docker.dummy/1.0" cannot contain a dot
    --- FAIL: TestPluginBackCompatMediaTypes (0.11s)
    FAIL

This patch applies the same changes as ee560a3b23191e3e37838128a1cf3d7db29b489c in the master branch.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

