### PR TITLE
macvlan, ipvlan-l2: only configure a default route when a gateway address is supplied

### DIFF
--- a/daemon/libnetwork/driverapi/driverapi.go
+++ b/daemon/libnetwork/driverapi/driverapi.go
@@ -186,6 +186,14 @@ type JoinInfo interface {
 	// DisableGatewayService tells libnetwork not to provide Default GW for the container
 	DisableGatewayService()
 
+	// ForceGw4 may be called by a driver to indicate that, even if it has not set up
+	// an IPv4 gateway, libnet should assume the endpoint has external IPv4 connectivity.
+	ForceGw4()
+
+	// ForceGw6 may be called by a driver to indicate that, even if it has not set up
+	// an IPv6 gateway, libnet should assume the endpoint has external IPv6 connectivity.
+	ForceGw6()
+
 	// AddTableEntry adds a table entry to the gossip layer
 	// passing the table name, key and an opaque value.
 	AddTableEntry(tableName string, key string, value []byte) error

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -748,6 +748,8 @@ func (te *testEndpoint) AddTableEntry(tableName string, key string, value []byte
 }
 
 func (te *testEndpoint) DisableGatewayService() {}
+func (te *testEndpoint) ForceGw4()              {}
+func (te *testEndpoint) ForceGw6()              {}
 
 func TestQueryEndpointInfo(t *testing.T) {
 	testQueryEndpointInfo(t, true)

--- a/daemon/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/daemon/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -96,16 +96,24 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 				if s == nil {
 					return fmt.Errorf("could not find a valid ipv4 subnet for endpoint %s", eid)
 				}
-				v4gw, _, err := net.ParseCIDR(s.GwIP)
-				if err != nil {
-					return fmt.Errorf("gateway %s is not a valid ipv4 address: %v", s.GwIP, err)
-				}
-				err = jinfo.SetGateway(v4gw)
-				if err != nil {
-					return err
+				if s.GwIP == "" {
+					// Can't set up a default gateway, but the network is not internal, so it should
+					// be treated as having external connectivity. (This preserves old behavior,
+					// where a gateway address was assigned from IPAM that did not necessarily
+					// correspond with a working gateway.)
+					jinfo.ForceGw4()
+				} else {
+					v4gw, _, err := net.ParseCIDR(s.GwIP)
+					if err != nil {
+						return fmt.Errorf("gateway %s is not a valid ipv4 address: %v", s.GwIP, err)
+					}
+					err = jinfo.SetGateway(v4gw)
+					if err != nil {
+						return err
+					}
 				}
 				log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv4_Addr: %s, Gateway: %s, Ipvlan_Mode: %s, Parent: %s",
-					ep.addr.IP.String(), v4gw.String(), n.config.IpvlanMode, n.config.Parent)
+					ep.addr.IP.String(), s.GwIP, n.config.IpvlanMode, n.config.Parent)
 			}
 			// parse and correlate the endpoint v6 address with the available v6 subnets
 			if len(n.config.Ipv6Subnets) > 0 {
@@ -113,20 +121,24 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 				if s == nil {
 					return fmt.Errorf("could not find a valid ipv6 subnet for endpoint %s", eid)
 				}
-				v6gw, _, err := net.ParseCIDR(s.GwIP)
-				if err != nil {
-					return fmt.Errorf("gateway %s is not a valid ipv6 address: %v", s.GwIP, err)
-				}
-				err = jinfo.SetGatewayIPv6(v6gw)
-				if err != nil {
-					return err
+				if s.GwIP == "" {
+					// Can't set up a default gateway, but the network is not internal, so it should
+					// be treated as having external connectivity. (This preserves old behavior,
+					// where a gateway address was assigned from IPAM that did not necessarily
+					// correspond with a working gateway.)
+					jinfo.ForceGw6()
+				} else {
+					v6gw, _, err := net.ParseCIDR(s.GwIP)
+					if err != nil {
+						return fmt.Errorf("gateway %s is not a valid ipv6 address: %v", s.GwIP, err)
+					}
+					err = jinfo.SetGatewayIPv6(v6gw)
+					if err != nil {
+						return err
+					}
 				}
 				log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv6_Addr: %s, Gateway: %s, Ipvlan_Mode: %s, Parent: %s",
-					ep.addrv6.IP.String(), v6gw.String(), n.config.IpvlanMode, n.config.Parent)
-			}
-			if len(n.config.Ipv4Subnets) == 0 && len(n.config.Ipv6Subnets) == 0 {
-				// With no addresses, don't need a gateway.
-				jinfo.DisableGatewayService()
+					ep.addrv6.IP.String(), s.GwIP, n.config.IpvlanMode, n.config.Parent)
 			}
 		}
 	} else {
@@ -138,11 +150,8 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 			log.G(ctx).Debugf("Ipvlan Endpoint Joined with IPv6_Addr: %s IpVlan_Mode: %s, Parent: %s",
 				ep.addrv6.IP.String(), n.config.IpvlanMode, n.config.Parent)
 		}
