### PR TITLE
fix content-type declared by /events API

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -45,6 +45,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   on API version `v1.52` and up. Older API versions still accept this field, but
   may take no effect, depending on the kernel version and OCI runtime in use.
 * Removed the `KernelMemoryTCP` field from the `GET /info` endpoint.
+* `GET /events` supports content-type negotiation and can produce either `application/x-ndjson` 
+  (Newline delimited JSON object stream) or `application/json-seq` (RFC7464).
 
 ## v1.51 API changes
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10176,7 +10176,8 @@ paths:
 
       operationId: "SystemEvents"
       produces:
-        - "application/json"
+        - "application/x-ndjson"
+        - "application/json-seq"
       responses:
         200:
           description: "no error"

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -11,6 +11,15 @@ const (
 
 	// MediaTypeMultiplexedStream is vendor specific MIME-Type set for stdin/stdout/stderr multiplexed streams
 	MediaTypeMultiplexedStream = "application/vnd.docker.multiplexed-stream"
+
+	// MediaTypeJSON is the MIME-Type for JSON objects
+	MediaTypeJSON = "application/json"
+
+	// MediaTypeNDJson is the MIME-Type for Newline Delimited JSON objects streams
+	MediaTypeNDJSON = "application/x-ndjson"
+
+	// MediaTypeJsonSequence is the MIME-Type for JSON Text Sequences (RFC7464)
+	MediaTypeJSONSequence = "application/json-seq"
 )
 
 // Ping contains response of Engine API:

--- a/client/internal/json-stream.go
+++ b/client/internal/json-stream.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"encoding/json"
+	"io"
+	"slices"
+
+	"github.com/moby/moby/api/types"
+)
+
+const rs = 0x1E
+
+type DecoderFn func(v any) error
+
+// NewJSONStreamDecoder builds adequate DecoderFn to read json records formatted with specified content-type
+func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
+	switch contentType {
+	case types.MediaTypeJSONSequence:
+		return json.NewDecoder(NewRSFilterReader(r)).Decode
+	case types.MediaTypeJSON, types.MediaTypeNDJSON:
+		fallthrough
+	default:
+		return json.NewDecoder(r).Decode
+	}
+}
+
+// RSFilterReader wraps an io.Reader and filters out ASCII RS characters
+type RSFilterReader struct {
+	reader io.Reader
+	buffer []byte
+}
+
+// NewRSFilterReader creates a new RSFilterReader that filters out RS characters
+func NewRSFilterReader(r io.Reader) *RSFilterReader {
+	return &RSFilterReader{
+		reader: r,
+		buffer: make([]byte, 4096), // Internal buffer for reading chunks
+	}
+}
+
+// Read implements the io.Reader interface, filtering out RS characters
+func (r *RSFilterReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	n, err = r.reader.Read(p)
+	filtered := slices.DeleteFunc(p[:n], func(b byte) bool { return b == rs })
+	return len(filtered), err
+}

--- a/client/internal/json-stream_test.go
+++ b/client/internal/json-stream_test.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/api/types"
+	"gotest.tools/v3/assert"
+)
+
+func Test_JsonSeqDecoder(t *testing.T) {
+	separator := string(rune(rs))
+	lf := "\n"
+	input := fmt.Sprintf(`%s{"hello":"world"}%s%s{ "hello": "again" }%s`, separator, lf, separator, lf)
+	decoder := NewJSONStreamDecoder(strings.NewReader(input), types.MediaTypeJSONSequence)
+	type Hello struct {
+		Hello string `json:"hello"`
+	}
+	var hello Hello
+	err := decoder(&hello)
+	assert.NilError(t, err)
+	assert.Equal(t, "world", hello.Hello)
+
+	var again Hello
+	err = decoder(&again)
+	assert.NilError(t, err)
+	assert.Equal(t, "again", again.Hello)
+}

