### PR TITLE
integration: migrate TestAPICreateDeletePredefinedNetworks from integration-cli 

### DIFF
--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -296,23 +296,6 @@ func getNwResource(t *testing.T, name string) *network.Inspect {
 	assert.NilError(t, err)
 	return &nr[0]
 }
-
-func (s *DockerNetworkSuite) TestDockerNetworkLsDefault(c *testing.T) {
-	defaults := []string{"bridge", "host", "none"}
-	for _, nn := range defaults {
-		assertNwIsAvailable(c, nn)
-	}
-}
-
-func (s *DockerNetworkSuite) TestDockerNetworkCreatePredefined(c *testing.T) {
-	predefined := []string{"bridge", "host", "none", "default"}
-	for _, nw := range predefined {
-		// predefined networks can't be created again
-		out, _, err := dockerCmdWithError("network", "create", nw)
-		assert.ErrorContains(c, err, "", out)
-	}
-}
-
 func (s *DockerNetworkSuite) TestDockerNetworkCreateHostBind(c *testing.T) {
 	cli.DockerCmd(c, "network", "create", "--subnet=192.168.10.0/24", "--gateway=192.168.10.1", "-o", "com.docker.network.bridge.host_binding_ipv4=192.168.10.1", "testbind")
 	assertNwIsAvailable(c, "testbind")
@@ -321,15 +304,6 @@ func (s *DockerNetworkSuite) TestDockerNetworkCreateHostBind(c *testing.T) {
 	cli.WaitRun(c, id)
 	out := cli.DockerCmd(c, "ps").Stdout()
 	assert.Assert(c, is.Contains(out, "192.168.10.1:5000->5000/tcp"))
-}
-
-func (s *DockerNetworkSuite) TestDockerNetworkRmPredefined(c *testing.T) {
-	predefined := []string{"bridge", "host", "none", "default"}
-	for _, nw := range predefined {
-		// predefined networks can't be removed
-		out, _, err := dockerCmdWithError("network", "rm", nw)
-		assert.ErrorContains(c, err, "", out)
-	}
 }
 
 func (s *DockerNetworkSuite) TestDockerNetworkLsFilter(c *testing.T) {

--- a/integration/network/network_test.go
+++ b/integration/network/network_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"testing"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -166,4 +167,47 @@ func TestNetworkInspectWithScope(t *testing.T) {
 
 	_, err = cli.NetworkInspect(ctx, name, client.NetworkInspectOptions{Scope: "local"})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+}
+
+func TestCreateDeletePredefinedNetworks(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	// Predefined networks differ per OS.
+	predefined := []string{"bridge", "host", "none"}
+	if testEnv.DaemonInfo.OSType == "windows" {
+		predefined = []string{"nat", "none"}
+	}
+
+	// Verify the daemon actually has those networks.
+	res, err := apiClient.NetworkList(ctx, client.NetworkListOptions{})
+	assert.NilError(t, err)
+
+	var actual []string
+	for _, nw := range res.Items {
+		if slices.Contains(predefined, nw.Name) {
+			actual = append(actual, nw.Name)
+		}
+	}
+	slices.Sort(actual)
+	slices.Sort(predefined)
+	assert.Check(t, is.DeepEqual(actual, predefined))
+
+	for _, name := range predefined {
+		t.Run(name, func(t *testing.T) {
+			// Creating a predefined network must fail.
+			_, err := apiClient.NetworkCreate(ctx, name, client.NetworkCreateOptions{})
+			assert.Check(t, is.ErrorContains(err, "operation is not permitted on predefined"))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsPermissionDenied))
+
+			// Deleting a predefined network must fail.
+			_, err = apiClient.NetworkRemove(ctx, name, client.NetworkRemoveOptions{})
+			assert.Check(t, is.ErrorContains(err, "is a pre-defined network and cannot be removed"))
+			assert.Check(t, is.ErrorType(err, cerrdefs.IsPermissionDenied))
+
+			// Sanity: it should still exist.
+			_, err = apiClient.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
+			assert.NilError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
- supersedes, closes https://github.com/moby/moby/pull/51268
- addresses https://github.com/moby/moby/issues/50159


- What I did
Migrated the legacy test TestAPICreateDeletePredefinedNetworks from integration-cli/docker_api_network_test.go to the new integration suite in integration/network/create_delete_predefined_test.go.

- How I did it
Reimplemented the test using the Go client APIs (client.NetworkCreate, client.NetworkRemove, client.NetworkList) instead of the old CLI test framework.
The test asserts that creating or deleting the predefined networks (bridge, host, none) fails, and verifies that each still exists afterward.

- How to verify it
Run the test with:

```
DOCKER_API_VERSION=1.51 \
TESTDIRS='./integration/network' \
TESTFLAGS='-test.run TestCreateDeletePredefinedNetworks' \
make test-integration
```

- Human readable description for the release notes

Migrate predefined network test from integration-cli to the integration test suite.  
This ensures that attempts to create or delete built-in networks (`bridge`, `host`, `none`) fail as expected, and validates they remain available.

![Cute puppy](https://place-puppy.com/puppy/y:400/x:300)



