### PR TITLE
Add `restarting` attribute on `die` events

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 ## v1.55 API changes
 
+* `GET /events`: `die` events for containers now include a `restarting`
+  attribute, set to `"true"` when the container is going to be restarted,
+  either by its restart policy or by a manual restart in progress. The
+  attribute is omitted when the container is not going to be restarted.
 * `GET /images/{name}/attestations` is a new endpoint that returns the in-toto
   attestation statements attached to an image. The `platform` query parameter
   selects the image variant (defaults to the daemon's host platform); it is

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -119,6 +119,12 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 		"exitCode":     strconv.Itoa(ctrExitStatus.ExitCode),
 		"execDuration": strconv.Itoa(int(execDuration.Seconds())),
 	}
+	if restart || c.HasBeenManuallyRestarted {
+		// The container will be restarted, either by the restart policy or
+		// by a manual "container restart" in progress.
+		attributes["restarting"] = "true"
+	}
+
 	daemon.Cleanup(context.TODO(), c)
 
 	if restart {


### PR DESCRIPTION
**- What I did**

Extend docker events Attributes so `die` events let consumer know container is going to restart
Primary use-case is for Docker Compose to detect a restarting container without the need to inspect container, see https://github.com/docker/compose/pull/13210

**- How I did it**

rely on existing `Restarting` and `HasBeenManuallyRestarted` container attributes

**- How to verify it**

run `docker events` and create then restart a container. Check for ` "restarting": "true"` attribute

**- Human readable description for the release notes**
```markdown changelog
Introduce `restarting` attribute for  `die` events to let consumer know container is going to restart
```

=> impact/api

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="1280" height="640" alt="image" src="https://github.com/user-attachments/assets/4df4bbc4-33a8-41b5-8d14-3dd98dd9488b" />

