### PR TITLE
daemon/config: More tests for DNS addresses

### DIFF
--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -649,6 +649,26 @@ func TestValidateMinAPIVersion(t *testing.T) {
 	}
 }
 
+func TestConfigDNS(t *testing.T) {
+	tests := []struct {
+		doc   string
+		input string
+	}{
+		{
+			doc:   "IPv6s with scope IDs",
+			input: `{"dns": ["::1%eth0", "::1%2"]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			var cfg Config
+			err := json.Unmarshal([]byte(tc.input), &cfg)
+			assert.Check(t, err == nil, "type: %T", err)
+		})
+	}
+}
+
 func TestConfigInvalidDNS(t *testing.T) {
 	tests := []struct {
 		doc         string
@@ -664,6 +684,11 @@ func TestConfigInvalidDNS(t *testing.T) {
 			doc:         "multiple DNS, invalid IP-address",
 			input:       `{"dns": ["2.2.2.2", "1.1.1.1o"]}`,
 			expectedErr: `ParseAddr("1.1.1.1o"): unexpected character (at "o")`,
+		},
+		{
+			doc:         "IPv4 with scope ID",
+			input:       `{"dns": ["1.1.1.1%eth0"]}`,
+			expectedErr: `ParseAddr("1.1.1.1%eth0"): unexpected character (at "%eth0")`,
 		},
 	}
 


### PR DESCRIPTION
Since moving from `net.IP` to `netip.Addr`, we can support more proper nameserver values. This commit adds some tests related to IPv6 scoping.