### PR TITLE
Dockerfile.windows: remove deprecated 7Zip4Powershell 

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -258,14 +258,11 @@ RUN `
   Remove-Item C:\gitsetup.zip; `
   `
   Write-Host INFO: Downloading containerd; `
-  Install-Package -Force 7Zip4PowerShell; `
   $location='https://github.com/containerd/containerd/releases/download/'+$Env:CONTAINERD_VERSION+'/containerd-'+$Env:CONTAINERD_VERSION.TrimStart('v')+'-windows-amd64.tar.gz'; `
   Download-File $location C:\containerd.tar.gz; `
   New-Item -Path C:\containerd -ItemType Directory; `
-  Expand-7Zip C:\containerd.tar.gz C:\; `
-  Expand-7Zip C:\containerd.tar C:\containerd; `
+  tar -xzf C:\containerd.tar.gz -C C:\containerd; `
   Remove-Item C:\containerd.tar.gz; `
-  Remove-Item C:\containerd.tar; `
   `
   # Ensure all directories exist that we will require below....
   $srcDir = """$Env:GOPATH`\src\github.com\docker\docker\bundles"""; `


### PR DESCRIPTION
`tar` utility is included in Windows 10 (17063+) and Windows Server 2019+ so we can use it directly.

This fixes recent Windows CI failures: https://github.com/moby/moby/actions/runs/17578675113/job/49940905820?pr=50932

```
 WARNING: The specified PackageManagement provider 'NuGet' is not available.
Install-Package : No match was found for the specified search criteria and 
package name '7Zip4PowerShell'. Try Get-PackageSource to see all available 
registered package sources.
At line:1 char:3086
+ ... ownloading containerd; Install-Package -Force 7Zip4PowerShell; $locat ...
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Microsoft.Power....InstallPacka 
   ge:InstallPackage) [Install-Package], Exception
    + FullyQualifiedErrorId : NoMatchFoundForCriteria,Microsoft.PowerShell.Pac 
```