### PR TITLE
daemon/server/imagebackend: add PullOptions, PushOptions structs

### DIFF
--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"context"
-	"io"
 	"time"
 
 	"github.com/distribution/reference"
@@ -24,9 +23,9 @@ import (
 	networkSettings "github.com/moby/moby/v2/daemon/network"
 	"github.com/moby/moby/v2/daemon/pkg/plugin"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	volumeopts "github.com/moby/moby/v2/daemon/volume/service/opts"
 	"github.com/moby/swarmkit/v2/agent/exec"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Backend defines the executor component for a swarm agent.
@@ -74,7 +73,7 @@ type VolumeBackend interface {
 
 // ImageBackend is used by an executor to perform image operations
 type ImageBackend interface {
-	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, ref reference.Named, options imagebackend.PullOptions) error
 	GetRepositories(context.Context, reference.Named, *registry.AuthConfig) ([]distribution.Repository, error)
 	GetImage(ctx context.Context, refOrID string, options backend.GetImageOpts) (*image.Image, error)
 }

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork"
 	networkSettings "github.com/moby/moby/v2/daemon/network"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	volumeopts "github.com/moby/moby/v2/daemon/volume/service/opts"
 	"github.com/moby/swarmkit/v2/agent/exec"
 	"github.com/moby/swarmkit/v2/api"
@@ -107,7 +108,11 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 
 		// Make sure the image has a tag, otherwise it will pull all tags.
 		ref := reference.TagNameOnly(named)
-		err := c.imageBackend.PullImage(ctx, ref, nil, metaHeaders, authConfig, pw)
+		err := c.imageBackend.PullImage(ctx, ref, imagebackend.PullOptions{
+			MetaHeaders: metaHeaders,
+			AuthConfig:  authConfig,
+			OutStream:   pw,
+		})
 		pw.CloseWithError(err)
 	}()
 

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -34,6 +34,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/stringid"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/buildbackend"
+	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
@@ -147,7 +148,14 @@ func (i *ImageService) pullForBuilder(ctx context.Context, name string, authConf
 		pullRegistryAuth = &resolvedConfig
 	}
 
