### PR TITLE
Skip unit test when prjquota not supported

### DIFF
--- a/daemon/internal/quota/projectquota_test.go
+++ b/daemon/internal/quota/projectquota_test.go
@@ -17,9 +17,8 @@ import (
 const testQuotaSize = 10 * 1024 * 1024
 
 func TestBlockDev(t *testing.T) {
-	if msg, ok := CanTestQuota(); !ok {
-		t.Skip(msg)
-	}
+	// Check if the test can be run
+	RequireSupported(t)
 
 	// get sparse xfs test image
 	imageFileName, err := PrepareQuotaTestImage(t)

--- a/daemon/volume/local/local_linux_test.go
+++ b/daemon/volume/local/local_linux_test.go
@@ -22,9 +22,8 @@ const (
 )
 
 func TestQuota(t *testing.T) {
-	if msg, ok := quota.CanTestQuota(); !ok {
-		t.Skip(msg)
-	}
+	// Check if the test can be run
+	quota.RequireSupported(t)
 
 	// get sparse xfs test image
 	imageFileName, err := quota.PrepareQuotaTestImage(t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Closes #51065.

**- What I did**

Added an additional prerequisite check before running `daemon/internal/quota` units tests. This fixes an issue where the tests could run in environments where they could never succeed.

In particular, I extended the `CanTestQuota` to also attempt a mount using the `prjquota` option. This ensures that XFS actually supports the quota option before running tests.

**- How I did it**

Added a function called `supportsQuota` that attempts a mount. It reuses some existing logic to prepare the XFS image (`PrepareQuotaTestImage`).

**- How to verify it**

Run the quota unit tests

```sh
TESTDIRS='./daemon/internal/quota/' ./hack/test/unit
```

The outcome depends on what the backing filesystem supports

* No XFS support: tests skipped (old check)
* XFS support, but missing quota support: tests skipped (new check)
* XFS support and quota support: tests run

Unfortunately I don't have easy access to a system where XFS support quotas, so I've been unable to verify the last scenario.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

<img height="400" alt="image" src="https://github.com/user-attachments/assets/8a1ad641-f7e7-4402-a44c-d87fcf88e358" />

Baby moose
