### PR TITLE
client: WithMockClient: match version behavior of actual client

### DIFF
--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -39,18 +38,16 @@ func TestCheckpointCreateError(t *testing.T) {
 }
 
 func TestCheckpointCreate(t *testing.T) {
-	expectedContainerID := "container_id"
-	expectedCheckpointID := "checkpoint_id"
-	expectedURL := "/containers/container_id/checkpoints"
+	const (
+		expectedContainerID  = "container_id"
+		expectedCheckpointID = "checkpoint_id"
+		expectedURL          = "/containers/container_id/checkpoints"
+	)
 
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 
 			createOptions := &CheckpointCreateOptions{}

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -36,15 +34,12 @@ func TestCheckpointDeleteError(t *testing.T) {
 }
 
 func TestCheckpointDelete(t *testing.T) {
-	expectedURL := "/containers/container_id/checkpoints/checkpoint_id"
+	const expectedURL = "/containers/container_id/checkpoints/checkpoint_id"
 
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodDelete {
-				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+				return nil, err
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -27,12 +25,12 @@ func TestCheckpointListError(t *testing.T) {
 }
 
 func TestCheckpointList(t *testing.T) {
-	expectedURL := "/containers/container_id/checkpoints"
+	const expectedURL = "/containers/container_id/checkpoints"
 
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			content, err := json.Marshal([]checkpoint.Summary{
 				{

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -16,7 +14,6 @@ import (
 
 func TestConfigRemoveError(t *testing.T) {
 	client, err := NewClientWithOpts(
-		WithVersion("1.30"),
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -34,16 +31,12 @@ func TestConfigRemoveError(t *testing.T) {
 }
 
 func TestConfigRemove(t *testing.T) {
-	expectedURL := "/v1.30/configs/config_id"
+	const expectedURL = "/configs/config_id"
 
 	client, err := NewClientWithOpts(
-		WithVersion("1.30"),
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodDelete {
-				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+				return nil, err
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -17,7 +15,6 @@ import (
 
 func TestConfigUpdateError(t *testing.T) {
 	client, err := NewClientWithOpts(
-		WithVersion("1.30"),
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -35,16 +32,12 @@ func TestConfigUpdateError(t *testing.T) {
 }
 
 func TestConfigUpdate(t *testing.T) {
-	expectedURL := "/v1.30/configs/config_id/update"
+	const expectedURL = "/configs/config_id/update"
 
 	client, err := NewClientWithOpts(
-		WithVersion("1.30"),
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -48,8 +47,8 @@ func TestContainerCommit(t *testing.T) {
 
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			containerID := query.Get("container")

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -63,15 +62,14 @@ func TestContainerStatPathNoHeaderError(t *testing.T) {
 }
 
 func TestContainerStatPath(t *testing.T) {
-	expectedURL := "/containers/container_id/archive"
-	expectedPath := "path/to/file"
+	const (
+		expectedURL  = "/containers/container_id/archive"
+		expectedPath = "path/to/file"
+	)
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodHead {
-				return nil, fmt.Errorf("expected HEAD method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodHead, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			path := query.Get("path")
@@ -143,15 +141,14 @@ func TestCopyToContainerEmptyResponse(t *testing.T) {
 }
 
 func TestCopyToContainer(t *testing.T) {
-	expectedURL := "/containers/container_id/archive"
-	expectedPath := "path/to/file"
+	const (
+		expectedURL  = "/containers/container_id/archive"
+		expectedPath = "path/to/file"
+	)
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPut {
-				return nil, fmt.Errorf("expected PUT method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodPut, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			path := query.Get("path")
@@ -259,15 +256,14 @@ func TestCopyFromContainerNoHeaderError(t *testing.T) {
 }
 
 func TestCopyFromContainer(t *testing.T) {
-	expectedURL := "/containers/container_id/archive"
-	expectedPath := "path/to/file"
+	const (
+		expectedURL  = "/containers/container_id/archive"
+		expectedPath = "path/to/file"
+	)
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodGet {
-				return nil, fmt.Errorf("expected GET method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			path := query.Get("path")

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -50,11 +49,11 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 }
 
 func TestContainerCreateWithName(t *testing.T) {
-	expectedURL := "/containers/create"
+	const expectedURL = "/containers/create"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			name := req.URL.Query().Get("name")
 			if name != "container_name" {
@@ -179,7 +178,6 @@ func TestContainerCreateCapabilities(t *testing.T) {
 				Body:       io.NopCloser(bytes.NewReader(b)),
 			}, nil
 		}),
-		WithVersion("1.24"),
 	)
 	assert.NilError(t, err)
 

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -54,8 +52,8 @@ func TestContainerDiff(t *testing.T) {
 
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			b, err := json.Marshal(expected)
 			if err != nil {

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -47,14 +46,11 @@ func TestContainerExecCreateConnectionError(t *testing.T) {
 }
 
 func TestContainerExecCreate(t *testing.T) {
-	expectedURL := "/containers/container_id/exec"
+	const expectedURL = "/containers/container_id/exec"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			// FIXME validate the content is the given ExecConfig ?
 			if err := req.ParseForm(); err != nil {
@@ -99,11 +95,11 @@ func TestContainerExecStartError(t *testing.T) {
 }
 
 func TestContainerExecStart(t *testing.T) {
-	expectedURL := "/exec/exec_id/start"
+	const expectedURL = "/exec/exec_id/start"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			if err := req.ParseForm(); err != nil {
 				return nil, err
@@ -142,11 +138,11 @@ func TestContainerExecInspectError(t *testing.T) {
 }
 
 func TestContainerExecInspect(t *testing.T) {
-	expectedURL := "/exec/exec_id/json"
+	const expectedURL = "/exec/exec_id/json"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			b, err := json.Marshal(container.ExecInspectResponse{
 				ID:          "exec_id",

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -33,13 +31,12 @@ func TestContainerExportError(t *testing.T) {
 }
 
 func TestContainerExport(t *testing.T) {
-	expectedURL := "/containers/container_id/export"
+	const expectedURL = "/containers/container_id/export"
 	client, err := NewClientWithOpts(
-		WithMockClient(func(r *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(r.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, r.URL)
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
-
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte("response"))),

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -71,11 +69,11 @@ func TestContainerInspectWithEmptyID(t *testing.T) {
 }
 
 func TestContainerInspect(t *testing.T) {
-	expectedURL := "/containers/container_id/json"
+	const expectedURL = "/containers/container_id/json"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			content, err := json.Marshal(container.InspectResponse{
 				ID:    "container_id",

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -33,11 +32,11 @@ func TestContainerKillError(t *testing.T) {
 }
 
 func TestContainerKill(t *testing.T) {
-	expectedURL := "/containers/container_id/kill"
+	const expectedURL = "/containers/container_id/kill"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			signal := req.URL.Query().Get("signal")
 			if signal != "SIGKILL" {

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -28,12 +27,14 @@ func TestContainerListError(t *testing.T) {
 }
 
 func TestContainerList(t *testing.T) {
-	expectedURL := "/containers/json"
-	expectedFilters := `{"before":{"container":true},"label":{"label1":true,"label2":true}}`
+	const (
+		expectedURL     = "/containers/json"
+		expectedFilters = `{"before":{"container":true},"label":{"label1":true,"label2":true}}`
+	)
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			all := query.Get("all")

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -56,7 +55,7 @@ func TestContainerLogsError(t *testing.T) {
 }
 
 func TestContainerLogs(t *testing.T) {
-	expectedURL := "/containers/container_id/logs"
+	const expectedURL = "/containers/container_id/logs"
 	cases := []struct {
 		options             ContainerLogsOptions
 		expectedQueryParams map[string]string
@@ -129,12 +128,12 @@ func TestContainerLogs(t *testing.T) {
 	}
 	for _, logCase := range cases {
 		client, err := NewClientWithOpts(
-			WithMockClient(func(r *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(r.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, r.URL)
+			WithMockClient(func(req *http.Request) (*http.Response, error) {
+				if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+					return nil, err
 				}
 				// Check query parameters
-				query := r.URL.Query()
+				query := req.URL.Query()
 				for key, expected := range logCase.expectedQueryParams {
 					actual := query.Get(key)
 					if actual != expected {

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -25,11 +23,11 @@ func TestContainerPauseError(t *testing.T) {
 }
 
 func TestContainerPause(t *testing.T) {
-	expectedURL := "/containers/container_id/pause"
+	const expectedURL = "/containers/container_id/pause"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			return &http.Response{
 				StatusCode: http.StatusOK,

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -38,10 +37,10 @@ func TestContainerRemoveNotFoundError(t *testing.T) {
 }
 
 func TestContainerRemove(t *testing.T) {
-	expectedURL := "/containers/container_id"
+	const expectedURL = "/containers/container_id"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+			return nil, err
 		}
 		query := req.URL.Query()
 		volume := query.Get("v")

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -30,10 +29,10 @@ func TestContainerRenameError(t *testing.T) {
 }
 
 func TestContainerRename(t *testing.T) {
-	expectedURL := "/containers/container_id/rename"
+	const expectedURL = "/containers/container_id/rename"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		name := req.URL.Query().Get("name")
 		if name != "newName" {

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -122,7 +122,7 @@ func TestContainerExecResize(t *testing.T) {
 
 func resizeTransport(t *testing.T, expectedURL, expectedHeight, expectedWidth string) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
-		assert.Check(t, is.Equal(req.URL.Path, expectedURL))
+		assert.Check(t, assertRequest(req, http.MethodPost, expectedURL))
 
 		query := req.URL.Query()
 		assert.Check(t, is.Equal(query.Get("h"), expectedHeight))

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -31,10 +30,10 @@ func TestContainerStartError(t *testing.T) {
 }
 
 func TestContainerStart(t *testing.T) {
-	expectedURL := "/containers/container_id/start"
+	const expectedURL = "/containers/container_id/start"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		// we're not expecting any payload, but if one is supplied, check it is valid.
 		if req.Header.Get("Content-Type") == "application/json" {

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -42,10 +41,10 @@ func TestContainerStopConnectionError(t *testing.T) {
 }
 
 func TestContainerStop(t *testing.T) {
-	const expectedURL = "/v1.42/containers/container_id/stop"
+	const expectedURL = "/containers/container_id/stop"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		s := req.URL.Query().Get("signal")
 		if s != "SIGKILL" {
@@ -59,7 +58,7 @@ func TestContainerStop(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 		}, nil
-	}), WithVersion("1.42"))
+	}))
 	assert.NilError(t, err)
 	timeout := 100
 	err = client.ContainerStop(context.Background(), "container_id", ContainerStopOptions{

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -32,7 +31,7 @@ func TestContainerTopError(t *testing.T) {
 }
 
 func TestContainerTop(t *testing.T) {
-	expectedURL := "/containers/container_id/top"
+	const expectedURL = "/containers/container_id/top"
 	expectedProcesses := [][]string{
 		{"p1", "p2"},
 		{"p3"},
@@ -40,8 +39,8 @@ func TestContainerTop(t *testing.T) {
 	expectedTitles := []string{"title1", "title2"}
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		query := req.URL.Query()
 		args := query.Get("ps_args")

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -30,10 +28,10 @@ func TestContainerUnpauseError(t *testing.T) {
 }
 
 func TestContainerUnpause(t *testing.T) {
-	expectedURL := "/containers/container_id/unpause"
+	const expectedURL = "/containers/container_id/unpause"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -32,11 +30,11 @@ func TestContainerUpdateError(t *testing.T) {
 }
 
 func TestContainerUpdate(t *testing.T) {
-	expectedURL := "/containers/container_id/update"
+	const expectedURL = "/containers/container_id/update"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 
 		b, err := json.Marshal(container.UpdateResponse{})

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -27,9 +27,9 @@ func TestImageHistory(t *testing.T) {
 		historyResponse  = `[{"Comment":"","Created":0,"CreatedBy":"","Id":"image_id1","Size":0,"Tags":["tag1","tag2"]},{"Comment":"","Created":0,"CreatedBy":"","Id":"image_id2","Size":0,"Tags":["tag1","tag2"]}]`
 		expectedPlatform = `{"architecture":"arm64","os":"linux","variant":"v8"}`
 	)
-	client, err := NewClientWithOpts(WithMockClient(func(r *http.Request) (*http.Response, error) {
-		assert.Check(t, is.Equal(r.URL.Path, expectedURL))
-		assert.Check(t, is.Equal(r.URL.Query().Get("platform"), expectedPlatform))
+	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		assert.Check(t, assertRequest(req, http.MethodGet, expectedURL))
+		assert.Check(t, is.Equal(req.URL.Query().Get("platform"), expectedPlatform))
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(historyResponse)),

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -68,7 +68,7 @@ func TestImageImport(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-				assert.Check(t, is.Equal(req.URL.Path, expectedURL))
+				assert.Check(t, assertRequest(req, http.MethodPost, expectedURL))
 				query := req.URL.Query()
 				assert.Check(t, is.DeepEqual(query, tc.expectedQueryParams))
 				return &http.Response{

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -44,11 +43,11 @@ func TestImageInspectWithEmptyID(t *testing.T) {
 }
 
 func TestImageInspect(t *testing.T) {
-	expectedURL := "/images/image_id/json"
+	const expectedURL = "/images/image_id/json"
 	expectedTags := []string{"tag1", "tag2"}
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		content, err := json.Marshal(image.InspectResponse{
 			ID:       "image_id",
@@ -71,7 +70,7 @@ func TestImageInspect(t *testing.T) {
 }
 
 func TestImageInspectWithPlatform(t *testing.T) {
-	expectedURL := "/images/image_id/json"
+	const expectedURL = "/images/image_id/json"
 	requestedPlatform := &ocispec.Platform{
 		OS:           "linux",
 		Architecture: "arm64",
@@ -81,8 +80,8 @@ func TestImageInspectWithPlatform(t *testing.T) {
 	assert.NilError(t, err)
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 
 		// Check if platform parameter is passed correctly

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -80,8 +80,8 @@ func TestImageList(t *testing.T) {
 	}
 	for _, listCase := range listCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			for key, expected := range listCase.expectedQueryParams {

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -82,7 +82,7 @@ func TestImageLoad(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-				assert.Check(t, is.Equal(req.URL.Path, expectedURL))
+				assert.Check(t, assertRequest(req, http.MethodPost, expectedURL))
 				assert.Check(t, is.Equal(req.Header.Get("Content-Type"), expectedContentType))
 				assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))
 				return &http.Response{

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -65,8 +64,8 @@ func TestImagePullWithPrivilegedFuncNoError(t *testing.T) {
 	const invalidAuth = "NotValid"
 	const validAuth = "IAmValid"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		auth := req.Header.Get(registry.AuthHeader)
 		if auth == invalidAuth {
@@ -167,8 +166,8 @@ func TestImagePullWithoutErrors(t *testing.T) {
 	for _, pullCase := range pullCases {
 		t.Run(pullCase.reference, func(t *testing.T) {
 			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+				if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+					return nil, err
 				}
 				query := req.URL.Query()
 				fromImage := query.Get("fromImage")

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -72,8 +71,8 @@ func TestImagePushWithPrivilegedFuncNoError(t *testing.T) {
 	const invalidAuth = "NotValid"
 	const validAuth = "IAmValid"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		auth := req.Header.Get(registry.AuthHeader)
 		if auth == invalidAuth {
@@ -171,8 +170,8 @@ func TestImagePushWithoutErrors(t *testing.T) {
 		t.Run(fmt.Sprintf("%s,all-tags=%t", tc.reference, tc.all), func(t *testing.T) {
 			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				expectedURL := fmt.Sprintf(expectedURLFormat, tc.expectedImage)
-				if !strings.HasPrefix(req.URL.Path, expectedURL) {
-					return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+				if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+					return nil, err
 				}
 				query := req.URL.Query()
 				tag := query.Get("tag")

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -35,7 +34,7 @@ func TestImageRemoveImageNotFound(t *testing.T) {
 }
 
 func TestImageRemove(t *testing.T) {
-	expectedURL := "/images/image_id"
+	const expectedURL = "/images/image_id"
 	removeCases := []struct {
 		force               bool
 		pruneChildren       bool
@@ -70,11 +69,8 @@ func TestImageRemove(t *testing.T) {
 	}
 	for _, removeCase := range removeCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodDelete {
-				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			for key, expected := range removeCase.expectedQueryParams {

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -65,7 +65,7 @@ func TestImageSave(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
 			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-				assert.Check(t, is.Equal(req.URL.Path, expectedURL))
+				assert.Check(t, assertRequest(req, http.MethodGet, expectedURL))
 				assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))
 				return &http.Response{
 					StatusCode: http.StatusOK,

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -57,10 +56,10 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 }
 
 func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
-	expectedURL := "/images/search"
+	const expectedURL = "/images/search"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		auth := req.Header.Get(registry.AuthHeader)
 		if auth == "NotValid" {
@@ -107,8 +106,8 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 	const expectedFilters = `{"is-automated":{"true":true},"stars":{"3":true}}`
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		query := req.URL.Query()
 		term := query.Get("term")

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -154,11 +153,8 @@ func TestImageTag(t *testing.T) {
 	}
 	for _, tagCase := range tagCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			for key, expected := range tagCase.expectedQueryParams {

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -34,15 +33,11 @@ func TestNetworkConnectError(t *testing.T) {
 }
 
 func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
-	expectedURL := "/networks/network_id/connect"
+	const expectedURL = "/networks/network_id/connect"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 
 		var connect NetworkConnectOptions
@@ -70,15 +65,11 @@ func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
 }
 
 func TestNetworkConnect(t *testing.T) {
-	expectedURL := "/networks/network_id/connect"
+	const expectedURL = "/networks/network_id/connect"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 
 		var connect NetworkConnectOptions

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -37,15 +35,11 @@ func TestNetworkCreateConnectionError(t *testing.T) {
 }
 
 func TestNetworkCreate(t *testing.T) {
-	expectedURL := "/networks/create"
+	const expectedURL = "/networks/create"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 
 		content, err := json.Marshal(network.CreateResponse{

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -33,15 +32,11 @@ func TestNetworkDisconnectError(t *testing.T) {
 }
 
 func TestNetworkDisconnect(t *testing.T) {
-	expectedURL := "/networks/network_id/disconnect"
+	const expectedURL = "/networks/network_id/disconnect"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 
 		var disconnect NetworkDisconnectOptions

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -61,11 +60,8 @@ func TestNetworkList(t *testing.T) {
 
 	for _, listCase := range listCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodGet {
-				return nil, fmt.Errorf("expected GET method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			actualFilters := query.Get("filters")

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -31,14 +29,11 @@ func TestNetworkRemoveError(t *testing.T) {
 }
 
 func TestNetworkRemove(t *testing.T) {
-	expectedURL := "/networks/network_id"
+	const expectedURL = "/networks/network_id"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodDelete {
-			return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -48,10 +46,10 @@ func TestNodeInspectWithEmptyID(t *testing.T) {
 }
 
 func TestNodeInspect(t *testing.T) {
-	expectedURL := "/nodes/node_id"
+	const expectedURL = "/nodes/node_id"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		content, err := json.Marshal(swarm.Node{
 			ID: "node_id",

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -52,8 +51,8 @@ func TestNodeList(t *testing.T) {
 	}
 	for _, listCase := range listCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			for key, expected := range listCase.expectedQueryParams {

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -31,7 +30,7 @@ func TestNodeRemoveError(t *testing.T) {
 }
 
 func TestNodeRemove(t *testing.T) {
-	expectedURL := "/nodes/node_id"
+	const expectedURL = "/nodes/node_id"
 
 	removeCases := []struct {
 		force         bool
@@ -48,11 +47,8 @@ func TestNodeRemove(t *testing.T) {
 
 	for _, removeCase := range removeCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodDelete {
-				return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+				return nil, err
 			}
 			force := req.URL.Query().Get("force")
 			if force != removeCase.expectedForce {

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -32,14 +30,11 @@ func TestNodeUpdateError(t *testing.T) {
 }
 
 func TestNodeUpdate(t *testing.T) {
-	expectedURL := "/nodes/node_id/update"
+	const expectedURL = "/nodes/node_id/update"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -31,14 +29,11 @@ func TestPluginDisableError(t *testing.T) {
 }
 
 func TestPluginDisable(t *testing.T) {
-	expectedURL := "/plugins/plugin_name/disable"
+	const expectedURL = "/plugins/plugin_name/disable"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -31,14 +29,11 @@ func TestPluginEnableError(t *testing.T) {
 }
 
 func TestPluginEnable(t *testing.T) {
-	expectedURL := "/plugins/plugin_name/enable"
+	const expectedURL = "/plugins/plugin_name/enable"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -40,10 +38,10 @@ func TestPluginInspectWithEmptyID(t *testing.T) {
 }
 
 func TestPluginInspect(t *testing.T) {
-	expectedURL := "/plugins/plugin_name"
+	const expectedURL = "/plugins/plugin_name"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		content, err := json.Marshal(plugin.Plugin{
 			ID: "plugin_id",

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -63,8 +62,8 @@ func TestPluginList(t *testing.T) {
 
 	for _, listCase := range listCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			for key, expected := range listCase.expectedQueryParams {

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -32,14 +31,11 @@ func TestPluginPushError(t *testing.T) {
 }
 
 func TestPluginPush(t *testing.T) {
-	expectedURL := "/plugins/plugin_name"
+	const expectedURL = "/plugins/plugin_name"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		auth := req.Header.Get(registry.AuthHeader)
 		if auth != "authtoken" {

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -31,14 +29,11 @@ func TestPluginRemoveError(t *testing.T) {
 }
 
 func TestPluginRemove(t *testing.T) {
-	expectedURL := "/plugins/plugin_name"
+	const expectedURL = "/plugins/plugin_name"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodDelete {
-			return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -31,14 +29,11 @@ func TestPluginSetError(t *testing.T) {
 }
 
 func TestPluginSet(t *testing.T) {
-	expectedURL := "/plugins/plugin_name/set"
+	const expectedURL = "/plugins/plugin_name/set"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -52,8 +52,8 @@ func TestSetHostHeader(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.host, func(t *testing.T) {
 			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-				if !strings.HasPrefix(req.URL.Path, testEndpoint) {
-					return nil, fmt.Errorf("expected URL %q, got %q", testEndpoint, req.URL)
+				if err := assertRequest(req, http.MethodGet, testEndpoint); err != nil {
+					return nil, err
 				}
 				if req.Host != tc.expectedHost {
 					return nil, fmt.Errorf("wxpected host %q, got %q", tc.expectedHost, req.Host)

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -48,10 +46,10 @@ func TestServiceInspectWithEmptyID(t *testing.T) {
 }
 
 func TestServiceInspect(t *testing.T) {
-	expectedURL := "/services/service_id"
+	const expectedURL = "/services/service_id"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		content, err := json.Marshal(swarm.Service{
 			ID: "service_id",

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -52,8 +51,8 @@ func TestServiceList(t *testing.T) {
 	}
 	for _, listCase := range listCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			for key, expected := range listCase.expectedQueryParams {

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -39,7 +38,7 @@ func TestServiceLogsError(t *testing.T) {
 }
 
 func TestServiceLogs(t *testing.T) {
-	expectedURL := "/services/service_id/logs"
+	const expectedURL = "/services/service_id/logs"
 	cases := []struct {
 		options             ContainerLogsOptions
 		expectedQueryParams map[string]string
@@ -94,12 +93,12 @@ func TestServiceLogs(t *testing.T) {
 		},
 	}
 	for _, logCase := range cases {
-		client, err := NewClientWithOpts(WithMockClient(func(r *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(r.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedURL, r.URL)
+		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			// Check query parameters
-			query := r.URL.Query()
+			query := req.URL.Query()
 			for key, expected := range logCase.expectedQueryParams {
 				actual := query.Get(key)
 				if actual != expected {

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -40,14 +38,11 @@ func TestServiceRemoveNotFoundError(t *testing.T) {
 }
 
 func TestServiceRemove(t *testing.T) {
-	expectedURL := "/services/service_id"
+	const expectedURL = "/services/service_id"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodDelete {
-			return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -44,7 +43,7 @@ func TestServiceUpdateConnectionError(t *testing.T) {
 }
 
 func TestServiceUpdate(t *testing.T) {
-	expectedURL := "/services/service_id/update"
+	const expectedURL = "/services/service_id/update"
 
 	updateCases := []struct {
 		swarmVersion    swarm.Version
@@ -69,11 +68,8 @@ func TestServiceUpdate(t *testing.T) {
 
 	for _, updateCase := range updateCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			version := req.URL.Query().Get("version")
 			if version != updateCase.expectedVersion {

--- a/client/swarm_get_unlock_key_test.go
+++ b/client/swarm_get_unlock_key_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -25,15 +23,14 @@ func TestSwarmGetUnlockKeyError(t *testing.T) {
 }
 
 func TestSwarmGetUnlockKey(t *testing.T) {
-	expectedURL := "/swarm/unlockkey"
-	unlockKey := "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeE"
+	const (
+		expectedURL = "/swarm/unlockkey"
+		unlockKey   = "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeE"
+	)
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodGet {
-			return nil, fmt.Errorf("expected GET method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 
 		key := swarm.UnlockKeyResponse{

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -24,14 +22,11 @@ func TestSwarmInitError(t *testing.T) {
 }
 
 func TestSwarmInit(t *testing.T) {
-	expectedURL := "/swarm/init"
+	const expectedURL = "/swarm/init"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -25,10 +23,10 @@ func TestSwarmInspectError(t *testing.T) {
 }
 
 func TestSwarmInspect(t *testing.T) {
-	expectedURL := "/swarm"
+	const expectedURL = "/swarm"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		content, err := json.Marshal(swarm.Swarm{
 			ClusterInfo: swarm.ClusterInfo{

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -24,14 +22,11 @@ func TestSwarmJoinError(t *testing.T) {
 }
 
 func TestSwarmJoin(t *testing.T) {
-	expectedURL := "/swarm/join"
+	const expectedURL = "/swarm/join"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -23,7 +22,7 @@ func TestSwarmLeaveError(t *testing.T) {
 }
 
 func TestSwarmLeave(t *testing.T) {
-	expectedURL := "/swarm/leave"
+	const expectedURL = "/swarm/leave"
 
 	leaveCases := []struct {
 		force         bool
@@ -40,11 +39,8 @@ func TestSwarmLeave(t *testing.T) {
 
 	for _, leaveCase := range leaveCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-			}
-			if req.Method != http.MethodPost {
-				return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+				return nil, err
 			}
 			force := req.URL.Query().Get("force")
 			if force != leaveCase.expectedForce {

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -24,14 +22,11 @@ func TestSwarmUnlockError(t *testing.T) {
 }
 
 func TestSwarmUnlock(t *testing.T) {
-	expectedURL := "/swarm/unlock"
+	const expectedURL = "/swarm/unlock"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -24,14 +22,11 @@ func TestSwarmUpdateError(t *testing.T) {
 }
 
 func TestSwarmUpdate(t *testing.T) {
-	expectedURL := "/swarm/update"
+	const expectedURL = "/swarm/update"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -24,10 +22,10 @@ func TestDiskUsageError(t *testing.T) {
 }
 
 func TestDiskUsage(t *testing.T) {
-	expectedURL := "/system/df"
+	const expectedURL = "/system/df"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 
 		du := system.DiskUsage{

--- a/client/system_events_test.go
+++ b/client/system_events_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -109,8 +108,8 @@ func TestEvents(t *testing.T) {
 
 	for _, eventsCase := range eventsCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 

--- a/client/system_info_test.go
+++ b/client/system_info_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -36,10 +34,10 @@ func TestInfoInvalidResponseJSONError(t *testing.T) {
 }
 
 func TestInfo(t *testing.T) {
-	expectedURL := "/info"
+	const expectedURL = "/info"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		info := &system.Info{
 			ID:         "daemonID",
@@ -65,10 +63,10 @@ func TestInfo(t *testing.T) {
 }
 
 func TestInfoWithDiscoveredDevices(t *testing.T) {
-	expectedURL := "/info"
+	const expectedURL = "/info"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		info := &system.Info{
 			ID:         "daemonID",

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -40,10 +38,10 @@ func TestTaskInspectWithEmptyID(t *testing.T) {
 }
 
 func TestTaskInspect(t *testing.T) {
-	expectedURL := "/tasks/task_id"
+	const expectedURL = "/tasks/task_id"
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		content, err := json.Marshal(swarm.Task{
 			ID: "task_id",

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -52,8 +51,8 @@ func TestTaskList(t *testing.T) {
 	}
 	for _, listCase := range listCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			for key, expected := range listCase.expectedQueryParams {

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -25,15 +23,11 @@ func TestVolumeCreateError(t *testing.T) {
 }
 
 func TestVolumeCreate(t *testing.T) {
-	expectedURL := "/volumes/create"
+	const expectedURL = "/volumes/create"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-
-		if req.Method != http.MethodPost {
-			return nil, fmt.Errorf("expected POST method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
+			return nil, err
 		}
 
 		content, err := json.Marshal(volume.Volume{

--- a/client/volume_inspect_test.go
+++ b/client/volume_inspect_test.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -48,7 +46,7 @@ func TestVolumeInspectWithEmptyID(t *testing.T) {
 }
 
 func TestVolumeInspect(t *testing.T) {
-	expectedURL := "/volumes/volume_id"
+	const expectedURL = "/volumes/volume_id"
 	expected := volume.Volume{
 		Name:       "name",
 		Driver:     "driver",
@@ -56,11 +54,8 @@ func TestVolumeInspect(t *testing.T) {
 	}
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodGet {
-			return nil, fmt.Errorf("expected GET method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+			return nil, err
 		}
 		content, err := json.Marshal(expected)
 		if err != nil {

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -52,8 +51,8 @@ func TestVolumeList(t *testing.T) {
 
 	for _, listCase := range listCases {
 		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-			if !strings.HasPrefix(req.URL.Path, expectedURL) {
-				return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
+			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
+				return nil, err
 			}
 			query := req.URL.Query()
 			actualFilters := query.Get("filters")

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -3,10 +3,8 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -43,14 +41,11 @@ func TestVolumeRemoveConnectionError(t *testing.T) {
 }
 
 func TestVolumeRemove(t *testing.T) {
-	expectedURL := "/volumes/volume_id"
+	const expectedURL = "/volumes/volume_id"
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodDelete {
-			return nil, fmt.Errorf("expected DELETE method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
+			return nil, err
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/client/volume_update_test.go
+++ b/client/volume_update_test.go
@@ -33,15 +33,14 @@ func TestVolumeUpdateError(t *testing.T) {
 }
 
 func TestVolumeUpdate(t *testing.T) {
-	expectedURL := "/volumes/test1"
-	expectedVersion := "version=10"
+	const (
+		expectedURL     = "/volumes/test1"
+		expectedVersion = "version=10"
+	)
 
 	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if !strings.HasPrefix(req.URL.Path, expectedURL) {
-			return nil, fmt.Errorf("Expected URL '%s', got '%s'", expectedURL, req.URL)
-		}
-		if req.Method != http.MethodPut {
-			return nil, fmt.Errorf("expected PUT method, got %s", req.Method)
+		if err := assertRequest(req, http.MethodPut, expectedURL); err != nil {
+			return nil, err
 		}
 		if !strings.Contains(req.URL.RawQuery, expectedVersion) {
 			return nil, fmt.Errorf("expected query to contain '%s', got '%s'", expectedVersion, req.URL.RawQuery)


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/51001


### client: WithMockClient: match version behavior of actual client

The WithMockClient option was explicitly resetting the client's API version (see [1]), which differs from the regular client, which is initialized with the current API version used by the client (see [2]).

This patch:

- reduces the `WithMockClient` to only set the custom HTTP client, leaving other fields un-touched.
- adds a test utility and updates tests to handle the API-version prefix
- removes redundant uses of `WithVersion()` in tests; for most test-cases it was used to make sure a current API version is used that supports the feature being tested, but there was no test to verify the behavior for lower API versions, so we may as well test against "latest".

[1]: https://github.com/moby/moby/blob/5a582729d86c810c3c74035ca9830ea8478f8276/client/client_mock_test.go#L22-L36
[2]: https://github.com/moby/moby/blob/5a582729d86c810c3c74035ca9830ea8478f8276/client/client.go#L167-L190

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

