### PR TITLE
api/t/ctr: deprecate NetworkSettingsBase, DefaultNetworkSettings

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -30,6 +30,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /images/json` now sets the value of `Containers` field for all images
   to the count of containers using the image.
   This field was previously always -1.
+* Deprecated: The field `NetworkSettings.Bridge` returned by `GET /containers/{id}/json`
+  is deprecated and will be removed in the next API version.
 
 ## v1.50 API changes
 

--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -986,9 +986,10 @@ are not part of the underlying image's Config, and deprecated:
 * `GET /containers/(name)/json` now accepts a `size` parameter. Setting this parameter to '1' returns container size information in the `SizeRw` and `SizeRootFs` fields.
 * `GET /containers/(name)/json` now returns a `NetworkSettings.Networks` field,
   detailing network settings per network. This field deprecates the
-  `NetworkSettings.Gateway`, `NetworkSettings.IPAddress`,
-  `NetworkSettings.IPPrefixLen`, and `NetworkSettings.MacAddress` fields, which
-  are still returned for backward-compatibility, but will be removed in a future version.
+  `NetworkSettings.EndpointID`, `NetworkSettings.Gateway`, `NetworkSettings.GlobalIPv6Address`,
+  `NetworkSettings.GlobalIPv6PrefixLen` `NetworkSettings.IPAddress`, `NetworkSettings.IPPrefixLen`,
+  `NetworkSettings.IPv6Gateway`, `NetworkSettings.MacAddress` fields, which are
+  still returned for backward-compatibility, but will be removed in a future version.
 * `GET /exec/(id)/json` now returns a `NetworkSettings.Networks` field,
   detailing networksettings per network. This field deprecates the
   `NetworkSettings.Gateway`, `NetworkSettings.IPAddress`,

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -1608,6 +1608,8 @@ definitions:
       Bridge:
         description: |
           Name of the default bridge interface when dockerd's --bridge flag is set.
+
+          Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
         type: "string"
         example: "docker0"
       SandboxID:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1620,6 +1620,8 @@ definitions:
       Bridge:
         description: |
           Name of the default bridge interface when dockerd's --bridge flag is set.
+
+          Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
         type: "string"
         example: "docker0"
       SandboxID:

--- a/api/types/container/network_settings.go
+++ b/api/types/container/network_settings.go
@@ -12,6 +12,9 @@ type NetworkSettings struct {
 }
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
+//
+// Deprecated: Most fields in NetworkSettingsBase are deprecated. Fields which aren't deprecated will move to
+// NetworkSettings in v29.0, and this struct will be removed.
 type NetworkSettingsBase struct {
 	Bridge     string  // Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
 	SandboxID  string  // SandboxID uniquely represents a container's network stack

--- a/api/types/container/network_settings.go
+++ b/api/types/container/network_settings.go
@@ -13,7 +13,7 @@ type NetworkSettings struct {
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
 type NetworkSettingsBase struct {
-	Bridge     string  // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
+	Bridge     string  // Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
 	SandboxID  string  // SandboxID uniquely represents a container's network stack
 	SandboxKey string  // SandboxKey identifies the sandbox
 	Ports      PortMap // Ports is a collection of PortBinding indexed by Port

--- a/api/types/container/network_settings.go
+++ b/api/types/container/network_settings.go
@@ -37,18 +37,44 @@ type NetworkSettingsBase struct {
 	SecondaryIPv6Addresses []network.Address // Deprecated: This field is never set and will be removed in a future release.
 }
 
-// DefaultNetworkSettings holds network information
-// during the 2 release deprecation period.
-// It will be removed in Docker 1.11.
+// DefaultNetworkSettings holds the networking state for the default bridge, if the container is connected to that
+// network.
+//
+// Deprecated: this struct is deprecated since Docker v1.11 and will be removed in v29. You should look for the default
+// network in NetworkSettings.Networks instead.
 type DefaultNetworkSettings struct {
-	EndpointID          string // EndpointID uniquely represents a service endpoint in a Sandbox
-	Gateway             string // Gateway holds the gateway address for the network
-	GlobalIPv6Address   string // GlobalIPv6Address holds network's global IPv6 address
-	GlobalIPv6PrefixLen int    // GlobalIPv6PrefixLen represents mask length of network's global IPv6 address
-	IPAddress           string // IPAddress holds the IPv4 address for the network
-	IPPrefixLen         int    // IPPrefixLen represents mask length of network's IPv4 address
-	IPv6Gateway         string // IPv6Gateway holds gateway address specific for IPv6
-	MacAddress          string // MacAddress holds the MAC address for the network
+	// EndpointID uniquely represents a service endpoint in a Sandbox
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	EndpointID string
+	// Gateway holds the gateway address for the network
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	Gateway string
+	// GlobalIPv6Address holds network's global IPv6 address
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	GlobalIPv6Address string
+	// GlobalIPv6PrefixLen represents mask length of network's global IPv6 address
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	GlobalIPv6PrefixLen int
+	// IPAddress holds the IPv4 address for the network
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	IPAddress string
+	// IPPrefixLen represents mask length of network's IPv4 address
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	IPPrefixLen int
+	// IPv6Gateway holds gateway address specific for IPv6
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	IPv6Gateway string
+	// MacAddress holds the MAC address for the network
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	MacAddress string
 }
 
 // NetworkSettingsSummary provides a summary of container's networks

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -242,13 +242,13 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, err
 
 // getDefaultNetworkSettings creates the deprecated structure that holds the information
 // about the bridge network for a container.
-func getDefaultNetworkSettings(networks map[string]*network.EndpointSettings) containertypes.DefaultNetworkSettings {
+func getDefaultNetworkSettings(networks map[string]*network.EndpointSettings) containertypes.DefaultNetworkSettings { //nolint:staticcheck // ignore SA1019: DefaultNetworkSettings is deprecated in v28.4.
 	nw, ok := networks[networktypes.NetworkBridge]
 	if !ok || nw.EndpointSettings == nil {
-		return containertypes.DefaultNetworkSettings{}
+		return containertypes.DefaultNetworkSettings{} //nolint:staticcheck // ignore SA1019: DefaultNetworkSettings is deprecated in v28.4.
 	}
 
-	return containertypes.DefaultNetworkSettings{
+	return containertypes.DefaultNetworkSettings{ //nolint:staticcheck // ignore SA1019: DefaultNetworkSettings is deprecated in v28.4.
 		EndpointID:          nw.EndpointSettings.EndpointID,
 		Gateway:             nw.EndpointSettings.Gateway,
 		GlobalIPv6Address:   nw.EndpointSettings.GlobalIPv6Address,

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -49,7 +49,7 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 	}
 
 	networkSettings := &containertypes.NetworkSettings{
-		NetworkSettingsBase: containertypes.NetworkSettingsBase{
+		NetworkSettingsBase: containertypes.NetworkSettingsBase{ //nolint:staticcheck // ignore SA1019: NetworkSettingsBase is deprecated in v28.4.
 			Bridge:                 ctr.NetworkSettings.Bridge,
 			SandboxID:              ctr.NetworkSettings.SandboxID,
 			SandboxKey:             ctr.NetworkSettings.SandboxKey,

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -103,7 +103,6 @@ func (s *DockerAPISuite) TestInspectAPIBridgeNetworkSettings121(c *testing.T) {
 	assert.NilError(c, err)
 
 	settings := inspectJSON.NetworkSettings
-	assert.Assert(c, settings.IPAddress != "")
 	assert.Assert(c, settings.Networks["bridge"] != nil)
-	assert.Equal(c, settings.IPAddress, settings.Networks["bridge"].IPAddress)
+	assert.Assert(c, settings.Networks["bridge"].IPAddress != "")
 }

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1045,9 +1045,6 @@ func (s *DockerCLINetworkSuite) TestInspectAPIMultipleNetworks(c *testing.T) {
 	err := json.Unmarshal(body, &inspectCurrent)
 	assert.NilError(c, err)
 	assert.Equal(c, len(inspectCurrent.NetworkSettings.Networks), 3)
-
-	bridge := inspectCurrent.NetworkSettings.Networks["bridge"]
-	assert.Equal(c, bridge.IPAddress, inspectCurrent.NetworkSettings.IPAddress)
 }
 
 func connectContainerToNetworks(t *testing.T, d *daemon.Daemon, cName string, nws []string) {

--- a/integration/networking/etchosts_test.go
+++ b/integration/networking/etchosts_test.go
@@ -97,9 +97,10 @@ ff02::2	ip6-allrouters
 			stdout := runCmd(ctrId, []string{"cat", "/etc/hosts"}, 0)
 			// Append the container's own addresses/name to the expected hosts file content.
 			inspect := container.Inspect(ctx, t, c, ctrId)
-			exp := tc.expEtcHosts + inspect.NetworkSettings.IPAddress + "\t" + inspect.Config.Hostname + "\n"
+			bridgeEp := inspect.NetworkSettings.Networks["bridge"]
+			exp := tc.expEtcHosts + bridgeEp.IPAddress + "\t" + inspect.Config.Hostname + "\n"
 			if tc.expIPv6Enabled {
-				exp += inspect.NetworkSettings.GlobalIPv6Address + "\t" + inspect.Config.Hostname + "\n"
+				exp += bridgeEp.GlobalIPv6Address + "\t" + inspect.Config.Hostname + "\n"
 			}
 			assert.Check(t, is.Equal(stdout, exp))
 		})

--- a/testutil/daemon/container.go
+++ b/testutil/daemon/container.go
@@ -23,14 +23,3 @@ func (d *Daemon) ActiveContainers(ctx context.Context, t testing.TB) []string {
 	}
 	return ids
 }
-
-// FindContainerIP returns the ip of the specified container
-func (d *Daemon) FindContainerIP(t testing.TB, id string) string {
-	t.Helper()
-	cli := d.NewClientT(t)
-	defer cli.Close()
-
-	i, err := cli.ContainerInspect(context.Background(), id)
-	assert.NilError(t, err)
-	return i.NetworkSettings.IPAddress
-}

--- a/vendor/github.com/moby/moby/api/swagger.yaml
+++ b/vendor/github.com/moby/moby/api/swagger.yaml
@@ -1620,6 +1620,8 @@ definitions:
       Bridge:
         description: |
           Name of the default bridge interface when dockerd's --bridge flag is set.
+
+          Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
         type: "string"
         example: "docker0"
       SandboxID:

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -12,6 +12,9 @@ type NetworkSettings struct {
 }
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
+//
+// Deprecated: Most fields in NetworkSettingsBase are deprecated. Fields which aren't deprecated will move to
+// NetworkSettings in v29.0, and this struct will be removed.
 type NetworkSettingsBase struct {
 	Bridge     string  // Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
 	SandboxID  string  // SandboxID uniquely represents a container's network stack

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -13,7 +13,7 @@ type NetworkSettings struct {
 
 // NetworkSettingsBase holds networking state for a container when inspecting it.
 type NetworkSettingsBase struct {
-	Bridge     string  // Bridge contains the name of the default bridge interface iff it was set through the daemon --bridge flag.
+	Bridge     string  // Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
 	SandboxID  string  // SandboxID uniquely represents a container's network stack
 	SandboxKey string  // SandboxKey identifies the sandbox
 	Ports      PortMap // Ports is a collection of PortBinding indexed by Port

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -37,18 +37,44 @@ type NetworkSettingsBase struct {
 	SecondaryIPv6Addresses []network.Address // Deprecated: This field is never set and will be removed in a future release.
 }
 
-// DefaultNetworkSettings holds network information
-// during the 2 release deprecation period.
-// It will be removed in Docker 1.11.
+// DefaultNetworkSettings holds the networking state for the default bridge, if the container is connected to that
+// network.
+//
+// Deprecated: this struct is deprecated since Docker v1.11 and will be removed in v29. You should look for the default
+// network in NetworkSettings.Networks instead.
 type DefaultNetworkSettings struct {
-	EndpointID          string // EndpointID uniquely represents a service endpoint in a Sandbox
-	Gateway             string // Gateway holds the gateway address for the network
-	GlobalIPv6Address   string // GlobalIPv6Address holds network's global IPv6 address
-	GlobalIPv6PrefixLen int    // GlobalIPv6PrefixLen represents mask length of network's global IPv6 address
-	IPAddress           string // IPAddress holds the IPv4 address for the network
-	IPPrefixLen         int    // IPPrefixLen represents mask length of network's IPv4 address
-	IPv6Gateway         string // IPv6Gateway holds gateway address specific for IPv6
-	MacAddress          string // MacAddress holds the MAC address for the network
+	// EndpointID uniquely represents a service endpoint in a Sandbox
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	EndpointID string
+	// Gateway holds the gateway address for the network
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	Gateway string
+	// GlobalIPv6Address holds network's global IPv6 address
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	GlobalIPv6Address string
+	// GlobalIPv6PrefixLen represents mask length of network's global IPv6 address
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	GlobalIPv6PrefixLen int
+	// IPAddress holds the IPv4 address for the network
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	IPAddress string
+	// IPPrefixLen represents mask length of network's IPv4 address
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	IPPrefixLen int
+	// IPv6Gateway holds gateway address specific for IPv6
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	IPv6Gateway string
+	// MacAddress holds the MAC address for the network
+	//
+	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
+	MacAddress string
 }
 
 // NetworkSettingsSummary provides a summary of container's networks


### PR DESCRIPTION
- Supersedes https://github.com/moby/moby/pull/45945

**- What I did**

**api/t/ctr: deprecate NetworkSettingsBase.Bridge**

This field provides little value as it's only set when the daemon is started with --bridge flag specified, and the inspected container is connected to the default bridge network.

Unfortunately, there's no equivalent field in NetworkSettings.Networks.

**api/t/ctr: deprecate NetworkSettingsBase**

Most fields in NetworkSettingsBase are deprecated, so deprecate the whole struct. The few fields which aren't deprecated will move to the NetworkSettings struct in v29.

**api/t/ctr: deprecate DefaultNetworkSettings**

This struct is only used to report the networking state for the default bridge network when the container is connected to it.

It was deprecated in v1.09 (API v1.21), and scheduled for removal in v1.11. Unfortunately, the deprecation warning was wrongly formatted in the Go code. However, deprecation warnings are already present in swagger.yaml, so don't touch it.

**- Human readable description for the release notes**

```markdown changelog
- Go-SDK: Deprecate field `NetworkSettingsBase.Bridge`, struct `NetworkSettingsBase`, all the fields of `DefaultNetworkSettings`, and struct `DefaultNetworkSettings`.
```
