### PR TITLE
daemon: remove some deprecated functions

### DIFF
--- a/daemon/builder/remotecontext/lazycontext.go
+++ b/daemon/builder/remotecontext/lazycontext.go
@@ -82,10 +82,3 @@ func (c *lazySource) prepareHash(relPath string, fi os.FileInfo) (string, error)
 	c.sums[relPath] = sum
 	return sum, nil
 }
-
-// Rel is an alias for [filepath.Rel].
-//
-// Deprecated: use [filepath.Rel] instead; this function is no longer used and will be removed in the next release.
-func Rel(basepath string, targpath string) (string, error) {
-	return filepath.Rel(basepath, targpath)
-}

--- a/daemon/config/config_linux.go
+++ b/daemon/config/config_linux.go
@@ -136,13 +136,6 @@ func (conf *Config) IsSwarmCompatible() error {
 	return nil
 }
 
-// ValidatePlatformConfig checks if any platform-specific configuration settings are invalid.
-//
-// Deprecated: this function was only used internally and is no longer used. Use [Validate] instead.
-func (conf *Config) ValidatePlatformConfig() error {
-	return validatePlatformConfig(conf)
-}
-
 // IsRootless returns conf.Rootless on Linux but false on Windows
 func (conf *Config) IsRootless() bool {
 	return conf.Rootless

--- a/daemon/config/config_windows.go
+++ b/daemon/config/config_windows.go
@@ -59,13 +59,6 @@ func (conf *Config) IsSwarmCompatible() error {
 	return nil
 }
 
-// ValidatePlatformConfig checks if any platform-specific configuration settings are invalid.
-//
-// Deprecated: this function was only used internally and is no longer used. Use [Validate] instead.
-func (conf *Config) ValidatePlatformConfig() error {
-	return validatePlatformConfig(conf)
-}
-
 // IsRootless returns conf.Rootless on Linux but false on Windows
 func (conf *Config) IsRootless() bool {
 	return false


### PR DESCRIPTION
### builder/remotecontext: remove deprecated "Rel()" utility

This function was deprecated in 54a556a5ef467b5d47a335f7665f644e0ce906bf,
and the package is now internal to the daemon, so we can remove it.
relates to:

- https://github.com/moby/moby/pull/49843
- https://github.com/moby/moby/pull/48985


### daemon/config: remove deprecated Config.

This function was deprecated in 83f8f4efd750fc5d3be61941ac0b42bcd2d6c320,
and the package is internal to the daemon, so we can remove it.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

