### PR TITLE
[28.x backport] api/checkpoint: Don't return null if no checkpoints

### DIFF
--- a/api/server/router/checkpoint/checkpoint_routes.go
+++ b/api/server/router/checkpoint/checkpoint_routes.go
@@ -38,6 +38,9 @@ func (cr *checkpointRouter) getContainerCheckpoints(ctx context.Context, w http.
 	if err != nil {
 		return err
 	}
+	if checkpoints == nil {
+		checkpoints = []checkpoint.Summary{}
+	}
 
 	return httputils.WriteJSON(w, http.StatusOK, checkpoints)
 }


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/51051

- related to: https://github.com/moby/moby/pull/51050#issuecomment-3338979094

This fixes a bug where no checkpoints would produce a `null` response instead of an empty array:

```
$ docker run -d --name foo nginx:alpine
17fbeff7185733f101c38cb8208359dd0ef141116a1345da2d3c3f58c11f3e14

$ curl --unix-socket /var/run/docker.sock http://local/containers/foo/checkpoints
null
```

With this patch, this becomes:
```
$ curl --unix-socket /var/run/docker.sock http://local/containers/foo/checkpoints
[]
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `GET containers/{name}/checkpoints` returning `null` instead of empty JSON array when there are no checkpoints.
```

**- A picture of a cute animal (not mandatory but encouraged)**

