### PR TITLE
gha: set timeouts for buildkit tests

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -28,7 +28,7 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-24.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 60 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
@@ -56,7 +56,7 @@ jobs:
 
   test-linux:
     runs-on: ubuntu-24.04
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 60 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-linux
@@ -162,7 +162,7 @@ jobs:
 
   build-windows:
     runs-on: windows-2022
-    timeout-minutes: 120
+    timeout-minutes: 60 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - validate-dco
@@ -266,7 +266,7 @@ jobs:
 
   test-windows:
     runs-on: windows-2022
-    timeout-minutes: 120 # guardrails timeout for the whole job
+    timeout-minutes: 60 # guardrails timeout for the whole job
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     needs:
       - build-windows
@@ -276,7 +276,7 @@ jobs:
       GOPATH: ${{ github.workspace }}\go
       GOBIN: ${{ github.workspace }}\go\bin
       BIN_OUT: ${{ github.workspace }}\out
-      TESTFLAGS: "-v --timeout=90m"
+      TESTFLAGS: "-v --timeout=40m"
       TEST_DOCKERD: "1"
     strategy:
       fail-fast: false


### PR DESCRIPTION
The Windows tests sometimes hang until they reach the timeout, but a normal run seems to be ~20 minutes, so adding a 30 minute timeout as it's easier to start it again than having to wait for more than an Hour to see it failed.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

