### PR TITLE
client: remove deprecated ImageListOptions.ContainerCount

### DIFF
--- a/client/image_list_opts.go
+++ b/client/image_list_opts.go
@@ -14,11 +14,6 @@ type ImageListOptions struct {
 	// SharedSize indicates whether the shared size of images should be computed.
 	SharedSize bool
 
-	// ContainerCount indicates whether container count should be computed.
-	//
-	// Deprecated: This field has been unused and is no longer required and will be removed in a future version.
-	ContainerCount bool
-
 	// Manifests indicates whether the image manifests should be returned.
 	Manifests bool
 }

--- a/vendor/github.com/moby/moby/client/image_list_opts.go
+++ b/vendor/github.com/moby/moby/client/image_list_opts.go
@@ -14,11 +14,6 @@ type ImageListOptions struct {
 	// SharedSize indicates whether the shared size of images should be computed.
 	SharedSize bool
 
-	// ContainerCount indicates whether container count should be computed.
-	//
-	// Deprecated: This field has been unused and is no longer required and will be removed in a future version.
-	ContainerCount bool
-
 	// Manifests indicates whether the image manifests should be returned.
 	Manifests bool
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50146

### client: remove deprecated ImageListOptions.ContainerCount

This field was deprecated in [moby@cfcbfab] when this struct still lived in the API. The field is no longer used, and we don't have to carry it forward as part of the new client module.

[moby@cfcbfab]: https://github.com/moby/moby/commit/cfcbfabb0ff8d2e0a38a118adbc64afc8152cfeb

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: remove deprecated `ImageListOptions.ContainerCount`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

