### PR TITLE
client: remove ImageInspectWithAPIOpts function

### DIFF
--- a/client/image_inspect_opts.go
+++ b/client/image_inspect_opts.go
@@ -48,14 +48,6 @@ func ImageInspectWithPlatform(platform *ocispec.Platform) ImageInspectOption {
 	})
 }
 
-// ImageInspectWithAPIOpts sets the API options for the image inspect operation.
-func ImageInspectWithAPIOpts(opts ImageInspectOptions) ImageInspectOption {
-	return imageInspectOptionFunc(func(clientOpts *imageInspectOpts) error {
-		clientOpts.apiOptions = opts
-		return nil
-	})
-}
-
 type imageInspectOpts struct {
 	raw        *bytes.Buffer
 	apiOptions ImageInspectOptions

--- a/client/image_inspect_opts.go
+++ b/client/image_inspect_opts.go
@@ -50,10 +50,10 @@ func ImageInspectWithPlatform(platform *ocispec.Platform) ImageInspectOption {
 
 type imageInspectOpts struct {
 	raw        *bytes.Buffer
-	apiOptions ImageInspectOptions
+	apiOptions imageInspectOptions
 }
 
-type ImageInspectOptions struct {
+type imageInspectOptions struct {
 	// Manifests returns the image manifests.
 	Manifests bool
 


### PR DESCRIPTION
### client: remove ImageInspectWithAPIOpts function

This function was providing a way to set all API options directly,
however the api type was moved to client in 853aed1 so this option no
longer makes sense as it's exposing a part of the private struct at this
point.


### client/image_inspect: Unexport ImageInspectOptions

This should be an implementation detail and should not be exported.