### PR TITLE
daemon/config: remove deprecated CommonConfig.CorsHeaders

### DIFF
--- a/daemon/command/config.go
+++ b/daemon/command/config.go
@@ -78,9 +78,6 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Var(allowNonDistributable, "allow-nondistributable-artifacts", "Allow push of nondistributable artifacts to registry")
 	_ = flags.MarkDeprecated("allow-nondistributable-artifacts", "Pushing nondistributable artifacts is now enabled by default. ")
 
-	// TODO(thaJeztah): option is used to produce error when used; remove in next release
-	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API; deprecated: this feature was deprecated in 27.0, and now removed")
-	_ = flags.MarkDeprecated("api-cors-header", "accessing Docker API through a browser is insecure; use a reverse proxy if you need CORS headers")
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	_ = flags.MarkDeprecated("restart", "Please use a restart policy on docker run")
 }

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -193,7 +193,6 @@ type CommonConfig struct {
 	Root                  string   `json:"data-root,omitempty"`
 	ExecRoot              string   `json:"exec-root,omitempty"`
 	SocketGroup           string   `json:"group,omitempty"`
-	CorsHeaders           string   `json:"api-cors-header,omitempty"` // Deprecated: CORS headers should not be set on the API. This feature will be removed in the next release. // TODO(thaJeztah): option is used to produce error when used; remove in next release
 
 	// Proxies holds the proxies that are configured for the daemon.
 	Proxies `json:"proxies"`
@@ -759,11 +758,6 @@ func Validate(config *Config) error {
 		if _, err := registry.ValidateMirror(mirror); err != nil {
 			return err
 		}
-	}
-
-	if config.CorsHeaders != "" {
-		// TODO(thaJeztah): option is used to produce error when used; remove in next release
-		return errors.New(`DEPRECATED: The "api-cors-header" config parameter and the dockerd "--api-cors-header" option have been removed; use a reverse proxy if you need CORS headers`)
 	}
 
 	if _, err := parseExecOptions(config.ExecOptions); err != nil {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -249,10 +249,6 @@ func (daemon *Daemon) fillAPIInfo(v *system.Info, cfg *config.Config) {
          to the 'Docker daemon attack surface' section in the documentation for
          more information: https://docs.docker.com/go/attack-surface/`
 
-	if cfg.CorsHeaders != "" {
-		v.Warnings = append(v.Warnings, `DEPRECATED: The "api-cors-header" config parameter and the dockerd "--api-cors-header" option will be removed in the next release. Use a reverse proxy if you need CORS headers.`)
-	}
-
 	for _, host := range cfg.Hosts {
 		// cnf.Hosts is normalized during startup, so should always have a scheme/proto
 		proto, addr, _ := strings.Cut(host, "://")


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48209
- https://github.com/moby/moby/pull/45313



This option was deprecated in Docker 27.0 through 7ea9acc97f4c884ecdaebd06ed0353b28263d118, and removed in 28.0 through ae96ce866f4b3dc09dc4eab019d7725a63623d94. The field was kept to provide a user-friendly error when used; this patch removes the field altogether.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

