### PR TITLE
internal/builder-next: make image exporter unpack option configurable

### DIFF
--- a/daemon/internal/builder-next/exporter/wrapper.go
+++ b/daemon/internal/builder-next/exporter/wrapper.go
@@ -47,8 +47,12 @@ func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, id int, exporter
 	if err != nil {
 		return nil, err
 	}
+
 	exporterAttrs[string(exptypes.OptKeyName)] = strings.Join(reposAndTags, ",")
-	exporterAttrs[string(exptypes.OptKeyUnpack)] = "true"
+
+	if _, has := exporterAttrs[string(exptypes.OptKeyUnpack)]; !has {
+		exporterAttrs[string(exptypes.OptKeyUnpack)] = "true"
+	}
 	if _, has := exporterAttrs[string(exptypes.OptKeyDanglingPrefix)]; !has {
 		exporterAttrs[string(exptypes.OptKeyDanglingPrefix)] = "moby-dangling"
 	}


### PR DESCRIPTION
The image exporter wrapper was unconditionally setting the unpack option to "true", which forced all exported images to be unpacked regardless of user preferences or specific build requirements.

Let's allow the user to actually override it if they really want that.