### PR TITLE
containerd: clean workdir when using volatile flag.

### DIFF
--- a/daemon/snapshotter/mount.go
+++ b/daemon/snapshotter/mount.go
@@ -3,7 +3,10 @@ package snapshotter
 import (
 	"context"
 	"os"
+	"path"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/log"
@@ -127,6 +130,18 @@ func (m mounter) Mount(mounts []mount.Mount, containerID string) (string, error)
 		return "", err
 	}
 
+	for _, mount := range mounts {
+		if slices.Contains(mount.Options, "volatile") {
+			if workDirIndex := slices.IndexFunc(mount.Options, func(s string) bool {
+				return strings.HasPrefix(s, "workdir=")
+			}); workDirIndex >= 0 {
+				workDir := strings.TrimPrefix(mount.Options[workDirIndex], "workdir=")
+				// overlay has a check in place to prevent mounting "volatile" system twice
+				volatileIncompatFile := path.Join(workDir, "work", "incompat", "volatile")
+				_ = os.RemoveAll(volatileIncompatFile)
+			}
+		}
+	}
 	return target, mount.All(mounts, target)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

make docker worked when `containerd-snapshotter` enabled, and containerd has `volatile` mount_option.

it do same work with #50151 but for `containerd-snapshotter`.

**- How I did it**

clear workdir before mount if there is `volatile`

**- How to verify it**

make `/etc/docker/daemon.json` has follow config
```json
    "features": {
        "containerd-snapshotter": true
    }
```
make `/etc/containerd/config.toml` has follow config

for containerd config file version 1
```toml
[plugins."overlayfs"]
    mount_options = ["volatile"]
```

for containerd config file version 2
```toml
version = 2
[plugins]
  [plugins."io.containerd.snapshotter.v1.overlayfs"]
    mount_options = ["volatile"]
```

then do some docker run `docker run -it --rm debian dd bs=1M count=1024 if=/dev/zero of=/data`
the cleanup process will be faster than before.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Support volatile mount_option for containerd-snapshotter
```

**- A picture of a cute animal (not mandatory but encouraged)**

