### PR TITLE
daemon/containerd: pass custom metaHeaders to resolver

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -82,7 +82,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 		opts = append(opts, containerd.WithPlatform(platforms.FormatAll(*platform)))
 	}
 
-	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig, ref)
+	resolver, _ := i.newResolverFromAuthConfig(ctx, authConfig, ref, metaHeaders)
 	opts = append(opts, containerd.WithResolver(resolver))
 
 	oldImage, err := i.resolveImage(ctx, ref.String())

--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -115,7 +115,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 	}
 
 	store := i.content
-	resolver, tracker := i.newResolverFromAuthConfig(ctx, authConfig, targetRef)
+	resolver, tracker := i.newResolverFromAuthConfig(ctx, authConfig, targetRef, metaHeaders)
 	pp := pushProgress{Tracker: tracker}
 	jobsQueue := newJobs()
 	finishProgress := jobsQueue.showProgress(ctx, out, combinedProgress([]progressUpdater{

--- a/daemon/containerd/resolver.go
+++ b/daemon/containerd/resolver.go
@@ -16,11 +16,14 @@ import (
 	"github.com/moby/moby/v2/pkg/useragent"
 )
 
-func (i *ImageService) newResolverFromAuthConfig(ctx context.Context, authConfig *registrytypes.AuthConfig, ref reference.Named) (remotes.Resolver, docker.StatusTracker) {
+func (i *ImageService) newResolverFromAuthConfig(ctx context.Context, authConfig *registrytypes.AuthConfig, ref reference.Named, metaHeaders http.Header) (remotes.Resolver, docker.StatusTracker) {
 	tracker := docker.NewInMemoryTracker()
 
 	hosts := hostsWrapper(i.registryHosts, authConfig, ref)
 	headers := http.Header{}
+	if metaHeaders != nil {
+		headers = metaHeaders.Clone()
+	}
 	headers.Set("User-Agent", dockerversion.DockerUserAgent(ctx, useragent.VersionInfo{Name: "containerd-client", Version: version.Version}, useragent.VersionInfo{Name: "storage-driver", Version: i.snapshotter}))
 
 	return docker.NewResolver(docker.ResolverOptions{


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50201#discussion_r2149701233
- relates to https://github.com/moby/moby/pull/1627

Similar to how [distribution.newRepository] in the legacy distribution code passes the (custom) http-headers. User-Agent is always set, and can't be overridden, so we apply it after setting the custom headers.

[distribution.newRepository]: https://github.com/moby/moby/blob/9ce272f804a9383c9aa593527d318c946bfb7b38/daemon/internal/distribution/registry.go#L74-L97

Before this patch:

```bash
docker run --rm -d --name debugger -p 127.0.0.1:5001:8080 mendhak/http-https-echo
DOCKER_CUSTOM_HEADERS=X-Meta-Hello=thaJeztah docker pull localhost:5001/myimage:latest
docker logs debugger
...
"headers": {
    "host": "localhost:5001",
    "user-agent": "docker/dev go/go1.24.7 git-commit/8e89fe7e8cbb3048f640846590175cbae4719b25 kernel/6.10.14-linuxkit os/linux arch/arm64 containerd-client/2.1.4+unknown storage-driver/overlayfs UpstreamClient(Docker-Client/28.3.2 \\(linux\\))",
    "accept": "application/json, */*",
    "accept-encoding": "zstd;q=1.0, gzip;q=0.8, deflate;q=0.5",
    "baggage": "trigger=api"
},
```

With this patch:

```bash
docker run --rm -d --name debugger -p 127.0.0.1:5001:8080 mendhak/http-https-echo
DOCKER_CUSTOM_HEADERS=X-Meta-Hello=thaJeztah docker pull localhost:5001/myimage:latest
docker logs debugger
...
"headers": {
    "host": "localhost:5001",
    "user-agent": "docker/dev go/go1.24.7 git-commit/8e89fe7e8cbb3048f640846590175cbae4719b25 kernel/6.10.14-linuxkit os/linux arch/arm64 containerd-client/2.1.4+unknown storage-driver/overlayfs UpstreamClient(Docker-Client/28.3.2 \\(linux\\))",
    "accept": "application/json, */*",
    "accept-encoding": "zstd;q=1.0, gzip;q=0.8, deflate;q=0.5",
    "baggage": "trigger=api",
    "x-meta-hello": "thaJeztah"
},
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix issue where custom meta-headers were not passed through when using the containerd image store.
```

**- A picture of a cute animal (not mandatory but encouraged)**

