### PR TITLE
api/types/image: move LoadResponse to client

### DIFF
--- a/api/types/image/image.go
+++ b/api/types/image/image.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"io"
 	"time"
 )
 
@@ -16,32 +15,4 @@ type Metadata struct {
 type PruneReport struct {
 	ImagesDeleted  []DeleteResponse
 	SpaceReclaimed uint64
-}
-
-// LoadResponse returns information to the client about a load process.
-//
-// TODO(thaJeztah): remove this type, and just use an io.ReadCloser
-//
-// This type was added in https://github.com/moby/moby/pull/18878, related
-// to https://github.com/moby/moby/issues/19177;
-//
-// Make docker load to output json when the response content type is json
-// Swarm hijacks the response from docker load and returns JSON rather
-// than plain text like the Engine does. This makes the API library to return
-// information to figure that out.
-//
-// However the "load" endpoint unconditionally returns JSON;
-// https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255
-//
-// PR https://github.com/moby/moby/pull/21959 made the response-type depend
-// on whether "quiet" was set, but this logic got changed in a follow-up
-// https://github.com/moby/moby/pull/25557, which made the JSON response-type
-// unconditionally, but the output produced depend on whether"quiet" was set.
-//
-// We should deprecated the "quiet" option, as it's really a client
-// responsibility.
-type LoadResponse struct {
-	// Body must be closed to avoid a resource leak
-	Body io.ReadCloser
-	JSON bool
 }

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -122,7 +122,7 @@ type ImageAPIClient interface {
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) ([]image.HistoryResponseItem, error)
-	ImageLoad(ctx context.Context, input io.Reader, _ ...ImageLoadOption) (image.LoadResponse, error)
+	ImageLoad(ctx context.Context, input io.Reader, _ ...ImageLoadOption) (LoadResponse, error)
 	ImageSave(ctx context.Context, images []string, _ ...ImageSaveOption) (io.ReadCloser, error)
 }
 

--- a/client/image_load.go
+++ b/client/image_load.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-
-	"github.com/moby/moby/api/types/image"
 )
 
 // ImageLoad loads an image in the docker host from the client host.
@@ -16,11 +14,11 @@ import (
 // Platform is an optional parameter that specifies the platform to load from
 // the provided multi-platform image. Passing a platform only has an effect
 // if the input image is a multi-platform image.
-func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...ImageLoadOption) (image.LoadResponse, error) {
+func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...ImageLoadOption) (LoadResponse, error) {
 	var opts imageLoadOpts
 	for _, opt := range loadOpts {
 		if err := opt.Apply(&opts); err != nil {
-			return image.LoadResponse{}, err
+			return LoadResponse{}, err
 		}
 	}
 
@@ -31,12 +29,12 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...I
 	}
 	if len(opts.apiOptions.Platforms) > 0 {
 		if err := cli.NewVersionError(ctx, "1.48", "platform"); err != nil {
-			return image.LoadResponse{}, err
+			return LoadResponse{}, err
 		}
 
 		p, err := encodePlatforms(opts.apiOptions.Platforms...)
 		if err != nil {
-			return image.LoadResponse{}, err
+			return LoadResponse{}, err
 		}
 		query["platform"] = p
 	}
@@ -45,10 +43,38 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...I
 		"Content-Type": {"application/x-tar"},
 	})
 	if err != nil {
-		return image.LoadResponse{}, err
+		return LoadResponse{}, err
 	}
-	return image.LoadResponse{
+	return LoadResponse{
 		Body: resp.Body,
 		JSON: resp.Header.Get("Content-Type") == "application/json",
 	}, nil
+}
+
+// LoadResponse returns information to the client about a load process.
+//
+// TODO(thaJeztah): remove this type, and just use an io.ReadCloser
+//
+// This type was added in https://github.com/moby/moby/pull/18878, related
+// to https://github.com/moby/moby/issues/19177;
+//
+// Make docker load to output json when the response content type is json
+// Swarm hijacks the response from docker load and returns JSON rather
+// than plain text like the Engine does. This makes the API library to return
+// information to figure that out.
+//
+// However the "load" endpoint unconditionally returns JSON;
+// https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255
+//
+// PR https://github.com/moby/moby/pull/21959 made the response-type depend
+// on whether "quiet" was set, but this logic got changed in a follow-up
+// https://github.com/moby/moby/pull/25557, which made the JSON response-type
+// unconditionally, but the output produced depend on whether"quiet" was set.
+//
+// We should deprecated the "quiet" option, as it's really a client
+// responsibility.
+type LoadResponse struct {
+	// Body must be closed to avoid a resource leak
+	Body io.ReadCloser
+	JSON bool
 }

--- a/vendor/github.com/moby/moby/api/types/image/image.go
+++ b/vendor/github.com/moby/moby/api/types/image/image.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"io"
 	"time"
 )
 
