### PR TITLE
vendor: github.com/deckarep/golang-set/v2 v2.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/cpuguy83/tar2go v0.3.1
 	github.com/creack/pty v1.1.24
-	github.com/deckarep/golang-set/v2 v2.3.0
+	github.com/deckarep/golang-set/v2 v2.8.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/docker/go-connections v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckarep/golang-set/v2 v2.3.0 h1:qs18EKUfHm2X9fA50Mr/M5hccg2tNnVqsiBImnyDs0g=
-github.com/deckarep/golang-set/v2 v2.3.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
+github.com/deckarep/golang-set/v2 v2.8.0 h1:swm0rlPCmdWn9mESxKOjWk8hXSqoxOp+ZlfuyaAdFlQ=
+github.com/deckarep/golang-set/v2 v2.8.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/vendor/github.com/deckarep/golang-set/v2/.gitignore
+++ b/vendor/github.com/deckarep/golang-set/v2/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+.idea

--- a/vendor/github.com/deckarep/golang-set/v2/README.md
+++ b/vendor/github.com/deckarep/golang-set/v2/README.md
@@ -6,6 +6,20 @@
 
 The missing `generic` set collection for the Go language.  Until Go has sets built-in...use this.
 
+## Psst
+* Hi there, 👋! Do you use or have interest in the [Zig programming language](https://ziglang.org/) created by Andrew Kelley? If so, the golang-set project has a new sibling project: [ziglang-set](https://github.com/deckarep/ziglang-set)! Come check it out!
+
+## Update 3/14/2025
+* Packaged version: `2.8.0` introduces support for true iterators for Go 1.23+. Please see [issue #141](https://github.com/deckarep/golang-set/issues/141)
+for further details on the implications of how iterations work between older Go versions vs newer Go versions. Additionally, this
+release has a minor unit-test spelling fix.
+
+## Update 12/3/2024
+* Packaged version: `2.7.0` fixes a long-standing bug with *JSON Unmarshaling*. A large refactor in the interest of performance
+introduced this bug and there was no way around it but to revert the code back to how it was previously. The performance
+difference was likely negligible to begin with. JSON Marshaling and Unmarshaling is now properly supported again without
+needing to do workarounds.
+
 ## Update 3/5/2023
 * Packaged version: `2.2.0` release includes a refactor to minimize pointer indirection, better method documentation standards and a few constructor convenience methods to increase ergonomics when appending items `Append` or creating a new set from an exist `Map`.
 * supports `new generic` syntax
@@ -16,6 +30,14 @@ The missing `generic` set collection for the Go language.  Until Go has sets bui
 
 Coming from Python one of the things I miss is the superbly wonderful set collection.  This is my attempt to mimic the primary features of the set collection from Python.
 You can of course argue that there is no need for a set in Go, otherwise the creators would have added one to the standard library.  To those I say simply ignore this repository and carry-on and to the rest that find this useful please contribute in helping me make it better by contributing with suggestions or PRs.
+
+## Install
+
+Use `go get` to install this package.
+
+```shell
+go get github.com/deckarep/golang-set/v2
+```
 
 ## Features
 
@@ -63,7 +85,7 @@ mySet := mapset.NewSet[int]()
 // Or perhaps you want a string set
 mySet := mapset.NewSet[string]()
 
-type myStruct {
+type myStruct struct {
   name string
   age uint8
 }

--- a/vendor/github.com/deckarep/golang-set/v2/set.go
+++ b/vendor/github.com/deckarep/golang-set/v2/set.go
@@ -62,6 +62,21 @@ type Set[T comparable] interface {
 	// are all in the set.
 	Contains(val ...T) bool
 
+	// ContainsOne returns whether the given item
+	// is in the set.
+	//
+	// Contains may cause the argument to escape to the heap.
+	// See: https://github.com/deckarep/golang-set/issues/118
+	ContainsOne(val T) bool
+
+	// ContainsAny returns whether at least one of the
+	// given items are in the set.
+	ContainsAny(val ...T) bool
+
+	// ContainsAnyElement returns whether at least one of the
+	// given element are in the set.
+	ContainsAnyElement(other Set[T]) bool
+
 	// Difference returns the difference between this set
 	// and other. The returned set will contain
 	// all elements of this set that are not also
@@ -92,6 +107,9 @@ type Set[T comparable] interface {
 	// of the method. Otherwise, Intersect will
 	// panic.
 	Intersect(other Set[T]) Set[T]
+
+	// IsEmpty determines if there are elements in the set.
+	IsEmpty() bool
 
 	// IsProperSubset determines if every element in this set is in
 	// the other set but the two sets are not equal.
@@ -165,7 +183,7 @@ type Set[T comparable] interface {
 	//
 	// Note that the argument to Union must be of the
 	// same type as the receiver of the method.
-	// Otherwise, IsSuperset will panic.
+	// Otherwise, Union will panic.
 	Union(other Set[T]) Set[T]
 
 	// Pop removes and returns an arbitrary item from the set.
@@ -238,4 +256,14 @@ func NewThreadUnsafeSetFromMapKeys[T comparable, V any](val map[T]V) Set[T] {
 	}
 
 	return s
+}
+
+// Elements returns an iterator that yields the elements of the set. Starting
+// with Go 1.23, users can use a for loop to iterate over it.
+func Elements[T comparable](s Set[T]) func(func(element T) bool) {
+	return func(yield func(element T) bool) {
+		s.Each(func(t T) bool {
+			return !yield(t)
+		})
+	}
 }

--- a/vendor/github.com/deckarep/golang-set/v2/sorted.go
+++ b/vendor/github.com/deckarep/golang-set/v2/sorted.go
@@ -1,0 +1,42 @@
+//go:build go1.21
+// +build go1.21
+
+/*
+Open Source Initiative OSI - The MIT License (MIT):Licensing
+
+The MIT License (MIT)
+Copyright (c) 2013 - 2023 Ralph Caraveo (deckarep@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package mapset
+
+import (
+	"cmp"
+	"slices"
+)
+
+// Sorted returns a sorted slice of a set of any ordered type in ascending order.
+// When sorting floating-point numbers, NaNs are ordered before other values.
+func Sorted[E cmp.Ordered](set Set[E]) []E {
+	s := set.ToSlice()
+	slices.Sort(s)
+	return s
+}

--- a/vendor/github.com/deckarep/golang-set/v2/threadunsafe.go
+++ b/vendor/github.com/deckarep/golang-set/v2/threadunsafe.go
@@ -26,7 +26,6 @@ SOFTWARE.
 package mapset
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -35,14 +34,16 @@ import (
 type threadUnsafeSet[T comparable] map[T]struct{}
 
 // Assert concrete type:threadUnsafeSet adheres to Set interface.
-var _ Set[string] = (threadUnsafeSet[string])(nil)
+var _ Set[string] = (*threadUnsafeSet[string])(nil)
 
-func newThreadUnsafeSet[T comparable]() threadUnsafeSet[T] {
-	return make(threadUnsafeSet[T])
+func newThreadUnsafeSet[T comparable]() *threadUnsafeSet[T] {
+	t := make(threadUnsafeSet[T])
+	return &t
 }
 
-func newThreadUnsafeSetWithSize[T comparable](cardinality int) threadUnsafeSet[T] {
-	return make(threadUnsafeSet[T], cardinality)
+func newThreadUnsafeSetWithSize[T comparable](cardinality int) *threadUnsafeSet[T] {
+	t := make(threadUnsafeSet[T], cardinality)
+	return &t
 }
 
 func (s threadUnsafeSet[T]) Add(v T) bool {
@@ -51,60 +52,94 @@ func (s threadUnsafeSet[T]) Add(v T) bool {
 	return prevLen != len(s)
 }
 
-func (s threadUnsafeSet[T]) Append(v ...T) int {
-	prevLen := len(s)
+func (s *threadUnsafeSet[T]) Append(v ...T) int {
+	prevLen := len(*s)
 	for _, val := range v {
-		(s)[val] = struct{}{}
+		(*s)[val] = struct{}{}
 	}
-	return len(s) - prevLen
+	return len(*s) - prevLen
 }
 
 // private version of Add which doesn't return a value
-func (s threadUnsafeSet[T]) add(v T) {
-	s[v] = struct{}{}
+func (s *threadUnsafeSet[T]) add(v T) {
+	(*s)[v] = struct{}{}
 }
 
-func (s threadUnsafeSet[T]) Cardinality() int {
-	return len(s)
+func (s *threadUnsafeSet[T]) Cardinality() int {
+	return len(*s)
 }
 
-func (s threadUnsafeSet[T]) Clear() {
+func (s *threadUnsafeSet[T]) Clear() {
 	// Constructions like this are optimised by compiler, and replaced by
 	// mapclear() function, defined in
 	// https://github.com/golang/go/blob/29bbca5c2c1ad41b2a9747890d183b6dd3a4ace4/src/runtime/map.go#L993)
-	for key := range s {
-		delete(s, key)
+	for key := range *s {
+		delete(*s, key)
 	}
 }
 
-func (s threadUnsafeSet[T]) Clone() Set[T] {
+func (s *threadUnsafeSet[T]) Clone() Set[T] {
 	clonedSet := newThreadUnsafeSetWithSize[T](s.Cardinality())
-	for elem := range s {
+	for elem := range *s {
 		clonedSet.add(elem)
 	}
 	return clonedSet
 }
 
-func (s threadUnsafeSet[T]) Contains(v ...T) bool {
+func (s *threadUnsafeSet[T]) Contains(v ...T) bool {
 	for _, val := range v {
-		if _, ok := s[val]; !ok {
+		if _, ok := (*s)[val]; !ok {
 			return false
 		}
 	}
 	return true
 }
 
-// private version of Contains for a single element v
-func (s threadUnsafeSet[T]) contains(v T) (ok bool) {
-	_, ok = s[v]
+func (s *threadUnsafeSet[T]) ContainsOne(v T) bool {
+	_, ok := (*s)[v]
 	return ok
 }
 
-func (s threadUnsafeSet[T]) Difference(other Set[T]) Set[T] {
-	o := other.(threadUnsafeSet[T])
+func (s *threadUnsafeSet[T]) ContainsAny(v ...T) bool {
+	for _, val := range v {
+		if _, ok := (*s)[val]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *threadUnsafeSet[T]) ContainsAnyElement(other Set[T]) bool {
+	o := other.(*threadUnsafeSet[T])
+
+	// loop over smaller set
+	if s.Cardinality() < other.Cardinality() {
+		for elem := range *s {
+			if o.contains(elem) {
+				return true
+			}
+		}
+	} else {
+		for elem := range *o {
+			if s.contains(elem) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// private version of Contains for a single element v
+func (s *threadUnsafeSet[T]) contains(v T) (ok bool) {
+	_, ok = (*s)[v]
+	return ok
+}
+
+func (s *threadUnsafeSet[T]) Difference(other Set[T]) Set[T] {
+	o := other.(*threadUnsafeSet[T])
 
 	diff := newThreadUnsafeSet[T]()
-	for elem := range s {
+	for elem := range *s {
 		if !o.contains(elem) {
 			diff.add(elem)
 		}
@@ -112,21 +147,21 @@ func (s threadUnsafeSet[T]) Difference(other Set[T]) Set[T] {
 	return diff
 }
 
-func (s threadUnsafeSet[T]) Each(cb func(T) bool) {
-	for elem := range s {
+func (s *threadUnsafeSet[T]) Each(cb func(T) bool) {
+	for elem := range *s {
 		if cb(elem) {
 			break
 		}
 	}
 }
 
-func (s threadUnsafeSet[T]) Equal(other Set[T]) bool {
-	o := other.(threadUnsafeSet[T])
+func (s *threadUnsafeSet[T]) Equal(other Set[T]) bool {
+	o := other.(*threadUnsafeSet[T])
 
 	if s.Cardinality() != other.Cardinality() {
 		return false
 	}
-	for elem := range s {
+	for elem := range *s {
 		if !o.contains(elem) {
 			return false
 		}
@@ -134,19 +169,19 @@ func (s threadUnsafeSet[T]) Equal(other Set[T]) bool {
 	return true
 }
 
-func (s threadUnsafeSet[T]) Intersect(other Set[T]) Set[T] {
-	o := other.(threadUnsafeSet[T])
+func (s *threadUnsafeSet[T]) Intersect(other Set[T]) Set[T] {
+	o := other.(*threadUnsafeSet[T])
 
 	intersection := newThreadUnsafeSet[T]()
 	// loop over smaller set
 	if s.Cardinality() < other.Cardinality() {
-		for elem := range s {
+		for elem := range *s {
 			if o.contains(elem) {
 				intersection.add(elem)
 			}
 		}
 	} else {
-		for elem := range o {
+		for elem := range *o {
 			if s.contains(elem) {
 				intersection.add(elem)
 			}
@@ -155,20 +190,24 @@ func (s threadUnsafeSet[T]) Intersect(other Set[T]) Set[T] {
 	return intersection
 }
 
-func (s threadUnsafeSet[T]) IsProperSubset(other Set[T]) bool {
+func (s *threadUnsafeSet[T]) IsEmpty() bool {
+	return s.Cardinality() == 0
+}
+
+func (s *threadUnsafeSet[T]) IsProperSubset(other Set[T]) bool {
 	return s.Cardinality() < other.Cardinality() && s.IsSubset(other)
 }
 
-func (s threadUnsafeSet[T]) IsProperSuperset(other Set[T]) bool {
+func (s *threadUnsafeSet[T]) IsProperSuperset(other Set[T]) bool {
 	return s.Cardinality() > other.Cardinality() && s.IsSuperset(other)
 }
 
-func (s threadUnsafeSet[T]) IsSubset(other Set[T]) bool {
-	o := other.(threadUnsafeSet[T])
+func (s *threadUnsafeSet[T]) IsSubset(other Set[T]) bool {
+	o := other.(*threadUnsafeSet[T])
 	if s.Cardinality() > other.Cardinality() {
 		return false
 	}
-	for elem := range s {
+	for elem := range *s {
 		if !o.contains(elem) {
 			return false
 		}
@@ -176,14 +215,14 @@ func (s threadUnsafeSet[T]) IsSubset(other Set[T]) bool {
 	return true
 }
 
-func (s threadUnsafeSet[T]) IsSuperset(other Set[T]) bool {
+func (s *threadUnsafeSet[T]) IsSuperset(other Set[T]) bool {
 	return other.IsSubset(s)
 }
 
-func (s threadUnsafeSet[T]) Iter() <-chan T {
+func (s *threadUnsafeSet[T]) Iter() <-chan T {
 	ch := make(chan T)
 	go func() {
-		for elem := range s {
+		for elem := range *s {
 			ch <- elem
 		}
 		close(ch)
@@ -192,12 +231,12 @@ func (s threadUnsafeSet[T]) Iter() <-chan T {
 	return ch
 }
 
-func (s threadUnsafeSet[T]) Iterator() *Iterator[T] {
+func (s *threadUnsafeSet[T]) Iterator() *Iterator[T] {
 	iterator, ch, stopCh := newIterator[T]()
 
 	go func() {
 	L:
-		for elem := range s {
+		for elem := range *s {
 			select {
 			case <-stopCh:
 				break L
@@ -212,9 +251,9 @@ func (s threadUnsafeSet[T]) Iterator() *Iterator[T] {
 
 // Pop returns a popped item in case set is not empty, or nil-value of T
 // if set is already empty
-func (s threadUnsafeSet[T]) Pop() (v T, ok bool) {
-	for item := range s {
-		delete(s, item)
+func (s *threadUnsafeSet[T]) Pop() (v T, ok bool) {
+	for item := range *s {
+		delete(*s, item)
 		return item, true
 	}
 	return v, false
@@ -239,16 +278,16 @@ func (s threadUnsafeSet[T]) String() string {
 	return fmt.Sprintf("Set{%s}", strings.Join(items, ", "))
 }
 
-func (s threadUnsafeSet[T]) SymmetricDifference(other Set[T]) Set[T] {
-	o := other.(threadUnsafeSet[T])
+func (s *threadUnsafeSet[T]) SymmetricDifference(other Set[T]) Set[T] {
+	o := other.(*threadUnsafeSet[T])
 
 	sd := newThreadUnsafeSet[T]()
-	for elem := range s {
+	for elem := range *s {
 		if !o.contains(elem) {
 			sd.add(elem)
 		}
 	}
-	for elem := range o {
+	for elem := range *o {
 		if !s.contains(elem) {
 			sd.add(elem)
 		}
@@ -266,7 +305,7 @@ func (s threadUnsafeSet[T]) ToSlice() []T {
 }
 
 func (s threadUnsafeSet[T]) Union(other Set[T]) Set[T] {
-	o := other.(threadUnsafeSet[T])
+	o := other.(*threadUnsafeSet[T])
 
 	n := s.Cardinality()
 	if o.Cardinality() > n {
@@ -277,10 +316,10 @@ func (s threadUnsafeSet[T]) Union(other Set[T]) Set[T] {
 	for elem := range s {
 		unionedSet.add(elem)
 	}
-	for elem := range o {
+	for elem := range *o {
 		unionedSet.add(elem)
 	}
-	return unionedSet
+	return &unionedSet
 }
 
 // MarshalJSON creates a JSON array from the set, it marshals all elements
@@ -301,25 +340,13 @@ func (s threadUnsafeSet[T]) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON recreates a set from a JSON array, it only decodes
 // primitive types. Numbers are decoded as json.Number.
-func (s threadUnsafeSet[T]) UnmarshalJSON(b []byte) error {
-	var i []any
-
-	d := json.NewDecoder(bytes.NewReader(b))
-	d.UseNumber()
-	err := d.Decode(&i)
+func (s *threadUnsafeSet[T]) UnmarshalJSON(b []byte) error {
+	var i []T
+	err := json.Unmarshal(b, &i)
 	if err != nil {
 		return err
 	}
-
-	for _, v := range i {
-		switch t := v.(type) {
-		case T:
-			s.add(t)
-		default:
-			// anything else must be skipped.
-			continue
-		}
-	}
+	s.Append(i...)
 
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -479,7 +479,7 @@ github.com/cyphar/filepath-securejoin
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/deckarep/golang-set/v2 v2.3.0
+# github.com/deckarep/golang-set/v2 v2.8.0
 ## explicit; go 1.18
 github.com/deckarep/golang-set/v2
 # github.com/dimchansky/utfbom v1.1.1


### PR DESCRIPTION
- feat: Support 1.23 iterator for set
- feat: add ContainsAnyElement method
- feat: add ContainsOne method
- feat: add IsEmpty functionality to set
- feat: add Sorted method
- feat: add ContainsAny functionality to Set
- Switch to pointer receivers, fixes UnmarshalJSON
    - fixes Unmarshalling threadUnsafeSet with json.Unmarshal panics

full diff: https://github.com/deckarep/golang-set/compare/v2.3.0...v2.8.0


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

