### PR TITLE
client: separate exec methods to ExecAPIClient interface

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -69,11 +69,7 @@ type ContainerAPIClient interface {
 	ContainerCommit(ctx context.Context, container string, options ContainerCommitOptions) (container.CommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
-	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
-	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
-	ContainerExecInspect(ctx context.Context, execID string) (ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
-	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
+	ExecAPIClient
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (container.InspectResponse, []byte, error)
@@ -97,6 +93,14 @@ type ContainerAPIClient interface {
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, container.PathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options CopyToContainerOptions) error
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (container.PruneReport, error)
+}
+
+type ExecAPIClient interface {
+	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
+	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
+	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
+	ContainerExecInspect(ctx context.Context, execID string) (ExecInspect, error)
+	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 }
 
 // DistributionAPIClient defines API client methods for the registry

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -69,11 +69,7 @@ type ContainerAPIClient interface {
 	ContainerCommit(ctx context.Context, container string, options ContainerCommitOptions) (container.CommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerDiff(ctx context.Context, container string) ([]container.FilesystemChange, error)
-	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
-	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
-	ContainerExecInspect(ctx context.Context, execID string) (ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
-	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
+	ExecAPIClient
 	ContainerExport(ctx context.Context, container string) (io.ReadCloser, error)
 	ContainerInspect(ctx context.Context, container string) (container.InspectResponse, error)
 	ContainerInspectWithRaw(ctx context.Context, container string, getSize bool) (container.InspectResponse, []byte, error)
@@ -97,6 +93,14 @@ type ContainerAPIClient interface {
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, container.PathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options CopyToContainerOptions) error
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (container.PruneReport, error)
+}
+
+type ExecAPIClient interface {
+	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
+	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
+	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
+	ContainerExecInspect(ctx context.Context, execID string) (ExecInspect, error)
+	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
 }
 
 // DistributionAPIClient defines API client methods for the registry


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/50971


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: add `ExecAPIClient` interface for exec methods provided by the client.
```

**- A picture of a cute animal (not mandatory but encouraged)**

