### PR TITLE
daemon: stop propagating Image.DockerVersion, Plugin.Config.DockerVersion fields

### DIFF
--- a/daemon/containerd/imagespec.go
+++ b/daemon/containerd/imagespec.go
@@ -7,7 +7,6 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/internal/image"
-	"github.com/moby/moby/v2/dockerversion"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -18,13 +17,12 @@ import (
 // - Details
 func dockerOciImageToDockerImagePartial(id image.ID, img dockerspec.DockerOCIImage) *image.Image {
 	v1Image := image.V1Image{
-		DockerVersion: dockerversion.Version,
-		Config:        dockerOCIImageConfigToContainerConfig(img.Config),
-		Architecture:  img.Platform.Architecture,
-		Variant:       img.Platform.Variant,
-		OS:            img.Platform.OS,
-		Author:        img.Author,
-		Created:       img.Created,
+		Config:       dockerOCIImageConfigToContainerConfig(img.Config),
+		Architecture: img.Platform.Architecture,
+		Variant:      img.Platform.Variant,
+		OS:           img.Platform.OS,
+		Author:       img.Author,
+		Created:      img.Created,
 	}
 
 	out := image.NewImage(id)

--- a/daemon/images/image_import.go
+++ b/daemon/images/image_import.go
@@ -14,7 +14,6 @@ import (
 	"github.com/moby/moby/v2/daemon/builder/dockerfile"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/layer"
-	"github.com/moby/moby/v2/dockerversion"
 	"github.com/moby/moby/v2/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -53,13 +52,12 @@ func (i *ImageService) ImportImage(ctx context.Context, newRef reference.Named, 
 	created := time.Now().UTC()
 	imgConfig, err := json.Marshal(&image.Image{
 		V1Image: image.V1Image{
-			DockerVersion: dockerversion.Version,
-			Config:        config,
-			Architecture:  platform.Architecture,
-			Variant:       platform.Variant,
-			OS:            platform.OS,
-			Created:       &created,
-			Comment:       msg,
+			Config:       config,
+			Architecture: platform.Architecture,
+			Variant:      platform.Variant,
+			OS:           platform.OS,
+			Created:      &created,
+			Comment:      msg,
 		},
 		RootFS: &image.RootFS{
 			Type:    "layers",

--- a/daemon/internal/image/cache/cache.go
+++ b/daemon/internal/image/cache/cache.go
@@ -11,7 +11,6 @@ import (
 	"github.com/moby/moby/v2/daemon/builder"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/layer"
-	"github.com/moby/moby/v2/dockerversion"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -141,12 +140,11 @@ func (ic *ImageCache) restoreCachedImage(parent, target *image.Image, cfg *conta
 
 	restoredImg := image.Image{
 		V1Image: image.V1Image{
-			DockerVersion: dockerversion.Version,
-			Config:        cfg,
-			Architecture:  target.Architecture,
-			OS:            target.OS,
-			Author:        target.Author,
-			Created:       history[len(history)-1].Created,
+			Config:       cfg,
+			Architecture: target.Architecture,
+			OS:           target.OS,
+			Author:       target.Author,
+			Created:      history[len(history)-1].Created,
 		},
 		RootFS:     rootFS,
 		History:    history,

--- a/daemon/internal/image/image.go
+++ b/daemon/internal/image/image.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/internal/layer"
-	"github.com/moby/moby/v2/dockerversion"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -236,7 +235,6 @@ func NewChildImage(img *Image, child ChildConfig, os string) *Image {
 
 	return &Image{
 		V1Image: V1Image{
-			DockerVersion:   dockerversion.Version,
 			Config:          child.Config,
 			Architecture:    img.BaseImgArch(),
 			Variant:         img.BaseImgVariant(),

--- a/daemon/pkg/plugin/backend_linux.go
+++ b/daemon/pkg/plugin/backend_linux.go
@@ -32,7 +32,6 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/stringid"
 	v2 "github.com/moby/moby/v2/daemon/pkg/plugin/v2"
 	"github.com/moby/moby/v2/daemon/server/backend"
-	"github.com/moby/moby/v2/dockerversion"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/authorization"
 	"github.com/moby/moby/v2/pkg/pools"
@@ -706,8 +705,6 @@ func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, 
 		Type:    "layers",
 		DiffIds: []string{rootFSBlob.Digest().String()},
 	}
-
-	config.DockerVersion = dockerversion.Version //nolint:staticcheck // ignore SA1019: field is deprecated.
 
 	configBlob, err := pm.blobStore.Writer(ctx, content.WithRef(name+"-config.json"))
 	if err != nil {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/50715
- relates to https://github.com/moby/moby/pull/51072


The DockerVersion field was used by the legacy builder, and set when importing an image; when importing an image, this would potentially result in less reproducible images, as the docker version used to import the image would be encoded in the image's "v1" fields.

For the legacy builder, including the version of docker used to build the image could still be useful information (but could be set as comment, similar to what BuildKit does), however, many code paths were also shared with other parts of the code; e.g., when listing images or inspecting images, the `DockerVersion` field would always be set to the current version of the docker daemon, and not taken from the information available in the image (if any).

This patch removes locations where the `DockerVersion` field was set to the current version of the daemon binary. When inspecting an image, the field is still set with the information in the image itself (which may be empty in most cases).

This also reduces the number of places where the `dockerversion` package is used, which still needs a new home.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

