### PR TITLE
api: image inspect: remove temporary backfill for Config fields

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -26,6 +26,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   a PortBinding with an empty HostIP and HostPort when calling `POST /containers/{id}/start`.
   This behavior is now deprecated, and a warning is returned by `POST /containers/create`.
   The next API version will drop empty `PortBindings` list altogether.
+* `GET /images/{name}/json` now omits the following `Config` fields when
+  not set, to closer align with the implementation of the [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/v1.1.1/specs-go/v1/config.go#L23-L62)
+  `Cmd`, `Entrypoint`, `Env`, `Labels`, `OnBuild`, `User`, `Volumes`, and `WorkingDir`.
 
 ## v1.51 API changes
 

--- a/daemon/server/router/image/inspect_response.go
+++ b/daemon/server/router/image/inspect_response.go
@@ -31,10 +31,10 @@ var legacyConfigFields = map[string]map[string]any{
 		"Volumes":      nil,
 		"WorkingDir":   "",
 	},
-	// Legacy fields for current API versions (v1.50 and up). These fields
+	// Legacy fields for current API versions (v1.50 and v1.52). These fields
 	// did not have an "omitempty" and were always included in the response,
 	// even if not set; see https://github.com/moby/moby/issues/50134
-	"current": {
+	"v1.50-v1.51": {
 		"Cmd":        nil,
 		"Entrypoint": nil,
 		"Env":        nil,

--- a/daemon/server/router/image/inspect_response_test.go
+++ b/daemon/server/router/image/inspect_response_test.go
@@ -40,12 +40,12 @@ func TestInspectResponse(t *testing.T) {
 			expected:     `{"AttachStderr":false,"AttachStdin":false,"AttachStdout":false,"Cmd":["/bin/sh"],"Domainname":"","Entrypoint":null,"Env":null,"Hostname":"","Image":"","Labels":null,"OnBuild":null,"OpenStdin":false,"StdinOnce":false,"StopSignal":"SIGQUIT","Tty":false,"User":"","Volumes":null,"WorkingDir":""}`,
 		},
 		{
-			doc: "api >= v1.50",
+			doc: "api v1.50 - v1.51",
 			cfg: &ocispec.ImageConfig{
 				Cmd:        []string{"/bin/sh"},
 				StopSignal: "SIGQUIT",
 			},
-			legacyConfig: legacyConfigFields["current"],
+			legacyConfig: legacyConfigFields["v1.50-v1.51"],
 			expected:     `{"Cmd":["/bin/sh"],"Entrypoint":null,"Env":null,"Labels":null,"OnBuild":null,"StopSignal":"SIGQUIT","User":"","Volumes":null,"WorkingDir":""}`,
 		},
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/48457
- https://github.com/moby/moby/pull/50135

Commit 4dc961d0e922381b8cd5e05223f172f3145c7494 (API v1.50) fixed the type used for Config to point to the correct type, which is the Config struct from the [Docker image spec] (which embeds the [OCI Image Specification] type); however, those types use an omitempty, which wasn't documented as part of the API changes, so f85394dd5d7ea27d5189f22a53eebd69e2acc7f3 added a temporary backfill for empty fields.

This removes that backfill for API v1.52 so that empty image config fields are now omitted.

[OCI Image Specification]: https://github.com/opencontainers/image-spec/blob/v1.1.1/specs-go/v1/config.go#L23-L62
[Docker image spec]: https://github.com/moby/docker-image-spec/blob/v1.3.1/specs-go/v1/image.go#L19-L32

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`GET /images/{name}/json`: omit empty `Config` fields when not set.
```

**- A picture of a cute animal (not mandatory but encouraged)**

