### PR TITLE
client: Change ImageRemove to accept handle.ImageHandle parameter

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/api/types/volume"
+	"github.com/moby/moby/client/handle"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -117,7 +118,7 @@ type ImageAPIClient interface {
 	ImageList(ctx context.Context, options ImageListOptions) ([]image.Summary, error)
 	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (io.ReadCloser, error)
-	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
+	ImageRemove(ctx context.Context, image handle.ImageHandle, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)

--- a/client/handle/handle.go
+++ b/client/handle/handle.go
@@ -1,0 +1,11 @@
+package handle
+
+import (
+	"context"
+
+	internalhandle "github.com/moby/moby/client/internal/handle"
+)
+
+type ImageHandle interface {
+	ResolveImage(ctx context.Context) (internalhandle.ImageResolveResult, error)
+}

--- a/client/handle/string.go
+++ b/client/handle/string.go
@@ -1,0 +1,23 @@
+package handle
+
+import (
+	"context"
+	"errors"
+
+	internalhandle "github.com/moby/moby/client/internal/handle"
+)
+
+func FromString(str string) *stringHandle {
+	return &stringHandle{str: str}
+}
+
+type stringHandle struct {
+	str string
+}
+
+func (h *stringHandle) ResolveImage(ctx context.Context) (internalhandle.ImageResolveResult, error) {
+	if h.str == "" {
+		return internalhandle.ImageResolveResult{}, errors.New("empty image name")
+	}
+	return internalhandle.ImageResolveResult{RefOrTruncatedID: h.str}, nil
+}

--- a/client/image_remove.go
+++ b/client/image_remove.go
@@ -6,10 +6,11 @@ import (
 	"net/url"
 
 	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client/handle"
 )
 
 // ImageRemove removes an image from the docker host.
-func (cli *Client) ImageRemove(ctx context.Context, imageID string, options ImageRemoveOptions) ([]image.DeleteResponse, error) {
+func (cli *Client) ImageRemove(ctx context.Context, img handle.ImageHandle, options ImageRemoveOptions) ([]image.DeleteResponse, error) {
 	query := url.Values{}
 
 	if options.Force {
@@ -27,7 +28,12 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options Imag
 		query["platforms"] = p
 	}
 
-	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
+	rimg, err := img.ResolveImage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cli.delete(ctx, "/images/"+rimg.RefOrTruncatedID, query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -11,6 +11,7 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client/handle"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -20,7 +21,7 @@ func TestImageRemoveError(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
-	_, err = client.ImageRemove(context.Background(), "image_id", ImageRemoveOptions{})
+	_, err = client.ImageRemove(context.Background(), handle.FromString("image_id"), ImageRemoveOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -28,7 +29,7 @@ func TestImageRemoveImageNotFound(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "no such image: unknown")))
 	assert.NilError(t, err)
 
-	_, err = client.ImageRemove(context.Background(), "unknown", ImageRemoveOptions{})
+	_, err = client.ImageRemove(context.Background(), handle.FromString("unknown"), ImageRemoveOptions{})
 	assert.Check(t, is.ErrorContains(err, "no such image: unknown"))
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 }
@@ -106,7 +107,7 @@ func TestImageRemove(t *testing.T) {
 			opts.Platforms = []ocispec.Platform{*removeCase.platform}
 		}
 
-		imageDeletes, err := client.ImageRemove(context.Background(), "image_id", opts)
+		imageDeletes, err := client.ImageRemove(context.Background(), handle.FromString("image_id"), opts)
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(imageDeletes, 2))
 	}

--- a/client/internal/handle/image.go
+++ b/client/internal/handle/image.go
@@ -1,0 +1,15 @@
+package internalhandle
+
+import "context"
+
+type ImageResolveResult struct {
+	RefOrTruncatedID string
+}
+
+type naiveHandle struct {
+	RefOrTruncatedID string
+}
+
+func (h *naiveHandle) Resolve(ctx context.Context) (ImageResolveResult, error) {
+	return ImageResolveResult{RefOrTruncatedID: h.RefOrTruncatedID}, nil
+}

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/integration-cli/cli/build"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -50,13 +51,13 @@ func (s *DockerAPISuite) TestAPIImagesDelete(c *testing.T) {
 
 	cli.DockerCmd(c, "tag", name, "test:tag1")
 
