### PR TITLE
integration-cli: remove startContainerGetOutput, runCommandWithOutput

### DIFF
--- a/integration-cli/docker_cli_cp_to_container_unix_test.go
+++ b/integration-cli/docker_cli_cp_to_container_unix_test.go
@@ -5,7 +5,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
 )
 
 func (s *DockerCLICpSuite) TestCpToContainerWithPermissions(c *testing.T) {
@@ -33,11 +33,12 @@ func (s *DockerCLICpSuite) TestCpToContainerWithPermissions(c *testing.T) {
 	srcPath := cpPath(tmpDir, "permdirtest")
 	dstPath := containerCpPath(containerName, "/")
 
-	args := []string{"cp", "-a", srcPath, dstPath}
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
+	res := icmd.RunCommand(dockerBinary, "cp", "-a", srcPath, dstPath)
+	out, err := res.Combined(), res.Error
 	assert.NilError(c, err, "output: %v", out)
 
-	out, err = startContainerGetOutput(c, containerName)
+	res = icmd.RunCommand(dockerBinary, "start", "-a", containerName)
+	out, err = res.Combined(), res.Error
 	assert.NilError(c, err, "output: %v", out)
 	assert.Equal(c, strings.TrimSpace(out), "2 2 700\n65534 65534 400", "output: %v", out)
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -2407,10 +2406,15 @@ func (s *DockerCLIRunSuite) TestRunTTYWithPipe(c *testing.T) {
 		}
 
 		expected := "the input device is not a TTY"
-		if runtime.GOOS == "windows" {
-			expected += ".  If you are using mintty, try prefixing the command with 'winpty'"
-		}
-		if out, _, err := runCommandWithOutput(cmd); err == nil {
+		res := icmd.RunCmd(icmd.Cmd{
+			Command: cmd.Args,
+			Env:     cmd.Env,
+			Dir:     cmd.Dir,
+			Stdin:   cmd.Stdin,
+			Stdout:  cmd.Stdout,
+		})
+		out, err := res.Combined(), res.Error
+		if err == nil {
 			errChan <- errors.New("run should have failed")
 			return
 		} else if !strings.Contains(out, expected) {

--- a/integration-cli/utils_test.go
+++ b/integration-cli/utils_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/pkg/errors"
-	"gotest.tools/v3/icmd"
 )
 
 func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
@@ -19,19 +18,6 @@ func getPrefixAndSlashFromDaemonPlatform() (prefix, slash string) {
 		return "c:", `\`
 	}
 	return "", "/"
-}
-
-// TODO: update code to call cmd.RunCmd directly, and remove this function
-// Deprecated: use gotest.tools/icmd
-func runCommandWithOutput(execCmd *exec.Cmd) (string, int, error) {
-	result := icmd.RunCmd(icmd.Cmd{
-		Command: execCmd.Args,
-		Env:     execCmd.Env,
-		Dir:     execCmd.Dir,
-		Stdin:   execCmd.Stdin,
-		Stdout:  execCmd.Stdout,
-	})
-	return result.Combined(), result.ExitCode, result.Error
 }
 
 // ParseCgroupPaths parses 'procCgroupData', which is output of '/proc/<pid>/cgroup', and returns


### PR DESCRIPTION
Some changes I had stashed locally to remove more of the (deprecated) test-utilities. Some of these can probably still be reduced further (and may not require the `icmd` package).


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

