### PR TITLE
Use libnftables in dynamically linked binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -501,6 +501,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             jq \
             libcap2-bin \
             libnet1 \
+            libnftables-dev \
             libnl-3-200 \
             libprotobuf-c1 \
             libyajl2 \
@@ -548,6 +549,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-build-aptlib,target=/var/lib/apt \
         xx-apt-get install --no-install-recommends -y \
             gcc \
             libc6-dev \
+            libnftables-dev \
             libseccomp-dev \
             libsystemd-dev \
             pkg-config

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler.go
@@ -4,6 +4,7 @@ package nftabler
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge/internal/firewaller"
@@ -50,6 +51,8 @@ type Nftabler struct {
 	table6  nftables.Table
 }
 
+// NewNftabler creates a new Nftabler instance, initializing the nftables tables.
+// Call Close() on the returned Nftabler to release resources when done.
 func NewNftabler(ctx context.Context, config firewaller.Config) (*Nftabler, error) {
 	nft := &Nftabler{config: config}
 
@@ -70,6 +73,12 @@ func NewNftabler(ctx context.Context, config firewaller.Config) (*Nftabler, erro
 	}
 
 	return nft, nil
+}
+
+// Close releases resources held by the Nftabler, the underlying nftables tables
+// are not modified or deleted.
+func (nft *Nftabler) Close() error {
+	return errors.Join(nft.table4.Close(), nft.table6.Close())
 }
 
 func (nft *Nftabler) init(ctx context.Context, family nftables.Family) (nftables.Table, error) {

--- a/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
@@ -1,4 +1,4 @@
-//go:build cgo && !static_build
+//go:build cgo && !static_build && !no_libnftables
 
 package nftables
 

--- a/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_cgo_linux.go
@@ -1,0 +1,78 @@
+//go:build cgo && !static_build
+
+package nftables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/containerd/log"
+	"go.opentelemetry.io/otel"
+)
+
+// #cgo pkg-config: libnftables
+// #cgo nocallback nft_run_cmd_from_buffer
+// #cgo nocallback nft_ctx_get_output_buffer
+// #cgo nocallback nft_ctx_get_error_buffer
+// #include <stdlib.h>
+// #include <nftables/libnftables.h>
+import "C"
+
+type nftHandle = *C.struct_nft_ctx
+
+// nftApply calls libnftables to execute the nftables commands in nftCmd.
+// Acquire t.applyLock before calling this function.
+func (t *table) nftApply(ctx context.Context, nftCmd []byte) error {
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply.cgo")
+	defer span.End()
+
+	if t.nftHandle == nil {
+		handle, err := newNftHandle()
+		if err != nil {
+			return err
+		}
+		t.nftHandle = handle
+	}
+
+	cCmd := C.CString(string(nftCmd))
+	defer C.free(unsafe.Pointer(cCmd))
+
+	ret := C.nft_run_cmd_from_buffer(t.nftHandle, cCmd)
+	stdout := C.GoString(C.nft_ctx_get_output_buffer(t.nftHandle))
+	stderr := C.GoString(C.nft_ctx_get_error_buffer(t.nftHandle))
+	if ret != 0 {
+		return fmt.Errorf("libnftables: failed to apply commands (code %d), stderr: %s", int(ret), stderr)
+	}
+	log.G(ctx).WithFields(log.Fields{"stdout": stdout, "stderr": stderr}).Debug("nftables: updated via libnftables")
+	return nil
+}
+
+func newNftHandle() (_ *C.struct_nft_ctx, retErr error) {
+	handle := C.nft_ctx_new(C.NFT_CTX_DEFAULT)
+	if handle == nil {
+		return nil, errors.New("libnftables: failed to create new nft handle")
+	}
+	defer func() {
+		if retErr != nil {
+			C.nft_ctx_free(handle)
+		}
+	}()
+	if ret := C.nft_ctx_buffer_output(handle); ret != 0 {
+		return nil, fmt.Errorf("libnftables: failed to set output buffer (code %d)", int(ret))
+	}
+	if ret := C.nft_ctx_buffer_error(handle); ret != 0 {
+		return nil, fmt.Errorf("libnftables: failed to set error buffer (code %d)", int(ret))
+	}
+	return handle, nil
+}
+
+func (t *table) closeNftHandle() {
+	t.applyLock.Lock()
+	defer t.applyLock.Unlock()
+	if t.nftHandle != nil {
+		C.nft_ctx_free(t.nftHandle)
+		t.nftHandle = nil
+	}
+}

