### PR TITLE
daemon/libnetwork/internal/kvstore: remove unused `BOLTDB`, `Backend` type, and `ErrBackendNotSupported`

### DIFF
--- a/daemon/libnetwork/internal/kvstore/kvstore.go
+++ b/daemon/libnetwork/internal/kvstore/kvstore.go
@@ -5,8 +5,6 @@ import (
 )
 
 var (
-	// ErrBackendNotSupported is thrown when the backend k/v store is not supported by libkv
-	ErrBackendNotSupported = errors.New("Backend storage not supported yet, please choose one of")
 	// ErrKeyModified is thrown during an atomic operation if the index does not match the one in the store
 	ErrKeyModified = errors.New("Unable to complete atomic operation, key modified")
 	// ErrKeyNotFound is thrown when the key is not found in the store during a Get operation

--- a/daemon/libnetwork/internal/kvstore/kvstore.go
+++ b/daemon/libnetwork/internal/kvstore/kvstore.go
@@ -4,12 +4,6 @@ import (
 	"errors"
 )
 
-// Backend represents a KV Store Backend
-type Backend string
-
-// BOLTDB backend
-const BOLTDB Backend = "boltdb"
-
 var (
 	// ErrBackendNotSupported is thrown when the backend k/v store is not supported by libkv
 	ErrBackendNotSupported = errors.New("Backend storage not supported yet, please choose one of")


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/47992
- https://github.com/moby/moby/pull/46041


### daemon/libnetwork/internal/kvstore: remove unused BOLTDB and Backend type

The `BOLTDB` const and related `Backend` type are no longer used since
[moby@ed08486].


[moby@ed08486]: https://github.com/moby/moby/commit/ed08486ec79b1d79dd6408d57086883501ffae52


### daemon/libnetwork/internal/kvstore: remove unused ErrBackendNotSupported

The `ErrBackendNotSupported` error was no longer used since [moby@37cbdeb].

[moby@37cbdeb]: https://github.com/moby/moby/commit/37cbdeb1f217a411cb6d2d264a7cc1ce97f89926




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

