### PR TITLE
ipams: Re-enable legacy remote plugins support

### DIFF
--- a/daemon/libnetwork/ipams/drivers.go
+++ b/daemon/libnetwork/ipams/drivers.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Register registers all the builtin drivers (ie. default, windowsipam, null
-// and remote). If 'pg' is nil, the remote driver won't be registered.
+// and remote). 'pg' is nil here in case of non-managed plugins which Windows is using.
 func Register(r ipamapi.Registerer, pg plugingetter.PluginGetter, lAddrPools, gAddrPools []*ipamutils.NetworkToSplit) error {
 	if err := defaultipam.Register(r, lAddrPools, gAddrPools); err != nil {
 		return err
@@ -22,10 +22,8 @@ func Register(r ipamapi.Registerer, pg plugingetter.PluginGetter, lAddrPools, gA
 	if err := null.Register(r); err != nil {
 		return err
 	}
-	if pg != nil {
-		if err := remoteIpam.Register(r, pg); err != nil {
-			return err
-		}
+	if err := remoteIpam.Register(r, pg); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
**- What I did**
https://github.com/moby/moby/commit/3c9718144f22557e7448c70d22129e4602d0984d which was part of big refactoring PR https://github.com/moby/moby/pull/47727 disabled remote IPAM plugins loading in case of plugin getter is nil.

However, in Windows that is always the case so this logic needs to be revisitted.

Closes #50596

**- How I did it**
Removed plugin getter is nil check competely. However, it can be also done just for Windows in case it causes issues like this.

**- How to verify it**
Windows side tested like it is described in linked issue so if CI passes this should be fine.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Fix a bug causing IPAM plugins to not be loaded on Windows
```
