### PR TITLE
gha: Add automatic PR labeling for modules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+module/client:
+  - changed-files:
+    - any-glob-to-any-file: 'client/**'
+
+module/api:
+  - changed-files:
+    - any-glob-to-any-file: 'api/**'
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Labeler"
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Labels
+        uses: actions/labeler@v6
+        with:
+          sync-labels: true


### PR DESCRIPTION
Sets up the labeler workflow to automatically label PRs affecting the `client` and `api` modules.

This allows to distinguish PRs targetting different modules.

Follow up: Figure out how to handle PRs that would end up with both labels. However, I think it's good to see what PRs would that affect.


