### PR TITLE
Tidy up when endpoint join fails

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -735,10 +735,14 @@ func (daemon *Daemon) connectToNetwork(ctx context.Context, cfg *config.Config, 
 			}
 		}
 	}()
-	ctr.NetworkSettings.Networks[nwName] = endpointConfig
 
 	delete(ctr.NetworkSettings.Networks, n.ID())
-
+	ctr.NetworkSettings.Networks[nwName] = endpointConfig
+	defer func() {
+		if retErr != nil {
+			delete(ctr.NetworkSettings.Networks, nwName)
+		}
+	}()
 	if err := daemon.updateEndpointNetworkSettings(cfg, ctr, n, ep); err != nil {
 		return err
 	}

--- a/daemon/libnetwork/default_gateway.go
+++ b/daemon/libnetwork/default_gateway.go
@@ -100,7 +100,7 @@ func (sb *Sandbox) clearDefaultGW() error {
 	if ep = sb.getEndpointInGWNetwork(); ep == nil {
 		return nil
 	}
-	if err := ep.sbLeave(context.TODO(), sb, false); err != nil {
+	if err := ep.sbLeave(context.TODO(), sb, ep.getNetwork(), false); err != nil {
 		return fmt.Errorf("container %s: endpoint leaving GW Network failed: %v", sb.containerID, err)
 	}
 	if err := ep.Delete(context.TODO(), false); err != nil {

--- a/daemon/libnetwork/default_gateway.go
+++ b/daemon/libnetwork/default_gateway.go
@@ -176,17 +176,16 @@ func (c *Controller) defaultGwNetwork() (*Network, error) {
 	return n, err
 }
 
+func (sb *Sandbox) isGatewayEndpoint(epId string) bool {
+	gw4, gw6 := sb.getGatewayEndpoint()
+	return (gw4 != nil && epId == gw4.ID()) || (gw6 != nil && epId == gw6.ID())
+}
+
 // getGatewayEndpoint returns the endpoints providing external connectivity to
 // the sandbox. If the gateway is dual-stack, ep4 and ep6 will point at the same
 // endpoint. If there is no IPv4/IPv6 connectivity, nil pointers will be returned.
 func (sb *Sandbox) getGatewayEndpoint() (ep4, ep6 *Endpoint) {
-	return selectGatewayEndpoint(sb.Endpoints())
-}
-
-// selectGatewayEndpoint is like getGatewayEndpoint, but selects only from
-// endpoints.
-func selectGatewayEndpoint(endpoints []*Endpoint) (ep4, ep6 *Endpoint) {
-	for _, ep := range endpoints {
+	for _, ep := range sb.Endpoints() {
 		if ep.getNetwork().Type() == "null" || ep.getNetwork().Type() == "host" {
 			continue
 		}

--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -325,22 +325,6 @@ func (sb *Sandbox) addEndpoint(ep *Endpoint) {
 	sb.endpoints = slices.Insert(sb.endpoints, i, ep)
 }
 
-func (sb *Sandbox) removeEndpoint(ep *Endpoint) {
-	sb.mu.Lock()
-	defer sb.mu.Unlock()
-
-	sb.removeEndpointRaw(ep)
-}
-
-func (sb *Sandbox) removeEndpointRaw(ep *Endpoint) {
-	for i, e := range sb.endpoints {
-		if e == ep {
-			sb.endpoints = append(sb.endpoints[:i], sb.endpoints[i+1:]...)
-			return
-		}
-	}
-}
-
 func (sb *Sandbox) GetEndpoint(id string) *Endpoint {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()

--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -36,27 +36,34 @@ func (sb *Sandbox) processOptions(options ...SandboxOption) {
 // Sandbox provides the control over the network container entity.
 // It is a one to one mapping with the container.
 type Sandbox struct {
-	id                 string
-	containerID        string
-	config             containerConfig
-	extDNS             []extDNSEntry
-	osSbox             *osl.Namespace
-	controller         *Controller
-	resolver           *Resolver
-	resolverOnce       sync.Once
+	id              string
+	containerID     string
+	config          containerConfig
+	extDNS          []extDNSEntry
+	osSbox          *osl.Namespace
+	controller      *Controller
+	resolver        *Resolver
+	resolverOnce    sync.Once
+	dbIndex         uint64
+	dbExists        bool
+	isStub          bool
+	inDelete        bool
+	ingress         bool
+	ndotsSet        bool
+	oslTypes        []osl.SandboxType // slice of properties of this sandbox
+	loadBalancerNID string            // NID that this SB is a load balancer for
+	mu              sync.Mutex
+
+	// joinLeaveMu is required as well as mu to modify the following fields,
+	// acquire joinLeaveMu first, and keep it at-least until gateway changes
+	// have been applied following updates to endpoints.
+	//
+	// mu is required to access these fields.
+	joinLeaveMu        sync.Mutex
 	endpoints          []*Endpoint
 	epPriority         map[string]int
 	populatedEndpoints map[string]struct{}
-	joinLeaveMu        sync.Mutex
-	dbIndex            uint64
-	dbExists           bool
-	isStub             bool
-	inDelete           bool
-	ingress            bool
-	ndotsSet           bool
-	oslTypes           []osl.SandboxType // slice of properties of this sandbox
-	loadBalancerNID    string            // NID that this SB is a load balancer for
-	mu                 sync.Mutex
+
 	// This mutex is used to serialize service related operation for an endpoint
 	// The lock is here because the endpoint is saved into the store so is not unique
 	service sync.Mutex

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -1075,7 +1075,8 @@ func TestBridgeIPAMStatus(t *testing.T) {
 	c := d.NewClientT(t, client.WithVersion("1.52"))
 
 	checkSubnets := func(
-		netName string, want networktypes.SubnetStatuses) bool {
+		netName string, want networktypes.SubnetStatuses,
+	) bool {
 		t.Helper()
 		nw, err := c.NetworkInspect(ctx, netName, client.NetworkInspectOptions{})
 		if assert.Check(t, err) && assert.Check(t, nw.Status != nil) {
@@ -1114,7 +1115,8 @@ func TestBridgeIPAMStatus(t *testing.T) {
 				AuxAddress: map[string]string{
 					"reserved":   auxIPv4FromRange,
 					"reserved_1": auxIPv4OutOfRange,
-				}}),
+				},
+			}),
 			network.WithIPv6(),
 			network.WithIPAMConfig(networktypes.IPAMConfig{
 				Subnet:  cidrv6.String(),

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -1218,3 +1218,76 @@ func TestBridgeIPAMStatus(t *testing.T) {
 		})
 	})
 }
+
+// TestJoinError checks that if network connection fails late in the process, it's
+// rolled back properly - the failed connection should not show up in container
+// or network inspect, and the container should not gain a network interface.
+func TestJoinError(t *testing.T) {
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+
+	const intNet = "intnet"
+	const gwAddr = "192.168.123.1"
+	network.CreateNoError(ctx, t, c, intNet,
+		network.WithInternal(),
+		network.WithIPAM("192.168.123.0/24", gwAddr),
+	)
+	defer network.RemoveNoError(ctx, t, c, intNet)
+
+	const extNet = "extnet"
+	network.CreateNoError(ctx, t, c, extNet)
+	defer network.RemoveNoError(ctx, t, c, extNet)
+
+	cid := ctr.Run(ctx, t, c,
+		ctr.WithNetworkMode(intNet),
+		ctr.WithPrivileged(true),
+	)
+	defer c.ContainerRemove(ctx, cid, client.ContainerRemoveOptions{Force: true})
+
+	// Add a default route to the container, so that connecting extNet will fail to
+	// set up its own default route.
+	res := ctr.ExecT(ctx, t, c, cid, []string{"ip", "route", "add", "default", "via", gwAddr})
+	assert.Equal(t, res.ExitCode, 0)
+
+	// Expect an error when connecting extNet.
+	err := c.NetworkConnect(ctx, extNet, cid, &networktypes.EndpointSettings{})
+	assert.Check(t, is.ErrorContains(err, "failed to set gateway: file exists"))
+
+	// Only intNet should show up in container inspect.
+	ctrInsp := ctr.Inspect(ctx, t, c, cid)
+	assert.Check(t, is.Len(ctrInsp.NetworkSettings.Networks, 1))
+	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, intNet))
+
+	// extNet should not report any attached containers
+	extNetInsp, err := c.NetworkInspect(ctx, extNet, client.NetworkInspectOptions{})
+	assert.Check(t, err)
+	assert.Check(t, is.Len(extNetInsp.Containers, 0))
+
+	// The container should have an eth0, but no eth1.
+	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth0"})
+	assert.Check(t, is.Equal(res.ExitCode, 0), "container should have an eth0")
+	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth1"})
+	assert.Check(t, is.Contains(res.Stderr(), "can't find device"), "container should not have an eth1")
+
+	// Remove the dodgy route.
+	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "route", "del", "default", "via", gwAddr})
+	assert.Equal(t, res.ExitCode, 0)
+
+	// Check network connect now succeeds.
+	err = c.NetworkConnect(ctx, extNet, cid, &networktypes.EndpointSettings{})
+	assert.Check(t, err)
+	ctrInsp = ctr.Inspect(ctx, t, c, cid)
+	assert.Check(t, is.Len(ctrInsp.NetworkSettings.Networks, 2))
+	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, intNet))
+	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, extNet))
+	extNetInsp, err = c.NetworkInspect(ctx, extNet, client.NetworkInspectOptions{})
+	assert.Check(t, err)
+	assert.Check(t, is.Len(extNetInsp.Containers, 1))
+	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth0"})
+	assert.Check(t, is.Equal(res.ExitCode, 0), "container should have an eth0")
+	res = ctr.ExecT(ctx, t, c, cid, []string{"ip", "link", "show", "eth1"})
+	assert.Check(t, is.Equal(res.ExitCode, 0), "container should have an eth1")
+}


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/50898

The repro in https://github.com/moby/moby/issues/50898 results in `Endpoint.Join` returning an error, the container isn't connected to the network. But ...
- The failed connection is left behind in `container inspect` / `NetworkSettings`.
  - The container isn't listed in `network inspect`.
- The veth device is left in the container.

**- How I did it**

See individual commit messages.

**- How to verify it**

After running the steps in https://github.com/moby/moby/issues/50898, the `mv2` network is not listed in `container inspect`, and its eth device is removed.

New integration test.

**- Human readable description for the release notes**
```markdown changelog
- Improved error handling for connection of a container to a network.
```
