### PR TITLE
client: remove unused Client.HTTPClient() method

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -381,12 +381,6 @@ func (cli *Client) DaemonHost() string {
 	return cli.host
 }
 
-// HTTPClient returns a copy of the HTTP client bound to the server
-func (cli *Client) HTTPClient() *http.Client {
-	c := *cli.client
-	return &c
-}
-
 // ParseHostURL parses a url string, validates the string is a host url, and
 // returns the parsed URL
 func ParseHostURL(host string) (*url.URL, error) {

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net"
-	"net/http"
 
 	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/build"
@@ -38,7 +37,6 @@ type stableAPIClient interface {
 	VolumeAPIClient
 	ClientVersion() string
 	DaemonHost() string
-	HTTPClient() *http.Client
 	ServerVersion(ctx context.Context) (types.Version, error)
 	NegotiateAPIVersion(ctx context.Context)
 	NegotiateAPIVersionPing(types.Ping)

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -381,12 +381,6 @@ func (cli *Client) DaemonHost() string {
 	return cli.host
 }
 
-// HTTPClient returns a copy of the HTTP client bound to the server
-func (cli *Client) HTTPClient() *http.Client {
-	c := *cli.client
-	return &c
-}
-
 // ParseHostURL parses a url string, validates the string is a host url, and
 // returns the parsed URL
 func ParseHostURL(host string) (*url.URL, error) {

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net"
-	"net/http"
 
 	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/build"
@@ -38,7 +37,6 @@ type stableAPIClient interface {
 	VolumeAPIClient
 	ClientVersion() string
 	DaemonHost() string
-	HTTPClient() *http.Client
 	ServerVersion(ctx context.Context) (types.Version, error)
 	NegotiateAPIVersion(ctx context.Context)
 	NegotiateAPIVersionPing(types.Ping)


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/1034#discussion_r188940829
- relates to https://github.com/moby/moby/pull/37071
- relates to https://github.com/moby/moby/issues/50968

### client: remove unused `Client.HTTPClient()` method

This method was introduced in [moby@5a84124] related to the (now removed) support for "compose on kubernetes" in the CLI. This functionality extended the CLI with endpoints that are not part of the engine API, but re-using the HTTP-client with the same (TLS) config as the CLI itself.

While such scenarios may be something to consider in future (i.e. more easily extend the API with custom endpoints), this method is not currently used, but defined as part of the CLI's interface. This patch removes the method for now, so that we can design from a clean slate in case we need this extensibility, instead of keeping methods that were added ad-hoc around.

[moby@5a84124]: https://github.com/moby/moby/commit/5a84124739a809bcdb5830fd385440027ddd910f

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: remove unused `Client.HTTPClient()` method
```

**- A picture of a cute animal (not mandatory but encouraged)**

