### PR TITLE
daemon: Ensure buildkit created container's isolation mode is consistent with daemon's config in Windows

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -424,6 +424,7 @@ func initBuildkit(ctx context.Context, d *daemon.Daemon, cdiCache *cdi.Cache) (_
 		Snapshotter:         d.ImageService().StorageDriver(),
 		ContainerdAddress:   cfg.ContainerdAddr,
 		ContainerdNamespace: cfg.ContainerdNamespace,
+		HyperVIsolation:     d.DefaultIsolation().IsHyperV(),
 		Callbacks: exporter.BuildkitCallbacks{
 			Exported: d.ImageExportedByBuildkit,
 			Named:    d.ImageNamedByBuildkit,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -205,6 +205,11 @@ func (daemon *Daemon) UsesSnapshotter() bool {
 	return daemon.usesSnapshotter
 }
 
+// DefaultIsolation returns the default isolation mode for the daemon to run in (only applicable on Windows).
+func (daemon *Daemon) DefaultIsolation() containertypes.Isolation {
+	return daemon.defaultIsolation
+}
+
 func (daemon *Daemon) loadContainers(ctx context.Context) (map[string]map[string]*container.Container, error) {
 	var mapLock sync.Mutex
 	driverContainers := make(map[string]map[string]*container.Container)

--- a/daemon/internal/builder-next/builder.go
+++ b/daemon/internal/builder-next/builder.go
@@ -98,6 +98,7 @@ type Opt struct {
 	Snapshotter         string
 	ContainerdAddress   string
 	ContainerdNamespace string
+	HyperVIsolation     bool
 	Callbacks           exporter.BuildkitCallbacks
 	CDICache            *cdi.Cache
 }

--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -161,6 +161,7 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 		cdiManager,
 		opt.ContainerdAddress,
 		opt.ContainerdNamespace,
+		opt.HyperVIsolation,
 	)
 	if err != nil {
 		return nil, err

--- a/daemon/internal/builder-next/executor_linux.go
+++ b/daemon/internal/builder-next/executor_linux.go
@@ -22,7 +22,7 @@ import (
 
 const networkName = "bridge"
 
-func newExecutor(root, cgroupParent string, net *libnetwork.Controller, dnsConfig *oci.DNSConfig, rootless bool, idmap user.IdentityMapping, apparmorProfile string, cdiManager *cdidevices.Manager, _, _ string) (executor.Executor, error) {
+func newExecutor(root, cgroupParent string, net *libnetwork.Controller, dnsConfig *oci.DNSConfig, rootless bool, idmap user.IdentityMapping, apparmorProfile string, cdiManager *cdidevices.Manager, _, _ string, _ bool) (executor.Executor, error) {
 	netRoot := filepath.Join(root, "net")
 	networkProviders := map[pb.NetMode]network.Provider{
 		pb.NetMode_UNSET: &bridgeProvider{Controller: net, Root: netRoot},
@@ -88,6 +88,7 @@ func newExecutorGD(root, cgroupParent string, net *libnetwork.Controller, dnsCon
 		cdiManager,
 		"",
 		"",
+		false,
 	)
 }
 

--- a/daemon/internal/builder-next/executor_others.go
+++ b/daemon/internal/builder-next/executor_others.go
@@ -10,6 +10,6 @@ import (
 	"github.com/moby/sys/user"
 )
 
-func newExecutor(_, _ string, _ *libnetwork.Controller, _ *oci.DNSConfig, _ bool, _ user.IdentityMapping, _ string, _ *cdidevices.Manager, _, _ string) (executor.Executor, error) {
+func newExecutor(_, _ string, _ *libnetwork.Controller, _ *oci.DNSConfig, _ bool, _ user.IdentityMapping, _ string, _ *cdidevices.Manager, _, _ string, _ bool) (executor.Executor, error) {
 	return &stubExecutor{}, nil
 }

--- a/daemon/internal/builder-next/executor_windows.go
+++ b/daemon/internal/builder-next/executor_windows.go
@@ -31,6 +31,7 @@ func newExecutor(
 	cdiManager *cdidevices.Manager,
 	containerdAddr string,
 	containerdNamespace string,
+	hypervIsolation bool,
 ) (executor.Executor, error) {
 	netRoot := filepath.Join(root, "net")
 	np := map[pb.NetMode]network.Provider{
@@ -50,6 +51,7 @@ func newExecutor(
 		DNSConfig:        dns,
 		CDIManager:       cdiManager,
 		NetworkProviders: np,
+		HyperVIsolation:  hypervIsolation,
 	}
 	return containerdexecutor.New(executorOpts), nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Currently, when enabling buildkit in Windows, the intermediate container created by buildlkit when building image will not follow docker daemon's configuration but stick to `process` isolation. This will cause bug in machines that does not support process isolation, making them unable to build images with buildkit.

This PR fixes this issue to ensure buildkit created container's isolation mode consistent with daemon's config.

**- How I did it**

1. Add `SpecOpts` to `ExecutorOption` (Done in buildkit's repository: https://github.com/moby/buildkit/pull/6206, superseded by https://github.com/moby/buildkit/pull/6224)
2. Expose `DefaultIsolation` field of docker daemon
3. Add `WithWindowsHyperV` specOpts when daemon's default isolation mode is `hyperv`.

**- How to verify it**

1. Follow this setup to enable buildkit in windows: https://gist.github.com/profnandaa/9ad40dbd90ebad99896ee0fed2916406
2. In a machine that does not support process isolation mode, run `docker buildx build .`
3. Will see errors like:
```
ERROR: failed to build: failed to solve: process "cmd /S /C echo \"hello wolrd"\" did not complete successfully: failed to create shim task: hcs:CreateComputeSystem hcdqcsa2mflizmrzrt2z9yox: 
The container operating system does not match the host operating system.
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Windows: Fix BuildKit creating containers which isolation mode is inconsistent with the daemon's config
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="185" height="265" alt="yasha" src="https://github.com/user-attachments/assets/ede49bf9-a3dc-4b7c-8d1f-008d01c238ef" />
