### PR TITLE
Fix panic on Windows when containerd is not enabled and snapshotter is

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1235,6 +1235,9 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	}
 
 	if d.imageService == nil {
+		if d.containerdClient == nil {
+			return nil, errors.New("containerd snapshotter is enabled but containerd is not configured")
+		}
 		log.G(ctx).Info("Starting daemon with containerd snapshotter integration enabled")
 
 		resp, err := d.containerdClient.IntrospectionService().Plugins(ctx, `type=="io.containerd.snapshotter.v1"`)


### PR DESCRIPTION
Throw an error if the containerd snapshotter is enabled on Windows but
containerd has not been configured. This fixes a panic in this case when
trying to use an uninitialized client.

Fixes #50543 

