### PR TITLE
client: Migrate tests to use functional opts and extract `clientConfig`

### DIFF
--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -18,10 +18,12 @@ import (
 )
 
 func TestCheckpointCreateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.CheckpointCreate(context.Background(), "nothing", checkpoint.CreateOptions{
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	err = client.CheckpointCreate(context.Background(), "nothing", checkpoint.CreateOptions{
 		CheckpointID: "noting",
 		Exit:         true,
 	})
@@ -42,8 +44,8 @@ func TestCheckpointCreate(t *testing.T) {
 	expectedCheckpointID := "checkpoint_id"
 	expectedURL := "/containers/container_id/checkpoints"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -70,9 +72,10 @@ func TestCheckpointCreate(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
-	err := client.CheckpointCreate(context.Background(), expectedContainerID, checkpoint.CreateOptions{
+	err = client.CheckpointCreate(context.Background(), expectedContainerID, checkpoint.CreateOptions{
 		CheckpointID: expectedCheckpointID,
 		Exit:         true,
 	})

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -16,11 +16,12 @@ import (
 )
 
 func TestCheckpointDeleteError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
 
-	err := client.CheckpointDelete(context.Background(), "container_id", checkpoint.DeleteOptions{
+	err = client.CheckpointDelete(context.Background(), "container_id", checkpoint.DeleteOptions{
 		CheckpointID: "checkpoint_id",
 	})
 
@@ -38,8 +39,8 @@ func TestCheckpointDeleteError(t *testing.T) {
 func TestCheckpointDelete(t *testing.T) {
 	expectedURL := "/containers/container_id/checkpoints/checkpoint_id"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -51,9 +52,10 @@ func TestCheckpointDelete(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
-	err := client.CheckpointDelete(context.Background(), "container_id", checkpoint.DeleteOptions{
+	err = client.CheckpointDelete(context.Background(), "container_id", checkpoint.DeleteOptions{
 		CheckpointID: "checkpoint_id",
 	})
 	assert.NilError(t, err)

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -17,19 +17,20 @@ import (
 )
 
 func TestCheckpointListError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.CheckpointList(context.Background(), "container_id", checkpoint.ListOptions{})
+	_, err = client.CheckpointList(context.Background(), "container_id", checkpoint.ListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestCheckpointList(t *testing.T) {
 	expectedURL := "/containers/container_id/checkpoints"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -46,7 +47,8 @@ func TestCheckpointList(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
 	checkpoints, err := client.CheckpointList(context.Background(), "container_id", checkpoint.ListOptions{})
 	assert.NilError(t, err)
@@ -54,10 +56,11 @@ func TestCheckpointList(t *testing.T) {
 }
 
 func TestCheckpointListContainerNotFound(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusNotFound, "Server error")),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.CheckpointList(context.Background(), "unknown", checkpoint.ListOptions{})
+	_, err = client.CheckpointList(context.Background(), "unknown", checkpoint.ListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }

--- a/client/client.go
+++ b/client/client.go
@@ -114,43 +114,13 @@ var _ APIClient = &Client{}
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
-	// scheme sets the scheme for the client
-	scheme string
-	// host holds the server address to connect to
-	host string
-	// proto holds the client protocol i.e. unix.
-	proto string
-	// addr holds the client address.
-	addr string
-	// basePath holds the path to prepend to the requests.
-	basePath string
-	// client used to send and receive http requests.
-	client *http.Client
-	// version of the server to talk to.
-	version string
-	// userAgent is the User-Agent header to use for HTTP requests. It takes
-	// precedence over User-Agent headers set in customHTTPHeaders, and other
-	// header variables. When set to an empty string, the User-Agent header
-	// is removed, and no header is sent.
-	userAgent *string
-	// custom HTTP headers configured by users.
-	customHTTPHeaders map[string]string
-	// manualOverride is set to true when the version was set by users.
-	manualOverride bool
-
-	// negotiateVersion indicates if the client should automatically negotiate
-	// the API version to use when making requests. API version negotiation is
-	// performed on the first request, after which negotiated is set to "true"
-	// so that subsequent requests do not re-negotiate.
-	negotiateVersion bool
+	clientConfig
 
 	// negotiated indicates that API version negotiation took place
 	negotiated atomic.Bool
 
 	// negotiateLock is used to single-flight the version negotiation process
 	negotiateLock sync.Mutex
-
-	traceOpts []otelhttp.Option
 
 	// When the client transport is an *http.Transport (default) we need to do some extra things (like closing idle connections).
 	// Store the original transport as the http.Client transport will be wrapped with tracing libs.
@@ -207,21 +177,23 @@ func NewClientWithOpts(ops ...Opt) (*Client, error) {
 		return nil, err
 	}
 	c := &Client{
-		host:    DefaultDockerHost,
-		version: DefaultAPIVersion,
-		client:  client,
-		proto:   hostURL.Scheme,
-		addr:    hostURL.Host,
-
-		traceOpts: []otelhttp.Option{
-			otelhttp.WithSpanNameFormatter(func(_ string, req *http.Request) string {
-				return req.Method + " " + req.URL.Path
-			}),
+		clientConfig: clientConfig{
+			host:    DefaultDockerHost,
+			version: DefaultAPIVersion,
+			client:  client,
+			proto:   hostURL.Scheme,
+			addr:    hostURL.Host,
+			traceOpts: []otelhttp.Option{
+				otelhttp.WithSpanNameFormatter(func(_ string, req *http.Request) string {
+					return req.Method + " " + req.URL.Path
+				}),
+			},
 		},
 	}
+	cfg := &c.clientConfig
 
 	for _, op := range ops {
-		if err := op(c); err != nil {
+		if err := op(cfg); err != nil {
 			return nil, err
 		}
 	}

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -29,7 +29,7 @@ func transportEnsureBody(f transportFunc) transportFunc {
 
 // WithMockClient is a test helper that allows you to inject a mock client for testing.
 func WithMockClient(doer func(*http.Request) (*http.Response, error)) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		c.client = &http.Client{
 			Transport: transportEnsureBody(transportFunc(doer)),
 		}

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -35,6 +35,22 @@ func newMockClient(doer func(*http.Request) (*http.Response, error)) *http.Clien
 	}
 }
 
+// WithMockClient is a test helper that allows you to inject a mock client for testing.
+func WithMockClient(doer func(*http.Request) (*http.Response, error)) Opt {
+	return func(c *Client) error {
+		c.client = &http.Client{
+			Transport: transportEnsureBody(transportFunc(doer)),
+		}
+		if !c.manualOverride {
+			c.version = ""
+		}
+		c.host = ""
+		c.proto = ""
+		c.addr = ""
+		return nil
+	}
+}
+
 func errorMock(statusCode int, message string) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
 		header := http.Header{}

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -27,14 +27,6 @@ func transportEnsureBody(f transportFunc) transportFunc {
 	}
 }
 
-func newMockClient(doer func(*http.Request) (*http.Response, error)) *http.Client {
-	return &http.Client{
-		// Some tests return a response with a nil body, this is incorrect semantically and causes a panic with wrapper transports (such as otelhttp's)
-		// Wrap the doer to ensure a body is always present even if it is empty.
-		Transport: transportEnsureBody(transportFunc(doer)),
-	}
-}
-
 // WithMockClient is a test helper that allows you to inject a mock client for testing.
 func WithMockClient(doer func(*http.Request) (*http.Response, error)) Opt {
 	return func(c *Client) error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -360,16 +360,16 @@ func TestNegotiateAPIVersionConnectionFailure(t *testing.T) {
 
 func TestNegotiateAPIVersionAutomatic(t *testing.T) {
 	var pingVersion string
-	httpClient := newMockClient(func(req *http.Request) (*http.Response, error) {
-		resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
-		resp.Header.Set("Api-Version", pingVersion)
-		resp.Body = io.NopCloser(strings.NewReader("OK"))
-		return resp, nil
-	})
 
 	ctx := context.Background()
 	client, err := NewClientWithOpts(
-		WithHTTPClient(httpClient),
+		WithHTTPClient(&http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
+				resp.Header.Set("Api-Version", pingVersion)
+				resp.Body = io.NopCloser(strings.NewReader("OK"))
+				return resp, nil
+			})}),
 		WithAPIVersionNegotiation(),
 	)
 	assert.NilError(t, err)

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -18,21 +18,23 @@ import (
 )
 
 func TestConfigInspectNotFound(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusNotFound, "Server error")),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "unknown")
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "unknown")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }
 
 func TestConfigInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
 		}),
-	}
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "")
+	)
+	assert.NilError(t, err)
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
@@ -42,39 +44,43 @@ func TestConfigInspectWithEmptyID(t *testing.T) {
 }
 
 func TestConfigInspectUnsupported(t *testing.T) {
-	client := &Client{
-		version: "1.29",
-		client:  &http.Client{},
-	}
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithVersion("1.29"),
+		WithHTTPClient(&http.Client{}),
+	)
+	assert.NilError(t, err)
+
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "nothing")
 	assert.Check(t, is.Error(err, `"config inspect" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
 func TestConfigInspectError(t *testing.T) {
-	client := &Client{
-		version: "1.30",
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithVersion("1.30"),
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "nothing")
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestConfigInspectConfigNotFound(t *testing.T) {
-	client := &Client{
-		version: "1.30",
-		client:  newMockClient(errorMock(http.StatusNotFound, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithVersion("1.30"),
+		WithMockClient(errorMock(http.StatusNotFound, "Server error")),
+	)
+	assert.NilError(t, err)
 
-	_, _, err := client.ConfigInspectWithRaw(context.Background(), "unknown")
+	_, _, err = client.ConfigInspectWithRaw(context.Background(), "unknown")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }
 
 func TestConfigInspect(t *testing.T) {
 	expectedURL := "/v1.30/configs/config_id"
-	client := &Client{
-		version: "1.30",
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithVersion("1.30"),
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -89,7 +95,8 @@ func TestConfigInspect(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(content)),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
 	configInspect, _, err := client.ConfigInspectWithRaw(context.Background(), "config_id")
 	assert.NilError(t, err)

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -17,10 +17,12 @@ import (
 )
 
 func TestContainerCommitError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerCommit(context.Background(), "nothing", container.CommitOptions{})
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	_, err = client.ContainerCommit(context.Background(), "nothing", container.CommitOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	_, err = client.ContainerCommit(context.Background(), "", container.CommitOptions{})
@@ -44,8 +46,8 @@ func TestContainerCommit(t *testing.T) {
 	)
 	expectedChanges := []string{"change1", "change2"}
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -89,7 +91,8 @@ func TestContainerCommit(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
 	r, err := client.ContainerCommit(context.Background(), expectedContainerID, container.CommitOptions{
 		Reference: specifiedReference,

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -17,10 +17,12 @@ import (
 )
 
 func TestContainerDiffError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerDiff(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	_, err = client.ContainerDiff(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	_, err = client.ContainerDiff(context.Background(), "")
@@ -50,8 +52,8 @@ func TestContainerDiff(t *testing.T) {
 		},
 	}
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -64,7 +66,8 @@ func TestContainerDiff(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
 	changes, err := client.ContainerDiff(context.Background(), "container_id")
 	assert.NilError(t, err)

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -17,11 +17,12 @@ import (
 )
 
 func TestContainerExecCreateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{})
+	_, err = client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	_, err = client.ContainerExecCreate(context.Background(), "", container.ExecOptions{})
@@ -47,8 +48,8 @@ func TestContainerExecCreateConnectionError(t *testing.T) {
 
 func TestContainerExecCreate(t *testing.T) {
 	expectedURL := "/containers/container_id/exec"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -77,7 +78,8 @@ func TestContainerExecCreate(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
 	r, err := client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{
 		User: "user",
@@ -87,17 +89,19 @@ func TestContainerExecCreate(t *testing.T) {
 }
 
 func TestContainerExecStartError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerExecStart(context.Background(), "nothing", container.ExecStartOptions{})
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	err = client.ContainerExecStart(context.Background(), "nothing", container.ExecStartOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestContainerExecStart(t *testing.T) {
 	expectedURL := "/exec/exec_id/start"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -117,9 +121,10 @@ func TestContainerExecStart(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
-	err := client.ContainerExecStart(context.Background(), "exec_id", container.ExecStartOptions{
+	err = client.ContainerExecStart(context.Background(), "exec_id", container.ExecStartOptions{
 		Detach: true,
 		Tty:    false,
 	})
@@ -127,17 +132,19 @@ func TestContainerExecStart(t *testing.T) {
 }
 
 func TestContainerExecInspectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerExecInspect(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	_, err = client.ContainerExecInspect(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestContainerExecInspect(t *testing.T) {
 	expectedURL := "/exec/exec_id/json"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -153,7 +160,8 @@ func TestContainerExecInspect(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
 	inspect, err := client.ContainerExecInspect(context.Background(), "exec_id")
 	assert.NilError(t, err)

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 func TestContainerKillError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerKill(context.Background(), "nothing", "SIGKILL")
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	err = client.ContainerKill(context.Background(), "nothing", "SIGKILL")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.ContainerKill(context.Background(), "", "")
@@ -32,8 +34,8 @@ func TestContainerKillError(t *testing.T) {
 
 func TestContainerKill(t *testing.T) {
 	expectedURL := "/containers/container_id/kill"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -46,8 +48,9 @@ func TestContainerKill(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
-	err := client.ContainerKill(context.Background(), "container_id", "SIGKILL")
+	err = client.ContainerKill(context.Background(), "container_id", "SIGKILL")
 	assert.NilError(t, err)
 }

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -18,18 +18,20 @@ import (
 )
 
 func TestContainerListError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerList(context.Background(), container.ListOptions{})
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	_, err = client.ContainerList(context.Background(), container.ListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestContainerList(t *testing.T) {
 	expectedURL := "/containers/json"
 	expectedFilters := `{"before":{"container":true},"label":{"label1":true,"label2":true}}`
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -76,7 +78,8 @@ func TestContainerList(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}),
-	}
+	)
+	assert.NilError(t, err)
 
 	containers, err := client.ContainerList(context.Background(), container.ListOptions{
 		Size:  true,

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -15,17 +15,19 @@ import (
 )
 
 func TestContainerPauseError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerPause(context.Background(), "nothing")
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+	)
+	assert.NilError(t, err)
+
+	err = client.ContainerPause(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestContainerPause(t *testing.T) {
 	expectedURL := "/containers/container_id/pause"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := NewClientWithOpts(
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if !strings.HasPrefix(req.URL.Path, expectedURL) {
 				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 			}
@@ -34,7 +36,9 @@ func TestContainerPause(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 			}, nil
 		}),
-	}
-	err := client.ContainerPause(context.Background(), "container_id")
+	)
+	assert.NilError(t, err)
+
+	err = client.ContainerPause(context.Background(), "container_id")
 	assert.NilError(t, err)
 }

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -18,12 +18,10 @@ import (
 )
 
 func TestContainersPruneError(t *testing.T) {
-	client := &Client{
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-		version: "1.25",
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")), WithVersion("1.25"))
+	assert.NilError(t, err)
 
-	_, err := client.ContainersPrune(context.Background(), filters.Args{})
+	_, err = client.ContainersPrune(context.Background(), filters.Args{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -83,30 +81,28 @@ func TestContainersPrune(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-				}
-				query := req.URL.Query()
-				for key, expected := range listCase.expectedQueryParams {
-					actual := query.Get(key)
-					assert.Check(t, is.Equal(expected, actual))
-				}
-				content, err := json.Marshal(container.PruneReport{
-					ContainersDeleted: []string{"container_id1", "container_id2"},
-					SpaceReclaimed:    9999,
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(content)),
-				}, nil
-			}),
-			version: "1.25",
-		}
+		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			query := req.URL.Query()
+			for key, expected := range listCase.expectedQueryParams {
+				actual := query.Get(key)
+				assert.Check(t, is.Equal(expected, actual))
+			}
+			content, err := json.Marshal(container.PruneReport{
+				ContainersDeleted: []string{"container_id1", "container_id2"},
+				SpaceReclaimed:    9999,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}), WithVersion("1.25"))
+		assert.NilError(t, err)
 
 		report, err := client.ContainersPrune(context.Background(), listCase.filters)
 		assert.NilError(t, err)

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -15,10 +15,9 @@ import (
 )
 
 func TestContainerRenameError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerRename(context.Background(), "nothing", "newNothing")
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	err = client.ContainerRename(context.Background(), "nothing", "newNothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.ContainerRename(context.Background(), "", "newNothing")
@@ -32,22 +31,21 @@ func TestContainerRenameError(t *testing.T) {
 
 func TestContainerRename(t *testing.T) {
 	expectedURL := "/containers/container_id/rename"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			name := req.URL.Query().Get("name")
-			if name != "newName" {
-				return nil, fmt.Errorf("name not set in URL query properly. Expected 'newName', got %s", name)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		name := req.URL.Query().Get("name")
+		if name != "newName" {
+			return nil, fmt.Errorf("name not set in URL query properly. Expected 'newName', got %s", name)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.ContainerRename(context.Background(), "container_id", "newName")
+	err = client.ContainerRename(context.Background(), "container_id", "newName")
 	assert.NilError(t, err)
 }

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -14,10 +14,9 @@ import (
 )
 
 func TestContainerResizeError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerResize(context.Background(), "container_id", ContainerResizeOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	err = client.ContainerResize(context.Background(), "container_id", ContainerResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.ContainerResize(context.Background(), "", ContainerResizeOptions{})
@@ -30,10 +29,9 @@ func TestContainerResizeError(t *testing.T) {
 }
 
 func TestContainerExecResizeError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerExecResize(context.Background(), "exec_id", ContainerResizeOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	err = client.ContainerExecResize(context.Background(), "exec_id", ContainerResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -72,10 +70,9 @@ func TestContainerResize(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client := &Client{
-				client: newMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)),
-			}
-			err := client.ContainerResize(context.Background(), "container_id", tc.opts)
+			client, err := NewClientWithOpts(WithMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)))
+			assert.NilError(t, err)
+			err = client.ContainerResize(context.Background(), "container_id", tc.opts)
 			assert.NilError(t, err)
 		})
 	}
@@ -115,10 +112,9 @@ func TestContainerExecResize(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client := &Client{
-				client: newMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)),
-			}
-			err := client.ContainerExecResize(context.Background(), "exec_id", tc.opts)
+			client, err := NewClientWithOpts(WithMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)))
+			assert.NilError(t, err)
+			err = client.ContainerExecResize(context.Background(), "exec_id", tc.opts)
 			assert.NilError(t, err)
 		})
 	}

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -16,10 +16,9 @@ import (
 )
 
 func TestContainerRestartError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerRestart(context.Background(), "nothing", container.StopOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	err = client.ContainerRestart(context.Background(), "nothing", container.StopOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.ContainerRestart(context.Background(), "", container.StopOptions{})
@@ -45,28 +44,26 @@ func TestContainerRestartConnectionError(t *testing.T) {
 
 func TestContainerRestart(t *testing.T) {
 	const expectedURL = "/v1.42/containers/container_id/restart"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			s := req.URL.Query().Get("signal")
-			if s != "SIGKILL" {
-				return nil, fmt.Errorf("signal not set in URL query. Expected 'SIGKILL', got '%s'", s)
-			}
-			t := req.URL.Query().Get("t")
-			if t != "100" {
-				return nil, fmt.Errorf("t (timeout) not set in URL query properly. Expected '100', got %s", t)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-		version: "1.42",
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		s := req.URL.Query().Get("signal")
+		if s != "SIGKILL" {
+			return nil, fmt.Errorf("signal not set in URL query. Expected 'SIGKILL', got '%s'", s)
+		}
+		t := req.URL.Query().Get("t")
+		if t != "100" {
+			return nil, fmt.Errorf("t (timeout) not set in URL query properly. Expected '100', got %s", t)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}), WithVersion("1.42"))
+	assert.NilError(t, err)
 	timeout := 100
-	err := client.ContainerRestart(context.Background(), "container_id", container.StopOptions{
+	err = client.ContainerRestart(context.Background(), "container_id", container.StopOptions{
 		Signal:  "SIGKILL",
 		Timeout: &timeout,
 	})

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -17,10 +17,9 @@ import (
 )
 
 func TestContainerStartError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerStart(context.Background(), "nothing", container.StartOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	err = client.ContainerStart(context.Background(), "nothing", container.StartOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.ContainerStart(context.Background(), "", container.StartOptions{})
@@ -34,31 +33,30 @@ func TestContainerStartError(t *testing.T) {
 
 func TestContainerStart(t *testing.T) {
 	expectedURL := "/containers/container_id/start"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		// we're not expecting any payload, but if one is supplied, check it is valid.
+		if req.Header.Get("Content-Type") == "application/json" {
+			var startConfig any
+			if err := json.NewDecoder(req.Body).Decode(&startConfig); err != nil {
+				return nil, fmt.Errorf("Unable to parse json: %s", err)
 			}
-			// we're not expecting any payload, but if one is supplied, check it is valid.
-			if req.Header.Get("Content-Type") == "application/json" {
-				var startConfig any
-				if err := json.NewDecoder(req.Body).Decode(&startConfig); err != nil {
-					return nil, fmt.Errorf("Unable to parse json: %s", err)
-				}
-			}
+		}
 
-			checkpoint := req.URL.Query().Get("checkpoint")
-			if checkpoint != "checkpoint_id" {
-				return nil, fmt.Errorf("checkpoint not set in URL query properly. Expected 'checkpoint_id', got %s", checkpoint)
-			}
+		checkpoint := req.URL.Query().Get("checkpoint")
+		if checkpoint != "checkpoint_id" {
+			return nil, fmt.Errorf("checkpoint not set in URL query properly. Expected 'checkpoint_id', got %s", checkpoint)
+		}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.ContainerStart(context.Background(), "container_id", container.StartOptions{CheckpointID: "checkpoint_id"})
+	err = client.ContainerStart(context.Background(), "container_id", container.StartOptions{CheckpointID: "checkpoint_id"})
 	assert.NilError(t, err)
 }

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -15,10 +15,9 @@ import (
 )
 
 func TestContainerStatsError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerStats(context.Background(), "nothing", false)
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	_, err = client.ContainerStats(context.Background(), "nothing", false)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	_, err = client.ContainerStats(context.Background(), "", false)
@@ -45,24 +44,23 @@ func TestContainerStats(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		client := &Client{
-			client: newMockClient(func(r *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(r.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, r.URL)
-				}
+		client, err := NewClientWithOpts(WithMockClient(func(r *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(r.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, r.URL)
+			}
 
-				query := r.URL.Query()
-				stream := query.Get("stream")
-				if stream != c.expectedStream {
-					return nil, fmt.Errorf("stream not set in URL query properly. Expected '%s', got %s", c.expectedStream, stream)
-				}
+			query := r.URL.Query()
+			stream := query.Get("stream")
+			if stream != c.expectedStream {
+				return nil, fmt.Errorf("stream not set in URL query properly. Expected '%s', got %s", c.expectedStream, stream)
+			}
 
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte("response"))),
-				}, nil
-			}),
-		}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte("response"))),
+			}, nil
+		}))
+		assert.NilError(t, err)
 		resp, err := client.ContainerStats(context.Background(), "container_id", c.stream)
 		assert.NilError(t, err)
 		t.Cleanup(func() {

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -17,10 +17,9 @@ import (
 )
 
 func TestContainerTopError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ContainerTop(context.Background(), "nothing", []string{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	_, err = client.ContainerTop(context.Background(), "nothing", []string{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	_, err = client.ContainerTop(context.Background(), "", []string{})
@@ -40,34 +39,33 @@ func TestContainerTop(t *testing.T) {
 	}
 	expectedTitles := []string{"title1", "title2"}
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			query := req.URL.Query()
-			args := query.Get("ps_args")
-			if args != "arg1 arg2" {
-				return nil, fmt.Errorf("args not set in URL query properly. Expected 'arg1 arg2', got %v", args)
-			}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		query := req.URL.Query()
+		args := query.Get("ps_args")
+		if args != "arg1 arg2" {
+			return nil, fmt.Errorf("args not set in URL query properly. Expected 'arg1 arg2', got %v", args)
+		}
 
-			b, err := json.Marshal(container.TopResponse{
-				Processes: [][]string{
-					{"p1", "p2"},
-					{"p3"},
-				},
-				Titles: []string{"title1", "title2"},
-			})
-			if err != nil {
-				return nil, err
-			}
+		b, err := json.Marshal(container.TopResponse{
+			Processes: [][]string{
+				{"p1", "p2"},
+				{"p3"},
+			},
+			Titles: []string{"title1", "title2"},
+		})
+		if err != nil {
+			return nil, err
+		}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader(b)),
-			}, nil
-		}),
-	}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(b)),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
 	processList, err := client.ContainerTop(context.Background(), "container_id", []string{"arg1", "arg2"})
 	assert.NilError(t, err)

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -15,10 +15,9 @@ import (
 )
 
 func TestContainerUnpauseError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	err := client.ContainerUnpause(context.Background(), "nothing")
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	err = client.ContainerUnpause(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.ContainerUnpause(context.Background(), "")
@@ -32,17 +31,16 @@ func TestContainerUnpauseError(t *testing.T) {
 
 func TestContainerUnpause(t *testing.T) {
 	expectedURL := "/containers/container_id/unpause"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
-	err := client.ContainerUnpause(context.Background(), "container_id")
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
+	err = client.ContainerUnpause(context.Background(), "container_id")
 	assert.NilError(t, err)
 }

--- a/client/distribution_inspect_test.go
+++ b/client/distribution_inspect_test.go
@@ -12,20 +12,17 @@ import (
 )
 
 func TestDistributionInspectUnsupported(t *testing.T) {
-	client := &Client{
-		version: "1.29",
-		client:  &http.Client{},
-	}
-	_, err := client.DistributionInspect(context.Background(), "foobar:1.0", "")
+	client, err := NewClientWithOpts(WithVersion("1.29"), WithHTTPClient(&http.Client{}))
+	assert.NilError(t, err)
+	_, err = client.DistributionInspect(context.Background(), "foobar:1.0", "")
 	assert.Check(t, is.Error(err, `"distribution inspect" requires API version 1.30, but the Docker daemon API version is 1.29`))
 }
 
 func TestDistributionInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			return nil, errors.New("should not make request")
-		}),
-	}
-	_, err := client.DistributionInspect(context.Background(), "", "")
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("should not make request")
+	}))
+	assert.NilError(t, err)
+	_, err = client.DistributionInspect(context.Background(), "", "")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 func TestImageLoadError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, err := client.ImageLoad(context.Background(), nil, ImageLoadWithQuiet(true))
+	_, err = client.ImageLoad(context.Background(), nil, ImageLoadWithQuiet(true))
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -82,18 +81,17 @@ func TestImageLoad(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client := &Client{
-				client: newMockClient(func(req *http.Request) (*http.Response, error) {
-					assert.Check(t, is.Equal(req.URL.Path, expectedURL))
-					assert.Check(t, is.Equal(req.Header.Get("Content-Type"), expectedContentType))
-					assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))
-					return &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewReader([]byte(expectedOutput))),
-						Header:     http.Header{"Content-Type": []string{tc.responseContentType}},
-					}, nil
-				}),
-			}
+			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+				assert.Check(t, is.Equal(req.URL.Path, expectedURL))
+				assert.Check(t, is.Equal(req.Header.Get("Content-Type"), expectedContentType))
+				assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(expectedOutput))),
+					Header:     http.Header{"Content-Type": []string{tc.responseContentType}},
+				}, nil
+			}))
+			assert.NilError(t, err)
 
 			input := bytes.NewReader([]byte(expectedInput))
 			imageLoadResponse, err := client.ImageLoad(context.Background(), input,

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -19,12 +19,10 @@ import (
 )
 
 func TestImagesPruneError(t *testing.T) {
-	client := &Client{
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-		version: "1.25",
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")), WithVersion("1.25"))
+	assert.NilError(t, err)
 
-	_, err := client.ImagesPrune(context.Background(), filters.NewArgs())
+	_, err = client.ImagesPrune(context.Background(), filters.NewArgs())
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -73,37 +71,35 @@ func TestImagesPrune(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-				}
-				query := req.URL.Query()
-				for key, expected := range listCase.expectedQueryParams {
-					actual := query.Get(key)
-					assert.Check(t, is.Equal(expected, actual))
-				}
-				content, err := json.Marshal(image.PruneReport{
-					ImagesDeleted: []image.DeleteResponse{
-						{
-							Deleted: "image_id1",
-						},
-						{
-							Deleted: "image_id2",
-						},
+		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			query := req.URL.Query()
+			for key, expected := range listCase.expectedQueryParams {
+				actual := query.Get(key)
+				assert.Check(t, is.Equal(expected, actual))
+			}
+			content, err := json.Marshal(image.PruneReport{
+				ImagesDeleted: []image.DeleteResponse{
+					{
+						Deleted: "image_id1",
 					},
-					SpaceReclaimed: 9999,
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(content)),
-				}, nil
-			}),
-			version: "1.25",
-		}
+					{
+						Deleted: "image_id2",
+					},
+				},
+				SpaceReclaimed: 9999,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}), WithVersion("1.25"))
+		assert.NilError(t, err)
 
 		report, err := client.ImagesPrune(context.Background(), listCase.filters)
 		assert.NilError(t, err)

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 func TestImageSaveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 	armv64 := ocispec.Platform{Architecture: "arm64", OS: "linux", Variant: "v8"}
-	_, err := client.ImageSave(context.Background(), []string{"nothing"}, ImageSaveWithPlatforms(armv64))
+	_, err = client.ImageSave(context.Background(), []string{"nothing"}, ImageSaveWithPlatforms(armv64))
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -65,16 +64,15 @@ func TestImageSave(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client := &Client{
-				client: newMockClient(func(req *http.Request) (*http.Response, error) {
-					assert.Check(t, is.Equal(req.URL.Path, expectedURL))
-					assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))
-					return &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewReader([]byte(expectedOutput))),
-					}, nil
-				}),
-			}
+			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+				assert.Check(t, is.Equal(req.URL.Path, expectedURL))
+				assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(expectedOutput))),
+				}, nil
+			}))
+			assert.NilError(t, err)
 			resp, err := client.ImageSave(context.Background(), []string{"image_id1", "image_id2"}, tc.options...)
 			assert.NilError(t, err)
 			defer assert.NilError(t, resp.Close())

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -19,42 +19,38 @@ import (
 )
 
 func TestImageSearchAnyError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	_, err = client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestImageSearchStatusUnauthorizedError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
-	}
-	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	assert.NilError(t, err)
+	_, err = client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
 }
 
 func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	assert.NilError(t, err)
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", errors.New("Error requesting privilege")
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
+	_, err = client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	assert.Check(t, is.Error(err, "Error requesting privilege"))
 }
 
 func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	assert.NilError(t, err)
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
 	}
-	_, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
+	_, err = client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
 		PrivilegeFunc: privilegeFunc,
 	})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
@@ -62,40 +58,39 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 
 func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 	expectedURL := "/images/search"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			auth := req.Header.Get(registry.AuthHeader)
-			if auth == "NotValid" {
-				return &http.Response{
-					StatusCode: http.StatusUnauthorized,
-					Body:       io.NopCloser(bytes.NewReader([]byte("Invalid credentials"))),
-				}, nil
-			}
-			if auth != "IAmValid" {
-				return nil, fmt.Errorf("invalid auth header: expected 'IAmValid', got %s", auth)
-			}
-			query := req.URL.Query()
-			term := query.Get("term")
-			if term != "some-image" {
-				return nil, fmt.Errorf("term not set in URL query properly. Expected 'some-image', got %s", term)
-			}
-			content, err := json.Marshal([]registry.SearchResult{
-				{
-					Name: "anything",
-				},
-			})
-			if err != nil {
-				return nil, err
-			}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		auth := req.Header.Get(registry.AuthHeader)
+		if auth == "NotValid" {
 			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader(content)),
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(bytes.NewReader([]byte("Invalid credentials"))),
 			}, nil
-		}),
-	}
+		}
+		if auth != "IAmValid" {
+			return nil, fmt.Errorf("invalid auth header: expected 'IAmValid', got %s", auth)
+		}
+		query := req.URL.Query()
+		term := query.Get("term")
+		if term != "some-image" {
+			return nil, fmt.Errorf("term not set in URL query properly. Expected 'some-image', got %s", term)
+		}
+		content, err := json.Marshal([]registry.SearchResult{
+			{
+				Name: "anything",
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(content)),
+		}, nil
+	}))
+	assert.NilError(t, err)
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "IAmValid", nil
 	}
@@ -111,34 +106,33 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 	const expectedURL = "/images/search"
 	const expectedFilters = `{"is-automated":{"true":true},"stars":{"3":true}}`
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			query := req.URL.Query()
-			term := query.Get("term")
-			if term != "some-image" {
-				return nil, fmt.Errorf("term not set in URL query properly. Expected 'some-image', got %s", term)
-			}
-			fltrs := query.Get("filters")
-			if fltrs != expectedFilters {
-				return nil, fmt.Errorf("filters not set in URL query properly. Expected '%s', got %s", expectedFilters, fltrs)
-			}
-			content, err := json.Marshal([]registry.SearchResult{
-				{
-					Name: "anything",
-				},
-			})
-			if err != nil {
-				return nil, err
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader(content)),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		query := req.URL.Query()
+		term := query.Get("term")
+		if term != "some-image" {
+			return nil, fmt.Errorf("term not set in URL query properly. Expected 'some-image', got %s", term)
+		}
+		fltrs := query.Get("filters")
+		if fltrs != expectedFilters {
+			return nil, fmt.Errorf("filters not set in URL query properly. Expected '%s', got %s", expectedFilters, fltrs)
+		}
+		content, err := json.Marshal([]registry.SearchResult{
+			{
+				Name: "anything",
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(content)),
+		}, nil
+	}))
+	assert.NilError(t, err)
 	results, err := client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("is-automated", "true"),

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -17,11 +17,10 @@ import (
 )
 
 func TestNetworkConnectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
+	err = client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	// Empty network ID or container ID
@@ -37,78 +36,76 @@ func TestNetworkConnectError(t *testing.T) {
 func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
 	expectedURL := "/networks/network_id/connect"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
 
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
 
-			var connect NetworkConnectOptions
-			if err := json.NewDecoder(req.Body).Decode(&connect); err != nil {
-				return nil, err
-			}
+		var connect NetworkConnectOptions
+		if err := json.NewDecoder(req.Body).Decode(&connect); err != nil {
+			return nil, err
+		}
 
-			if connect.Container != "container_id" {
-				return nil, fmt.Errorf("expected 'container_id', got %s", connect.Container)
-			}
+		if connect.Container != "container_id" {
+			return nil, fmt.Errorf("expected 'container_id', got %s", connect.Container)
+		}
 
-			if connect.EndpointConfig != nil {
-				return nil, fmt.Errorf("expected connect.EndpointConfig to be nil, got %v", connect.EndpointConfig)
-			}
+		if connect.EndpointConfig != nil {
+			return nil, fmt.Errorf("expected connect.EndpointConfig to be nil, got %v", connect.EndpointConfig)
+		}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
+	err = client.NetworkConnect(context.Background(), "network_id", "container_id", nil)
 	assert.NilError(t, err)
 }
 
 func TestNetworkConnect(t *testing.T) {
 	expectedURL := "/networks/network_id/connect"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
 
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
 
-			var connect NetworkConnectOptions
-			if err := json.NewDecoder(req.Body).Decode(&connect); err != nil {
-				return nil, err
-			}
+		var connect NetworkConnectOptions
+		if err := json.NewDecoder(req.Body).Decode(&connect); err != nil {
+			return nil, err
+		}
 
-			if connect.Container != "container_id" {
-				return nil, fmt.Errorf("expected 'container_id', got %s", connect.Container)
-			}
+		if connect.Container != "container_id" {
+			return nil, fmt.Errorf("expected 'container_id', got %s", connect.Container)
+		}
 
-			if connect.EndpointConfig == nil {
-				return nil, fmt.Errorf("expected connect.EndpointConfig to be not nil, got %v", connect.EndpointConfig)
-			}
+		if connect.EndpointConfig == nil {
+			return nil, fmt.Errorf("expected connect.EndpointConfig to be not nil, got %v", connect.EndpointConfig)
+		}
 
-			if connect.EndpointConfig.NetworkID != "NetworkID" {
-				return nil, fmt.Errorf("expected 'NetworkID', got %s", connect.EndpointConfig.NetworkID)
-			}
+		if connect.EndpointConfig.NetworkID != "NetworkID" {
+			return nil, fmt.Errorf("expected 'NetworkID', got %s", connect.EndpointConfig.NetworkID)
+		}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.NetworkConnect(context.Background(), "network_id", "container_id", &network.EndpointSettings{
+	err = client.NetworkConnect(context.Background(), "network_id", "container_id", &network.EndpointSettings{
 		NetworkID: "NetworkID",
 	})
 	assert.NilError(t, err)

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -17,11 +17,10 @@ import (
 )
 
 func TestNetworkCreateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, err := client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{})
+	_, err = client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -40,29 +39,28 @@ func TestNetworkCreateConnectionError(t *testing.T) {
 func TestNetworkCreate(t *testing.T) {
 	expectedURL := "/networks/create"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
 
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
 
-			content, err := json.Marshal(network.CreateResponse{
-				ID:      "network_id",
-				Warning: "warning",
-			})
-			if err != nil {
-				return nil, err
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader(content)),
-			}, nil
-		}),
-	}
+		content, err := json.Marshal(network.CreateResponse{
+			ID:      "network_id",
+			Warning: "warning",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(content)),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
 	enableIPv6 := true
 	networkResponse, err := client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -16,11 +16,10 @@ import (
 )
 
 func TestNetworkDisconnectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
+	err = client.NetworkDisconnect(context.Background(), "network_id", "container_id", false)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	// Empty network ID or container ID
@@ -36,36 +35,35 @@ func TestNetworkDisconnectError(t *testing.T) {
 func TestNetworkDisconnect(t *testing.T) {
 	expectedURL := "/networks/network_id/disconnect"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
 
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
 
-			var disconnect NetworkDisconnectOptions
-			if err := json.NewDecoder(req.Body).Decode(&disconnect); err != nil {
-				return nil, err
-			}
+		var disconnect NetworkDisconnectOptions
+		if err := json.NewDecoder(req.Body).Decode(&disconnect); err != nil {
+			return nil, err
+		}
 
-			if disconnect.Container != "container_id" {
-				return nil, fmt.Errorf("expected 'container_id', got %s", disconnect.Container)
-			}
+		if disconnect.Container != "container_id" {
+			return nil, fmt.Errorf("expected 'container_id', got %s", disconnect.Container)
+		}
 
-			if !disconnect.Force {
-				return nil, fmt.Errorf("expected Force to be true, got %v", disconnect.Force)
-			}
+		if !disconnect.Force {
+			return nil, fmt.Errorf("expected Force to be true, got %v", disconnect.Force)
+		}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.NetworkDisconnect(context.Background(), "network_id", "container_id", true)
+	err = client.NetworkDisconnect(context.Background(), "network_id", "container_id", true)
 	assert.NilError(t, err)
 }

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -18,12 +18,13 @@ import (
 )
 
 func TestNetworksPruneError(t *testing.T) {
-	client := &Client{
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-		version: "1.25",
-	}
+	client, err := NewClientWithOpts(
+		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
+		WithVersion("1.25"),
+	)
+	assert.NilError(t, err)
 
-	_, err := client.NetworksPrune(context.Background(), filters.NewArgs())
+	_, err = client.NetworksPrune(context.Background(), filters.NewArgs())
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -72,8 +73,8 @@ func TestNetworksPrune(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := NewClientWithOpts(
+			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(req.URL.Path, expectedURL) {
 					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
 				}
@@ -93,8 +94,9 @@ func TestNetworksPrune(t *testing.T) {
 					Body:       io.NopCloser(bytes.NewReader(content)),
 				}, nil
 			}),
-			version: "1.25",
-		}
+			WithVersion("1.25"),
+		)
+		assert.NilError(t, err)
 
 		report, err := client.NetworksPrune(context.Background(), listCase.filters)
 		assert.NilError(t, err)

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 func TestNodeRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.NodeRemove(context.Background(), "node_id", NodeRemoveOptions{Force: false})
+	err = client.NodeRemove(context.Background(), "node_id", NodeRemoveOptions{Force: false})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.NodeRemove(context.Background(), "", NodeRemoveOptions{Force: false})
@@ -48,27 +47,26 @@ func TestNodeRemove(t *testing.T) {
 	}
 
 	for _, removeCase := range removeCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-				}
-				if req.Method != http.MethodDelete {
-					return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
-				}
-				force := req.URL.Query().Get("force")
-				if force != removeCase.expectedForce {
-					return nil, fmt.Errorf("force not set in URL query properly. expected '%s', got %s", removeCase.expectedForce, force)
-				}
+		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			if req.Method != http.MethodDelete {
+				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+			}
+			force := req.URL.Query().Get("force")
+			if force != removeCase.expectedForce {
+				return nil, fmt.Errorf("force not set in URL query properly. expected '%s', got %s", removeCase.expectedForce, force)
+			}
 
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
-				}, nil
-			}),
-		}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
+			}, nil
+		}))
+		assert.NilError(t, err)
 
-		err := client.NodeRemove(context.Background(), "node_id", NodeRemoveOptions{Force: removeCase.force})
+		err = client.NodeRemove(context.Background(), "node_id", NodeRemoveOptions{Force: removeCase.force})
 		assert.NilError(t, err)
 	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -73,6 +73,11 @@ func WithHost(host string) Opt {
 		if transport, ok := c.client.Transport.(*http.Transport); ok {
 			return sockets.ConfigureTransport(transport, c.proto, c.addr)
 		}
+		// For test transports (like transportFunc), we skip transport configuration
+		// but still set the host fields so that the client can use them for headers
+		if _, ok := c.client.Transport.(transportFunc); ok {
+			return nil
+		}
 		return fmt.Errorf("cannot apply host to transport: %T", c.client.Transport)
 	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -16,8 +16,43 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+type clientConfig struct {
+	// scheme sets the scheme for the client
+	scheme string
+	// host holds the server address to connect to
+	host string
+	// proto holds the client protocol i.e. unix.
+	proto string
+	// addr holds the client address.
+	addr string
+	// basePath holds the path to prepend to the requests.
+	basePath string
+	// client used to send and receive http requests.
+	client *http.Client
+	// version of the server to talk to.
+	version string
+	// userAgent is the User-Agent header to use for HTTP requests. It takes
+	// precedence over User-Agent headers set in customHTTPHeaders, and other
+	// header variables. When set to an empty string, the User-Agent header
+	// is removed, and no header is sent.
+	userAgent *string
+	// custom HTTP headers configured by users.
+	customHTTPHeaders map[string]string
+	// manualOverride is set to true when the version was set by users.
+	manualOverride bool
+
+	// negotiateVersion indicates if the client should automatically negotiate
+	// the API version to use when making requests. API version negotiation is
+	// performed on the first request, after which negotiated is set to "true"
+	// so that subsequent requests do not re-negotiate.
+	negotiateVersion bool
+
+	// traceOpts is a list of options to configure the tracing span.
+	traceOpts []otelhttp.Option
+}
+
 // Opt is a configuration option to initialize a [Client].
-type Opt func(*Client) error
+type Opt func(*clientConfig) error
 
 // FromEnv configures the client with values from environment variables. It
 // is the equivalent of using the [WithTLSClientConfigFromEnv], [WithHostFromEnv],
@@ -32,7 +67,7 @@ type Opt func(*Client) error
 //     which to load the TLS certificates ("ca.pem", "cert.pem", "key.pem').
 //   - DOCKER_TLS_VERIFY ([EnvTLSVerify]) to enable or disable TLS verification
 //     (off by default).
-func FromEnv(c *Client) error {
+func FromEnv(c *clientConfig) error {
 	ops := []Opt{
 		WithTLSClientConfigFromEnv(),
 		WithHostFromEnv(),
@@ -50,7 +85,7 @@ func FromEnv(c *Client) error {
 // used to set the Timeout and KeepAlive settings of the client. It returns
 // an error if the client does not have a [http.Transport] configured.
 func WithDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		if transport, ok := c.client.Transport.(*http.Transport); ok {
 			transport.DialContext = dialContext
 			return nil
@@ -61,7 +96,7 @@ func WithDialContext(dialContext func(ctx context.Context, network, addr string)
 
 // WithHost overrides the client host with the specified one.
 func WithHost(host string) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		hostURL, err := ParseHostURL(host)
 		if err != nil {
 			return err
@@ -86,7 +121,7 @@ func WithHost(host string) Opt {
 // DOCKER_HOST ([EnvOverrideHost]) environment variable. If DOCKER_HOST is not set,
 // or set to an empty value, the host is not modified.
 func WithHostFromEnv() Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		if host := os.Getenv(EnvOverrideHost); host != "" {
 			return WithHost(host)(c)
 		}
@@ -96,7 +131,7 @@ func WithHostFromEnv() Opt {
 
 // WithHTTPClient overrides the client's HTTP client with the specified one.
 func WithHTTPClient(client *http.Client) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		if client != nil {
 			c.client = client
 		}
@@ -106,7 +141,7 @@ func WithHTTPClient(client *http.Client) Opt {
 
 // WithTimeout configures the time limit for requests made by the HTTP client.
 func WithTimeout(timeout time.Duration) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		c.client.Timeout = timeout
 		return nil
 	}
@@ -116,7 +151,7 @@ func WithTimeout(timeout time.Duration) Opt {
 // It overrides any User-Agent set in headers. When set to an empty string,
 // the User-Agent header is removed, and no header is sent.
 func WithUserAgent(ua string) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		c.userAgent = &ua
 		return nil
 	}
@@ -126,7 +161,7 @@ func WithUserAgent(ua string) Opt {
 // It does not allow for built-in headers (such as "User-Agent", if set) to
 // be overridden. Also see [WithUserAgent].
 func WithHTTPHeaders(headers map[string]string) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		c.customHTTPHeaders = headers
 		return nil
 	}
@@ -134,7 +169,7 @@ func WithHTTPHeaders(headers map[string]string) Opt {
 
 // WithScheme overrides the client scheme with the specified one.
 func WithScheme(scheme string) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		c.scheme = scheme
 		return nil
 	}
@@ -142,7 +177,7 @@ func WithScheme(scheme string) Opt {
 
 // WithTLSClientConfig applies a TLS config to the client transport.
 func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		transport, ok := c.client.Transport.(*http.Transport)
 		if !ok {
 			return fmt.Errorf("cannot apply tls config to transport: %T", c.client.Transport)
@@ -173,7 +208,7 @@ func WithTLSClientConfig(cacertPath, certPath, keyPath string) Opt {
 //   - DOCKER_TLS_VERIFY ([EnvTLSVerify]) to enable or disable TLS verification
 //     (off by default).
 func WithTLSClientConfigFromEnv() Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		dockerCertPath := os.Getenv(EnvOverrideCertPath)
 		if dockerCertPath == "" {
 			return nil
@@ -204,7 +239,7 @@ func WithTLSClientConfigFromEnv() Opt {
 // and callers should verify if the version is in the correct format and
 // lower than the maximum supported version as defined by [DefaultAPIVersion].
 func WithVersion(version string) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		if v := strings.TrimPrefix(version, "v"); v != "" {
 			c.version = v
 			c.manualOverride = true
@@ -222,7 +257,7 @@ func WithVersion(version string) Opt {
 // and callers should verify if the version is in the correct format and
 // lower than the maximum supported version as defined by [DefaultAPIVersion].
 func WithVersionFromEnv() Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		return WithVersion(os.Getenv(EnvOverrideAPIVersion))(c)
 	}
 }
@@ -232,7 +267,7 @@ func WithVersionFromEnv() Opt {
 // to use when making requests. API version negotiation is performed on the first
 // request; subsequent requests do not re-negotiate.
 func WithAPIVersionNegotiation() Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		c.negotiateVersion = true
 		return nil
 	}
@@ -246,7 +281,7 @@ func WithTraceProvider(provider trace.TracerProvider) Opt {
 
 // WithTraceOptions sets tracing span options for the client.
 func WithTraceOptions(opts ...otelhttp.Option) Opt {
-	return func(c *Client) error {
+	return func(c *clientConfig) error {
 		c.traceOpts = append(c.traceOpts, opts...)
 		return nil
 	}

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -66,10 +66,10 @@ func TestWithUserAgent(t *testing.T) {
 	t.Run("user-agent", func(t *testing.T) {
 		c, err := NewClientWithOpts(
 			WithUserAgent(userAgent),
-			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
+			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), userAgent))
 				return &http.Response{StatusCode: http.StatusOK}, nil
-			})),
+			}),
 		)
 		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
@@ -80,11 +80,11 @@ func TestWithUserAgent(t *testing.T) {
 		c, err := NewClientWithOpts(
 			WithUserAgent(userAgent),
 			WithHTTPHeaders(map[string]string{"User-Agent": "should-be-ignored/1.0.0", "Other-Header": "hello-world"}),
-			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
+			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), userAgent))
 				assert.Check(t, is.Equal(req.Header.Get("Other-Header"), "hello-world"))
 				return &http.Response{StatusCode: http.StatusOK}, nil
-			})),
+			}),
 		)
 		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
@@ -94,11 +94,11 @@ func TestWithUserAgent(t *testing.T) {
 	t.Run("custom headers", func(t *testing.T) {
 		c, err := NewClientWithOpts(
 			WithHTTPHeaders(map[string]string{"User-Agent": "from-custom-headers/1.0.0", "Other-Header": "hello-world"}),
-			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
+			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), "from-custom-headers/1.0.0"))
 				assert.Check(t, is.Equal(req.Header.Get("Other-Header"), "hello-world"))
 				return &http.Response{StatusCode: http.StatusOK}, nil
-			})),
+			}),
 		)
 		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
@@ -108,11 +108,11 @@ func TestWithUserAgent(t *testing.T) {
 	t.Run("no user-agent set", func(t *testing.T) {
 		c, err := NewClientWithOpts(
 			WithHTTPHeaders(map[string]string{"Other-Header": "hello-world"}),
-			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
+			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), ""))
 				assert.Check(t, is.Equal(req.Header.Get("Other-Header"), "hello-world"))
 				return &http.Response{StatusCode: http.StatusOK}, nil
-			})),
+			}),
 		)
 		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())
@@ -123,11 +123,11 @@ func TestWithUserAgent(t *testing.T) {
 		c, err := NewClientWithOpts(
 			WithUserAgent(""),
 			WithHTTPHeaders(map[string]string{"User-Agent": "from-custom-headers/1.0.0", "Other-Header": "hello-world"}),
-			WithHTTPClient(newMockClient(func(req *http.Request) (*http.Response, error) {
+			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), ""))
 				assert.Check(t, is.Equal(req.Header.Get("Other-Header"), "hello-world"))
 				return &http.Response{StatusCode: http.StatusOK}, nil
-			})),
+			}),
 		)
 		assert.NilError(t, err)
 		_, err = c.Ping(context.Background())

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 func TestPluginDisableError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.PluginDisable(context.Background(), "plugin_name", PluginDisableOptions{})
+	err = client.PluginDisable(context.Background(), "plugin_name", PluginDisableOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.PluginDisable(context.Background(), "", PluginDisableOptions{})
@@ -34,21 +33,20 @@ func TestPluginDisableError(t *testing.T) {
 func TestPluginDisable(t *testing.T) {
 	expectedURL := "/plugins/plugin_name/disable"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.PluginDisable(context.Background(), "plugin_name", PluginDisableOptions{})
+	err = client.PluginDisable(context.Background(), "plugin_name", PluginDisableOptions{})
 	assert.NilError(t, err)
 }

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -18,11 +18,10 @@ import (
 )
 
 func TestPluginListError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, err := client.PluginList(context.Background(), filters.NewArgs())
+	_, err = client.PluginList(context.Background(), filters.NewArgs())
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -63,35 +62,34 @@ func TestPluginList(t *testing.T) {
 	}
 
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			query := req.URL.Query()
+			for key, expected := range listCase.expectedQueryParams {
+				actual := query.Get(key)
+				if actual != expected {
+					return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
 				}
-				query := req.URL.Query()
-				for key, expected := range listCase.expectedQueryParams {
-					actual := query.Get(key)
-					if actual != expected {
-						return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
-					}
-				}
-				content, err := json.Marshal([]*plugin.Plugin{
-					{
-						ID: "plugin_id1",
-					},
-					{
-						ID: "plugin_id2",
-					},
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(content)),
-				}, nil
-			}),
-		}
+			}
+			content, err := json.Marshal([]*plugin.Plugin{
+				{
+					ID: "plugin_id1",
+				},
+				{
+					ID: "plugin_id2",
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}))
+		assert.NilError(t, err)
 
 		plugins, err := client.PluginList(context.Background(), listCase.filters)
 		assert.NilError(t, err)

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -16,11 +16,10 @@ import (
 )
 
 func TestPluginPushError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, err := client.PluginPush(context.Background(), "plugin_name", "")
+	_, err = client.PluginPush(context.Background(), "plugin_name", "")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	_, err = client.PluginPush(context.Background(), "", "")
@@ -35,25 +34,24 @@ func TestPluginPushError(t *testing.T) {
 func TestPluginPush(t *testing.T) {
 	expectedURL := "/plugins/plugin_name"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
-			auth := req.Header.Get(registry.AuthHeader)
-			if auth != "authtoken" {
-				return nil, fmt.Errorf("invalid auth header: expected 'authtoken', got %s", auth)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		auth := req.Header.Get(registry.AuthHeader)
+		if auth != "authtoken" {
+			return nil, fmt.Errorf("invalid auth header: expected 'authtoken', got %s", auth)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	_, err := client.PluginPush(context.Background(), "plugin_name", "authtoken")
+	_, err = client.PluginPush(context.Background(), "plugin_name", "authtoken")
 	assert.NilError(t, err)
 }

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -17,46 +17,40 @@ import (
 )
 
 func TestSecretCreateUnsupported(t *testing.T) {
-	client := &Client{
-		version: "1.24",
-		client:  &http.Client{},
-	}
-	_, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
+	client, err := NewClientWithOpts(WithVersion("1.24"), WithHTTPClient(&http.Client{}))
+	assert.NilError(t, err)
+	_, err = client.SecretCreate(context.Background(), swarm.SecretSpec{})
 	assert.Check(t, is.Error(err, `"secret create" requires API version 1.25, but the Docker daemon API version is 1.24`))
 }
 
 func TestSecretCreateError(t *testing.T) {
-	client := &Client{
-		version: "1.25",
-		client:  newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
+	client, err := NewClientWithOpts(WithVersion("1.25"), WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	_, err = client.SecretCreate(context.Background(), swarm.SecretSpec{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestSecretCreate(t *testing.T) {
 	expectedURL := "/v1.25/secrets/create"
-	client := &Client{
-		version: "1.25",
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
-			b, err := json.Marshal(swarm.SecretCreateResponse{
-				ID: "test_secret",
-			})
-			if err != nil {
-				return nil, err
-			}
-			return &http.Response{
-				StatusCode: http.StatusCreated,
-				Body:       io.NopCloser(bytes.NewReader(b)),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithVersion("1.25"), WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		b, err := json.Marshal(swarm.SecretCreateResponse{
+			ID: "test_secret",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(bytes.NewReader(b)),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
 	r, err := client.SecretCreate(context.Background(), swarm.SecretSpec{})
 	assert.NilError(t, err)

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -21,10 +21,9 @@ import (
 )
 
 func TestServiceCreateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, ServiceCreateOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	_, err = client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, ServiceCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -42,16 +41,48 @@ func TestServiceCreateConnectionError(t *testing.T) {
 
 func TestServiceCreate(t *testing.T) {
 	expectedURL := "/services/create"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		b, err := json.Marshal(swarm.ServiceCreateResponse{
+			ID: "service_id",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(b)),
+		}, nil
+	}))
+	assert.NilError(t, err)
+
+	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, ServiceCreateOptions{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(r.ID, "service_id"))
+}
+
+func TestServiceCreateCompatiblePlatforms(t *testing.T) {
+	client, err := NewClientWithOpts(WithVersion("1.30"), WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if strings.HasPrefix(req.URL.Path, "/v1.30/services/create") {
+			var serviceSpec swarm.ServiceSpec
+
+			// check if the /distribution endpoint returned correct output
+			err := json.NewDecoder(req.Body).Decode(&serviceSpec)
+			if err != nil {
+				return nil, err
 			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
+
+			assert.Check(t, is.Equal("foobar:1.0@sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96", serviceSpec.TaskTemplate.ContainerSpec.Image))
+			assert.Check(t, is.Len(serviceSpec.TaskTemplate.Placement.Platforms, 1))
+
+			p := serviceSpec.TaskTemplate.Placement.Platforms[0]
 			b, err := json.Marshal(swarm.ServiceCreateResponse{
-				ID: "service_id",
+				ID: "service_" + p.OS + "_" + p.Architecture,
 			})
 			if err != nil {
 				return nil, err
@@ -60,65 +91,30 @@ func TestServiceCreate(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
-		}),
-	}
-
-	r, err := client.ServiceCreate(context.Background(), swarm.ServiceSpec{}, ServiceCreateOptions{})
-	assert.NilError(t, err)
-	assert.Check(t, is.Equal(r.ID, "service_id"))
-}
-
-func TestServiceCreateCompatiblePlatforms(t *testing.T) {
-	client := &Client{
-		version: "1.30",
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if strings.HasPrefix(req.URL.Path, "/v1.30/services/create") {
-				var serviceSpec swarm.ServiceSpec
-
-				// check if the /distribution endpoint returned correct output
-				err := json.NewDecoder(req.Body).Decode(&serviceSpec)
-				if err != nil {
-					return nil, err
-				}
-
-				assert.Check(t, is.Equal("foobar:1.0@sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96", serviceSpec.TaskTemplate.ContainerSpec.Image))
-				assert.Check(t, is.Len(serviceSpec.TaskTemplate.Placement.Platforms, 1))
-
-				p := serviceSpec.TaskTemplate.Placement.Platforms[0]
-				b, err := json.Marshal(swarm.ServiceCreateResponse{
-					ID: "service_" + p.OS + "_" + p.Architecture,
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(b)),
-				}, nil
-			} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/") {
-				b, err := json.Marshal(registrytypes.DistributionInspect{
-					Descriptor: ocispec.Descriptor{
-						Digest: "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96",
+		} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/") {
+			b, err := json.Marshal(registrytypes.DistributionInspect{
+				Descriptor: ocispec.Descriptor{
+					Digest: "sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96",
+				},
+				Platforms: []ocispec.Platform{
+					{
+						Architecture: "amd64",
+						OS:           "linux",
 					},
-					Platforms: []ocispec.Platform{
-						{
-							Architecture: "amd64",
-							OS:           "linux",
-						},
-					},
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(b)),
-				}, nil
-			} else {
-				return nil, fmt.Errorf("unexpected URL '%s'", req.URL.Path)
+				},
+			})
+			if err != nil {
+				return nil, err
 			}
-		}),
-	}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		} else {
+			return nil, fmt.Errorf("unexpected URL '%s'", req.URL.Path)
+		}
+	}))
+	assert.NilError(t, err)
 
 	spec := swarm.ServiceSpec{TaskTemplate: swarm.TaskSpec{ContainerSpec: &swarm.ContainerSpec{Image: "foobar:1.0"}}}
 
@@ -149,49 +145,47 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 		{"cannotresolve", "cannotresolve:latest"},
 	}
 
-	client := &Client{
-		version: "1.30",
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if strings.HasPrefix(req.URL.Path, "/v1.30/services/create") {
-				// reset and set image received by the service create endpoint
-				serviceCreateImage = ""
-				var service swarm.ServiceSpec
-				if err := json.NewDecoder(req.Body).Decode(&service); err != nil {
-					return nil, errors.New("could not parse service create request")
-				}
-				serviceCreateImage = service.TaskTemplate.ContainerSpec.Image
-
-				b, err := json.Marshal(swarm.ServiceCreateResponse{
-					ID: "service_id",
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(b)),
-				}, nil
-			} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/cannotresolve") {
-				// unresolvable image
-				return nil, errors.New("cannot resolve image")
-			} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/") {
-				// resolvable images
-				b, err := json.Marshal(registrytypes.DistributionInspect{
-					Descriptor: ocispec.Descriptor{
-						Digest: digest.Digest(dgst),
-					},
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(b)),
-				}, nil
+	client, err := NewClientWithOpts(WithVersion("1.30"), WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if strings.HasPrefix(req.URL.Path, "/v1.30/services/create") {
+			// reset and set image received by the service create endpoint
+			serviceCreateImage = ""
+			var service swarm.ServiceSpec
+			if err := json.NewDecoder(req.Body).Decode(&service); err != nil {
+				return nil, errors.New("could not parse service create request")
 			}
-			return nil, fmt.Errorf("unexpected URL '%s'", req.URL.Path)
-		}),
-	}
+			serviceCreateImage = service.TaskTemplate.ContainerSpec.Image
+
+			b, err := json.Marshal(swarm.ServiceCreateResponse{
+				ID: "service_id",
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/cannotresolve") {
+			// unresolvable image
+			return nil, errors.New("cannot resolve image")
+		} else if strings.HasPrefix(req.URL.Path, "/v1.30/distribution/") {
+			// resolvable images
+			b, err := json.Marshal(registrytypes.DistributionInspect{
+				Descriptor: ocispec.Descriptor{
+					Digest: digest.Digest(dgst),
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		return nil, fmt.Errorf("unexpected URL '%s'", req.URL.Path)
+	}))
+	assert.NilError(t, err)
 
 	// run pin by digest tests
 	for _, p := range pinByDigestTests {

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -18,11 +18,10 @@ import (
 )
 
 func TestServiceListError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, err := client.ServiceList(context.Background(), ServiceListOptions{})
+	_, err = client.ServiceList(context.Background(), ServiceListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -52,35 +51,34 @@ func TestServiceList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			query := req.URL.Query()
+			for key, expected := range listCase.expectedQueryParams {
+				actual := query.Get(key)
+				if actual != expected {
+					return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
 				}
-				query := req.URL.Query()
-				for key, expected := range listCase.expectedQueryParams {
-					actual := query.Get(key)
-					if actual != expected {
-						return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
-					}
-				}
-				content, err := json.Marshal([]swarm.Service{
-					{
-						ID: "service_id1",
-					},
-					{
-						ID: "service_id2",
-					},
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(content)),
-				}, nil
-			}),
-		}
+			}
+			content, err := json.Marshal([]swarm.Service{
+				{
+					ID: "service_id1",
+				},
+				{
+					ID: "service_id2",
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}))
+		assert.NilError(t, err)
 
 		services, err := client.ServiceList(context.Background(), listCase.options)
 		assert.NilError(t, err)

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 func TestServiceRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.ServiceRemove(context.Background(), "service_id")
+	err = client.ServiceRemove(context.Background(), "service_id")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.ServiceRemove(context.Background(), "")
@@ -32,11 +31,10 @@ func TestServiceRemoveError(t *testing.T) {
 }
 
 func TestServiceRemoveNotFoundError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusNotFound, "no such service: service_id")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "no such service: service_id")))
+	assert.NilError(t, err)
 
-	err := client.ServiceRemove(context.Background(), "service_id")
+	err = client.ServiceRemove(context.Background(), "service_id")
 	assert.Check(t, is.ErrorContains(err, "no such service: service_id"))
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }
@@ -44,21 +42,20 @@ func TestServiceRemoveNotFoundError(t *testing.T) {
 func TestServiceRemove(t *testing.T) {
 	expectedURL := "/services/service_id"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodDelete {
-				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodDelete {
+			return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.ServiceRemove(context.Background(), "service_id")
+	err = client.ServiceRemove(context.Background(), "service_id")
 	assert.NilError(t, err)
 }

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -16,31 +16,29 @@ import (
 )
 
 func TestSwarmInitError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, err := client.SwarmInit(context.Background(), swarm.InitRequest{})
+	_, err = client.SwarmInit(context.Background(), swarm.InitRequest{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestSwarmInit(t *testing.T) {
 	expectedURL := "/swarm/init"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(`"body"`))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`"body"`))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
 	resp, err := client.SwarmInit(context.Background(), swarm.InitRequest{
 		ListenAddr: "0.0.0.0:2377",

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -16,33 +16,31 @@ import (
 )
 
 func TestSwarmJoinError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{})
+	err = client.SwarmJoin(context.Background(), swarm.JoinRequest{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestSwarmJoin(t *testing.T) {
 	expectedURL := "/swarm/join"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.SwarmJoin(context.Background(), swarm.JoinRequest{
+	err = client.SwarmJoin(context.Background(), swarm.JoinRequest{
 		ListenAddr: "0.0.0.0:2377",
 	})
 	assert.NilError(t, err)

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -16,32 +16,30 @@ import (
 )
 
 func TestSwarmUnlockError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
+	err = client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestSwarmUnlock(t *testing.T) {
 	expectedURL := "/swarm/unlock"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
+	err = client.SwarmUnlock(context.Background(), swarm.UnlockRequest{UnlockKey: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
 	assert.NilError(t, err)
 }

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -16,32 +16,30 @@ import (
 )
 
 func TestSwarmUpdateError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, SwarmUpdateFlags{})
+	err = client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, SwarmUpdateFlags{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestSwarmUpdate(t *testing.T) {
 	expectedURL := "/swarm/update"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(""))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodPost {
+			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, SwarmUpdateFlags{})
+	err = client.SwarmUpdate(context.Background(), swarm.Version{}, swarm.Spec{}, SwarmUpdateFlags{})
 	assert.NilError(t, err)
 }

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -17,39 +17,37 @@ import (
 )
 
 func TestDiskUsageError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
-	_, err := client.DiskUsage(context.Background(), DiskUsageOptions{})
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
+	_, err = client.DiskUsage(context.Background(), DiskUsageOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestDiskUsage(t *testing.T) {
 	expectedURL := "/system/df"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
 
-			du := system.DiskUsage{
-				LayersSize: int64(100),
-				Images:     nil,
-				Containers: nil,
-				Volumes:    nil,
-			}
+		du := system.DiskUsage{
+			LayersSize: int64(100),
+			Images:     nil,
+			Containers: nil,
+			Volumes:    nil,
+		}
 
-			b, err := json.Marshal(du)
-			if err != nil {
-				return nil, err
-			}
+		b, err := json.Marshal(du)
+		if err != nil {
+			return nil, err
+		}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader(b)),
-			}, nil
-		}),
-	}
-	_, err := client.DiskUsage(context.Background(), DiskUsageOptions{})
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(b)),
+		}, nil
+	}))
+	assert.NilError(t, err)
+	_, err = client.DiskUsage(context.Background(), DiskUsageOptions{})
 	assert.NilError(t, err)
 }

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -18,21 +18,19 @@ import (
 )
 
 func TestTaskInspectError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, _, err := client.TaskInspectWithRaw(context.Background(), "nothing")
+	_, _, err = client.TaskInspectWithRaw(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestTaskInspectWithEmptyID(t *testing.T) {
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			return nil, errors.New("should not make request")
-		}),
-	}
-	_, _, err := client.TaskInspectWithRaw(context.Background(), "")
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("should not make request")
+	}))
+	assert.NilError(t, err)
+	_, _, err = client.TaskInspectWithRaw(context.Background(), "")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
@@ -43,23 +41,22 @@ func TestTaskInspectWithEmptyID(t *testing.T) {
 
 func TestTaskInspect(t *testing.T) {
 	expectedURL := "/tasks/task_id"
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			content, err := json.Marshal(swarm.Task{
-				ID: "task_id",
-			})
-			if err != nil {
-				return nil, err
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader(content)),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		content, err := json.Marshal(swarm.Task{
+			ID: "task_id",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(content)),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
 	taskInspect, _, err := client.TaskInspectWithRaw(context.Background(), "task_id")
 	assert.NilError(t, err)

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -18,11 +18,10 @@ import (
 )
 
 func TestTaskListError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	_, err := client.TaskList(context.Background(), TaskListOptions{})
+	_, err = client.TaskList(context.Background(), TaskListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -52,35 +51,34 @@ func TestTaskList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client := &Client{
-			client: newMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if !strings.HasPrefix(req.URL.Path, expectedURL) {
+				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			}
+			query := req.URL.Query()
+			for key, expected := range listCase.expectedQueryParams {
+				actual := query.Get(key)
+				if actual != expected {
+					return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
 				}
-				query := req.URL.Query()
-				for key, expected := range listCase.expectedQueryParams {
-					actual := query.Get(key)
-					if actual != expected {
-						return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
-					}
-				}
-				content, err := json.Marshal([]swarm.Task{
-					{
-						ID: "task_id1",
-					},
-					{
-						ID: "task_id2",
-					},
-				})
-				if err != nil {
-					return nil, err
-				}
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader(content)),
-				}, nil
-			}),
-		}
+			}
+			content, err := json.Marshal([]swarm.Task{
+				{
+					ID: "task_id1",
+				},
+				{
+					ID: "task_id2",
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(content)),
+			}, nil
+		}))
+		assert.NilError(t, err)
 
 		tasks, err := client.TaskList(context.Background(), listCase.options)
 		assert.NilError(t, err)

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -15,11 +15,10 @@ import (
 )
 
 func TestVolumeRemoveError(t *testing.T) {
-	client := &Client{
-		client: newMockClient(errorMock(http.StatusInternalServerError, "Server error")),
-	}
+	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	assert.NilError(t, err)
 
-	err := client.VolumeRemove(context.Background(), "volume_id", false)
+	err = client.VolumeRemove(context.Background(), "volume_id", false)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
 	err = client.VolumeRemove(context.Background(), "", false)
@@ -46,21 +45,20 @@ func TestVolumeRemoveConnectionError(t *testing.T) {
 func TestVolumeRemove(t *testing.T) {
 	expectedURL := "/volumes/volume_id"
 
-	client := &Client{
-		client: newMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodDelete {
-				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
-			}
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
-			}, nil
-		}),
-	}
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		if !strings.HasPrefix(req.URL.Path, expectedURL) {
+			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		}
+		if req.Method != http.MethodDelete {
+			return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
+		}, nil
+	}))
+	assert.NilError(t, err)
 
-	err := client.VolumeRemove(context.Background(), "volume_id", false)
+	err = client.VolumeRemove(context.Background(), "volume_id", false)
 	assert.NilError(t, err)
 }


### PR DESCRIPTION
- Add `WithMockClient` for the unit tests the create a client with mocked http transport (instead of creating the `Client` struct directly and messing with internal fields)
- Refactor all unit tests to use functional opts
- Change `client.Opt` to mutate an internal config field instead of the whole `Client` instance


**- How to verify it**

CI