--- a/daemon/libnetwork/internal/nftables/nft_exec_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_exec_linux.go
@@ -1,0 +1,66 @@
+//go:build !cgo || static_build
+
+package nftables
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/containerd/log"
+	"go.opentelemetry.io/otel"
+)
+
+type nftHandle = struct{}
+
+func (t *table) nftApply(ctx context.Context, nftCmd []byte) error {
+	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply.exec")
+	defer span.End()
+
+	cmd := exec.Command(nftPath, "-f", "-")
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("getting stdin pipe for nft: %w", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("getting stdout pipe for nft: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("getting stderr pipe for nft: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting nft: %w", err)
+	}
+	if _, err := stdinPipe.Write(nftCmd); err != nil {
+		return fmt.Errorf("sending nft commands: %w", err)
+	}
+	if err := stdinPipe.Close(); err != nil {
+		return fmt.Errorf("closing nft input pipe: %w", err)
+	}
+
+	stdoutBuf := strings.Builder{}
+	if _, err := io.Copy(&stdoutBuf, stdoutPipe); err != nil {
+		return fmt.Errorf("reading stdout of nft: %w", err)
+	}
+	stdout := stdoutBuf.String()
+	stderrBuf := strings.Builder{}
+	if _, err := io.Copy(&stderrBuf, stderrPipe); err != nil {
+		return fmt.Errorf("reading stderr of nft: %w", err)
+	}
+	stderr := stderrBuf.String()
+
+	err = cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("running nft: %s %w", stderr, err)
+	}
+	log.G(ctx).WithFields(log.Fields{"stdout": stdout, "stderr": stderr}).Debug("nftables: updated")
+	return nil
+}
+
+func (t *table) closeNftHandle() {
+}

--- a/daemon/libnetwork/internal/nftables/nft_exec_linux.go
+++ b/daemon/libnetwork/internal/nftables/nft_exec_linux.go
@@ -1,4 +1,4 @@
-//go:build !cgo || static_build
+//go:build !cgo || static_build || no_libnftables
 
 package nftables
 

--- a/daemon/libnetwork/internal/nftables/nftables_linux.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux.go
@@ -48,7 +48,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"iter"
 	"os/exec"
 	"runtime"
@@ -59,7 +58,6 @@ import (
 	"text/template"
 
 	"github.com/containerd/log"
-	"go.opentelemetry.io/otel"
 )
 
 // Prefix for OTEL span names.
@@ -193,6 +191,7 @@ type table struct {
 	MustFlush      bool
 
 	applyLock sync.Mutex
+	nftHandle nftHandle // applyLock must be held to access
 }
 
 // Table is a handle for an nftables table.
@@ -235,6 +234,16 @@ func NewTable(family Family, name string) (Table, error) {
 	return t, nil
 }
 
