### PR TITLE
daemon/command: disable c8d snapshotter when userns remapping enabled

### DIFF
--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -26,7 +26,7 @@ func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *testing.T) {
 	testRequires(c, UserNamespaceInKernel)
 
 	ctx := testutil.GetContext(c)
-	s.d.StartWithBusybox(ctx, c, "--userns-remap", "default")
+	s.d.StartWithBusybox(ctx, c, "--userns-remap", "default", "--storage-driver", "vfs")
 
 	out, err := s.d.Cmd("run", "busybox", "stat", "-c", "%u:%g", "/bin/cat")
 	assert.Check(c, err)

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -38,8 +38,8 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	dUserRemap := daemon.New(t)
-	dUserRemap.Start(t, "--userns-remap", "default")
+	dUserRemap := daemon.New(t, daemon.WithUserNsRemap("default"))
+	dUserRemap.Start(t)
 	clientUserRemap := dUserRemap.NewClientT(t)
 	defer clientUserRemap.Close()
 


### PR DESCRIPTION
- Temporary workaround for https://github.com/moby/moby/issues/47377

**- What I did**

Buildkit fails when userns remapping is enabled and c8d snapshotter is used. As a temporary workaround, disable c8d snapshotter when userns remapping is enabled. This will need a proper fix in the future.

**- How to verify it**

```shell
# Should return nothing
$ docker info | grep snapshotter

# Should build successfully
$ echo -e 'FROM alpine\nRUN /bin/true' >Dockerfile.test
$ docker build -f Dockerfile.test --no-cache .
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- containerd image store is temporarily not available when userns remapping is enabled as a workaround for [moby#47377](https://github.com/moby/moby/issues/47377)
```
