### PR TITLE
use consistent alias for docker image spec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -194,6 +194,8 @@ linters:
           alias: c8dimages
         - pkg: github.com/opencontainers/image-spec/specs-go/v1
           alias: ocispec
+        - pkg: github.com/moby/docker-image-spec/specs-go/v1
+          alias: dockerspec
         - pkg: go.etcd.io/bbolt
           alias: bolt
           # Enforce that gotest.tools/v3/assert/cmp is always aliased as "is"

--- a/daemon/containerd/image.go
+++ b/daemon/containerd/image.go
@@ -12,7 +12,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
-	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/v2/daemon/images"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
@@ -54,7 +54,7 @@ func (i *ImageService) GetImage(ctx context.Context, refOrID string, options ima
 		return nil, err
 	}
 
-	var ociImage imagespec.DockerOCIImage
+	var ociImage dockerspec.DockerOCIImage
 	err = im.ReadConfig(ctx, &ociImage)
 	if err != nil {
 		return nil, err

--- a/daemon/containerd/image_builder.go
+++ b/daemon/containerd/image_builder.go
@@ -21,7 +21,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
-	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/pkg/progress"
 	"github.com/moby/moby/api/pkg/streamformatter"
@@ -491,7 +491,7 @@ func (i *ImageService) CreateImage(ctx context.Context, config []byte, parent st
 	return image.Clone(imgToCreate, createdImageId), nil
 }
 
-func (i *ImageService) createImageOCI(ctx context.Context, imgToCreate imagespec.DockerOCIImage,
+func (i *ImageService) createImageOCI(ctx context.Context, imgToCreate dockerspec.DockerOCIImage,
 	parentDigest digest.Digest, layers []ocispec.Descriptor,
 	containerConfig container.Config,
 ) (image.ID, error) {
@@ -536,7 +536,7 @@ func (i *ImageService) createImageOCI(ctx context.Context, imgToCreate imagespec
 
 // writeContentsForImage will commit oci image config and manifest into containerd's content store.
 func writeContentsForImage(ctx context.Context, snName string, cs content.Store,
-	newConfig imagespec.DockerOCIImage, layers []ocispec.Descriptor,
+	newConfig dockerspec.DockerOCIImage, layers []ocispec.Descriptor,
 	containerConfig container.Config,
 ) (
 	manifestDesc ocispec.Descriptor,

--- a/daemon/containerd/image_commit.go
+++ b/daemon/containerd/image_commit.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/server/backend"
@@ -38,7 +38,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 	cs := i.content
 
 	var parentManifest ocispec.Manifest
-	var parentImage imagespec.DockerOCIImage
+	var parentImage dockerspec.DockerOCIImage
 
 	// ImageManifest can be nil when committing an image with base FROM scratch
 	if container.ImageManifest != nil {
@@ -93,7 +93,7 @@ func (i *ImageService) CommitImage(ctx context.Context, cc backend.CommitConfig)
 
 // generateCommitImageConfig generates an OCI Image config based on the
 // container's image and the CommitConfig options.
-func generateCommitImageConfig(baseConfig imagespec.DockerOCIImage, diffID digest.Digest, opts backend.CommitConfig) imagespec.DockerOCIImage {
+func generateCommitImageConfig(baseConfig dockerspec.DockerOCIImage, diffID digest.Digest, opts backend.CommitConfig) dockerspec.DockerOCIImage {
 	if opts.Author == "" {
 		opts.Author = baseConfig.Author
 	}
@@ -116,7 +116,7 @@ func generateCommitImageConfig(baseConfig imagespec.DockerOCIImage, diffID diges
 		diffIds = append(diffIds, diffID)
 	}
 
-	return imagespec.DockerOCIImage{
+	return dockerspec.DockerOCIImage{
 		Image: ocispec.Image{
 			Platform: ocispec.Platform{
 				Architecture: arch,

--- a/daemon/containerd/image_import.go
+++ b/daemon/containerd/image_import.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/google/uuid"
-	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
@@ -91,7 +91,7 @@ func (i *ImageService) ImportImage(ctx context.Context, ref reference.Named, pla
 
 	dockerCfg := containerConfigToDockerOCIImageConfig(imageConfig)
 	createdAt := time.Now()
-	config := imagespec.DockerOCIImage{
+	config := dockerspec.DockerOCIImage{
 		Image: ocispec.Image{
 			Platform: *platform,
 			Created:  &createdAt,

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
-	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	imagetypes "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/sliceutil"
@@ -62,7 +62,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 		}
 	}
 
-	var img imagespec.DockerOCIImage
+	var img dockerspec.DockerOCIImage
 	if multi.Best != nil {
 		if err := multi.Best.ReadConfig(ctx, &img); err != nil {
 			return nil, err

--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -3,7 +3,7 @@ package containerd
 import (
 	"slices"
 
-	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/internal/image"
@@ -16,7 +16,7 @@ import (
 // - V1Image.ContainerConfig
 // - V1Image.Container
 // - Details
-func dockerOciImageToDockerImagePartial(id image.ID, img imagespec.DockerOCIImage) *image.Image {
+func dockerOciImageToDockerImagePartial(id image.ID, img dockerspec.DockerOCIImage) *image.Image {
 	v1Image := image.V1Image{
 		DockerVersion: dockerversion.Version,
 		Config:        dockerOCIImageConfigToContainerConfig(img.Config),
@@ -39,8 +39,8 @@ func dockerOciImageToDockerImagePartial(id image.ID, img imagespec.DockerOCIImag
 	return out
 }
 
-func dockerImageToDockerOCIImage(img image.Image) imagespec.DockerOCIImage {
-	return imagespec.DockerOCIImage{
+func dockerImageToDockerOCIImage(img image.Image) dockerspec.DockerOCIImage {
+	return dockerspec.DockerOCIImage{
 		Image: ocispec.Image{
 			Created: img.Created,
 			Author:  img.Author,
@@ -61,9 +61,9 @@ func dockerImageToDockerOCIImage(img image.Image) imagespec.DockerOCIImage {
 	}
 }
 
-func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.DockerOCIImageConfig {
+func containerConfigToDockerOCIImageConfig(cfg *container.Config) dockerspec.DockerOCIImageConfig {
 	var ociCfg ocispec.ImageConfig
-	var ext imagespec.DockerOCIImageConfigExt
+	var ext dockerspec.DockerOCIImageConfigExt
 
 	if cfg != nil {
 		ociCfg = ocispec.ImageConfig{
@@ -89,13 +89,13 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 		ext.Shell = cfg.Shell
 	}
 
-	return imagespec.DockerOCIImageConfig{
+	return dockerspec.DockerOCIImageConfig{
 		ImageConfig:             ociCfg,
 		DockerOCIImageConfigExt: ext,
 	}
 }
 
-func dockerOCIImageConfigToContainerConfig(cfg imagespec.DockerOCIImageConfig) *container.Config {
+func dockerOCIImageConfigToContainerConfig(cfg dockerspec.DockerOCIImageConfig) *container.Config {
 	exposedPorts := make(network.PortSet, len(cfg.ExposedPorts))
 	for k := range cfg.ExposedPorts {
 		if p, err := network.ParsePort(k); err == nil {

--- a/daemon/images/imagespec.go
+++ b/daemon/images/imagespec.go
@@ -1,14 +1,14 @@
 package images
 
 import (
-	imagespec "github.com/moby/docker-image-spec/specs-go/v1"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.DockerOCIImageConfig {
+func containerConfigToDockerOCIImageConfig(cfg *container.Config) dockerspec.DockerOCIImageConfig {
 	var ociCfg ocispec.ImageConfig
-	var ext imagespec.DockerOCIImageConfigExt
+	var ext dockerspec.DockerOCIImageConfigExt
 
 	if cfg != nil {
 		ociCfg = ocispec.ImageConfig{
@@ -34,7 +34,7 @@ func containerConfigToDockerOCIImageConfig(cfg *container.Config) imagespec.Dock
 		ext.Shell = cfg.Shell
 	}
 
-	return imagespec.DockerOCIImageConfig{
+	return dockerspec.DockerOCIImageConfig{
 		ImageConfig:             ociCfg,
 		DockerOCIImageConfigExt: ext,
 	}


### PR DESCRIPTION
This package was aliased as "imagespec" in some places, and "dockerspec" in other places, which made it easy to confuse.

Change all uses of this package to be aliased as "dockerspec" and configure an "importas" linting check to enforce it.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

