### PR TITLE
integration/service: rename var to prevent shadowing

### DIFF
--- a/integration/service/jobs_test.go
+++ b/integration/service/jobs_test.go
@@ -25,8 +25,8 @@ func TestCreateJob(t *testing.T) {
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
 
-	client := d.NewClientT(t)
-	defer client.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	for _, mode := range []swarmtypes.ServiceMode{
 		{ReplicatedJob: &swarmtypes.ReplicatedJob{}},
@@ -34,7 +34,7 @@ func TestCreateJob(t *testing.T) {
 	} {
 		id := swarm.CreateService(ctx, t, d, swarm.ServiceWithMode(mode))
 
-		poll.WaitOn(t, swarm.RunningTasksCount(ctx, client, id, 1), swarm.ServicePoll)
+		poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, id, 1), swarm.ServicePoll)
 	}
 }
 

--- a/integration/service/update_test.go
+++ b/integration/service/update_test.go
@@ -23,53 +23,53 @@ func TestServiceUpdateLabel(t *testing.T) {
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	serviceName := "TestService_" + t.Name()
 	serviceID := swarm.CreateService(ctx, t, d, swarm.ServiceWithName(serviceName))
-	service := getService(ctx, t, cli, serviceID)
+	service := getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{}))
 
 	// add label to empty set
 	service.Spec.Labels["foo"] = "bar"
-	_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err := apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
-	service = getService(ctx, t, cli, serviceID)
+	poll.WaitOn(t, serviceSpecIsUpdated(ctx, apiClient, serviceID, service.Version.Index), swarm.ServicePoll)
+	service = getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
 	// add label to non-empty set
 	service.Spec.Labels["foo2"] = "bar"
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
-	service = getService(ctx, t, cli, serviceID)
+	poll.WaitOn(t, serviceSpecIsUpdated(ctx, apiClient, serviceID, service.Version.Index), swarm.ServicePoll)
+	service = getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar", "foo2": "bar"}))
 
 	delete(service.Spec.Labels, "foo2")
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
-	service = getService(ctx, t, cli, serviceID)
+	poll.WaitOn(t, serviceSpecIsUpdated(ctx, apiClient, serviceID, service.Version.Index), swarm.ServicePoll)
+	service = getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
 	delete(service.Spec.Labels, "foo")
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
-	service = getService(ctx, t, cli, serviceID)
+	poll.WaitOn(t, serviceSpecIsUpdated(ctx, apiClient, serviceID, service.Version.Index), swarm.ServicePoll)
+	service = getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{}))
 
 	// now make sure we can add again
 	service.Spec.Labels["foo"] = "bar"
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceSpecIsUpdated(ctx, cli, serviceID, service.Version.Index), swarm.ServicePoll)
-	service = getService(ctx, t, cli, serviceID)
+	poll.WaitOn(t, serviceSpecIsUpdated(ctx, apiClient, serviceID, service.Version.Index), swarm.ServicePoll)
+	service = getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.DeepEqual(service.Spec.Labels, map[string]string{"foo": "bar"}))
 
-	err = cli.ServiceRemove(ctx, serviceID)
+	err = apiClient.ServiceRemove(ctx, serviceID)
 	assert.NilError(t, err)
 }
 
@@ -79,12 +79,12 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	secretName := "TestSecret_" + t.Name()
 	secretTarget := "targetName"