+// Close releases resources associated with the table. It does not modify or delete
+// the underlying nftables table.
+func (t Table) Close() error {
+	if t.IsValid() {
+		t.t.closeNftHandle()
+		t.t = nil
+	}
+	return nil
+}
+
 // Name returns the name of the table, or an empty string if t is not valid.
 func (t Table) Name() string {
 	if !t.IsValid() {
@@ -245,6 +254,9 @@ func (t Table) Name() string {
 
 // Family returns the address family of the nftables table described by [TableRef].
 func (t Table) Family() Family {
+	if !t.IsValid() {
+		return ""
+	}
 	return t.t.Family
 }
 
@@ -464,7 +476,7 @@ func (t *Table) Apply(ctx context.Context, tm Modifier) (retErr error) {
 		return fmt.Errorf("failed to execute template nft ruleset: %w", err)
 	}
 
-	if err := nftApply(ctx, buf.Bytes()); err != nil {
+	if err := t.t.nftApply(ctx, buf.Bytes()); err != nil {
 		// On error, log a line-numbered version of the generated "nft" input (because
 		// nft error messages refer to line numbers).
 		var sb strings.Builder
@@ -497,10 +509,15 @@ func (t Table) Reload(ctx context.Context) error {
 	if !t.IsValid() {
 		return errors.New("invalid table")
 	}
+	t.t.applyLock.Lock()
+	defer t.t.applyLock.Unlock()
 	return t.t.reload(ctx)
 }
 
 func (t *table) reload(ctx context.Context) error {
+	if !Enabled() {
+		return errors.New("nftables is not enabled")
+	}
 	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(log.Fields{"table": t.Name, "family": t.Family}))
 	log.G(ctx).Warn("nftables: reloading table")
 
@@ -510,7 +527,7 @@ func (t *table) reload(ctx context.Context) error {
 		return fmt.Errorf("failed to execute reload template: %w", err)
 	}
 
-	if err := nftApply(ctx, buf.Bytes()); err != nil {
+	if err := t.nftApply(ctx, buf.Bytes()); err != nil {
 		// On error, log a line-numbered version of the generated "nft" input (because
 		// nft error messages refer to line numbers).
 		var sb strings.Builder
@@ -1065,56 +1082,5 @@ func parseTemplate() error {
 	if err != nil {
 		return fmt.Errorf("parsing 'reloadTemplText': %w", err)
 	}
-	return nil
-}
-
-// nftApply runs the "nft" command.
-func nftApply(ctx context.Context, nftCmd []byte) error {
-	ctx, span := otel.Tracer("").Start(ctx, spanPrefix+".nftApply")
-	defer span.End()
-
-	if !Enabled() {
-		return errors.New("nftables is not enabled")
-	}
-	cmd := exec.Command(nftPath, "-f", "-")
-	stdinPipe, err := cmd.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("getting stdin pipe for nft: %w", err)
-	}
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("getting stdout pipe for nft: %w", err)
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("getting stderr pipe for nft: %w", err)
-	}
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("starting nft: %w", err)
-	}
-	if _, err := stdinPipe.Write(nftCmd); err != nil {
-		return fmt.Errorf("sending nft commands: %w", err)
-	}
-	if err := stdinPipe.Close(); err != nil {
-		return fmt.Errorf("closing nft input pipe: %w", err)
-	}
-
-	stdoutBuf := strings.Builder{}
-	if _, err := io.Copy(&stdoutBuf, stdoutPipe); err != nil {
-		return fmt.Errorf("reading stdout of nft: %w", err)
-	}
-	stdout := stdoutBuf.String()
-	stderrBuf := strings.Builder{}
-	if _, err := io.Copy(&stderrBuf, stderrPipe); err != nil {
-		return fmt.Errorf("reading stderr of nft: %w", err)
-	}
-	stderr := stderrBuf.String()
-
-	err = cmd.Wait()
-	if err != nil {
-		return fmt.Errorf("running nft: %s %w", stderr, err)
-	}
-	log.G(ctx).WithFields(log.Fields{"stdout": stdout, "stderr": stderr}).Debug("nftables: updated")
 	return nil
 }

--- a/daemon/libnetwork/internal/nftables/nftables_linux_test.go
+++ b/daemon/libnetwork/internal/nftables/nftables_linux_test.go
@@ -54,8 +54,10 @@ func TestTable(t *testing.T) {
 
 	tbl4, err := NewTable(IPv4, "ipv4_table")
 	assert.NilError(t, err)
+	defer tbl4.Close()
 	tbl6, err := NewTable(IPv6, "ipv6_table")
 	assert.NilError(t, err)
+	defer tbl6.Close()
 
 	// Update nftables and check what happened.
 	applyAndCheck(t, tbl4, Modifier{}, t.Name()+"/created4.golden")
@@ -68,6 +70,7 @@ func TestChain(t *testing.T) {
 	// Create a table.
 	tbl, err := NewTable(IPv4, "this_is_a_table")
 	assert.NilError(t, err)
+	defer tbl.Close()
 
 	// Create a base chain.
 	const bcName = "this_is_a_base_chain"
@@ -122,6 +125,7 @@ func TestChainRuleGroups(t *testing.T) {
 
 	tbl, err := NewTable(IPv4, "testtable")
 	assert.NilError(t, err)
+	defer tbl.Close()
 	tm := Modifier{}
 	chainName := "testchain"
 	tm.Create(Chain{Name: chainName})
@@ -137,6 +141,7 @@ func TestIgnoreExist(t *testing.T) {
 	defer testSetup(t)()
 	tbl, err := NewTable(IPv4, "this_is_a_table")
 	assert.NilError(t, err)
+	defer tbl.Close()
 	tm := Modifier{}
 
 	// Create a chain with a single rule, add the rule again but drop the duplicate.
@@ -179,6 +184,7 @@ func TestVMap(t *testing.T) {
 	// Create a table.
 	tbl, err := NewTable(IPv6, "this_is_a_table")
 	assert.NilError(t, err)
+	defer tbl.Close()
 	tm := Modifier{}
 
 	// Create a verdict map.
@@ -203,8 +209,10 @@ func TestSet(t *testing.T) {
 	// Create v4 and v6 tables.
 	tbl4, err := NewTable(IPv4, "table4")
 	assert.NilError(t, err)
+	defer tbl4.Close()
 	tbl6, err := NewTable(IPv6, "table6")
 	assert.NilError(t, err)
+	defer tbl6.Close()
 
 	// Create a set in each table.
 	const set4Name = "set4"
@@ -234,6 +242,7 @@ func TestReload(t *testing.T) {
 	const tableName = "this_is_a_table"
 	tbl, err := NewTable(IPv4, tableName)
 	assert.NilError(t, err)
+	defer tbl.Close()
 	tm := Modifier{}
 
 	const bcName = "a_base_chain"
@@ -627,6 +636,7 @@ func TestValidation(t *testing.T) {
 			defer testSetup(t)()
 			tbl, err := NewTable(IPv4, "tablename")
 			assert.NilError(t, err)
+			defer tbl.Close()
 			tm := Modifier{cmds: tc.cmds}
 			err = tbl.Apply(context.Background(), tm)
 			assert.Check(t, err != nil, "expected error containing '%s'", tc.expErr)

--- a/daemon/libnetwork/resolver_unix.go
+++ b/daemon/libnetwork/resolver_unix.go
@@ -97,6 +97,7 @@ func (r *Resolver) setupNftablesNAT(ctx context.Context, laddr, ltcpaddr, resolv
 	if err != nil {
 		return err
 	}
+	defer table.Close()
 	tm := nftables.Modifier{}
 
 	const dnatChain = "dns-dnat"


### PR DESCRIPTION
**- What I did**

When dockerd is dynamically linked, use cgo to call functions in libnftables instead of exec-ing the nft binary.

On my M2 macbook, using the library knocks about 20ms off each update, down to less than 1ms. Initialisation and teardown operations happen sequentially, so the time saving comes directly off the total.

Using libnftables brings nftables update performance in line with iptables - typical times ...

|  | iptables | nft | libnftables |
|-|---------|----|-----------|
|docker network create --ipv6 b46 | 48ms | 57ms | 10ms |
|docker run --rm -ti --network b46 -p 8080:80 busybox (start) | 95ms | 185ms | 109ms |

<details>
<summary>Click for OTEL traces ...</summary>

### Network create

#### iptables

<img width="1487" height="561" alt="network-create-iptables" src="https://github.com/user-attachments/assets/b6bb7ca3-ce78-4906-a6f8-cb1c9f549357" />

#### nft binary

<img width="1487" height="675" alt="network-create-execnft" src="https://github.com/user-attachments/assets/17cf5ce0-71e2-49ed-a546-ea8cfc479929" />

#### libnftables

<img width="1839" height="751" alt="network-create-cgonft" src="https://github.com/user-attachments/assets/c116f952-2a09-4469-a332-0b516687e12c" />

### Container start

#### iptables

<img width="1484" height="926" alt="container-start-iptables" src="https://github.com/user-attachments/assets/bd65fc07-2f09-4661-a8c3-c5b1862eb837" />

#### nft binary

<img width="1484" height="929" alt="container-start-execnft" src="https://github.com/user-attachments/assets/7db9cc78-2ab9-4a43-af51-b648b73f0bd3" />

#### libnftables

<img width="1843" height="1092" alt="Screenshot 2025-09-24 at 18 15 54" src="https://github.com/user-attachments/assets/c885ee07-3ab1-4de0-b3d6-311737c76fa2" />

</details>

**- How I did it**

Use cgo to call libnftables functions.

In packaging scripts/config, we'll need to add a build dependency on `libnftables-dev` and a installation dependency on `libnftables`.

**- How to verify it**

Unit tests use the library, integration tests (against the statically linked binary) use the nft tool.

**- Human readable description for the release notes**
```markdown changelog
- When dynamically linked, the Docker daemon now depends on libnftables.
```
