### PR TITLE
daemon: refactor network-list filtering code; unify list and prune filter terms

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -11109,10 +11109,11 @@ paths:
                containers are returned.
             - `driver=<driver-name>` Matches a network's driver.
             - `id=<network-id>` Matches all or part of a network ID.
-            - `label=<key>` or `label=<key>=<value>` of a network label.
+            - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Matches networks with (or without, in case `label!=...` is used) the specified labels.
             - `name=<network-name>` Matches all or part of a network name.
             - `scope=["swarm"|"global"|"local"]` Filters networks by scope (`swarm`, `global`, or `local`).
             - `type=["custom"|"builtin"]` Filters networks by type. The `custom` keyword returns all user-defined networks.
+            - `until=<timestamp>` Matches networks created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
           type: "string"
       tags: ["Network"]
 
@@ -11408,6 +11409,15 @@ paths:
             Available filters:
             - `until=<timestamp>` Prune networks created before this timestamp. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon machine’s time.
             - `label` (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) Prune networks with (or without, in case `label!=...` is used) the specified labels.
+            - `driver=<driver-name>` Prune networks based on their driver.
+            - `name=<network-name>` Prune networks by all or part of a network name.
+            - `scope=["swarm"|"global"|"local"]` Prune networks by scope (`swarm`, `global`, or `local`).
+
+            All the filters supported by the `GET /networks` endpoint are also supported here for consistency.
+            The filters not listed above are not very useful for pruning.
+            - `type=["custom"|"builtin"]` Built-in networks cannot be removed.
+            - `id=<network-id>` Equivalent to `DELETE /networks/{id}`.
+            - `dangling=<boolean>` Networks in use by a container cannot be removed.
           type: "string"
       responses:
         200:

