### PR TITLE
api/types/events: Message: remove deprecated Status, ID, and From fields

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   saved.
 * `POST /images/load` now accepts multiple `platform` query-arguments
   to allow selecting which platform(s) of a multi-platform image to load.
+* `GET /events` no longer includes the deprecated `status`, `id`, and `from`
+  fields. These fields were removed in API v1.22, but still included
+  in the response.
 * Deprecated: the Engine was automatically backfilling empty `PortBindings` lists with
   a PortBinding with an empty HostIP and HostPort when calling `POST /containers/{id}/start`.
   This behavior is now deprecated, and a warning is returned by `POST /containers/create`.

--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -110,15 +110,6 @@ type Actor struct {
 
 // Message represents the information an event contains
 type Message struct {
-	// Deprecated: use Action instead.
-	// Information from JSONMessage.
-	// With data only in container events.
-	Status string `json:"status,omitempty"`
-	// Deprecated: use Actor.ID instead.
-	ID string `json:"id,omitempty"`
-	// Deprecated: use Actor.Attributes["image"] instead.
-	From string `json:"from,omitempty"`
-
 	Type   Type
 	Action Action
 	Actor  Actor

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -82,29 +82,14 @@ func (e *Events) Evict(l chan any) {
 // Log creates a local scope message and publishes it
 func (e *Events) Log(action eventtypes.Action, eventType eventtypes.Type, actor eventtypes.Actor) {
 	now := time.Now().UTC()
-	jm := eventtypes.Message{
+	e.PublishMessage(eventtypes.Message{
 		Action:   action,
 		Type:     eventType,
 		Actor:    actor,
 		Scope:    "local",
 		Time:     now.Unix(),
 		TimeNano: now.UnixNano(),
-	}
-
-	// fill deprecated fields for container and images
-	switch eventType {
-	case eventtypes.ContainerEventType:
-		jm.ID = actor.ID                    //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-		jm.Status = string(action)          //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-		jm.From = actor.Attributes["image"] //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-	case eventtypes.ImageEventType:
-		jm.ID = actor.ID           //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-		jm.Status = string(action) //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-	default:
-		// TODO(thaJeztah): make switch exhaustive
-	}
-
-	e.PublishMessage(jm)
+	})
 }
 
 // PublishMessage broadcasts event to listeners. Each listener has 100 milliseconds to

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -12,19 +12,6 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-// validateLegacyFields validates that the legacy "Status", "ID", and "From"
-// fields are set to the same value as their "current" (non-legacy) fields.
-//
-// These fields were deprecated since v1.10 (https://github.com/moby/moby/pull/18888).
-//
-// TODO remove this once we removed the deprecated `ID`, `Status`, and `From` fields.
-func validateLegacyFields(t *testing.T, msg events.Message) {
-	t.Helper()
-	assert.Check(t, is.Equal(msg.Status, string(msg.Action)), "Legacy Status field does not match Action")                        //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-	assert.Check(t, is.Equal(msg.ID, msg.Actor.ID), "Legacy ID field does not match Actor.ID")                                    //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-	assert.Check(t, is.Equal(msg.From, msg.Actor.Attributes["image"]), "Legacy From field does not match Actor.Attributes.image") //nolint:staticcheck // ignore SA1019: field is deprecated but set for backward compatibility.
-}
-
 func TestEventsLog(t *testing.T) {
 	e := New()
 	_, l1, _ := e.Subscribe()
@@ -44,7 +31,6 @@ func TestEventsLog(t *testing.T) {
 
 		jmsg, ok := msg.(events.Message)
 		assert.Assert(t, ok, "unexpected type: %T", msg)
-		validateLegacyFields(t, jmsg)
 		assert.Check(t, is.Equal(jmsg.Action, events.Action("test")))
 		assert.Check(t, is.Equal(jmsg.Actor.ID, "cont"))
 		assert.Check(t, is.Equal(jmsg.Actor.Attributes["image"], "image"))
@@ -57,7 +43,6 @@ func TestEventsLog(t *testing.T) {
 
 		jmsg, ok := msg.(events.Message)
 		assert.Assert(t, ok, "unexpected type: %T", msg)
-		validateLegacyFields(t, jmsg)
 		assert.Check(t, is.Equal(jmsg.Action, events.Action("test")))
 		assert.Check(t, is.Equal(jmsg.Actor.ID, "cont"))
 		assert.Check(t, is.Equal(jmsg.Actor.Attributes["image"], "image"))
@@ -120,7 +105,6 @@ func TestLogEvents(t *testing.T) {
 	assert.Assert(t, is.Len(current, eventsLimit))
 
 	first := current[0]
-	validateLegacyFields(t, first)
 	assert.Check(t, is.Equal(first.Action, events.Action("action_16")))
 
 	last := current[len(current)-1]

--- a/vendor/github.com/moby/moby/api/types/events/events.go
+++ b/vendor/github.com/moby/moby/api/types/events/events.go
@@ -110,15 +110,6 @@ type Actor struct {
 
 // Message represents the information an event contains
 type Message struct {
-	// Deprecated: use Action instead.
-	// Information from JSONMessage.
-	// With data only in container events.
-	Status string `json:"status,omitempty"`
-	// Deprecated: use Actor.ID instead.
-	ID string `json:"id,omitempty"`
-	// Deprecated: use Actor.Attributes["image"] instead.
-	From string `json:"from,omitempty"`
-
 	Type   Type
 	Action Action
 	Actor  Actor


### PR DESCRIPTION
depends on / stacked on:

- [x] https://github.com/moby/moby/pull/50949
- [x] https://github.com/moby/moby/pull/50852


relates to:

- https://github.com/moby/moby/pull/18888
- https://github.com/moby/moby/pull/42770
- https://github.com/moby/moby/pull/46336

### api/docs: fix events example response

Don't include the deprecated `id`, `status`, and `from` fields
in the response; they're no longer part of the API since v1.22
([moby@72f188]).

[moby@72f188]: https://github.com/moby/moby/commit/72f1881df102fce9ad31e98045b91c204dd44513

### daemon/events: remove tests for deprecated API fields

These fields were deprecated in [moby@72f188] (docker v1.10, API v1.22),
and we shouldn't test for them.

[moby@72f188]: https://github.com/moby/moby/commit/72f1881df102fce9ad31e98045b91c204dd44513


### daemon/events: don't include deprecated `status`, `id`, and `from` fields

These fields were deprecated in [moby@72f188] (docker v1.10, API v1.22),
but the daemon still included them in the response.

[moby@72f188]: https://github.com/moby/moby/commit/72f1881df102fce9ad31e98045b91c204dd44513


### api/types/events: Message: remove deprecated Status, ID, and From fields

These fields were deprecated in [moby@72f188] (docker v1.10, API v1.22),
with the deprecation message updated to be in the correct format in
[moby@247f47] (docker v23.0).

[moby@72f188]: https://github.com/moby/moby/commit/72f1881df102fce9ad31e98045b91c204dd44513
[moby@247f47]: https://github.com/moby/moby/commit/247f4796d21d98909974410ff27b61233776ae3a




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`GET /events` no longer includes the deprecated `status`, `id`, and `from` fields. These fields were removed in API v1.22, but still included in the response. These fields are now omitted when using API v1.52 or later.
```

**- A picture of a cute animal (not mandatory but encouraged)**