-		// If n.config.Internal was set locally by the driver because there's no parent
-		// interface, libnetwork doesn't know the network is internal. So, stop it from
-		// adding a gateway endpoint.
-		jinfo.DisableGatewayService()
 	}
+	jinfo.DisableGatewayService()
 	iNames := jinfo.InterfaceName()
 	err = iNames.SetNames(vethName, containerVethPrefix, netlabel.GetIfname(epOpts))
 	if err != nil {

--- a/daemon/libnetwork/drivers/remote/driver_test.go
+++ b/daemon/libnetwork/drivers/remote/driver_test.go
@@ -208,6 +208,9 @@ func (test *testEndpoint) DisableGatewayService() {
 	test.disableGatewayService = true
 }
 
+func (test *testEndpoint) ForceGw4() {}
+func (test *testEndpoint) ForceGw6() {}
+
 func (test *testEndpoint) AddTableEntry(tableName string, key string, value []byte) error {
 	return nil
 }

--- a/daemon/libnetwork/drivers/windows/windows_test.go
+++ b/daemon/libnetwork/drivers/windows/windows_test.go
@@ -134,6 +134,9 @@ func (test *testEndpoint) SetGatewayIPv6(ipv6 net.IP) error {
 	return nil
 }
 
+func (test *testEndpoint) ForceGw4() {}
+func (test *testEndpoint) ForceGw6() {}
+
 func (test *testEndpoint) SetNames(_, _, _ string) error {
 	return nil
 }

--- a/daemon/libnetwork/sandbox_linux.go
+++ b/daemon/libnetwork/sandbox_linux.go
@@ -106,7 +106,7 @@ func (sb *Sandbox) updateGateway(ep4, ep6 *Endpoint) error {
 			if err := osSbox.SetGateway(joinInfo.gw); err != nil {
 				return fmt.Errorf("failed to set gateway: %v", err)
 			}
-		} else {
+		} else if !joinInfo.forceGw4 {
 			if err := osSbox.SetDefaultRouteIPv4(ep4.iface.srcName); err != nil {
 				return fmt.Errorf("failed to set IPv4 default route: %v", err)
 			}
@@ -120,9 +120,9 @@ func (sb *Sandbox) updateGateway(ep4, ep6 *Endpoint) error {
 
 		if joinInfo.gw6 != nil {
 			if err := osSbox.SetGatewayIPv6(joinInfo.gw6); err != nil {
-				return fmt.Errorf("failed to set IPv6 gateway: %v", err)
+				return fmt.Errorf("failed to set IPv6 gateway (%s): %v", joinInfo.gw6, err)
 			}
-		} else {
+		} else if !joinInfo.forceGw6 {
 			if err := osSbox.SetDefaultRouteIPv6(ep6.iface.srcName); err != nil {
 				return fmt.Errorf("failed to set IPv6 default route: %v", err)
 			}


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/50898
- fix https://github.com/moby/moby/issues/50985

When no `--gateway` is supplied for a macvlan or "l2" ipvlan, an address is allocated from IPAM and configured as the default route.

When IPv6 autoconfiguration is enabled on the parent interface's network, it may also set up a default route. If the kernel wins the race, container creation fails with an error because a default route already exists when Docker tries to set it up.

So, don't try to guess the gateway address by picking one from IPAM (it's not like the bridge driver, where the gateway address is assigned to the bridge - all the drivers do with the address is configure the default route).

Also, when no gateway is configured, don't let the libnet code assume the `docker_gwbridge` is needed.

This will be a breaking change if there are users who haven't been configuring a gateway address, where the gateway is using the first host address in the Docker network's ip-range (the address that'll have been picked for IPAM). Those users will now need to explicitly configure the gateway.

**- How I did it**

**- How to verify it**

Updated integration tests.

The commands noted in the linked issue no longer fail.

**- Human readable description for the release notes**
```markdown changelog
- macvlan and ipvlan-l2 networks: no default gateway will be configured unless a `--gateway` is explicitly included in IPAM configuration. This addresses an issue which could cause container startup to fail in networks with IPv6 auto-configuration enabled.
```

