### PR TITLE
client: ImageBuildResponse: remove OSType field

### DIFF
--- a/client/image_build.go
+++ b/client/image_build.go
@@ -38,8 +38,7 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 	}
 
 	return ImageBuildResponse{
-		Body:   resp.Body,
-		OSType: resp.Header.Get("Ostype"),
+		Body: resp.Body,
 	}, nil
 }
 

--- a/client/image_build_opts.go
+++ b/client/image_build_opts.go
@@ -72,6 +72,5 @@ type ImageBuildOutput struct {
 // returned by a server after building
 // an image.
 type ImageBuildResponse struct {
-	Body   io.ReadCloser
-	OSType string
+	Body io.ReadCloser
 }

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -187,21 +187,17 @@ func TestImageBuild(t *testing.T) {
 				}
 			}
 
-			headers := http.Header{}
-			headers.Add("Ostype", "MyOS")
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte("body"))),
-				Header:     headers,
 			}, nil
 		}))
 		assert.NilError(t, err)
 		buildResponse, err := client.ImageBuild(context.Background(), nil, buildCase.buildOptions)
 		assert.NilError(t, err)
-		assert.Check(t, is.Equal(buildResponse.OSType, "MyOS"))
 		response, err := io.ReadAll(buildResponse.Body)
 		assert.NilError(t, err)
-		buildResponse.Body.Close()
+		_ = buildResponse.Body.Close()
 		assert.Check(t, is.Equal(string(response), "body"))
 	}
 }

--- a/vendor/github.com/moby/moby/client/image_build.go
+++ b/vendor/github.com/moby/moby/client/image_build.go
@@ -38,8 +38,7 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 	}
 
 	return ImageBuildResponse{
-		Body:   resp.Body,
-		OSType: resp.Header.Get("Ostype"),
+		Body: resp.Body,
 	}, nil
 }
 

--- a/vendor/github.com/moby/moby/client/image_build_opts.go
+++ b/vendor/github.com/moby/moby/client/image_build_opts.go
@@ -72,6 +72,5 @@ type ImageBuildOutput struct {
 // returned by a server after building
 // an image.
 type ImageBuildResponse struct {
-	Body   io.ReadCloser
-	OSType string
+	Body io.ReadCloser
 }


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/11397
- https://github.com/moby/moby/pull/18472
- https://github.com/docker/cli/pull/6432

This field was used in the CLI to produce a warning added in [moby@4a8b3ca] to print a warning when building Linux images from a Windows client. Window's filesystem does not have an "executable" bit, which mean that, for example, copying a shell script to an image during build would lose the executable bit. So for Windows clients, the executable bit would be set on all files, unconditionally.

Originally this was detected in the client, which had direct access to the API response headers, but when refactoring the client to use a common library in [moby@535c4c9], this was refactored into a `ImageBuildResponse` wrapper, deconstructing the API response into an `io.Reader` and a string field containing only the `OSType` header.

The warning was removed in [cli@af65ee4], so we don't have to carry this field in the new client module going forward.

With the field removed, we can consider the client to return the full HTTP response again, but leaving that for a follow-up, as we may want to rewrite these streaming functions altogether.

[moby@4a8b3ca]: https://github.com/moby/moby/commit/4a8b3cad6096854027151dfbcfb4b2cd8841ad95
[moby@535c4c9]: https://github.com/moby/moby/commit/535c4c9a59b1e58c897677d6948a595cb3d28639
[cli@af65ee4]: https://github.com/docker/cli/commit/af65ee4584196d543a3d548de4de97b62850505e

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: ImageBuildResponse: remove OSType field.
```

**- A picture of a cute animal (not mandatory but encouraged)**

