### PR TITLE
daemon, client: remove version-gate for daemon-side AutoRemove

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -48,10 +48,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	}
 
 	if hostConfig != nil {
-		if versions.LessThan(cli.ClientVersion(), "1.25") {
-			// When using API 1.24 and under, the client is responsible for removing the container
-			hostConfig.AutoRemove = false
-		}
 		if platform != nil && platform.OS == "linux" && versions.LessThan(cli.ClientVersion(), "1.42") {
 			// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
 			hostConfig.ConsoleSize = [2]uint{0, 0}

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -524,11 +524,6 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 
 	version := httputils.VersionFromContext(ctx)
 
-	// When using API 1.24 and under, the client is responsible for removing the container
-	if versions.LessThan(version, "1.25") {
-		hostConfig.AutoRemove = false
-	}
-
 	if versions.LessThan(version, "1.40") {
 		// Ignore BindOptions.NonRecursive because it was added in API 1.40.
 		for _, m := range hostConfig.Mounts {

--- a/vendor/github.com/moby/moby/client/container_create.go
+++ b/vendor/github.com/moby/moby/client/container_create.go
@@ -48,10 +48,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	}
 
 	if hostConfig != nil {
-		if versions.LessThan(cli.ClientVersion(), "1.25") {
-			// When using API 1.24 and under, the client is responsible for removing the container
-			hostConfig.AutoRemove = false
-		}
 		if platform != nil && platform.OS == "linux" && versions.LessThan(cli.ClientVersion(), "1.42") {
 			// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
 			hostConfig.ConsoleSize = [2]uint{0, 0}


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/6525
- https://github.com/moby/moby/pull/20848
- https://github.com/docker/cli/pull/101

Support for daemon-side auto-remove was added in API v1.25; on older versions of the daemon, the client was responsible for removing the container after it exited (see [moby@6dd8e10])

On API versions < 1.30, it used the events API for this purpose, and would wait for a "die", "detach" or "detroy" events to know the container exited, and could be removed or (when attached, but without a TTY) to get the container's exit-status. (see [cli@38591f2]).

API version 1.24 (docker 1.12) is 9 Years old (July 29, 2016), and API 1.30 (docker 17.06) is 8 Years old (Jun 20, 2017), and long EOL. While technically, a CLI could negotiate API 1.30 or older, this would only be in cases where either API version negotiation failed, or the version was explicitly overridden through `DOCKER_API_VERSION` for testing.

This patch removes the version-gate for daemon-side AutoRemove; version- specific handling is removed from the client (and a related patch in the CLI).

[moby@6dd8e10]: https://github.com/moby/moby/commit/6dd8e10d6ed7a7371c5c1824ad58c4403a7b3bfd
[cli@38591f2]: https://github.com/docker/cli/commit/38591f20d07795aaef45d400df89ca12f29c603b

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

