### PR TITLE
[28.x backport] api: deprecate `KernelMemoryTCP` support

### DIFF
--- a/api/server/router/container/container_routes.go
+++ b/api/server/router/container/container_routes.go
@@ -531,7 +531,7 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		}
 
 		// Ignore KernelMemoryTCP because it was added in API 1.40.
-		hostConfig.KernelMemoryTCP = 0
+		hostConfig.KernelMemoryTCP = 0 //nolint:staticcheck // ignore SA1019 This field is still used for legacy support.
 
 		// Older clients (API < 1.40) expects the default to be shareable, make them happy
 		if hostConfig.IpcMode.IsEmpty() {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -636,6 +636,9 @@ definitions:
           by the default (runc) runtime.
 
           This field is omitted when empty.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
+          for cgroups v1. This field will be removed in a future release.
         type: "integer"
         format: "int64"
       MemoryReservation:
@@ -6350,6 +6353,8 @@ definitions:
 
           Kernel memory TCP limits are not supported when using cgroups v2, which
           does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -394,7 +394,12 @@ type Resources struct {
 
 	// KernelMemory specifies the kernel memory limit (in bytes) for the container.
 	// Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes.
-	KernelMemory      int64     `json:",omitempty"`
+	KernelMemory int64 `json:",omitempty"`
+	// Hard limit for kernel TCP buffer memory (in bytes).
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
+	// for cgroups v1.
 	KernelMemoryTCP   int64     `json:",omitempty"` // Hard limit for kernel TCP buffer memory (in bytes)
 	MemoryReservation int64     // Memory soft limit (in bytes)
 	MemorySwap        int64     // Total memory usage (memory + swap); set `-1` to enable unlimited swap

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -9,19 +9,23 @@ import (
 // Info contains response of Engine API:
 // GET "/info"
 type Info struct {
-	ID                 string
-	Containers         int
-	ContainersRunning  int
-	ContainersPaused   int
-	ContainersStopped  int
-	Images             int
-	Driver             string
-	DriverStatus       [][2]string
-	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
-	Plugins            PluginsInfo
-	MemoryLimit        bool
-	SwapLimit          bool
-	KernelMemory       bool `json:",omitempty"` // Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes
+	ID                string
+	Containers        int
+	ContainersRunning int
+	ContainersPaused  int
+	ContainersStopped int
+	Images            int
+	Driver            string
+	DriverStatus      [][2]string
+	SystemStatus      [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
+	Plugins           PluginsInfo
+	MemoryLimit       bool
+	SwapLimit         bool
+	KernelMemory      bool `json:",omitempty"` // Deprecated: kernel 5.4 deprecated kmem.limit_in_bytes
+	// KernelMemoryLimit is not supported on cgroups v2.
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with kernel 6.12, the kernel has deprecated kernel memory tcp accounting
 	KernelMemoryTCP    bool `json:",omitempty"` // KernelMemoryTCP is not supported on cgroups v2.
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -112,8 +112,8 @@ func getMemoryResources(config containertypes.Resources) *specs.LinuxMemory {
 		memory.Kernel = &config.KernelMemory //nolint:staticcheck // ignore SA1019: memory.Kernel is deprecated: kernel-memory limits are not supported in cgroups v2, and were obsoleted in [kernel v5.4]. This field should no longer be used, as it may be ignored by runtimes.
 	}
 
-	if config.KernelMemoryTCP != 0 {
-		memory.KernelTCP = &config.KernelMemoryTCP
+	if config.KernelMemoryTCP != 0 { //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
+		memory.KernelTCP = &config.KernelMemoryTCP //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
 	}
 
 	if memory != (specs.LinuxMemory{}) {

--- a/daemon/info_unix.go
+++ b/daemon/info_unix.go
@@ -35,7 +35,7 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 		v.MemoryLimit = sysInfo.MemoryLimit
 		v.SwapLimit = sysInfo.SwapLimit
 		v.KernelMemory = sysInfo.KernelMemory
-		v.KernelMemoryTCP = sysInfo.KernelMemoryTCP
+		v.KernelMemoryTCP = sysInfo.KernelMemoryTCP //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
 		v.OomKillDisable = sysInfo.OomKillDisable
 		v.CPUCfsPeriod = sysInfo.CPUCfs
 		v.CPUCfsQuota = sysInfo.CPUCfs
@@ -94,7 +94,7 @@ func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysI
 		if !v.SwapLimit {
 			v.Warnings = append(v.Warnings, "WARNING: No swap limit support")
 		}
-		if !v.KernelMemoryTCP && v.CgroupVersion == "1" {
+		if !v.KernelMemoryTCP && v.CgroupVersion == "1" { //nolint:staticcheck // ignore SA1019: memory.KernelTCP is deprecated: kernel memory tcp accounting is not supported in cgroups v2, and has been deprecated in [kernel v6.12]. This field should no longer be used, as it may be ignored by runtimes.
 			// kernel memory is not available for cgroup v2.
 			// Warning is not printed on cgroup v2, because there is no action user can take.
 			v.Warnings = append(v.Warnings, "WARNING: No kernel memory TCP limit support")

--- a/docs/api/v1.50.yaml
+++ b/docs/api/v1.50.yaml
@@ -636,6 +636,9 @@ definitions:
           by the default (runc) runtime.
 
           This field is omitted when empty.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
+          for cgroups v1. This field will be removed in a future release.
         type: "integer"
         format: "int64"
       MemoryReservation:
@@ -6351,6 +6354,8 @@ definitions:
 
           Kernel memory TCP limits are not supported when using cgroups v2, which
           does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/docs/api/v1.51.yaml
+++ b/docs/api/v1.51.yaml
@@ -636,6 +636,9 @@ definitions:
           by the default (runc) runtime.
 
           This field is omitted when empty.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated `memory.kmem.tcp.limit_in_bytes` field
+          for cgroups v1. This field will be removed in a future release.
         type: "integer"
         format: "int64"
       MemoryReservation:
@@ -6350,6 +6353,8 @@ definitions:
 
           Kernel memory TCP limits are not supported when using cgroups v2, which
           does not support the corresponding `memory.kmem.tcp.limit_in_bytes` cgroup.
+
+          **Deprecated**: This field is deprecated as kernel 6.12 has deprecated kernel memory TCP accounting.
         type: "boolean"
         example: true
       CpuCfsPeriod:

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -22,6 +22,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   This field was previously always -1.
 * Deprecated: The field `NetworkSettings.Bridge` returned by `GET /containers/{id}/json`
   is deprecated and will be removed in the next API version.
+* Deprecated: The field `KernelMemoryTCP` as part of `POST /containers/{id}/update`
+  and returned by `GET /containers/{id}/json` is deprecated and will be removed
+  in the next API version.
+* Deprecated: The field `KernelMemoryTCP` as part of `GET /info` is deprecated
+  and will be removed in the next API version.
 
 ## v1.50 API changes
 

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -72,6 +72,10 @@ type cgroupMemInfo struct {
 
 	// Whether kernel memory TCP limit is supported or not. Kernel memory TCP
 	// limit (`memory.kmem.tcp.limit_in_bytes`) is not supported on cgroups v2.
+	//
+	// Deprecated: This field is deprecated and will be removed in the next release.
+	// Starting with 6.12, the kernel has deprecated kernel memory tcp accounting
+	// for cgroups v1.
 	KernelMemoryTCP bool
 }
 


### PR DESCRIPTION
**- What I did**

- Part of https://github.com/moby/moby/issues/50990
- Backports https://github.com/moby/moby/pull/51066

Starting with kernel v6.12, kernel memory TCP accounting is deprecated for cgroups v1. Note: kernel memory TCP accounting is not supported by cgroups v2.

See https://github.com/torvalds/linux/commit/d046ff46ee3b920ac617564226d2a0494d9af772


(cherry picked from commit fb2f8115c8dd68b9303f043e540a23d9a27e569c)

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
Deprecate support for kernel memory TCP accounting (`KernelMemoryTCP`)
```

**- A picture of a cute animal (not mandatory but encouraged)**

