### PR TITLE
client: move ExecStartOptions, ExecAttachOptions, ExecOptions to client

### DIFF
--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -24,22 +24,6 @@ type ExecOptions struct {
 	Cmd          []string // Execution commands and args
 }
 
-// ExecStartOptions is a temp struct used by execStart
-// Config fields is part of ExecConfig in runconfig package
-type ExecStartOptions struct {
-	// ExecStart will first check if it's detached
-	Detach bool
-	// Check if there's a tty
-	Tty bool
-	// Terminal size [height, width], unused if Tty == false
-	ConsoleSize *[2]uint `json:",omitempty"`
-}
-
-// ExecAttachOptions is a temp struct used by execAttach.
-//
-// TODO(thaJeztah): make this a separate type; ContainerExecAttach does not use the Detach option, and cannot run detached.
-type ExecAttachOptions = ExecStartOptions
-
 // ExecInspect holds information returned by exec inspect.
 //
 // It is used by the client to unmarshal a [ExecInspectResponse],

--- a/api/types/container/exec.go
+++ b/api/types/container/exec.go
@@ -8,22 +8,6 @@ import "github.com/moby/moby/api/types/common"
 // TODO(thaJeztah): make this a distinct type.
 type ExecCreateResponse = common.IDResponse
 
-// ExecOptions is a small subset of the Config struct that holds the configuration
-// for the exec feature of docker.
-type ExecOptions struct {
-	User         string   // User that will run the command
-	Privileged   bool     // Is the container in privileged mode
-	Tty          bool     // Attach standard streams to a tty.
-	ConsoleSize  *[2]uint `json:",omitempty"` // Initial console size [height, width]
-	AttachStdin  bool     // Attach the standard input, makes possible user interaction
-	AttachStderr bool     // Attach the standard error
-	AttachStdout bool     // Attach the standard output
-	DetachKeys   string   // Escape keys for detach
-	Env          []string // Environment variables
-	WorkingDir   string   // Working directory
-	Cmd          []string // Execution commands and args
-}
-
 // ExecInspect holds information returned by exec inspect.
 //
 // It is used by the client to unmarshal a [ExecInspectResponse],

--- a/api/types/container/exec_create_request.go
+++ b/api/types/container/exec_create_request.go
@@ -1,0 +1,17 @@
+package container
+
+// ExecCreateRequest is a small subset of the Config struct that holds the configuration
+// for the exec feature of docker.
+type ExecCreateRequest struct {
+	User         string   // User that will run the command
+	Privileged   bool     // Is the container in privileged mode
+	Tty          bool     // Attach standard streams to a tty.
+	ConsoleSize  *[2]uint `json:",omitempty"` // Initial console size [height, width]
+	AttachStdin  bool     // Attach the standard input, makes possible user interaction
+	AttachStderr bool     // Attach the standard error
+	AttachStdout bool     // Attach the standard output
+	DetachKeys   string   // Escape keys for detach
+	Env          []string // Environment variables
+	WorkingDir   string   // Working directory
+	Cmd          []string // Execution commands and args
+}

--- a/api/types/container/exec_start_request.go
+++ b/api/types/container/exec_start_request.go
@@ -1,0 +1,12 @@
+package container
+
+// ExecStartRequest is a temp struct used by execStart
+// Config fields is part of ExecConfig in runconfig package
+type ExecStartRequest struct {
+	// ExecStart will first check if it's detached
+	Detach bool
+	// Check if there's a tty
+	Tty bool
+	// Terminal size [height, width], unused if Tty == false
+	ConsoleSize *[2]uint `json:",omitempty"`
+}

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -70,7 +70,7 @@ type ContainerAPIClient interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
 	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
