### PR TITLE
project: mark 23.0 branch as unmaintained (EOL)

### DIFF
--- a/project/BRANCHES-AND-TAGS.md
+++ b/project/BRANCHES-AND-TAGS.md
@@ -16,13 +16,13 @@ Currently (and previously) maintained release branches are documented in the tab
 | Branch Name                 | Sponsoring Maintainer(s)                       | Contribution Status   | Expected End of Maintenance | Known Distributors                        |
 |-----------------------------|------------------------------------------------|-----------------------|-----------------------------|-------------------------------------------|
 | master (development branch) | The Moby Project [MAINTAINERS](../MAINTAINERS) | N/A                   | -                           | N/A                                       |
-| 28.x                        | The Moby Project [MAINTAINERS](../MAINTAINERS) | Maintained            | After 29.x                  | [Docker, Inc.][docker], [Microsoft][msft]      |
+| 28.x                        | The Moby Project [MAINTAINERS](../MAINTAINERS) | Maintained            | After 29.x                  | [Docker, Inc.][docker], [Microsoft][msft] |
 | 27.x                        |                                                | Unmaintained          |                             |                                           |
 | 26.1                        |                                                | Unmaintained          |                             |                                           |
 | 26.0                        |                                                | Unmaintained          |                             |                                           |
 | 25.0                        | @corhere                                       | Maintained            | TBD                         | [Amazon][al2023], [Mirantis][mcr]         |
 | 24.0                        |                                                | Unmaintained          |                             |                                           |
-| 23.0                        | @corhere                                       | Maintained (security) | [2025-05-19][mcr23-maint]   | [Mirantis][mcr]                           |
+| 23.0                        |                                                | Unmaintained          | [2025-05-19][mcr23-maint]   |                                           |
 | Older than 23.0             |                                                | Unmaintained          |                             |                                           |
 
 [al2023]: https://docs.aws.amazon.com/linux/


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50998#issuecomment-3306386467

Mirantis Container Runtime 23.0 reached EOL on May 19, and the 23.0 branch is no longer maintained.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

