### PR TITLE
client/checkpoint_list: Wrap result in a struct

### DIFF
--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"context"
-
-	"github.com/moby/moby/api/types/checkpoint"
 )
 
 // CheckpointAPIClient defines API client methods for the checkpoints.
@@ -14,5 +12,5 @@ import (
 type CheckpointAPIClient interface {
 	CheckpointCreate(ctx context.Context, container string, options CheckpointCreateOptions) error
 	CheckpointDelete(ctx context.Context, container string, options CheckpointDeleteOptions) error
-	CheckpointList(ctx context.Context, container string, options CheckpointListOptions) ([]checkpoint.Summary, error)
+	CheckpointList(ctx context.Context, container string, options CheckpointListOptions) (CheckpointListResult, error)
 }

--- a/client/checkpoint_list.go
+++ b/client/checkpoint_list.go
@@ -13,9 +13,14 @@ type CheckpointListOptions struct {
 	CheckpointDir string
 }
 
+// CheckpointListResult holds the result from the CheckpointList method.
+type CheckpointListResult struct {
+	Checkpoints []checkpoint.Summary
+}
+
 // CheckpointList returns the checkpoints of the given container in the docker host.
-func (cli *Client) CheckpointList(ctx context.Context, container string, options CheckpointListOptions) ([]checkpoint.Summary, error) {
-	var checkpoints []checkpoint.Summary
+func (cli *Client) CheckpointList(ctx context.Context, container string, options CheckpointListOptions) (CheckpointListResult, error) {
+	var out CheckpointListResult
 
 	query := url.Values{}
 	if options.CheckpointDir != "" {
@@ -25,9 +30,9 @@ func (cli *Client) CheckpointList(ctx context.Context, container string, options
 	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return checkpoints, err
+		return out, err
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&checkpoints)
-	return checkpoints, err
+	err = json.NewDecoder(resp.Body).Decode(&out.Checkpoints)
+	return out, err
 }

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -48,9 +48,9 @@ func TestCheckpointList(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	checkpoints, err := client.CheckpointList(context.Background(), "container_id", CheckpointListOptions{})
+	res, err := client.CheckpointList(context.Background(), "container_id", CheckpointListOptions{})
 	assert.NilError(t, err)
-	assert.Check(t, is.Len(checkpoints, 1))
+	assert.Check(t, is.Len(res.Checkpoints, 1))
 }
 
 func TestCheckpointListContainerNotFound(t *testing.T) {

--- a/integration/container/checkpoint_test.go
+++ b/integration/container/checkpoint_test.go
@@ -77,10 +77,10 @@ func TestCheckpoint(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(true, inspect.State.Running))
 
-	checkpoints, err := apiClient.CheckpointList(ctx, cID, client.CheckpointListOptions{})
+	res, err := apiClient.CheckpointList(ctx, cID, client.CheckpointListOptions{})
 	assert.NilError(t, err)
-	assert.Equal(t, len(checkpoints), 1)
-	assert.Equal(t, checkpoints[0].Name, "test")
+	assert.Equal(t, len(res.Checkpoints), 1)
+	assert.Equal(t, res.Checkpoints[0].Name, "test")
 
 	// Create a test file on a tmpfs mount.
 	cmd := []string{"touch", "/tmp/test-file"}
@@ -103,11 +103,11 @@ func TestCheckpoint(t *testing.T) {
 	assert.Check(t, is.Equal(false, inspect.State.Running))
 
 	// Check that both checkpoints are listed.
-	checkpoints, err = apiClient.CheckpointList(ctx, cID, client.CheckpointListOptions{})
+	res, err = apiClient.CheckpointList(ctx, cID, client.CheckpointListOptions{})
 	assert.NilError(t, err)
-	assert.Equal(t, len(checkpoints), 2)
+	assert.Equal(t, len(res.Checkpoints), 2)
 	cptNames := make([]string, 2)
-	for i, c := range checkpoints {
+	for i, c := range res.Checkpoints {
 		cptNames[i] = c.Name
 	}
 	sort.Strings(cptNames)

--- a/vendor/github.com/moby/moby/client/checkpoint.go
+++ b/vendor/github.com/moby/moby/client/checkpoint.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"context"
-
-	"github.com/moby/moby/api/types/checkpoint"
 )
 
 // CheckpointAPIClient defines API client methods for the checkpoints.
@@ -14,5 +12,5 @@ import (
 type CheckpointAPIClient interface {
 	CheckpointCreate(ctx context.Context, container string, options CheckpointCreateOptions) error
 	CheckpointDelete(ctx context.Context, container string, options CheckpointDeleteOptions) error
-	CheckpointList(ctx context.Context, container string, options CheckpointListOptions) ([]checkpoint.Summary, error)
+	CheckpointList(ctx context.Context, container string, options CheckpointListOptions) (CheckpointListResult, error)
 }

--- a/vendor/github.com/moby/moby/client/checkpoint_list.go
+++ b/vendor/github.com/moby/moby/client/checkpoint_list.go
@@ -13,9 +13,14 @@ type CheckpointListOptions struct {
 	CheckpointDir string
 }
 
+// CheckpointListResult holds the result from the CheckpointList method.
+type CheckpointListResult struct {
+	Checkpoints []checkpoint.Summary
+}
+
 // CheckpointList returns the checkpoints of the given container in the docker host.
-func (cli *Client) CheckpointList(ctx context.Context, container string, options CheckpointListOptions) ([]checkpoint.Summary, error) {
-	var checkpoints []checkpoint.Summary
+func (cli *Client) CheckpointList(ctx context.Context, container string, options CheckpointListOptions) (CheckpointListResult, error) {
+	var out CheckpointListResult
 
 	query := url.Values{}
 	if options.CheckpointDir != "" {
@@ -25,9 +30,9 @@ func (cli *Client) CheckpointList(ctx context.Context, container string, options
 	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return checkpoints, err
+		return out, err
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&checkpoints)
-	return checkpoints, err
+	err = json.NewDecoder(resp.Body).Decode(&out.Checkpoints)
+	return out, err
 }


### PR DESCRIPTION
The CheckpointList method previously returned a raw slice of checkpoint.Summary, which made it difficult to extend the API response with additional metadata or fields in the future without breaking backward compatibility.