### PR TITLE
daemon: backfill empty PBs slices for backward compat

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -22,6 +22,10 @@ keywords: "API, Docker, rcli, REST, documentation"
   saved.
 * `POST /images/load` now accepts multiple `platform` query-arguments
   to allow selecting which platform(s) of a multi-platform image to load.
+* Deprecated: the Engine was automatically backfilling empty `PortBindings` lists with
+  a PortBinding with an empty HostIP and HostPort when calling `POST /containers/{id}/start`.
+  This behavior is now deprecated, and a warning is returned by `POST /containers/create`.
+  The next API version will drop empty `PortBindings` list altogether.
 
 ## v1.51 API changes
 

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -1017,13 +1017,24 @@ func (d *Daemon) TamperWithContainerConfig(t testing.TB, containerID string, tam
 	configBytes, err := os.ReadFile(configPath)
 	assert.NilError(t, err)
 
+	hostConfigPath := filepath.Join(d.Root, "containers", containerID, "hostconfig.json")
+	hostConfigBytes, err := os.ReadFile(hostConfigPath)
+	assert.NilError(t, err)
+
 	var c container.Container
 	assert.NilError(t, json.Unmarshal(configBytes, &c))
+	assert.NilError(t, json.Unmarshal(hostConfigBytes, &c.HostConfig))
+
 	c.State = container.NewState()
 	tamper(&c)
+
 	configBytes, err = json.Marshal(&c)
 	assert.NilError(t, err)
 	assert.NilError(t, os.WriteFile(configPath, configBytes, 0o600))
+
+	hostConfigBytes, err = json.Marshal(&c.HostConfig)
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(hostConfigPath, hostConfigBytes, 0o600))
 }
 
 // cleanupRaftDir removes swarmkit wal files if present


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/50710#discussion_r2315840899

**- What I did**

So far, on ContainerStart, the daemon was silently backfilling empty PortBindings slices with a PortBinding with unspecified HostIP and HostPort. This was done by github.com/docker/go-connections/nat.SortPortMap.

This backfilling doesn't make much sense, and we're trying to remove that package. So, move the backfilling to the API server, keep it for older API versions, deprecate it for API 1.52, and drop it for API 1.53 and above.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- API: Deprecation: the Engine was automatically backfilling empty `PortBindings` lists with a PortBinding with an empty HostIP and HostPort when starting a container. This behavior is deprecated for API 1.52, and will be dropped in API 1.53.
```
