### PR TITLE
api/types/registry: remove deprecated AuthConfig.Email field

### DIFF
--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```
@@ -2103,12 +2102,6 @@ definitions:
       username:
         type: "string"
       password:
-        type: "string"
-      email:
-        description: |
-          Email is an optional value associated with the username.
-
-          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```
@@ -2103,12 +2102,6 @@ definitions:
       username:
         type: "string"
       password:
-        type: "string"
-      email:
-        description: |
-          Email is an optional value associated with the username.
-
-          > **Deprecated**: This field is deprecated since docker 1.11 (API v1.23) and will be removed in a future release.
         type: "string"
       serveraddress:
         type: "string"

--- a/api/types/registry/authconfig.go
+++ b/api/types/registry/authconfig.go
@@ -24,11 +24,6 @@ type AuthConfig struct {
 	Password string `json:"password,omitempty"`
 	Auth     string `json:"auth,omitempty"`
 
-	// Email is an optional value associated with the username.
-	//
-	// Deprecated: This field is deprecated since docker 1.11 (API v1.23) and will be removed in the next release.
-	Email string `json:"email,omitempty"`
-
 	ServerAddress string `json:"serveraddress,omitempty"`
 
 	// IdentityToken is used to authenticate the user and get

--- a/vendor/github.com/moby/moby/api/types/registry/authconfig.go
+++ b/vendor/github.com/moby/moby/api/types/registry/authconfig.go
@@ -24,11 +24,6 @@ type AuthConfig struct {
 	Password string `json:"password,omitempty"`
 	Auth     string `json:"auth,omitempty"`
 
-	// Email is an optional value associated with the username.
-	//
-	// Deprecated: This field is deprecated since docker 1.11 (API v1.23) and will be removed in the next release.
-	Email string `json:"email,omitempty"`
-
 	ServerAddress string `json:"serveraddress,omitempty"`
 
 	// IdentityToken is used to authenticate the user and get


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/20565
- https://github.com/moby/moby/pull/50792


This field was no longer used since Docker 1.11 (API version 1.23) through [moby@aee260d] and [engine-api@9a9e468] but kept, and deprecated in [engine-api@167efc7] with a fix-up in [moby@6cfff7e8803a7].

This patch removes the field so that we don't have to carry it in the new moby/api module.

[moby@aee260d]: https://github.com/moby/moby/commit/aee260d4eb3aa0fc86ee5038010b7bbc24512ae5
[engine-api@9a9e468]: https://github.com/docker-archive-public/docker.engine-api/commit/9a9e468f503eb731d6fdc9d7f98c122e1b397c86
[engine-api@167efc7]: https://github.com/docker-archive-public/docker.engine-api/commit/167efc72bb24d7ad2bcc91760a9a5d37572e104f
[moby@6cfff7e8803a7]: https://github.com/moby/moby/commit/6cfff7e8803a71b4acb74768b5121e7d17a9e098

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/registry: remove deprecated AuthConfig.Email field
```

**- A picture of a cute animal (not mandatory but encouraged)**

