### PR TITLE
daemon/internal/compat: add extra fields recursively, and don't replace

### DIFF
--- a/daemon/internal/compat/compat_test.go
+++ b/daemon/internal/compat/compat_test.go
@@ -55,13 +55,16 @@ func TestWrap(t *testing.T) {
 			},
 			expected: `{"legacy_field":"hello","name":"daemon"}`,
 		},
-		{
-			name: "replace field",
-			options: []compat.Option{compat.WithExtraFields(map[string]any{"version": struct {
-				Major, Minor int
-			}{Major: 1, Minor: 0}})},
-			expected: `{"name":"daemon","newfield":"new field","version":{"Major":1,"Minor":0}}`,
-		},
+		// TODO(thaJeztah): add a "replace" option to allow replacing existing fields.
+		/*
+			{
+				name: "replace field",
+				options: []compat.Option{compat.WithExtraFields(map[string]any{"version": struct {
+					Major, Minor int
+				}{Major: 1, Minor: 0}})},
+				expected: `{"name":"daemon","newfield":"new field","version":{"Major":1,"Minor":0}}`,
+			},
+		*/
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This was a bit of an oversight; when setting additional fields to add, the compat package currently replaces fields unconditionally. This may have sounded like an OK idea, but it makes it more complicated to augment responses where current versions use an "omitempty", but older API versions should return default / zero-values.

This patch:

- Changes the meaning of "extra fields"; extra fields are only used if the field is not present in the response.
- Makes the merging of "extra fields" recursive; this makes it easier to patch responses where extra fields must be added to nested structs. Previously, this would require the nested struct to be wrapped with a `compat.Wrap` and replaced as a whole; lacking a "replace" option made that more complicated, so making the extra fields recursive.
- Comment-out a test that tested the old behavior of replacing fields; we currently have no cases where we must _replace_ fields or structs, so I did not yet implement such an option, but we can implement a `WithReplaceFields` (e.g.) once there's a need.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

