### PR TITLE
daemon/cluster: improve use of lockedManagerAction

### DIFF
--- a/daemon/cluster/cluster.go
+++ b/daemon/cluster/cluster.go
@@ -432,7 +432,7 @@ func detectLockedError(err error) error {
 	return err
 }
 
-func (c *Cluster) lockedManagerAction(fn func(ctx context.Context, state nodeState) error) error {
+func (c *Cluster) lockedManagerAction(ctx context.Context, fn func(ctx context.Context, state nodeState) error) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -441,7 +441,6 @@ func (c *Cluster) lockedManagerAction(fn func(ctx context.Context, state nodeSta
 		return c.errNoManager(state)
 	}
 
-	ctx := context.TODO()
 	ctx, cancel := context.WithTimeout(ctx, swarmRequestTimeout)
 	defer cancel()
 

--- a/daemon/cluster/configs.go
+++ b/daemon/cluster/configs.go
@@ -14,7 +14,7 @@ import (
 func (c *Cluster) GetConfig(input string) (types.Config, error) {
 	var config *swarmapi.Config
 
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		s, err := getConfig(ctx, state.controlClient, input)
 		if err != nil {
 			return err
@@ -65,7 +65,7 @@ func (c *Cluster) GetConfigs(options swarmbackend.ConfigListOptions) ([]types.Co
 // CreateConfig creates a new config in a managed swarm cluster.
 func (c *Cluster) CreateConfig(s types.ConfigSpec) (string, error) {
 	var resp *swarmapi.CreateConfigResponse
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		configSpec := convert.ConfigSpecToGRPC(s)
 
 		r, err := state.controlClient.CreateConfig(ctx,
@@ -83,7 +83,7 @@ func (c *Cluster) CreateConfig(s types.ConfigSpec) (string, error) {
 
 // RemoveConfig removes a config from a managed swarm cluster.
 func (c *Cluster) RemoveConfig(input string) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		config, err := getConfig(ctx, state.controlClient, input)
 		if err != nil {
 			return err
@@ -101,7 +101,7 @@ func (c *Cluster) RemoveConfig(input string) error {
 // UpdateConfig updates a config in a managed swarm cluster.
 // Note: this is not exposed to the CLI but is available from the API only
 func (c *Cluster) UpdateConfig(input string, version uint64, spec types.ConfigSpec) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		config, err := getConfig(ctx, state.controlClient, input)
 		if err != nil {
 			return err

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -88,7 +88,7 @@ func (c *Cluster) getNetworks(filters *swarmapi.ListNetworksRequest_Filters) ([]
 func (c *Cluster) GetNetwork(input string) (network.Inspect, error) {
 	var nw *swarmapi.Network
 
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		n, err := getNetwork(ctx, state.controlClient, input)
 		if err != nil {
 			return err
@@ -274,7 +274,7 @@ func (c *Cluster) CreateNetwork(s network.CreateRequest) (string, error) {
 	}
 
 	var resp *swarmapi.CreateNetworkResponse
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		networkSpec := convert.BasicNetworkCreateToGRPC(s)
 		r, err := state.controlClient.CreateNetwork(ctx, &swarmapi.CreateNetworkRequest{Spec: &networkSpec})
 		if err != nil {
@@ -291,7 +291,7 @@ func (c *Cluster) CreateNetwork(s network.CreateRequest) (string, error) {
 
 // RemoveNetwork removes a cluster network.
 func (c *Cluster) RemoveNetwork(input string) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		nw, err := getNetwork(ctx, state.controlClient, input)
 		if err != nil {
 			return err

--- a/daemon/cluster/nodes.go
+++ b/daemon/cluster/nodes.go
@@ -51,7 +51,7 @@ func (c *Cluster) GetNodes(options swarmbackend.NodeListOptions) ([]types.Node, 
 func (c *Cluster) GetNode(input string) (types.Node, error) {
 	var node *swarmapi.Node
 
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		n, err := getNode(ctx, state.controlClient, input)
 		if err != nil {
 			return err
@@ -67,7 +67,7 @@ func (c *Cluster) GetNode(input string) (types.Node, error) {
 
 // UpdateNode updates existing nodes properties.
 func (c *Cluster) UpdateNode(input string, version uint64, spec types.NodeSpec) error {
-	return c.lockedManagerAction(func(_ context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(_ context.Context, state nodeState) error {
 		nodeSpec, err := convert.NodeSpecToGRPC(spec)
 		if err != nil {
 			return errdefs.InvalidParameter(err)
@@ -98,7 +98,7 @@ func (c *Cluster) UpdateNode(input string, version uint64, spec types.NodeSpec) 
 
 // RemoveNode removes a node from a cluster
 func (c *Cluster) RemoveNode(input string, force bool) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		node, err := getNode(ctx, state.controlClient, input)
 		if err != nil {
 			return err

--- a/daemon/cluster/secrets.go
+++ b/daemon/cluster/secrets.go
@@ -14,7 +14,7 @@ import (
 func (c *Cluster) GetSecret(input string) (types.Secret, error) {
 	var secret *swarmapi.Secret
 
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		s, err := getSecret(ctx, state.controlClient, input)
 		if err != nil {
 			return err
@@ -66,7 +66,7 @@ func (c *Cluster) GetSecrets(options swarmbackend.SecretListOptions) ([]types.Se
 // CreateSecret creates a new secret in a managed swarm cluster.
 func (c *Cluster) CreateSecret(s types.SecretSpec) (string, error) {
 	var resp *swarmapi.CreateSecretResponse
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		secretSpec := convert.SecretSpecToGRPC(s)
 
 		r, err := state.controlClient.CreateSecret(ctx,
@@ -84,7 +84,7 @@ func (c *Cluster) CreateSecret(s types.SecretSpec) (string, error) {
 
 // RemoveSecret removes a secret from a managed swarm cluster.
 func (c *Cluster) RemoveSecret(input string) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		secret, err := getSecret(ctx, state.controlClient, input)
 		if err != nil {
 			return err
@@ -102,7 +102,7 @@ func (c *Cluster) RemoveSecret(input string) error {
 // UpdateSecret updates a secret in a managed swarm cluster.
 // Note: this is not exposed to the CLI but is available from the API only
 func (c *Cluster) UpdateSecret(input string, version uint64, spec types.SecretSpec) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		secret, err := getSecret(ctx, state.controlClient, input)
 		if err != nil {
 			return err

--- a/daemon/cluster/services.go
+++ b/daemon/cluster/services.go
@@ -162,7 +162,7 @@ func (c *Cluster) GetServices(options swarmbackend.ServiceListOptions) ([]swarm.
 // GetService returns a service based on an ID or name.
 func (c *Cluster) GetService(input string, insertDefaults bool) (swarm.Service, error) {
 	var service *swarmapi.Service
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		s, err := getService(ctx, state.controlClient, input, insertDefaults)
 		if err != nil {
 			return err
@@ -182,7 +182,7 @@ func (c *Cluster) GetService(input string, insertDefaults bool) (swarm.Service, 
 // CreateService creates a new service in a managed swarm cluster.
 func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRegistry bool) (*swarm.ServiceCreateResponse, error) {
 	var resp *swarm.ServiceCreateResponse
-	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		err := c.populateNetworkID(ctx, state.controlClient, &s)
 		if err != nil {
 			return err
@@ -284,7 +284,7 @@ func (c *Cluster) CreateService(s swarm.ServiceSpec, encodedAuth string, queryRe
 func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swarm.ServiceSpec, flags swarmbackend.ServiceUpdateOptions, queryRegistry bool) (*swarm.ServiceUpdateResponse, error) {
 	var resp *swarm.ServiceUpdateResponse
 
-	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		err := c.populateNetworkID(ctx, state.controlClient, &spec)
 		if err != nil {
 			return err
@@ -414,7 +414,7 @@ func (c *Cluster) UpdateService(serviceIDOrName string, version uint64, spec swa
 
 // RemoveService removes a service from a managed swarm cluster.
 func (c *Cluster) RemoveService(input string) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		service, err := getService(ctx, state.controlClient, input, false)
 		if err != nil {
 			return err

--- a/daemon/cluster/swarm.go
+++ b/daemon/cluster/swarm.go
@@ -219,7 +219,7 @@ func (c *Cluster) Join(req types.JoinRequest) error {
 // Inspect retrieves the configuration properties of a managed swarm cluster.
 func (c *Cluster) Inspect() (types.Swarm, error) {
 	var swarm types.Swarm
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		s, err := c.inspect(ctx, state)
 		if err != nil {
 			return err
@@ -242,7 +242,7 @@ func (c *Cluster) inspect(ctx context.Context, state nodeState) (types.Swarm, er
 
 // Update updates configuration of a managed swarm cluster.
 func (c *Cluster) Update(version uint64, spec types.Spec, flags swarmbackend.UpdateFlags) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		swarm, err := getSwarm(ctx, state.controlClient)
 		if err != nil {
 			return err
@@ -285,7 +285,7 @@ func (c *Cluster) Update(version uint64, spec types.Spec, flags swarmbackend.Upd
 // GetUnlockKey returns the unlock key for the swarm.
 func (c *Cluster) GetUnlockKey() (string, error) {
 	var resp *swarmapi.GetUnlockKeyResponse
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		client := swarmapi.NewCAClient(state.grpcConn)
 
 		r, err := client.GetUnlockKey(ctx, &swarmapi.GetUnlockKeyRequest{})

--- a/daemon/cluster/tasks.go
+++ b/daemon/cluster/tasks.go
@@ -15,7 +15,7 @@ import (
 func (c *Cluster) GetTasks(options swarmbackend.TaskListOptions) ([]types.Task, error) {
 	var r *swarmapi.ListTasksResponse
 
-	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		filterTransform := func(filter filters.Args) error {
 			if filter.Contains("service") {
 				serviceFilters := filter.Get("service")
@@ -77,7 +77,7 @@ func (c *Cluster) GetTasks(options swarmbackend.TaskListOptions) ([]types.Task, 
 // GetTask returns a task by an ID.
 func (c *Cluster) GetTask(input string) (types.Task, error) {
 	var task *swarmapi.Task
-	err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		t, err := getTask(ctx, state.controlClient, input)
 		if err != nil {
 			return err

--- a/daemon/cluster/volumes.go
+++ b/daemon/cluster/volumes.go
@@ -17,7 +17,7 @@ import (
 func (c *Cluster) GetVolume(nameOrID string) (volumetypes.Volume, error) {
 	var volume *swarmapi.Volume
 
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		v, err := getVolume(ctx, state.controlClient, nameOrID)
 		if err != nil {
 			return err
@@ -33,7 +33,7 @@ func (c *Cluster) GetVolume(nameOrID string) (volumetypes.Volume, error) {
 // GetVolumes returns all of the volumes matching the given options from a swarm cluster.
 func (c *Cluster) GetVolumes(options volumebackend.ListOptions) ([]*volumetypes.Volume, error) {
 	var volumes []*volumetypes.Volume
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		r, err := state.controlClient.ListVolumes(
 			ctx, &swarmapi.ListVolumesRequest{},
 			grpc.MaxCallRecvMsgSize(defaultRecvSizeForListResponse),
@@ -61,7 +61,7 @@ func (c *Cluster) GetVolumes(options volumebackend.ListOptions) ([]*volumetypes.
 // Returns the volume ID if creation is successful, or an error if not.
 func (c *Cluster) CreateVolume(v volumetypes.CreateOptions) (*volumetypes.Volume, error) {
 	var resp *swarmapi.CreateVolumeResponse
-	if err := c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	if err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		volumeSpec := convert.VolumeCreateToGRPC(&v)
 
 		r, err := state.controlClient.CreateVolume(
@@ -89,7 +89,7 @@ func (c *Cluster) CreateVolume(v volumetypes.CreateOptions) (*volumetypes.Volume
 
 // RemoveVolume removes a volume from the swarm cluster.
 func (c *Cluster) RemoveVolume(nameOrID string, force bool) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		volume, err := getVolume(ctx, state.controlClient, nameOrID)
 		if err != nil {
 			if force && cerrdefs.IsNotFound(err) {
@@ -108,7 +108,7 @@ func (c *Cluster) RemoveVolume(nameOrID string, force bool) error {
 
 // UpdateVolume updates a volume in the swarm cluster.
 func (c *Cluster) UpdateVolume(nameOrID string, version uint64, volume volumetypes.UpdateOptions) error {
-	return c.lockedManagerAction(func(ctx context.Context, state nodeState) error {
+	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		v, err := getVolume(ctx, state.controlClient, nameOrID)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added a context parameter to `(*Cluster).lockedManagerAction` as an intermediate step towards plumbing contexts from Engine API handlers into Swarm API requests.
- Refactored some functions which open-coded `lockedManagerAction` to use `lockedManagerAction` and to do as much as possible outside the critical section.

**- How I did it**
- `eg` and manual editing

**- How to verify it**
Integration tests

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

