### PR TITLE
gha: add missing dependency to Windows workflows

### DIFF
--- a/.github/workflows/windows-2022.yml
+++ b/.github/workflows/windows-2022.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   run:
+    needs: validate-dco
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     uses: ./.github/workflows/.windows.yml
     secrets: inherit

--- a/.github/workflows/windows-2025.yml
+++ b/.github/workflows/windows-2025.yml
@@ -27,6 +27,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   run:
+    needs: validate-dco
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
     uses: ./.github/workflows/.windows.yml
     secrets: inherit


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/50983

The Windows test workflow jobs were missing the dependency on the `validate-dco` job so they ran regardless whether the DCO check passed or not.