### PR TITLE
fix: client vendor with config struct changes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -456,3 +456,11 @@ func (cli *Client) dialer() func(context.Context) (net.Conn, error) {
 		}
 	}
 }
+
+// transportFunc allows us to inject a mock transport for testing. We define it
+// here so we can detect the tlsconfig and return nil for only this type.
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return tf(req)
+}

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/moby/moby/api/types/common"
 )
 
-// transportFunc allows us to inject a mock transport for testing. We define it
-// here so we can detect the tlsconfig and return nil for only this type.
-type transportFunc func(*http.Request) (*http.Response, error)
-
-func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return tf(req)
-}
-
 func transportEnsureBody(f transportFunc) transportFunc {
 	return func(req *http.Request) (*http.Response, error) {
 		resp, err := f(req)


### PR DESCRIPTION
**- What I did**
Follow-up to https://github.com/moby/moby/pull/50847

**- How I did it**
Moved `transportFunc` definition out of test scope and revendored client.

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

