### PR TITLE
daemon/server: fix requests not logged with --log-level=trace

### DIFF
--- a/daemon/server/middleware.go
+++ b/daemon/server/middleware.go
@@ -16,7 +16,7 @@ func (s *Server) handlerWithGlobalMiddlewares(handler httputils.APIFunc) httputi
 		next = m.WrapHandler(next)
 	}
 
-	if log.GetLevel() == log.DebugLevel {
+	if log.GetLevel() >= log.DebugLevel {
 		next = middleware.DebugRequestMiddleware(next)
 	}
 


### PR DESCRIPTION
Before this patch, debug and trace-level logs were enabled, but the debugging middleware was not, the request-body was not logged when enabling trace-level logs:

    INFO[2025-09-16T07:55:07.500241927Z] Daemon has completed initialization
    INFO[2025-09-16T07:55:07.500267802Z] API listen on /var/run/docker.sock
    TRAC[2025-09-16T07:55:08.502387094Z] garbage collected                             d="437.583µs"
    DEBU[2025-09-16T07:55:13.215510096Z] stat snapshot                                 key="sha256:6aba5e0d32d91e3e923854dcb30588dc4112bfa1dae82b89535ad31d322a7b19" snapshotter=overlayfs
    DEBU[2025-09-16T07:55:13.216532430Z] prepare snapshot                              key=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485-init-key parent="sha256:6aba5e0d32d91e3e923854dcb30588dc4112bfa1dae82b89535ad31d322a7b19" snapshotter=overlayfs
    TRAC[2025-09-16T07:55:13.219691055Z] event published                               ns=moby topic=/snapshot/prepare type=containerd.events.SnapshotPrepare
    DEBU[2025-09-16T07:55:13.226507180Z] commit snapshot                               key=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485-init-key name=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485-init snapshotter=overlayfs
    TRAC[2025-09-16T07:55:13.227871055Z] event published                               ns=moby topic=/snapshot/commit type=containerd.events.SnapshotCommit
    DEBU[2025-09-16T07:55:13.228132471Z] prepare snapshot                              key=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485 parent=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485-init snapshotter=overlayfs
    TRAC[2025-09-16T07:55:13.229071055Z] event published                               ns=moby topic=/snapshot/prepare type=containerd.events.SnapshotPrepare
    DEBU[2025-09-16T07:55:13.229489180Z] get snapshot mounts                           key=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485 snapshotter=overlayfs
    DEBU[2025-09-16T07:55:13.229824721Z] container mounted via snapshotter             container=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485 root=/var/lib/docker/rootfs/overlayfs/80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485 snapshotter=overlayfs
    DEBU[2025-09-16T07:55:13.229849096Z] container mounted via layerStore              container=80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485 root=/var/lib/docker/rootfs/overlayfs/80813e376c0610bcd3fc1cbe7b6b1f3427a22eca06e4d34f6d5fb9c4d4589485 storage-driver=overlayfs

With this patch applied, the debugging middleware is enabled both with debug- and trace-level logging enabled:

    INFO[2025-09-16T07:56:31.024794341Z] Daemon has completed initialization
    INFO[2025-09-16T07:56:31.024856591Z] API listen on /var/run/docker.sock
    TRAC[2025-09-16T07:56:32.026944049Z] garbage collected                             d="640.167µs"
    DEBU[2025-09-16T07:56:36.729870218Z] handling HEAD request                         method=HEAD module=api request-url=/_ping vars="map[]"
    DEBU[2025-09-16T07:56:36.731114885Z] handling POST request                         form-data="{\"AttachStderr\":true,\"AttachStdin\":false,\"AttachStdout\":true,\"Cmd\":null,\"Domainname\":\"\",\"Entrypoint\":null,\"Env\":null,\"HostConfig\":{\"AutoRemove\":false,\"Binds\":null,\"BlkioDeviceReadBps\":[],\"BlkioDeviceReadIOps\":[],\"BlkioDeviceWriteBps\":[],\"BlkioDeviceWriteIOps\":[],\"BlkioWeight\":0,\"BlkioWeightDevice\":[],\"CapAdd\":null,\"CapDrop\":null,\"Cgroup\":\"\",\"CgroupParent\":\"\",\"CgroupnsMode\":\"\",\"ConsoleSize\":[23,104],\"ContainerIDFile\":\"\",\"CpuCount\":0,\"CpuPercent\":0,\"CpuPeriod\":0,\"CpuQuota\":0,\"CpuRealtimePeriod\":0,\"CpuRealtimeRuntime\":0,\"CpuShares\":0,\"CpusetCpus\":\"\",\"CpusetMems\":\"\",\"DeviceCgroupRules\":null,\"DeviceRequests\":null,\"Devices\":[],\"Dns\":[],\"DnsOptions\":[],\"DnsSearch\":[],\"ExtraHosts\":null,\"GroupAdd\":null,\"IOMaximumBandwidth\":0,\"IOMaximumIOps\":0,\"IpcMode\":\"\",\"Isolation\":\"\",\"Links\":null,\"LogConfig\":{\"Config\":{},\"Type\":\"\"},\"MaskedPaths\":null,\"Memory\":0,\"MemoryReservation\":0,\"MemorySwap\":0,\"MemorySwappiness\":-1,\"NanoCpus\":0,\"NetworkMode\":\"default\",\"OomKillDisable\":false,\"OomScoreAdj\":0,\"PidMode\":\"\",\"PidsLimit\":0,\"PortBindings\":{},\"Privileged\":false,\"PublishAllPorts\":false,\"ReadonlyPaths\":null,\"ReadonlyRootfs\":false,\"RestartPolicy\":{\"MaximumRetryCount\":0,\"Name\":\"no\"},\"SecurityOpt\":null,\"ShmSize\":0,\"UTSMode\":\"\",\"Ulimits\":[],\"UsernsMode\":\"\",\"VolumeDriver\":\"\",\"VolumesFrom\":null},\"Hostname\":\"\",\"Image\":\"busybox\",\"Labels\":{},\"NetworkingConfig\":{\"EndpointsConfig\":{\"default\":{\"Aliases\":null,\"DNSNames\":null,\"DriverOpts\":null,\"EndpointID\":\"\",\"Gateway\":\"\",\"GlobalIPv6Address\":\"\",\"GlobalIPv6PrefixLen\":0,\"GwPriority\":0,\"IPAMConfig\":null,\"IPAddress\":\"\",\"IPPrefixLen\":0,\"IPv6Gateway\":\"\",\"Links\":null,\"MacAddress\":\"\",\"NetworkID\":\"\"}}},\"OnBuild\":null,\"OpenStdin\":false,\"StdinOnce\":false,\"Tty\":false,\"User\":\"\",\"Volumes\":{},\"WorkingDir\":\"\"}" method=POST module=api request-url=/v1.51/containers/create vars="map[version:1.51]"
    DEBU[2025-09-16T07:56:36.751584218Z] stat snapshot                                 key="sha256:6aba5e0d32d91e3e923854dcb30588dc4112bfa1dae82b89535ad31d322a7b19" snapshotter=overlayfs
    DEBU[2025-09-16T07:56:36.752634302Z] prepare snapshot                              key=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41-init-key parent="sha256:6aba5e0d32d91e3e923854dcb30588dc4112bfa1dae82b89535ad31d322a7b19" snapshotter=overlayfs
    TRAC[2025-09-16T07:56:36.755453593Z] event published                               ns=moby topic=/snapshot/prepare type=containerd.events.SnapshotPrepare
    DEBU[2025-09-16T07:56:36.827076427Z] commit snapshot                               key=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41-init-key name=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41-init snapshotter=overlayfs
    TRAC[2025-09-16T07:56:36.828276635Z] event published                               ns=moby topic=/snapshot/commit type=containerd.events.SnapshotCommit
    DEBU[2025-09-16T07:56:36.828467885Z] prepare snapshot                              key=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41 parent=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41-init snapshotter=overlayfs
    TRAC[2025-09-16T07:56:36.829163010Z] event published                               ns=moby topic=/snapshot/prepare type=containerd.events.SnapshotPrepare
    DEBU[2025-09-16T07:56:36.829448927Z] get snapshot mounts                           key=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41 snapshotter=overlayfs
    DEBU[2025-09-16T07:56:36.829850302Z] container mounted via snapshotter             container=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41 root=/var/lib/docker/rootfs/overlayfs/786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41 snapshotter=overlayfs
    DEBU[2025-09-16T07:56:36.829872593Z] container mounted via layerStore              container=786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41 root=/var/lib/docker/rootfs/overlayfs/786e5174c57aa5057b4fd0a3c01013fe98d6fa3e5aaf9f1f89224175be74ba41 storage-driver=overlayfs

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix requests not being logged when running the daemon with `--log-level=trace`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

