### PR TITLE
image inspect: fix legacy fields for API < v1.52 response

### DIFF
--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -425,13 +425,17 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 			"DockerVersion": imageInspect.DockerVersion, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
 			"Author":        imageInspect.Author,
 		}))
+
+		// preserve fields in the image Config that have an "omitempty"
+		// in the OCI spec, but weren't omitted in API v1.51 and lower.
 		if versions.LessThan(version, "1.50") {
-			legacyOptions = append(legacyOptions, compat.WithExtraFields(legacyConfigFields["v1.49"]))
+			legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{
+				"Config": legacyConfigFields["v1.49"],
+			}))
 		} else {
-			// inspectResponse preserves fields in the response that have an
-			// "omitempty" in the OCI spec, but didn't omit such fields in
-			// legacy responses before API v1.50.
-			legacyOptions = append(legacyOptions, compat.WithExtraFields(legacyConfigFields["v1.50-v1.51"]))
+			legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{
+				"Config": legacyConfigFields["v1.50-v1.51"],
+			}))
 		}
 	}
 

--- a/daemon/server/router/image/inspect_response_test.go
+++ b/daemon/server/router/image/inspect_response_test.go
@@ -6,6 +6,7 @@ import (
 
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/v2/daemon/internal/compat"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -59,10 +60,11 @@ func TestInspectResponse(t *testing.T) {
 					ImageConfig: *tc.cfg,
 				}
 			}
-			out, err := json.Marshal(&inspectCompatResponse{
-				InspectResponse: imgInspect,
-				legacyConfig:    tc.legacyConfig,
-			})
+			legacyConfigResponse := compat.Wrap(imgInspect, compat.WithExtraFields(map[string]any{
+				"Config": tc.legacyConfig,
+			}))
+
+			out, err := json.Marshal(&legacyConfigResponse)
 			assert.NilError(t, err)
 
 			var outMap struct{ Config json.RawMessage }


### PR DESCRIPTION
- relates to / regression in https://github.com/moby/moby/pull/51070
- [x] depends on https://github.com/moby/moby/pull/51097

### image inspect: fix legacy fields for API < v1.52 response

This was a mistake I made in eafca64a6bb6fda72cfe07c294780e65173de1ce,
which was extracted from a set of changes that I had in progress, but
I forgot that patch was unfinished (whoops!); before that commit, the
legacy "Config" fields were handled through the `inspectCompatResponse`,
which applied the legacy fields to the `Config` struct within the image
inspect response.

When changing the implementation to use the `compat` package, those
fields were applied at the top-level of the response, instead of the
`Config`; additional changes were needed for the `compat` package to
support pathing nested structs, and to prevent "extra" fields from
overwriting fields that already existed in the response; these changes
were implemented in e204ba1dcaba62beaadd1d95574f8784d9c4dd7c.

This patch:

- Removes the old `inspectCompatResponse` implementation, which was
  no longer used.
- Updates the router to patch the `Config` fields, using the fixes
  and enhancements that were implemented in e204ba1dcaba62beaadd1d95574f8784d9c4dd7c.


**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

