### PR TITLE
image: pull/load/save attestation manifest and signatures with image

### DIFF
--- a/daemon/hosts.go
+++ b/daemon/hosts.go
@@ -86,7 +86,7 @@ func mirrorsToRegistryHosts(mirrors []string, dHost docker.RegistryHost) []docke
 	var mirrorHosts []docker.RegistryHost
 	for _, mirror := range mirrors {
 		h := dHost
-		h.Capabilities = docker.HostCapabilityPull | docker.HostCapabilityResolve
+		h.Capabilities = docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityReferrers
 
 		u, err := url.Parse(mirror)
 		if err != nil || u.Host == "" {

--- a/daemon/hosts_test.go
+++ b/daemon/hosts_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestMirrorsToHosts(t *testing.T) {
-	pullCaps := docker.HostCapabilityPull | docker.HostCapabilityResolve
-	allCaps := docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush
+	pullCaps := docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityReferrers
+	allCaps := docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush | docker.HostCapabilityReferrers
 	defaultRegistry := testRegistryHost("https", "registry-1.docker.com", "/v2", allCaps)
 	for _, tc := range []struct {
 		mirrors  []string

--- a/daemon/pkg/plugin/registry.go
+++ b/daemon/pkg/plugin/registry.go
@@ -73,7 +73,7 @@ func (pm *Manager) registryHostsFn(auth *registry.AuthConfig, httpFallback bool)
 				continue
 			}
 
-			caps := docker.HostCapabilityPull | docker.HostCapabilityResolve
+			caps := docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityReferrers
 			if !ep.Mirror {
 				caps = caps | docker.HostCapabilityPush
 			}

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.5
 	github.com/hashicorp/memberlist v0.4.0
 	github.com/hashicorp/serf v0.8.5
+	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/ishidawataru/sctp v0.0.0-20250829011129-4b890084db30
 	github.com/miekg/dns v1.1.66
 	github.com/mistifyio/go-zfs/v3 v3.0.1
@@ -63,6 +64,7 @@ require (
 	github.com/moby/moby/api v1.52.0
 	github.com/moby/moby/client v0.1.0
 	github.com/moby/patternmatcher v0.6.0
+	github.com/moby/policy-helpers v0.0.0-20251105011237-bcaa71c99f14
 	github.com/moby/profiles/apparmor v0.1.0
 	github.com/moby/profiles/seccomp v0.1.0
 	github.com/moby/pubsub v1.0.0
@@ -188,13 +190,11 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hiddeco/sshsig v0.2.0 // indirect
-	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmoiron/sqlx v1.3.3 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/moby/policy-helpers v0.0.0-20251105011237-bcaa71c99f14 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect


### PR DESCRIPTION
~depends on https://github.com/containerd/containerd/pull/12311~

Updates docker pull to pull related attestation manifest and any signatures for that manifest in cosign referrer objects.

These objects are transferred with the image when running docker save and docker load and can be used to identify the image in future updates.

Push is not updated atm as the current push semantics in containerd mode do not have correct immutability guaranteed and don't work with image indexes.

Currently, all the blobs of attestation manifest are pulled. Technically we only need provenance attestation (atm). Not sure if it is worth to add custom filtering for that or just persist the sbom blob by default as well.

[manual test if interested](https://gist.github.com/tonistiigi/4252f260ae7091ca769a895411983c86)