### PR TITLE
api/types/network: separate Summary from Inspect

### DIFF
--- a/api/types/network/network.go
+++ b/api/types/network/network.go
@@ -38,32 +38,36 @@ type CreateRequest struct {
 	CheckDuplicate *bool `json:",omitempty"`
 }
 
+type Network struct {
+	Name       string            // Name is the name of the network
+	ID         string            `json:"Id"` // ID uniquely identifies a network on a single machine
+	Created    time.Time         // Created is the time the network created
+	Scope      string            // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level)
+	Driver     string            // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
+	EnableIPv4 bool              // EnableIPv4 represents whether IPv4 is enabled
+	EnableIPv6 bool              // EnableIPv6 represents whether IPv6 is enabled
+	IPAM       IPAM              // IPAM is the network's IP Address Management
+	Internal   bool              // Internal represents if the network is used internal only
+	Attachable bool              // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
+	Ingress    bool              // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
+	ConfigFrom ConfigReference   // ConfigFrom specifies the source which will provide the configuration for this network.
+	ConfigOnly bool              // ConfigOnly networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
+	Options    map[string]string // Options holds the network specific options to use for when creating the network
+	Labels     map[string]string // Labels holds metadata specific to the network being created
+	Peers      []PeerInfo        `json:",omitempty"` // List of peer nodes for an overlay network
+}
+
 // Inspect is the body of the "get network" http response message.
 type Inspect struct {
-	Name       string                      // Name is the name of the network
-	ID         string                      `json:"Id"` // ID uniquely identifies a network on a single machine
-	Created    time.Time                   // Created is the time the network created
-	Scope      string                      // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level)
-	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
-	EnableIPv4 bool                        // EnableIPv4 represents whether IPv4 is enabled
-	EnableIPv6 bool                        // EnableIPv6 represents whether IPv6 is enabled
-	IPAM       IPAM                        // IPAM is the network's IP Address Management
-	Internal   bool                        // Internal represents if the network is used internal only
-	Attachable bool                        // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
-	Ingress    bool                        // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
-	ConfigFrom ConfigReference             // ConfigFrom specifies the source which will provide the configuration for this network.
-	ConfigOnly bool                        // ConfigOnly networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
+	Network
 	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
-	Options    map[string]string           // Options holds the network specific options to use for when creating the network
-	Labels     map[string]string           // Labels holds metadata specific to the network being created
-	Peers      []PeerInfo                  `json:",omitempty"` // List of peer nodes for an overlay network
 	Services   map[string]ServiceInfo      `json:",omitempty"`
 }
 
