### PR TITLE
Bump go.mod minimum-go-version to 1.24

### DIFF
--- a/daemon/libnetwork/portallocator/osallocator_linux_test.go
+++ b/daemon/libnetwork/portallocator/osallocator_linux_test.go
@@ -268,7 +268,7 @@ func TestSocketBacklogEqualsSomaxconn(t *testing.T) {
 			out, err := exec.Command("ss", "-Stl", "sport", "=", fmt.Sprintf("inet:%d", port)).Output()
 			assert.NilError(t, err)
 
-			t.Logf("ss output:\n" + string(out))
+			t.Log("ss output:\n" + string(out))
 
 			lines := strings.Split(string(out), "\n")
 			assert.Assert(t, len(lines) >= 2)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/moby/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0


### PR DESCRIPTION
**- What I did**

- blocks https://github.com/moby/moby/pull/50845

Match the minor version of Go used in the dev container (and therefore in CI).

**- How I did it**

The `Logf` -> `Log` change in a test is for this [govet change](https://tip.golang.org/doc/go1.24#vet:~:text=s%20is%20a%20non%2Dconstant%20format%20string%2C%20with%20no%20other%20arguments).

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

