### PR TITLE
client: rename validateAPIVersion to validateServiceSpecForAPIVersion

### DIFF
--- a/client/service_create.go
+++ b/client/service_create.go
@@ -37,7 +37,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		return response, err
 	}
 	if versions.LessThan(cli.version, "1.30") {
-		if err := validateAPIVersion(service, cli.version); err != nil {
+		if err := validateServiceSpecForAPIVersion(service, cli.version); err != nil {
 			return response, err
 		}
 	}
@@ -196,7 +196,7 @@ func validateServiceSpec(s swarm.ServiceSpec) error {
 	return nil
 }
 
-func validateAPIVersion(c swarm.ServiceSpec, apiVersion string) error {
+func validateServiceSpecForAPIVersion(c swarm.ServiceSpec, apiVersion string) error {
 	for _, m := range c.TaskTemplate.ContainerSpec.Mounts {
 		if m.BindOptions != nil {
 			if m.BindOptions.NonRecursive && versions.LessThan(apiVersion, "1.40") {

--- a/vendor/github.com/moby/moby/client/service_create.go
+++ b/vendor/github.com/moby/moby/client/service_create.go
@@ -37,7 +37,7 @@ func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec,
 		return response, err
 	}
 	if versions.LessThan(cli.version, "1.30") {
-		if err := validateAPIVersion(service, cli.version); err != nil {
+		if err := validateServiceSpecForAPIVersion(service, cli.version); err != nil {
 			return response, err
 		}
 	}
@@ -196,7 +196,7 @@ func validateServiceSpec(s swarm.ServiceSpec) error {
 	return nil
 }
 
-func validateAPIVersion(c swarm.ServiceSpec, apiVersion string) error {
+func validateServiceSpecForAPIVersion(c swarm.ServiceSpec, apiVersion string) error {
 	for _, m := range c.TaskTemplate.ContainerSpec.Mounts {
 		if m.BindOptions != nil {
 			if m.BindOptions.NonRecursive && versions.LessThan(apiVersion, "1.40") {


### PR DESCRIPTION
This function is used to validate a service-spec for a specific API version; renaming it to be less ambiguous.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

