### PR TITLE
nftables: iterate over rules

### DIFF
--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -49,6 +49,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"os/exec"
 	"runtime"
 	"slices"
@@ -1036,9 +1037,9 @@ func (t *table) updatesApplied() {
 	t.MustFlush = false
 }
 
-/* Can't make text/template range over this, not sure why ...
+// Rules returns an iterator that yields the chain's rules in order.
 func (c *chain) Rules() iter.Seq[string] {
-	groups := make([]int, 0, len(c.ruleGroups))
+	groups := make([]RuleGroup, 0, len(c.ruleGroups))
 	for group := range c.ruleGroups {
 		groups = append(groups, group)
 	}
@@ -1052,23 +1053,6 @@ func (c *chain) Rules() iter.Seq[string] {
 			}
 		}
 	}
-}
-*/
-
-// Rules returns the chain's rules, in order.
-func (c *chain) Rules() []string {
-	groups := make([]RuleGroup, 0, len(c.ruleGroups))
-	nRules := 0
-	for group := range c.ruleGroups {
-		groups = append(groups, group)
-		nRules += len(c.ruleGroups[group])
-	}
-	slices.Sort(groups)
-	rules := make([]string, 0, nRules)
-	for _, group := range groups {
-		rules = append(rules, c.ruleGroups[group]...)
-	}
-	return rules
 }
 
 func parseTemplate() error {


### PR DESCRIPTION
**- What I did**

When generating the rules for an nftables chain, rather than collecting rules into a slice and iterating over that, use an iterator.

**- How I did it**

I tried this when we were using Go 1.23 (and left the commented out function in), but text/template only got support for range-over-function in Go 1.24.

**- How to verify it**

Existing tests, including unit test `TestChainRuleGroups` which checks rule ordering.

**- Human readable description for the release notes**
```markdown changelog

```

