### PR TITLE
Deprecate and remove kernel memory tcp

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -50,6 +50,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   This field was previously always -1.
 * Deprecated: The field `NetworkSettings.Bridge` returned by `GET /containers/{id}/json`
   is deprecated and will be removed in the next API version.
+* Deprecated: The field `KernelMemoryTCP` as part of `POST /containers/{id}/update`
+  and returned by `GET /containers/{id}/json` is deprecated and will be removed
+  in the next API version.
+* Deprecated: The field `KernelMemoryTCP` as part of `GET /info` is deprecated
+  and will be removed in the next API version.
 
 ## v1.50 API changes
 

--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -40,6 +40,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   `GlobalIPv6Address`, `GlobalIPv6PrefixLen`, `IPAddress`, `IPPrefixLen`,
   `IPv6Gateway`, and `MacAddress` fields. These fields were deprecated in
   API v1.21 (docker v1.9.0) but kept around for backward compatibility.
+* Removed the `KernelMemoryTCP` field from the `POST /containers/{id}/update` and
+  `GET /containers/{id}/json` endpoints, any value it is set to will be ignored
+  on API version `v1.52` and up. Older API versions still accept this field, but
+  may take no effect, depending on the kernel version and OCI runtime in use.
+* Removed the `KernelMemoryTCP` field from the `GET /info` endpoint.
 
 ## v1.51 API changes
 

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -636,6 +636,9 @@ definitions:
           by the default (runc) runtime.
 
           This field is omitted when empty.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
+          for cgroups v1. This field will be removed in a future release.
         type: "integer"
         format: "int64"
       MemoryReservation:
@@ -6350,6 +6353,8 @@ definitions:
 
           Kernel memory TCP limits are not supported when using cgroups v2, which
           does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -648,6 +648,9 @@ definitions:
           by the default (runc) runtime.
 
           This field is omitted when empty.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
+          for cgroups v1. This field will be removed in a future release.
         type: "integer"
         format: "int64"
       MemoryReservation:
@@ -6399,6 +6402,8 @@ definitions:
 
           Kernel memory TCP limits are not supported when using cgroups v2, which
           does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -641,18 +641,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/DeviceRequest"
-      KernelMemoryTCP:
-        description: |
-          Hard limit for kernel TCP buffer memory (in bytes). Depending on the
-          OCI runtime in use, this option may be ignored. It is no longer supported
-          by the default (runc) runtime.
-
-          This field is omitted when empty.
-
-          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
-          for cgroups v1. This field will be removed in a future release.
-        type: "integer"
-        format: "int64"
       MemoryReservation:
         description: "Memory soft limit in bytes."
         type: "integer"
@@ -6393,17 +6381,6 @@ definitions:
         example: true
       SwapLimit:
         description: "Indicates if the host has memory swap limit support enabled."
-        type: "boolean"
-        example: true
-      KernelMemoryTCP:
-        description: |
-          Indicates if the host has kernel memory TCP limit support enabled. This
-          field is omitted if not supported.
-
-          Kernel memory TCP limits are not supported when using cgroups v2, which
-          does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
-
-          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -648,6 +648,9 @@ definitions:
           by the default (runc) runtime.
 
           This field is omitted when empty.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
+          for cgroups v1. This field will be removed in a future release.
         type: "integer"
         format: "int64"
       MemoryReservation:
@@ -6399,6 +6402,8 @@ definitions:
 
           Kernel memory TCP limits are not supported when using cgroups v2, which
           does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -641,18 +641,6 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/DeviceRequest"
-      KernelMemoryTCP:
-        description: |
-          Hard limit for kernel TCP buffer memory (in bytes). Depending on the
-          OCI runtime in use, this option may be ignored. It is no longer supported
-          by the default (runc) runtime.
-
-          This field is omitted when empty.
-
-          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
-          for cgroups v1. This field will be removed in a future release.
-        type: "integer"
-        format: "int64"
       MemoryReservation:
         description: "Memory soft limit in bytes."
         type: "integer"
