### PR TITLE
[28.x backport] api/docs: remove email field from example auth

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.25.yaml
+++ b/docs/api/v1.25.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.26.yaml
+++ b/docs/api/v1.26.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.27.yaml
+++ b/docs/api/v1.27.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.28.yaml
+++ b/docs/api/v1.28.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.29.yaml
+++ b/docs/api/v1.29.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.30.yaml
+++ b/docs/api/v1.30.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.31.yaml
+++ b/docs/api/v1.31.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.32.yaml
+++ b/docs/api/v1.32.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.33.yaml
+++ b/docs/api/v1.33.yaml
@@ -60,7 +60,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.34.yaml
+++ b/docs/api/v1.34.yaml
@@ -62,7 +62,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.35.yaml
+++ b/docs/api/v1.35.yaml
@@ -71,7 +71,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.36.yaml
+++ b/docs/api/v1.36.yaml
@@ -71,7 +71,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.37.yaml
+++ b/docs/api/v1.37.yaml
@@ -71,7 +71,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.38.yaml
+++ b/docs/api/v1.38.yaml
@@ -71,7 +71,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.39.yaml
+++ b/docs/api/v1.39.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.40.yaml
+++ b/docs/api/v1.40.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.41.yaml
+++ b/docs/api/v1.41.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.42.yaml
+++ b/docs/api/v1.42.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.43.yaml
+++ b/docs/api/v1.43.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.44.yaml
+++ b/docs/api/v1.44.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.45.yaml
+++ b/docs/api/v1.45.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.46.yaml
+++ b/docs/api/v1.46.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.47.yaml
+++ b/docs/api/v1.47.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.48.yaml
+++ b/docs/api/v1.48.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.49.yaml
+++ b/docs/api/v1.49.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.50.yaml
+++ b/docs/api/v1.50.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```

--- a/docs/api/v1.51.yaml
+++ b/docs/api/v1.51.yaml
@@ -81,7 +81,6 @@ info:
     {
       "username": "string",
       "password": "string",
-      "email": "string",
       "serveraddress": "string"
     }
     ```


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51060

relates to:

- https://github.com/moby/moby/pull/20565
- https://github.com/moby/moby/pull/51059


This field was no longer used since Docker 1.11 (API version 1.23) through [moby@aee260d] and [engine-api@9a9e468] but kept and deprecated in [engine-api@167efc7], however the docs still used it in an example.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

