### PR TITLE
api/types/image: InspectResponse: remove deprecated fields

### DIFF
--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
-	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/storage"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -63,22 +62,6 @@ type InspectResponse struct {
 	// and omitted otherwise.
 	Created string `json:",omitempty"`
 
-	// Container is the ID of the container that was used to create the image.
-	//
-	// Depending on how the image was created, this field may be empty.
-	//
-	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
-	Container string `json:",omitempty"`
-
-	// ContainerConfig is an optional field containing the configuration of the
-	// container that was last committed when creating the image.
-	//
-	// Previous versions of Docker builder used this field to store build cache,
-	// and it is not in active use anymore.
-	//
-	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
-	ContainerConfig *container.Config `json:",omitempty"`
-
 	// DockerVersion is the version of Docker that was used to build the image.
 	//
 	// Depending on how the image was created, this field may be omitted.
@@ -107,12 +90,6 @@ type InspectResponse struct {
 
 	// Size is the total size of the image including all layers it is composed of.
 	Size int64
-
-	// VirtualSize is the total size of the image including all layers it is
-	// composed of.
-	//
-	// Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
-	VirtualSize int64 `json:"VirtualSize,omitempty"`
 
 	// GraphDriver holds information about the storage driver used to store the
 	// container's and image's filesystem.

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -42,15 +42,6 @@ type InspectResponse struct {
 	// the manifest is generated and its digest calculated.
 	RepoDigests []string
 
-	// Parent is the ID of the parent image.
-	//
-	// Depending on how the image was created, this field may be empty and
-	// is only set for images that were built/created locally. This field
-	// is omitted if the image was pulled from an image registry.
-	//
-	// Deprecated: this field is deprecated, and will be removed in the next release.
-	Parent string `json:",omitempty"`
-
 	// Comment is an optional message that can be set when committing or
 	// importing the image. This field is omitted if not set.
 	Comment string `json:",omitempty"`
@@ -61,13 +52,6 @@ type InspectResponse struct {
 	// This information is only available if present in the image,
 	// and omitted otherwise.
 	Created string `json:",omitempty"`
-
-	// DockerVersion is the version of Docker that was used to build the image.
-	//
-	// Depending on how the image was created, this field may be omitted.
-	//
-	// Deprecated: this field is deprecated, and will be removed in the next release.
-	DockerVersion string `json:",omitempty"`
 
 	// Author is the name of the author that was specified when committing the
 	// image, or as specified through MAINTAINER (deprecated) in the Dockerfile.

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -91,13 +91,13 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 			RepoTags:    repoTags,
 			Descriptor:  &target,
 			RepoDigests: repoDigests,
-			Parent:      parent, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
 			Size:        size,
 			Manifests:   manifests,
 			Metadata: imagetypes.Metadata{
 				LastTagTime: lastUpdated,
 			},
 		},
+		Parent: parent, // field is deprecated with the legacy builder, but returned by the API if present.
 	}
 
 	if multi.Best != nil {

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts imagebackend.ImageInspectOpts) (*imagetypes.InspectResponse, error) {
+func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts imagebackend.ImageInspectOpts) (*imagebackend.InspectData, error) {
 	requestedPlatform := opts.Platform
 
 	c8dImg, err := i.resolveImage(ctx, refOrID)
@@ -85,16 +85,18 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 		target = multi.Best.Target()
 	}
 
-	resp := &imagetypes.InspectResponse{
-		ID:          target.Digest.String(),
-		RepoTags:    repoTags,
-		Descriptor:  &target,
-		RepoDigests: repoDigests,
-		Parent:      parent, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
-		Size:        size,
-		Manifests:   manifests,
-		Metadata: imagetypes.Metadata{
-			LastTagTime: lastUpdated,
+	resp := &imagebackend.InspectData{
+		InspectResponse: imagetypes.InspectResponse{
+			ID:          target.Digest.String(),
+			RepoTags:    repoTags,
+			Descriptor:  &target,
+			RepoDigests: repoDigests,
+			Parent:      parent, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
+			Size:        size,
+			Manifests:   manifests,
+			Metadata: imagetypes.Metadata{
+				LastTagTime: lastUpdated,
+			},
 		},
 	}
 

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -43,7 +43,7 @@ type ImageService interface {
 	ImageHistory(ctx context.Context, name string, platform *ocispec.Platform) ([]*imagetype.HistoryResponseItem, error)
 	CommitImage(ctx context.Context, c backend.CommitConfig) (image.ID, error)
 	SquashImage(id, parent string) (string, error)
-	ImageInspect(ctx context.Context, refOrID string, opts imagebackend.ImageInspectOpts) (*imagetype.InspectResponse, error)
+	ImageInspect(ctx context.Context, refOrID string, opts imagebackend.ImageInspectOpts) (*imagebackend.InspectData, error)
 	ImageDiskUsage(ctx context.Context) (int64, error)
 
 	// Layers

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -56,20 +56,18 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 	imgConfig := containerConfigToDockerOCIImageConfig(img.Config)
 	return &imagebackend.InspectData{
 		InspectResponse: imagetypes.InspectResponse{
-			ID:            img.ID().String(),
-			RepoTags:      repoTags,
-			RepoDigests:   repoDigests,
-			Parent:        img.Parent.String(), //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present (built with legacy builder).
-			Comment:       comment,
-			Created:       created,
-			DockerVersion: img.DockerVersion, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
-			Author:        img.Author,
-			Config:        &imgConfig,
-			Architecture:  img.Architecture,
-			Variant:       img.Variant,
-			Os:            img.OperatingSystem(),
-			OsVersion:     img.OSVersion,
-			Size:          size,
+			ID:           img.ID().String(),
+			RepoTags:     repoTags,
+			RepoDigests:  repoDigests,
+			Comment:      comment,
+			Created:      created,
+			Author:       img.Author,
+			Config:       &imgConfig,
+			Architecture: img.Architecture,
+			Variant:      img.Variant,
+			Os:           img.OperatingSystem(),
+			OsVersion:    img.OSVersion,
+			Size:         size,
 			GraphDriver: &storage.DriverData{
 				Name: i.layerStore.DriverName(),
 				Data: layerMetadata,
@@ -82,6 +80,8 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 				LastTagTime: lastUpdated,
 			},
 		},
+		Parent:          img.Parent.String(),  // field is deprecated with the legacy builder, but still included in response when present (built with legacy builder).
+		DockerVersion:   img.DockerVersion,    // field is deprecated with the legacy builder, but still included in response when present.
 		Container:       img.Container,        // field is deprecated, but still set on API < v1.45.
 		ContainerConfig: &img.ContainerConfig, // field is deprecated, but still set on API < v1.45.
 	}, nil

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -12,7 +12,7 @@ import (
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 )
 
-func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts imagebackend.ImageInspectOpts) (*imagetypes.InspectResponse, error) {
+func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts imagebackend.ImageInspectOpts) (*imagebackend.InspectData, error) {
 	img, err := i.GetImage(ctx, refOrID, imagebackend.GetImageOpts{Platform: opts.Platform})
 	if err != nil {
 		return nil, err
@@ -54,34 +54,36 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 	}
 
 	imgConfig := containerConfigToDockerOCIImageConfig(img.Config)
-	return &imagetypes.InspectResponse{
-		ID:              img.ID().String(),
-		RepoTags:        repoTags,
-		RepoDigests:     repoDigests,
-		Parent:          img.Parent.String(), //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present (built with legacy builder).
-		Comment:         comment,
-		Created:         created,
-		Container:       img.Container,        //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
-		ContainerConfig: &img.ContainerConfig, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
-		DockerVersion:   img.DockerVersion,    //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
-		Author:          img.Author,
-		Config:          &imgConfig,
-		Architecture:    img.Architecture,
-		Variant:         img.Variant,
-		Os:              img.OperatingSystem(),
-		OsVersion:       img.OSVersion,
-		Size:            size,
-		GraphDriver: &storage.DriverData{
-			Name: i.layerStore.DriverName(),
-			Data: layerMetadata,
+	return &imagebackend.InspectData{
+		InspectResponse: imagetypes.InspectResponse{
+			ID:            img.ID().String(),
+			RepoTags:      repoTags,
+			RepoDigests:   repoDigests,
+			Parent:        img.Parent.String(), //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present (built with legacy builder).
+			Comment:       comment,
+			Created:       created,
+			DockerVersion: img.DockerVersion, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
+			Author:        img.Author,
+			Config:        &imgConfig,
+			Architecture:  img.Architecture,
+			Variant:       img.Variant,
+			Os:            img.OperatingSystem(),
+			OsVersion:     img.OSVersion,
+			Size:          size,
+			GraphDriver: &storage.DriverData{
+				Name: i.layerStore.DriverName(),
+				Data: layerMetadata,
+			},
+			RootFS: imagetypes.RootFS{
+				Type:   img.RootFS.Type,
+				Layers: layers,
+			},
+			Metadata: imagetypes.Metadata{
+				LastTagTime: lastUpdated,
+			},
 		},
-		RootFS: imagetypes.RootFS{
-			Type:   img.RootFS.Type,
-			Layers: layers,
-		},
-		Metadata: imagetypes.Metadata{
-			LastTagTime: lastUpdated,
-		},
+		Container:       img.Container,        // field is deprecated, but still set on API < v1.45.
+		ContainerConfig: &img.ContainerConfig, // field is deprecated, but still set on API < v1.45.
 	}, nil
 }
 

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -4,7 +4,9 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/filters"
+	imagetypes "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -54,4 +56,24 @@ type GetImageOpts struct {
 type ImageInspectOpts struct {
 	Manifests bool
 	Platform  *ocispec.Platform
+}
+
+type InspectData struct {
+	imagetypes.InspectResponse
+
+	// Container is the ID of the container that was used to create the image.
+	//
+	// Depending on how the image was created, this field may be empty.
+	//
+	// This field is removed in API v1.45, but used for API <= v1.44 responses.
+	Container string
+
+	// ContainerConfig is an optional field containing the configuration of the
+	// container that was last committed when creating the image.
+	//
+	// Previous versions of Docker builder used this field to store build cache,
+	// and it is not in active use anymore.
+	//
+	// This field is removed in API v1.45, but used for API <= v1.44 responses.
+	ContainerConfig *container.Config
 }

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -61,6 +61,22 @@ type ImageInspectOpts struct {
 type InspectData struct {
 	imagetypes.InspectResponse
 
+	// Parent is the ID of the parent image.
+	//
+	// Depending on how the image was created, this field may be empty and
+	// is only set for images that were built/created locally. This field
+	// is omitted if the image was pulled from an image registry.
+	//
+	// This field is deprecated with the legacy builder, but returned by the API if present.
+	Parent string `json:",omitempty"`
+
+	// DockerVersion is the version of Docker that was used to build the image.
+	//
+	// Depending on how the image was created, this field may be omitted.
+	//
+	// This field is deprecated with the legacy builder, but returned by the API if present.
+	DockerVersion string `json:",omitempty"`
+
 	// Container is the ID of the container that was used to create the image.
 	//
 	// Depending on how the image was created, this field may be empty.

--- a/daemon/server/router/image/backend.go
+++ b/daemon/server/router/image/backend.go
@@ -26,7 +26,7 @@ type imageBackend interface {
 	ImageHistory(ctx context.Context, imageName string, platform *ocispec.Platform) ([]*image.HistoryResponseItem, error)
 	Images(ctx context.Context, opts imagebackend.ListOptions) ([]*image.Summary, error)
 	GetImage(ctx context.Context, refOrID string, options imagebackend.GetImageOpts) (*dockerimage.Image, error)
-	ImageInspect(ctx context.Context, refOrID string, options imagebackend.ImageInspectOpts) (*image.InspectResponse, error)
+	ImageInspect(ctx context.Context, refOrID string, options imagebackend.ImageInspectOpts) (*imagebackend.InspectData, error)
 	TagImage(ctx context.Context, id dockerimage.ID, newRef reference.Named) error
 	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*image.PruneReport, error)
 }

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -379,13 +379,14 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 		return errdefs.InvalidParameter(errors.New("conflicting options: manifests and platform options cannot both be set"))
 	}
 
-	imageInspect, err := ir.backend.ImageInspect(ctx, vars["name"], imagebackend.ImageInspectOpts{
+	inspectData, err := ir.backend.ImageInspect(ctx, vars["name"], imagebackend.ImageInspectOpts{
 		Manifests: manifests,
 		Platform:  platform,
 	})
 	if err != nil {
 		return err
 	}
+	imageInspect := inspectData.InspectResponse
 
 	var legacyOptions []compat.Option
 
@@ -409,9 +410,11 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 			imageInspect.Created = time.Time{}.Format(time.RFC3339Nano)
 		}
 	}
-	if versions.GreaterThanOrEqualTo(version, "1.45") {
-		imageInspect.Container = ""        //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
-		imageInspect.ContainerConfig = nil //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
+	if versions.LessThan(version, "1.45") {
+		legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{
+			"Container":       inspectData.Container,
+			"ContainerConfig": inspectData.ContainerConfig,
+		}))
 	}
 	if versions.LessThan(version, "1.48") {
 		imageInspect.Descriptor = nil
@@ -420,10 +423,10 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 		// These fields have "omitempty" on API v1.52 and higher,
 		// but older API versions returned them unconditionally.
 		legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{
-			"Parent":        imageInspect.Parent, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present (built with legacy builder).
-			"Comment":       imageInspect.Comment,
-			"DockerVersion": imageInspect.DockerVersion, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
-			"Author":        imageInspect.Author,
+			"Parent":        inspectData.Parent, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present (built with legacy builder).
+			"Comment":       inspectData.Comment,
+			"DockerVersion": inspectData.DockerVersion, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
+			"Author":        inspectData.Author,
 		}))
 
 		// preserve fields in the image Config that have an "omitempty"

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -423,9 +423,9 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 		// These fields have "omitempty" on API v1.52 and higher,
 		// but older API versions returned them unconditionally.
 		legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{
-			"Parent":        inspectData.Parent, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present (built with legacy builder).
+			"Parent":        inspectData.Parent, // field is deprecated, but still included in response when present (built with legacy builder).
 			"Comment":       inspectData.Comment,
-			"DockerVersion": inspectData.DockerVersion, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
+			"DockerVersion": inspectData.DockerVersion, // field is deprecated, but still included in response when present.
 			"Author":        inspectData.Author,
 		}))
 
@@ -439,6 +439,15 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 			legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{
 				"Config": legacyConfigFields["v1.50-v1.51"],
 			}))
