### PR TITLE
Pass context to DNS resolver start and network driverapi

### DIFF
--- a/daemon/libnetwork/controller.go
+++ b/daemon/libnetwork/controller.go
@@ -217,7 +217,7 @@ func New(ctx context.Context, cfgOptions ...config.Option) (_ *Controller, retEr
 	if err := c.cleanupLocalEndpoints(); err != nil {
 		log.G(ctx).WithError(err).Warnf("error during endpoint cleanup")
 	}
-	c.networkCleanup()
+	c.networkCleanup(ctx)
 
 	if err := c.startExternalKeyListener(); err != nil {
 		return nil, err
@@ -658,7 +658,7 @@ func (c *Controller) NewNetwork(ctx context.Context, networkType, name string, i
 	}
 	defer func() {
 		if retErr != nil {
-			if err := nw.deleteNetwork(); err != nil {
+			if err := nw.deleteNetwork(ctx); err != nil {
 				log.G(ctx).Warnf("couldn't roll back driver network on network %s creation failure: %v", nw.name, retErr)
 			}
 		}

--- a/daemon/libnetwork/controller.go
+++ b/daemon/libnetwork/controller.go
@@ -833,7 +833,7 @@ func (c *Controller) addNetwork(ctx context.Context, n *Network) error {
 		return err
 	}
 
-	n.startResolver()
+	n.startResolver(ctx)
 
 	return nil
 }

--- a/daemon/libnetwork/driverapi/driverapi.go
+++ b/daemon/libnetwork/driverapi/driverapi.go
@@ -36,7 +36,7 @@ type Driver interface {
 
 	// DeleteEndpoint invokes the driver method to delete an endpoint
 	// passing the network id and endpoint id.
-	DeleteEndpoint(nid, eid string) error
+	DeleteEndpoint(ctx context.Context, nid, eid string) error
 
 	// EndpointOperInfo retrieves from the driver the operational data related to the specified endpoint
 	EndpointOperInfo(nid, eid string) (map[string]any, error)
@@ -45,7 +45,7 @@ type Driver interface {
 	Join(ctx context.Context, nid, eid string, sboxKey string, jinfo JoinInfo, epOpts, sbOpts map[string]any) error
 
 	// Leave method is invoked when a Sandbox detaches from an endpoint.
-	Leave(nid, eid string) error
+	Leave(ctx context.Context, nid, eid string) error
 
 	// Type returns the type of this driver, the network type this driver manages
 	Type() string

--- a/daemon/libnetwork/driverapi/driverapi.go
+++ b/daemon/libnetwork/driverapi/driverapi.go
@@ -25,7 +25,7 @@ type Driver interface {
 
 	// DeleteNetwork invokes the driver method to delete network passing
 	// the network id.
-	DeleteNetwork(nid string) error
+	DeleteNetwork(ctx context.Context, nid string) error
 
 	// CreateEndpoint invokes the driver method to create an endpoint
 	// passing the network id, endpoint id endpoint information and driver

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -909,14 +909,14 @@ func (d *driver) createNetwork(ctx context.Context, config *networkConfiguration
 	return bridgeSetup.apply(ctx)
 }
 
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(ctx context.Context, nid string) error {
 	d.configNetwork.Lock()
 	defer d.configNetwork.Unlock()
 
-	return d.deleteNetwork(nid)
+	return d.deleteNetwork(ctx, nid)
 }
 
-func (d *driver) deleteNetwork(nid string) error {
+func (d *driver) deleteNetwork(ctx context.Context, nid string) error {
 	var err error
 
 	// Get network handler and remove it from driver
@@ -932,7 +932,7 @@ func (d *driver) deleteNetwork(nid string) error {
 		// with its parent, make sure it's not in the store before reporting that it does
 		// not exist.
 		if err := d.storeDelete(&networkConfiguration{ID: nid}); err != nil && !errors.Is(err, datastore.ErrKeyNotFound) {
-			log.G(context.TODO()).WithFields(log.Fields{
+			log.G(ctx).WithFields(log.Fields{
 				"error":   err,
 				"network": nid,
 			}).Warnf("Failed to delete network from bridge store")
@@ -946,17 +946,17 @@ func (d *driver) deleteNetwork(nid string) error {
 
 	// delete endpoints belong to this network
 	for _, ep := range n.endpoints {
-		if err := n.releasePorts(ep); err != nil {
-			log.G(context.TODO()).Warn(err)
+		if err := n.releasePorts(ctx, ep); err != nil {
+			log.G(ctx).Warn(err)
 		}
 		if link, err := d.nlh.LinkByName(ep.srcName); err == nil {
 			if err := d.nlh.LinkDel(link); err != nil {
-				log.G(context.TODO()).WithError(err).Errorf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+				log.G(ctx).WithError(err).Errorf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
 			}
 		}
 
 		if err := d.storeDelete(ep); err != nil {
-			log.G(context.TODO()).Warnf("Failed to remove bridge endpoint %.7s from store: %v", ep.id, err)
+			log.G(ctx).Warnf("Failed to remove bridge endpoint %.7s from store: %v", ep.id, err)
 		}
 	}
 
@@ -982,18 +982,18 @@ func (d *driver) deleteNetwork(nid string) error {
 		// it is not the default one (to keep the backward compatible behavior.)
 		if !config.DefaultBridge {
 			if err := d.nlh.LinkDel(n.bridge.Link); err != nil {
-				log.G(context.TODO()).Warnf("Failed to remove bridge interface %s on network %s delete: %v", config.BridgeName, nid, err)
+				log.G(ctx).Warnf("Failed to remove bridge interface %s on network %s delete: %v", config.BridgeName, nid, err)
 			}
 		}
 	case ifaceCreatedByUser:
 		// Don't delete the bridge interface if it was not created by libnetwork.
 	}
 
-	if err := n.firewallerNetwork.DelNetworkLevelRules(context.TODO()); err != nil {
-		log.G(context.TODO()).WithError(err).Warnf("Failed to clean iptables rules for bridge network")
+	if err := n.firewallerNetwork.DelNetworkLevelRules(ctx); err != nil {
+		log.G(ctx).WithError(err).Warnf("Failed to clean iptables rules for bridge network")
 	}
 	if err := iptables.DelInterfaceFirewalld(n.config.BridgeName); err != nil {
-		log.G(context.TODO()).WithError(err).Warnf("Failed to clean firewalld rules for bridge network")
+		log.G(ctx).WithError(err).Warnf("Failed to clean firewalld rules for bridge network")
 	}
 
 	return d.storeDelete(config)
@@ -1479,7 +1479,7 @@ func (d *driver) Leave(ctx context.Context, nid, eid string) error {
 	}
 
 	if endpoint.portMapping != nil {
-		if err := network.releasePorts(endpoint); err != nil {
+		if err := network.releasePorts(ctx, endpoint); err != nil {
 			return err
 		}
 		if err = d.storeUpdate(ctx, endpoint); err != nil {

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -601,22 +601,22 @@ func TestCreateMultipleNetworks(t *testing.T) {
 	}
 	checkFirewallerNetworks()
 
-	if err := d.DeleteNetwork("1"); err != nil {
+	if err := d.DeleteNetwork(context.Background(), "1"); err != nil {
 		t.Log(err)
 	}
 	checkFirewallerNetworks()
 
-	if err := d.DeleteNetwork("2"); err != nil {
+	if err := d.DeleteNetwork(context.Background(), "2"); err != nil {
 		t.Log(err)
 	}
 	checkFirewallerNetworks()
 
-	if err := d.DeleteNetwork("3"); err != nil {
+	if err := d.DeleteNetwork(context.Background(), "3"); err != nil {
 		t.Log(err)
 	}
 	checkFirewallerNetworks()
 
-	if err := d.DeleteNetwork("4"); err != nil {
+	if err := d.DeleteNetwork(context.Background(), "4"); err != nil {
 		t.Log(err)
 	}
 	checkFirewallerNetworks()
@@ -1230,7 +1230,7 @@ func TestCreateWithExistingBridge(t *testing.T) {
 		t.Fatal("Creating bridge network with existing bridge interface unexpectedly modified the IP address of the bridge")
 	}
 
-	if err := d.DeleteNetwork(brName); err != nil {
+	if err := d.DeleteNetwork(context.Background(), brName); err != nil {
 		t.Fatalf("Failed to delete network %s: %v", brName, err)
 	}
 

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -839,7 +839,7 @@ func testQueryEndpointInfo(t *testing.T, ulPxyEnabled bool) {
 	}
 
 	// release host mapped ports
-	err = d.Leave("net1", "ep1")
+	err = d.Leave(context.Background(), "net1", "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -953,7 +953,7 @@ func TestLinkContainers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to revoke external connectivity: %v", err)
 	}
-	err = d.Leave("net1", "ep2")
+	err = d.Leave(context.Background(), "net1", "ep2")
 	if err != nil {
 		t.Fatal("Failed to unlink ep1 and ep2")
 	}

--- a/daemon/libnetwork/drivers/bridge/network_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/network_linux_test.go
@@ -148,10 +148,10 @@ func TestLinkDelete(t *testing.T) {
 	err = d.CreateEndpoint(context.Background(), "dummy", "ep1", te.Interface(), nil)
 	assert.NilError(t, err)
 
-	err = d.DeleteEndpoint("dummy", "")
+	err = d.DeleteEndpoint(context.Background(), "dummy", "")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Assert(t, is.Error(err, "invalid endpoint id: "))
 
-	err = d.DeleteEndpoint("dummy", "ep1")
+	err = d.DeleteEndpoint(context.Background(), "dummy", "ep1")
 	assert.NilError(t, err)
 }

--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux.go
@@ -392,14 +392,14 @@ func configurePortBindingIPv6(
 }
 
 // releasePorts attempts to release all port bindings, does not stop on failure
-func (n *bridgeNetwork) releasePorts(ep *bridgeEndpoint) error {
+func (n *bridgeNetwork) releasePorts(ctx context.Context, ep *bridgeEndpoint) error {
 	n.Lock()
 	pbs := ep.portMapping
 	ep.portMapping = nil
 	ep.portBindingState = portBindingMode{}
 	n.Unlock()
 
-	return n.unmapPBs(context.TODO(), pbs)
+	return n.unmapPBs(ctx, pbs)
 }
 
 func (n *bridgeNetwork) unmapPBs(ctx context.Context, bindings []portmapperapi.PortBinding) error {

--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -862,7 +862,7 @@ func TestAddPortMappings(t *testing.T) {
 			}
 
 			// Release anything that was allocated.
-			err = n.releasePorts(&bridgeEndpoint{portMapping: pbs})
+			err = n.releasePorts(ctx, &bridgeEndpoint{portMapping: pbs})
 			if tc.expReleaseErr == "" {
 				assert.Check(t, err)
 			} else {

--- a/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/port_mapping_linux_test.go
@@ -101,7 +101,7 @@ func TestPortMappingConfig(t *testing.T) {
 	}
 
 	// release host mapped ports
-	err = d.Leave("dummy", "ep1")
+	err = d.Leave(context.Background(), "dummy", "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestPortMappingV6Config(t *testing.T) {
 	}
 
 	// release host mapped ports
-	err = d.Leave("dummy", "ep1")
+	err = d.Leave(context.Background(), "dummy", "ep1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/libnetwork/drivers/host/host.go
+++ b/daemon/libnetwork/drivers/host/host.go
@@ -44,7 +44,7 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 	return nil
 }
 
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(_ context.Context, nid, eid string) error {
 	return nil
 }
 
@@ -58,7 +58,7 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(_ context.Context, nid, eid string) error {
 	return nil
 }
 

--- a/daemon/libnetwork/drivers/host/host.go
+++ b/daemon/libnetwork/drivers/host/host.go
@@ -36,7 +36,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	return nil
 }
 
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(_ context.Context, nid string) error {
 	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 

--- a/daemon/libnetwork/drivers/host/host_test.go
+++ b/daemon/libnetwork/drivers/host/host_test.go
@@ -31,7 +31,7 @@ func TestDriver(t *testing.T) {
 		t.Fatal("Second network creation failed with unexpected error type")
 	}
 
-	err = d.DeleteNetwork("first")
+	err = d.DeleteNetwork(context.Background(), "first")
 	if err == nil {
 		t.Fatal("network deletion should fail on this driver")
 	}
@@ -40,7 +40,7 @@ func TestDriver(t *testing.T) {
 	}
 
 	// we don't really check if it is there or not, delete is not allowed for this driver, period.
-	err = d.DeleteNetwork("unknown")
+	err = d.DeleteNetwork(context.Background(), "unknown")
 	if err == nil {
 		t.Fatal("any network deletion should fail on this driver")
 	}

--- a/daemon/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
+++ b/daemon/libnetwork/drivers/ipvlan/ipvlan_endpoint.go
@@ -60,7 +60,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 }
 
 // DeleteEndpoint remove the endpoint and associated netlink interface
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(ctx context.Context, nid, eid string) error {
 	if err := validateID(nid, eid); err != nil {
 		return err
 	}
@@ -74,12 +74,12 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	}
 	if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
 		if err := ns.NlHandle().LinkDel(link); err != nil {
-			log.G(context.TODO()).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+			log.G(ctx).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
 		}
 	}
 
 	if err := d.storeDelete(ep); err != nil {
-		log.G(context.TODO()).Warnf("Failed to remove ipvlan endpoint %.7s from store: %v", ep.id, err)
+		log.G(ctx).Warnf("Failed to remove ipvlan endpoint %.7s from store: %v", ep.id, err)
 	}
 	n.deleteEndpoint(ep.id)
 	return nil

--- a/daemon/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
+++ b/daemon/libnetwork/drivers/ipvlan/ipvlan_joinleave.go
@@ -165,7 +165,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(ctx context.Context, nid, eid string) error {
 	network, err := d.getNetwork(nid)
 	if err != nil {
 		return err

--- a/daemon/libnetwork/drivers/ipvlan/ipvlan_network.go
+++ b/daemon/libnetwork/drivers/ipvlan/ipvlan_network.go
@@ -132,7 +132,7 @@ func (d *driver) GetSkipGwAlloc(opts options.Generic) (ipv4, ipv6 bool, _ error)
 }
 
 // DeleteNetwork deletes the network for the specified driver type
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(ctx context.Context, nid string) error {
 	n := d.network(nid)
 	if n == nil {
 		return fmt.Errorf("network id %s not found", nid)
@@ -145,14 +145,14 @@ func (d *driver) DeleteNetwork(nid string) error {
 			if n.config.Parent == getDummyName(nid) {
 				err := delDummyLink(n.config.Parent)
 				if err != nil {
-					log.G(context.TODO()).Debugf("link %s was not deleted, continuing the delete network operation: %v",
+					log.G(ctx).Debugf("link %s was not deleted, continuing the delete network operation: %v",
 						n.config.Parent, err)
 				}
 			} else {
 				// only delete the link if it matches iface.vlan naming
 				err := delVlanLink(n.config.Parent)
 				if err != nil {
-					log.G(context.TODO()).Debugf("link %s was not deleted, continuing the delete network operation: %v",
+					log.G(ctx).Debugf("link %s was not deleted, continuing the delete network operation: %v",
 						n.config.Parent, err)
 				}
 			}
@@ -161,12 +161,12 @@ func (d *driver) DeleteNetwork(nid string) error {
 	for _, ep := range n.endpoints {
 		if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
 			if err := ns.NlHandle().LinkDel(link); err != nil {
-				log.G(context.TODO()).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+				log.G(ctx).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
 			}
 		}
 
 		if err := d.storeDelete(ep); err != nil {
-			log.G(context.TODO()).Warnf("Failed to remove ipvlan endpoint %.7s from store: %v", ep.id, err)
+			log.G(ctx).Warnf("Failed to remove ipvlan endpoint %.7s from store: %v", ep.id, err)
 		}
 	}
 	// delete the *network

--- a/daemon/libnetwork/drivers/macvlan/macvlan_endpoint.go
+++ b/daemon/libnetwork/drivers/macvlan/macvlan_endpoint.go
@@ -64,7 +64,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 }
 
 // DeleteEndpoint removes the endpoint and associated netlink interface
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(ctx context.Context, nid, eid string) error {
 	if err := validateID(nid, eid); err != nil {
 		return err
 	}

--- a/daemon/libnetwork/drivers/macvlan/macvlan_joinleave.go
+++ b/daemon/libnetwork/drivers/macvlan/macvlan_joinleave.go
@@ -124,7 +124,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(ctx context.Context, nid, eid string) error {
 	network, err := d.getNetwork(nid)
 	if err != nil {
 		return err

--- a/daemon/libnetwork/drivers/macvlan/macvlan_network.go
+++ b/daemon/libnetwork/drivers/macvlan/macvlan_network.go
@@ -151,7 +151,7 @@ func (d *driver) parentHasSingleUser(n *network) bool {
 }
 
 // DeleteNetwork deletes the network for the specified driver type
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(ctx context.Context, nid string) error {
 	n := d.network(nid)
 	if n == nil {
 		return fmt.Errorf("network id %s not found", nid)
@@ -162,14 +162,14 @@ func (d *driver) DeleteNetwork(nid string) error {
 		if n.config.Parent == getDummyName(nid) {
 			err := delDummyLink(n.config.Parent)
 			if err != nil {
-				log.G(context.TODO()).Debugf("link %s was not deleted, continuing the delete network operation: %v",
+				log.G(ctx).Debugf("link %s was not deleted, continuing the delete network operation: %v",
 					n.config.Parent, err)
 			}
 		} else {
 			// only delete the link if it matches iface.vlan naming
 			err := delVlanLink(n.config.Parent)
 			if err != nil {
-				log.G(context.TODO()).Debugf("link %s was not deleted, continuing the delete network operation: %v",
+				log.G(ctx).Debugf("link %s was not deleted, continuing the delete network operation: %v",
 					n.config.Parent, err)
 			}
 		}
@@ -177,12 +177,12 @@ func (d *driver) DeleteNetwork(nid string) error {
 	for _, ep := range n.endpoints {
 		if link, err := ns.NlHandle().LinkByName(ep.srcName); err == nil {
 			if err := ns.NlHandle().LinkDel(link); err != nil {
-				log.G(context.TODO()).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
+				log.G(ctx).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.srcName, ep.id)
 			}
 		}
 
 		if err := d.storeDelete(ep); err != nil {
-			log.G(context.TODO()).Warnf("Failed to remove macvlan endpoint %.7s from store: %v", ep.id, err)
+			log.G(ctx).Warnf("Failed to remove macvlan endpoint %.7s from store: %v", ep.id, err)
 		}
 	}
 	// delete the *network

--- a/daemon/libnetwork/drivers/null/null.go
+++ b/daemon/libnetwork/drivers/null/null.go
@@ -44,7 +44,7 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 	return nil
 }
 
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(_ context.Context, nid, eid string) error {
 	return nil
 }
 
@@ -58,7 +58,7 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(_ context.Context, nid, eid string) error {
 	return nil
 }
 

--- a/daemon/libnetwork/drivers/null/null.go
+++ b/daemon/libnetwork/drivers/null/null.go
@@ -36,7 +36,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	return nil
 }
 
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(_ context.Context, nid string) error {
 	return types.ForbiddenErrorf("network of type %q cannot be deleted", NetworkType)
 }
 

--- a/daemon/libnetwork/drivers/null/null_test.go
+++ b/daemon/libnetwork/drivers/null/null_test.go
@@ -31,7 +31,7 @@ func TestDriver(t *testing.T) {
 		t.Fatalf("Second network creation failed with unexpected error type")
 	}
 
-	err = d.DeleteNetwork("first")
+	err = d.DeleteNetwork(context.Background(), "first")
 	if err == nil {
 		t.Fatalf("network deletion should fail on this driver")
 	}
@@ -40,7 +40,7 @@ func TestDriver(t *testing.T) {
 	}
 
 	// we don't really check if it is there or not, delete is not allowed for this driver, period.
-	err = d.DeleteNetwork("unknown")
+	err = d.DeleteNetwork(context.Background(), "unknown")
 	if err == nil {
 		t.Fatalf("any network deletion should fail on this driver")
 	}

--- a/daemon/libnetwork/drivers/overlay/joinleave.go
+++ b/daemon/libnetwork/drivers/overlay/joinleave.go
@@ -231,7 +231,7 @@ func (d *driver) EventNotify(nid, tableName, key string, prev, value []byte) {
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(ctx context.Context, nid, eid string) error {
 	if err := validateID(nid, eid); err != nil {
 		return err
 	}

--- a/daemon/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/daemon/libnetwork/drivers/overlay/ov_endpoint.go
@@ -81,7 +81,7 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 	return nil
 }
 
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(ctx context.Context, nid, eid string) error {
 	nlh := ns.NlHandle()
 
 	if err := validateID(nid, eid); err != nil {
@@ -107,11 +107,11 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 
 	link, err := nlh.LinkByName(ep.ifName)
 	if err != nil {
-		log.G(context.TODO()).Debugf("Failed to retrieve interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+		log.G(ctx).Debugf("Failed to retrieve interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
 		return nil
 	}
 	if err := nlh.LinkDel(link); err != nil {
-		log.G(context.TODO()).Debugf("Failed to delete interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
+		log.G(ctx).Debugf("Failed to delete interface (%s)'s link on endpoint (%s) delete: %v", ep.ifName, ep.id, err)
 	}
 
 	return nil

--- a/daemon/libnetwork/drivers/overlay/ov_network.go
+++ b/daemon/libnetwork/drivers/overlay/ov_network.go
@@ -196,7 +196,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	return nil
 }
 
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(ctx context.Context, nid string) error {
 	if nid == "" {
 		return errors.New("invalid network id")
 	}
@@ -219,7 +219,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 		if ep.ifName != "" {
 			if link, err := ns.NlHandle().LinkByName(ep.ifName); err == nil {
 				if err := ns.NlHandle().LinkDel(link); err != nil {
-					log.G(context.TODO()).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.ifName, ep.id)
+					log.G(ctx).WithError(err).Warnf("Failed to delete interface (%s)'s link on endpoint (%s) delete", ep.ifName, ep.id)
 				}
 			}
 		}
@@ -228,14 +228,14 @@ func (d *driver) DeleteNetwork(nid string) error {
 	if n.secure {
 		for _, s := range n.subnets {
 			if err := d.programMangle(s.vni, false); err != nil {
-				log.G(context.TODO()).WithFields(log.Fields{
+				log.G(ctx).WithFields(log.Fields{
 					"error":      err,
 					"network_id": n.id,
 					"subnet":     s.subnetIP,
 				}).Warn("Failed to clean up iptables rules during overlay network deletion")
 			}
 			if err := d.programInput(s.vni, false); err != nil {
-				log.G(context.TODO()).WithFields(log.Fields{
+				log.G(ctx).WithFields(log.Fields{
 					"error":      err,
 					"network_id": n.id,
 					"subnet":     s.subnetIP,

--- a/daemon/libnetwork/drivers/remote/driver.go
+++ b/daemon/libnetwork/drivers/remote/driver.go
@@ -197,7 +197,7 @@ func (d *driver) GetSkipGwAlloc(opts options.Generic) (ipv4, ipv6 bool, _ error)
 	return resp.SkipIPv4, resp.SkipIPv6, nil
 }
 
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(_ context.Context, nid string) error {
 	return d.call("DeleteNetwork", &api.DeleteNetworkRequest{NetworkID: nid}, &api.DeleteNetworkResponse{})
 }
 

--- a/daemon/libnetwork/drivers/remote/driver.go
+++ b/daemon/libnetwork/drivers/remote/driver.go
@@ -201,7 +201,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	return d.call("DeleteNetwork", &api.DeleteNetworkRequest{NetworkID: nid}, &api.DeleteNetworkResponse{})
 }
 
-func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]any) (retErr error) {
+func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]any) (retErr error) {
 	if ifInfo == nil {
 		return errors.New("must not be called with nil InterfaceInfo")
 	}
@@ -230,7 +230,7 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 
 	defer func() {
 		if retErr != nil {
-			if err := d.DeleteEndpoint(nid, eid); err != nil {
+			if err := d.DeleteEndpoint(ctx, nid, eid); err != nil {
 				retErr = fmt.Errorf("%w; failed to roll back: %w", err, retErr)
 			} else {
 				retErr = fmt.Errorf("%w; rolled back", retErr)
@@ -266,7 +266,7 @@ func (d *driver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo drive
 	return nil
 }
 
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(ctx context.Context, nid, eid string) error {
 	deleteRequest := &api.DeleteEndpointRequest{
 		NetworkID:  nid,
 		EndpointID: eid,
@@ -287,7 +287,7 @@ func (d *driver) EndpointOperInfo(nid, eid string) (map[string]any, error) {
 }
 
 // Join method is invoked when a Sandbox is attached to an endpoint.
-func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, options map[string]any) (retErr error) {
+func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, _, options map[string]any) (retErr error) {
 	join := &api.JoinRequest{
 		NetworkID:  nid,
 		EndpointID: eid,
@@ -304,7 +304,7 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 
 	defer func() {
 		if retErr != nil {
-			if err := d.Leave(nid, eid); err != nil {
+			if err := d.Leave(ctx, nid, eid); err != nil {
 				retErr = fmt.Errorf("%w; failed to roll back: %w", err, retErr)
 			} else {
 				retErr = fmt.Errorf("%w; rolled back", retErr)
@@ -358,7 +358,7 @@ func (d *driver) Join(_ context.Context, nid, eid string, sboxKey string, jinfo 
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(ctx context.Context, nid, eid string) error {
 	leave := &api.LeaveRequest{
 		NetworkID:  nid,
 		EndpointID: eid,

--- a/daemon/libnetwork/drivers/remote/driver_test.go
+++ b/daemon/libnetwork/drivers/remote/driver_test.go
@@ -484,10 +484,10 @@ func TestRemoteDriver(t *testing.T) {
 	if _, err = d.EndpointOperInfo(netID, endID); err != nil {
 		t.Fatal(err)
 	}
-	if err = d.Leave(netID, endID); err != nil {
+	if err = d.Leave(context.Background(), netID, endID); err != nil {
 		t.Fatal(err)
 	}
-	if err = d.DeleteEndpoint(netID, endID); err != nil {
+	if err = d.DeleteEndpoint(context.Background(), netID, endID); err != nil {
 		t.Fatal(err)
 	}
 	if err = d.DeleteNetwork(netID); err != nil {

--- a/daemon/libnetwork/drivers/remote/driver_test.go
+++ b/daemon/libnetwork/drivers/remote/driver_test.go
@@ -490,7 +490,7 @@ func TestRemoteDriver(t *testing.T) {
 	if err = d.DeleteEndpoint(context.Background(), netID, endID); err != nil {
 		t.Fatal(err)
 	}
-	if err = d.DeleteNetwork(netID); err != nil {
+	if err = d.DeleteNetwork(context.Background(), netID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/daemon/libnetwork/drivers/windows/overlay/joinleave_windows.go
+++ b/daemon/libnetwork/drivers/windows/overlay/joinleave_windows.go
@@ -125,7 +125,7 @@ func (d *driver) DecodeTableEntry(tablename string, key string, value []byte) (s
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(ctx context.Context, nid, eid string) error {
 	if err := validateID(nid, eid); err != nil {
 		return err
 	}

--- a/daemon/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/daemon/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -212,7 +212,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	return nil
 }
 
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(ctx context.Context, nid, eid string) error {
 	if err := validateID(nid, eid); err != nil {
 		return err
 	}

--- a/daemon/libnetwork/drivers/windows/overlay/ov_network_windows.go
+++ b/daemon/libnetwork/drivers/windows/overlay/ov_network_windows.go
@@ -79,7 +79,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	existingNetwork := d.network(id)
 	if existingNetwork != nil {
 		log.G(ctx).Debugf("Network preexists. Deleting %s", id)
-		err := d.DeleteNetwork(id)
+		err := d.DeleteNetwork(ctx, id)
 		if err != nil {
 			log.G(ctx).Errorf("Error deleting stale network %s", err.Error())
 		}
@@ -156,7 +156,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	}
 
 	for _, staleNetwork := range staleNetworks {
-		d.DeleteNetwork(staleNetwork)
+		d.DeleteNetwork(ctx, staleNetwork)
 	}
 
 	n.name = networkName
@@ -185,7 +185,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	return err
 }
 
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(ctx context.Context, nid string) error {
 	if nid == "" {
 		return fmt.Errorf("invalid network id")
 	}

--- a/daemon/libnetwork/drivers/windows/windows.go
+++ b/daemon/libnetwork/drivers/windows/windows.go
@@ -812,7 +812,7 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 	return nil
 }
 
-func (d *driver) DeleteEndpoint(nid, eid string) error {
+func (d *driver) DeleteEndpoint(ctx context.Context, nid, eid string) error {
 	n, err := d.getNetwork(nid)
 	if err != nil {
 		return types.InternalMaskableErrorf("%v", err)
@@ -837,7 +837,7 @@ func (d *driver) DeleteEndpoint(nid, eid string) error {
 	}
 
 	if err := d.storeDelete(ep); err != nil {
-		log.G(context.TODO()).Warnf("Failed to remove bridge endpoint %.7s from store: %v", ep.id, err)
+		log.G(ctx).Warnf("Failed to remove bridge endpoint %.7s from store: %v", ep.id, err)
 	}
 	return nil
 }
@@ -917,7 +917,7 @@ func (d *driver) Join(ctx context.Context, nid, eid string, sboxKey string, jinf
 }
 
 // Leave method is invoked when a Sandbox detaches from an endpoint.
-func (d *driver) Leave(nid, eid string) error {
+func (d *driver) Leave(ctx context.Context, nid, eid string) error {
 	network, err := d.getNetwork(nid)
 	if err != nil {
 		return types.InternalMaskableErrorf("%v", err)

--- a/daemon/libnetwork/drivers/windows/windows.go
+++ b/daemon/libnetwork/drivers/windows/windows.go
@@ -427,7 +427,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 
 		defer func() {
 			if err != nil {
-				d.DeleteNetwork(n.id)
+				d.DeleteNetwork(ctx, n.id)
 			}
 		}()
 
@@ -476,7 +476,7 @@ func (d *driver) CreateNetwork(ctx context.Context, id string, option map[string
 	return d.storeUpdate(config)
 }
 
-func (d *driver) DeleteNetwork(nid string) error {
+func (d *driver) DeleteNetwork(ctx context.Context, nid string) error {
 	n, err := d.getNetwork(nid)
 	if err != nil {
 		return types.InternalMaskableErrorf("%v", err)
@@ -500,7 +500,7 @@ func (d *driver) DeleteNetwork(nid string) error {
 	// delete endpoints belong to this network
 	for _, ep := range n.endpoints {
 		if err := d.storeDelete(ep); err != nil {
-			log.G(context.TODO()).Warnf("Failed to remove bridge endpoint %.7s from store: %v", ep.id, err)
+			log.G(ctx).Warnf("Failed to remove bridge endpoint %.7s from store: %v", ep.id, err)
 		}
 	}
 

--- a/daemon/libnetwork/drivers/windows/windows_test.go
+++ b/daemon/libnetwork/drivers/windows/windows_test.go
@@ -51,7 +51,7 @@ func testNetwork(networkType string, t *testing.T) {
 		t.Fatalf("Failed to create an endpoint : %s", err.Error())
 	}
 
-	err = d.DeleteEndpoint("dummy", "ep1")
+	err = d.DeleteEndpoint(context.Background(), "dummy", "ep1")
 	if err != nil {
 		t.Fatalf("Failed to delete an endpoint : %s", err.Error())
 	}

--- a/daemon/libnetwork/drivers/windows/windows_test.go
+++ b/daemon/libnetwork/drivers/windows/windows_test.go
@@ -38,7 +38,7 @@ func testNetwork(networkType string, t *testing.T) {
 		t.Fatalf("Failed to create bridge: %v", err)
 	}
 	defer func() {
-		err = d.DeleteNetwork("dummy")
+		err = d.DeleteNetwork(context.Background(), "dummy")
 		if err != nil {
 			t.Fatalf("Failed to create bridge: %v", err)
 		}

--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -828,7 +828,7 @@ func (b *badDriver) CreateEndpoint(_ context.Context, nid, eid string, ifInfo dr
 	return errors.New("I will not create any endpoint")
 }
 
-func (b *badDriver) DeleteEndpoint(nid, eid string) error {
+func (b *badDriver) DeleteEndpoint(_ context.Context, nid, eid string) error {
 	return nil
 }
 
@@ -840,7 +840,7 @@ func (b *badDriver) Join(_ context.Context, nid, eid string, sboxKey string, jin
 	return errors.New("I will not allow any join")
 }
 
-func (b *badDriver) Leave(nid, eid string) error {
+func (b *badDriver) Leave(_ context.Context, nid, eid string) error {
 	return nil
 }
 

--- a/daemon/libnetwork/libnetwork_internal_test.go
+++ b/daemon/libnetwork/libnetwork_internal_test.go
@@ -820,7 +820,7 @@ func (b *badDriver) CreateNetwork(ctx context.Context, nid string, options map[s
 	return nil
 }
 
-func (b *badDriver) DeleteNetwork(nid string) error {
+func (b *badDriver) DeleteNetwork(_ context.Context, nid string) error {
 	return nil
 }
 

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -1249,7 +1249,7 @@ func (n *Network) createEndpoint(ctx context.Context, name string, options ...En
 	}
 	defer func() {
 		if err != nil {
-			if e := ep.deleteEndpoint(false); e != nil {
+			if e := ep.deleteEndpoint(ctx, false); e != nil {
 				log.G(ctx).Warnf("cleaning up endpoint failed %s : %v", name, e)
 			}
 		}

--- a/daemon/libnetwork/network.go
+++ b/daemon/libnetwork/network.go
@@ -996,7 +996,11 @@ func (n *Network) Delete(options ...NetworkDeleteOption) error {
 	for _, opt := range options {
 		opt(&params)
 	}
-	return n.delete(false, params.rmLBEndpoint)
+	ctx, span := otel.Tracer("").Start(context.TODO(), "Network.Delete", trace.WithAttributes(
+		attribute.String("network.ID", n.ID()),
+		attribute.String("network.Name", n.Name())))
+	defer span.End()
+	return n.delete(ctx, false, params.rmLBEndpoint)
 }
 
 // This function gets called in 3 ways:
@@ -1007,7 +1011,7 @@ func (n *Network) Delete(options ...NetworkDeleteOption) error {
 //     remove load balancer and network if endpoint count == 1
 //   - controller.networkCleanup() -- (true, true)
 //     remove the network no matter what
-func (n *Network) delete(force bool, rmLBEndpoint bool) error {
+func (n *Network) delete(ctx context.Context, force bool, rmLBEndpoint bool) error {
 	n.mu.Lock()
 	c := n.ctrlr
 	name := n.name
@@ -1058,7 +1062,7 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 				return err
 			}
 			// continue deletion when force is true even on error
-			log.G(context.TODO()).Warnf("Error deleting load balancer sandbox: %v", err)
+			log.G(ctx).Warnf("Error deleting load balancer sandbox: %v", err)
 		}
 	}
 
@@ -1069,7 +1073,7 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 
 	// Mark the network for deletion
 	n.inDelete = true
-	if err = c.storeNetwork(context.TODO(), n); err != nil {
+	if err = c.storeNetwork(ctx, n); err != nil {
 		return fmt.Errorf("error marking network %s (%s) for deletion: %v", n.Name(), n.ID(), err)
 	}
 
@@ -1087,7 +1091,7 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 	// bindings cleanup requires the network in the store.
 	n.cancelDriverWatches()
 	if err = n.leaveCluster(); err != nil {
-		log.G(context.TODO()).Errorf("Failed leaving network %s from the agent cluster: %v", n.Name(), err)
+		log.G(ctx).Errorf("Failed leaving network %s from the agent cluster: %v", n.Name(), err)
 	}
 
 	// Cleanup the service discovery for this network
@@ -1101,11 +1105,11 @@ func (n *Network) delete(force bool, rmLBEndpoint bool) error {
 	}
 
 	// Delete the network from the dataplane
-	if err = n.deleteNetwork(); err != nil {
+	if err = n.deleteNetwork(ctx); err != nil {
 		if !force {
 			return err
 		}
-		log.G(context.TODO()).Debugf("driver failed to delete stale network %s (%s): %v", n.Name(), n.ID(), err)
+		log.G(ctx).Debugf("driver failed to delete stale network %s (%s): %v", n.Name(), n.ID(), err)
 	}
 
 removeFromStore:
@@ -1120,7 +1124,7 @@ removeFromStore:
 	// always find it's zero (which is usually correct because the daemon had
 	// stopped), but older daemons fix it on startup anyway.
 	if err = c.deleteFromStore(&endpointCnt{n: n}); err != nil {
-		log.G(context.TODO()).Debugf("Error deleting endpoint count from store for stale network %s (%s) for deletion: %v", n.Name(), n.ID(), err)
+		log.G(ctx).Debugf("Error deleting endpoint count from store for stale network %s (%s) for deletion: %v", n.Name(), n.ID(), err)
 	}
 
 	if err = c.deleteStoredNetwork(n); err != nil {
@@ -1130,20 +1134,20 @@ removeFromStore:
 	return nil
 }
 
-func (n *Network) deleteNetwork() error {
+func (n *Network) deleteNetwork(ctx context.Context) error {
 	d, err := n.driver(true)
 	if err != nil {
 		return fmt.Errorf("failed deleting Network: %v", err)
 	}
 
-	if err := d.DeleteNetwork(n.ID()); err != nil {
+	if err := d.DeleteNetwork(ctx, n.ID()); err != nil {
 		// Forbidden Errors should be honored
 		if cerrdefs.IsPermissionDenied(err) {
 			return err
 		}
 
 		if _, ok := err.(types.MaskableError); !ok {
-			log.G(context.TODO()).Warnf("driver error deleting network %s : %v", n.name, err)
+			log.G(ctx).Warnf("driver error deleting network %s : %v", n.name, err)
 		}
 	}
 

--- a/daemon/libnetwork/network_unix.go
+++ b/daemon/libnetwork/network_unix.go
@@ -3,6 +3,7 @@
 package libnetwork
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -17,7 +18,7 @@ type platformNetwork struct{} //nolint:nolintlint,unused // only populated on wi
 
 // Stub implementations for DNS related functions
 
-func (n *Network) startResolver() {
+func (n *Network) startResolver(context.Context) {
 }
 
 func deleteEpFromResolver(epName string, epIface *EndpointInterface, resolvers []*Resolver) error {

--- a/daemon/libnetwork/resolver.go
+++ b/daemon/libnetwork/resolver.go
@@ -171,7 +171,7 @@ func (r *Resolver) SetupFunc(port uint16) func() {
 }
 
 // Start starts the name server for the container.
-func (r *Resolver) Start() error {
+func (r *Resolver) Start(ctx context.Context) error {
 	r.startCh <- struct{}{}
 	defer func() { <-r.startCh }()
 
@@ -180,7 +180,7 @@ func (r *Resolver) Start() error {
 		return r.err
 	}
 
-	if err := r.setupNAT(context.TODO()); err != nil {
+	if err := r.setupNAT(ctx); err != nil {
 		return fmt.Errorf("setting up DNAT/SNAT rules failed: %v", err)
 	}
 
@@ -188,7 +188,7 @@ func (r *Resolver) Start() error {
 	r.server = s
 	go func() {
 		if err := s.ActivateAndServe(); err != nil {
-			r.log(context.TODO()).WithError(err).Error("[resolver] failed to start PacketConn DNS server")
+			r.log(context.Background()).WithError(err).Error("[resolver] PacketConn DNS server failed")
 		}
 	}()
 
@@ -196,7 +196,7 @@ func (r *Resolver) Start() error {
 	r.tcpServer = tcpServer
 	go func() {
 		if err := tcpServer.ActivateAndServe(); err != nil {
-			r.log(context.TODO()).WithError(err).Error("[resolver] failed to start TCP DNS server")
+			r.log(context.Background()).WithError(err).Error("[resolver] TCP DNS server failed")
 		}
 	}()
 	return nil

--- a/daemon/libnetwork/sandbox_dns_unix.go
+++ b/daemon/libnetwork/sandbox_dns_unix.go
@@ -56,7 +56,7 @@ func (sb *Sandbox) rebuildHostsFile(ctx context.Context) error {
 	return nil
 }
 
-func (sb *Sandbox) startResolver(restore bool) {
+func (sb *Sandbox) startResolver(ctx context.Context, restore bool) {
 	sb.resolverOnce.Do(func() {
 		var err error
 		// The resolver is started with proxyDNS=false if the sandbox does not currently
@@ -77,19 +77,19 @@ func (sb *Sandbox) startResolver(restore bool) {
 		if !restore {
 			err = sb.rebuildDNS()
 			if err != nil {
-				log.G(context.TODO()).Errorf("Updating resolv.conf failed for container %s, %q", sb.ContainerID(), err)
+				log.G(ctx).Errorf("Updating resolv.conf failed for container %s, %q", sb.ContainerID(), err)
 				return
 			}
 		}
 		sb.resolver.SetExtServers(sb.extDNS)
 
 		if err = sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0)); err != nil {
-			log.G(context.TODO()).Errorf("Resolver Setup function failed for container %s, %q", sb.ContainerID(), err)
+			log.G(ctx).Errorf("Resolver Setup function failed for container %s, %q", sb.ContainerID(), err)
 			return
 		}
 
-		if err = sb.resolver.Start(); err != nil {
-			log.G(context.TODO()).Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
+		if err = sb.resolver.Start(ctx); err != nil {
+			log.G(ctx).Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
 		}
 	})
 }

--- a/daemon/libnetwork/sandbox_dns_unix_test.go
+++ b/daemon/libnetwork/sandbox_dns_unix_test.go
@@ -37,7 +37,7 @@ func TestDNSOptions(t *testing.T) {
 	}
 
 	defer cleanup(sb)
-	sb.startResolver(false)
+	sb.startResolver(context.Background(), false)
 
 	err = sb.setupDNS()
 	assert.NilError(t, err)
@@ -63,7 +63,7 @@ func TestDNSOptions(t *testing.T) {
 	sb2, err := c.NewSandbox(context.Background(), "cnt2", nil)
 	assert.NilError(t, err)
 	defer cleanup(sb2)
-	sb2.startResolver(false)
+	sb2.startResolver(context.Background(), false)
 
 	sb2.config.dnsOptionsList = []string{"ndots:0"}
 	err = sb2.setupDNS()

--- a/daemon/libnetwork/sandbox_linux.go
+++ b/daemon/libnetwork/sandbox_linux.go
@@ -187,7 +187,7 @@ func (sb *Sandbox) SetKey(ctx context.Context, basePath string) error {
 		sb.resolver.Stop()
 
 		if err := sb.osSbox.InvokeFunc(sb.resolver.SetupFunc(0)); err == nil {
-			if err := sb.resolver.Start(); err != nil {
+			if err := sb.resolver.Start(ctx); err != nil {
 				log.G(ctx).Errorf("Resolver Start failed for container %s, %q", sb.ContainerID(), err)
 			}
 		} else {
@@ -294,7 +294,7 @@ func (sb *Sandbox) restoreOslSandbox() error {
 			routes = append(routes, joinInfo.StaticRoutes...)
 		}
 		if ep.needResolver() {
-			sb.startResolver(true)
+			sb.startResolver(context.TODO(), true)
 		}
 	}
 
@@ -365,7 +365,7 @@ func (sb *Sandbox) populateNetworkResourcesOS(ctx context.Context, ep *Endpoint)
 	ep.mu.Unlock()
 
 	if ep.needResolver() {
-		sb.startResolver(false)
+		sb.startResolver(ctx, false)
 	}
 
 	if i != nil && i.srcName != "" {

--- a/daemon/libnetwork/store.go
+++ b/daemon/libnetwork/store.go
@@ -127,11 +127,11 @@ retry:
 	return nil
 }
 
-func (c *Controller) networkCleanup() {
+func (c *Controller) networkCleanup(ctx context.Context) {
 	for _, n := range c.getNetworksFromStore(context.TODO()) {
 		if n.inDelete {
 			log.G(context.TODO()).Infof("Removing stale network %s (%s)", n.Name(), n.ID())
-			if err := n.delete(true, true); err != nil {
+			if err := n.delete(ctx, true, true); err != nil {
 				log.G(context.TODO()).Debugf("Error while removing stale network: %v", err)
 			}
 		}

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -105,6 +105,7 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 		"exitCode":     strconv.Itoa(ctrExitStatus.ExitCode),
 		"execDuration": strconv.Itoa(int(execDuration.Seconds())),
 	}
+
 	daemon.Cleanup(context.TODO(), c)
 
 	if restart {

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -268,6 +268,10 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 // Cleanup releases any network resources allocated to the container along with any rules
 // around how containers are linked together.  It also unmounts the container's root filesystem.
 func (daemon *Daemon) Cleanup(ctx context.Context, container *container.Container) {
+	ctx, span := otel.Tracer("").Start(ctx, "daemon.Cleanup", trace.WithAttributes(
+		attribute.String("container.ID", container.ID), attribute.String("container.Name", container.Name)))
+	defer span.End()
+
 	// Microsoft HCS containers get in a bad state if host resources are
 	// released while the container still exists.
 	if ctr, ok := container.State.C8dContainer(); ok {


### PR DESCRIPTION
**- What I did**

Passed context though to the code that sets up DNS in the containter's netns, so its `nftApply` shows up in the container-start's OTEL trace etc. Container cleanup generated several low-level OTEL spans with no clear parent, fixed that too.

**- How I did it**

Passed context to more places.

**- How to verify it**

The nftApply trace belonging to container start is in the right place now ...
<img width="1043" height="60" alt="container-start-execnft-resolver" src="https://github.com/user-attachments/assets/8e0c744b-098d-480c-b5c5-e616994835c6" />

And, fewer top level spans for container exit ...

Before ...
<img width="1065" height="1457" alt="container-exit-before" src="https://github.com/user-attachments/assets/79831bd0-58e0-42f1-8159-d6bf35b8017b" />
After ...
<img width="1070" height="612" alt="container-exit-after" src="https://github.com/user-attachments/assets/292281dd-8ff9-4e46-b350-f97105edf6ed" />

(It could be improved further by adding spans further up the call chain.)

**- Human readable description for the release notes**
```markdown changelog

```

