### PR TITLE
daemon/server/backend: remove ExecInspect, ExecProcessConfig alias

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -184,7 +184,7 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Co
 
 // ContainerExecInspect returns low-level information about the exec
 // command. An error is returned if the exec cannot be found.
-func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, error) {
+func (daemon *Daemon) ContainerExecInspect(id string) (*containertypes.ExecInspectResponse, error) {
 	e := daemon.execCommands.Get(id)
 	if e == nil {
 		return nil, errExecNotFound(id)
@@ -209,11 +209,11 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*backend.ExecInspect, err
 		privileged = &e.Privileged
 	}
 
-	return &backend.ExecInspect{
+	return &containertypes.ExecInspectResponse{
 		ID:       e.ID,
 		Running:  e.Running,
 		ExitCode: e.ExitCode,
-		ProcessConfig: &backend.ExecProcessConfig{
+		ProcessConfig: &containertypes.ExecProcessConfig{
 			Tty:        e.Tty,
 			Entrypoint: e.Entrypoint,
 			Arguments:  e.Args,

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -149,14 +149,6 @@ type ExecStartConfig struct {
 	ConsoleSize *[2]uint `json:",omitempty"`
 }
 
-// ExecInspect holds information about a running process started
-// with docker exec.
-type ExecInspect = container.ExecInspectResponse
-
-// ExecProcessConfig holds information about the exec process
-// running on the host.
-type ExecProcessConfig = container.ExecProcessConfig
-
 // CreateImageConfig is the configuration for creating an image from a
 // container.
 type CreateImageConfig struct {

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -15,7 +15,7 @@ import (
 // execBackend includes functions to implement to provide exec functionality.
 type execBackend interface {
 	ContainerExecCreate(name string, options *container.ExecCreateRequest) (string, error)
-	ContainerExecInspect(id string) (*backend.ExecInspect, error)
+	ContainerExecInspect(id string) (*container.ExecInspectResponse, error)
 	ContainerExecResize(ctx context.Context, name string, height, width uint32) error
 	ContainerExecStart(ctx context.Context, name string, options backend.ExecStartConfig) error
 	ExecExists(name string) (bool, error)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50482

Type type was defined before the API had a definition fro the exec-inspect response. When a type definition was added in [moby@2a34207], the definition was moved from the backend to the API, and the backend type implemented as an alias.

Technically, we could keep a _concrete_ type for the backend, and handle conversion to the corresponding API type in the router, but currently, this would likely only add extra complexity.

We could still opt for doing so when the backend requires additional fields or changes that should not be reflected in the API response.

[moby@2a34207]: https://github.com/moby/moby/commit/2a342079c632ee9b253fd5c497ce9dad82cf3a18

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

