### PR TITLE
hack/dind-systemd: enable, collect firewalld debug logs

### DIFF
--- a/hack/dind-systemd
+++ b/hack/dind-systemd
@@ -63,10 +63,10 @@ if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
 	}
 fi
 
-# Allow connections coming from the host (through eth0). This is needed to
-# access the daemon port (independently of which port is used), or run a
-# 'remote' Delve session, etc...
 if [ "${FIREWALLD:-}" = "true" ]; then
+	# Allow connections coming from the host (through eth0). This is needed to
+	# access the daemon port (independently of which port is used), or run a
+	# 'remote' Delve session, etc...
 	cat > /etc/firewalld/zones/trusted.xml << EOF
 <?xml version="1.0" encoding="utf-8"?>
 <zone target="ACCEPT">
@@ -75,6 +75,13 @@ if [ "${FIREWALLD:-}" = "true" ]; then
   <interface name="eth0"/>
   <forward/>
 </zone>
+EOF
+
+	# Increase firewalld log verbosity to help debug issues
+	cat > /etc/systemd/system/firewalld.service << EOF
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/firewalld --nofork --nopid --debug=4
 EOF
 fi
 

--- a/hack/dind-systemd
+++ b/hack/dind-systemd
@@ -83,6 +83,25 @@ EOF
 ExecStart=
 ExecStart=/usr/sbin/firewalld --nofork --nopid --debug=4
 EOF
+
+	# Copy firewalld logs into the bundles/ folder on shutdown to let the CI
+	# include it in jobs reports.
+	cat > /etc/systemd/system/collect-firewalld-logs.service << EOF
+[Unit]
+Description=Collect firewalld logs on shutdown
+After=firewalld.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=true
+ExecStop=cp /var/log/firewalld /go/src/github.com/docker/docker/bundles/firewalld.log
+
+[Install]
+WantedBy=firewalld.service
+EOF
+
+	systemctl enable collect-firewalld-logs.service
 fi
 
 env > /etc/docker-entrypoint-env


### PR DESCRIPTION
**- What I did**

**hack/dind-systemd: enable firewalld debug logs**

Increase firewalld logs verbosity to help debug issues.

**hack/dind-systemd: collect firewalld logs**

Add a systemd service 'collect-firewalld-logs.service' that copies firewalld log file into bundles/ on container shutdown. This won't provide much value for developers who run `make shell`, but it'll be useful on CI to include firewalld logs in the exported artifacts.

The CI is already configured to pick every *.log file from bundles/, so no further change is needed on that side.

