### PR TITLE
client: ContainerCommitOptions: change "Pause" to "NoPause"

### DIFF
--- a/client/container_commit.go
+++ b/client/container_commit.go
@@ -16,7 +16,7 @@ type ContainerCommitOptions struct {
 	Comment   string
 	Author    string
 	Changes   []string
-	Pause     bool
+	NoPause   bool // NoPause disables pausing the container during commit.
 	Config    *container.Config
 }
 
@@ -54,7 +54,7 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 	for _, change := range options.Changes {
 		query.Add("changes", change)
 	}
-	if !options.Pause {
+	if options.NoPause {
 		query.Set("pause", "0")
 	}
 

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -98,7 +98,7 @@ func TestContainerCommit(t *testing.T) {
 		Comment:   expectedComment,
 		Author:    expectedAuthor,
 		Changes:   expectedChanges,
-		Pause:     false,
+		NoPause:   true,
 	})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(r.ID, "new_container_id"))

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -144,7 +144,7 @@ func (daemon *Daemon) CreateImageFromContainer(ctx context.Context, name string,
 		return "", errdefs.Conflict(fmt.Errorf("You cannot commit container %s which is being removed", container.ID))
 	}
 
-	if c.Pause && !container.State.IsPaused() {
+	if !c.NoPause && !container.State.IsPaused() {
 		daemon.containerPause(container)
 		defer daemon.containerUnpause(container)
 	}

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -153,7 +153,7 @@ type ExecStartConfig struct {
 // container.
 type CreateImageConfig struct {
 	Tag     reference.NamedTagged
-	Pause   bool
+	NoPause bool
 	Author  string
 	Comment string
 	Config  *container.Config

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -71,8 +71,13 @@ func (c *containerRouter) postCommit(ctx context.Context, w http.ResponseWriter,
 		return errdefs.InvalidParameter(err)
 	}
 
+	var noPause bool
+	if r.Form.Has("pause") && !httputils.BoolValue(r, "pause") {
+		noPause = true
+	}
+
 	imgID, err := c.backend.CreateImageFromContainer(ctx, r.Form.Get("container"), &backend.CreateImageConfig{
-		Pause:   httputils.BoolValueOrDefault(r, "pause", true), // TODO(dnephin): remove pause arg, and always pause in backend
+		NoPause: noPause,
 		Tag:     ref,
 		Author:  r.Form.Get("author"),
 		Comment: r.Form.Get("comment"),

--- a/vendor/github.com/moby/moby/client/container_commit.go
+++ b/vendor/github.com/moby/moby/client/container_commit.go
@@ -16,7 +16,7 @@ type ContainerCommitOptions struct {
 	Comment   string
 	Author    string
 	Changes   []string
-	Pause     bool
+	NoPause   bool // NoPause disables pausing the container during commit.
 	Config    *container.Config
 }
 
@@ -54,7 +54,7 @@ func (cli *Client) ContainerCommit(ctx context.Context, containerID string, opti
 	for _, change := range options.Changes {
 		query.Add("changes", change)
 	}
-	if !options.Pause {
+	if options.NoPause {
 		query.Set("pause", "0")
 	}
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/6787
- https://github.com/moby/moby/pull/47155



### client: ContainerCommitOptions: change "Pause" to "NoPause"

Commit [moby@17d870b] (API v1.13, docker v1.1.0) changed the default to pause containers during commit, keeping the behavior opt-in for older API versions. This version-gate was removed in [moby@1b1147e] because API versions lower than v1.23 were no longer supported.

However, the client still required opting-in to pausing containers, which is handled by setting the `Pause` field to true by default. This patch changes the client option to reflect the default; after this change, we should also consider changing the API make disabling pause a more explicit option, and to change the "pause" argument to a "no-pause".

[moby@17d870b]: https://github.com/moby/moby/commit/17d870bed5ef997c30da1e8b9843f4e84202f8d4
[moby@1b1147e]: https://github.com/moby/moby/commit/1b1147e46b732caeaed4ae365cd56ccbfdf40233

### daemon/server/backend: CreateImageConfig: change "Pause" to "NoPause"

Commit [moby@17d870b] (API v1.13, docker v1.1.0) changed the default to pause
containers during commit, keeping the behavior opt-in for older API versions.
This version-gate was removed in [moby@1b1147e] because API versions lower
than v1.23 were no longer supported.

However, the `CreateImageConfig` struct still used `Pause`, and required opting-
in to enable pausing. This patch changes the struct to reflect the default.
after this change, we should also consider changing the API make disabling
pause a more explicit option, and to change the "pause" argument to a
"no-pause".

[moby@17d870b]: https://github.com/moby/moby/commit/17d870bed5ef997c30da1e8b9843f4e84202f8d4
[moby@1b1147e]: https://github.com/moby/moby/commit/1b1147e46b732caeaed4ae365cd56ccbfdf40233

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: `ContainerCommitOptions`: remove `Pause` field in favor of  `NoPause`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