-	_, err = apiClient.ImageRemove(testutil.GetContext(c), id, client.ImageRemoveOptions{})
+	_, err = apiClient.ImageRemove(testutil.GetContext(c), handle.FromString(id), client.ImageRemoveOptions{})
 	assert.ErrorContains(c, err, "unable to delete")
 
-	_, err = apiClient.ImageRemove(testutil.GetContext(c), "test:noexist", client.ImageRemoveOptions{})
+	_, err = apiClient.ImageRemove(testutil.GetContext(c), handle.FromString("test:noexist"), client.ImageRemoveOptions{})
 	assert.ErrorContains(c, err, "No such image")
 
-	_, err = apiClient.ImageRemove(testutil.GetContext(c), "test:tag1", client.ImageRemoveOptions{})
+	_, err = apiClient.ImageRemove(testutil.GetContext(c), handle.FromString("test:tag1"), client.ImageRemoveOptions{})
 	assert.NilError(c, err)
 }
 

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
@@ -801,7 +802,7 @@ func TestBuildHistoryDoesNotPreventRemoval(t *testing.T) {
 	err := buildImage("history-a")
 	assert.NilError(t, err)
 
-	resp, err := apiClient.ImageRemove(ctx, "history-a", client.ImageRemoveOptions{})
+	resp, err := apiClient.ImageRemove(ctx, handle.FromString("history-a"), client.ImageRemoveOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, slices.ContainsFunc(resp, func(r image.DeleteResponse) bool {
 		return r.Deleted != ""

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/integration/internal/process"
@@ -700,7 +701,7 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 			poll.WaitOn(t, waitFn)
 		})
 
-		_, err := c.ImageRemove(ctx, mountedImage, client.ImageRemoveOptions{})
+		_, err := c.ImageRemove(ctx, handle.FromString(mountedImage), client.ImageRemoveOptions{})
 		assert.ErrorContains(t, err, fmt.Sprintf("container %s is using its referenced image", cID[:12]))
 
 		// Remove that container which should free the references in the volume
@@ -708,7 +709,7 @@ func testLiveRestoreVolumeReferences(t *testing.T) {
 		assert.NilError(t, err)
 
 		// Now we should be able to remove the volume
-		_, err = c.ImageRemove(ctx, mountedImage, client.ImageRemoveOptions{})
+		_, err = c.ImageRemove(ctx, handle.FromString(mountedImage), client.ImageRemoveOptions{})
 		assert.NilError(t, err)
 	})
 

--- a/integration/daemon/migration_test.go
+++ b/integration/daemon/migration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
@@ -137,7 +138,7 @@ func TestMigrateSaveLoad(t *testing.T) {
 	list, err := apiClient.ImageList(ctx, client.ImageListOptions{})
 	assert.NilError(t, err)
 	for _, i := range list {
-		_, err = apiClient.ImageRemove(ctx, i.ID, client.ImageRemoveOptions{Force: true})
+		_, err = apiClient.ImageRemove(ctx, handle.FromString(i.ID), client.ImageRemoveOptions{Force: true})
 		assert.NilError(t, err)
 	}
 

--- a/integration/image/history_test.go
+++ b/integration/image/history_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/platforms"
 	buildtypes "github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/client"
+	handle "github.com/moby/moby/client/handle"
 	build "github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
@@ -78,7 +79,7 @@ func TestAPIImageHistoryCrossPlatform(t *testing.T) {
 
 	imgID := build.GetImageIDFromBody(t, resp.Body)
 	t.Cleanup(func() {
-		apiClient.ImageRemove(ctx, imgID, client.ImageRemoveOptions{Force: true})
+		apiClient.ImageRemove(ctx, handle.FromString(imgID), client.ImageRemoveOptions{Force: true})
 	})
 
 	testCases := []struct {
@@ -136,6 +137,6 @@ func pullImageForPlatform(t *testing.T, ctx context.Context, apiClient client.AP
 	assert.NilError(t, err)
 
 	t.Cleanup(func() {
-		_, _ = apiClient.ImageRemove(ctx, ref, client.ImageRemoveOptions{Force: true})
+		_, _ = apiClient.ImageRemove(ctx, handle.FromString(ref), client.ImageRemoveOptions{Force: true})
 	})
 }

--- a/integration/image/inspect_test.go
+++ b/integration/image/inspect_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/client"
+	handle "github.com/moby/moby/client/handle"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
 	"github.com/moby/moby/v2/internal/testutil/specialimage"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -54,7 +55,7 @@ func TestImageInspectUniqueRepoDigests(t *testing.T) {
 		err := apiClient.ImageTag(ctx, "busybox", imgName)
 		assert.NilError(t, err)
 		defer func() {
-			_, _ = apiClient.ImageRemove(ctx, imgName, client.ImageRemoveOptions{Force: true})
+			_, _ = apiClient.ImageRemove(ctx, handle.FromString(imgName), client.ImageRemoveOptions{Force: true})
 		}()
 	}
 

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
+	handle "github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/integration/internal/container"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -81,7 +82,7 @@ func TestPruneLexographicalOrder(t *testing.T) {
 	err = apiClient.ImageTag(ctx, id, "busybox:z")
 	assert.NilError(t, err)
 
-	_, err = apiClient.ImageRemove(ctx, "busybox:latest", client.ImageRemoveOptions{Force: true})
+	_, err = apiClient.ImageRemove(ctx, handle.FromString("busybox:latest"), client.ImageRemoveOptions{Force: true})
 	assert.NilError(t, err)
 
 	// run container

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -18,6 +18,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/moby/moby/client"
+	handle "github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
 	"github.com/moby/moby/v2/internal/testutil/registry"
 	"github.com/opencontainers/go-digest"
@@ -218,7 +219,7 @@ func TestImagePullKeepOldAsDangling(t *testing.T) {
 
 	assert.NilError(t, apiClient.ImageTag(ctx, "busybox:latest", "alpine:latest"))
 
-	_, err = apiClient.ImageRemove(ctx, "busybox:latest", client.ImageRemoveOptions{})
+	_, err = apiClient.ImageRemove(ctx, handle.FromString("busybox:latest"), client.ImageRemoveOptions{})
 	assert.NilError(t, err)
 
 	rc, err := apiClient.ImagePull(ctx, "alpine:latest", client.ImagePullOptions{})

--- a/integration/image/remove_test.go
+++ b/integration/image/remove_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/integration/internal/container"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
 	"github.com/moby/moby/v2/internal/testutil/specialimage"
@@ -52,7 +53,7 @@ func TestRemoveImageOrphaning(t *testing.T) {
 	assert.Check(t, is.Equal(resp.ID, commitResp2.ID))
 
 	// try to remove the image, should not error out.
-	_, err = apiClient.ImageRemove(ctx, imgName, client.ImageRemoveOptions{})
+	_, err = apiClient.ImageRemove(ctx, handle.FromString(imgName), client.ImageRemoveOptions{})
 	assert.NilError(t, err)
 
 	// check if the first image is still there
@@ -86,7 +87,7 @@ func TestRemoveByDigest(t *testing.T) {
 	}
 	assert.Assert(t, id != "")
 
-	_, err = apiClient.ImageRemove(ctx, id, client.ImageRemoveOptions{})
+	_, err = apiClient.ImageRemove(ctx, handle.FromString(id), client.ImageRemoveOptions{})
 	assert.NilError(t, err, "error removing %s", id)
 
 	_, err = apiClient.ImageInspect(ctx, "busybox")
@@ -142,7 +143,7 @@ func TestRemoveWithPlatform(t *testing.T) {
 		{platform: &platformHost, deleted: descs[0]},
 		{platform: &someOtherPlatform, deleted: descs[3]},
 	} {
-		resp, err := apiClient.ImageRemove(ctx, imgName, client.ImageRemoveOptions{
+		resp, err := apiClient.ImageRemove(ctx, handle.FromString(imgName), client.ImageRemoveOptions{
 			Platforms: []ocispec.Platform{*tc.platform},
 			Force:     true,
 		})
@@ -155,7 +156,7 @@ func TestRemoveWithPlatform(t *testing.T) {
 	}
 
 	// Delete the rest
-	resp, err := apiClient.ImageRemove(ctx, imgName, client.ImageRemoveOptions{})
+	resp, err := apiClient.ImageRemove(ctx, handle.FromString(imgName), client.ImageRemoveOptions{})
 	assert.NilError(t, err)
 
 	assert.Check(t, is.Len(resp, 2))

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
+	handle "github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
@@ -325,7 +326,7 @@ func TestSaveAndLoadPlatform(t *testing.T) {
 			assert.NilError(t, err)
 
 			// remove the pulled image
-			_, err = apiClient.ImageRemove(ctx, repoName, client.ImageRemoveOptions{})
+			_, err = apiClient.ImageRemove(ctx, handle.FromString(repoName), client.ImageRemoveOptions{})
 			assert.NilError(t, err)
 
 			// load the full exported image (all platforms in it)
@@ -346,7 +347,7 @@ func TestSaveAndLoadPlatform(t *testing.T) {
 			}
 
 			// remove the loaded image
-			_, err = apiClient.ImageRemove(ctx, repoName, client.ImageRemoveOptions{})
+			_, err = apiClient.ImageRemove(ctx, handle.FromString(repoName), client.ImageRemoveOptions{})
 			assert.NilError(t, err)
 
 			// pull the image again (start fresh)
@@ -363,7 +364,7 @@ func TestSaveAndLoadPlatform(t *testing.T) {
 			assert.NilError(t, err)
 
 			// remove the pulled image
-			_, err = apiClient.ImageRemove(ctx, repoName, client.ImageRemoveOptions{})
+			_, err = apiClient.ImageRemove(ctx, handle.FromString(repoName), client.ImageRemoveOptions{})
 			assert.NilError(t, err)
 
 			// load the exported image on the specified platforms only

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -11,6 +11,7 @@ import (
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
 	"gotest.tools/v3/assert"
@@ -25,7 +26,7 @@ func Do(ctx context.Context, t *testing.T, apiClient client.APIClient, buildCtx 
 	assert.NilError(t, err)
 	img := GetImageIDFromBody(t, resp.Body)
 	t.Cleanup(func() {
-		apiClient.ImageRemove(ctx, img, client.ImageRemoveOptions{Force: true})
+		apiClient.ImageRemove(ctx, handle.FromString(img), client.ImageRemoveOptions{Force: true})
 	})
 	return img
 }

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/daemon/volume/safepath"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
@@ -147,7 +148,7 @@ func TestRunMountImage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testImage := setupTestImage(t, ctx, apiClient, tc.name)
 			if testImage != "" {
-				defer apiClient.ImageRemove(ctx, testImage, client.ImageRemoveOptions{Force: true})
+				defer apiClient.ImageRemove(ctx, handle.FromString(testImage), client.ImageRemoveOptions{Force: true})
 			}
 
 			cfg := containertypes.Config{
@@ -193,7 +194,7 @@ func TestRunMountImage(t *testing.T) {
 			if tc.name == "image_remove" {
 				img, _ := apiClient.ImageInspect(ctx, testImage)
 				imgId := strings.Split(img.ID, ":")[1]
-				_, removeErr := apiClient.ImageRemove(ctx, testImage, client.ImageRemoveOptions{})
+				_, removeErr := apiClient.ImageRemove(ctx, handle.FromString(testImage), client.ImageRemoveOptions{})
 				assert.ErrorContains(t, removeErr, fmt.Sprintf(`container %s is using its referenced image %s`, id[:12], imgId[:12]))
 			}
 
@@ -202,7 +203,7 @@ func TestRunMountImage(t *testing.T) {
 				stopErr := apiClient.ContainerStop(ctx, id, client.ContainerStopOptions{})
 				assert.NilError(t, stopErr)
 
-				_, removeErr := apiClient.ImageRemove(ctx, testImage, client.ImageRemoveOptions{Force: true})
+				_, removeErr := apiClient.ImageRemove(ctx, handle.FromString(testImage), client.ImageRemoveOptions{Force: true})
 				assert.NilError(t, removeErr)
 
 				startContainer(id)

--- a/internal/testutil/environment/clean.go
+++ b/internal/testutil/environment/clean.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 )
@@ -117,7 +118,7 @@ func deleteAllImages(ctx context.Context, t testing.TB, apiclient client.ImageAP
 
 func removeImage(ctx context.Context, t testing.TB, apiclient client.ImageAPIClient, ref string) {
 	t.Helper()
-	_, err := apiclient.ImageRemove(ctx, ref, client.ImageRemoveOptions{
+	_, err := apiclient.ImageRemove(ctx, handle.FromString(ref), client.ImageRemoveOptions{
 		Force: true,
 	})
 	if cerrdefs.IsNotFound(err) {

--- a/internal/testutil/fakestorage/storage.go
+++ b/internal/testutil/fakestorage/storage.go
@@ -13,6 +13,7 @@ import (
 
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/environment"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
@@ -112,7 +113,7 @@ func (f *remoteFileServer) Close() error {
 			}
 		}
 		if f.image != "" {
-			if _, err := f.client.ImageRemove(context.Background(), f.image, client.ImageRemoveOptions{Force: true}); err != nil {
+			if _, err := f.client.ImageRemove(context.Background(), handle.FromString(f.image), client.ImageRemoveOptions{Force: true}); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "Error closing remote file server: removing image: %v\n", err)
 			}
 		}

--- a/internal/testutil/fixtures/load/frozen.go
+++ b/internal/testutil/fixtures/load/frozen.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/handle"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/term"
 	"github.com/pkg/errors"
@@ -73,7 +74,7 @@ func FrozenImagesLinux(ctx context.Context, apiClient client.APIClient, images .
 			if err := apiClient.ImageTag(ctx, img.srcName, img.destName); err != nil {
 				return errors.Wrapf(err, "failed to tag %s as %s", img.srcName, img.destName)
 			}
-			if _, err := apiClient.ImageRemove(ctx, img.srcName, client.ImageRemoveOptions{}); err != nil {
+			if _, err := apiClient.ImageRemove(ctx, handle.FromString(img.srcName), client.ImageRemoveOptions{}); err != nil {
 				return errors.Wrapf(err, "failed to remove %s", img.srcName)
 			}
 		}
@@ -174,7 +175,7 @@ func pullTagAndRemove(ctx context.Context, apiClient client.APIClient, ref strin
 	if err := apiClient.ImageTag(ctx, ref, tag); err != nil {
 		return errors.Wrapf(err, "failed to tag %s as %s", ref, tag)
 	}
-	_, err = apiClient.ImageRemove(ctx, ref, client.ImageRemoveOptions{})
+	_, err = apiClient.ImageRemove(ctx, handle.FromString(ref), client.ImageRemoveOptions{})
 	return errors.Wrapf(err, "failed to remove %s", ref)
 }
 

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/api/types/volume"
+	"github.com/moby/moby/client/handle"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -117,7 +118,7 @@ type ImageAPIClient interface {
 	ImageList(ctx context.Context, options ImageListOptions) ([]image.Summary, error)
 	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (io.ReadCloser, error)
 	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (io.ReadCloser, error)
-	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
+	ImageRemove(ctx context.Context, image handle.ImageHandle, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (image.PruneReport, error)

--- a/vendor/github.com/moby/moby/client/handle/handle.go
+++ b/vendor/github.com/moby/moby/client/handle/handle.go
@@ -1,0 +1,11 @@
+package handle
+
+import (
+	"context"
+
+	internalhandle "github.com/moby/moby/client/internal/handle"
+)
+
+type ImageHandle interface {
+	ResolveImage(ctx context.Context) (internalhandle.ImageResolveResult, error)
+}

--- a/vendor/github.com/moby/moby/client/handle/string.go
+++ b/vendor/github.com/moby/moby/client/handle/string.go
@@ -1,0 +1,23 @@
+package handle
+
+import (
+	"context"
+	"errors"
+
+	internalhandle "github.com/moby/moby/client/internal/handle"
+)
+
+func FromString(str string) *stringHandle {
+	return &stringHandle{str: str}
+}
+
+type stringHandle struct {
+	str string
+}
+
+func (h *stringHandle) ResolveImage(ctx context.Context) (internalhandle.ImageResolveResult, error) {
+	if h.str == "" {
+		return internalhandle.ImageResolveResult{}, errors.New("empty image name")
+	}
+	return internalhandle.ImageResolveResult{RefOrTruncatedID: h.str}, nil
+}

--- a/vendor/github.com/moby/moby/client/image_remove.go
+++ b/vendor/github.com/moby/moby/client/image_remove.go
@@ -6,10 +6,11 @@ import (
 	"net/url"
 
 	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/client/handle"
 )
 
 // ImageRemove removes an image from the docker host.
-func (cli *Client) ImageRemove(ctx context.Context, imageID string, options ImageRemoveOptions) ([]image.DeleteResponse, error) {
+func (cli *Client) ImageRemove(ctx context.Context, img handle.ImageHandle, options ImageRemoveOptions) ([]image.DeleteResponse, error) {
 	query := url.Values{}
 
 	if options.Force {
@@ -27,7 +28,12 @@ func (cli *Client) ImageRemove(ctx context.Context, imageID string, options Imag
 		query["platforms"] = p
 	}
 
-	resp, err := cli.delete(ctx, "/images/"+imageID, query, nil)
+	rimg, err := img.ResolveImage(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cli.delete(ctx, "/images/"+rimg.RefOrTruncatedID, query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/moby/moby/client/internal/handle/image.go
+++ b/vendor/github.com/moby/moby/client/internal/handle/image.go
@@ -1,0 +1,15 @@
+package internalhandle
+
+import "context"
+
+type ImageResolveResult struct {
+	RefOrTruncatedID string
+}
+
+type naiveHandle struct {
+	RefOrTruncatedID string
+}
+
+func (h *naiveHandle) Resolve(ctx context.Context) (ImageResolveResult, error) {
+	return ImageResolveResult{RefOrTruncatedID: h.RefOrTruncatedID}, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -967,6 +967,8 @@ github.com/moby/moby/api/types/volume
 # github.com/moby/moby/client v0.1.0-beta.0 => ./client
 ## explicit; go 1.23.0
 github.com/moby/moby/client
+github.com/moby/moby/client/handle
+github.com/moby/moby/client/internal/handle
 github.com/moby/moby/client/internal/timestamp
 github.com/moby/moby/client/pkg/jsonmessage
 github.com/moby/moby/client/pkg/stringid


### PR DESCRIPTION
- addresses: https://github.com/moby/moby/issues/49366

The ImageRemove method signature has been updated to accept a handle.ImageHandle interface instead of a string for the image parameter.

This change introduces a new abstraction layer for image references that allows for more flexible image resolution strategies. For example, we could add a handle that pulls image if it doesn't exist, like:

```go
client.ImageRemove(ctx,
   handle.LocalImageOrPull("ubuntu:latest")
)

// I know, ImageRemove is kinda weird for this example, but you get the idea!
```

Currently only a naive image resolution is available that directly corresponds to the previous behavior of just passing a string image reference.



The same could be applied to other objects like Networks or Volumes.