+		}
+	} else {
+		if inspectData.Parent != "" {
+			// field is deprecated, but still included in response when present (built with legacy builder).
+			legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{"Parent": inspectData.Parent}))
+		}
+		if inspectData.DockerVersion != "" {
+			// field is deprecated, but still included in response when present.
+			legacyOptions = append(legacyOptions, compat.WithExtraFields(map[string]any{"DockerVersion": inspectData.DockerVersion}))
 		}
 	}
 

--- a/vendor/github.com/moby/moby/api/types/image/image_inspect.go
+++ b/vendor/github.com/moby/moby/api/types/image/image_inspect.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
-	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/storage"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -63,22 +62,6 @@ type InspectResponse struct {
 	// and omitted otherwise.
 	Created string `json:",omitempty"`
 
-	// Container is the ID of the container that was used to create the image.
-	//
-	// Depending on how the image was created, this field may be empty.
-	//
-	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
-	Container string `json:",omitempty"`
-
-	// ContainerConfig is an optional field containing the configuration of the
-	// container that was last committed when creating the image.
-	//
-	// Previous versions of Docker builder used this field to store build cache,
-	// and it is not in active use anymore.
-	//
-	// Deprecated: this field is omitted in API v1.45, but kept for backward compatibility.
-	ContainerConfig *container.Config `json:",omitempty"`
-
 	// DockerVersion is the version of Docker that was used to build the image.
 	//
 	// Depending on how the image was created, this field may be omitted.
