### PR TITLE
daemon: fix build after revendoring api module

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -215,10 +215,6 @@ func (daemon *Daemon) updateEndpointNetworkSettings(cfg *config.Config, ctr *con
 		return err
 	}
 
-	if ctr.HostConfig.NetworkMode == network.DefaultNetwork {
-		ctr.NetworkSettings.Bridge = cfg.BridgeConfig.Iface
-	}
-
 	return nil
 }
 

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/moby/api/types/storage"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
-	"github.com/moby/moby/v2/daemon/network"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/errdefs"
 )
@@ -49,19 +48,10 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 	}
 
 	networkSettings := &containertypes.NetworkSettings{
-		NetworkSettingsBase: containertypes.NetworkSettingsBase{ //nolint:staticcheck // ignore SA1019: NetworkSettingsBase is deprecated in v28.4.
-			Bridge:                 ctr.NetworkSettings.Bridge,
-			SandboxID:              ctr.NetworkSettings.SandboxID,
-			SandboxKey:             ctr.NetworkSettings.SandboxKey,
-			Ports:                  ports,
-			HairpinMode:            ctr.NetworkSettings.HairpinMode,
-			LinkLocalIPv6Address:   ctr.NetworkSettings.LinkLocalIPv6Address,
-			LinkLocalIPv6PrefixLen: ctr.NetworkSettings.LinkLocalIPv6PrefixLen,
-			SecondaryIPAddresses:   ctr.NetworkSettings.SecondaryIPAddresses,
-			SecondaryIPv6Addresses: ctr.NetworkSettings.SecondaryIPv6Addresses,
-		},
-		DefaultNetworkSettings: getDefaultNetworkSettings(ctr.NetworkSettings.Networks),
-		Networks:               apiNetworks,
+		SandboxID:  ctr.NetworkSettings.SandboxID,
+		SandboxKey: ctr.NetworkSettings.SandboxKey,
+		Ports:      ports,
+		Networks:   apiNetworks,
 	}
 
 	mountPoints := ctr.GetMountPoints()
@@ -238,24 +228,4 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, err
 		DetachKeys:  e.DetachKeys,
 		Pid:         pid,
 	}, nil
