### PR TITLE
Makefile: update goswagger/swagger:0.32.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ swagger-gen:
 		-w /go/src/github.com/docker/docker \
 		--entrypoint hack/generate-swagger-api.sh \
 		-e GOPATH=/go \
-		quay.io/goswagger/swagger:0.7.4
+		quay.io/goswagger/swagger:0.32.3
 
 .PHONY: swagger-docs
 swagger-docs: ## preview the API documentation


### PR DESCRIPTION
**- What I did**

This change updates the docker image used for `swagger-gen` make target to `quay.io/goswagger/swagger:0.32.3`.

This is to resolve the target failing to run on modern runtimes due to the older image (a Docker v1 image) no longer supported.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

