### PR TITLE
[28.x backport] graphdriver/windows: Potential fix for access denied

### DIFF
--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -799,37 +799,25 @@ func writeLayerReexec() {
 }
 
 // writeLayer writes a layer from a tar file.
-func writeLayer(layerData io.Reader, home string, id string, parentLayerPaths ...string) (size int64, retErr error) {
-	err := winio.EnableProcessPrivileges([]string{winio.SeSecurityPrivilege, winio.SeBackupPrivilege, winio.SeRestorePrivilege})
-	if err != nil {
-		return 0, err
-	}
-	if noreexec {
-		defer func() {
-			if err := winio.DisableProcessPrivileges([]string{winio.SeSecurityPrivilege, winio.SeBackupPrivilege, winio.SeRestorePrivilege}); err != nil {
-				// This should never happen, but just in case when in debugging mode.
-				// See https://github.com/docker/docker/pull/28002#discussion_r86259241 for rationale.
-				panic("Failed to disabled process privileges while in non re-exec mode")
-			}
-		}()
-	}
-
-	w, err := hcsshim.NewLayerWriter(hcsshim.DriverInfo{Flavour: filterDriver, HomeDir: home}, id, parentLayerPaths)
-	if err != nil {
-		return 0, err
-	}
-
-	defer func() {
-		if err := w.Close(); err != nil {
-			// This error should not be discarded as a failure here
-			// could result in an invalid layer on disk
-			if retErr == nil {
-				retErr = err
-			}
+func writeLayer(layerData io.Reader, home string, id string, parentLayerPaths ...string) (size int64, _ error) {
+	err := winio.RunWithPrivileges([]string{winio.SeSecurityPrivilege, winio.SeBackupPrivilege, winio.SeRestorePrivilege}, func() error {
+		var err error
+		w, err := hcsshim.NewLayerWriter(hcsshim.DriverInfo{Flavour: filterDriver, HomeDir: home}, id, parentLayerPaths)
+		if err != nil {
+			return err
 		}
-	}()
 
-	return writeLayerFromTar(layerData, w, filepath.Join(home, id))
+		s, err := writeLayerFromTar(layerData, w, filepath.Join(home, id))
+		if err != nil {
+			// Close, but don't override the error from writeLayerFromTar
+			_ = w.Close()
+			return err
+		}
+
+		size = s
+		return w.Close()
+	})
+	return size, err
 }
 
 // resolveID computes the layerID information based on the given id.


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50870

Use `winio.RunWithPrivileges` to get the privileges. It's better because it also locks the Go runtime thread so if the Go scheduler decides to run this code on a different thread, it will still have the expected privileges.

A naive attempt at fixing an error experienced by Docker Desktop user when using Windows containers:

```
failed to register layer: re-exec error: exit status 1: output: hcsshim::ProcessUtilityVMImage \\?\C:\ProgramData\Docker\windowsfilter\<hash1>\UtilityVM: Access is denied.
failed to register layer: re-exec error: exit status 1: output: hcsshim::ProcessBaseLayer \\?\C:\ProgramData\Docker\windowsfilter\<hash2>: Access is denied.
failed to register layer: re-exec error: exit status 1: output: hcsshim::ProcessBaseLayer \\?\C:\ProgramData\Docker\windowsfilter\<hash3>: Access is denied.
```

Unfortunately I can't reproduce the issue on a Windows VM, but this definitely won't hurt.

At least, I verified that the daemon still works on Windows.

Inspired by: https://github.com/containerd/containerd/issues/8206

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Windows: Potentially fix an issue with "access denied" error when pulling images
```

**- A picture of a cute animal (not mandatory but encouraged)**

