### PR TITLE
API: /info: remove magic `<unknown>` values for API < 1.39

### DIFF
--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -87,14 +87,6 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 			}
 			info.SecurityOptions = nameOnly
 		}
-		if versions.LessThan(version, "1.39") {
-			if info.KernelVersion == "" {
-				info.KernelVersion = "<unknown>"
-			}
-			if info.OperatingSystem == "" {
-				info.OperatingSystem = "<unknown>"
-			}
-		}
 		if versions.LessThan(version, "1.44") {
 			for k, rt := range info.Runtimes {
 				// Status field introduced in API v1.44.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/37472

daemon versions before v18.09 (API v1.39) returned a magic `<unknown>` value for the `KernelVersion` and `OperatingSystem` if these values were not set. Commit e6e8ab50fad5397f7be07fa00ba2bca85860cbe8 removed this magic values, but kept a fallback for old versions of the CLI that expected this value to be pre-formatted this way. Given that this change was over 7 Years ago, and never was a strict contract of the API, we can remove this fallback. Current versions of the CLI properly handle presentation, so this would only impact EOL versions of the CLI.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