--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"time"
-
-	"github.com/moby/moby/api/types/filters"
 )
 
 const (
@@ -114,21 +112,6 @@ type NetworkingConfig struct {
 // ConfigReference specifies the source which provides a network's configuration
 type ConfigReference struct {
 	Network string
-}
-
-var acceptedFilters = map[string]bool{
-	"dangling": true,
-	"driver":   true,
-	"id":       true,
-	"label":    true,
-	"name":     true,
-	"scope":    true,
-	"type":     true,
-}
-
-// ValidateFilters validates the list of filter args with the available filters.
-func ValidateFilters(filter filters.Args) error {
-	return filter.Validate(acceptedFilters)
 }
 
 // PruneReport contains the response for Engine API:

--- a/daemon/cluster.go
+++ b/daemon/cluster.go
@@ -1,9 +1,9 @@
 package daemon
 
 import (
-	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/network"
 	lncluster "github.com/moby/moby/v2/daemon/libnetwork/cluster"
+	dnetwork "github.com/moby/moby/v2/daemon/network"
 )
 
 // Cluster is the interface for [github.com/moby/moby/v2/daemon/cluster.Cluster].
@@ -22,6 +22,6 @@ type ClusterStatus interface {
 // NetworkManager provides methods to manage networks
 type NetworkManager interface {
 	GetNetwork(input string) (network.Inspect, error)
-	GetNetworks(filters.Args) ([]network.Inspect, error)
+	GetNetworks(dnetwork.Filter) ([]network.Inspect, error)
 	RemoveNetwork(input string) error
 }

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"strings"
+	"time"
 
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/moby/moby/api/types/network"
@@ -268,6 +269,11 @@ func (nw FilterNetwork) Labels() map[string]string {
 
 func (nw FilterNetwork) Scope() string {
 	return scope.Swarm
+}
+
+func (nw FilterNetwork) Created() time.Time {
+	t, _ := gogotypes.TimestampFromProto(nw.N.Meta.CreatedAt)
+	return t
 }
 
 func (nw FilterNetwork) ContainerAttachments() int {

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -240,3 +240,42 @@ func IsIngressNetwork(n *swarmapi.Network) bool {
 	_, ok := n.Spec.Annotations.Labels["com.docker.swarm.internal"]
 	return ok && n.Spec.Annotations.Name == "ingress"
 }
+
+// FilterNetwork adapts [swarmapi.Network] to the
+// [github.com/moby/moby/v2/daemon/network.FilterNetwork] interface.
+type FilterNetwork struct {
+	N *swarmapi.Network
+}
+
+func (nw FilterNetwork) ID() string {
+	return nw.N.ID
+}
+
+func (nw FilterNetwork) Name() string {
+	return nw.N.Spec.Annotations.Name
+}
+
+func (nw FilterNetwork) Driver() string {
+	if nw.N.DriverState != nil {
+		return nw.N.DriverState.Name
+	}
+	return ""
+}
+
+func (nw FilterNetwork) Labels() map[string]string {
+	return nw.N.Spec.Annotations.Labels
+}
+
+func (nw FilterNetwork) Scope() string {
+	return scope.Swarm
+}
+
+func (nw FilterNetwork) ContainerAttachments() int {
+	// Not tracked in swarmkit
+	return 0
+}
+
+func (nw FilterNetwork) ServiceAttachments() int {
+	// Not tracked in swarmkit
+	return 0
+}

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -17,6 +17,11 @@ import (
 
 // GetNetworks returns all current cluster managed networks.
 func (c *Cluster) GetNetworks(filter filters.Args) ([]network.Inspect, error) {
+	flt, err := networkSettings.NewFilter(filter)
+	if err != nil {
+		return nil, err
+	}
+
 	var f *swarmapi.ListNetworksRequest_Filters
 
 	if filter.Len() > 0 {
@@ -32,49 +37,35 @@ func (c *Cluster) GetNetworks(filter filters.Args) ([]network.Inspect, error) {
 		}
 	}
 
-	list, err := c.getNetworks(f)
+	list, err := c.listNetworks(context.TODO(), f)
 	if err != nil {
 		return nil, err
 	}
-	filterPredefinedNetworks(&list)
-
-	return networkSettings.FilterNetworks(list, filter)
-}
-
-func filterPredefinedNetworks(networks *[]network.Inspect) {
-	if networks == nil {
-		return
-	}
-	var idxs []int
-	for i, nw := range *networks {
-		if v, ok := nw.Labels["com.docker.swarm.predefined"]; ok && v == "true" {
-			idxs = append(idxs, i)
+	var filtered []network.Inspect
+	for _, n := range list {
+		if n.Spec.Annotations.Labels["com.docker.swarm.predefined"] == "true" {
+			continue
+		}
+		nw := convert.BasicNetworkFromGRPC(*n)
+		if flt.Matches(nw) {
+			filtered = append(filtered, nw)
 		}
 	}
-	for i, idx := range idxs {
-		idx -= i
-		*networks = append((*networks)[:idx], (*networks)[idx+1:]...)
-	}
+
+	return filtered, nil
 }
 
-func (c *Cluster) getNetworks(filters *swarmapi.ListNetworksRequest_Filters) ([]network.Inspect, error) {
-	var r *swarmapi.ListNetworksResponse
-	err := c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
-		var err error
-		r, err = state.controlClient.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: filters})
-		return err
+func (c *Cluster) listNetworks(ctx context.Context, filters *swarmapi.ListNetworksRequest_Filters) ([]*swarmapi.Network, error) {
+	var list []*swarmapi.Network
+	err := c.lockedManagerAction(ctx, func(ctx context.Context, state nodeState) error {
+		l, err := state.controlClient.ListNetworks(ctx, &swarmapi.ListNetworksRequest{Filters: filters})
+		if err != nil {
+			return err
+		}
+		list = l.Networks
+		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	networks := make([]network.Inspect, 0, len(r.Networks))
-
-	for _, nw := range r.Networks {
-		networks = append(networks, convert.BasicNetworkFromGRPC(*nw))
-	}
-
-	return networks, nil
+	return list, err
 }
 
 // GetNetwork returns a cluster network by an ID.
@@ -99,9 +90,17 @@ func (c *Cluster) GetNetwork(input string) (network.Inspect, error) {
 func (c *Cluster) GetNetworksByName(name string) ([]network.Inspect, error) {
 	// Note that swarmapi.GetNetworkRequest.Name is not functional.
 	// So we cannot just use that with c.GetNetwork.
-	return c.getNetworks(&swarmapi.ListNetworksRequest_Filters{
+	list, err := c.listNetworks(context.TODO(), &swarmapi.ListNetworksRequest_Filters{
 		Names: []string{name},
 	})
+	if err != nil {
+		return nil, err
+	}
+	nr := make([]network.Inspect, len(list))
+	for i, n := range list {
+		nr[i] = convert.BasicNetworkFromGRPC(*n)
+	}
+	return nr, nil
 }
 
 func attacherKey(target, containerID string) string {

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -16,17 +16,10 @@ import (
 
 // GetNetworks returns all current cluster managed networks.
 func (c *Cluster) GetNetworks(filter networkSettings.Filter) ([]network.Inspect, error) {
-	var f *swarmapi.ListNetworksRequest_Filters
-
-	if !filter.IsZero() {
-		f = &swarmapi.ListNetworksRequest_Filters{
-			Names:        filter.Get("name"),
-			NamePrefixes: filter.Get("name"),
-			IDPrefixes:   filter.Get("id"),
-		}
-	}
-
-	list, err := c.listNetworks(context.TODO(), f)
+	// Filtering on the Swarmkit side seems rather broken. It picks the
+	// first of Names, NamePrefixes, IDPrefixes to filter on and ignores the
+	// rest.
+	list, err := c.listNetworks(context.TODO(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -46,9 +46,8 @@ func (c *Cluster) GetNetworks(filter filters.Args) ([]network.Inspect, error) {
 		if n.Spec.Annotations.Labels["com.docker.swarm.predefined"] == "true" {
 			continue
 		}
-		nw := convert.BasicNetworkFromGRPC(*n)
-		if flt.Matches(nw) {
-			filtered = append(filtered, nw)
+		if flt.Matches(convert.FilterNetwork{N: n}) {
+			filtered = append(filtered, convert.BasicNetworkFromGRPC(*n))
 		}
 	}
 

--- a/daemon/libnetwork/agent.go
+++ b/daemon/libnetwork/agent.go
@@ -539,6 +539,11 @@ func (n *Network) Services() map[string]ServiceInfo {
 	return sinfo
 }
 
+// ServiceAttachments returns len(n.Services()).
+func (n *Network) ServiceAttachments() int {
+	return len(n.Services())
+}
+
 // clusterAgent returns the cluster agent if the network is a swarm-scoped,
 // multi-host network.
 func (n *Network) clusterAgent() (agent *nwAgent, ok bool) {

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -249,6 +249,11 @@ func (n *Network) Type() string {
 	return n.networkType
 }
 
+// Driver is an alias for [Network.Type].
+func (n *Network) Driver() string {
+	return n.Type()
+}
+
 func (n *Network) Resolvers() []*Resolver {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -1281,6 +1286,11 @@ func (n *Network) Endpoints() []*Endpoint {
 		log.G(context.TODO()).Error(err)
 	}
 	return endpoints
+}
+
+// ContainerAttachments returns len(n.Endpoints()).
+func (n *Network) ContainerAttachments() int {
+	return len(n.Endpoints())
 }
 
 // WalkEndpoints uses the provided function to walk the Endpoints.

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -601,8 +601,8 @@ func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkLis
 	allNetworks := daemon.getAllNetworks()
 	networks := make([]networktypes.Inspect, 0, len(allNetworks))
 	for _, n := range allNetworks {
-		nr := buildNetworkResource(n)
-		if flt.Matches(nr) {
+		if flt.Matches(n) {
+			nr := buildNetworkResource(n)
 			if config.Detailed {
 				nr.Containers = buildContainerAttachments(n)
 				if config.Verbose {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
-	"github.com/moby/moby/api/types/filters"
 	networktypes "github.com/moby/moby/api/types/network"
 	clustertypes "github.com/moby/moby/v2/daemon/cluster/provider"
 	"github.com/moby/moby/v2/daemon/config"
@@ -591,17 +590,11 @@ func (daemon *Daemon) deleteNetwork(nw *libnetwork.Network, dynamic bool) error 
 }
 
 // GetNetworks returns a list of all networks
-func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkListConfig) ([]networktypes.Inspect, error) {
-	flt, err := network.NewFilter(filter)
-	if err != nil {
-		return nil, err
-	}
-	flt.IDAlsoMatchesName = config.IDAlsoMatchesName
-
+func (daemon *Daemon) GetNetworks(filter network.Filter, config backend.NetworkListConfig) ([]networktypes.Inspect, error) {
 	allNetworks := daemon.getAllNetworks()
 	networks := make([]networktypes.Inspect, 0, len(allNetworks))
 	for _, n := range allNetworks {
-		if flt.Matches(n) {
+		if filter.Matches(n) {
 			nr := buildNetworkResource(n)
 			if config.Detailed {
 				nr.Containers = buildContainerAttachments(n)

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -596,6 +596,7 @@ func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkLis
 	if err != nil {
 		return nil, err
 	}
+	flt.IDAlsoMatchesName = config.IDAlsoMatchesName
 
 	allNetworks := daemon.getAllNetworks()
 	networks := make([]networktypes.Inspect, 0, len(allNetworks))

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -592,33 +592,23 @@ func (daemon *Daemon) deleteNetwork(nw *libnetwork.Network, dynamic bool) error 
 
 // GetNetworks returns a list of all networks
 func (daemon *Daemon) GetNetworks(filter filters.Args, config backend.NetworkListConfig) ([]networktypes.Inspect, error) {
-	var idx map[string]*libnetwork.Network
-	if config.Detailed {
-		idx = make(map[string]*libnetwork.Network)
+	flt, err := network.NewFilter(filter)
+	if err != nil {
+		return nil, err
 	}
 
 	allNetworks := daemon.getAllNetworks()
 	networks := make([]networktypes.Inspect, 0, len(allNetworks))
 	for _, n := range allNetworks {
 		nr := buildNetworkResource(n)
-		networks = append(networks, nr)
-		if config.Detailed {
-			idx[nr.ID] = n
-		}
-	}
-
-	var err error
-	networks, err = network.FilterNetworks(networks, filter)
-	if err != nil {
-		return nil, err
-	}
-
-	if config.Detailed {
-		for i, nw := range networks {
-			networks[i].Containers = buildContainerAttachments(idx[nw.ID])
-			if config.Verbose {
-				networks[i].Services = buildServiceAttachments(idx[nw.ID])
+		if flt.Matches(nr) {
+			if config.Detailed {
+				nr.Containers = buildContainerAttachments(n)
+				if config.Verbose {
+					nr.Services = buildServiceAttachments(n)
+				}
 			}
+			networks = append(networks, nr)
 		}
 	}
 

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -11,6 +11,10 @@ type Filter struct {
 	args filters.Args
 
 	filterByUse, danglingOnly bool
+
+	// IDAlsoMatchesName makes the "id" filter term also match against
+	// network names.
+	IDAlsoMatchesName bool
 }
 
 // NewFilter returns a network filter that filters by the provided args.
@@ -55,7 +59,8 @@ func (f Filter) Matches(nw network.Summary) bool {
 		return false
 	}
 	if f.args.Contains("id") &&
-		!f.args.Match("id", nw.ID) {
+		!f.args.Match("id", nw.ID) &&
+		(!f.IDAlsoMatchesName || !f.args.Match("id", nw.Name)) {
 		return false
 	}
 	if f.args.Contains("label") &&
@@ -64,11 +69,6 @@ func (f Filter) Matches(nw network.Summary) bool {
 	}
 	if f.args.Contains("scope") &&
 		!f.args.ExactMatch("scope", nw.Scope) {
-		return false
-	}
-	if f.args.Contains("idOrName") &&
-		!f.args.Match("name", nw.Name) &&
-		!f.args.Match("id", nw.Name) {
 		return false
 	}
 	if f.filterByUse &&

--- a/daemon/network/filter.go
+++ b/daemon/network/filter.go
@@ -7,123 +7,109 @@ import (
 	"github.com/pkg/errors"
 )
 
-// FilterNetworks filters network list according to user specified filter
-// and returns user chosen networks
-func FilterNetworks(nws []network.Inspect, filter filters.Args) ([]network.Inspect, error) {
-	// if filter is empty, return original network list
-	if filter.Len() == 0 {
-		return nws, nil
-	}
+type Filter struct {
+	args filters.Args
 
-	displayNet := nws[:0]
-	for _, nw := range nws {
-		if filter.Contains("driver") {
-			if !filter.ExactMatch("driver", nw.Driver) {
-				continue
-			}
-		}
-		if filter.Contains("name") {
-			if !filter.Match("name", nw.Name) {
-				continue
-			}
-		}
-		if filter.Contains("id") {
-			if !filter.Match("id", nw.ID) {
-				continue
-			}
-		}
-		if filter.Contains("label") {
-			if !filter.MatchKVList("label", nw.Labels) {
-				continue
-			}
-		}
-		if filter.Contains("scope") {
-			if !filter.ExactMatch("scope", nw.Scope) {
-				continue
-			}
-		}
+	filterByUse, danglingOnly bool
+}
 
-		if filter.Contains("idOrName") {
-			if !filter.Match("name", nw.Name) && !filter.Match("id", nw.Name) {
-				continue
-			}
-		}
-		displayNet = append(displayNet, nw)
-	}
-
-	if values := filter.Get("dangling"); len(values) > 0 {
+// NewFilter returns a network filter that filters by the provided args.
+//
+// An [errdefs.InvalidParameter] error is returned if the filter args are not
+// well-formed.
+func NewFilter(args filters.Args) (Filter, error) {
+	var filterByUse, danglingOnly bool
+	if values := args.Get("dangling"); len(values) > 0 {
 		if len(values) > 1 {
-			return nil, errdefs.InvalidParameter(errors.New(`got more than one value for filter key "dangling"`))
+			return Filter{}, errdefs.InvalidParameter(errors.New(`got more than one value for filter key "dangling"`))
 		}
 
-		var danglingOnly bool
+		filterByUse = true
 		switch values[0] {
 		case "0", "false":
 			// dangling is false already
 		case "1", "true":
 			danglingOnly = true
 		default:
-			return nil, errdefs.InvalidParameter(errors.New(`invalid value for filter 'dangling', must be "true" (or "1"), or "false" (or "0")`))
+			return Filter{}, errdefs.InvalidParameter(errors.New(`invalid value for filter 'dangling', must be "true" (or "1"), or "false" (or "0")`))
 		}
-
-		displayNet = filterNetworkByUse(displayNet, danglingOnly)
 	}
-
-	if filter.Contains("type") {
-		typeNet := []network.Inspect{}
-		errFilter := filter.WalkValues("type", func(fval string) error {
-			passList, err := filterNetworkByType(displayNet, fval)
-			if err != nil {
-				return err
-			}
-			typeNet = append(typeNet, passList...)
-			return nil
-		})
-		if errFilter != nil {
-			return nil, errFilter
-		}
-		displayNet = typeNet
+	if err := args.WalkValues("type", validateNetworkTypeFilter); err != nil {
+		return Filter{}, err
 	}
-
-	return displayNet, nil
+	return Filter{args: args, filterByUse: filterByUse, danglingOnly: danglingOnly}, nil
 }
 
-func filterNetworkByUse(nws []network.Inspect, danglingOnly bool) []network.Inspect {
-	retNws := []network.Inspect{}
-
-	filterFunc := func(nw network.Inspect) bool {
-		if danglingOnly {
-			return !IsPredefined(nw.Name) && len(nw.Containers) == 0 && len(nw.Services) == 0
-		}
-		return IsPredefined(nw.Name) || len(nw.Containers) > 0 || len(nw.Services) > 0
+// Matches returns true if nw satisfies the filter criteria.
+func (f Filter) Matches(nw network.Summary) bool {
+	if f.args.Len() == 0 {
+		return true
 	}
 
-	for _, nw := range nws {
-		if filterFunc(nw) {
-			retNws = append(retNws, nw)
-		}
+	if f.args.Contains("driver") &&
+		!f.args.ExactMatch("driver", nw.Driver) {
+		return false
 	}
-
-	return retNws
+	if f.args.Contains("name") &&
+		!f.args.Match("name", nw.Name) {
+		return false
+	}
+	if f.args.Contains("id") &&
+		!f.args.Match("id", nw.ID) {
+		return false
+	}
+	if f.args.Contains("label") &&
+		!f.args.MatchKVList("label", nw.Labels) {
+		return false
+	}
+	if f.args.Contains("scope") &&
+		!f.args.ExactMatch("scope", nw.Scope) {
+		return false
+	}
+	if f.args.Contains("idOrName") &&
+		!f.args.Match("name", nw.Name) &&
+		!f.args.Match("id", nw.Name) {
+		return false
+	}
+	if f.filterByUse &&
+		!matchesUse(f.danglingOnly, nw) {
+		return false
+	}
+	if netTypes := f.args.Get("type"); len(netTypes) > 0 &&
+		!matchesType(netTypes, nw) {
+		return false
+	}
+	return true
 }
 
-func filterNetworkByType(nws []network.Inspect, netType string) ([]network.Inspect, error) {
-	retNws := []network.Inspect{}
+func matchesUse(danglingOnly bool, nw network.Summary) bool {
+	if danglingOnly {
+		return !IsPredefined(nw.Name) && len(nw.Containers) == 0 && len(nw.Services) == 0
+	}
+	return IsPredefined(nw.Name) || len(nw.Containers) > 0 || len(nw.Services) > 0
+}
+
+func validateNetworkTypeFilter(netType string) error {
 	switch netType {
-	case "builtin":
-		for _, nw := range nws {
-			if IsPredefined(nw.Name) {
-				retNws = append(retNws, nw)
-			}
-		}
-	case "custom":
-		for _, nw := range nws {
-			if !IsPredefined(nw.Name) {
-				retNws = append(retNws, nw)
-			}
-		}
+	case "builtin", "custom":
+		return nil
 	default:
-		return nil, errors.Errorf("invalid filter: 'type'='%s'", netType)
+		return errors.Errorf("invalid filter: 'type'='%s'", netType)
 	}
-	return retNws, nil
+}
+
+func matchesType(netTypes []string, nw network.Summary) bool {
+	var matched bool
+	for _, netType := range netTypes {
+		switch netType {
+		case "builtin":
+			matched = IsPredefined(nw.Name)
+		case "custom":
+			matched = !IsPredefined(nw.Name)
+		}
+		if matched {
+			break
+		}
+	}
+	return matched
 }

--- a/daemon/network/filter_test.go
+++ b/daemon/network/filter_test.go
@@ -10,50 +10,71 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/moby/moby/api/types/filters"
-	"github.com/moby/moby/api/types/network"
 )
 
+type mockFilterNetwork struct {
+	FilterNetwork
+	name, driver, scope string
+	containers          int
+}
+
+func (n mockFilterNetwork) Name() string {
+	return n.name
+}
+
+func (n mockFilterNetwork) Driver() string {
+	return n.driver
+}
+
+func (n mockFilterNetwork) Scope() string {
+	return n.scope
+}
+
+func (n mockFilterNetwork) ContainerAttachments() int {
+	return n.containers
+}
+
+func (n mockFilterNetwork) ServiceAttachments() int {
+	return 0
+}
+
 func TestFilter(t *testing.T) {
-	networks := []network.Summary{
+	networks := []mockFilterNetwork{
 		{
-			Name:   "host",
-			Driver: "host",
-			Scope:  "local",
+			name:   "host",
+			driver: "host",
+			scope:  "local",
 		},
 		{
-			Name:   "bridge",
-			Driver: "bridge",
-			Scope:  "local",
+			name:   "bridge",
+			driver: "bridge",
+			scope:  "local",
 		},
 		{
-			Name:   "none",
-			Driver: "null",
-			Scope:  "local",
+			name:   "none",
+			driver: "null",
+			scope:  "local",
 		},
 		{
-			Name:   "myoverlay",
-			Driver: "overlay",
-			Scope:  "swarm",
+			name:   "myoverlay",
+			driver: "overlay",
+			scope:  "swarm",
 		},
 		{
-			Name:   "mydrivernet",
-			Driver: "mydriver",
-			Scope:  "local",
+			name:   "mydrivernet",
+			driver: "mydriver",
+			scope:  "local",
 		},
 		{
-			Name:   "mykvnet",
-			Driver: "mykvdriver",
-			Scope:  "global",
+			name:   "mykvnet",
+			driver: "mykvdriver",
+			scope:  "global",
 		},
 		{
-			Name:   "networkwithcontainer",
-			Driver: "nwc",
-			Scope:  "local",
-			Containers: map[string]network.EndpointResource{
-				"customcontainer": {
-					Name: "customendpoint",
-				},
-			},
+			name:       "networkwithcontainer",
+			driver:     "nwc",
+			scope:      "local",
+			containers: 1,
 		},
 	}
 
@@ -151,7 +172,7 @@ func TestFilter(t *testing.T) {
 			got := map[string]bool{}
 			for _, nw := range networks {
 				if flt.Matches(nw) {
-					got[nw.Name] = true
+					got[nw.Name()] = true
 				}
 			}
 

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/lazyregexp"
 	"github.com/moby/moby/v2/daemon/internal/timestamp"
 	"github.com/moby/moby/v2/daemon/libnetwork"
+	dnetwork "github.com/moby/moby/v2/daemon/network"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/pkg/errors"
@@ -24,12 +25,6 @@ var (
 	errPruneRunning = errdefs.Conflict(errors.New("a prune operation is already running"))
 
 	containersAcceptedFilters = map[string]bool{
-		"label":  true,
-		"label!": true,
-		"until":  true,
-	}
-
-	networksAcceptedFilters = map[string]bool{
 		"label":  true,
 		"label!": true,
 		"until":  true,
@@ -96,10 +91,8 @@ func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.
 }
 
 // localNetworksPrune removes unused local networks
-func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filters.Args) *network.PruneReport {
+func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters dnetwork.Filter) *network.PruneReport {
 	rep := &network.PruneReport{}
-
-	until, _ := getUntilFromPruneFilters(pruneFilters)
 
 	// When the function returns true, the walk will stop.
 	daemon.netController.WalkNetworks(func(nw *libnetwork.Network) bool {
@@ -112,10 +105,7 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filte
 		if nw.ConfigOnly() {
 			return false
 		}
-		if !until.IsZero() && nw.Created().After(until) {
-			return false
-		}
-		if !matchLabels(pruneFilters, nw.Labels()) {
+		if !pruneFilters.Matches(nw) {
 			return false
 		}
 		if !nw.IsPruneable() {
@@ -137,10 +127,8 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters filte
 var networkIsInUse = lazyregexp.New(`network ([[:alnum:]]+) is in use`)
 
 // clusterNetworksPrune removes unused cluster networks
-func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error) {
+func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters dnetwork.Filter) (*network.PruneReport, error) {
 	rep := &network.PruneReport{}
-
-	until, _ := getUntilFromPruneFilters(pruneFilters)
 
 	cluster := daemon.GetCluster()
 
@@ -162,12 +150,6 @@ func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters fil
 				// Routing-mesh network removal has to be explicitly invoked by user
 				continue
 			}
-			if !until.IsZero() && nw.Created.After(until) {
-				continue
-			}
-			if !matchLabels(pruneFilters, nw.Labels) {
-				continue
-			}
 			// https://github.com/moby/moby/issues/24186
 			// `docker network inspect` unfortunately displays ONLY those containers that are local to that node.
 			// So we try to remove it anyway and check the error
@@ -187,21 +169,11 @@ func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters fil
 }
 
 // NetworksPrune removes unused networks
-func (daemon *Daemon) NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error) {
+func (daemon *Daemon) NetworksPrune(ctx context.Context, pruneFilters dnetwork.Filter) (*network.PruneReport, error) {
 	if !daemon.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}
 	defer daemon.pruneRunning.Store(false)
-
-	// make sure that only accepted filters have been received
-	err := pruneFilters.Validate(networksAcceptedFilters)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := getUntilFromPruneFilters(pruneFilters); err != nil {
-		return nil, err
-	}
 
 	rep := &network.PruneReport{}
 	if clusterRep, err := daemon.clusterNetworksPrune(ctx, pruneFilters); err == nil {

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -173,7 +173,6 @@ type PluginDisableConfig struct {
 // NetworkListConfig stores the options available for listing networks
 type NetworkListConfig struct {
 	// TODO(@cpuguy83): naming is hard, this is pulled from what was being used in the router before moving here
-	Detailed          bool
-	Verbose           bool
-	IDAlsoMatchesName bool
+	Detailed bool
+	Verbose  bool
 }

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -173,6 +173,7 @@ type PluginDisableConfig struct {
 // NetworkListConfig stores the options available for listing networks
 type NetworkListConfig struct {
 	// TODO(@cpuguy83): naming is hard, this is pulled from what was being used in the router before moving here
-	Detailed bool
-	Verbose  bool
+	Detailed          bool
+	Verbose           bool
+	IDAlsoMatchesName bool
 }

--- a/daemon/server/router/network/backend.go
+++ b/daemon/server/router/network/backend.go
@@ -3,26 +3,26 @@ package network
 import (
 	"context"
 
-	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/network"
+	dnetwork "github.com/moby/moby/v2/daemon/network"
 	"github.com/moby/moby/v2/daemon/server/backend"
 )
 
 // Backend is all the methods that need to be implemented
 // to provide network specific functionality.
 type Backend interface {
-	GetNetworks(filters.Args, backend.NetworkListConfig) ([]network.Inspect, error)
+	GetNetworks(dnetwork.Filter, backend.NetworkListConfig) ([]network.Inspect, error)
 	CreateNetwork(ctx context.Context, nc network.CreateRequest) (*network.CreateResponse, error)
 	ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
 	DeleteNetwork(networkID string) error
-	NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error)
+	NetworksPrune(ctx context.Context, pruneFilters dnetwork.Filter) (*network.PruneReport, error)
 }
 
 // ClusterBackend is all the methods that need to be implemented
 // to provide cluster network specific functionality.
 type ClusterBackend interface {
-	GetNetworks(filters.Args) ([]network.Inspect, error)
+	GetNetworks(dnetwork.Filter) ([]network.Inspect, error)
 	GetNetwork(name string) (network.Inspect, error)
 	GetNetworksByName(name string) ([]network.Inspect, error)
 	CreateNetwork(nc network.CreateRequest) (string, error)

--- a/daemon/server/router/network/network_routes.go
+++ b/daemon/server/router/network/network_routes.go
@@ -114,11 +114,11 @@ func (n *networkRouter) getNetwork(ctx context.Context, w http.ResponseWriter, r
 
 	// TODO(@cpuguy83): All this logic for figuring out which network to return does not belong here
 	// Instead there should be a backend function to just get one network.
-	filter := filters.NewArgs(filters.Arg("idOrName", term))
+	filter := filters.NewArgs(filters.Arg("id", term))
 	if networkScope != "" {
 		filter.Add("scope", networkScope)
 	}
-	networks, _ := n.backend.GetNetworks(filter, backend.NetworkListConfig{Detailed: true, Verbose: verbose})
+	networks, _ := n.backend.GetNetworks(filter, backend.NetworkListConfig{Detailed: true, Verbose: verbose, IDAlsoMatchesName: true})
 	for _, nw := range networks {
 		if nw.ID == term {
 			return httputils.WriteJSON(w, http.StatusOK, nw)
@@ -322,8 +322,8 @@ func (n *networkRouter) findUniqueNetwork(term string) (network.Inspect, error) 
 	listByFullName := map[string]network.Inspect{}
 	listByPartialID := map[string]network.Inspect{}
 
-	filter := filters.NewArgs(filters.Arg("idOrName", term))
-	networks, _ := n.backend.GetNetworks(filter, backend.NetworkListConfig{Detailed: true})
+	filter := filters.NewArgs(filters.Arg("id", term))
+	networks, _ := n.backend.GetNetworks(filter, backend.NetworkListConfig{Detailed: true, IDAlsoMatchesName: true})
 	for _, nw := range networks {
 		if nw.ID == term {
 			return nw, nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Stacked on top of #50831 

**- What I did**
- Replaced the buggy internal uses of the hidden `idOrName` term (which matched all networks irrespective of value, as if the term wasn't present) with an implementation that actually works as intended
- Moved network filter term validation from the api module to the daemon
- Unified the set of available filter terms for list-networks and prune-networks APIs
- Filtered networks before converting so cycles aren't wasted converting a struct that won't be returned to the client

**- How I did it**
See individual commit messages.

**- How to verify it**
Existing tests.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
 - The `GET /networks` API has been extended with support for the `label!` and `until` filters.
 - The `POST /networks/prune` API has been extended with support for the `driver`, `name` and `scope` filters.
```

**- A picture of a cute animal (not mandatory but encouraged)**

