### PR TITLE
introduce ImagePullResponse with helper method to manage JSONMessage stream decoding

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -114,7 +114,7 @@ type ImageAPIClient interface {
 	ImageImport(ctx context.Context, source ImageImportSource, ref string, options ImageImportOptions) (io.ReadCloser, error)
 
 	ImageList(ctx context.Context, options ImageListOptions) ([]image.Summary, error)
-	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (io.ReadCloser, error)
+	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (ImagePullResponse, error)
 	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -2,19 +2,84 @@ package client
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
+	"iter"
 	"net/url"
 	"strings"
+	"sync"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/client/pkg/jsonmessage"
 )
+
+func newImagePullResponse(rc io.ReadCloser) ImagePullResponse {
+	return ImagePullResponse{
+		rc:    rc,
+		close: &sync.Once{},
+	}
+}
+
+type ImagePullResponse struct {
+	rc    io.ReadCloser
+	close *sync.Once
+}
+
+// Read implements io.ReadCloser
+func (r ImagePullResponse) Read(p []byte) (n int, err error) {
+	return r.rc.Read(p)
+}
+
+// Close implements io.ReadCloser
+func (r ImagePullResponse) Close() error {
+	if r.close == nil {
+		return nil
+	}
+	var err error
+	r.close.Do(func() {
+		if r.rc != nil {
+			err = r.rc.Close()
+		}
+	})
+	return err
+}
+
+// JSONMessages decodes the response stream as a sequence of JSONMessages.
+// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
+func (r ImagePullResponse) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
+	context.AfterFunc(ctx, func() {
+		r.Close()
+	})
+	dec := json.NewDecoder(r)
+	return func(yield func(jsonmessage.JSONMessage, error) bool) {
+		defer r.Close()
+		for {
+			var jm jsonmessage.JSONMessage
+			err := dec.Decode(&jm)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if ctx.Err() != nil {
+				yield(jm, ctx.Err())
+				return
+			}
+			if !yield(jm, err) {
+				return
+			}
+		}
+	}
+}
 
 // ImagePull requests the docker host to pull an image from a remote registry.
 // It executes the privileged function if the operation is unauthorized
 // and it tries one more time.
-// It's up to the caller to handle the [io.ReadCloser] and close it.
-func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePullOptions) (io.ReadCloser, error) {
+// Callers can use [ImagePullResponse.JSONMessages] to monitor pull progress as
+// a sequence of JSONMessages, [ImagePullResponse.Close] does not need to be
+// called in this case. Or, use the [io.Reader] interface and call
+// [ImagePullResponse.Close] after processing.
+func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePullOptions) (ImagePullResponse, error) {
 	// FIXME(vdemeester): there is currently used in a few way in docker/docker
 	// - if not in trusted content, ref is used to pass the whole reference, and tag is empty
 	// - if in trusted content, ref is used to pass the reference name, and tag for the digest
@@ -23,7 +88,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 
 	ref, err := reference.ParseNormalizedNamed(refStr)
 	if err != nil {
-		return nil, err
+		return ImagePullResponse{}, err
 	}
 
 	query := url.Values{}
@@ -40,9 +105,10 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		resp, err = cli.tryImageCreate(ctx, query, options.PrivilegeFunc)
 	}
 	if err != nil {
-		return nil, err
+		return ImagePullResponse{}, err
 	}
