### PR TITLE
gha: skip "vm" checks if `ci/validate-only` label is set

### DIFF
--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     continue-on-error: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     strategy:
       fail-fast: false
       matrix:
@@ -174,7 +175,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     continue-on-error: ${{ github.event_name != 'pull_request' }}
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only'))
     needs:
       - integration
     steps:


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/50899#issuecomment-3255442027
- https://github.com/moby/moby/pull/50731
- https://github.com/moby/moby/pull/49819


commit f0c069ffc9b51d698ff7a0694e985f424e7e0051 added support for a `ci/validate-only` label to skip tests and only run the validation checks. Commit 09ecd74cf3459f86768fb60f27923d1f33991d24 was merged later, but was authored before that feature was merged, so did not account for the label, so the "vm" checks would always run.

This applies the additional conditions to skip the "vm" checks if the `ci/validate-only` label is set.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

