### PR TITLE
api/types/container: remove deprecated ExecOptions.Detach

### DIFF
--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -22,9 +22,6 @@ type ExecOptions struct {
 	Env          []string // Environment variables
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
-
-	// Deprecated: the Detach field is not used, and will be removed in a future release.
-	Detach bool
 }
 
 // ExecStartOptions is a temp struct used by execStart

--- a/vendor/github.com/moby/moby/api/types/container/exec.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec.go
@@ -22,9 +22,6 @@ type ExecOptions struct {
 	Env          []string // Environment variables
 	WorkingDir   string   // Working directory
 	Cmd          []string // Execution commands and args
-
-	// Deprecated: the Detach field is not used, and will be removed in a future release.
-	Detach bool
 }
 
 // ExecStartOptions is a temp struct used by execStart


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50218


This field was deprecated in 0c182d4d57e30e77fd940201205db20403fc7282, which should be included in a 28.x release, but we don't need to carry it in the new module.

We should also considering duplicating the `ExecOptions` type as a client option, and renaming it to `ExecCreateRequest`, so that we can decouple client options from the shape of the request.

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