-	return resp.Body, nil
+
+	return newImagePullResponse(resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/client/image_pull_opts.go
+++ b/client/image_pull_opts.go
@@ -1,6 +1,8 @@
 package client
 
-import "context"
+import (
+	"context"
+)
 
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -153,9 +153,7 @@ func TestImagePullStoredDigestForOtherRepo(t *testing.T) {
 
 	// Now, pull a totally different repo with a the same digest
 	rdr, err = apiClient.ImagePull(ctx, path.Join(registry.DefaultURL, "other:image@"+desc.Digest.String()), client.ImagePullOptions{})
-	if rdr != nil {
-		assert.Check(t, rdr.Close())
-	}
+	assert.Check(t, rdr.Close())
 	assert.Assert(t, err != nil, "Expected error, got none: %v", err)
 	assert.Assert(t, cerrdefs.IsNotFound(err), err)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -114,7 +114,7 @@ type ImageAPIClient interface {
 	ImageImport(ctx context.Context, source ImageImportSource, ref string, options ImageImportOptions) (io.ReadCloser, error)
 
 	ImageList(ctx context.Context, options ImageListOptions) ([]image.Summary, error)
-	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (io.ReadCloser, error)
+	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (ImagePullResponse, error)
 	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (io.ReadCloser, error)
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -2,19 +2,84 @@ package client
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
+	"iter"
 	"net/url"
 	"strings"
+	"sync"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/client/pkg/jsonmessage"
 )
+
+func newImagePullResponse(rc io.ReadCloser) ImagePullResponse {
+	return ImagePullResponse{
+		rc:    rc,
+		close: &sync.Once{},
+	}
+}
+
+type ImagePullResponse struct {
+	rc    io.ReadCloser
+	close *sync.Once
+}
+
+// Read implements io.ReadCloser
+func (r ImagePullResponse) Read(p []byte) (n int, err error) {
+	return r.rc.Read(p)
+}
+
+// Close implements io.ReadCloser
+func (r ImagePullResponse) Close() error {
+	if r.close == nil {
+		return nil
+	}
+	var err error
+	r.close.Do(func() {
+		if r.rc != nil {
+			err = r.rc.Close()
+		}
+	})
+	return err
+}
+
+// JSONMessages decodes the response stream as a sequence of JSONMessages.
+// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
+func (r ImagePullResponse) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
+	context.AfterFunc(ctx, func() {
+		r.Close()
+	})
+	dec := json.NewDecoder(r)
+	return func(yield func(jsonmessage.JSONMessage, error) bool) {
+		defer r.Close()
+		for {
+			var jm jsonmessage.JSONMessage
+			err := dec.Decode(&jm)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if ctx.Err() != nil {
+				yield(jm, ctx.Err())
+				return
+			}
+			if !yield(jm, err) {
+				return
+			}
+		}
+	}
+}
 
 // ImagePull requests the docker host to pull an image from a remote registry.
 // It executes the privileged function if the operation is unauthorized
 // and it tries one more time.
-// It's up to the caller to handle the [io.ReadCloser] and close it.
-func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePullOptions) (io.ReadCloser, error) {
+// Callers can use [ImagePullResponse.JSONMessages] to monitor pull progress as
+// a sequence of JSONMessages, [ImagePullResponse.Close] does not need to be
+// called in this case. Or, use the [io.Reader] interface and call
+// [ImagePullResponse.Close] after processing.
+func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePullOptions) (ImagePullResponse, error) {
 	// FIXME(vdemeester): there is currently used in a few way in docker/docker
 	// - if not in trusted content, ref is used to pass the whole reference, and tag is empty
 	// - if in trusted content, ref is used to pass the reference name, and tag for the digest
@@ -23,7 +88,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 
 	ref, err := reference.ParseNormalizedNamed(refStr)
 	if err != nil {
-		return nil, err
+		return ImagePullResponse{}, err
 	}
 
 	query := url.Values{}
@@ -40,9 +105,10 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		resp, err = cli.tryImageCreate(ctx, query, options.PrivilegeFunc)
 	}
 	if err != nil {
-		return nil, err
+		return ImagePullResponse{}, err
 	}
-	return resp.Body, nil
+
+	return newImagePullResponse(resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/vendor/github.com/moby/moby/client/image_pull_opts.go
+++ b/vendor/github.com/moby/moby/client/image_pull_opts.go
@@ -1,6 +1,8 @@
 package client
 
-import "context"
+import (
+	"context"
+)
 
 // ImagePullOptions holds information to pull images.
 type ImagePullOptions struct {


### PR DESCRIPTION
**- What I did**

Introduce `ImagePullResponse` with helper method to manage `JSONMessage` stream decoding. Still can be consumed as a raw `io.Reader` for backward compatibility

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
`ImagePull` now returns an object with `JSONMessages` method returning iterator over the message objects.
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="275" height="183" alt="image" src="https://github.com/user-attachments/assets/8d46880c-cdd3-4b7a-aa28-f5f6f1a4939b" />

