### PR TITLE
c8d/history: Fix non-native platforms

### DIFF
--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -113,6 +113,9 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
         name: Build dev image
         uses: docker/bake-action@v6
         with:
@@ -202,6 +205,9 @@ jobs:
           version: ${{ env.SETUP_BUILDX_VERSION }}
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       -
         name: Build dev image
         uses: docker/bake-action@v6

--- a/integration/image/history_test.go
+++ b/integration/image/history_test.go
@@ -1,11 +1,20 @@
 package image
 
 import (
+	"context"
+	"io"
 	"testing"
 
-	"github.com/moby/moby/v2/integration/internal/build"
+	"github.com/containerd/platforms"
+	buildtypes "github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/client"
+	build "github.com/moby/moby/v2/integration/internal/build"
+	"github.com/moby/moby/v2/testutil"
 	"github.com/moby/moby/v2/testutil/fakecontext"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 )
 
 func TestAPIImagesHistory(t *testing.T) {
@@ -30,4 +39,103 @@ func TestAPIImagesHistory(t *testing.T) {
 	}
 
 	assert.Assert(t, found)
+}
+
+// TestAPIImageHistoryCrossPlatform tests the image history functionality
+// when dealing with cross-platform image builds.
+// This is a regression test for https://github.com/moby/moby/issues/50851
+// where `docker history` fails with "snapshot does not exist" error for
+// images built for non-native platforms.
+func TestAPIImageHistoryCrossPlatform(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	// Determine the non-native platform to use for testing
+	nonNativePlatform := ocispec.Platform{OS: testEnv.DaemonInfo.OSType, Architecture: "amd64"}
+	if testEnv.DaemonInfo.Architecture == "amd64" {
+		nonNativePlatform = ocispec.Platform{OS: testEnv.DaemonInfo.OSType, Architecture: "arm64"}
+	}
+
+	// We need to pull the image for the non-native platform
+	// TODO: Make sure we have a multi-platform frozen image we could use
+	pullImageForPlatform(t, ctx, apiClient, "alpine", nonNativePlatform)
+
+	dockerfile := "FROM alpine\nRUN true"
+
+	buildCtx := fakecontext.New(t, t.TempDir(), fakecontext.WithDockerfile(dockerfile))
+	defer buildCtx.Close()
+
+	// Build the image for a non-native platform
+	resp, err := apiClient.ImageBuild(ctx, buildCtx.AsTarReader(t), buildtypes.ImageBuildOptions{
+		Version:  buildtypes.BuilderBuildKit,
+		Tags:     []string{"cross-platform-test"},
+		Platform: platforms.FormatAll(nonNativePlatform),
+	})
+	assert.NilError(t, err)
+	defer resp.Body.Close()
+
+	imgID := build.GetImageIDFromBody(t, resp.Body)
+	t.Cleanup(func() {
+		apiClient.ImageRemove(ctx, imgID, client.ImageRemoveOptions{Force: true})
+	})
+
+	testCases := []struct {
+		name     string
+		imageRef string
+		options  []client.ImageHistoryOption
+	}{
+		{
+			name:     "without explicit platform",
+			imageRef: imgID,
+			options:  nil,
+		},
+		{
+			name:     "with explicit platform",
+			imageRef: imgID,
+			options:  []client.ImageHistoryOption{client.ImageHistoryWithPlatform(nonNativePlatform)},
+		},
+		{
+			name:     "using image reference",
+			imageRef: "cross-platform-test",
+			options:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutil.StartSpan(ctx, t)
+
+			hist, err := apiClient.ImageHistory(ctx, tc.imageRef, tc.options...)
+
+			assert.NilError(t, err)
+			found := false
+			for _, layer := range hist {
+				if layer.ID == imgID {
+					found = true
+					break
+				}
+			}
+			assert.Assert(t, found, "History should contain the built image ID")
+			assert.Assert(t, is.Len(hist, 3))
+
+			for i, layer := range hist {
+				assert.Assert(t, layer.Size >= 0, "Layer %d should not have negative size", i)
+			}
+		})
+	}
+}
+
+func pullImageForPlatform(t *testing.T, ctx context.Context, apiClient client.APIClient, ref string, platform ocispec.Platform) {
+	pullResp, err := apiClient.ImagePull(ctx, ref, client.ImagePullOptions{Platform: platforms.FormatAll(platform)})
+	assert.NilError(t, err)
+	_, _ = io.Copy(io.Discard, pullResp)
+
+	_, err = apiClient.ImageInspect(ctx, ref)
+	assert.NilError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = apiClient.ImageRemove(ctx, ref, client.ImageRemoveOptions{Force: true})
+	})
 }

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -1,11 +1,14 @@
 package build
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
 	"testing"
 
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
+	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
@@ -30,6 +33,7 @@ func Do(ctx context.Context, t *testing.T, apiClient client.APIClient, buildCtx 
 // GetImageIDFromBody reads the image ID from the build response body.
 func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 	var id string
+	buf := bytes.NewBuffer(nil)
 	dec := json.NewDecoder(body)
 	for {
 		var jm jsonmessage.JSONMessage
@@ -38,6 +42,19 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 			break
 		}
 		assert.NilError(t, err)
+
+		if handled := processBuildkitAux(t, &jm, &id); handled {
+			continue
+		}
+
+		buf.Reset()
+		jm.Display(buf, false)
+		if buf.Len() == 0 {
+			continue
+		}
+
+		t.Log(buf.String())
+
 		if jm.Aux == nil {
 			continue
 		}
@@ -48,11 +65,49 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 				continue
 			}
 			id = br.ID
-			break
+			continue
 		}
+
+		t.Log("Raw Aux", string(*jm.Aux))
 	}
 	_, _ = io.Copy(io.Discard, body)
 
 	assert.Assert(t, id != "", "could not read image ID from build output")
 	return id
+}
+
+func processBuildkitAux(t *testing.T, jm *jsonmessage.JSONMessage, id *string) bool {
+	if jm.ID == "moby.buildkit.trace" {
+		var dt []byte
+		if err := json.Unmarshal(*jm.Aux, &dt); err != nil {
+			t.Log("Error unmarshalling buildkit trace", err)
+			return true
+		}
+		var sr controlapi.StatusResponse
+		if err := proto.Unmarshal(dt, &sr); err != nil {
+			t.Log("Error unmarshalling buildkit trace proto", err)
+			return true
+		}
+		for _, vtx := range sr.GetVertexes() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetStatuses() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetLogs() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetWarnings() {
+			t.Log(vtx.String())
+		}
+		return true
+	}
+	if jm.ID == "moby.image.id" {
+		var br build.Result
+		if err := json.Unmarshal(*jm.Aux, &br); err == nil {
+			*id = br.ID
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/50851

When building a non-native platform, it's not unpacked by default.
History tries to read the disk usage of all the layer and it doesn't handle missing snapshots gracefully. 
This patch fixes this.        


```markdown changelog
containerd image store: Fix `docker history` failing with `snapshot X does not exist` when calling on a non-native image that was built locally
```