### PR TITLE
client: Client.negotiateAPIVersionPing: trim v-prefix before handling

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -275,7 +275,7 @@ func (cli *Client) checkVersion(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		cli.negotiateAPIVersionPing(ping)
+		cli.negotiateAPIVersionPing(ping.APIVersion)
 	}
 	return nil
 }
@@ -324,7 +324,7 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 			// FIXME(thaJeztah): Ping returns an error when failing to connect to the API; we should not swallow the error here, and instead returning it.
 			return
 		}
-		cli.negotiateAPIVersionPing(ping)
+		cli.negotiateAPIVersionPing(ping.APIVersion)
 	}
 }
 
@@ -347,16 +347,18 @@ func (cli *Client) NegotiateAPIVersionPing(pingResponse types.Ping) {
 		cli.negotiateLock.Lock()
 		defer cli.negotiateLock.Unlock()
 
-		cli.negotiateAPIVersionPing(pingResponse)
+		cli.negotiateAPIVersionPing(pingResponse.APIVersion)
 	}
 }
 
 // negotiateAPIVersionPing queries the API and updates the version to match the
 // API version from the ping response.
-func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
+func (cli *Client) negotiateAPIVersionPing(pingVersion string) {
+	pingVersion = strings.TrimPrefix(pingVersion, "v")
+
 	// default to the latest version before versioning headers existed
-	if pingResponse.APIVersion == "" {
-		pingResponse.APIVersion = fallbackAPIVersion
+	if pingVersion == "" {
+		pingVersion = fallbackAPIVersion
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version
@@ -365,8 +367,8 @@ func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
 	}
 
 	// if server version is lower than the client version, downgrade
-	if versions.LessThan(pingResponse.APIVersion, cli.version) {
-		cli.version = pingResponse.APIVersion
+	if versions.LessThan(pingVersion, cli.version) {
+		cli.version = pingVersion
 	}
 
 	// Store the results, so that automatic API version negotiation (if enabled)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -369,7 +369,8 @@ func TestNegotiateAPIVersionAutomatic(t *testing.T) {
 				resp.Header.Set("Api-Version", pingVersion)
 				resp.Body = io.NopCloser(strings.NewReader("OK"))
 				return resp, nil
-			})}),
+			}),
+		}),
 		WithAPIVersionNegotiation(),
 	)
 	assert.NilError(t, err)

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -275,7 +275,7 @@ func (cli *Client) checkVersion(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		cli.negotiateAPIVersionPing(ping)
+		cli.negotiateAPIVersionPing(ping.APIVersion)
 	}
 	return nil
 }
@@ -324,7 +324,7 @@ func (cli *Client) NegotiateAPIVersion(ctx context.Context) {
 			// FIXME(thaJeztah): Ping returns an error when failing to connect to the API; we should not swallow the error here, and instead returning it.
 			return
 		}
-		cli.negotiateAPIVersionPing(ping)
+		cli.negotiateAPIVersionPing(ping.APIVersion)
 	}
 }
 
@@ -347,16 +347,18 @@ func (cli *Client) NegotiateAPIVersionPing(pingResponse types.Ping) {
 		cli.negotiateLock.Lock()
 		defer cli.negotiateLock.Unlock()
 
-		cli.negotiateAPIVersionPing(pingResponse)
+		cli.negotiateAPIVersionPing(pingResponse.APIVersion)
 	}
 }
 
 // negotiateAPIVersionPing queries the API and updates the version to match the
 // API version from the ping response.
-func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
+func (cli *Client) negotiateAPIVersionPing(pingVersion string) {
+	pingVersion = strings.TrimPrefix(pingVersion, "v")
+
 	// default to the latest version before versioning headers existed
-	if pingResponse.APIVersion == "" {
-		pingResponse.APIVersion = fallbackAPIVersion
+	if pingVersion == "" {
+		pingVersion = fallbackAPIVersion
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version
@@ -365,8 +367,8 @@ func (cli *Client) negotiateAPIVersionPing(pingResponse types.Ping) {
 	}
 
 	// if server version is lower than the client version, downgrade
-	if versions.LessThan(pingResponse.APIVersion, cli.version) {
-		cli.version = pingResponse.APIVersion
+	if versions.LessThan(pingVersion, cli.version) {
+		cli.version = pingVersion
 	}
 
 	// Store the results, so that automatic API version negotiation (if enabled)


### PR DESCRIPTION
### client: TestPingHeadFallback: check method, path, and fix example response

Validate that the client is connecting with the expected endpoint path and
method(s). Also fix the Api-Version response to align with the actual format
returned, which doesn't include a "v" prefix;

    curl -sI --unix-socket /var/run/docker.sock 'http://localhost/_ping' | grep 'Api-Version'
    Api-Version: 1.51


### client: Client.negotiateAPIVersionPing: trim v-prefix before handling

Trim any v-prefix passed to this function to make sure we detect empty
API versions.

In most cases, the ping-response will originate from the API server, but
the exported `Client.NegotiateAPIVersionPing` allows a ping-response to
be passed manually.

While updating, also update the signature to only accept the version, as
only the `PingResponse.APIVersion` is used by this function.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

