### PR TITLE
[23.0 backport] Fix download-frozen-image-v2

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -68,7 +68,7 @@ fetch_blob() {
 			-D-
 	)"
 	curlHeaders="$(echo "$curlHeaders" | tr -d '\r')"
-	if grep -qE "^HTTP/[0-9].[0-9] 3" <<< "$curlHeaders"; then
+	if grep -qE "^HTTP/[0-9](.[0-9])* 3" <<< "$curlHeaders"; then
 		rm -f "$targetFile"
 
 		local blobRedirect

--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -59,30 +59,11 @@ fetch_blob() {
 	shift
 	local curlArgs=("$@")
 
-	local curlHeaders
-	curlHeaders="$(
-		curl -S "${curlArgs[@]}" \
-			-H "Authorization: Bearer $token" \
-			"$registryBase/v2/$image/blobs/$digest" \
-			-o "$targetFile" \
-			-D-
-	)"
-	curlHeaders="$(echo "$curlHeaders" | tr -d '\r')"
-	if grep -qE "^HTTP/[0-9](.[0-9])* 3" <<< "$curlHeaders"; then
-		rm -f "$targetFile"
-
-		local blobRedirect
-		blobRedirect="$(echo "$curlHeaders" | awk -F ': ' 'tolower($1) == "location" { print $2; exit }')"
-		if [ -z "$blobRedirect" ]; then
-			echo >&2 "error: failed fetching '$image' blob '$digest'"
-			echo "$curlHeaders" | head -1 >&2
-			return 1
-		fi
-
-		curl -fSL "${curlArgs[@]}" \
-			"$blobRedirect" \
-			-o "$targetFile"
-	fi
+	curl -L -S "${curlArgs[@]}" \
+		-H "Authorization: Bearer $token" \
+		"$registryBase/v2/$image/blobs/$digest" \
+		-o "$targetFile" \
+		-D-
 }
 
 # handle 'application/vnd.docker.distribution.manifest.v2+json' manifest


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50662

- fixes: https://github.com/moby/moby/issues/50655
- duplicated by / closes https://github.com/moby/moby/pull/50663
- closes https://github.com/moby/moby/pull/50658
- closes https://github.com/moby/moby/pull/50656

## download-frozen-image-v2: Use curl -L
    
Passing the Auth to the redirected location was fixed in curl 7.58: https://curl.se/changes.html#7_58_0 so we no longer need the extra handling and can just use `-L` to let curl handle redirects.
    

## download-frozen-image-v2: handle 307 responses without decimal
    
Correctly parse HTTP response that doesn't contain an HTTP version with a decimal place:

```
< HTTP/2 307
```

The previous version would only match strings like `HTTP/2.0 307`.