@@ -107,12 +90,6 @@ type InspectResponse struct {
 
 	// Size is the total size of the image including all layers it is composed of.
 	Size int64
-
-	// VirtualSize is the total size of the image including all layers it is
-	// composed of.
-	//
-	// Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
-	VirtualSize int64 `json:"VirtualSize,omitempty"`
 
 	// GraphDriver holds information about the storage driver used to store the
 	// container's and image's filesystem.

--- a/vendor/github.com/moby/moby/api/types/image/image_inspect.go
+++ b/vendor/github.com/moby/moby/api/types/image/image_inspect.go
@@ -42,15 +42,6 @@ type InspectResponse struct {
 	// the manifest is generated and its digest calculated.
 	RepoDigests []string
 
-	// Parent is the ID of the parent image.
-	//
-	// Depending on how the image was created, this field may be empty and
-	// is only set for images that were built/created locally. This field
-	// is omitted if the image was pulled from an image registry.
-	//
-	// Deprecated: this field is deprecated, and will be removed in the next release.
-	Parent string `json:",omitempty"`
-
 	// Comment is an optional message that can be set when committing or
 	// importing the image. This field is omitted if not set.
 	Comment string `json:",omitempty"`
@@ -61,13 +52,6 @@ type InspectResponse struct {
 	// This information is only available if present in the image,
 	// and omitted otherwise.
 	Created string `json:",omitempty"`
-
-	// DockerVersion is the version of Docker that was used to build the image.
-	//
-	// Depending on how the image was created, this field may be omitted.
-	//
-	// Deprecated: this field is deprecated, and will be removed in the next release.
-	DockerVersion string `json:",omitempty"`
 
 	// Author is the name of the author that was specified when committing the
 	// image, or as specified through MAINTAINER (deprecated) in the Dockerfile.


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/51099
- [x] depends on / stacked on https://github.com/moby/moby/pull/51101
- [x] depends on / stacked on https://github.com/moby/moby/pull/51102
- [x] depends on / stacked on https://github.com/moby/moby/pull/51104

relates to:

- https://github.com/moby/moby/pull/17924
- https://github.com/moby/moby/pull/45346
- https://github.com/moby/moby/pull/45469
- https://github.com/moby/moby/pull/46939
- https://github.com/moby/moby/pull/47430
- https://github.com/moby/moby/pull/51109

### api/types/image: InspectResponse: remove deprecated fields

The InspectResponse type contains various fields that are deprecated
and removed from current API versions, but that were kept for the API
server to produce the fields when downgrading to older API versions.

This patch:

- Introduces a `imagebackend.InspectData` type for the daemon to use for
  returning the data needed to propagate the API response. It currently
  embeds the API response type and combines it with the legacy fields,
  but this could be changed to return the internal Image type, and
  mapping the fields to the API response type in the router.
- Removes the deprecated fields from the `InspectResposne` struct; this
  means that [`client.ImageInspect`] won't unmarshal those fields, but
  the [`docker image inspect`] CLI command defaults to printing the raw
  output as returned by the API, so can continue to show any field returned
  in the API response. As a side-note; we should change the CLI to default
  to show the unmarshalled response, and introduce a `--format=jsonraw`
  (or `--raw`) option to make printing the raw response opt-in.

This patch removes the following fields from the `InspectResponse` type;

- `VirtualSize`: this field became obsolete with the migration to content-
  addressable images in docker v1.10 ([moby@4352da7]), but was still returned
  with a copy of the `Size` field. It was deprecated in API v1.43 ([moby@1261fe6]),
  and removed in API v1.44 ([moby@913b0f5]).
- `Container` and `ContainerConfig`: both fields were deprecated in
  API v1.44 ([moby@1602e2f]), and removed in API v1.45 ([moby@03cddc6]).


remove deprecated Container, ContainerConfig, VirtualSize

[moby@4352da7]: https://github.com/moby/moby/commit/4352da7803d182a6013a5238ce20a7c749db979a
[moby@1261fe6]: https://github.com/moby/moby/commit/1261fe69a3586bb102182aa885197822419c768c
[moby@913b0f5]: https://github.com/moby/moby/commit/913b0f51cab18a56247a950f5f1e75ca79b63039
[moby@1602e2f]: https://github.com/moby/moby/commit/1602e2f4f1abc662ac02648353b54f6a4cfe7a6b
[moby@03cddc6]: https://github.com/moby/moby/commit/03cddc62f4bcd48fbc3a31dd94f2bf84e44840dd
[`client.ImageInspect`]: https://github.com/moby/moby/blob/f739c61c69a7155362993c2a2a624e838b3893bc/client/image_inspect.go#L14-L64
[`docker image inspect`]: https://github.com/docker/cli/blob/74e3520724d77e63ef75987cbd0c0cde507ab971/cli/command/image/inspect.go#L59-L81

### api/types/image: InspectResponse: remove deprecated Parent, DockerVersion

The InspectResponse type contains various fields that are deprecated
and removed from current API versions, but that were kept for the API
server to produce the fields when downgrading to older API versions.

- The `Parent` field is only used for the legacy builder, and only set for
  images that are built locally (i.e., not persisted when pulling an image).
- The `DockerVersion` field is only set when building images with the legacy
  builder, and empty in most cases.

Both fields were implicitly deprecated with the deprecation of the legacy
builder, and deprecated for the API in [moby@bd8a99b], which was backported
to the 28.x release.

This patch:

- Removes the deprecated fields from the `InspectResposne` struct; this
  means that [`client.ImageInspect`] won't unmarshal those fields, but
  the [`docker image inspect`] CLI command defaults to printing the raw
  output as returned by the API, so can continue to show any field returned
  in the API response. As a side-note; we should change the CLI to default
  to show the unmarshalled response, and introduce a `--format=jsonraw`
  (or `--raw`) option to make printing the raw response opt-in.
- Updates the API server to backfill the fields if they are set.

[moby@bd8a99b]: https://github.com/moby/moby/commit/bd8a99b4004b0b766db7f5f79dfc2dad553b9426
[`client.ImageInspect`]: https://github.com/moby/moby/blob/f739c61c69a7155362993c2a2a624e838b3893bc/client/image_inspect.go#L14-L64
[`docker image inspect`]: https://github.com/docker/cli/blob/74e3520724d77e63ef75987cbd0c0cde507ab971/cli/command/image/inspect.go#L59-L81

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types/image: `InspectResponse`: remove deprecated `VirtualSize`, `Container`, `ContainerConfig`, `Parent`, and `DockerVersion` fields.
```

**- A picture of a cute animal (not mandatory but encouraged)**