-}
-
-// getDefaultNetworkSettings creates the deprecated structure that holds the information
-// about the bridge network for a container.
-func getDefaultNetworkSettings(networks map[string]*network.EndpointSettings) containertypes.DefaultNetworkSettings { //nolint:staticcheck // ignore SA1019: DefaultNetworkSettings is deprecated in v28.4.
-	nw, ok := networks[networktypes.NetworkBridge]
-	if !ok || nw.EndpointSettings == nil {
-		return containertypes.DefaultNetworkSettings{} //nolint:staticcheck // ignore SA1019: DefaultNetworkSettings is deprecated in v28.4.
-	}
-
-	return containertypes.DefaultNetworkSettings{ //nolint:staticcheck // ignore SA1019: DefaultNetworkSettings is deprecated in v28.4.
-		EndpointID:          nw.EndpointSettings.EndpointID,
-		Gateway:             nw.EndpointSettings.Gateway,
-		GlobalIPv6Address:   nw.EndpointSettings.GlobalIPv6Address,
-		GlobalIPv6PrefixLen: nw.EndpointSettings.GlobalIPv6PrefixLen,
-		IPAddress:           nw.EndpointSettings.IPAddress,
-		IPPrefixLen:         nw.EndpointSettings.IPPrefixLen,
-		IPv6Gateway:         nw.EndpointSettings.IPv6Gateway,
-		MacAddress:          nw.EndpointSettings.MacAddress,
-	}
 }

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -13,18 +13,12 @@ import (
 // Settings stores configuration details about the daemon network config
 // TODO Windows. Many of these fields can be factored out.,
 type Settings struct {
-	Bridge                 string
-	SandboxID              string
-	SandboxKey             string
-	HairpinMode            bool
-	LinkLocalIPv6Address   string
-	LinkLocalIPv6PrefixLen int
-	Networks               map[string]*EndpointSettings
-	Service                *clustertypes.ServiceConfig
-	Ports                  container.PortMap
-	SecondaryIPAddresses   []networktypes.Address
-	SecondaryIPv6Addresses []networktypes.Address
-	HasSwarmEndpoint       bool
+	SandboxID        string
+	SandboxKey       string
+	Networks         map[string]*EndpointSettings
+	Service          *clustertypes.ServiceConfig
+	Ports            container.PortMap
+	HasSwarmEndpoint bool
 }
 
 // EndpointSettings is a package local wrapper for

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -42,6 +42,11 @@ PY_TEST_OPTIONS="$PY_TEST_OPTIONS --deselect=tests/integration/models_containers
 # automatically in linking containers. Thus, this test is expected to fail — skip it. See https://github.com/moby/moby/pull/50719
 PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_test.py::CreateContainerTest::test_create_with_links"
 
+# The NetworkSettings.MacAddress field has been deprecated since Docker 1.9, and starting with v29.0, the Engine won't
+# include it in API respoonses. Thus, this test is expected to fail — skip it.
+# See https://github.com/moby/moby/pull/50846 and https://github.com/moby/moby/pull/50957
+PY_TEST_OPTIONS="${PY_TEST_OPTIONS} --deselect=tests/integration/api_container_test.py::CreateContainerTest::test_create_with_mac_address"
+
 (
 	bundle .integration-daemon-start
 

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -6,75 +6,10 @@ import (
 
 // NetworkSettings exposes the network settings in the api
 type NetworkSettings struct {
-	NetworkSettingsBase
-	DefaultNetworkSettings
-	Networks map[string]*network.EndpointSettings
-}
-
-// NetworkSettingsBase holds networking state for a container when inspecting it.
-//
-// Deprecated: Most fields in NetworkSettingsBase are deprecated. Fields which aren't deprecated will move to
-// NetworkSettings in v29.0, and this struct will be removed.
-type NetworkSettingsBase struct {
-	Bridge     string  // Deprecated: This field is only set when the daemon is started with the --bridge flag specified.
 	SandboxID  string  // SandboxID uniquely represents a container's network stack
 	SandboxKey string  // SandboxKey identifies the sandbox
 	Ports      PortMap // Ports is a collection of PortBinding indexed by Port
-
-	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
-	//
-	// Deprecated: This field is never set and will be removed in a future release.
-	HairpinMode bool
-	// LinkLocalIPv6Address is an IPv6 unicast address using the link-local prefix
-	//
-	// Deprecated: This field is never set and will be removed in a future release.
-	LinkLocalIPv6Address string
-	// LinkLocalIPv6PrefixLen is the prefix length of an IPv6 unicast address
-	//
-	// Deprecated: This field is never set and will be removed in a future release.
-	LinkLocalIPv6PrefixLen int
-	SecondaryIPAddresses   []network.Address // Deprecated: This field is never set and will be removed in a future release.
-	SecondaryIPv6Addresses []network.Address // Deprecated: This field is never set and will be removed in a future release.
-}
-
-// DefaultNetworkSettings holds the networking state for the default bridge, if the container is connected to that
-// network.
-//
-// Deprecated: this struct is deprecated since Docker v1.11 and will be removed in v29. You should look for the default
-// network in NetworkSettings.Networks instead.
-type DefaultNetworkSettings struct {
-	// EndpointID uniquely represents a service endpoint in a Sandbox
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	EndpointID string
-	// Gateway holds the gateway address for the network
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	Gateway string
-	// GlobalIPv6Address holds network's global IPv6 address
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	GlobalIPv6Address string
-	// GlobalIPv6PrefixLen represents mask length of network's global IPv6 address
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	GlobalIPv6PrefixLen int
-	// IPAddress holds the IPv4 address for the network
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	IPAddress string
-	// IPPrefixLen represents mask length of network's IPv4 address
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	IPPrefixLen int
-	// IPv6Gateway holds gateway address specific for IPv6
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	IPv6Gateway string
-	// MacAddress holds the MAC address for the network
-	//
-	// Deprecated: This field will be removed in v29. You should look for the default network in NetworkSettings.Networks instead.
-	MacAddress string
+	Networks   map[string]*network.EndpointSettings
 }
 
 // NetworkSettingsSummary provides a summary of container's networks

--- a/vendor/github.com/moby/moby/api/types/network/network_types.go
+++ b/vendor/github.com/moby/moby/api/types/network/network_types.go
@@ -34,12 +34,6 @@ type CreateRequest struct {
 	CheckDuplicate *bool `json:",omitempty"`
 }
 
-// Address represents an IP address
-type Address struct {
-	Addr      string
-	PrefixLen int
-}
-
 // ServiceInfo represents service parameters with the list of service's tasks
 type ServiceInfo struct {
 	VIP          string


### PR DESCRIPTION
Complete the removal of the deprecated network structs by dropping the remaining references in daemon code.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Revendored the api module to pick up the changes from #50846 and fixed the build.

**- How I did it**

**- How to verify it**
`go vet ./...`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

