### PR TITLE
daemon/images: minor linting fixes

### DIFF
--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -71,9 +71,8 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 		if err != nil {
 			return err
 		}
-		timestamp := time.Unix(seconds, nanoseconds)
-		if beforeFilter.IsZero() || beforeFilter.After(timestamp) {
-			beforeFilter = timestamp
+		if tsUnix := time.Unix(seconds, nanoseconds); beforeFilter.IsZero() || beforeFilter.After(tsUnix) {
+			beforeFilter = tsUnix
 		}
 		return nil
 	})
@@ -135,7 +134,7 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 		}
 
 		// Skip any images with an unsupported operating system to avoid a potential
-		// panic when indexing through the layerstore. Don't error as we want to list
+		// panic when indexing through the layerStore. Don't error as we want to list
 		// the other images. This should never happen, but here as a safety precaution.
 		if err := image.CheckOS(img.OperatingSystem()); err != nil {
 			continue
@@ -247,13 +246,13 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 			summary.SharedSize = 0
 			for _, id := range img.RootFS.DiffIDs {
 				rootFS.Append(id)
-				chid := rootFS.ChainID()
+				chID := rootFS.ChainID()
 
-				if layerRefs[chid] > 1 {
-					if _, ok := allLayers[chid]; !ok {
-						return nil, fmt.Errorf("layer %v was not found (corruption?)", chid)
+				if layerRefs[chID] > 1 {
+					if _, ok := allLayers[chID]; !ok {
+						return nil, fmt.Errorf("layer %v was not found (corruption?)", chID)
 					}
-					summary.SharedSize += allLayers[chid].DiffSize()
+					summary.SharedSize += allLayers[chID].DiffSize()
 				}
 			}
 		}
@@ -275,7 +274,7 @@ func newImageSummary(image *image.Image, size int64) *imagetypes.Summary {
 		Created:  created,
 		Size:     size,
 		// -1 indicates that the value has not been set (avoids ambiguity
-		// between 0 (default) and "not set". We cannot use a pointer (nil)
+		// between 0 (default) and "not set"). We cannot use a pointer (nil)
 		// for this, as the JSON representation uses "omitempty", which would
 		// consider both "0" and "nil" to be "empty".
 		SharedSize: -1,


### PR DESCRIPTION
Minor issues to make my IDE happy:

- rename var that shadowed import
- rename vars to use the correct camelCase format
- fix minor grammar / formatting in comments


