### PR TITLE
Windows containers: report HNS network name in inspect

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -349,7 +349,6 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 			if n.Scope() == scope.Global {
 				continue
 			}
-			v.Name = n.Name()
 			ipamDriver, ipamOptions, _, _ = n.IpamConfig()
 
 			// This will not cause network delete from HNS as the network
@@ -394,6 +393,9 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 		}
 
 		name := v.Name
+		if n != nil {
+			name = n.Name()
+		}
 
 		// If there is no nat network create one from the first NAT network
 		// encountered if it doesn't already exist

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -266,7 +266,7 @@ func (daemon *Daemon) initNetworkController(daemonCfg *config.Config, activeSand
 				ipamDriver, ipamOptions, v4Conf, v6Conf := v.IpamConfig()
 				netOption := map[string]string{}
 				for k, v := range v.DriverOptions() {
-					if k != winlibnetwork.NetworkName && k != winlibnetwork.HNSID {
+					if k != winlibnetwork.HNSID {
 						netOption[k] = v
 					}
 				}

--- a/daemon/libnetwork/drivers/windows/windows.go
+++ b/daemon/libnetwork/drivers/windows/windows.go
@@ -422,6 +422,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 
 		config.HnsID = hnsresponse.Id
 		genData[HNSID] = config.HnsID
+		genData[NetworkName] = network.Name
 		n.created = true
 
 		defer func() {


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/50924

After creating a new network, inspect shows that there's no value for option "com.docker.network.windowsshim.networkname". After restarting the daemon, it shows up with the docker network name (not the HNS network name, which defaults to the docker network's id).

Creating the network with "-o com.docker.network.windowsshim.networkname" sets the HNS network name, and it shows up in inspect. Until the daemon is restarted, then it shows the docker network name.

When Windows reboots, it deletes HNS networks. They're re-created from Docker's store, but the HNS network name is lost.

**- How I did it**

Set the option value to the HNS network name on creation (the id if no name is given), and on restore after restart use the name reported by HNS. On restore after reboot, preserve the HNS name recorded in Docker's driver-opts.

**- How to verify it**

```
docker network create -d nat n1
docker network create -d nat -o com.docker.network.windowsshim.networkname=n2name n2
```

Check `com.docker.network.windowsshim.networkname` reported in `inspect` is as-expected for each network (Docker's network id, and `n2name`), and that they match the HNS names (`Get-HnsNetwork -id <hns id from inspect>`).

Restart the daemon and check nothing changed.

Reboot and check the HNS network names are preserved, the HNS network ids will change.

**- Human readable description for the release notes**
```markdown changelog
- Windows: `network inspect`: the HNS network name is now reported in option `com.docker.network.windowsshim.networkname` rather than the Docker network name, which was only reported after a daemon restart.
```