@@ -6393,17 +6381,6 @@ definitions:
         example: true
       SwapLimit:
         description: "Indicates if the host has memory swap limit support enabled."
-        type: "boolean"
-        example: true
-      KernelMemoryTCP:
-        description: |
-          Indicates if the host has kernel memory TCP limit support enabled. This
-          field is omitted if not supported.
-
-          Kernel memory TCP limits are not supported when using cgroups v2, which
-          does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
-
-          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -390,6 +390,11 @@ type Resources struct {
 	DeviceCgroupRules    []string        // List of rule to be added to the device cgroup
 	DeviceRequests       []DeviceRequest // List of device requests for device drivers
 
+	// Hard limit for kernel TCP buffer memory (in bytes).
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
+	// for cgroups v1.
 	KernelMemoryTCP   int64     `json:",omitempty"` // Hard limit for kernel TCP buffer memory (in bytes)
 	MemoryReservation int64     // Memory soft limit (in bytes)
 	MemorySwap        int64     // Total memory usage (memory + swap); set `-1` to enable unlimited swap

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -389,19 +389,12 @@ type Resources struct {
 	Devices              []DeviceMapping // List of devices to map inside the container
 	DeviceCgroupRules    []string        // List of rule to be added to the device cgroup
 	DeviceRequests       []DeviceRequest // List of device requests for device drivers
-
-	// Hard limit for kernel TCP buffer memory (in bytes).
-	//
-	// Deprecated: This field is deprecated and will be removed in the next release.
-	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
-	// for cgroups v1.
-	KernelMemoryTCP   int64     `json:",omitempty"` // Hard limit for kernel TCP buffer memory (in bytes)
-	MemoryReservation int64     // Memory soft limit (in bytes)
-	MemorySwap        int64     // Total memory usage (memory + swap); set `-1` to enable unlimited swap
-	MemorySwappiness  *int64    // Tuning container memory swappiness behaviour
-	OomKillDisable    *bool     // Whether to disable OOM Killer or not
-	PidsLimit         *int64    // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
-	Ulimits           []*Ulimit // List of ulimits to be set in the container
+	MemoryReservation    int64           // Memory soft limit (in bytes)
+	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
+	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
+	OomKillDisable       *bool           // Whether to disable OOM Killer or not
+	PidsLimit            *int64          // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
+	Ulimits              []*Ulimit       // List of ulimits to be set in the container
 
 	// Applicable to Windows
 	CPUCount           int64  `json:"CpuCount"`   // CPU count

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -9,25 +9,18 @@ import (
 // Info contains response of Engine API:
 // GET "/info"
 type Info struct {
-	ID                string
-	Containers        int
-	ContainersRunning int
-	ContainersPaused  int
-	ContainersStopped int
-	Images            int
-	Driver            string
-	DriverStatus      [][2]string
-	SystemStatus      [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
-	Plugins           PluginsInfo
-	MemoryLimit       bool
-	SwapLimit         bool
-
-	// KernelMemoryLimit is not supported on cgroups v2.
-	//
-	// Deprecated: This field is deprecated and will be removed in the next release.
-	// Starting with kernel 6.12, the kernel has deprecated kernel memory tcp accounting
-	KernelMemoryTCP bool `json:",omitempty"`
-
+	ID                 string
+	Containers         int
+	ContainersRunning  int
+	ContainersPaused   int
+	ContainersStopped  int
+	Images             int
+	Driver             string
+	DriverStatus       [][2]string
+	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
+	Plugins            PluginsInfo
+	MemoryLimit        bool
+	SwapLimit          bool
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
 	CPUShares          bool

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -9,19 +9,25 @@ import (
 // Info contains response of Engine API:
 // GET "/info"
 type Info struct {
-	ID                 string
-	Containers         int
-	ContainersRunning  int
-	ContainersPaused   int
-	ContainersStopped  int
-	Images             int
-	Driver             string
-	DriverStatus       [][2]string
-	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
-	Plugins            PluginsInfo
-	MemoryLimit        bool
-	SwapLimit          bool
-	KernelMemoryTCP    bool `json:",omitempty"` // KernelMemoryTCP is not supported on cgroups v2.
+	ID                string
+	Containers        int
+	ContainersRunning int
+	ContainersPaused  int
+	ContainersStopped int
+	Images            int
+	Driver            string
+	DriverStatus      [][2]string
+	SystemStatus      [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
+	Plugins           PluginsInfo
+	MemoryLimit       bool
+	SwapLimit         bool
+
+	// KernelMemoryLimit is not supported on cgroups v2.
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with kernel 6.12, the kernel has deprecated kernel memory tcp accounting
+	KernelMemoryTCP bool `json:",omitempty"`
+
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
 	CPUShares          bool

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -103,9 +103,6 @@ func getMemoryResources(config containertypes.Resources) *specs.LinuxMemory {
 	if config.OomKillDisable != nil {
 		memory.DisableOOMKiller = config.OomKillDisable
 	}
-	if config.KernelMemoryTCP != 0 { //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
-		memory.KernelTCP = &config.KernelMemoryTCP //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
-	}
 
 	if memory != (specs.LinuxMemory{}) {
 		return &memory

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -103,8 +103,8 @@ func getMemoryResources(config containertypes.Resources) *specs.LinuxMemory {
 	if config.OomKillDisable != nil {
 		memory.DisableOOMKiller = config.OomKillDisable
 	}
-	if config.KernelMemoryTCP != 0 {
-		memory.KernelTCP = &config.KernelMemoryTCP
+	if config.KernelMemoryTCP != 0 { //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
+		memory.KernelTCP = &config.KernelMemoryTCP //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
 	}
 
 	if memory != (specs.LinuxMemory{}) {

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -34,7 +34,7 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 	if v.CgroupDriver != cgroupNoneDriver {
 		v.MemoryLimit = sysInfo.MemoryLimit
 		v.SwapLimit = sysInfo.SwapLimit
-		v.KernelMemoryTCP = sysInfo.KernelMemoryTCP
+		v.KernelMemoryTCP = sysInfo.KernelMemoryTCP //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
 		v.OomKillDisable = sysInfo.OomKillDisable
 		v.CPUCfsPeriod = sysInfo.CPUCfs
 		v.CPUCfsQuota = sysInfo.CPUCfs
@@ -93,7 +93,7 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 		if !v.SwapLimit {
 			v.Warnings = append(v.Warnings, "WARNING: No swap limit support")
 		}
-		if !v.KernelMemoryTCP && v.CgroupVersion == "1" {
+		if !v.KernelMemoryTCP && v.CgroupVersion == "1" { //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
 			// kernel memory is not available for cgroup v2.
 			// Warning is not printed on cgroup v2, because there is no action user can take.
 			v.Warnings = append(v.Warnings, "WARNING: No kernel memory TCP limit support")

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -34,7 +34,6 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 	if v.CgroupDriver != cgroupNoneDriver {
 		v.MemoryLimit = sysInfo.MemoryLimit
 		v.SwapLimit = sysInfo.SwapLimit
-		v.KernelMemoryTCP = sysInfo.KernelMemoryTCP //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
 		v.OomKillDisable = sysInfo.OomKillDisable
 		v.CPUCfsPeriod = sysInfo.CPUCfs
 		v.CPUCfsQuota = sysInfo.CPUCfs
@@ -92,11 +91,6 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 		}
 		if !v.SwapLimit {
 			v.Warnings = append(v.Warnings, "WARNING: No swap limit support")
-		}
-		if !v.KernelMemoryTCP && v.CgroupVersion == "1" { //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
-			// kernel memory is not available for cgroup v2.
-			// Warning is not printed on cgroup v2, because there is no action user can take.
-			v.Warnings = append(v.Warnings, "WARNING: No kernel memory TCP limit support")
 		}
 		if !v.OomKillDisable && v.CgroupVersion == "1" {
 			// oom kill disable is not available for cgroup v2.

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -537,9 +537,6 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 			}
 		}
 
-		// Ignore KernelMemoryTCP because it was added in API 1.40.
-		hostConfig.KernelMemoryTCP = 0 //nolint:staticcheck // ignore SA1019 This field is still used for legacy support.
-
 		// Older clients (API < 1.40) expects the default to be shareable, make them happy
 		if hostConfig.IpcMode.IsEmpty() {
 			hostConfig.IpcMode = container.IPCModeShareable

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -538,7 +538,7 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		}
 
 		// Ignore KernelMemoryTCP because it was added in API 1.40.
-		hostConfig.KernelMemoryTCP = 0
+		hostConfig.KernelMemoryTCP = 0 //nolint:staticcheck // ignore SA1019 This field is still used for legacy support.
 
 		// Older clients (API < 1.40) expects the default to be shareable, make them happy
 		if hostConfig.IpcMode.IsEmpty() {

--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -84,7 +84,6 @@ func applyMemoryCgroupInfoV2(info *SysInfo) {
 	info.MemoryReservation = true
 	info.OomKillDisable = false
 	info.MemorySwappiness = false
-	info.KernelMemoryTCP = false
 }
 
 func applyCPUCgroupInfoV2(info *SysInfo) {

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -66,6 +66,10 @@ type cgroupMemInfo struct {
 
 	// Whether kernel memory TCP limit is supported or not. Kernel memory TCP
 	// limit (`memory.kmem.tcp.limit_in_bytes`) is not supported on cgroups v2.
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
+	// for cgroups v1.
 	KernelMemoryTCP bool
 }
 

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -63,14 +63,6 @@ type cgroupMemInfo struct {
 
 	// Whether memory swappiness is supported or not
 	MemorySwappiness bool
-
-	// Whether kernel memory TCP limit is supported or not. Kernel memory TCP
-	// limit (`memory.kmem.tcp.limit_in_bytes`) is not supported on cgroups v2.
-	//
-	// Deprecated: This field is deprecated and will be removed in the next release.
-	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
-	// for cgroups v1.
-	KernelMemoryTCP bool
 }
 
 type cgroupCPUInfo struct {

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -152,11 +152,6 @@ func applyMemoryCgroupInfo(info *SysInfo) {
 	if !info.MemorySwappiness {
 		info.Warnings = append(info.Warnings, "Your kernel does not support memory swappiness")
 	}
-
-	// Option is deprecated in runc, but still accepted in our API, so setting
-	// the field to allow feature detection, but don't warn if it's missing, to
-	// make the daemon logs a bit less noisy.
-	info.KernelMemoryTCP = cgroupEnabled(mountPoint, "memory.kmem.tcp.limit_in_bytes")
 }
 
 // applyCPUCgroupInfo adds the cpu cgroup controller information to the info.

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -390,6 +390,11 @@ type Resources struct {
 	DeviceCgroupRules    []string        // List of rule to be added to the device cgroup
 	DeviceRequests       []DeviceRequest // List of device requests for device drivers
 
+	// Hard limit for kernel TCP buffer memory (in bytes).
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
+	// for cgroups v1.
 	KernelMemoryTCP   int64     `json:",omitempty"` // Hard limit for kernel TCP buffer memory (in bytes)
 	MemoryReservation int64     // Memory soft limit (in bytes)
 	MemorySwap        int64     // Total memory usage (memory + swap); set `-1` to enable unlimited swap

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -389,19 +389,12 @@ type Resources struct {
 	Devices              []DeviceMapping // List of devices to map inside the container
 	DeviceCgroupRules    []string        // List of rule to be added to the device cgroup
 	DeviceRequests       []DeviceRequest // List of device requests for device drivers
-
-	// Hard limit for kernel TCP buffer memory (in bytes).
-	//
-	// Deprecated: This field is deprecated and will be removed in the next release.
-	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
-	// for cgroups v1.
-	KernelMemoryTCP   int64     `json:",omitempty"` // Hard limit for kernel TCP buffer memory (in bytes)
-	MemoryReservation int64     // Memory soft limit (in bytes)
-	MemorySwap        int64     // Total memory usage (memory + swap); set `-1` to enable unlimited swap
-	MemorySwappiness  *int64    // Tuning container memory swappiness behaviour
-	OomKillDisable    *bool     // Whether to disable OOM Killer or not
-	PidsLimit         *int64    // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
-	Ulimits           []*Ulimit // List of ulimits to be set in the container
+	MemoryReservation    int64           // Memory soft limit (in bytes)
+	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
+	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
+	OomKillDisable       *bool           // Whether to disable OOM Killer or not
+	PidsLimit            *int64          // Setting PIDs limit for a container; Set `0` or `-1` for unlimited, or `null` to not change.
+	Ulimits              []*Ulimit       // List of ulimits to be set in the container
 
 	// Applicable to Windows
 	CPUCount           int64  `json:"CpuCount"`   // CPU count

--- a/vendor/github.com/moby/moby/api/types/system/info.go
+++ b/vendor/github.com/moby/moby/api/types/system/info.go
@@ -9,25 +9,18 @@ import (
 // Info contains response of Engine API:
 // GET "/info"
 type Info struct {
-	ID                string
-	Containers        int
-	ContainersRunning int
-	ContainersPaused  int
-	ContainersStopped int
-	Images            int
-	Driver            string
-	DriverStatus      [][2]string
-	SystemStatus      [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
-	Plugins           PluginsInfo
-	MemoryLimit       bool
-	SwapLimit         bool
-
-	// KernelMemoryLimit is not supported on cgroups v2.
-	//
-	// Deprecated: This field is deprecated and will be removed in the next release.
-	// Starting with kernel 6.12, the kernel has deprecated kernel memory tcp accounting
-	KernelMemoryTCP bool `json:",omitempty"`
-
+	ID                 string
+	Containers         int
+	ContainersRunning  int
+	ContainersPaused   int
+	ContainersStopped  int
+	Images             int
+	Driver             string
+	DriverStatus       [][2]string
+	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
+	Plugins            PluginsInfo
+	MemoryLimit        bool
+	SwapLimit          bool
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
 	CPUShares          bool

--- a/vendor/github.com/moby/moby/api/types/system/info.go
+++ b/vendor/github.com/moby/moby/api/types/system/info.go
@@ -9,19 +9,25 @@ import (
 // Info contains response of Engine API:
 // GET "/info"
 type Info struct {
-	ID                 string
-	Containers         int
-	ContainersRunning  int
-	ContainersPaused   int
-	ContainersStopped  int
-	Images             int
-	Driver             string
-	DriverStatus       [][2]string
-	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
-	Plugins            PluginsInfo
-	MemoryLimit        bool
-	SwapLimit          bool
-	KernelMemoryTCP    bool `json:",omitempty"` // KernelMemoryTCP is not supported on cgroups v2.
+	ID                string
+	Containers        int
+	ContainersRunning int
+	ContainersPaused  int
+	ContainersStopped int
+	Images            int
+	Driver            string
+	DriverStatus      [][2]string
+	SystemStatus      [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
+	Plugins           PluginsInfo
+	MemoryLimit       bool
+	SwapLimit         bool
+
+	// KernelMemoryLimit is not supported on cgroups v2.
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with kernel 6.12, the kernel has deprecated kernel memory tcp accounting
+	KernelMemoryTCP bool `json:",omitempty"`
+
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
 	CPUShares          bool


### PR DESCRIPTION
**- What I did**

- fixes https://github.com/moby/moby/issues/50990

Kernel v6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` along with all other kernel memory TCP accounting for cgroups v1. [1]

This change deprecates and removes support for `KernelMemoryTCP` from the API module.

[1] https://github.com/torvalds/linux/commit/d046ff46ee3b920ac617564226d2a0494d9af772

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api: remove support for kernel memory TCP accounting (`KernelMemoryTCP`)
```

**- A picture of a cute animal (not mandatory but encouraged)**

