### PR TITLE
d/network: filter networks individually

### DIFF
--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -17,6 +17,11 @@ import (
 
 // GetNetworks returns all current cluster managed networks.
 func (c *Cluster) GetNetworks(filter filters.Args) ([]network.Inspect, error) {
+	flt, err := networkSettings.NewFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+
 	var f *swarmapi.ListNetworksRequest_Filters
 
 	if filter.Len() > 0 {
@@ -32,49 +37,35 @@ func (c *Cluster) GetNetworks(filter filters.Args) ([]network.Inspect, error) {
 		}
 	}
 
-	list, err := c.getNetworks(f)
+	list, err := c.listNetworks(context.TODO(), f)
 	if err != nil {
 		return nil, err
 	}
-	filterPredefinedNetworks(&list)
-
-	return networkSettings.FilterNetworks(list, filter)
-}
-
-func filterPredefinedNetworks(networks *[]network.Inspect) {
-	if networks == nil {
-		return
-	}
-	var idxs []int
-	for i, nw := range *networks {
-		if v, ok := nw.Labels["com.docker.swarm.predefined"]; ok && v == "true" {
-			idxs = append(idxs, i)
+	var filtered []network.Inspect
+	for _, n := range list {
+		if n.Spec.Annotations.Labels["com.docker.swarm.predefined"] == "true" {
+			continue
+		}
+		nw := convert.BasicNetworkFromGRPC(*n)
+		if flt.Matches(nw) {
+			filtered = append(filtered, nw)
 		}
 	}
-	for i, idx := range idxs {
-		idx -= i
-		*networks = append((*networks)[:idx], (*networks)[idx+1:]...)
-	}
+
+	return filtered, nil
 }
 
-func (c *Cluster) getNetworks(filters *swarmapi.ListNetworksRequest_Filters) ([]network.Inspect, error) {
-	var r *swarmapi.ListNetworksResponse
-	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
-		var err error
-		r, err = state.controlClient.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: filters})
-		return err
+func (c *Cluster) listNetworks(ctx context.Context, filters *swarmapi.ListNetworksRequest_Filters) ([]*swarmapi.Network, error) {
+	var list []*swarmapi.Network
+	err := c.lockedManagerAction(ctx, func(ctx context.Context, state nodeState) error {
+		l, err := state.controlClient.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: filters})
+		if err != nil {
+			return err
+		}
+		list = l.Networks
+		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	networks := make([]network.Inspect, 0, len(r.Networks))
-
-	for _, nw := range r.Networks {
-		networks = append(networks, convert.BasicNetworkFromGRPC(*nw))
-	}
-
-	return networks, nil
+	return list, err
 }
 
 // GetNetwork returns a cluster network by an ID.
@@ -99,9 +90,17 @@ func (c *Cluster) GetNetwork(input string) (network.Inspect, error) {
 func (c *Cluster) GetNetworksByName(name string) ([]network.Inspect, error) {
 	// Note that swarmapi.GetNetworkRequest.Name is not functional.
 	// So we cannot just use that with c.GetNetwork.
-	return c.getNetworks(&swarmapi.ListNetworksRequest_Filters{
+	list, err := c.listNetworks(context.TODO(), &swarmapi.ListNetworksRequest_Filters{
 		Names: []string{name},
 	})
+	if err != nil {
+		return nil, err
+	}
+	nr := make([]network.Inspect, len(list))
+	for i, n := range list {
+		nr[i] = convert.BasicNetworkFromGRPC(*n)
+	}
+	return nr, nil
 }
 
 func attacherKey(target, containerID string) string {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -592,33 +592,23 @@ func (daemon *Daemon) deleteNetwork(nw *libnetwork.Network, dynamic bool) error 
 
 // GetNetworks returns a list of all networks
 func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkListConfig) ([]networktypes.Inspect, error) {
-	var idx map[string]*libnetwork.Network
-	if config.Detailed {
-		idx = make(map[string]*libnetwork.Network)
+	flt, err := network.NewFilter(filter)
+	if err != nil {
+		return nil, err
 	}
 
 	allNetworks := daemon.getAllNetworks()
 	networks := make([]networktypes.Inspect, 0, len(allNetworks))
 	for _, n := range allNetworks {
 		nr := buildNetworkResource(n)
-		networks = append(networks, nr)
-		if config.Detailed {
-			idx[nr.ID] = n
-		}
-	}
-
-	var err error
-	networks, err = network.FilterNetworks(networks, filter)
-	if err != nil {
-		return nil, err
-	}
-
-	if config.Detailed {
-		for i, nw := range networks {
-			networks[i].Containers = buildContainerAttachments(idx[nw.ID])
-			if config.Verbose {
-				networks[i].Services = buildServiceAttachments(idx[nw.ID])
+		if flt.Matches(nr) {
+			if config.Detailed {
+				nr.Containers = buildContainerAttachments(n)
+				if config.Verbose {
+					nr.Services = buildServiceAttachments(n)
+				}
 			}
+			networks = append(networks, nr)
 		}
 	}
 

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -7,123 +7,109 @@ import (
 	"github.com/pkg/errors"
 )
 
-// FilterNetworks filters network list according to user specified filter
-// and returns user chosen networks
-func FilterNetworks(nws []network.Inspect, filter filters.Args) ([]network.Inspect, error) {
-	// if filter is empty, return original network list
-	if filter.Len() == 0 {
-		return nws, nil
-	}
+type Filter struct {
+	args filters.Args
 
-	displayNet := nws[:0]
-	for _, nw := range nws {
-		if filter.Contains("driver") {
-			if !filter.ExactMatch("driver", nw.Driver) {
-				continue
-			}
-		}
-		if filter.Contains("name") {
-			if !filter.Match("name", nw.Name) {
-				continue
-			}
-		}
-		if filter.Contains("id") {
-			if !filter.Match("id", nw.ID) {
-				continue
-			}
-		}
-		if filter.Contains("label") {
-			if !filter.MatchKVList("label", nw.Labels) {
-				continue
-			}
-		}
-		if filter.Contains("scope") {
-			if !filter.ExactMatch("scope", nw.Scope) {
-				continue
-			}
-		}
+	filterByUse, danglingOnly bool
+}
 
-		if filter.Contains("idOrName") {
-			if !filter.Match("name", nw.Name) && !filter.Match("id", nw.Name) {
-				continue
-			}
-		}
-		displayNet = append(displayNet, nw)
-	}
-
-	if values := filter.Get("dangling"); len(values) > 0 {
+// NewFilter returns a network filter that filters by the provided args.
+//
+// An [errdefs.InvalidParameter] error is returned if the filter args are not
+// well-formed.
+func NewFilter(args filters.Args) (Filter, error) {
+	var filterByUse, danglingOnly bool
+	if values := args.Get("dangling"); len(values) > 0 {
 		if len(values) > 1 {
-			return nil, errdefs.InvalidParameter(errors.New(`got more than one value for filter key "dangling"`))
+			return Filter{}, errdefs.InvalidParameter(errors.New(`got more than one value for filter key "dangling"`))
 		}
 
-		var danglingOnly bool
+		filterByUse = true
 		switch values[0] {
 		case "0", "false":
 			// dangling is false already
 		case "1", "true":
 			danglingOnly = true
 		default:
-			return nil, errdefs.InvalidParameter(errors.New(`invalid value for filter 'dangling', must be "true" (or "1"), or "false" (or "0")`))
+			return Filter{}, errdefs.InvalidParameter(errors.New(`invalid value for filter 'dangling', must be "true" (or "1"), or "false" (or "0")`))
 		}
-
-		displayNet = filterNetworkByUse(displayNet, danglingOnly)
 	}
-
-	if filter.Contains("type") {
-		typeNet := []network.Inspect{}
-		errFilter := filter.WalkValues("type", func(fval string) error {
-			passList, err := filterNetworkByType(displayNet, fval)
-			if err != nil {
-				return err
-			}
-			typeNet = append(typeNet, passList...)
-			return nil
-		})
-		if errFilter != nil {
-			return nil, errFilter
-		}
-		displayNet = typeNet
+	if err := args.WalkValues("type", validateNetworkTypeFilter); err != nil {
+		return Filter{}, err
 	}
-
-	return displayNet, nil
+	return Filter{args: args, filterByUse: filterByUse, danglingOnly: danglingOnly}, nil
 }
 
-func filterNetworkByUse(nws []network.Inspect, danglingOnly bool) []network.Inspect {
-	retNws := []network.Inspect{}
-
-	filterFunc := func(nw network.Inspect) bool {
-		if danglingOnly {
-			return !IsPredefined(nw.Name) && len(nw.Containers) == 0 && len(nw.Services) == 0
-		}
-		return IsPredefined(nw.Name) || len(nw.Containers) > 0 || len(nw.Services) > 0
+// Matches returns true if nw satisfies the filter criteria.
+func (f Filter) Matches(nw network.Summary) bool {
+	if f.args.Len() == 0 {
+		return true
 	}
 
-	for _, nw := range nws {
-		if filterFunc(nw) {
-			retNws = append(retNws, nw)
-		}
+	if f.args.Contains("driver") &&
+		!f.args.ExactMatch("driver", nw.Driver) {
+		return false
 	}
-
-	return retNws
+	if f.args.Contains("name") &&
+		!f.args.Match("name", nw.Name) {
+		return false
+	}
+	if f.args.Contains("id") &&
+		!f.args.Match("id", nw.ID) {
+		return false
+	}
+	if f.args.Contains("label") &&
+		!f.args.MatchKVList("label", nw.Labels) {
+		return false
+	}
+	if f.args.Contains("scope") &&
+		!f.args.ExactMatch("scope", nw.Scope) {
+		return false
+	}
+	if f.args.Contains("idOrName") &&
+		!f.args.Match("name", nw.Name) &&
+		!f.args.Match("id", nw.Name) {
+		return false
+	}
+	if f.filterByUse &&
+		!matchesUse(f.danglingOnly, nw) {
+		return false
+	}
+	if netTypes := f.args.Get("type"); len(netTypes) > 0 &&
+		!matchesType(netTypes, nw) {
+		return false
+	}
+	return true
 }
 
-func filterNetworkByType(nws []network.Inspect, netType string) ([]network.Inspect, error) {
-	retNws := []network.Inspect{}
+func matchesUse(danglingOnly bool, nw network.Summary) bool {
+	if danglingOnly {
+		return !IsPredefined(nw.Name) && len(nw.Containers) == 0 && len(nw.Services) == 0
+	}
+	return IsPredefined(nw.Name) || len(nw.Containers) > 0 || len(nw.Services) > 0
+}
+
+func validateNetworkTypeFilter(netType string) error {
 	switch netType {
-	case "builtin":
-		for _, nw := range nws {
-			if IsPredefined(nw.Name) {
-				retNws = append(retNws, nw)
-			}
-		}
-	case "custom":
-		for _, nw := range nws {
-			if !IsPredefined(nw.Name) {
-				retNws = append(retNws, nw)
-			}
-		}
+	case "builtin", "custom":
+		return nil
 	default:
-		return nil, errors.Errorf("invalid filter: 'type'='%s'", netType)
+		return errors.Errorf("invalid filter: 'type'='%s'", netType)
 	}
-	return retNws, nil
+}
+
+func matchesType(netTypes []string, nw network.Summary) bool {
+	var matched bool
+	for _, netType := range netTypes {
+		switch netType {
+		case "builtin":
+			matched = IsPredefined(nw.Name)
+		case "custom":
+			matched = !IsPredefined(nw.Name)
+		}
+		if matched {
+			break
+		}
+	}
+	return matched
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I improved the code to filter a list of networks by a predicate specified in an Engine API request. It is simpler, more readable, more future-proof and more efficient.

**- How I did it**
Internally a network is represented by either a `libnetwork.Network` or a `swarmapi.Network`. The daemon functions backing the API server map these values to the Engine API `network.Inspect` type on demand. Since they have to convert, the functions to get a list of networks have to loop over the slice of `Networks` and append them to a slice of `network.Inspect` values.

The function used to filter the list of networks by a user-supplied predicate takes a `[]network.Inspect` and returns a shorter slice. Therefore the daemon functions backing the API server have to loop through the list twice; once to convert, and again inside the FilterNetworks function to prune networks from the slice. Each time an item is deleted from a slice, all items at higher indices need to be copied to lower indices in the backing array.

Replace `FilterNetworks` with a function that accepts a single network summary and returns a boolean. The daemon network-list functions can filter in the conversion loop, which cuts down on a nontrivial amount of copying. Split the validation of the filter predicate from filter evaluation to both make it more ergonomic to use inside loops, and to make invalid states (a filter with an ill-formed predicate) unrepresentable.

This change also future-proofs the network filter for when `network.Inspect` becomes a distinct type that embeds a `network.Summary`. Callers that need to build a filtered list of `network.Inspect` values will be able to evaluate the filter on the embedded `Summary` then append the full `Inspect` value of matching networks to the output slice, all without any further changes to the filter code.

**- How to verify it**
Existing unit/integration tests.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

