### PR TITLE
libcontainerd/remote: assorted cleanups

### DIFF
--- a/daemon/internal/libcontainerd/remote/client.go
+++ b/daemon/internal/libcontainerd/remote/client.go
@@ -257,7 +257,7 @@ func (t *task) Start(ctx context.Context) error {
 // for the container main process, the stdin fifo will be created in Create not
 // the Start call. stdinCloseSync channel should be closed after Start exec
 // process.
-func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (_ libcontainerdtypes.Process, retErr error) {
+func (t *task) Exec(ctx context.Context, execID string, spec *specs.Process, withStdin bool, attachStdio libcontainerdtypes.StdioCallback) (_ libcontainerdtypes.Process, retErr error) {
 	var (
 		rio            cio.IO
 		stdinCloseSync = make(chan containerd.Process, 1)
@@ -270,7 +270,7 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 		return nil, wrapError(err)
 	}
 
-	fifos := newFIFOSet(md.Labels[DockerContainerBundlePath], processID, withStdin, spec.Terminal)
+	fifos := newFIFOSet(md.Labels[DockerContainerBundlePath], execID, withStdin, spec.Terminal)
 
 	defer func() {
 		if retErr != nil && rio != nil {
@@ -279,7 +279,7 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 		}
 	}()
 
-	p, err := t.Task.Exec(ctx, processID, spec, func(id string) (cio.IO, error) {
+	p, err := t.Task.Exec(ctx, execID, spec, func(id string) (cio.IO, error) {
 		var err error
 		rio, err = t.ctr.createIO(fifos, stdinCloseSync, attachStdio)
 		return rio, err

--- a/daemon/internal/libcontainerd/remote/client.go
+++ b/daemon/internal/libcontainerd/remote/client.go
@@ -298,10 +298,10 @@ func (t *task) Exec(ctx context.Context, processID string, spec *specs.Process, 
 	defer func() { stdinCloseSync <- p }()
 
 	if err := p.Start(ctx); err != nil {
-		// use new context for cleanup because old one may be cancelled by user, but leave a timeout to make sure
-		// we are not waiting forever if containerd is unresponsive or to work around fifo cancelling issues in
-		// older containerd-shim
-		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		// don't cancel cleanup if the context is cancelled, but add a timeout
+		// to make sure we are not waiting forever if containerd is unresponsive
+		// or to work around fifo cancelling issues in older containerd-shim.
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 45*time.Second)
 		defer cancel()
 		p.Delete(ctx)
 		return nil, wrapError(err)

--- a/daemon/internal/libcontainerd/remote/client.go
+++ b/daemon/internal/libcontainerd/remote/client.go
@@ -726,13 +726,11 @@ func (c *client) bundleDir(id string) string {
 }
 
 func wrapError(err error) error {
-	switch {
-	case err == nil:
-		return nil
-	case cerrdefs.IsNotFound(err):
-		return errdefs.NotFound(err)
+	if err == nil || cerrdefs.IsNotFound(err) {
+		return err
 	}
 
+	// TODO(thaJeztah): don't depend on string-matching errors and remove wrapError; https://github.com/moby/moby/issues/50882
 	msg := err.Error()
 	for _, s := range []string{"container does not exist", "not found", "no such container"} {
 		if strings.Contains(msg, s) {


### PR DESCRIPTION
### libcontainerd/remote: rename var that shadowed import


### libcontainerd/remote: task.Exec: make defer error-handling more explicit

Use a named output variable to more clearly indicate what error is being
checked, and scope `err` variables used in this function.


### libcontainerd/remote: task.Exec: preserve parent context during cleanup

Use `context.WithoutCancel()` to preserve the parent context during cleanup
instead of creating a new context. This still prevents context-cancellation
from terminating the cleanup, but makes sure that tracing and logging are
wired up; https://github.com/containerd/containerd/blob/v2.1.4/client/process.go#L232-L263

### libcontainerd/remote: task.Exec: rename processID -> execID

This argument is set from ExecConfig.ID, which we refer to as "execID"
in most places; rename the argument to match that terminology.

### libcontainerd/remote: task.Exec: log warning on cleanup failure

Not exactly sure what errors we can expect here if the process failed
to start, but logging as a warning instead of discarding won't do harm.

### libcontainerd/remote: container.NewTask: move vars closer to where used

### libcontainerd/remote: wrapError: don't convert c8d errdefs error

The moby codebase is now able to handle containerd errdefs errors directly
so there's no need to wrap a c8d "NotFound" error. We still need to look
if we can remove this function altogether; it's unclear what conditions
could result in the string-matching being needed.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