-	resp, err := cli.SecretCreate(ctx, swarmtypes.SecretSpec{
+	resp, err := apiClient.SecretCreate(ctx, swarmtypes.SecretSpec{
 		Annotations: swarmtypes.Annotations{
 			Name: secretName,
 		},
@@ -95,7 +95,7 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 	serviceName := "TestService_" + t.Name()
 	serviceID := swarm.CreateService(ctx, t, d, swarm.ServiceWithName(serviceName))
-	service := getService(ctx, t, cli, serviceID)
+	service := getService(ctx, t, apiClient, serviceID)
 
 	// add secret
 	service.Spec.TaskTemplate.ContainerSpec.Secrets = append(service.Spec.TaskTemplate.ContainerSpec.Secrets,
@@ -110,11 +110,11 @@ func TestServiceUpdateSecrets(t *testing.T) {
 			SecretName: secretName,
 		},
 	)
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceIsUpdated(ctx, apiClient, serviceID), swarm.ServicePoll)
 
-	service = getService(ctx, t, cli, serviceID)
+	service = getService(ctx, t, apiClient, serviceID)
 	secrets := service.Spec.TaskTemplate.ContainerSpec.Secrets
 	assert.Assert(t, is.Equal(1, len(secrets)))
 
@@ -125,13 +125,13 @@ func TestServiceUpdateSecrets(t *testing.T) {
 
 	// remove
 	service.Spec.TaskTemplate.ContainerSpec.Secrets = []*swarmtypes.SecretReference{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
-	service = getService(ctx, t, cli, serviceID)
+	poll.WaitOn(t, serviceIsUpdated(ctx, apiClient, serviceID), swarm.ServicePoll)
+	service = getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.Equal(0, len(service.Spec.TaskTemplate.ContainerSpec.Secrets)))
 
-	err = cli.ServiceRemove(ctx, serviceID)
+	err = apiClient.ServiceRemove(ctx, serviceID)
 	assert.NilError(t, err)
 }
 
@@ -141,12 +141,12 @@ func TestServiceUpdateConfigs(t *testing.T) {
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	configName := "TestConfig_" + t.Name()
 	configTarget := "targetName"
-	resp, err := cli.ConfigCreate(ctx, swarmtypes.ConfigSpec{
+	resp, err := apiClient.ConfigCreate(ctx, swarmtypes.ConfigSpec{
 		Annotations: swarmtypes.Annotations{
 			Name: configName,
 		},
@@ -157,7 +157,7 @@ func TestServiceUpdateConfigs(t *testing.T) {
 
 	serviceName := "TestService_" + t.Name()
 	serviceID := swarm.CreateService(ctx, t, d, swarm.ServiceWithName(serviceName))
-	service := getService(ctx, t, cli, serviceID)
+	service := getService(ctx, t, apiClient, serviceID)
 
 	// add config
 	service.Spec.TaskTemplate.ContainerSpec.Configs = append(service.Spec.TaskTemplate.ContainerSpec.Configs,
@@ -172,11 +172,11 @@ func TestServiceUpdateConfigs(t *testing.T) {
 			ConfigName: configName,
 		},
 	)
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceIsUpdated(ctx, apiClient, serviceID), swarm.ServicePoll)
 
-	service = getService(ctx, t, cli, serviceID)
+	service = getService(ctx, t, apiClient, serviceID)
 	configs := service.Spec.TaskTemplate.ContainerSpec.Configs
 	assert.Assert(t, is.Equal(1, len(configs)))
 
@@ -187,13 +187,13 @@ func TestServiceUpdateConfigs(t *testing.T) {
 
 	// remove
 	service.Spec.TaskTemplate.ContainerSpec.Configs = []*swarmtypes.ConfigReference{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
-	service = getService(ctx, t, cli, serviceID)
+	poll.WaitOn(t, serviceIsUpdated(ctx, apiClient, serviceID), swarm.ServicePoll)
+	service = getService(ctx, t, apiClient, serviceID)
 	assert.Check(t, is.Equal(0, len(service.Spec.TaskTemplate.ContainerSpec.Configs)))
 
-	err = cli.ServiceRemove(ctx, serviceID)
+	err = apiClient.ServiceRemove(ctx, serviceID)
 	assert.NilError(t, err)
 }
 
@@ -203,12 +203,12 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	cli := d.NewClientT(t)
-	defer cli.Close()
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
 
 	// Create a overlay network
 	testNet := "testNet" + t.Name()
-	overlayID := network.CreateNoError(ctx, t, cli, testNet,
+	overlayID := network.CreateNoError(ctx, t, apiClient, testNet,
 		network.WithDriver("overlay"))
 
 	var instances uint64 = 1
@@ -219,9 +219,9 @@ func TestServiceUpdateNetwork(t *testing.T) {
 		swarm.ServiceWithName(serviceName),
 		swarm.ServiceWithNetwork(testNet))
 
-	poll.WaitOn(t, swarm.RunningTasksCount(ctx, cli, serviceID, instances), swarm.ServicePoll)
-	service := getService(ctx, t, cli, serviceID)
-	netInfo, err := cli.NetworkInspect(ctx, testNet, client.NetworkInspectOptions{
+	poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, instances), swarm.ServicePoll)
+	service := getService(ctx, t, apiClient, serviceID)
+	netInfo, err := apiClient.NetworkInspect(ctx, testNet, client.NetworkInspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})
@@ -230,11 +230,11 @@ func TestServiceUpdateNetwork(t *testing.T) {
 
 	// Remove network from service
 	service.Spec.TaskTemplate.Networks = []swarmtypes.NetworkAttachmentConfig{}
-	_, err = cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+	_, err = apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 	assert.NilError(t, err)
-	poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
+	poll.WaitOn(t, serviceIsUpdated(ctx, apiClient, serviceID), swarm.ServicePoll)
 
-	netInfo, err = cli.NetworkInspect(ctx, testNet, client.NetworkInspectOptions{
+	netInfo, err = apiClient.NetworkInspect(ctx, testNet, client.NetworkInspectOptions{
 		Verbose: true,
 		Scope:   "swarm",
 	})
@@ -242,10 +242,10 @@ func TestServiceUpdateNetwork(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, len(netInfo.Containers) == 0, "Load balancing endpoint still exists in network")
 
-	err = cli.NetworkRemove(ctx, overlayID)
+	err = apiClient.NetworkRemove(ctx, overlayID)
 	assert.NilError(t, err)
 
-	err = cli.ServiceRemove(ctx, serviceID)
+	err = apiClient.ServiceRemove(ctx, serviceID)
 	assert.NilError(t, err)
 }
 
@@ -278,8 +278,8 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 
 	d := swarm.NewSwarm(ctx, t, testEnv)
 	defer d.Stop(t)
-	cli := d.NewClientT(t)
-	defer func() { _ = cli.Close() }()
+	apiClient := d.NewClientT(t)
+	defer func() { _ = apiClient.Close() }()
 	var (
 		serviceID string
 		service   swarmtypes.Service
@@ -290,7 +290,7 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 			if i == 0 {
 				serviceID = swarm.CreateService(ctx, t, d, swarm.ServiceWithPidsLimit(tc.pidsLimit))
 			} else {
-				service = getService(ctx, t, cli, serviceID)
+				service = getService(ctx, t, apiClient, serviceID)
 				if service.Spec.TaskTemplate.Resources == nil {
 					service.Spec.TaskTemplate.Resources = &swarmtypes.ResourceRequirements{}
 				}
@@ -298,14 +298,14 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 					service.Spec.TaskTemplate.Resources.Limits = &swarmtypes.Limit{}
 				}
 				service.Spec.TaskTemplate.Resources.Limits.Pids = tc.pidsLimit
-				_, err := cli.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
+				_, err := apiClient.ServiceUpdate(ctx, serviceID, service.Version, service.Spec, client.ServiceUpdateOptions{})
 				assert.NilError(t, err)
-				poll.WaitOn(t, serviceIsUpdated(ctx, cli, serviceID), swarm.ServicePoll)
+				poll.WaitOn(t, serviceIsUpdated(ctx, apiClient, serviceID), swarm.ServicePoll)
 			}
 
-			poll.WaitOn(t, swarm.RunningTasksCount(ctx, cli, serviceID, 1), swarm.ServicePoll)
-			service = getService(ctx, t, cli, serviceID)
-			container := getServiceTaskContainer(ctx, t, cli, serviceID)
+			poll.WaitOn(t, swarm.RunningTasksCount(ctx, apiClient, serviceID, 1), swarm.ServicePoll)
+			service = getService(ctx, t, apiClient, serviceID)
+			container := getServiceTaskContainer(ctx, t, apiClient, serviceID)
 			assert.Equal(t, service.Spec.TaskTemplate.Resources.Limits.Pids, tc.expected)
 			if tc.expected == 0 {
 				if container.HostConfig.Resources.PidsLimit != nil {
@@ -318,7 +318,7 @@ func TestServiceUpdatePidsLimit(t *testing.T) {
 		})
 	}
 
-	err := cli.ServiceRemove(ctx, serviceID)
+	err := apiClient.ServiceRemove(ctx, serviceID)
 	assert.NilError(t, err)
 }
 
@@ -339,9 +339,9 @@ func getServiceTaskContainer(ctx context.Context, t *testing.T, cli client.APICl
 	return ctr
 }
 
-func getService(ctx context.Context, t *testing.T, cli client.ServiceAPIClient, serviceID string) swarmtypes.Service {
+func getService(ctx context.Context, t *testing.T, apiClient client.ServiceAPIClient, serviceID string) swarmtypes.Service {
 	t.Helper()
-	service, _, err := cli.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
+	service, _, err := apiClient.ServiceInspectWithRaw(ctx, serviceID, client.ServiceInspectOptions{})
 	assert.NilError(t, err)
 	return service
 }


### PR DESCRIPTION
Use "apiClient" for the client (most places use either `apiClient` or `c`) to prevent shadowing the `client` import.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

