### PR TITLE
Consolidate api port types

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
+	"github.com/moby/moby/api/types/network"
 )
 
 // MinimumDuration puts a minimum on user configured duration.
@@ -28,7 +29,7 @@ type Config struct {
 	AttachStdin     bool                // Attach the standard input, makes possible user interaction
 	AttachStdout    bool                // Attach the standard output
 	AttachStderr    bool                // Attach the standard error
-	ExposedPorts    PortSet             `json:",omitempty"` // List of exposed ports
+	ExposedPorts    network.PortSet     `json:",omitempty"` // List of exposed ports
 	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
 	OpenStdin       bool                // Open stdin
 	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.

--- a/api/types/container/hostconfig.go
+++ b/api/types/container/hostconfig.go
@@ -421,7 +421,7 @@ type HostConfig struct {
 	ContainerIDFile string            // File (path) where the containerId is written
 	LogConfig       LogConfig         // Configuration of the logs for this container
 	NetworkMode     NetworkMode       // Network mode to use for the container
-	PortBindings    PortMap           // Port mapping between the exposed port (container) and the host
+	PortBindings    network.PortMap   // Port mapping between the exposed port (container) and the host
 	RestartPolicy   RestartPolicy     // Restart policy to be used for the container
 	AutoRemove      bool              // Automatically remove container when it exits
 	VolumeDriver    string            // Name of the volume driver used to mount volumes

--- a/api/types/container/network_settings.go
+++ b/api/types/container/network_settings.go
@@ -6,10 +6,13 @@ import (
 
 // NetworkSettings exposes the network settings in the api
 type NetworkSettings struct {
-	SandboxID  string  // SandboxID uniquely represents a container's network stack
-	SandboxKey string  // SandboxKey identifies the sandbox
-	Ports      PortMap // Ports is a collection of PortBinding indexed by Port
-	Networks   map[string]*network.EndpointSettings
+	SandboxID  string // SandboxID uniquely represents a container's network stack
+	SandboxKey string // SandboxKey identifies the sandbox
+
+	// Ports is a collection of [network.PortBinding] indexed by [network.Port]
+	Ports network.PortMap
+
+	Networks map[string]*network.EndpointSettings
 }
 
 // NetworkSettingsSummary provides a summary of container's networks

--- a/api/types/network/port.go
+++ b/api/types/network/port.go
@@ -1,4 +1,4 @@
-package container
+package network
 
 import (
 	"errors"
@@ -10,24 +10,24 @@ import (
 	"unique"
 )
 
-// NetworkProtocol represents a network protocol for a port.
-type NetworkProtocol string
+// IPProtocol represents a network protocol for a port.
+type IPProtocol string
 
 const (
-	TCP  NetworkProtocol = "tcp"
-	UDP  NetworkProtocol = "udp"
-	SCTP NetworkProtocol = "sctp"
+	TCP  IPProtocol = "tcp"
+	UDP  IPProtocol = "udp"
+	SCTP IPProtocol = "sctp"
 )
 
 // Sentinel port proto value for zero Port and PortRange values.
-var protoZero unique.Handle[NetworkProtocol]
+var protoZero unique.Handle[IPProtocol]
 
 // Port is a type representing a single port number and protocol in the format "<portnum>/[<proto>]".
 //
 // The zero port value, i.e. Port{}, is invalid; use [ParsePort] to create a valid Port value.
 type Port struct {
 	num   uint16
-	proto unique.Handle[NetworkProtocol]
+	proto unique.Handle[IPProtocol]
 }
 
 // ParsePort parses s as a [Port].
@@ -64,7 +64,7 @@ func MustParsePort(s string) Port {
 // PortFrom returns a [Port] with the given number and protocol.
 //
 // If no protocol is specified (i.e. proto == ""), then PortFrom returns Port{}, false.
-func PortFrom(num uint16, proto NetworkProtocol) (p Port, ok bool) {
+func PortFrom(num uint16, proto IPProtocol) (p Port, ok bool) {
 	if proto == "" {
 		return Port{}, false
 	}
@@ -78,7 +78,7 @@ func (p Port) Num() uint16 {
 }
 
 // Proto returns p's network protocol.
-func (p Port) Proto() NetworkProtocol {
+func (p Port) Proto() IPProtocol {
 	return p.proto.Value()
 }
 
@@ -163,7 +163,7 @@ type PortMap = map[Port][]PortBinding
 type PortRange struct {
 	start uint16
 	end   uint16
-	proto unique.Handle[NetworkProtocol]
+	proto unique.Handle[IPProtocol]
 }
 
 // ParsePortRange parses s as a [PortRange].
@@ -212,7 +212,7 @@ func MustParsePortRange(s string) PortRange {
 // PortRangeFrom returns a [PortRange] with the given start and end port numbers and protocol.
 //
 // If end < start or no protocol is specified (i.e. proto == ""), then PortRangeFrom returns PortRange{}, false.
-func PortRangeFrom(start, end uint16, proto NetworkProtocol) (pr PortRange, ok bool) {
+func PortRangeFrom(start, end uint16, proto IPProtocol) (pr PortRange, ok bool) {
 	if end < start || proto == "" {
 		return PortRange{}, false
 	}
@@ -231,7 +231,7 @@ func (pr PortRange) End() uint16 {
 }
 
 // Proto returns pr's network protocol.
-func (pr PortRange) Proto() NetworkProtocol {
+func (pr PortRange) Proto() IPProtocol {
 	return pr.proto.Value()
 }
 
@@ -335,12 +335,12 @@ func parsePortNumber(rawPort string) (uint16, error) {
 
 // normalizePortProto normalizes the protocol string such that "tcp", "TCP", and "tCp" are equivalent.
 // If proto is not specified, it defaults to "tcp".
-func normalizePortProto(proto string) unique.Handle[NetworkProtocol] {
+func normalizePortProto(proto string) unique.Handle[IPProtocol] {
 	if proto == "" {
 		return unique.Make(TCP)
 	}
 
 	proto = strings.ToLower(proto)
 
-	return unique.Make(NetworkProtocol(proto))
+	return unique.Make(IPProtocol(proto))
 }

--- a/api/types/network/port_test.go
+++ b/api/types/network/port_test.go
@@ -1,4 +1,4 @@
-package container
+package network
 
 import (
 	"encoding/json"
@@ -51,7 +51,7 @@ func TestPort(t *testing.T) {
 	t.Run("PortFrom", func(t *testing.T) {
 		tests := []struct {
 			num   uint16
-			proto NetworkProtocol
+			proto IPProtocol
 		}{
 			{0, TCP},
 			{80, TCP},
@@ -80,7 +80,7 @@ func TestPort(t *testing.T) {
 
 		negativeTests := []struct {
 			num   uint16
-			proto NetworkProtocol
+			proto IPProtocol
 		}{
 			{0, ""},
 			{80, ""},
@@ -293,7 +293,7 @@ func TestPortRange(t *testing.T) {
 		tests := []struct {
 			start uint16
 			end   uint16
-			proto NetworkProtocol
+			proto IPProtocol
 		}{
 			{0, 0, TCP},
 			{0, 1234, TCP},
@@ -325,7 +325,7 @@ func TestPortRange(t *testing.T) {
 		negativeTests := []struct {
 			start uint16
 			end   uint16
-			proto NetworkProtocol
+			proto IPProtocol
 		}{
 			{1234, 80, TCP}, // end < start
 			{0, 0, ""},      // empty protocol
@@ -583,7 +583,7 @@ func BenchmarkPortRangeAll(b *testing.B) {
 	})
 }
 
-func portFrom(num uint16, proto NetworkProtocol) Port {
+func portFrom(num uint16, proto IPProtocol) Port {
 	p, ok := PortFrom(num, proto)
 	if !ok {
 		panic("invalid port")
@@ -591,7 +591,7 @@ func portFrom(num uint16, proto NetworkProtocol) Port {
 	return p
 }
 
-func portRangeFrom(start, end uint16, proto NetworkProtocol) PortRange {
+func portRangeFrom(start, end uint16, proto IPProtocol) PortRange {
 	pr, ok := PortRangeFrom(start, end, proto)
 	if !ok {
 		panic("invalid port range")

--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -54,25 +54,6 @@ const (
 	PortConfigPublishModeHost PortConfigPublishMode = "host"
 )
 
-// PortConfigProtocol represents the protocol of a port.
-//
-// Deprecated: use [network.IPProtocol] instead.
-type PortConfigProtocol = network.IPProtocol
-
-const (
-	// TODO(stevvooe): These should be used generally, not just for PortConfig.
-
-	// PortConfigProtocolTCP TCP
-	// Deprecated: use [network.TCP] instead.
-	PortConfigProtocolTCP PortConfigProtocol = network.TCP
-	// PortConfigProtocolUDP UDP
-	// Deprecated: use [network.UDP] instead.
-	PortConfigProtocolUDP PortConfigProtocol = network.UDP
-	// PortConfigProtocolSCTP SCTP
-	// Deprecated: use [network.SCTP] instead.
-	PortConfigProtocolSCTP PortConfigProtocol = network.SCTP
-)
-
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
 	NetworkID string     `json:",omitempty"`

--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -32,7 +32,7 @@ const (
 // PortConfig represents the config of a port.
 type PortConfig struct {
 	Name     string             `json:",omitempty"`
-	Protocol PortConfigProtocol `json:",omitempty"`
+	Protocol network.IPProtocol `json:",omitempty"`
 	// TargetPort is the port inside the container
 	TargetPort uint32 `json:",omitempty"`
 	// PublishedPort is the port on the swarm hosts
@@ -55,17 +55,22 @@ const (
 )
 
 // PortConfigProtocol represents the protocol of a port.
-type PortConfigProtocol string
+//
+// Deprecated: use [network.IPProtocol] instead.
+type PortConfigProtocol = network.IPProtocol
 
 const (
 	// TODO(stevvooe): These should be used generally, not just for PortConfig.
 
 	// PortConfigProtocolTCP TCP
-	PortConfigProtocolTCP PortConfigProtocol = "tcp"
+	// Deprecated: use [network.TCP] instead.
+	PortConfigProtocolTCP PortConfigProtocol = network.TCP
 	// PortConfigProtocolUDP UDP
-	PortConfigProtocolUDP PortConfigProtocol = "udp"
+	// Deprecated: use [network.UDP] instead.
+	PortConfigProtocolUDP PortConfigProtocol = network.UDP
 	// PortConfigProtocolSCTP SCTP
-	PortConfigProtocolSCTP PortConfigProtocol = "sctp"
+	// Deprecated: use [network.SCTP] instead.
+	PortConfigProtocolSCTP PortConfigProtocol = network.SCTP
 )
 
 // EndpointVirtualIP represents the virtual ip of a port.

--- a/daemon/builder/dockerfile/internals_test.go
+++ b/daemon/builder/dockerfile/internals_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/builder"
 	"github.com/moby/moby/v2/daemon/builder/remotecontext"
 	"github.com/moby/moby/v2/daemon/internal/image"
@@ -135,9 +136,9 @@ func fullMutableRunConfig() *container.Config {
 	return &container.Config{
 		Cmd: []string{"command", "arg1"},
 		Env: []string{"env1=foo", "env2=bar"},
-		ExposedPorts: container.PortSet{
-			container.MustParsePort("1000/tcp"): {},
-			container.MustParsePort("1001/tcp"): {},
+		ExposedPorts: network.PortSet{
+			network.MustParsePort("1000/tcp"): {},
+			network.MustParsePort("1001/tcp"): {},
 		},
 		Volumes: map[string]struct{}{
 			"one": {},
@@ -160,7 +161,7 @@ func TestDeepCopyRunConfig(t *testing.T) {
 
 	ctrCfg.Cmd[1] = "arg2"
 	ctrCfg.Env[1] = "env2=new"
-	ctrCfg.ExposedPorts[container.MustParsePort("10002")] = struct{}{}
+	ctrCfg.ExposedPorts[network.MustParsePort("10002")] = struct{}{}
 	ctrCfg.Volumes["three"] = struct{}{}
 	ctrCfg.Entrypoint[1] = "arg2"
 	ctrCfg.OnBuild[0] = "start"

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -144,7 +144,7 @@ func endpointFromGRPC(e *swarmapi.Endpoint) types.Endpoint {
 func swarmPortConfigToAPIPortConfig(portConfig *swarmapi.PortConfig) types.PortConfig {
 	return types.PortConfig{
 		Name:          portConfig.Name,
-		Protocol:      types.PortConfigProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(portConfig.Protocol)])),
+		Protocol:      network.IPProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(portConfig.Protocol)])),
 		PublishMode:   types.PortConfigPublishMode(strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(portConfig.PublishMode)])),
 		TargetPort:    portConfig.TargetPort,
 		PublishedPort: portConfig.PublishedPort,

--- a/daemon/cluster/convert/task.go
+++ b/daemon/cluster/convert/task.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/moby/moby/api/types/network"
 	types "github.com/moby/moby/api/types/swarm"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 )
@@ -75,7 +76,7 @@ func TaskFromGRPC(t swarmapi.Task) (types.Task, error) {
 	for _, p := range t.Status.PortStatus.Ports {
 		task.Status.PortStatus.Ports = append(task.Status.PortStatus.Ports, types.PortConfig{
 			Name:          p.Name,
-			Protocol:      types.PortConfigProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(p.Protocol)])),
+			Protocol:      network.IPProtocol(strings.ToLower(swarmapi.PortConfig_Protocol_name[int32(p.Protocol)])),
 			PublishMode:   types.PortConfigPublishMode(strings.ToLower(swarmapi.PortConfig_PublishMode_name[int32(p.PublishMode)])),
 			TargetPort:    p.TargetPort,
 			PublishedPort: p.PublishedPort,

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -143,8 +143,8 @@ func (c *containerConfig) image() string {
 	return reference.FamiliarString(reference.TagNameOnly(ref))
 }
 
-func (c *containerConfig) portBindings() container.PortMap {
-	portBindings := container.PortMap{}
+func (c *containerConfig) portBindings() network.PortMap {
+	portBindings := network.PortMap{}
 	if c.task.Endpoint == nil {
 		return portBindings
 	}
@@ -158,12 +158,12 @@ func (c *containerConfig) portBindings() container.PortMap {
 			continue
 		}
 
-		port, ok := container.PortFrom(uint16(portConfig.TargetPort), container.NetworkProtocol(portConfig.Protocol.String()))
+		port, ok := network.PortFrom(uint16(portConfig.TargetPort), network.IPProtocol(portConfig.Protocol.String()))
 		if !ok {
 			continue
 		}
 
-		binding := []container.PortBinding{
+		binding := []network.PortBinding{
 			{},
 		}
 
@@ -188,8 +188,8 @@ func (c *containerConfig) init() *bool {
 	return &init
 }
 
-func (c *containerConfig) exposedPorts() map[container.Port]struct{} {
-	exposedPorts := make(map[container.Port]struct{})
+func (c *containerConfig) exposedPorts() map[network.Port]struct{} {
+	exposedPorts := make(map[network.Port]struct{})
 	if c.task.Endpoint == nil {
 		return exposedPorts
 	}
@@ -203,7 +203,7 @@ func (c *containerConfig) exposedPorts() map[container.Port]struct{} {
 			continue
 		}
 
-		port, ok := container.PortFrom(uint16(portConfig.TargetPort), container.NetworkProtocol(portConfig.Protocol.String()))
+		port, ok := network.PortFrom(uint16(portConfig.TargetPort), network.IPProtocol(portConfig.Protocol.String()))
 		if !ok {
 			continue
 		}

--- a/daemon/cluster/executor/container/controller.go
+++ b/daemon/cluster/executor/container/controller.go
@@ -11,6 +11,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
+	"github.com/moby/moby/api/types/network"
 	executorpkg "github.com/moby/moby/v2/daemon/cluster/executor"
 	"github.com/moby/moby/v2/daemon/libnetwork"
 	"github.com/moby/swarmkit/v2/agent/exec"
@@ -639,17 +640,17 @@ func parsePortStatus(ctnr container.InspectResponse) (*api.PortStatus, error) {
 	return status, nil
 }
 
-func parsePortMap(portMap container.PortMap) ([]*api.PortConfig, error) {
+func parsePortMap(portMap network.PortMap) ([]*api.PortConfig, error) {
 	exposedPorts := make([]*api.PortConfig, 0, len(portMap))
 
 	for port, mapping := range portMap {
 		var protocol api.PortConfig_Protocol
 		switch port.Proto() {
-		case container.TCP:
+		case network.TCP:
 			protocol = api.ProtocolTCP
-		case container.UDP:
+		case network.UDP:
 			protocol = api.ProtocolUDP
-		case container.SCTP:
+		case network.SCTP:
 			protocol = api.ProtocolSCTP
 		default:
 			return nil, fmt.Errorf("invalid protocol: %s", port.Proto())

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -372,7 +372,7 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 	return nil
 }
 
-func validatePortBindings(ports containertypes.PortMap) error {
+func validatePortBindings(ports networktypes.PortMap) error {
 	for port := range ports {
 		if !port.IsValid() {
 			return errors.Errorf("invalid port specification: %q", port.String())
@@ -384,7 +384,7 @@ func validatePortBindings(ports containertypes.PortMap) error {
 				continue
 			}
 
-			if _, err := containertypes.ParsePortRange(pb.HostPort); err != nil {
+			if _, err := networktypes.ParsePortRange(pb.HostPort); err != nil {
 				return errors.Errorf("invalid port specification: %q", pb.HostPort)
 			}
 		}

--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -22,6 +22,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	mounttypes "github.com/moby/moby/api/types/mount"
+	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	libcontainerdtypes "github.com/moby/moby/v2/daemon/internal/libcontainerd/types"
@@ -651,7 +652,7 @@ func (container *Container) BackfillEmptyPBs() {
 		if len(pb) > 0 || pb == nil {
 			continue
 		}
-		container.HostConfig.PortBindings[portProto] = []containertypes.PortBinding{
+		container.HostConfig.PortBindings[portProto] = []networktypes.PortBinding{
 			{}, // Backfill an empty PortBinding
 		}
 	}

--- a/daemon/container/view.go
+++ b/daemon/container/view.go
@@ -39,8 +39,8 @@ type Snapshot struct {
 	Running      bool
 	Paused       bool
 	Managed      bool
-	ExposedPorts container.PortSet
-	PortBindings container.PortSet
+	ExposedPorts network.PortSet
+	PortBindings network.PortSet
 	Health       container.HealthStatus
 	HostConfig   struct {
 		Isolation string
@@ -318,8 +318,8 @@ func (v *View) transform(ctr *Container) *Snapshot {
 		Name:         ctr.Name,
 		Pid:          ctr.State.Pid,
 		Managed:      ctr.Managed,
-		ExposedPorts: make(container.PortSet),
-		PortBindings: make(container.PortSet),
+		ExposedPorts: make(network.PortSet),
+		PortBindings: make(network.PortSet),
 		Health:       health,
 		Running:      ctr.State.Running,
 		Paused:       ctr.State.Paused,
@@ -398,8 +398,8 @@ func (v *View) transform(ctr *Container) *Snapshot {
 				continue
 			}
 			for _, binding := range bindings {
-				// TODO(thaJeztah): if this is always a port/proto (no range), we can simplify this to [container.ParsePort].
-				h, err := container.ParsePortRange(binding.HostPort)
+				// TODO(thaJeztah): if this is always a port/proto (no range), we can simplify this to [network.ParsePort].
+				h, err := network.ParsePortRange(binding.HostPort)
 				if err != nil {
 					log.G(context.TODO()).WithError(err).Warn("invalid host port map")
 					continue

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -94,7 +94,7 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 		}
 	}
 
-	portBindings := make(containertypes.PortMap, len(ctr.HostConfig.PortBindings))
+	portBindings := make(networktypes.PortMap, len(ctr.HostConfig.PortBindings))
 	for p, b := range ctr.HostConfig.PortBindings {
 		portBindings[p] = slices.Clone(b)
 	}
@@ -119,13 +119,13 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 
 		for _, binding := range bindings {
 			var (
-				portRange containertypes.PortRange
+				portRange networktypes.PortRange
 				err       error
 			)
 
 			// Empty HostPort means to map to an ephemeral port.
 			if binding.HostPort != "" {
-				portRange, err = containertypes.ParsePortRange(binding.HostPort)
+				portRange, err = networktypes.ParsePortRange(binding.HostPort)
 				if err != nil {
 					return nil, fmt.Errorf("error parsing HostPort value(%s):%v", binding.HostPort, err)
 				}

--- a/daemon/container_unix_test.go
+++ b/daemon/container_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/config"
 	"gotest.tools/v3/assert"
 )
@@ -14,12 +15,12 @@ import (
 // This should not be tested on Windows because Windows doesn't support "host" network mode.
 func TestContainerWarningHostAndPublishPorts(t *testing.T) {
 	testCases := []struct {
-		ports    containertypes.PortMap
+		ports    network.PortMap
 		warnings []string
 	}{
-		{ports: containertypes.PortMap{}},
-		{ports: containertypes.PortMap{
-			containertypes.MustParsePort("8080"): []containertypes.PortBinding{{HostPort: "8989"}},
+		{ports: network.PortMap{}},
+		{ports: network.PortMap{
+			network.MustParsePort("8080"): []network.PortBinding{{HostPort: "8989"}},
 		}, warnings: []string{"Published ports are discarded when using host network mode"}},
 	}
 	muteLogs(t)

--- a/daemon/containerd/image_import_test.go
+++ b/daemon/containerd/image_import_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -11,8 +12,8 @@ import (
 // regression test for https://github.com/moby/moby/issues/45904
 func TestContainerConfigToDockerImageConfig(t *testing.T) {
 	ociCFG := containerConfigToDockerOCIImageConfig(&container.Config{
-		ExposedPorts: container.PortSet{
-			container.MustParsePort("80/tcp"): struct{}{},
+		ExposedPorts: network.PortSet{
+			network.MustParsePort("80/tcp"): struct{}{},
 		},
 	})
 

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -5,6 +5,7 @@ import (
 
 	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/dockerversion"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -95,9 +96,9 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 }
 
 func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *container.Config {
-	exposedPorts := make(container.PortSet, len(cfg.ExposedPorts))
+	exposedPorts := make(network.PortSet, len(cfg.ExposedPorts))
 	for k := range cfg.ExposedPorts {
-		if p, err := container.ParsePort(k); err == nil {
+		if p, err := network.ParsePort(k); err == nil {
 			exposedPorts[p] = struct{}{}
 		}
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -11,6 +11,7 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/idtools"
 	"github.com/moby/moby/v2/daemon/libnetwork"
@@ -220,9 +221,9 @@ func TestContainerInitDNS(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	configImage := &containertypes.Config{
-		ExposedPorts: containertypes.PortSet{
-			containertypes.MustParsePort("1111/tcp"): struct{}{},
-			containertypes.MustParsePort("2222/tcp"): struct{}{},
+		ExposedPorts: network.PortSet{
+			network.MustParsePort("1111/tcp"): struct{}{},
+			network.MustParsePort("2222/tcp"): struct{}{},
 		},
 		Env: []string{"VAR1=1", "VAR2=2"},
 		Volumes: map[string]struct{}{
@@ -232,9 +233,9 @@ func TestMerge(t *testing.T) {
 	}
 
 	configUser := &containertypes.Config{
-		ExposedPorts: containertypes.PortSet{
-			containertypes.MustParsePort("2222/tcp"): struct{}{},
-			containertypes.MustParsePort("3333/tcp"): struct{}{},
+		ExposedPorts: network.PortSet{
+			network.MustParsePort("2222/tcp"): struct{}{},
+			network.MustParsePort("3333/tcp"): struct{}{},
 		},
 		Env: []string{"VAR2=3", "VAR3=3"},
 		Volumes: map[string]struct{}{
@@ -273,8 +274,8 @@ func TestMerge(t *testing.T) {
 	}
 
 	configImage2 := &containertypes.Config{
-		ExposedPorts: map[containertypes.Port]struct{}{
-			containertypes.MustParsePort("0/tcp"): {},
+		ExposedPorts: map[network.Port]struct{}{
+			network.MustParsePort("0/tcp"): {},
 		},
 	}
 

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -34,7 +34,7 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, options
 	}
 
 	// TODO(thaJeztah): do we need a deep copy here? Otherwise we could use maps.Clone (see https://github.com/moby/moby/commit/7917a36cc787ada58987320e67cc6d96858f3b55)
-	ports := make(containertypes.PortMap, len(ctr.NetworkSettings.Ports))
+	ports := make(networktypes.PortMap, len(ctr.NetworkSettings.Ports))
 	for k, pm := range ctr.NetworkSettings.Ports {
 		ports[k] = pm
 	}

--- a/daemon/internal/image/cache/compare_test.go
+++ b/daemon/internal/image/cache/compare_test.go
@@ -5,24 +5,25 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestCompare(t *testing.T) {
-	ports1 := container.PortSet{
-		container.MustParsePort("1111/tcp"): struct{}{},
-		container.MustParsePort("2222/tcp"): struct{}{},
+	ports1 := network.PortSet{
+		network.MustParsePort("1111/tcp"): struct{}{},
+		network.MustParsePort("2222/tcp"): struct{}{},
 	}
-	ports2 := container.PortSet{
-		container.MustParsePort("3333/tcp"): struct{}{},
-		container.MustParsePort("4444/tcp"): struct{}{},
+	ports2 := network.PortSet{
+		network.MustParsePort("3333/tcp"): struct{}{},
+		network.MustParsePort("4444/tcp"): struct{}{},
 	}
-	ports3 := container.PortSet{
-		container.MustParsePort("1111/tcp"): struct{}{},
-		container.MustParsePort("2222/tcp"): struct{}{},
-		container.MustParsePort("5555/tcp"): struct{}{},
+	ports3 := network.PortSet{
+		network.MustParsePort("1111/tcp"): struct{}{},
+		network.MustParsePort("2222/tcp"): struct{}{},
+		network.MustParsePort("5555/tcp"): struct{}{},
 	}
 	volumes1 := map[string]struct{}{
 		"/test1": {},

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/log"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/server/backend"
@@ -403,7 +404,7 @@ func portOp(key string, filter map[string]bool) func(value string) error {
 			return fmt.Errorf("filter for '%s' should not contain ':': %s", key, value)
 		}
 		// support two formats, original format <portnum>/[<proto>] or <startport-endport>/[<proto>]
-		portRange, err := containertypes.ParsePortRange(value)
+		portRange, err := network.ParsePortRange(value)
 		if err != nil {
 			return fmt.Errorf("error while looking up for %s %s: %s", key, value, err)
 		}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1027,13 +1027,13 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 
 		for _, binding := range bindings {
 			var (
-				portRange containertypes.PortRange
+				portRange networktypes.PortRange
 				err       error
 			)
 
 			// Empty HostPort means to map to an ephemeral port.
 			if binding.HostPort != "" {
-				portRange, err = containertypes.ParsePortRange(binding.HostPort)
+				portRange, err = networktypes.ParsePortRange(binding.HostPort)
 				if err != nil {
 					return nil, fmt.Errorf("error parsing HostPort value(%s):%v", binding.HostPort, err)
 				}
@@ -1063,8 +1063,8 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 }
 
 // getPortMapInfo retrieves the current port-mapping programmed for the given sandbox
-func getPortMapInfo(sb *libnetwork.Sandbox) containertypes.PortMap {
-	pm := containertypes.PortMap{}
+func getPortMapInfo(sb *libnetwork.Sandbox) networktypes.PortMap {
+	pm := networktypes.PortMap{}
 	if sb == nil {
 		return pm
 	}
@@ -1075,7 +1075,7 @@ func getPortMapInfo(sb *libnetwork.Sandbox) containertypes.PortMap {
 	return pm
 }
 
-func getEndpointPortMapInfo(pm containertypes.PortMap, ep *libnetwork.Endpoint) {
+func getEndpointPortMapInfo(pm networktypes.PortMap, ep *libnetwork.Endpoint) {
 	driverInfo, _ := ep.DriverInfo()
 	if driverInfo == nil {
 		// It is not an error for epInfo to be nil
@@ -1085,7 +1085,7 @@ func getEndpointPortMapInfo(pm containertypes.PortMap, ep *libnetwork.Endpoint) 
 	if expData, ok := driverInfo[netlabel.ExposedPorts]; ok {
 		if exposedPorts, ok := expData.([]lntypes.TransportPort); ok {
 			for _, tp := range exposedPorts {
-				natPort, ok := containertypes.PortFrom(tp.Port, containertypes.NetworkProtocol(tp.Proto.String()))
+				natPort, ok := networktypes.PortFrom(tp.Port, networktypes.IPProtocol(tp.Proto.String()))
 				if !ok {
 					log.G(context.TODO()).Errorf("Invalid exposed port: %s", tp.String())
 					continue
@@ -1105,7 +1105,7 @@ func getEndpointPortMapInfo(pm containertypes.PortMap, ep *libnetwork.Endpoint) 
 	if portMapping, ok := mapData.([]lntypes.PortBinding); ok {
 		for _, pp := range portMapping {
 			// Use an empty string for the host natPort if there's no natPort assigned.
-			natPort, ok := containertypes.PortFrom(pp.Port, containertypes.NetworkProtocol(pp.Proto.String()))
+			natPort, ok := networktypes.PortFrom(pp.Port, networktypes.IPProtocol(pp.Proto.String()))
 			if !ok {
 				log.G(context.TODO()).Errorf("Invalid port binding: %s", pp.String())
 				continue
@@ -1115,7 +1115,7 @@ func getEndpointPortMapInfo(pm containertypes.PortMap, ep *libnetwork.Endpoint) 
 			if pp.HostPort > 0 {
 				hp = strconv.Itoa(int(pp.HostPort))
 			}
-			natBndg := containertypes.PortBinding{HostPort: hp}
+			natBndg := networktypes.PortBinding{HostPort: hp}
 			natBndg.HostIP, _ = netip.AddrFromSlice(pp.HostIP)
 			pm[natPort] = append(pm[natPort], natBndg)
 		}

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	clustertypes "github.com/moby/moby/v2/daemon/cluster/provider"
 	"github.com/pkg/errors"
@@ -17,7 +16,7 @@ type Settings struct {
 	SandboxKey       string
 	Networks         map[string]*EndpointSettings
 	Service          *clustertypes.ServiceConfig
-	Ports            container.PortMap
+	Ports            networktypes.PortMap
 	HasSwarmEndpoint bool
 }
 

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -901,7 +901,7 @@ func handlePortBindingsBC(hostConfig *container.HostConfig, version string) stri
 			emptyPBs = append(emptyPBs, port.String())
 		}
 
-		hostConfig.PortBindings[port] = []container.PortBinding{{}}
+		hostConfig.PortBindings[port] = []network.PortBinding{{}}
 	}
 
 	if len(emptyPBs) > 0 {

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -504,8 +504,8 @@ func (s *DockerAPISuite) TestContainerAPIBadPort(c *testing.T) {
 	}
 
 	hostConfig := container.HostConfig{
-		PortBindings: container.PortMap{
-			container.MustParsePort("8080/tcp"): []container.PortBinding{
+		PortBindings: network.PortMap{
+			network.MustParsePort("8080/tcp"): []network.PortBinding{
 				{
 					HostPort: "aa80",
 				},

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/integration-cli/cli"
 	"github.com/moby/moby/v2/integration-cli/cli/build"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
@@ -92,7 +92,7 @@ func (s *DockerCLICreateSuite) TestCreateWithPortRange(c *testing.T) {
 
 	var containers []struct {
 		HostConfig *struct {
-			PortBindings map[containertypes.Port][]containertypes.PortBinding
+			PortBindings network.PortMap
 		}
 	}
 	err := json.Unmarshal([]byte(out), &containers)
@@ -118,7 +118,7 @@ func (s *DockerCLICreateSuite) TestCreateWithLargePortRange(c *testing.T) {
 
 	var containers []struct {
 		HostConfig *struct {
-			PortBindings map[containertypes.Port][]containertypes.PortBinding
+			PortBindings network.PortMap
 		}
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/stringid"
 	"github.com/moby/moby/v2/integration-cli/cli"
@@ -2168,7 +2168,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughExpose(c *testing.T) {
 	id = strings.TrimSpace(id)
 
 	portstr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
-	var ports container.PortMap
+	var ports network.PortMap
 	if err := json.Unmarshal([]byte(portstr), &ports); err != nil {
 		c.Fatal(err)
 	}
@@ -2505,7 +2505,7 @@ func (s *DockerCLIRunSuite) TestRunAllowPortRangeThroughPublish(c *testing.T) {
 	id = strings.TrimSpace(id)
 	portStr := inspectFieldJSON(c, id, "NetworkSettings.Ports")
 
-	var ports container.PortMap
+	var ports network.PortMap
 	err := json.Unmarshal([]byte(portStr), &ports)
 	assert.NilError(c, err, "failed to unmarshal: %v", portStr)
 	for port, binding := range ports {

--- a/integration/container/daemon_test.go
+++ b/integration/container/daemon_test.go
@@ -3,7 +3,7 @@ package container
 import (
 	"testing"
 
-	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -71,13 +71,13 @@ func TestNetworkStateCleanupOnDaemonStart(t *testing.T) {
 	defer d.Stop(t)
 
 	apiClient := d.NewClientT(t)
-	mappedPort := containertypes.MustParsePort("80/tcp")
+	mappedPort := network.MustParsePort("80/tcp")
 
 	// The intention of this container is to ignore stop signals.
 	// Sadly this means the test will take longer, but at least this test can be parallelized.
 	cid := container.Run(ctx, t, apiClient,
 		container.WithExposedPorts("80/tcp"),
-		container.WithPortMap(containertypes.PortMap{mappedPort: {{}}}),
+		container.WithPortMap(network.PortMap{mappedPort: {{}}}),
 		container.WithCmd("/bin/sh", "-c", "while true; do echo hello; sleep 1; done"))
 	defer func() {
 		err := apiClient.ContainerRemove(ctx, cid, client.ContainerRemoveOptions{Force: true})

--- a/integration/container/nat_test.go
+++ b/integration/container/nat_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"gotest.tools/v3/assert"
@@ -122,8 +122,8 @@ func startServerContainer(ctx context.Context, t *testing.T, msg string, port ui
 		container.WithCmd("sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port)),
 		container.WithExposedPorts(fmt.Sprintf("%d/tcp", port)),
 		func(c *container.TestContainerConfig) {
-			c.HostConfig.PortBindings = containertypes.PortMap{
-				containertypes.MustParsePort(fmt.Sprintf("%d/tcp", port)): []containertypes.PortBinding{
+			c.HostConfig.PortBindings = network.PortMap{
+				network.MustParsePort(fmt.Sprintf("%d/tcp", port)): []network.PortBinding{
 					{
 						HostPort: fmt.Sprintf("%d", port),
 					},

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -74,18 +74,18 @@ func WithSysctls(sysctls map[string]string) func(*TestContainerConfig) {
 // WithExposedPorts sets the exposed ports of the container
 func WithExposedPorts(ports ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.Config.ExposedPorts = map[container.Port]struct{}{}
+		c.Config.ExposedPorts = map[network.Port]struct{}{}
 		for _, port := range ports {
-			p, _ := container.ParsePort(port)
+			p, _ := network.ParsePort(port)
 			c.Config.ExposedPorts[p] = struct{}{}
 		}
 	}
 }
 
 // WithPortMap sets/replaces port mappings.
-func WithPortMap(pm container.PortMap) func(*TestContainerConfig) {
+func WithPortMap(pm network.PortMap) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {
-		c.HostConfig.PortBindings = container.PortMap{}
+		c.HostConfig.PortBindings = network.PortMap{}
 		for p, b := range pm {
 			c.HostConfig.PortBindings[p] = slices.Clone(b)
 		}

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -354,7 +354,7 @@ func createServices(ctx context.Context, t *testing.T, d *daemon.Daemon, section
 					hp, err := strconv.Atoi(hostPort.HostPort)
 					assert.NilError(t, err)
 					portConfig = append(portConfig, swarmtypes.PortConfig{
-						Protocol:      swarmtypes.PortConfigProtocol(ctrPP.Proto()),
+						Protocol:      ctrPP.Proto(),
 						PublishedPort: uint32(hp),
 						TargetPort:    uint32(ctrPP.Num()),
 					})

--- a/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
+++ b/integration/network/bridge/iptablesdoc/iptablesdoc_linux_test.go
@@ -30,7 +30,7 @@ import (
 	"text/template"
 	"time"
 
-	containertypes "github.com/moby/moby/api/types/container"
+	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
@@ -53,7 +53,7 @@ var (
 
 type ctrDesc struct {
 	name         string
-	portMappings containertypes.PortMap
+	portMappings networktypes.PortMap
 }
 
 type networkDesc struct {
@@ -82,7 +82,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -95,7 +95,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -108,7 +108,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -142,7 +142,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -155,7 +155,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -167,7 +167,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -179,7 +179,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "8080"}}},
 				},
 			},
 		}},

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"text/template"
 
-	containertypes "github.com/moby/moby/api/types/container"
+	networktypes "github.com/moby/moby/api/types/network"
 	swarmtypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
@@ -50,7 +50,7 @@ var (
 
 type ctrDesc struct {
 	name         string
-	portMappings containertypes.PortMap
+	portMappings networktypes.PortMap
 }
 
 type networkDesc struct {
@@ -79,7 +79,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -92,7 +92,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -105,7 +105,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -139,7 +139,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -152,7 +152,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}},
 				},
 			},
 		}},
@@ -178,7 +178,7 @@ var index = []section{
 			containers: []ctrDesc{
 				{
 					name:         "c1",
-					portMappings: containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "8080"}}},
+					portMappings: networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostIP: netip.MustParseAddr("127.0.0.1"), HostPort: "8080"}}},
 				},
 			},
 		}},

--- a/integration/network/overlay/overlay_test.go
+++ b/integration/network/overlay/overlay_test.go
@@ -82,7 +82,7 @@ func TestHostPortMappings(t *testing.T) {
 		swarm.ServiceWithNetwork(netName),
 		swarm.ServiceWithEndpoint(&swarmtypes.EndpointSpec{
 			Ports: []swarmtypes.PortConfig{
-				{Protocol: swarmtypes.PortConfigProtocolTCP, TargetPort: 80, PublishedPort: 80, PublishMode: swarmtypes.PortConfigPublishModeHost},
+				{Protocol: networktypes.TCP, TargetPort: 80, PublishedPort: 80, PublishMode: swarmtypes.PortConfigPublishModeHost},
 			},
 		}))
 	defer apiClient.ServiceRemove(ctx, svcID)

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -276,7 +276,7 @@ func TestServiceRemoveKeepsIngressNetwork(t *testing.T) {
 		swarm.ServiceWithEndpoint(&swarmtypes.EndpointSpec{
 			Ports: []swarmtypes.PortConfig{
 				{
-					Protocol:    swarmtypes.PortConfigProtocolTCP,
+					Protocol:    networktypes.TCP,
 					TargetPort:  80,
 					PublishMode: swarmtypes.PortConfigPublishModeIngress,
 				},

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
@@ -388,7 +387,7 @@ func TestBridgeINCRouted(t *testing.T) {
 			container.WithNetworkMode(netName),
 			container.WithName("ctr-"+gwMode),
 			container.WithExposedPorts("80/tcp"),
-			container.WithPortMap(containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {}}),
+			container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {}}),
 		)
 		t.Cleanup(func() {
 			c.ContainerRemove(ctx, ctrId, client.ContainerRemoveOptions{Force: true})
@@ -565,7 +564,7 @@ func TestAccessToPublishedPort(t *testing.T) {
 				container.WithNetworkMode(serverNetName),
 				container.WithName("ctr-server"),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {containertypes.PortBinding{HostPort: "8080"}}}),
+				container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {networktypes.PortBinding{HostPort: "8080"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, ctrId, client.ContainerRemoveOptions{Force: true})
@@ -688,7 +687,7 @@ func TestInterNetworkDirectRouting(t *testing.T) {
 				container.WithNetworkMode(serverNetName),
 				container.WithName("ctr-pub"),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {containertypes.PortBinding{HostPort: "8080"}}}),
+				container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {networktypes.PortBinding{HostPort: "8080"}}}),
 				container.WithCmd("httpd", "-f"),
 			)
 			defer c.ContainerRemove(ctx, ctrPubId, client.ContainerRemoveOptions{Force: true})
@@ -1063,7 +1062,7 @@ func TestDisableIPv6OnInterface(t *testing.T) {
 				container.WithName(ctrName),
 				container.WithNetworkMode(tc.netName),
 				container.WithExposedPorts("80/tcp"),
-				container.WithPortMap(containertypes.PortMap{containertypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}}),
+				container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80/tcp"): {{HostPort: "8080"}}}),
 				container.WithEndpointSettings(tc.netName, &networktypes.EndpointSettings{
 					DriverOpts: map[string]string{
 						netlabel.EndpointSysctls: "net.ipv6.conf.IFNAME.disable_ipv6=1",
@@ -1505,7 +1504,7 @@ func TestGatewaySelection(t *testing.T) {
 		container.WithName(ctrName),
 		container.WithNetworkMode(netName4),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(containertypes.PortMap{containertypes.MustParsePort("80"): {{HostPort: "8080"}}}),
+		container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80"): {{HostPort: "8080"}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, ctrId, client.ContainerRemoveOptions{Force: true})
@@ -1956,7 +1955,7 @@ func TestDropInForwardChain(t *testing.T) {
 		ctrId := container.Run(ctx, t, c,
 			container.WithNetworkMode(netName46),
 			container.WithExposedPorts("80"),
-			container.WithPortMap(containertypes.PortMap{containertypes.MustParsePort("80"): {{HostPort: hostPort}}}),
+			container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80"): {{HostPort: hostPort}}}),
 			container.WithCmd("httpd", "-f"),
 		)
 		defer c.ContainerRemove(ctx, ctrId, client.ContainerRemoveOptions{Force: true})

--- a/integration/networking/nat_windows_test.go
+++ b/integration/networking/nat_windows_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	containertypes "github.com/moby/moby/api/types/container"
+	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/integration/internal/network"
@@ -98,13 +98,13 @@ func TestFlakyPortMappedHairpinWindows(t *testing.T) {
 	serverId := container.Run(ctx, t, c,
 		container.WithNetworkMode(serverNetName),
 		container.WithExposedPorts("80"),
-		container.WithPortMap(containertypes.PortMap{containertypes.MustParsePort("80"): {{HostIP: netip.IPv4Unspecified()}}}),
+		container.WithPortMap(networktypes.PortMap{networktypes.MustParsePort("80"): {{HostIP: netip.IPv4Unspecified()}}}),
 		container.WithCmd("httpd", "-f"),
 	)
 	defer c.ContainerRemove(ctx, serverId, client.ContainerRemoveOptions{Force: true})
 
 	inspect := container.Inspect(ctx, t, c, serverId)
-	hostPort := inspect.NetworkSettings.Ports[containertypes.MustParsePort("80/tcp")][0].HostPort
+	hostPort := inspect.NetworkSettings.Ports[networktypes.MustParsePort("80/tcp")][0].HostPort
 
 	attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()

--- a/internal/testutil/fakestorage/storage.go
+++ b/internal/testutil/fakestorage/storage.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/environment"
@@ -164,7 +165,7 @@ COPY . /static`); err != nil {
 	// Find out the system assigned port
 	i, err := c.ContainerInspect(context.Background(), b.ID)
 	assert.NilError(t, err)
-	ports, exists := i.NetworkSettings.Ports[containertypes.MustParsePort("80/tcp")]
+	ports, exists := i.NetworkSettings.Ports[network.MustParsePort("80/tcp")]
 	assert.Assert(t, exists, "unable to find port 80/tcp for %s", ctrName)
 	if len(ports) == 0 {
 		t.Fatalf("no ports mapped for 80/tcp for %s: %#v", ctrName, i.NetworkSettings.Ports)

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
+	"github.com/moby/moby/api/types/network"
 )
 
 // MinimumDuration puts a minimum on user configured duration.
@@ -28,7 +29,7 @@ type Config struct {
 	AttachStdin     bool                // Attach the standard input, makes possible user interaction
 	AttachStdout    bool                // Attach the standard output
 	AttachStderr    bool                // Attach the standard error
-	ExposedPorts    PortSet             `json:",omitempty"` // List of exposed ports
+	ExposedPorts    network.PortSet     `json:",omitempty"` // List of exposed ports
 	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
 	OpenStdin       bool                // Open stdin
 	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.

--- a/vendor/github.com/moby/moby/api/types/container/hostconfig.go
+++ b/vendor/github.com/moby/moby/api/types/container/hostconfig.go
@@ -421,7 +421,7 @@ type HostConfig struct {
 	ContainerIDFile string            // File (path) where the containerId is written
 	LogConfig       LogConfig         // Configuration of the logs for this container
 	NetworkMode     NetworkMode       // Network mode to use for the container
-	PortBindings    PortMap           // Port mapping between the exposed port (container) and the host
+	PortBindings    network.PortMap   // Port mapping between the exposed port (container) and the host
 	RestartPolicy   RestartPolicy     // Restart policy to be used for the container
 	AutoRemove      bool              // Automatically remove container when it exits
 	VolumeDriver    string            // Name of the volume driver used to mount volumes

--- a/vendor/github.com/moby/moby/api/types/container/network_settings.go
+++ b/vendor/github.com/moby/moby/api/types/container/network_settings.go
@@ -6,10 +6,13 @@ import (
 
 // NetworkSettings exposes the network settings in the api
 type NetworkSettings struct {
-	SandboxID  string  // SandboxID uniquely represents a container's network stack
-	SandboxKey string  // SandboxKey identifies the sandbox
-	Ports      PortMap // Ports is a collection of PortBinding indexed by Port
-	Networks   map[string]*network.EndpointSettings
+	SandboxID  string // SandboxID uniquely represents a container's network stack
+	SandboxKey string // SandboxKey identifies the sandbox
+
+	// Ports is a collection of [network.PortBinding] indexed by [network.Port]
+	Ports network.PortMap
+
+	Networks map[string]*network.EndpointSettings
 }
 
 // NetworkSettingsSummary provides a summary of container's networks

--- a/vendor/github.com/moby/moby/api/types/network/port.go
+++ b/vendor/github.com/moby/moby/api/types/network/port.go
@@ -1,4 +1,4 @@
-package container
+package network
 
 import (
 	"errors"
@@ -10,24 +10,24 @@ import (
 	"unique"
 )
 
-// NetworkProtocol represents a network protocol for a port.
-type NetworkProtocol string
+// IPProtocol represents a network protocol for a port.
+type IPProtocol string
 
 const (
-	TCP  NetworkProtocol = "tcp"
-	UDP  NetworkProtocol = "udp"
-	SCTP NetworkProtocol = "sctp"
+	TCP  IPProtocol = "tcp"
+	UDP  IPProtocol = "udp"
+	SCTP IPProtocol = "sctp"
 )
 
 // Sentinel port proto value for zero Port and PortRange values.
-var protoZero unique.Handle[NetworkProtocol]
+var protoZero unique.Handle[IPProtocol]
 
 // Port is a type representing a single port number and protocol in the format "<portnum>/[<proto>]".
 //
 // The zero port value, i.e. Port{}, is invalid; use [ParsePort] to create a valid Port value.
 type Port struct {
 	num   uint16
-	proto unique.Handle[NetworkProtocol]
+	proto unique.Handle[IPProtocol]
 }
 
 // ParsePort parses s as a [Port].
@@ -64,7 +64,7 @@ func MustParsePort(s string) Port {
 // PortFrom returns a [Port] with the given number and protocol.
 //
 // If no protocol is specified (i.e. proto == ""), then PortFrom returns Port{}, false.
-func PortFrom(num uint16, proto NetworkProtocol) (p Port, ok bool) {
+func PortFrom(num uint16, proto IPProtocol) (p Port, ok bool) {
 	if proto == "" {
 		return Port{}, false
 	}
@@ -78,7 +78,7 @@ func (p Port) Num() uint16 {
 }
 
 // Proto returns p's network protocol.
-func (p Port) Proto() NetworkProtocol {
+func (p Port) Proto() IPProtocol {
 	return p.proto.Value()
 }
 
@@ -163,7 +163,7 @@ type PortMap = map[Port][]PortBinding
 type PortRange struct {
 	start uint16
 	end   uint16
-	proto unique.Handle[NetworkProtocol]
+	proto unique.Handle[IPProtocol]
 }
 
 // ParsePortRange parses s as a [PortRange].
@@ -212,7 +212,7 @@ func MustParsePortRange(s string) PortRange {
 // PortRangeFrom returns a [PortRange] with the given start and end port numbers and protocol.
 //
 // If end < start or no protocol is specified (i.e. proto == ""), then PortRangeFrom returns PortRange{}, false.
-func PortRangeFrom(start, end uint16, proto NetworkProtocol) (pr PortRange, ok bool) {
+func PortRangeFrom(start, end uint16, proto IPProtocol) (pr PortRange, ok bool) {
 	if end < start || proto == "" {
 		return PortRange{}, false
 	}
@@ -231,7 +231,7 @@ func (pr PortRange) End() uint16 {
 }
 
 // Proto returns pr's network protocol.
-func (pr PortRange) Proto() NetworkProtocol {
+func (pr PortRange) Proto() IPProtocol {
 	return pr.proto.Value()
 }
 
@@ -335,12 +335,12 @@ func parsePortNumber(rawPort string) (uint16, error) {
 
 // normalizePortProto normalizes the protocol string such that "tcp", "TCP", and "tCp" are equivalent.
 // If proto is not specified, it defaults to "tcp".
-func normalizePortProto(proto string) unique.Handle[NetworkProtocol] {
+func normalizePortProto(proto string) unique.Handle[IPProtocol] {
 	if proto == "" {
 		return unique.Make(TCP)
 	}
 
 	proto = strings.ToLower(proto)
 
-	return unique.Make(NetworkProtocol(proto))
+	return unique.Make(IPProtocol(proto))
 }

--- a/vendor/github.com/moby/moby/api/types/swarm/network.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/network.go
@@ -54,25 +54,6 @@ const (
 	PortConfigPublishModeHost PortConfigPublishMode = "host"
 )
 
-// PortConfigProtocol represents the protocol of a port.
-//
-// Deprecated: use [network.IPProtocol] instead.
-type PortConfigProtocol = network.IPProtocol
-
-const (
-	// TODO(stevvooe): These should be used generally, not just for PortConfig.
-
-	// PortConfigProtocolTCP TCP
-	// Deprecated: use [network.TCP] instead.
-	PortConfigProtocolTCP PortConfigProtocol = network.TCP
-	// PortConfigProtocolUDP UDP
-	// Deprecated: use [network.UDP] instead.
-	PortConfigProtocolUDP PortConfigProtocol = network.UDP
-	// PortConfigProtocolSCTP SCTP
-	// Deprecated: use [network.SCTP] instead.
-	PortConfigProtocolSCTP PortConfigProtocol = network.SCTP
-)
-
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
 	NetworkID string     `json:",omitempty"`

--- a/vendor/github.com/moby/moby/api/types/swarm/network.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/network.go
@@ -32,7 +32,7 @@ const (
 // PortConfig represents the config of a port.
 type PortConfig struct {
 	Name     string             `json:",omitempty"`
-	Protocol PortConfigProtocol `json:",omitempty"`
+	Protocol network.IPProtocol `json:",omitempty"`
 	// TargetPort is the port inside the container
 	TargetPort uint32 `json:",omitempty"`
 	// PublishedPort is the port on the swarm hosts
@@ -55,17 +55,22 @@ const (
 )
 
 // PortConfigProtocol represents the protocol of a port.
-type PortConfigProtocol string
+//
+// Deprecated: use [network.IPProtocol] instead.
+type PortConfigProtocol = network.IPProtocol
 
 const (
 	// TODO(stevvooe): These should be used generally, not just for PortConfig.
 
 	// PortConfigProtocolTCP TCP
-	PortConfigProtocolTCP PortConfigProtocol = "tcp"
+	// Deprecated: use [network.TCP] instead.
+	PortConfigProtocolTCP PortConfigProtocol = network.TCP
 	// PortConfigProtocolUDP UDP
-	PortConfigProtocolUDP PortConfigProtocol = "udp"
+	// Deprecated: use [network.UDP] instead.
+	PortConfigProtocolUDP PortConfigProtocol = network.UDP
 	// PortConfigProtocolSCTP SCTP
-	PortConfigProtocolSCTP PortConfigProtocol = "sctp"
+	// Deprecated: use [network.SCTP] instead.
+	PortConfigProtocolSCTP PortConfigProtocol = network.SCTP
 )
 
 // EndpointVirtualIP represents the virtual ip of a port.


### PR DESCRIPTION
**- What I did**
Follow-up to #50710 

**- How I did it**
Moved the container port/port range types under network package and deprecated and removed the usage of swarm.PortConfigProtocol.

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/swarm: deprecated and dropped support for `PortConfigProtocol`; use `network.IPProtocol` instead.
```

**- A picture of a cute animal (not mandatory but encouraged)**