@@ -16,32 +15,4 @@ type Metadata struct {
 type PruneReport struct {
 	ImagesDeleted  []DeleteResponse
 	SpaceReclaimed uint64
-}
-
-// LoadResponse returns information to the client about a load process.
-//
-// TODO(thaJeztah): remove this type, and just use an io.ReadCloser
-//
-// This type was added in https://github.com/moby/moby/pull/18878, related
-// to https://github.com/moby/moby/issues/19177;
-//
-// Make docker load to output json when the response content type is json
-// Swarm hijacks the response from docker load and returns JSON rather
-// than plain text like the Engine does. This makes the API library to return
-// information to figure that out.
-//
-// However the "load" endpoint unconditionally returns JSON;
-// https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255
-//
-// PR https://github.com/moby/moby/pull/21959 made the response-type depend
-// on whether "quiet" was set, but this logic got changed in a follow-up
-// https://github.com/moby/moby/pull/25557, which made the JSON response-type
-// unconditionally, but the output produced depend on whether"quiet" was set.
-//
-// We should deprecated the "quiet" option, as it's really a client
-// responsibility.
-type LoadResponse struct {
-	// Body must be closed to avoid a resource leak
-	Body io.ReadCloser
-	JSON bool
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -122,7 +122,7 @@ type ImageAPIClient interface {
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) ([]image.HistoryResponseItem, error)
-	ImageLoad(ctx context.Context, input io.Reader, _ ...ImageLoadOption) (image.LoadResponse, error)
+	ImageLoad(ctx context.Context, input io.Reader, _ ...ImageLoadOption) (LoadResponse, error)
 	ImageSave(ctx context.Context, images []string, _ ...ImageSaveOption) (io.ReadCloser, error)
 }
 

--- a/vendor/github.com/moby/moby/client/image_load.go
+++ b/vendor/github.com/moby/moby/client/image_load.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-
-	"github.com/moby/moby/api/types/image"
 )
 
 // ImageLoad loads an image in the docker host from the client host.
@@ -16,11 +14,11 @@ import (
 // Platform is an optional parameter that specifies the platform to load from
 // the provided multi-platform image. Passing a platform only has an effect
 // if the input image is a multi-platform image.
-func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...ImageLoadOption) (image.LoadResponse, error) {
+func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...ImageLoadOption) (LoadResponse, error) {
 	var opts imageLoadOpts
 	for _, opt := range loadOpts {
 		if err := opt.Apply(&opts); err != nil {
-			return image.LoadResponse{}, err
+			return LoadResponse{}, err
 		}
 	}
 
@@ -31,12 +29,12 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...I
 	}
 	if len(opts.apiOptions.Platforms) > 0 {
 		if err := cli.NewVersionError(ctx, "1.48", "platform"); err != nil {
-			return image.LoadResponse{}, err
+			return LoadResponse{}, err
 		}
 
 		p, err := encodePlatforms(opts.apiOptions.Platforms...)
 		if err != nil {
-			return image.LoadResponse{}, err
+			return LoadResponse{}, err
 		}
 		query["platform"] = p
 	}
@@ -45,10 +43,38 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...I
 		"Content-Type": {"application/x-tar"},
 	})
 	if err != nil {
-		return image.LoadResponse{}, err
+		return LoadResponse{}, err
 	}
-	return image.LoadResponse{
+	return LoadResponse{
 		Body: resp.Body,
 		JSON: resp.Header.Get("Content-Type") == "application/json",
 	}, nil
+}
+
+// LoadResponse returns information to the client about a load process.
+//
+// TODO(thaJeztah): remove this type, and just use an io.ReadCloser
+//
+// This type was added in https://github.com/moby/moby/pull/18878, related
+// to https://github.com/moby/moby/issues/19177;
+//
+// Make docker load to output json when the response content type is json
+// Swarm hijacks the response from docker load and returns JSON rather
+// than plain text like the Engine does. This makes the API library to return
+// information to figure that out.
+//
+// However the "load" endpoint unconditionally returns JSON;
+// https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255
+//
+// PR https://github.com/moby/moby/pull/21959 made the response-type depend
+// on whether "quiet" was set, but this logic got changed in a follow-up
+// https://github.com/moby/moby/pull/25557, which made the JSON response-type
+// unconditionally, but the output produced depend on whether"quiet" was set.
+//
+// We should deprecated the "quiet" option, as it's really a client
+// responsibility.
+type LoadResponse struct {
+	// Body must be closed to avoid a resource leak
+	Body io.ReadCloser
+	JSON bool
 }


### PR DESCRIPTION
- addresses part of https://github.com/moby/moby/issues/50740

It's not the response coming from the API, but a wrapper for a response reader. We should ultimately remove it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

