### PR TITLE
api/types/network: CreateRequest: remove deprecated CheckDuplicate field

### DIFF
--- a/api/types/network/network_types.go
+++ b/api/types/network/network_types.go
@@ -28,10 +28,6 @@ type CreateRequest struct {
 	ConfigFrom *ConfigReference  // ConfigFrom specifies the source which will provide the configuration for this network. The specified network must be a config-only network; see [CreateOptions.ConfigOnly].
 	Options    map[string]string // Options specifies the network-specific options to use for when creating the network.
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
-
-	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
-	// package to older daemons.
-	CheckDuplicate *bool `json:",omitempty"`
 }
 
 // ServiceInfo represents service parameters with the list of service's tasks

--- a/vendor/github.com/moby/moby/api/types/network/network_types.go
+++ b/vendor/github.com/moby/moby/api/types/network/network_types.go
@@ -28,10 +28,6 @@ type CreateRequest struct {
 	ConfigFrom *ConfigReference  // ConfigFrom specifies the source which will provide the configuration for this network. The specified network must be a config-only network; see [CreateOptions.ConfigOnly].
 	Options    map[string]string // Options specifies the network-specific options to use for when creating the network.
 	Labels     map[string]string // Labels holds metadata specific to the network being created.
-
-	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client
-	// package to older daemons.
-	CheckDuplicate *bool `json:",omitempty"`
 }
 
 // ServiceInfo represents service parameters with the list of service's tasks


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46251

CheckDuplicate is removed in API v1.44, and no longer used by daemons supporting that API version (v25.0.0-beta.1 and up) regardless of the API version used, but it must be set to true when sent to older daemons (see [moby@78479b1]).

This patch moves adding the field to the client through an ad-hoc struct so that we don't have to carry the field in the API module.

We can remove this once daemon versions v24.0 and lower are no longer expected to be used (when [Mirantis Container Runtime v23 is EOL](https://github.com/moby/moby/blob/v2.0.0-beta.0/project/BRANCHES-AND-TAGS.md)).

This field was removed from API v1.44 and no longer used by daemons supporting that API version (v25.0.0-beta.1 and up) regardless of the API version used, but for older version of the daemon required this option to be set.

[moby@78479b1]: https://github.com/moby/moby/commit/78479b19158290e7338ceb3985bb809b83de5fd4

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/network: CreateRequest: remove deprecated CheckDuplicate field
```

**- A picture of a cute animal (not mandatory but encouraged)**

