### PR TITLE
api/types/image: make `InspectResponse.GraphDriver` optional

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2057,6 +2057,7 @@ definitions:
         format: "int64"
         example: 1239828
       GraphDriver:
+        x-nullable: true
         $ref: "#/definitions/DriverData"
       RootFS:
         description: |

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -111,7 +111,7 @@ type InspectResponse struct {
 
 	// GraphDriver holds information about the storage driver used to store the
 	// container's and image's filesystem.
-	GraphDriver storage.DriverData
+	GraphDriver *storage.DriverData `json:"GraphDriver,omitempty"`
 
 	// RootFS contains information about the image's RootFS, including the
 	// layer IDs.

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -12,7 +12,6 @@ import (
 	"github.com/distribution/reference"
 	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
 	imagetypes "github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/api/types/storage"
 	"github.com/moby/moby/v2/daemon/internal/sliceutil"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -95,10 +94,6 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 		DockerVersion: "",
 		Size:          size,
 		Manifests:     manifests,
-		GraphDriver: storage.DriverData{
-			Name: i.snapshotter,
-			Data: nil,
-		},
 		Metadata: imagetypes.Metadata{
 			LastTagTime: lastUpdated,
 		},

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -71,7 +71,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 		Os:              img.OperatingSystem(),
 		OsVersion:       img.OSVersion,
 		Size:            size,
-		GraphDriver: storage.DriverData{
+		GraphDriver: &storage.DriverData{
 			Name: i.layerStore.DriverName(),
 			Data: layerMetadata,
 		},

--- a/integration/daemon/default_storage_test.go
+++ b/integration/daemon/default_storage_test.go
@@ -73,8 +73,10 @@ func TestGraphDriverPersistence(t *testing.T) {
 	assert.Check(t, is.Equal(info.Driver, prevDriver))
 
 	// Verify our image is still there
-	_, err = c.ImageInspect(ctx, testImage)
+	imageInspect, err := c.ImageInspect(ctx, testImage)
 	assert.NilError(t, err, "Test image should still be available after daemon restart")
+	assert.Check(t, imageInspect.GraphDriver != nil, "GraphDriver should be set for graphdriver backend")
+	assert.Check(t, is.Equal(imageInspect.GraphDriver.Name, prevDriver), "Image graphdriver data should match")
 
 	// Verify our container is still there
 	_, err = c.ContainerInspect(ctx, containerID)

--- a/vendor/github.com/moby/moby/api/types/image/image_inspect.go
+++ b/vendor/github.com/moby/moby/api/types/image/image_inspect.go
@@ -111,7 +111,7 @@ type InspectResponse struct {
 
 	// GraphDriver holds information about the storage driver used to store the
 	// container's and image's filesystem.
-	GraphDriver storage.DriverData
+	GraphDriver *storage.DriverData `json:"GraphDriver,omitempty"`
 
 	// RootFS contains information about the image's RootFS, including the
 	// layer IDs.


### PR DESCRIPTION
**- What I did**
Split from #50857

This change makes the `GraphDriver` field in `image.InspectResponse` optional. This field will only be returned when using moby engine graph drivers as a backend storage implementation. It will be omitted when using the containerd image backend.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api: make `GraphDriver` field in `image.InspectResponse` optional. This field will continue to be emitted when using the legacy graph drivers and will be omitted when using the containerd image backend.
```

**- A picture of a cute animal (not mandatory but encouraged)**

