### PR TITLE
[28.x backport] Unmap IPv4 addresses loaded from store

### DIFF
--- a/libnetwork/drivers/bridge/bridge_linux.go
+++ b/libnetwork/drivers/bridge/bridge_linux.go
@@ -1218,6 +1218,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 func (ep *bridgeEndpoint) netipAddrs() (v4, v6 netip.Addr) {
 	if ep.addr != nil {
 		v4, _ = netip.AddrFromSlice(ep.addr.IP)
+		v4 = v4.Unmap()
 	}
 	if ep.addrv6 != nil {
 		v6, _ = netip.AddrFromSlice(ep.addrv6.IP)


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/50827

**- What I did**

- related to https://github.com/moby/moby/issues/50692

IPv4-mapped IPv6 addresses are accepted by `iptables`, and do the right thing (so there's no obvious behavioural change). But, maybe this will help with the linked issue, or at-least rule out a potential difference from rules in 28.0.x.

**- How I did it**

When converting an endpoint's IPv4 `net.IPNet` to a `netip.Addr`, unmap it so that iptables rules don't contain IPv4-mapped IPv6 addresses - which they do otherwise, when the net.IPNet is loaded from the store.

**- How to verify it**

- Enable live-restore.
- `docker network create b4`
- `docker run -d --rm --network b4 --name c1 busybox top`
- Restart the daemon.

Without the change ...

```
DEBU[2025-08-27T16:21:36.545721342Z] Network (33c8cf6) restored
DEBU[2025-08-27T16:21:36.545868426Z] /usr/sbin/iptables, [--wait -t raw -C PREROUTING -d ::ffff:172.19.0.2 ! -i br-c4ed16cae1fd -j DROP]
DEBU[2025-08-27T16:21:36.546533634Z] Endpoint (8f9cd0f) restored to network (c4ed16c)
```

With the change ...

```
DEBU[2025-08-27T16:20:24.777808878Z] Network (170c742) restored
DEBU[2025-08-27T16:20:24.777946628Z] /usr/sbin/iptables, [--wait -t raw -C PREROUTING -d 172.19.0.2 ! -i br-c4ed16cae1fd -j DROP]
DEBU[2025-08-27T16:20:24.778534628Z] Endpoint (8f9cd0f) restored to network (c4ed16c)
```

**- Human readable description for the release notes**
```markdown changelog
- Fix an issue that could cause slow container restart on live-restore.
```
