### PR TITLE
contrib: remove udev rules for hiding loopback devices

### DIFF
--- a/contrib/udev/80-docker.rules
+++ b/contrib/udev/80-docker.rules
@@ -1,3 +1,0 @@
-# hide docker's loopback devices from udisks, and thus from user desktops
-SUBSYSTEM=="block", ENV{DM_NAME}=="docker-*", ENV{UDISKS_PRESENTATION_HIDE}="1", ENV{UDISKS_IGNORE}="1"
-SUBSYSTEM=="block", DEVPATH=="/devices/virtual/block/loop*", ATTR{loop/backing_file}=="/var/lib/docker/*", ENV{UDISKS_PRESENTATION_HIDE}="1", ENV{UDISKS_IGNORE}="1"


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/2983

This reverts commit dbb47f63ab637a4766f72eac55f66493cf1c6f5b, which added these rules to hide loopback devices from udisks. These rules were for devicemapper, which we no longer support, and use hard-coded paths, making them not practical for other purposes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

