### PR TITLE
api: omit legacy fields from image inspect if not set

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -34,6 +34,12 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /images/{name}/json` now omits the following `Config` fields when
   not set, to closer align with the implementation of the [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/v1.1.1/specs-go/v1/config.go#L23-L62)
   `Cmd`, `Entrypoint`, `Env`, `Labels`, `OnBuild`, `User`, `Volumes`, and `WorkingDir`.
+* `GET /images/{name}/json` now omits the following fields if their value
+  is empty: `Parent`, `Comment`, `DockerVersion`, `Author`. The `Parent`
+  and `DockerVersion` fields were set by the legacy builder, and are no
+  longer set when using BuildKit. The `Author` field is set through the
+  `MAINTAINER` Dockerfile instruction, which is deprecated, and the `Comment`
+  field is option, and may not be set depending on how the image was created.
 * `GET /containers/{id}/json`: the `NetworkSettings` no longer returns the deprecated
   `Bridge`, `HairpinMode`, `LinkLocalIPv6Address`, `LinkLocalIPv6PrefixLen`,
   `SecondaryIPAddresses`, `SecondaryIPv6Addresses`, `EndpointID`, `Gateway`,

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -1826,13 +1826,13 @@ definitions:
           is only set for images that were built/created locally. This field
           is empty if the image was pulled from an image registry.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: ""
       Comment:
         description: |
           Optional message that was set when committing or importing the image.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: ""
       Created:
         description: |
@@ -1851,14 +1851,14 @@ definitions:
 
           Depending on how the image was created, this field may be empty.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: "27.0.1"
       Author:
         description: |
           Name of the author that was specified when committing the image, or as
           specified through MAINTAINER (deprecated) in the Dockerfile.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: ""
       Config:
         $ref: "#/definitions/ImageConfig"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1839,13 +1839,13 @@ definitions:
           is only set for images that were built/created locally. This field
           is empty if the image was pulled from an image registry.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: ""
       Comment:
         description: |
           Optional message that was set when committing or importing the image.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: ""
       Created:
         description: |
@@ -1864,14 +1864,14 @@ definitions:
 
           Depending on how the image was created, this field may be empty.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: "27.0.1"
       Author:
         description: |
           Name of the author that was specified when committing the image, or as
           specified through MAINTAINER (deprecated) in the Dockerfile.
         type: "string"
-        x-nullable: false
+        x-nullable: true
         example: ""
       Config:
         $ref: "#/definitions/ImageConfig"

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -47,12 +47,12 @@ type InspectResponse struct {
 	//
 	// Depending on how the image was created, this field may be empty and
 	// is only set for images that were built/created locally. This field
-	// is empty if the image was pulled from an image registry.
-	Parent string
+	// is omitted if the image was pulled from an image registry.
+	Parent string `json:",omitempty"`
 
 	// Comment is an optional message that can be set when committing or
-	// importing the image.
-	Comment string
+	// importing the image. This field is omitted if not set.
+	Comment string `json:",omitempty"`
 
 	// Created is the date and time at which the image was created, formatted in
 	// RFC 3339 nano-seconds (time.RFC3339Nano).
@@ -79,12 +79,13 @@ type InspectResponse struct {
 
 	// DockerVersion is the version of Docker that was used to build the image.
 	//
-	// Depending on how the image was created, this field may be empty.
-	DockerVersion string
+	// Depending on how the image was created, this field may be omitted.
+	DockerVersion string `json:",omitempty"`
 
 	// Author is the name of the author that was specified when committing the
 	// image, or as specified through MAINTAINER (deprecated) in the Dockerfile.
-	Author string
+	// This field is omitted if not set.
+	Author string `json:",omitempty"`
 	Config *dockerspec.DockerOCIImageConfig
 
 	// Architecture is the hardware CPU architecture that the image runs on.

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -418,6 +418,14 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 		imageInspect.Descriptor = nil
 	}
 	if versions.LessThan(version, "1.52") {
+		// These fields have "omitempty" on API v1.52 and higher,
+		// but older API versions returned them unconditionally.
+		legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{
+			"Parent":        imageInspect.Parent,
+			"Comment":       imageInspect.Comment,
+			"DockerVersion": imageInspect.DockerVersion,
+			"Author":        imageInspect.Author,
+		}))
 		if versions.LessThan(version, "1.50") {
 			legacyOptions = append(legacyOptions, compat.WithExtraFields(legacyConfigFields["v1.49"]))
 		} else {

--- a/vendor/github.com/moby/moby/api/types/image/image_inspect.go
+++ b/vendor/github.com/moby/moby/api/types/image/image_inspect.go
@@ -47,12 +47,12 @@ type InspectResponse struct {
 	//
 	// Depending on how the image was created, this field may be empty and
 	// is only set for images that were built/created locally. This field
-	// is empty if the image was pulled from an image registry.
-	Parent string
+	// is omitted if the image was pulled from an image registry.
+	Parent string `json:",omitempty"`
 
 	// Comment is an optional message that can be set when committing or
-	// importing the image.
-	Comment string
+	// importing the image. This field is omitted if not set.
+	Comment string `json:",omitempty"`
 
 	// Created is the date and time at which the image was created, formatted in
 	// RFC 3339 nano-seconds (time.RFC3339Nano).
@@ -79,12 +79,13 @@ type InspectResponse struct {
 
 	// DockerVersion is the version of Docker that was used to build the image.
 	//
-	// Depending on how the image was created, this field may be empty.
-	DockerVersion string
+	// Depending on how the image was created, this field may be omitted.
+	DockerVersion string `json:",omitempty"`
 
 	// Author is the name of the author that was specified when committing the
 	// image, or as specified through MAINTAINER (deprecated) in the Dockerfile.
-	Author string
+	// This field is omitted if not set.
+	Author string `json:",omitempty"`
 	Config *dockerspec.DockerOCIImageConfig
 
 	// Architecture is the hardware CPU architecture that the image runs on.


### PR DESCRIPTION
The image inspect response has various fields that are either optional, or only used if the image was built using the deprecated legacy builder. This patch marks them as "omitempty" to omit them from the response if not set:

- The `Parent` field is only used for the legacy builder, and only set for images that are built locally (i.e., not persisted when pulling an image).
- The `Comment` field is optional, and may not be set, depending on how the image is produced.
- The `DockerVersion` field is only set when building images with the legacy builder, and empty in most cases.
- The `Author` field can be set through the `MAINTAINER` instruction in Dockerfiles, and through the `--author` option on `docker commit`, but is optional, and won't be set in most situations.


With this patch:

On API v1.52

    DOCKER_API_VERSION=v1.52 docker inspect busybox
    [
        {
            "Id": "sha256:d82f458899c9696cb26a7c02d5568f81c8c8223f8661bb2a7988b269c8b9051e",
            "RepoTags": ["busybox:latest"],
            "RepoDigests": ["busybox@sha256:d82f458899c9696cb26a7c02d5568f81c8c8223f8661bb2a7988b269c8b9051e"],
            "Created": "2024-09-26T21:31:42Z",
            "Config": {
                "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
                "Cmd": ["sh"]
            },
            "Architecture": "arm64",
            "Variant": "v8",
            "Os": "linux",
            "Size": 1913388,
            "RootFS": {
                "Type": "layers",
                "Layers": ["sha256:6aba5e0d32d91e3e923854dcb30588dc4112bfa1dae82b89535ad31d322a7b19"]
            },
            "Metadata": {
                "LastTagTime": "2025-10-03T22:24:18.440035424Z"
            },
            "Descriptor": {
                "mediaType": "application/vnd.oci.image.index.v1+json",
                "digest": "sha256:d82f458899c9696cb26a7c02d5568f81c8c8223f8661bb2a7988b269c8b9051e",
                "size": 9535
            }
        }
    ]

On API v1.51 or lower:

    DOCKER_API_VERSION=v1.51 docker inspect busybox
    [
        {
            "Architecture": "arm64",
            "Author": "",
            "Cmd": null,
            "Comment": "",
            "Config": {
                "Cmd": ["sh"],
                "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
            },
            "Created": "2024-09-26T21:31:42Z",
            "Descriptor": {
                "digest": "sha256:d82f458899c9696cb26a7c02d5568f81c8c8223f8661bb2a7988b269c8b9051e",
                "mediaType": "application/vnd.oci.image.index.v1+json",
                "size": 9535
            },
            "DockerVersion": "",
            "Entrypoint": null,
            "Env": null,
            "Id": "sha256:d82f458899c9696cb26a7c02d5568f81c8c8223f8661bb2a7988b269c8b9051e",
            "Labels": null,
            "Metadata": {
                "LastTagTime": "2025-10-03T22:24:18.440035424Z"
            },
            "OnBuild": null,
            "Os": "linux",
            "Parent": "",
            "RepoDigests": ["busybox@sha256:d82f458899c9696cb26a7c02d5568f81c8c8223f8661bb2a7988b269c8b9051e"],
            "RepoTags": ["busybox:latest"],
            "RootFS": {
                "Layers": ["sha256:6aba5e0d32d91e3e923854dcb30588dc4112bfa1dae82b89535ad31d322a7b19"],
                "Type": "layers"
            },
            "Size": 1913388,
            "User": "",
            "Variant": "v8",
            "Volumes": null,
            "WorkingDir": ""
        }
    ]

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`GET /images/{name}/json` now omits the following fields if their value is empty: `Parent`, `Comment`, `DockerVersion`, `Author`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

