### PR TITLE
client: Unified WithPlatform option

### DIFF
--- a/client/image_history.go
+++ b/client/image_history.go
@@ -3,23 +3,10 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/moby/moby/api/types/image"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
-
-// ImageHistoryWithPlatform sets the platform for the image history operation.
-func ImageHistoryWithPlatform(platform ocispec.Platform) ImageHistoryOption {
-	return imageHistoryOptionFunc(func(opt *imageHistoryOpts) error {
-		if opt.apiOptions.Platform != nil {
-			return fmt.Errorf("platform already set to %s", *opt.apiOptions.Platform)
-		}
-		opt.apiOptions.Platform = &platform
-		return nil
-	})
-}
 
 // ImageHistory returns the changes in an image in history format.
 func (cli *Client) ImageHistory(ctx context.Context, imageID string, historyOpts ...ImageHistoryOption) ([]image.HistoryResponseItem, error) {
@@ -27,7 +14,7 @@ func (cli *Client) ImageHistory(ctx context.Context, imageID string, historyOpts
 
 	var opts imageHistoryOpts
 	for _, o := range historyOpts {
-		if err := o.Apply(&opts); err != nil {
+		if err := o.applyImageHistoryOption(ctx, &opts); err != nil {
 			return nil, err
 		}
 	}

--- a/client/image_history_opts.go
+++ b/client/image_history_opts.go
@@ -10,12 +10,6 @@ type ImageHistoryOption interface {
 	applyImageHistoryOption(ctx context.Context, opts *imageHistoryOpts) error
 }
 
-type imageHistoryOptionFunc func(opt *imageHistoryOpts) error
-
-func (f imageHistoryOptionFunc) applyImageHistoryOption(ctx context.Context, o *imageHistoryOpts) error {
-	return f(o)
-}
-
 type imageHistoryOpts struct {
 	apiOptions imageHistoryOptions
 }
@@ -23,16 +17,4 @@ type imageHistoryOpts struct {
 type imageHistoryOptions struct {
 	// Platform from the manifest list to use for history.
 	Platform *ocispec.Platform
-}
-
-// WithPlatform selects the specific platform of a multi-platform image.  This
-// effectively causes the operation to work on a single-platform image manifest
-// dereferenced from the original OCI index using the provided platform.
-//
-// Minimum API version: 1.48
-func WithHistoryPlatform(platform ocispec.Platform) ImageHistoryOption {
-	return imageHistoryOptionFunc(func(opts *imageHistoryOpts) error {
-		opts.apiOptions.Platform = &platform
-		return nil
-	})
 }

--- a/client/image_history_opts.go
+++ b/client/image_history_opts.go
@@ -1,14 +1,18 @@
 package client
 
-import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+import (
+	"context"
 
-// ImageHistoryOption is a type representing functional options for the image history operation.
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
 type ImageHistoryOption interface {
-	Apply(*imageHistoryOpts) error
+	applyImageHistoryOption(ctx context.Context, opts *imageHistoryOpts) error
 }
+
 type imageHistoryOptionFunc func(opt *imageHistoryOpts) error
 
-func (f imageHistoryOptionFunc) Apply(o *imageHistoryOpts) error {
+func (f imageHistoryOptionFunc) applyImageHistoryOption(ctx context.Context, o *imageHistoryOpts) error {
 	return f(o)
 }
 
@@ -19,4 +23,16 @@ type imageHistoryOpts struct {
 type imageHistoryOptions struct {
 	// Platform from the manifest list to use for history.
 	Platform *ocispec.Platform
+}
+
+// WithPlatform selects the specific platform of a multi-platform image.  This
+// effectively causes the operation to work on a single-platform image manifest
+// dereferenced from the original OCI index using the provided platform.
+//
+// Minimum API version: 1.48
+func WithHistoryPlatform(platform ocispec.Platform) ImageHistoryOption {
+	return imageHistoryOptionFunc(func(opts *imageHistoryOpts) error {
+		opts.apiOptions.Platform = &platform
+		return nil
+	})
 }

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -47,7 +47,7 @@ func TestImageHistory(t *testing.T) {
 		},
 	}
 
-	imageHistories, err := client.ImageHistory(context.Background(), "image_id", WithHistoryPlatform(ocispec.Platform{
+	imageHistories, err := client.ImageHistory(context.Background(), "image_id", WithPlatform(ocispec.Platform{
 		Architecture: "arm64",
 		OS:           "linux",
 		Variant:      "v8",

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -47,7 +47,7 @@ func TestImageHistory(t *testing.T) {
 		},
 	}
 
-	imageHistories, err := client.ImageHistory(context.Background(), "image_id", ImageHistoryWithPlatform(ocispec.Platform{
+	imageHistories, err := client.ImageHistory(context.Background(), "image_id", WithHistoryPlatform(ocispec.Platform{
 		Architecture: "arm64",
 		OS:           "linux",
 		Variant:      "v8",

--- a/client/image_inspect.go
+++ b/client/image_inspect.go
@@ -19,7 +19,7 @@ func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts
 
 	var opts imageInspectOpts
 	for _, opt := range inspectOpts {
-		if err := opt.Apply(&opts); err != nil {
+		if err := opt.applyImageInspectOption(ctx, &opts); err != nil {
 			return image.InspectResponse{}, fmt.Errorf("error applying image inspect option: %w", err)
 		}
 	}

--- a/client/image_inspect_opts.go
+++ b/client/image_inspect_opts.go
@@ -17,18 +17,6 @@ func (f imageInspectOptionFunc) applyImageInspectOption(ctx context.Context, o *
 	return f(o)
 }
 
-// WithPlatform selects the specific platform of a multi-platform image.  This
-// effectively causes the operation to work on a single-platform image manifest
-// dereferenced from the original OCI index using the provided platform.
-//
-// Minimum API version: 1.49
-func WithInspectPlatform(platform ocispec.Platform) ImageInspectOption {
-	return imageInspectOptionFunc(func(opts *imageInspectOpts) error {
-		opts.apiOptions.Platform = &platform
-		return nil
-	})
-}
-
 // WithRawResponse instructs the client to additionally store the
 // raw inspect response in the provided buffer.
 func WithRawResponse(raw *bytes.Buffer) ImageInspectOption {

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -108,7 +108,7 @@ func TestImageInspectWithPlatform(t *testing.T) {
 
 	var opts []ImageInspectOption
 	if requestedPlatform != nil {
-		opts = append(opts, WithInspectPlatform(*requestedPlatform))
+		opts = append(opts, WithPlatform(*requestedPlatform))
 	}
 
 	imageInspect, err := client.ImageInspect(context.Background(), "image_id", opts...)

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -106,7 +106,12 @@ func TestImageInspectWithPlatform(t *testing.T) {
 	}))
 	assert.NilError(t, err)
 
-	imageInspect, err := client.ImageInspect(context.Background(), "image_id", ImageInspectWithPlatform(requestedPlatform))
+	var opts []ImageInspectOption
+	if requestedPlatform != nil {
+		opts = append(opts, WithInspectPlatform(*requestedPlatform))
+	}
+
+	imageInspect, err := client.ImageInspect(context.Background(), "image_id", opts...)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(imageInspect.ID, "image_id"))
 	assert.Check(t, is.Equal(imageInspect.Architecture, "arm64"))

--- a/client/opt_platform.go
+++ b/client/opt_platform.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type withSinglePlatformOption struct {
+	platform ocispec.Platform
+}
+
+// WithPlatform selects the specific platform of a multi-platform image.  This
+// effectively causes the operation to work on a single-platform image manifest
+// dereferenced from the original OCI index using the provided platform.
+//
+// Minimum API version requirements:
+//
+// - ImageInspect: 1.49
+//
+// - ImageHistory: 1.48
+func WithPlatform(platform ocispec.Platform) *withSinglePlatformOption {
+	return &withSinglePlatformOption{platform: platform}
+}
+
+func (o *withSinglePlatformOption) applyImageHistoryOption(ctx context.Context, opts *imageHistoryOpts) error {
+	if opts.apiOptions.Platform != nil {
+		return fmt.Errorf("platform already set to %v", opts.apiOptions.Platform)
+	}
+
+	opts.apiOptions.Platform = &o.platform
+	return nil
+}
+
+func (o *withSinglePlatformOption) applyImageInspectOption(ctx context.Context, opts *imageInspectOpts) error {
+	if opts.apiOptions.Platform != nil {
+		return fmt.Errorf("platform already set to %v", opts.apiOptions.Platform)
+	}
+
+	opts.apiOptions.Platform = &o.platform
+	return nil
+}

--- a/integration/image/history_test.go
+++ b/integration/image/history_test.go
@@ -94,7 +94,7 @@ func TestAPIImageHistoryCrossPlatform(t *testing.T) {
 		{
 			name:     "with explicit platform",
 			imageRef: imgID,
-			options:  []client.ImageHistoryOption{client.WithHistoryPlatform(nonNativePlatform)},
+			options:  []client.ImageHistoryOption{client.WithPlatform(nonNativePlatform)},
 		},
 		{
 			name:     "using image reference",

--- a/integration/image/history_test.go
+++ b/integration/image/history_test.go
@@ -94,7 +94,7 @@ func TestAPIImageHistoryCrossPlatform(t *testing.T) {
 		{
 			name:     "with explicit platform",
 			imageRef: imgID,
-			options:  []client.ImageHistoryOption{client.ImageHistoryWithPlatform(nonNativePlatform)},
+			options:  []client.ImageHistoryOption{client.WithHistoryPlatform(nonNativePlatform)},
 		},
 		{
 			name:     "using image reference",

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -24,7 +24,7 @@ func TestImageInspectEmptyTagsAndDigests(t *testing.T) {
 	danglingID := iimage.Load(ctx, t, apiClient, specialimage.Dangling)
 
 	var raw bytes.Buffer
-	inspect, err := apiClient.ImageInspect(ctx, danglingID, client.ImageInspectWithRawResponse(&raw))
+	inspect, err := apiClient.ImageInspect(ctx, danglingID, client.WithRawResponse(&raw))
 	assert.NilError(t, err)
 
 	// Must be a zero length array, not null.
@@ -163,10 +163,10 @@ func TestImageInspectWithPlatform(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var opts []client.ImageInspectOption
 			if tc.requestedPlatform != nil {
-				opts = append(opts, client.ImageInspectWithPlatform(tc.requestedPlatform))
+				opts = append(opts, client.WithInspectPlatform(*tc.requestedPlatform))
 			}
 			if tc.withManifests {
-				opts = append(opts, client.ImageInspectWithManifests(true))
+				opts = append(opts, client.WithImageManifests(true))
 			}
 			inspect, err := apiClient.ImageInspect(ctx, imageID, opts...)
 			if tc.expectedError != "" {

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -163,7 +163,7 @@ func TestImageInspectWithPlatform(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var opts []client.ImageInspectOption
 			if tc.requestedPlatform != nil {
-				opts = append(opts, client.WithInspectPlatform(*tc.requestedPlatform))
+				opts = append(opts, client.WithPlatform(*tc.requestedPlatform))
 			}
 			if tc.withManifests {
 				opts = append(opts, client.WithImageManifests(true))

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -339,7 +339,7 @@ func TestSaveAndLoadPlatform(t *testing.T) {
 
 			// verify the loaded image has all the expected platforms
 			for _, p := range tc.expectedSavedPlatforms {
-				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.ImageInspectWithPlatform(&p))
+				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.WithInspectPlatform(p))
 				assert.NilError(t, err)
 				assert.Check(t, is.Equal(inspectResponse.Os, p.OS))
 				assert.Check(t, is.Equal(inspectResponse.Architecture, p.Architecture))
@@ -377,7 +377,7 @@ func TestSaveAndLoadPlatform(t *testing.T) {
 
 			// verify the image was loaded for the specified platforms
 			for _, p := range tc.expectedLoadedPlatforms {
-				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.ImageInspectWithPlatform(&p))
+				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.WithInspectPlatform(p))
 				assert.NilError(t, err)
 				assert.Check(t, is.Equal(inspectResponse.Os, p.OS))
 				assert.Check(t, is.Equal(inspectResponse.Architecture, p.Architecture))

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -339,7 +339,7 @@ func TestSaveAndLoadPlatform(t *testing.T) {
 
 			// verify the loaded image has all the expected platforms
 			for _, p := range tc.expectedSavedPlatforms {
-				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.WithInspectPlatform(p))
+				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.WithPlatform(p))
 				assert.NilError(t, err)
 				assert.Check(t, is.Equal(inspectResponse.Os, p.OS))
 				assert.Check(t, is.Equal(inspectResponse.Architecture, p.Architecture))
@@ -377,7 +377,7 @@ func TestSaveAndLoadPlatform(t *testing.T) {
 
 			// verify the image was loaded for the specified platforms
 			for _, p := range tc.expectedLoadedPlatforms {
-				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.WithInspectPlatform(p))
+				inspectResponse, err := apiClient.ImageInspect(ctx, repoName, client.WithPlatform(p))
 				assert.NilError(t, err)
 				assert.Check(t, is.Equal(inspectResponse.Os, p.OS))
 				assert.Check(t, is.Equal(inspectResponse.Architecture, p.Architecture))

--- a/vendor/github.com/moby/moby/client/image_history.go
+++ b/vendor/github.com/moby/moby/client/image_history.go
@@ -3,23 +3,10 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/moby/moby/api/types/image"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
-
-// ImageHistoryWithPlatform sets the platform for the image history operation.
-func ImageHistoryWithPlatform(platform ocispec.Platform) ImageHistoryOption {
-	return imageHistoryOptionFunc(func(opt *imageHistoryOpts) error {
-		if opt.apiOptions.Platform != nil {
-			return fmt.Errorf("platform already set to %s", *opt.apiOptions.Platform)
-		}
-		opt.apiOptions.Platform = &platform
-		return nil
-	})
-}
 
 // ImageHistory returns the changes in an image in history format.
 func (cli *Client) ImageHistory(ctx context.Context, imageID string, historyOpts ...ImageHistoryOption) ([]image.HistoryResponseItem, error) {
@@ -27,7 +14,7 @@ func (cli *Client) ImageHistory(ctx context.Context, imageID string, historyOpts
 
 	var opts imageHistoryOpts
 	for _, o := range historyOpts {
-		if err := o.Apply(&opts); err != nil {
+		if err := o.applyImageHistoryOption(ctx, &opts); err != nil {
 			return nil, err
 		}
 	}

--- a/vendor/github.com/moby/moby/client/image_history_opts.go
+++ b/vendor/github.com/moby/moby/client/image_history_opts.go
@@ -10,12 +10,6 @@ type ImageHistoryOption interface {
 	applyImageHistoryOption(ctx context.Context, opts *imageHistoryOpts) error
 }
 
-type imageHistoryOptionFunc func(opt *imageHistoryOpts) error
-
-func (f imageHistoryOptionFunc) applyImageHistoryOption(ctx context.Context, o *imageHistoryOpts) error {
-	return f(o)
-}
-
 type imageHistoryOpts struct {
 	apiOptions imageHistoryOptions
 }
@@ -23,16 +17,4 @@ type imageHistoryOpts struct {
 type imageHistoryOptions struct {
 	// Platform from the manifest list to use for history.
 	Platform *ocispec.Platform
-}
-
-// WithPlatform selects the specific platform of a multi-platform image.  This
-// effectively causes the operation to work on a single-platform image manifest
-// dereferenced from the original OCI index using the provided platform.
-//
-// Minimum API version: 1.48
-func WithHistoryPlatform(platform ocispec.Platform) ImageHistoryOption {
-	return imageHistoryOptionFunc(func(opts *imageHistoryOpts) error {
-		opts.apiOptions.Platform = &platform
-		return nil
-	})
 }

--- a/vendor/github.com/moby/moby/client/image_history_opts.go
+++ b/vendor/github.com/moby/moby/client/image_history_opts.go
@@ -1,14 +1,18 @@
 package client
 
-import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+import (
+	"context"
 
-// ImageHistoryOption is a type representing functional options for the image history operation.
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
 type ImageHistoryOption interface {
-	Apply(*imageHistoryOpts) error
+	applyImageHistoryOption(ctx context.Context, opts *imageHistoryOpts) error
 }
+
 type imageHistoryOptionFunc func(opt *imageHistoryOpts) error
 
-func (f imageHistoryOptionFunc) Apply(o *imageHistoryOpts) error {
+func (f imageHistoryOptionFunc) applyImageHistoryOption(ctx context.Context, o *imageHistoryOpts) error {
 	return f(o)
 }
 
@@ -19,4 +23,16 @@ type imageHistoryOpts struct {
 type imageHistoryOptions struct {
 	// Platform from the manifest list to use for history.
 	Platform *ocispec.Platform
+}
+
+// WithPlatform selects the specific platform of a multi-platform image.  This
+// effectively causes the operation to work on a single-platform image manifest
+// dereferenced from the original OCI index using the provided platform.
+//
+// Minimum API version: 1.48
+func WithHistoryPlatform(platform ocispec.Platform) ImageHistoryOption {
+	return imageHistoryOptionFunc(func(opts *imageHistoryOpts) error {
+		opts.apiOptions.Platform = &platform
+		return nil
+	})
 }

--- a/vendor/github.com/moby/moby/client/image_inspect.go
+++ b/vendor/github.com/moby/moby/client/image_inspect.go
@@ -19,7 +19,7 @@ func (cli *Client) ImageInspect(ctx context.Context, imageID string, inspectOpts
 
 	var opts imageInspectOpts
 	for _, opt := range inspectOpts {
-		if err := opt.Apply(&opts); err != nil {
+		if err := opt.applyImageInspectOption(ctx, &opts); err != nil {
 			return image.InspectResponse{}, fmt.Errorf("error applying image inspect option: %w", err)
 		}
 	}

--- a/vendor/github.com/moby/moby/client/image_inspect_opts.go
+++ b/vendor/github.com/moby/moby/client/image_inspect_opts.go
@@ -17,18 +17,6 @@ func (f imageInspectOptionFunc) applyImageInspectOption(ctx context.Context, o *
 	return f(o)
 }
 
-// WithPlatform selects the specific platform of a multi-platform image.  This
-// effectively causes the operation to work on a single-platform image manifest
-// dereferenced from the original OCI index using the provided platform.
-//
-// Minimum API version: 1.49
-func WithInspectPlatform(platform ocispec.Platform) ImageInspectOption {
-	return imageInspectOptionFunc(func(opts *imageInspectOpts) error {
-		opts.apiOptions.Platform = &platform
-		return nil
-	})
-}
-
 // WithRawResponse instructs the client to additionally store the
 // raw inspect response in the provided buffer.
 func WithRawResponse(raw *bytes.Buffer) ImageInspectOption {

--- a/vendor/github.com/moby/moby/client/opt_platform.go
+++ b/vendor/github.com/moby/moby/client/opt_platform.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type withSinglePlatformOption struct {
+	platform ocispec.Platform
+}
+
+// WithPlatform selects the specific platform of a multi-platform image.  This
+// effectively causes the operation to work on a single-platform image manifest
+// dereferenced from the original OCI index using the provided platform.
+//
+// Minimum API version requirements:
+//
+// - ImageInspect: 1.49
+//
+// - ImageHistory: 1.48
+func WithPlatform(platform ocispec.Platform) *withSinglePlatformOption {
+	return &withSinglePlatformOption{platform: platform}
+}
+
+func (o *withSinglePlatformOption) applyImageHistoryOption(ctx context.Context, opts *imageHistoryOpts) error {
+	if opts.apiOptions.Platform != nil {
+		return fmt.Errorf("platform already set to %v", opts.apiOptions.Platform)
+	}
+
+	opts.apiOptions.Platform = &o.platform
+	return nil
+}
+
+func (o *withSinglePlatformOption) applyImageInspectOption(ctx context.Context, opts *imageInspectOpts) error {
+	if opts.apiOptions.Platform != nil {
+		return fmt.Errorf("platform already set to %v", opts.apiOptions.Platform)
+	}
+
+	opts.apiOptions.Platform = &o.platform
+	return nil
+}


### PR DESCRIPTION
- stacked on: https://github.com/moby/moby/pull/50930
- related to: https://github.com/moby/moby/issues/50927
- fixes: https://github.com/moby/moby/issues/50967

Use a single `WithPlatform` functional option for ImageInspect and
ImageHistory which both can accept a single platform to operate on.

The non-unified functional opts returning the same type are neatly grouped in GoDoc:

<img width="592" height="87" alt="image" src="https://github.com/user-attachments/assets/da57aaa7-05fc-4e8f-b38c-ec1c5e7cf130" />


the only issue are with the unified options like `WithPlatform`:

<img width="664" height="404" alt="image" src="https://github.com/user-attachments/assets/550e4684-87f6-41b7-be2a-d76c0ad821d8" />
