### PR TITLE
daemon/internal: add "compat" package for legacy responses

### DIFF
--- a/daemon/internal/compat/compat.go
+++ b/daemon/internal/compat/compat.go
@@ -1,0 +1,77 @@
+// Package compat provides tools for backward-compatible API responses.
+package compat
+
+import "encoding/json"
+
+// Wrapper augments a struct to add or omit fields for legacy JSON responses.
+type Wrapper struct {
+	Base any
+
+	extraFields map[string]any
+	omitFields  []string
+}
+
+// MarshalJSON merges the JSON with extra fields or omits fields.
+func (w *Wrapper) MarshalJSON() ([]byte, error) {
+	base, err := json.Marshal(w.Base)
+	if err != nil {
+		return nil, err
+	}
+	if len(w.omitFields) == 0 && len(w.extraFields) == 0 {
+		return base, nil
+	}
+
+	var merged map[string]any
+	if err := json.Unmarshal(base, &merged); err != nil {
+		return nil, err
+	}
+
+	for _, key := range w.omitFields {
+		delete(merged, key)
+	}
+	for key, val := range w.extraFields {
+		merged[key] = val
+	}
+
+	return json.Marshal(merged)
+}
+
+type options struct {
+	extraFields map[string]any
+	omitFields  []string
+}
+
+// Option for Wrapper.
+type Option func(*options)
+
+// WithExtraFields adds fields to the marshaled output.
+func WithExtraFields(fields map[string]any) Option {
+	return func(c *options) {
+		if c.extraFields == nil {
+			c.extraFields = make(map[string]any)
+		}
+		for k, v := range fields {
+			c.extraFields[k] = v
+		}
+	}
+}
+
+// WithOmittedFields removes fields from the marshaled output.
+func WithOmittedFields(fields ...string) Option {
+	return func(c *options) {
+		c.omitFields = append(c.omitFields, fields...)
+	}
+}
+
+// Wrap constructs a Wrapper from the given type.
+func Wrap(base any, opts ...Option) *Wrapper {
+	cfg := options{extraFields: make(map[string]any)}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Wrapper{
+		Base:        base,
+		extraFields: cfg.extraFields,
+		omitFields:  cfg.omitFields,
+	}
+}

--- a/daemon/internal/compat/compat_test.go
+++ b/daemon/internal/compat/compat_test.go
@@ -1,0 +1,105 @@
+package compat_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/internal/compat"
+)
+
+type Info struct {
+	Name     string        `json:"name"`
+	Version  string        `json:"version"`
+	NewField string        `json:"newfield"`
+	Nested   *NestedStruct `json:"legacy,omitempty"`
+}
+
+type NestedStruct struct {
+	Field1 string `json:"field1"`
+	Field2 int    `json:"field2"`
+}
+
+func TestWrap(t *testing.T) {
+	info := &Info{
+		Name:     "daemon",
+		Version:  "v2.0",
+		NewField: "new field",
+	}
+
+	tests := []struct {
+		name     string
+		options  []compat.Option
+		expected string
+	}{
+		{
+			name:     "none",
+			expected: `{"name":"daemon","version":"v2.0","newfield":"new field"}`,
+		},
+		{
+			name:     "extra fields",
+			options:  []compat.Option{compat.WithExtraFields(map[string]any{"legacy_field": "hello"})},
+			expected: `{"legacy_field":"hello","name":"daemon","newfield":"new field","version":"v2.0"}`,
+		},
+		{
+			name:     "omit fields",
+			options:  []compat.Option{compat.WithOmittedFields("newfield", "version")},
+			expected: `{"name":"daemon"}`,
+		},
+		{
+			name: "omit and extra fields",
+			options: []compat.Option{
+				compat.WithExtraFields(map[string]any{"legacy_field": "hello"}),
+				compat.WithOmittedFields("newfield", "version"),
+			},
+			expected: `{"legacy_field":"hello","name":"daemon"}`,
+		},
+		{
+			name: "replace field",
+			options: []compat.Option{compat.WithExtraFields(map[string]any{"version": struct {
+				Major, Minor int
+			}{Major: 1, Minor: 0}})},
+			expected: `{"name":"daemon","newfield":"new field","version":{"Major":1,"Minor":0}}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := compat.Wrap(info, tc.options...)
+			data, err := json.Marshal(resp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != tc.expected {
+				t.Errorf("\nExpected: %s\nGot:      %s", tc.expected, string(data))
+			}
+		})
+	}
+}
+
+func TestNestedCompat(t *testing.T) {
+	info := &Info{
+		Name:     "daemon",
+		Version:  "v2.0",
+		NewField: "new field",
+	}
+
+	detail := &NestedStruct{
+		Field1: "ok",
+		Field2: 42,
+	}
+	nested := compat.Wrap(detail, compat.WithExtraFields(map[string]any{
+		"legacy_field": "hello",
+	}))
+	resp := compat.Wrap(info, compat.WithExtraFields(map[string]any{
+		"nested": nested,
+	}))
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	const expected = `{"name":"daemon","nested":{"field1":"ok","field2":42,"legacy_field":"hello"},"newfield":"new field","version":"v2.0"}`
+	if string(data) != expected {
+		t.Errorf("\nExpected: %s\nGot:      %s", expected, string(data))
+	}
+}


### PR DESCRIPTION
Add a package to help augmenting API responses with additional fields, replacing fields, or to remove fields from the response to allow for legacy API responses to be produced without having to keep deprecated fields in the API type definitions.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

