### PR TITLE
[28.x backport] daemon: Daemon.getInspectData: inline struct-literals

### DIFF
--- a/daemon/inspect_linux.go
+++ b/daemon/inspect_linux.go
@@ -7,13 +7,13 @@ import (
 )
 
 // This sets platform-specific fields
-func setPlatformSpecificContainerFields(container *containerpkg.Container, contJSONBase *container.ContainerJSONBase) *container.ContainerJSONBase {
-	contJSONBase.AppArmorProfile = container.AppArmorProfile
-	contJSONBase.ResolvConfPath = container.ResolvConfPath
-	contJSONBase.HostnamePath = container.HostnamePath
-	contJSONBase.HostsPath = container.HostsPath
+func setPlatformSpecificContainerFields(ctr *containerpkg.Container, resp *container.ContainerJSONBase) *container.ContainerJSONBase {
+	resp.AppArmorProfile = ctr.AppArmorProfile
+	resp.ResolvConfPath = ctr.ResolvConfPath
+	resp.HostnamePath = ctr.HostnamePath
+	resp.HostsPath = ctr.HostsPath
 
-	return contJSONBase
+	return resp
 }
 
 func inspectExecProcessConfig(e *containerpkg.ExecConfig) *backend.ExecProcessConfig {

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -7,8 +7,8 @@ import (
 )
 
 // This sets platform-specific fields
-func setPlatformSpecificContainerFields(container *containerpkg.Container, contJSONBase *container.ContainerJSONBase) *container.ContainerJSONBase {
-	return contJSONBase
+func setPlatformSpecificContainerFields(ctr *containerpkg.Container, resp *container.ContainerJSONBase) *container.ContainerJSONBase {
+	return resp
 }
 
 func inspectExecProcessConfig(e *containerpkg.ExecConfig) *backend.ExecProcessConfig {


### PR DESCRIPTION
- backports https://github.com/moby/moby/pull/50810 to help the transition to the API module

Also rename the "container" argument, which shadowed an import.


(cherry picked from commit 44972d7427c3f11bb0a8b6f04e2f6c46b582a9d8)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