-	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
+	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -69,11 +69,11 @@ type ContainerAPIClient interface {
 	ContainerCommit(ctx context.Context, container string, options ContainerCommitOptions) (container.CommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
-	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
-	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
+	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (container.InspectResponse, []byte, error)

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -94,7 +94,7 @@ func TestContainerExecStartError(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	err = client.ContainerExecStart(context.Background(), "nothing", container.ExecStartOptions{})
+	err = client.ContainerExecStart(context.Background(), "nothing", ExecStartOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -108,12 +108,12 @@ func TestContainerExecStart(t *testing.T) {
 			if err := req.ParseForm(); err != nil {
 				return nil, err
 			}
-			options := &container.ExecStartOptions{}
-			if err := json.NewDecoder(req.Body).Decode(options); err != nil {
+			request := &container.ExecStartRequest{}
+			if err := json.NewDecoder(req.Body).Decode(request); err != nil {
 				return nil, err
 			}
-			if options.Tty || !options.Detach {
-				return nil, fmt.Errorf("expected ExecStartOptions{Detach:true,Tty:false}, got %v", options)
+			if request.Tty || !request.Detach {
+				return nil, fmt.Errorf("expected ExecStartOptions{Detach:true,Tty:false}, got %v", request)
 			}
 
 			return &http.Response{
@@ -124,7 +124,7 @@ func TestContainerExecStart(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	err = client.ContainerExecStart(context.Background(), "exec_id", container.ExecStartOptions{
+	err = client.ContainerExecStart(context.Background(), "exec_id", ExecStartOptions{
 		Detach: true,
 		Tty:    false,
 	})

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -22,14 +22,14 @@ func TestContainerExecCreateError(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	_, err = client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{})
+	_, err = client.ContainerExecCreate(context.Background(), "container_id", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	_, err = client.ContainerExecCreate(context.Background(), "", container.ExecOptions{})
+	_, err = client.ContainerExecCreate(context.Background(), "", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	_, err = client.ContainerExecCreate(context.Background(), "    ", container.ExecOptions{})
+	_, err = client.ContainerExecCreate(context.Background(), "    ", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -42,7 +42,7 @@ func TestContainerExecCreateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{})
+	_, err = client.ContainerExecCreate(context.Background(), "container_id", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
@@ -60,7 +60,7 @@ func TestContainerExecCreate(t *testing.T) {
 			if err := req.ParseForm(); err != nil {
 				return nil, err
 			}
-			execConfig := &container.ExecOptions{}
+			execConfig := &container.ExecCreateRequest{}
 			if err := json.NewDecoder(req.Body).Decode(execConfig); err != nil {
 				return nil, err
 			}
@@ -81,7 +81,7 @@ func TestContainerExecCreate(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	r, err := client.ContainerExecCreate(context.Background(), "container_id", container.ExecOptions{
+	r, err := client.ContainerExecCreate(context.Background(), "container_id", ExecCreateOptions{
 		User: "user",
 	})
 	assert.NilError(t, err)

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -93,7 +93,7 @@ func (daemon *Daemon) getActiveContainer(name string) (*container.Container, err
 }
 
 // ContainerExecCreate sets up an exec in a running container.
-func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.ExecOptions) (string, error) {
+func (daemon *Daemon) ContainerExecCreate(name string, options *containertypes.ExecCreateRequest) (string, error) {
 	cntr, err := daemon.getActiveContainer(name)
 	if err != nil {
 		return "", err

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -14,7 +14,7 @@ import (
 
 // execBackend includes functions to implement to provide exec functionality.
 type execBackend interface {
-	ContainerExecCreate(name string, options *container.ExecOptions) (string, error)
+	ContainerExecCreate(name string, options *container.ExecCreateRequest) (string, error)
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, name string, height, width uint32) error
 	ContainerExecStart(ctx context.Context, name string, options backend.ExecStartConfig) error

--- a/daemon/server/router/container/exec.go
+++ b/daemon/server/router/container/exec.go
@@ -39,7 +39,7 @@ func (c *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 		return err
 	}
 
-	execConfig := &container.ExecOptions{}
+	execConfig := &container.ExecCreateRequest{}
 	if err := httputils.ReadJSON(r, execConfig); err != nil {
 		return err
 	}

--- a/daemon/server/router/container/exec.go
+++ b/daemon/server/router/container/exec.go
@@ -78,7 +78,7 @@ func (c *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		stdout, stderr, outStream io.Writer
 	)
 
-	options := &container.ExecStartOptions{}
+	options := &container.ExecStartRequest{}
 	if err := httputils.ReadJSON(r, options); err != nil {
 		return err
 	}

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration-cli/checker"
 	"github.com/moby/moby/v2/integration-cli/cli"
@@ -65,7 +64,7 @@ func (s *DockerAPISuite) TestExecAPICreateContainerPaused(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	_, err = apiClient.ContainerExecCreate(testutil.GetContext(c), name, container.ExecOptions{
+	_, err = apiClient.ContainerExecCreate(testutil.GetContext(c), name, client.ExecCreateOptions{
 		Cmd: []string{"true"},
 	})
 	assert.ErrorContains(c, err, "Container "+name+" is paused, unpause the container before exec", "Expected message when creating exec command with Container %s is paused", name)
@@ -129,7 +128,7 @@ func (s *DockerAPISuite) TestExecAPIStartWithDetach(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	createResp, err := apiClient.ContainerExecCreate(ctx, name, container.ExecOptions{
+	createResp, err := apiClient.ContainerExecCreate(ctx, name, client.ExecCreateOptions{
 		Cmd:          []string{"true"},
 		AttachStderr: true,
 	})

--- a/integration/config/config_test.go
+++ b/integration/config/config_test.go
@@ -10,7 +10,6 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/pkg/stdcopy"
-	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
@@ -312,7 +311,7 @@ func TestTemplatedConfig(t *testing.T) {
 	tasks := swarm.GetRunningTasks(ctx, t, c, serviceID)
 	assert.Assert(t, len(tasks) > 0, "no running tasks found for service %s", serviceID)
 
-	resp := swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
+	resp := swarm.ExecTask(ctx, t, d, tasks[0], client.ExecCreateOptions{
 		Cmd:          []string{"/bin/cat", "/templated_config"},
 		AttachStdout: true,
 		AttachStderr: true,
@@ -327,7 +326,7 @@ func TestTemplatedConfig(t *testing.T) {
 
 	outBuf.Reset()
 	errBuf.Reset()
-	resp = swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
+	resp = swarm.ExecTask(ctx, t, d, tasks[0], client.ExecCreateOptions{
 		Cmd:          []string{"mount"},
 		AttachStdout: true,
 		AttachStderr: true,

--- a/integration/container/exec_linux_test.go
+++ b/integration/container/exec_linux_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/versions"
+	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
@@ -21,7 +21,7 @@ func TestExecConsoleSize(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient, container.WithImage("busybox"))
 
 	result, err := container.Exec(ctx, apiClient, cID, []string{"stty", "size"},
-		func(ec *containertypes.ExecOptions) {
+		func(ec *client.ExecCreateOptions) {
 			ec.Tty = true
 			ec.ConsoleSize = &[2]uint{57, 123}
 		},

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -41,7 +41,7 @@ func TestExecWithCloseStdin(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	resp, err := apiClient.ContainerExecAttach(ctx, execResp.ID, containertypes.ExecAttachOptions{})
+	resp, err := apiClient.ContainerExecAttach(ctx, execResp.ID, client.ExecAttachOptions{})
 	assert.NilError(t, err)
 	defer resp.Close()
 
@@ -101,7 +101,7 @@ func TestExec(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(inspect.ExecID, id.ID))
 
-	resp, err := apiClient.ContainerExecAttach(ctx, id.ID, containertypes.ExecAttachOptions{})
+	resp, err := apiClient.ContainerExecAttach(ctx, id.ID, client.ExecAttachOptions{})
 	assert.NilError(t, err)
 	defer resp.Close()
 	r, err := io.ReadAll(resp.Reader)
@@ -134,7 +134,7 @@ func TestExecResize(t *testing.T) {
 	assert.NilError(t, err)
 	execID := resp.ID
 	assert.NilError(t, err)
-	err = apiClient.ContainerExecStart(ctx, execID, containertypes.ExecStartOptions{Detach: true})
+	err = apiClient.ContainerExecStart(ctx, execID, client.ExecStartOptions{Detach: true})
 	assert.NilError(t, err)
 
 	t.Run("success", func(t *testing.T) {

--- a/integration/container/exec_test.go
+++ b/integration/container/exec_test.go
@@ -12,7 +12,6 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/common"
-	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
@@ -34,7 +33,7 @@ func TestExecWithCloseStdin(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient)
 
 	const expected = "closeIO"
-	execResp, err := apiClient.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
+	execResp, err := apiClient.ContainerExecCreate(ctx, cID, client.ExecCreateOptions{
 		AttachStdin:  true,
 		AttachStdout: true,
 		Cmd:          []string{"sh", "-c", "cat && echo " + expected},
@@ -89,7 +88,7 @@ func TestExec(t *testing.T) {
 
 	cID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithWorkingDir("/root"))
 
-	id, err := apiClient.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
+	id, err := apiClient.ContainerExecCreate(ctx, cID, client.ExecCreateOptions{
 		WorkingDir:   "/tmp",
 		Env:          []string{"FOO=BAR"},
 		AttachStdout: true,
@@ -127,7 +126,7 @@ func TestExecResize(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		cmd = []string{"sleep", "240"}
 	}
-	resp, err := apiClient.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
+	resp, err := apiClient.ContainerExecCreate(ctx, cID, client.ExecCreateOptions{
 		Tty: true, // Windows requires a TTY for the resize to work, otherwise fails with "is not a tty: failed precondition", see https://github.com/moby/moby/pull/48665#issuecomment-2412530345
 		Cmd: cmd,
 	})
@@ -296,8 +295,8 @@ func TestExecUser(t *testing.T) {
 	withoutEtcGroups := container.WithImage(build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nRUN rm /etc/group"))))
 	withoutEtcPasswd := container.WithImage(build.Do(ctx, t, apiClient, fakecontext.New(t, "", fakecontext.WithDockerfile("FROM busybox\nRUN rm /etc/passwd"))))
 
-	withUser := func(user string) func(options *containertypes.ExecOptions) {
-		return func(options *containertypes.ExecOptions) { options.User = user }
+	withUser := func(user string) func(options *client.ExecCreateOptions) {
+		return func(options *client.ExecCreateOptions) { options.User = user }
 	}
 
 	tests := []struct {

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -66,7 +66,7 @@ func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []stri
 	execID := cresp.ID
 
 	// run it, with stdout/stderr attached
-	aresp, err := apiClient.ContainerExecAttach(ctx, execID, container.ExecAttachOptions{})
+	aresp, err := apiClient.ContainerExecAttach(ctx, execID, client.ExecAttachOptions{})
 	if err != nil {
 		return ExecResult{}, err
 	}

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 )
 
@@ -47,9 +46,9 @@ func (res ExecResult) AssertSuccess(t testing.TB) {
 // containing stdout, stderr, and exit code. Note:
 //   - this is a synchronous operation;
 //   - cmd stdin is closed.
-func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []string, ops ...func(*container.ExecOptions)) (ExecResult, error) {
+func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []string, ops ...func(*client.ExecCreateOptions)) (ExecResult, error) {
 	// prepare exec
-	execOptions := container.ExecOptions{
+	execOptions := client.ExecCreateOptions{
 		AttachStdout: true,
 		AttachStderr: true,
 		Cmd:          cmd,
@@ -87,7 +86,7 @@ func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []stri
 }
 
 // ExecT calls Exec() and aborts the test if an error occurs.
-func ExecT(ctx context.Context, t testing.TB, apiClient client.APIClient, id string, cmd []string, ops ...func(*container.ExecOptions)) ExecResult {
+func ExecT(ctx context.Context, t testing.TB, apiClient client.APIClient, id string, cmd []string, ops ...func(*client.ExecCreateOptions)) ExecResult {
 	t.Helper()
 	res, err := Exec(ctx, apiClient, id, cmd, ops...)
 	if err != nil {

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -219,7 +219,7 @@ func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtyp
 	resp, err := apiClient.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, options)
 	assert.NilError(t, err, "error creating exec")
 
-	attach, err := apiClient.ContainerExecAttach(ctx, resp.ID, container.ExecAttachOptions{})
+	attach, err := apiClient.ContainerExecAttach(ctx, resp.ID, client.ExecAttachOptions{})
 	assert.NilError(t, err, "error attaching to exec")
 	return attach
 }

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
@@ -211,7 +210,7 @@ func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClien
 }
 
 // ExecTask runs the passed in exec config on the given task
-func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, options container.ExecOptions) client.HijackedResponse {
+func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtypes.Task, options client.ExecCreateOptions) client.HijackedResponse {
 	t.Helper()
 	apiClient := d.NewClientT(t)
 	defer apiClient.Close()

--- a/integration/secret/secret_test.go
+++ b/integration/secret/secret_test.go
@@ -10,7 +10,6 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/pkg/stdcopy"
-	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
@@ -313,7 +312,7 @@ func TestTemplatedSecret(t *testing.T) {
 	tasks := swarm.GetRunningTasks(ctx, t, c, serviceID)
 	assert.Assert(t, len(tasks) > 0, "no running tasks found for service %s", serviceID)
 
-	resp := swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
+	resp := swarm.ExecTask(ctx, t, d, tasks[0], client.ExecCreateOptions{
 		Cmd:          []string{"/bin/cat", "/run/secrets/templated_secret"},
 		AttachStdout: true,
 		AttachStderr: true,
@@ -328,7 +327,7 @@ func TestTemplatedSecret(t *testing.T) {
 
 	outBuf.Reset()
 	errBuf.Reset()
-	resp = swarm.ExecTask(ctx, t, d, tasks[0], container.ExecOptions{
+	resp = swarm.ExecTask(ctx, t, d, tasks[0], client.ExecCreateOptions{
 		Cmd:          []string{"mount"},
 		AttachStdout: true,
 		AttachStderr: true,

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -40,7 +40,7 @@ func TestEventsExecDie(t *testing.T) {
 		),
 	})
 
-	err = apiClient.ContainerExecStart(ctx, id.ID, containertypes.ExecStartOptions{
+	err = apiClient.ContainerExecStart(ctx, id.ID, client.ExecStartOptions{
 		Detach: true,
 		Tty:    false,
 	})

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/mount"
@@ -28,7 +27,7 @@ func TestEventsExecDie(t *testing.T) {
 
 	cID := container.Run(ctx, t, apiClient)
 
-	id, err := apiClient.ContainerExecCreate(ctx, cID, containertypes.ExecOptions{
+	id, err := apiClient.ContainerExecCreate(ctx, cID, client.ExecCreateOptions{
 		Cmd: []string{"echo", "hello"},
 	})
 	assert.NilError(t, err)

--- a/vendor/github.com/moby/moby/api/types/container/exec.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec.go
@@ -24,22 +24,6 @@ type ExecOptions struct {
 	Cmd          []string // Execution commands and args
 }
 
-// ExecStartOptions is a temp struct used by execStart
-// Config fields is part of ExecConfig in runconfig package
-type ExecStartOptions struct {
-	// ExecStart will first check if it's detached
-	Detach bool
-	// Check if there's a tty
-	Tty bool
-	// Terminal size [height, width], unused if Tty == false
-	ConsoleSize *[2]uint `json:",omitempty"`
-}
-
-// ExecAttachOptions is a temp struct used by execAttach.
-//
-// TODO(thaJeztah): make this a separate type; ContainerExecAttach does not use the Detach option, and cannot run detached.
-type ExecAttachOptions = ExecStartOptions
-
 // ExecInspect holds information returned by exec inspect.
 //
 // It is used by the client to unmarshal a [ExecInspectResponse],

--- a/vendor/github.com/moby/moby/api/types/container/exec.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec.go
@@ -8,22 +8,6 @@ import "github.com/moby/moby/api/types/common"
 // TODO(thaJeztah): make this a distinct type.
 type ExecCreateResponse = common.IDResponse
 
-// ExecOptions is a small subset of the Config struct that holds the configuration
-// for the exec feature of docker.
-type ExecOptions struct {
-	User         string   // User that will run the command
-	Privileged   bool     // Is the container in privileged mode
-	Tty          bool     // Attach standard streams to a tty.
-	ConsoleSize  *[2]uint `json:",omitempty"` // Initial console size [height, width]
-	AttachStdin  bool     // Attach the standard input, makes possible user interaction
-	AttachStderr bool     // Attach the standard error
-	AttachStdout bool     // Attach the standard output
-	DetachKeys   string   // Escape keys for detach
-	Env          []string // Environment variables
-	WorkingDir   string   // Working directory
-	Cmd          []string // Execution commands and args
-}
-
 // ExecInspect holds information returned by exec inspect.
 //
 // It is used by the client to unmarshal a [ExecInspectResponse],

--- a/vendor/github.com/moby/moby/api/types/container/exec_create_request.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec_create_request.go
@@ -1,0 +1,17 @@
+package container
+
+// ExecCreateRequest is a small subset of the Config struct that holds the configuration
+// for the exec feature of docker.
+type ExecCreateRequest struct {
+	User         string   // User that will run the command
+	Privileged   bool     // Is the container in privileged mode
+	Tty          bool     // Attach standard streams to a tty.
+	ConsoleSize  *[2]uint `json:",omitempty"` // Initial console size [height, width]
+	AttachStdin  bool     // Attach the standard input, makes possible user interaction
+	AttachStderr bool     // Attach the standard error
+	AttachStdout bool     // Attach the standard output
+	DetachKeys   string   // Escape keys for detach
+	Env          []string // Environment variables
+	WorkingDir   string   // Working directory
+	Cmd          []string // Execution commands and args
+}

--- a/vendor/github.com/moby/moby/api/types/container/exec_start_request.go
+++ b/vendor/github.com/moby/moby/api/types/container/exec_start_request.go
@@ -1,0 +1,12 @@
+package container
+
+// ExecStartRequest is a temp struct used by execStart
+// Config fields is part of ExecConfig in runconfig package
+type ExecStartRequest struct {
+	// ExecStart will first check if it's detached
+	Detach bool
+	// Check if there's a tty
+	Tty bool
+	// Terminal size [height, width], unused if Tty == false
+	ConsoleSize *[2]uint `json:",omitempty"`
+}

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -70,7 +70,7 @@ type ContainerAPIClient interface {
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
 	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
-	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
+	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -69,11 +69,11 @@ type ContainerAPIClient interface {
 	ContainerCommit(ctx context.Context, container string, options ContainerCommitOptions) (container.CommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
-	ContainerExecAttach(ctx context.Context, execID string, options container.ExecAttachOptions) (HijackedResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, options container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
-	ContainerExecStart(ctx context.Context, execID string, options container.ExecStartOptions) error
+	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (container.InspectResponse, []byte, error)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/50740
- relates to https://github.com/moby/moby/issues/50964


- move api/types/container.ExecStartOptions to the client
- move api/types/container.ExecAttachOptions to the client
- rename api/types/container.ExecStartOptions to ExecStartRequest
- move api/types/container.ExecOptions to the client
- rename api/types/container.ExecOptions to ExecCreateRequest

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