-	if err := i.PullImage(ctx, reference.TagNameOnly(ref), platform, nil, pullRegistryAuth, output); err != nil {
+	pullOptions := imagebackend.PullOptions{
+		AuthConfig: pullRegistryAuth,
+		OutStream:  output,
+	}
+	if platform != nil {
+		pullOptions.Platforms = append(pullOptions.Platforms, *platform)
+	}
+	if err := i.PullImage(ctx, reference.TagNameOnly(ref), pullOptions); err != nil {
 		return nil, err
 	}
 

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/filters"
 	imagetype "github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/v2/daemon/builder"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/images"
@@ -29,7 +28,7 @@ type ImageService interface {
 	// Images
 
 	PullImage(ctx context.Context, ref reference.Named, options imagebackend.PullOptions) error
-	PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PushImage(ctx context.Context, ref reference.Named, options imagebackend.PushOptions) error
 	CreateImage(ctx context.Context, config []byte, parent string, contentStoreDigest digest.Digest) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, options imagebackend.RemoveOptions) ([]imagetype.DeleteResponse, error)
 	ExportImage(ctx context.Context, names []string, platformList []ocispec.Platform, outStream io.Writer) error

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -28,7 +28,7 @@ import (
 type ImageService interface {
 	// Images
 
-	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, ref reference.Named, options imagebackend.PullOptions) error
 	PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 	CreateImage(ctx context.Context, config []byte, parent string, contentStoreDigest digest.Digest) (builder.Image, error)
 	ImageDelete(ctx context.Context, imageRef string, options imagebackend.RemoveOptions) ([]imagetype.DeleteResponse, error)

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -17,16 +17,27 @@ import (
 	progressutils "github.com/moby/moby/v2/daemon/internal/distribution/utils"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
 // PullImage initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error {
+func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, options imagebackend.PullOptions) error {
+	if len(options.Platforms) > 1 {
+		// TODO(thaJeztah): add support for pulling multiple platforms
+		return cerrdefs.ErrInvalidArgument.WithMessage("multiple platforms is not supported")
+	}
 	start := time.Now()
 
-	err := i.pullImageWithReference(ctx, ref, platform, metaHeaders, authConfig, outStream)
+	var platform *ocispec.Platform
+	if len(options.Platforms) > 0 {
+		p := options.Platforms[0]
+		platform = &p
+	}
+
+	err := i.pullImageWithReference(ctx, ref, platform, options.MetaHeaders, options.AuthConfig, options.OutStream)
 	metrics.ImageActions.WithValues("pull").UpdateSince(start)
 	if err != nil {
 		return err
@@ -44,7 +55,7 @@ func (i *ImageService) PullImage(ctx context.Context, ref reference.Named, platf
 		// Note that this is a special case where GetImage returns both an image
 		// and an error: https://github.com/moby/moby/blob/v28.3.3/daemon/images/image.go#L186-L193
 		if cerrdefs.IsNotFound(err) && img != nil {
-			po := streamformatter.NewJSONProgressOutput(outStream, false)
+			po := streamformatter.NewJSONProgressOutput(options.OutStream, false)
 			progress.Messagef(po, "", `WARNING: %s`, err.Error())
 			log.G(ctx).WithError(err).WithField("image", reference.FamiliarName(ref)).Warn("ignoring platform mismatch on single-arch image")
 		} else if err != nil {

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -16,6 +16,13 @@ type PullOptions struct {
 	OutStream   io.Writer
 }
 
+type PushOptions struct {
+	Platforms   []ocispec.Platform
+	MetaHeaders http.Header
+	AuthConfig  *registry.AuthConfig
+	OutStream   io.Writer
+}
+
 type RemoveOptions struct {
 	Platforms     []ocispec.Platform
 	Force         bool

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -1,9 +1,20 @@
 package imagebackend
 
 import (
+	"io"
+	"net/http"
+
 	"github.com/moby/moby/api/types/filters"
+	"github.com/moby/moby/api/types/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+type PullOptions struct {
+	Platforms   []ocispec.Platform
+	MetaHeaders http.Header
+	AuthConfig  *registry.AuthConfig
+	OutStream   io.Writer
+}
 
 type RemoveOptions struct {
 	Platforms     []ocispec.Platform

--- a/daemon/server/router/image/backend.go
+++ b/daemon/server/router/image/backend.go
@@ -39,7 +39,7 @@ type importExportBackend interface {
 }
 
 type registryBackend interface {
-	PullImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PullImage(ctx context.Context, ref reference.Named, options imagebackend.PullOptions) error
 	PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
 }
 

--- a/daemon/server/router/image/backend.go
+++ b/daemon/server/router/image/backend.go
@@ -40,7 +40,7 @@ type importExportBackend interface {
 
 type registryBackend interface {
 	PullImage(ctx context.Context, ref reference.Named, options imagebackend.PullOptions) error
-	PushImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registry.AuthConfig, outStream io.Writer) error
+	PushImage(ctx context.Context, ref reference.Named, options imagebackend.PushOptions) error
 }
 
 type Searcher interface {

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -103,7 +103,15 @@ func (ir *imageRouter) postImagesCreate(ctx context.Context, w http.ResponseWrit
 		//
 		// TODO(thaJeztah): accept empty values but return an error when failing to decode.
 		authConfig, _ := authconfig.Decode(r.Header.Get(registry.AuthHeader))
-		progressErr = ir.backend.PullImage(ctx, ref, platform, metaHeaders, authConfig, output)
+		pullOptions := imagebackend.PullOptions{
+			AuthConfig:  authConfig,
+			MetaHeaders: metaHeaders,
+			OutStream:   output,
+		}
+		if platform != nil {
+			pullOptions.Platforms = append(pullOptions.Platforms, *platform)
+		}
+		progressErr = ir.backend.PullImage(ctx, ref, pullOptions)
 	} else { // import
 		src := r.Form.Get("fromSrc")
 

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -222,8 +222,15 @@ func (ir *imageRouter) postImagesPush(ctx context.Context, w http.ResponseWriter
 			platform = p
 		}
 	}
-
-	if err := ir.backend.PushImage(ctx, ref, platform, metaHeaders, authConfig, output); err != nil {
+	pushOptions := imagebackend.PushOptions{
+		AuthConfig:  authConfig,
+		MetaHeaders: metaHeaders,
+		OutStream:   output,
+	}
+	if platform != nil {
+		pushOptions.Platforms = append(pushOptions.Platforms, *platform)
+	}
+	if err := ir.backend.PushImage(ctx, ref, pushOptions); err != nil {
 		if !output.Flushed() {
 			return err
 		}


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/issues/48760
- https://github.com/moby/moby/issues/42053


### daemon/server/imagebackend: add PullOptions struct

The PullImage method for the ImageService used positional arguments for its
options, which made it more difficult to introduce new options. This patch
introduces a `PullOptions` struct to specify the options. As part of these
changes, the `platform` option was already adjusted to accept a slice of
platforms, which currently is not supported, but may be in the near future.

### daemon/server/imagebackend: add PushOptions struct

The PushImage method for the ImageService used positional arguments for its
options, which made it more difficult to introduce new options. This patch
introduces a `PushOptions` struct to specify the options. As part of these
changes, the `platform` option was already adjusted to accept a slice of
platforms, which currently is not supported, but may be in the near future.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

