### PR TITLE
api/docs: fix events example response

### DIFF
--- a/api/docs/v1.24.md
+++ b/api/docs/v1.24.md
@@ -2496,8 +2496,6 @@ Docker daemon report the following event:
     Transfer-Encoding: chunked
 
     {
-      "status": "pull",
-      "id": "alpine:latest",
       "Type": "image",
       "Action": "pull",
       "Actor": {
@@ -2510,9 +2508,6 @@ Docker daemon report the following event:
       "timeNano": 1461943101301854122
     }
     {
-      "status": "create",
-      "id": "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743",
-      "from": "alpine",
       "Type": "container",
       "Action": "create",
       "Actor": {
@@ -2527,9 +2522,6 @@ Docker daemon report the following event:
       "timeNano": 1461943101381709551
     }
     {
-      "status": "attach",
-      "id": "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743",
-      "from": "alpine",
       "Type": "container",
       "Action": "attach",
       "Actor": {
@@ -2558,9 +2550,6 @@ Docker daemon report the following event:
       "timeNano": 1461943101394865557
     }
     {
-      "status": "start",
-      "id": "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743",
-      "from": "alpine",
       "Type": "container",
       "Action": "start",
       "Actor": {
@@ -2575,9 +2564,6 @@ Docker daemon report the following event:
       "timeNano": 1461943101607533796
     }
     {
-      "status": "resize",
-      "id": "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743",
-      "from": "alpine",
       "Type": "container",
       "Action": "resize",
       "Actor": {
@@ -2594,9 +2580,6 @@ Docker daemon report the following event:
       "timeNano": 1461943101610269268
     }
     {
-      "status": "die",
-      "id": "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743",
-      "from": "alpine",
       "Type": "container",
       "Action": "die",
       "Actor": {
@@ -2626,9 +2609,6 @@ Docker daemon report the following event:
       "timeNano": 1461943105230860245
     }
     {
-      "status": "destroy",
-      "id": "ede54ee1afda366ab42f824e8a5ffd195155d853ceaec74a927f249ea270c743",
-      "from": "alpine",
       "Type": "container",
       "Action": "destroy",
       "Actor": {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50832

Don't include the deprecated `id`, `status`, and `from` fields in the response; they're no longer part of the API since v1.22 ([moby@72f188]).

[moby@72f188]: https://github.com/moby/moby/commit/72f1881df102fce9ad31e98045b91c204dd44513


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

