### PR TITLE
Add go modules to version response

### DIFF
--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	runcoptions "github.com/containerd/containerd/api/types/runc/options"
@@ -183,6 +184,51 @@ func (daemon *Daemon) fillPlatformVersion(ctx context.Context, v *types.Version,
 			return err
 		}
 		log.G(ctx).WithError(err).Warn("Failed to fill rootless version")
+	}
+
+	if err := daemon.fillModuleversion(ctx, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (daemon *Daemon) fillModuleversion(ctx context.Context, v *types.Version) error {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		log.G(ctx).Warn("Failed to read build info")
+		return nil
+	}
+
+	if len(v.Components) > 0 && v.Components[0].Name == "Engine" && v.Components[0].Details != nil {
+		v.Components[0].Details["Module"] = info.Main.Path
+		v.Components[0].Details["ModuleVersion"] = info.Main.Version
+	}
+
+	for _, dep := range info.Deps {
+		var name string
+		switch dep.Path {
+		case "github.com/moby/moby/v2":
+			name = "moby"
+		case "github.com/moby/moby/api":
+			name = "moby/api"
+		case "github.com/moby/moby/client":
+			name = "moby/client"
+		case "github.com/containerd/containerd/v2":
+			name = "containerd/client"
+		case "github.com/containerd/containerd/api":
+			name = "containerd/api"
+		default:
+			continue
+		}
+
+		v.Components = append(v.Components, types.ComponentVersion{
+			Name:    name,
+			Version: dep.Version,
+			Details: map[string]string{
+				"Module": dep.Path,
+			},
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
Add moby and containerd modules to version output along with the module path.
Add the main module path to the engine version output.

Example docker version output (with one change to support showing up under Engine)
```
Server:
 Engine:
  Version:          dev
  API version:      1.52 (minimum version 1.24)
  Go version:       go1.24.7
  Git commit:       f835ff6987c5f907eebbc4d709fd6400e41cfe8b
  Built:            Tue Sep  9 01:12:15 2025
  OS/Arch:          linux/amd64
  Experimental:     false
  Module:           github.com/moby/moby/v2
 containerd:
  Version:          v2.1.0-386-g955897c27.m
  GitCommit:        955897c275bdef3596175daa3350db9746c62c6e.m
 runc:
  Version:          1.1.12
  GitCommit:        v1.1.12-0-g51d5e946
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
 containerd/api:
  Version:          v1.9.0
  Module:           github.com/containerd/containerd/api
 containerd/client:
  Version:          v2.1.4
  Module:           github.com/containerd/containerd/v2
 moby/api:
  Version:          v1.52.0-beta.1
  Module:           github.com/moby/moby/api

```