--- a/daemon/server/httputils/json-seq.go
+++ b/daemon/server/httputils/json-seq.go
@@ -1,0 +1,44 @@
+package httputils
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/moby/moby/api/types"
+)
+
+const rs = 0x1E
+
+type EncoderFn func(any) error
+
+// NewJSONStreamEncoder builds adequate EncoderFn to write json records using selected content-type formalism
+func NewJSONStreamEncoder(w io.Writer, contentType string) EncoderFn {
+	jsonEncoder := json.NewEncoder(w)
+	switch contentType {
+	case types.MediaTypeJSONSequence:
+		jseq := &jsonSeq{
+			w:    w,
+			json: jsonEncoder,
+		}
+		return jseq.Encode
+	case types.MediaTypeNDJSON, types.MediaTypeJSON:
+		fallthrough
+	default:
+		return jsonEncoder.Encode
+	}
+}
+
+type jsonSeq struct {
+	w    io.Writer
+	json *json.Encoder
+}
+
+// Encode prefixes every written record with an ASCII record separator.
+func (js *jsonSeq) Encode(record any) error {
+	_, err := js.w.Write([]byte{rs})
+	if err != nil {
+		return err
+	}
+	// JSON-seq also requires a LF character, bu json.Encoder already adds one
+	return js.json.Encode(record)
+}

--- a/vendor/github.com/moby/moby/api/types/types.go
+++ b/vendor/github.com/moby/moby/api/types/types.go
@@ -11,6 +11,15 @@ const (
 
 	// MediaTypeMultiplexedStream is vendor specific MIME-Type set for stdin/stdout/stderr multiplexed streams
 	MediaTypeMultiplexedStream = "application/vnd.docker.multiplexed-stream"
+
+	// MediaTypeJSON is the MIME-Type for JSON objects
+	MediaTypeJSON = "application/json"
+
+	// MediaTypeNDJson is the MIME-Type for Newline Delimited JSON objects streams
+	MediaTypeNDJSON = "application/x-ndjson"
+
+	// MediaTypeJsonSequence is the MIME-Type for JSON Text Sequences (RFC7464)
+	MediaTypeJSONSequence = "application/json-seq"
 )
 
 // Ping contains response of Engine API:

--- a/vendor/github.com/moby/moby/client/internal/json-stream.go
+++ b/vendor/github.com/moby/moby/client/internal/json-stream.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"encoding/json"
+	"io"
+	"slices"
+
+	"github.com/moby/moby/api/types"
+)
+
+const rs = 0x1E
+
+type DecoderFn func(v any) error
+
+// NewJSONStreamDecoder builds adequate DecoderFn to read json records formatted with specified content-type
+func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
+	switch contentType {
+	case types.MediaTypeJSONSequence:
+		return json.NewDecoder(NewRSFilterReader(r)).Decode
+	case types.MediaTypeJSON, types.MediaTypeNDJSON:
+		fallthrough
+	default:
+		return json.NewDecoder(r).Decode
+	}
+}
+
+// RSFilterReader wraps an io.Reader and filters out ASCII RS characters
+type RSFilterReader struct {
+	reader io.Reader
+	buffer []byte
+}
+
+// NewRSFilterReader creates a new RSFilterReader that filters out RS characters
+func NewRSFilterReader(r io.Reader) *RSFilterReader {
+	return &RSFilterReader{
+		reader: r,
+		buffer: make([]byte, 4096), // Internal buffer for reading chunks
+	}
+}
+
+// Read implements the io.Reader interface, filtering out RS characters
+func (r *RSFilterReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	n, err = r.reader.Read(p)
+	filtered := slices.DeleteFunc(p[:n], func(b byte) bool { return b == rs })
+	return len(filtered), err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -966,6 +966,7 @@ github.com/moby/moby/api/types/volume
 # github.com/moby/moby/client v0.1.0-beta.0 => ./client
 ## explicit; go 1.23.0
 github.com/moby/moby/client
+github.com/moby/moby/client/internal
 github.com/moby/moby/client/internal/timestamp
 github.com/moby/moby/client/pkg/jsonmessage
 github.com/moby/moby/client/pkg/stringid


### PR DESCRIPTION
**- What I did**

fixed `/events` API to report content-type as [`application/x-ndjson`](https://github.com/ndjson/ndjson-spec)
using `application/json` in this API is wrong, I assume client always ignore Content-Type set here otherwise they would only unmarshal the first object in the stream and miss all others.

There's unfortunately no official mime type for line-delimited json object streams

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
`events` API now reports content-type as `application/x-ndjson` for newline-delimited JSON event stream
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/6bc3ff61-a9c7-4360-a253-a79d5d8e7a85" />

