### PR TITLE
testutil/daemon: fix some footguns for running integration tests interactively

### DIFF
--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -216,9 +216,8 @@ func New(t testing.TB, ops ...Option) *Daemon {
 	if dest == "" {
 		dest = os.Getenv("DEST")
 	}
+	assert.Assert(t, dest != "", "Please set the DOCKER_INTEGRATION_DAEMON_DEST or the DEST environment variable")
 	dest = filepath.Join(dest, t.Name())
-
-	assert.Check(t, dest != "", "Please set the DOCKER_INTEGRATION_DAEMON_DEST or the DEST environment variable")
 
 	if os.Getenv("DOCKER_ROOTLESS") != "" {
 		if os.Getenv("DOCKER_REMAP_ROOT") != "" {
@@ -412,6 +411,9 @@ func (d *Daemon) ScanLogs(ctx context.Context, match func(s string) bool) (bool,
 
 // TailLogs tails N lines from the daemon logs
 func (d *Daemon) TailLogs(n int) ([][]byte, error) {
+	if d.logFile == nil {
+		return nil, errors.New("d.logFile is nil")
+	}
 	logF, err := os.Open(d.logFile.Name())
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening daemon log file after failed start")

--- a/testutil/daemon/daemon.go
+++ b/testutil/daemon/daemon.go
@@ -127,9 +127,11 @@ func NewDaemon(workingDir string, ops ...Option) (*Daemon, error) {
 
 	userlandProxy := true
 	if env := os.Getenv("DOCKER_USERLANDPROXY"); env != "" {
-		if val, err := strconv.ParseBool(env); err != nil {
-			userlandProxy = val
+		val, err := strconv.ParseBool(env)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse DOCKER_USERLANDPROXY")
 		}
+		userlandProxy = val
 	}
 	d := &Daemon{
 		id:            id,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed `DOCKER_USERLANDPROXY=0` so the userland proxy is disabled in integration tests when set.
- Made integration tests fail with an actionable message if neither `DOCKER_INTEGRATION_DAEMON_DEST` nor `DEST` environment variables are set instead of nil-dereference panicking.

**- How I did it**

**- How to verify it**
```console
$ go test -run TestEmptyPortBindingsBC ./integration/network/bridge
[...]
INFO: Testing against a local daemon
--- FAIL: TestEmptyPortBindingsBC (0.03s)
    bridge_linux_test.go:949: assertion failed: dest is "": Please set the DOCKER_INTEGRATION_DAEMON_DEST or the DEST environment variable
FAIL
FAIL    github.com/moby/moby/v2/integration/network/bridge      0.072s
FAIL
$ DOCKER_INTEGRATION_DAEMON_DEST=/var/tmp go test -run TestEmptyPortBindingsBC ./integration/network/bridge
--- FAIL: TestEmptyPortBindingsBC (0.53s)
    daemon.go:332: [d7f02733db7e8] unable to configure the Docker daemon with file /dev/null: merged configuration validation from file and command line flags failed: invalid userland-proxy-path: userland-proxy is enabled, but userland-proxy-path is not set
    bridge_linux_test.go:950: [d7f02733db7e8] failed to start daemon with arguments [--config-file /dev/null --data-root /var/tmp/TestEmptyPortBindingsBC/d7f02733db7e8/root --exec-root /tmp/dxr/d7f02733db7e8 --pidfile /var/tmp/TestEmptyPortBindingsBC/d7f02733db7e8/docker.pid --userland-proxy=true --containerd-namespace d7f02733db7e8 --containerd-plugins-namespace d7f02733db7e8p --containerd /var/run/docker/containerd/containerd.sock --host unix:///tmp/docker-integration/d7f02733db7e8.sock --debug] : [d7f02733db7e8] daemon exited during startup: exit status 1
FAIL
FAIL    github.com/moby/moby/v2/integration/network/bridge      0.584s
FAIL
$ DOCKER_USERLANDPROXY=0 DOCKER_INTEGRATION_DAEMON_DEST=/var/tmp go test -run TestEmptyPortBindingsBC ./integration/network/bridge
[...]
ok      github.com/moby/moby/v2/integration/network/bridge      0.969s
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