-// Summary is used as response when listing networks. It currently is an alias
-// for [Inspect], but may diverge in the future, as not all information may
-// be included when listing networks.
-type Summary = Inspect
+// Summary is used as response when listing networks.
+type Summary struct {
+	Network
+}
 
 // Address represents an IP address
 type Address struct {

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -46,12 +46,12 @@ func TestNetworkInspect(t *testing.T) {
 				"web": {},
 			}
 			content, err = json.Marshal(network.Inspect{
-				Name:     "mynetwork",
+				Network:  network.Network{Name: "mynetwork"},
 				Services: s,
 			})
 		} else {
 			content, err = json.Marshal(network.Inspect{
-				Name: "mynetwork",
+				Network: network.Network{Name: "mynetwork"},
 			})
 		}
 		if err != nil {

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -74,8 +74,10 @@ func TestNetworkList(t *testing.T) {
 			}
 			content, err := json.Marshal([]network.Summary{
 				{
-					Name:   "network",
-					Driver: "bridge",
+					Network: network.Network{
+						Name:   "network",
+						Driver: "bridge",
+					},
 				},
 			})
 			if err != nil {

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -138,7 +138,7 @@ func swarmPortConfigToAPIPortConfig(portConfig *swarmapi.PortConfig) types.PortC
 }
 
 // BasicNetworkFromGRPC converts a grpc Network to a NetworkResource.
-func BasicNetworkFromGRPC(n swarmapi.Network) network.Inspect {
+func BasicNetworkFromGRPC(n swarmapi.Network) network.Network {
 	spec := n.Spec
 	var ipam network.IPAM
 	if n.IPAM != nil {
@@ -157,7 +157,7 @@ func BasicNetworkFromGRPC(n swarmapi.Network) network.Inspect {
 		}
 	}
 
-	nr := network.Inspect{
+	nr := network.Network{
 		ID:         n.ID,
 		Name:       n.Spec.Annotations.Name,
 		Scope:      scope.Swarm,

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -172,7 +172,5 @@ type PluginDisableConfig struct {
 
 // NetworkListConfig stores the options available for listing networks
 type NetworkListConfig struct {
-	// TODO(@cpuguy83): naming is hard, this is pulled from what was being used in the router before moving here
-	Detailed bool
-	Verbose  bool
+	WithServices bool
 }

--- a/daemon/server/router/network/backend.go
+++ b/daemon/server/router/network/backend.go
@@ -13,6 +13,7 @@ import (
 // to provide network specific functionality.
 type Backend interface {
 	GetNetworks(dnetwork.Filter, backend.NetworkListConfig) ([]network.Inspect, error)
+	GetNetworkSummaries(dnetwork.Filter) ([]network.Summary, error)
 	CreateNetwork(ctx context.Context, nc network.CreateRequest) (*network.CreateResponse, error)
 	ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
@@ -24,8 +25,9 @@ type Backend interface {
 // to provide cluster network specific functionality.
 type ClusterBackend interface {
 	GetNetworks(dnetwork.Filter) ([]network.Inspect, error)
+	GetNetworkSummaries(dnetwork.Filter) ([]network.Summary, error)
 	GetNetwork(name string) (network.Inspect, error)
-	GetNetworksByName(name string) ([]network.Inspect, error)
+	GetNetworksByName(name string) ([]network.Network, error)
 	CreateNetwork(nc network.CreateRequest) (string, error)
 	RemoveNetwork(name string) error
 }

--- a/integration/network/delete_test.go
+++ b/integration/network/delete_test.go
@@ -12,7 +12,7 @@ import (
 	"gotest.tools/v3/skip"
 )
 
-func containsNetwork(nws []networktypes.Inspect, networkID string) bool {
+func containsNetwork(nws []networktypes.Summary, networkID string) bool {
 	for _, n := range nws {
 		if n.ID == networkID {
 			return true

--- a/vendor/github.com/moby/moby/api/types/network/network.go
+++ b/vendor/github.com/moby/moby/api/types/network/network.go
@@ -38,32 +38,36 @@ type CreateRequest struct {
 	CheckDuplicate *bool `json:",omitempty"`
 }
 
+type Network struct {
+	Name       string            // Name is the name of the network
+	ID         string            `json:"Id"` // ID uniquely identifies a network on a single machine
+	Created    time.Time         // Created is the time the network created
+	Scope      string            // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level)
+	Driver     string            // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
+	EnableIPv4 bool              // EnableIPv4 represents whether IPv4 is enabled
+	EnableIPv6 bool              // EnableIPv6 represents whether IPv6 is enabled
+	IPAM       IPAM              // IPAM is the network's IP Address Management
+	Internal   bool              // Internal represents if the network is used internal only
+	Attachable bool              // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
+	Ingress    bool              // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
+	ConfigFrom ConfigReference   // ConfigFrom specifies the source which will provide the configuration for this network.
+	ConfigOnly bool              // ConfigOnly networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
+	Options    map[string]string // Options holds the network specific options to use for when creating the network
+	Labels     map[string]string // Labels holds metadata specific to the network being created
+	Peers      []PeerInfo        `json:",omitempty"` // List of peer nodes for an overlay network
+}
+
 // Inspect is the body of the "get network" http response message.
 type Inspect struct {
-	Name       string                      // Name is the name of the network
-	ID         string                      `json:"Id"` // ID uniquely identifies a network on a single machine
-	Created    time.Time                   // Created is the time the network created
-	Scope      string                      // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level)
-	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
-	EnableIPv4 bool                        // EnableIPv4 represents whether IPv4 is enabled
-	EnableIPv6 bool                        // EnableIPv6 represents whether IPv6 is enabled
-	IPAM       IPAM                        // IPAM is the network's IP Address Management
-	Internal   bool                        // Internal represents if the network is used internal only
-	Attachable bool                        // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
-	Ingress    bool                        // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
-	ConfigFrom ConfigReference             // ConfigFrom specifies the source which will provide the configuration for this network.
-	ConfigOnly bool                        // ConfigOnly networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
+	Network
 	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
-	Options    map[string]string           // Options holds the network specific options to use for when creating the network
-	Labels     map[string]string           // Labels holds metadata specific to the network being created
-	Peers      []PeerInfo                  `json:",omitempty"` // List of peer nodes for an overlay network
 	Services   map[string]ServiceInfo      `json:",omitempty"`
 }
 
-// Summary is used as response when listing networks. It currently is an alias
-// for [Inspect], but may diverge in the future, as not all information may
-// be included when listing networks.
-type Summary = Inspect
+// Summary is used as response when listing networks.
+type Summary struct {
+	Network
+}
 
 // Address represents an IP address
 type Address struct {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Stacked on top of #50860

**- What I did**
I made network.Summary and network.Inspect distinct types so they can be extended independently.

**- How I did it**
- Moved all fields common to both `GET /networks` (List Networks) and `GET /networks/{id}` (Inspect Network) API endpoints into a base `network.Network` struct.
- Changed `network.Summary` and `network.Inspect` to distinct struct types which both embed `network.Network`
- Added backend methods which return `[]network.Summary`, distinct from the existing `[]network.Inspect` methods

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Types `"github.com/moby/moby/api/types/network".Summary` and `"github.com/moby/moby/api/types/network".Inspect` are no longer aliases, and most of their fields have been moved into an embedded struct. Engine API clients may require some source-level changes when migrating to the new github.com/moby/moby/api module.
```

**- A picture of a cute animal (not mandatory but encouraged)**

