### PR TITLE
api: docs: remove deprecated BridgeNfIptables, BridgeNfIp6tables

### DIFF
--- a/api/docs/v1.48.yaml
+++ b/api/docs/v1.48.yaml
@@ -6552,7 +6552,7 @@ definitions:
 
           > **Deprecated**: netfilter module is now loaded on-demand and no longer
           > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
+          > `false` and will be removed in a API v1.50.
         type: "boolean"
         example: false
       BridgeNfIp6tables:
@@ -6563,7 +6563,7 @@ definitions:
 
           > **Deprecated**: netfilter module is now loaded on-demand, and no longer
           > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
+          > `false` and will be removed in a API v1.50.
         type: "boolean"
         example: false
       Debug:

--- a/api/docs/v1.49.yaml
+++ b/api/docs/v1.49.yaml
@@ -6552,7 +6552,7 @@ definitions:
 
           > **Deprecated**: netfilter module is now loaded on-demand and no longer
           > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
+          > `false` and will be removed in a API v1.50.
         type: "boolean"
         example: false
       BridgeNfIp6tables:
@@ -6563,7 +6563,7 @@ definitions:
 
           > **Deprecated**: netfilter module is now loaded on-demand, and no longer
           > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
+          > `false` and will be removed in a API v1.50.
         type: "boolean"
         example: false
       Debug:

--- a/api/docs/v1.50.yaml
+++ b/api/docs/v1.50.yaml
@@ -6387,29 +6387,6 @@ definitions:
         description: "Indicates IPv4 forwarding is enabled."
         type: "boolean"
         example: true
-      BridgeNfIptables:
-        description: |
-          Indicates if `bridge-nf-call-iptables` is available on the host when
-          the daemon was started.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
-      BridgeNfIp6tables:
-        description: |
-          Indicates if `bridge-nf-call-ip6tables` is available on the host.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand, and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
       Debug:
         description: |
           Indicates if the daemon is running in debug-mode / with debug-level

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -6388,29 +6388,6 @@ definitions:
         description: "Indicates IPv4 forwarding is enabled."
         type: "boolean"
         example: true
-      BridgeNfIptables:
-        description: |
-          Indicates if `bridge-nf-call-iptables` is available on the host when
-          the daemon was started.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
-      BridgeNfIp6tables:
-        description: |
-          Indicates if `bridge-nf-call-ip6tables` is available on the host.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand, and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
       Debug:
         description: |
           Indicates if the daemon is running in debug-mode / with debug-level

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -6403,29 +6403,6 @@ definitions:
         description: "Indicates IPv4 forwarding is enabled."
         type: "boolean"
         example: true
-      BridgeNfIptables:
-        description: |
-          Indicates if `bridge-nf-call-iptables` is available on the host when
-          the daemon was started.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
-      BridgeNfIp6tables:
-        description: |
-          Indicates if `bridge-nf-call-ip6tables` is available on the host.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand, and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
       Debug:
         description: |
           Indicates if the daemon is running in debug-mode / with debug-level

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6403,29 +6403,6 @@ definitions:
         description: "Indicates IPv4 forwarding is enabled."
         type: "boolean"
         example: true
-      BridgeNfIptables:
-        description: |
-          Indicates if `bridge-nf-call-iptables` is available on the host when
-          the daemon was started.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
-      BridgeNfIp6tables:
-        description: |
-          Indicates if `bridge-nf-call-ip6tables` is available on the host.
-
-          <p><br /></p>
-
-          > **Deprecated**: netfilter module is now loaded on-demand, and no longer
-          > during daemon startup, making this field obsolete. This field is always
-          > `false` and will be removed in a API v1.49.
-        type: "boolean"
-        example: false
       Debug:
         description: |
           Indicates if the daemon is running in debug-mode / with debug-level


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49904
- relates to https://github.com/moby/moby/pull/49114


The `BridgeNfIptables` and `BridgeNfIp6tables` were removed in API v1.50 in commit 6505d3877cbcd39c426cb7b92be2f94037313c6a, and only returned in lower API versions.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

