### PR TITLE
[28.x backport] c8d/history: Fix non-native platforms

### DIFF
--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -110,6 +110,9 @@ jobs:
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
         name: Build dev image
         uses: docker/bake-action@v6
         with:
@@ -198,6 +201,9 @@ jobs:
           version: ${{ env.SETUP_BUILDX_VERSION }}
           driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
           buildkitd-flags: --debug
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       -
         name: Build dev image
         uses: docker/bake-action@v6

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -1,16 +1,19 @@
 package build
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
 	"testing"
 
+	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/testutil/fakecontext"
+	controlapi "github.com/moby/buildkit/api/services/control"
 	"gotest.tools/v3/assert"
 )
 
@@ -31,6 +34,7 @@ func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fa
 // GetImageIDFromBody reads the image ID from the build response body.
 func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 	var id string
+	buf := bytes.NewBuffer(nil)
 	dec := json.NewDecoder(body)
 	for {
 		var jm jsonmessage.JSONMessage
@@ -39,6 +43,19 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 			break
 		}
 		assert.NilError(t, err)
+
+		if handled := processBuildkitAux(t, &jm, &id); handled {
+			continue
+		}
+
+		buf.Reset()
+		jm.Display(buf, false)
+		if buf.Len() == 0 {
+			continue
+		}
+
+		t.Log(buf.String())
+
 		if jm.Aux == nil {
 			continue
 		}
@@ -49,11 +66,49 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 				continue
 			}
 			id = br.ID
-			break
+			continue
 		}
+
+		t.Log("Raw Aux", string(*jm.Aux))
 	}
 	_, _ = io.Copy(io.Discard, body)
 
 	assert.Assert(t, id != "", "could not read image ID from build output")
 	return id
+}
+
+func processBuildkitAux(t *testing.T, jm *jsonmessage.JSONMessage, id *string) bool {
+	if jm.ID == "moby.buildkit.trace" {
+		var dt []byte
+		if err := json.Unmarshal(*jm.Aux, &dt); err != nil {
+			t.Log("Error unmarshalling buildkit trace", err)
+			return true
+		}
+		var sr controlapi.StatusResponse
+		if err := proto.Unmarshal(dt, &sr); err != nil {
+			t.Log("Error unmarshalling buildkit trace proto", err)
+			return true
+		}
+		for _, vtx := range sr.GetVertexes() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetStatuses() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetLogs() {
+			t.Log(vtx.String())
+		}
+		for _, vtx := range sr.GetWarnings() {
+			t.Log(vtx.String())
+		}
+		return true
+	}
+	if jm.ID == "moby.image.id" {
+		var br build.Result
+		if err := json.Unmarshal(*jm.Aux, &br); err == nil {
+			*id = br.ID
+			return true
+		}
+	}
+	return false
 }

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -30,12 +30,10 @@ func Do(ctx context.Context, t *testing.T, client client.APIClient, buildCtx *fa
 
 // GetImageIDFromBody reads the image ID from the build response body.
 func GetImageIDFromBody(t *testing.T, body io.Reader) string {
-	var (
-		jm  jsonmessage.JSONMessage
-		br  build.Result
-		dec = json.NewDecoder(body)
-	)
+	var id string
+	dec := json.NewDecoder(body)
 	for {
+		var jm jsonmessage.JSONMessage
 		err := dec.Decode(&jm)
 		if err == io.EOF {
 			break
@@ -44,10 +42,18 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 		if jm.Aux == nil {
 			continue
 		}
-		assert.NilError(t, json.Unmarshal(*jm.Aux, &br))
-		assert.Assert(t, br.ID != "", "could not read image ID from build output")
-		break
+
+		var br build.Result
+		if err := json.Unmarshal(*jm.Aux, &br); err == nil {
+			if br.ID == "" {
+				continue
+			}
+			id = br.ID
+			break
+		}
 	}
-	io.Copy(io.Discard, body)
-	return br.ID
+	_, _ = io.Copy(io.Discard, body)
+
+	assert.Assert(t, id != "", "could not read image ID from build output")
+	return id
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50867

- fixes: https://github.com/moby/moby/issues/50851

When building a non-native platform, it's not unpacked by default.
History tries to read the disk usage of all the layer and it doesn't handle missing snapshots gracefully. 
This patch fixes this.        


```markdown changelog
containerd image store: Fix `docker history` failing with `snapshot X does not exist` when calling on a non-native image that was built locally
```