### PR TITLE
integration-cli: remove deprecated buildImageSuccessfully, buildImage utilities

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1588,7 +1588,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsCreate(c *testing.T) {
 	var testImg string
 	if testEnv.DaemonInfo.OSType != "windows" {
 		testImg = "test-mount-config"
-		buildImageSuccessfully(c, testImg, build.WithDockerfile(`
+		cli.BuildCmd(c, testImg, build.WithDockerfile(`
 	FROM busybox
 	RUN mkdir `+destPath+` && touch `+destPath+slash+`bar
 	CMD cat `+destPath+slash+`bar

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -16,7 +16,7 @@ import (
 
 func (s *DockerAPISuite) TestAPIImagesSaveAndLoad(c *testing.T) {
 	testRequires(c, Network)
-	buildImageSuccessfully(c, "saveandload", build.WithDockerfile("FROM busybox\nENV FOO bar"))
+	cli.BuildCmd(c, "saveandload", build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, "saveandload")
 
 	ctx := testutil.GetContext(c)
@@ -45,7 +45,7 @@ func (s *DockerAPISuite) TestAPIImagesDelete(c *testing.T) {
 		testRequires(c, Network)
 	}
 	name := "test-api-images-delete"
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nENV FOO bar"))
 	id := getIDByName(c, name)
 
 	cli.DockerCmd(c, "tag", name, "test:tag1")

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -61,7 +61,7 @@ func (s *DockerCLIBuildSuite) TestBuildShCmdJSONEntrypoint(c *testing.T) {
 		expected = "cmd /S /C echo test"
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
     FROM busybox
     ENTRYPOINT ["echo"]
     CMD echo test
@@ -78,7 +78,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementUser(c *testing.T) 
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   FROM scratch
   ENV user foo
   USER ${user}
@@ -101,7 +101,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementVolume(c *testing.T
 		volumePath = "/quux"
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   ENV volume `+volumePath+`
   VOLUME ${volume}
@@ -119,7 +119,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementExpose(c *testing.T
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   FROM scratch
   ENV port 80
   EXPOSE ${port}
@@ -141,7 +141,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementExpose(c *testing.T
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementWorkdir(c *testing.T) {
 	const name = "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   FROM busybox
   ENV MYWORKDIR /work
   RUN mkdir ${MYWORKDIR}
@@ -161,7 +161,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementWorkdir(c *testing.
 func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementAddCopy(c *testing.T) {
 	const name = "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
   FROM `+minimalBaseImage()+`
   ENV baz foo
@@ -187,7 +187,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvironmentReplacementEnv(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildenvironmentreplacement"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   FROM busybox
   ENV foo zzz
   ENV bar ${foo}
@@ -271,7 +271,7 @@ func (s *DockerCLIBuildSuite) TestBuildHandleEscapesInVolume(c *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`
+		cli.BuildCmd(c, name, build.WithDockerfile(fmt.Sprintf(`
   FROM scratch
   ENV FOO bar
   VOLUME %s
@@ -292,7 +292,7 @@ func (s *DockerCLIBuildSuite) TestBuildOnBuildLowercase(c *testing.T) {
 	const name = "testbuildonbuildlowercase"
 	const name2 = "testbuildonbuildlowercase2"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   FROM busybox
   onbuild run echo quux
   `))
@@ -316,7 +316,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvEscapes(c *testing.T) {
 	// ENV expansions work differently in Windows
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildenvescapes"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
     FROM busybox
     ENV TEST foo
     CMD echo \$
@@ -332,7 +332,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnvOverwrite(c *testing.T) {
 	// ENV expansions work differently in Windows
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildenvoverwrite"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
     FROM busybox
     ENV TEST foo
     CMD echo ${TEST}
@@ -366,11 +366,11 @@ func (s *DockerCLIBuildSuite) TestBuildOnBuildEntrypointJSON(c *testing.T) {
 	const name1 = "onbuildcmd"
 	const name2 = "onbuildgenerated"
 
-	buildImageSuccessfully(c, name1, build.WithDockerfile(`
+	cli.BuildCmd(c, name1, build.WithDockerfile(`
 FROM busybox
 ONBUILD ENTRYPOINT ["echo"]`))
 
-	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf("FROM %s\nCMD [\"hello world\"]\n", name1)))
+	cli.BuildCmd(c, name2, build.WithDockerfile(fmt.Sprintf("FROM %s\nCMD [\"hello world\"]\n", name1)))
 
 	out := cli.DockerCmd(c, "run", name2).Combined()
 	if !regexp.MustCompile(`(?m)^hello world`).MatchString(out) {
@@ -460,12 +460,12 @@ ADD folder/file /test/changetarget`))
 	if err := ctx.Add("folder/file", "first"); err != nil {
 		c.Fatal(err)
 	}
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id1 := getIDByName(c, name)
 	if err := ctx.Add("folder/file", "second"); err != nil {
 		c.Fatal(err)
 	}
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id2 := getIDByName(c, name)
 	if id1 == id2 {
 		c.Fatal("cache was used even though file contents in folder was changed")
@@ -474,7 +474,7 @@ ADD folder/file /test/changetarget`))
 
 func (s *DockerCLIBuildSuite) TestBuildAddSingleFileToRoot(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testaddimg", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testaddimg", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -692,7 +692,7 @@ func (s *DockerCLIBuildSuite) TestBuildCopyWildcardInName(c *testing.T) {
 	// say which OSs this works on or not.
 	testRequires(c, DaemonIsLinux, UnixCli)
 
-	buildImageSuccessfully(c, "testcopywildcardinname", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopywildcardinname", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 	COPY *.txt /tmp/
 	RUN [ "$(cat /tmp/\*.txt)" = 'hi there' ]
@@ -710,7 +710,7 @@ func (s *DockerCLIBuildSuite) TestBuildCopyWildcardCache(c *testing.T) {
 		}))
 	defer ctx.Close()
 
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id1 := getIDByName(c, name)
 
 	// Now make sure we use a cache the 2nd time even with wild cards.
@@ -718,7 +718,7 @@ func (s *DockerCLIBuildSuite) TestBuildCopyWildcardCache(c *testing.T) {
 	ctx.Add("Dockerfile", `FROM busybox
 	COPY file*.txt /tmp/`)
 
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id2 := getIDByName(c, name)
 
 	if id1 != id2 {
@@ -728,7 +728,7 @@ func (s *DockerCLIBuildSuite) TestBuildCopyWildcardCache(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildAddSingleFileToNonExistingDir(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testaddsinglefiletononexistingdir", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testaddsinglefiletononexistingdir", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -743,7 +743,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`),
 
 func (s *DockerCLIBuildSuite) TestBuildAddDirContentToRoot(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testadddircontenttoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testadddircontenttoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -757,7 +757,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`),
 
 func (s *DockerCLIBuildSuite) TestBuildAddDirContentToExistingDir(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testadddircontenttoexistingdir", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testadddircontenttoexistingdir", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -773,7 +773,7 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`),
 
 func (s *DockerCLIBuildSuite) TestBuildAddWholeDirToRoot(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testaddwholedirtoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testaddwholedirtoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -790,11 +790,11 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 
 // Testing #5941 : Having an etc directory in context conflicts with the /etc/mtab
 func (s *DockerCLIBuildSuite) TestBuildAddOrCopyEtcToRootShouldNotConflict(c *testing.T) {
-	buildImageSuccessfully(c, "testaddetctoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testaddetctoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM `+minimalBaseImage()+`
 ADD . /`),
 		build.WithFile("etc/test_file", "test1")))
-	buildImageSuccessfully(c, "testcopyetctoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopyetctoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM `+minimalBaseImage()+`
 COPY . /`),
 		build.WithFile("etc/test_file", "test1")))
@@ -803,7 +803,7 @@ COPY . /`),
 // Testing #9401 : Losing setuid flag after a ADD
 func (s *DockerCLIBuildSuite) TestBuildAddPreservesFilesSpecialBits(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testaddetctoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testaddetctoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 ADD suidbin /usr/bin/suidbin
 RUN chmod 4755 /usr/bin/suidbin
@@ -816,7 +816,7 @@ RUN [ $(ls -l /usr/bin/suidbin | awk '{print $1}') = '-rwsr-xr-x' ]`),
 
 func (s *DockerCLIBuildSuite) TestBuildCopySingleFileToRoot(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testcopysinglefiletoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopysinglefiletoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -854,7 +854,7 @@ COPY test_file .`),
 
 func (s *DockerCLIBuildSuite) TestBuildCopySingleFileToExistDir(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testcopysinglefiletoexistdir", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopysinglefiletoexistdir", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -870,7 +870,7 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 
 func (s *DockerCLIBuildSuite) TestBuildCopySingleFileToNonExistDir(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific
-	buildImageSuccessfully(c, "testcopysinglefiletononexistdir", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopysinglefiletononexistdir", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -885,7 +885,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`),
 
 func (s *DockerCLIBuildSuite) TestBuildCopyDirContentToRoot(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testcopydircontenttoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopydircontenttoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -899,7 +899,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`),
 
 func (s *DockerCLIBuildSuite) TestBuildCopyDirContentToExistDir(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testcopydircontenttoexistdir", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopydircontenttoexistdir", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -915,7 +915,7 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`),
 
 func (s *DockerCLIBuildSuite) TestBuildCopyWholeDirToRoot(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Linux specific test
-	buildImageSuccessfully(c, "testcopywholedirtoroot", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testcopywholedirtoroot", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 RUN echo 'dockerio:x:1001:' >> /etc/group
@@ -995,7 +995,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddBadLinks(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	if _, err := os.Stat(nonExistingFile); err == nil || !os.IsNotExist(err) {
 		c.Fatalf("%s shouldn't have been written and it shouldn't exist", nonExistingFile)
 	}
@@ -1030,7 +1030,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddBadLinksVolume(c *testing.T) {
 		c.Fatal(err)
 	}
 
-	buildImageSuccessfully(c, "test-link-absolute-volume", build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, "test-link-absolute-volume", build.WithExternalBuildContext(ctx))
 	if _, err := os.Stat(nonExistingFile); err == nil || !os.IsNotExist(err) {
 		c.Fatalf("%s shouldn't have been written and it shouldn't exist", nonExistingFile)
 	}
@@ -1124,7 +1124,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithInaccessibleFilesInContext(c *testing
 		defer os.Remove(target)
 		// This is used to ensure we don't follow links when checking if everything in the context is accessible
 		// This test doesn't require that we run commands as an unprivileged user
-		buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+		cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	}
 	{
 		const name = "testbuildignoredinaccessible"
@@ -1203,7 +1203,7 @@ func (s *DockerCLIBuildSuite) TestBuildRm(c *testing.T) {
 	for _, tc := range testCases {
 		containerCountBefore := getContainerCount(c)
 
-		buildImageSuccessfully(c, name, cli.WithFlags(tc.buildflags...), build.WithDockerfile(`FROM busybox
+		cli.BuildCmd(c, name, cli.WithFlags(tc.buildflags...), build.WithDockerfile(`FROM busybox
 	RUN echo hello world`))
 
 		containerCountAfter := getContainerCount(c)
@@ -1239,7 +1239,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumes(c *testing.T) {
 		}
 	)
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM scratch
 		VOLUME /test1
 		VOLUME /test2
     VOLUME /test3 /test4
@@ -1258,7 +1258,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumes(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildMaintainer(c *testing.T) {
 	const name = "testbuildmaintainer"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         MAINTAINER dockerio`))
 
 	expected := "dockerio"
@@ -1272,7 +1272,7 @@ func (s *DockerCLIBuildSuite) TestBuildUser(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuilduser"
 	expected := "dockerio"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		USER dockerio
 		RUN [ $(whoami) = 'dockerio' ]`))
@@ -1307,7 +1307,7 @@ func (s *DockerCLIBuildSuite) TestBuildRelativeWorkdir(c *testing.T) {
 		expectedFinal = `/test2/test3`
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		RUN sh -c "[ "$PWD" = "`+expected1+`" ]"
 		WORKDIR test1
 		RUN sh -c "[ "$PWD" = "`+expected2+`" ]"
@@ -1326,7 +1326,7 @@ func (s *DockerCLIBuildSuite) TestBuildRelativeWorkdir(c *testing.T) {
 // Windows semantics. Most path handling verifications are in unit tests
 func (s *DockerCLIBuildSuite) TestBuildWindowsWorkdirProcessing(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
-	buildImageSuccessfully(c, "testbuildwindowsworkdirprocessing", build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, "testbuildwindowsworkdirprocessing", build.WithDockerfile(`FROM busybox
 		WORKDIR C:\\foo
 		WORKDIR bar
 		RUN sh -c "[ "$PWD" = "C:/foo/bar" ]"
@@ -1341,7 +1341,7 @@ func (s *DockerCLIBuildSuite) TestBuildWindowsAddCopyPathProcessing(c *testing.T
 	// support backslash such as .\\ being equivalent to ./ and c:\\ being
 	// equivalent to c:/. This is not currently (nor ever has been) supported
 	// by docker on the Windows platform.
-	buildImageSuccessfully(c, "testbuildwindowsaddcopypathprocessing", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testbuildwindowsaddcopypathprocessing", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 			# No trailing slash on COPY/ADD
 			# Results in dir being changed to a file
@@ -1378,7 +1378,7 @@ func (s *DockerCLIBuildSuite) TestBuildWorkdirWithEnvVariables(c *testing.T) {
 		expected = `/test1/test2`
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		ENV DIRPATH /test1
 		ENV SUBDIRNAME test2
 		WORKDIR $DIRPATH
@@ -1400,7 +1400,7 @@ func (s *DockerCLIBuildSuite) TestBuildRelativeCopy(c *testing.T) {
 		expected = `/test1/test2`
 	}
 
-	buildImageSuccessfully(c, "testbuildrelativecopy", build.WithBuildContext(c,
+	cli.BuildCmd(c, "testbuildrelativecopy", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 			WORKDIR /test1
 			WORKDIR test2
@@ -1461,7 +1461,7 @@ func (s *DockerCLIBuildSuite) TestBuildEnv(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // ENV expansion is different in Windows
 	const name = "testbuildenv"
 	expected := "[PATH=/test:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375]"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		ENV PATH /test:$PATH
 		ENV PORT 2375
 		RUN [ $(env | grep PORT) = 'PORT=2375' ]`))
@@ -1477,7 +1477,7 @@ func (s *DockerCLIBuildSuite) TestBuildPATH(c *testing.T) {
 	defPath := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 	fn := func(dockerfile string, expected string) {
-		buildImageSuccessfully(c, "testbldpath", build.WithDockerfile(dockerfile))
+		cli.BuildCmd(c, "testbldpath", build.WithDockerfile(dockerfile))
 		res := inspectField(c, "testbldpath", "Config.Env")
 		if res != expected {
 			c.Fatalf("Env %q, expected %q for dockerfile:%q", res, expected, dockerfile)
@@ -1509,7 +1509,7 @@ func (s *DockerCLIBuildSuite) TestBuildContextCleanup(c *testing.T) {
 		c.Fatalf("failed to list contents of tmp dir: %s", err)
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         ENTRYPOINT ["/bin/echo"]`))
 
 	entriesFinal, err := os.ReadDir(filepath.Join(testEnv.DaemonInfo.DockerRootDir, "tmp"))
@@ -1567,7 +1567,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmd(c *testing.T) {
 	const name = "testbuildcmd"
 	expected := "[/bin/echo Hello World]"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         CMD ["/bin/echo", "Hello World"]`))
 
 	res := inspectField(c, name, "Config.Cmd")
@@ -1581,7 +1581,7 @@ func (s *DockerCLIBuildSuite) TestBuildExpose(c *testing.T) {
 	const name = "testbuildexpose"
 	expected := "map[2375/tcp:{}]"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM scratch
         EXPOSE 2375`))
 
 	res := inspectField(c, name, "Config.ExposedPorts")
@@ -1617,7 +1617,7 @@ func (s *DockerCLIBuildSuite) TestBuildExposeMorePorts(c *testing.T) {
 	tmpl.Execute(buf, portList)
 
 	const name = "testbuildexpose"
-	buildImageSuccessfully(c, name, build.WithDockerfile(buf.String()))
+	cli.BuildCmd(c, name, build.WithDockerfile(buf.String()))
 
 	// check if all the ports are saved inside Config.ExposedPorts
 	res := inspectFieldJSON(c, name, "Config.ExposedPorts")
@@ -1642,7 +1642,7 @@ func (s *DockerCLIBuildSuite) TestBuildExposeMorePorts(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildExposeOrder(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
 	buildID := func(name, exposed string) string {
-		buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM scratch
+		cli.BuildCmd(c, name, build.WithDockerfile(fmt.Sprintf(`FROM scratch
 		EXPOSE %s`, exposed)))
 		id := inspectField(c, name, "Id")
 		return id
@@ -1659,7 +1659,7 @@ func (s *DockerCLIBuildSuite) TestBuildExposeUpperCaseProto(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Expose not implemented on Windows
 	const name = "testbuildexposeuppercaseproto"
 	expected := "map[5678/udp:{}]"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM scratch
         EXPOSE 5678/UDP`))
 	res := inspectField(c, name, "Config.ExposedPorts")
 	if res != expected {
@@ -1671,7 +1671,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypointInheritance(c *testing.T) 
 	const name = "testbuildentrypointinheritance"
 	const name2 = "testbuildentrypointinheritance2"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
         ENTRYPOINT ["/bin/echo"]`))
 	res := inspectField(c, name, "Config.Entrypoint")
 
@@ -1680,7 +1680,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypointInheritance(c *testing.T) 
 		c.Fatalf("Entrypoint %s, expected %s", res, expected)
 	}
 
-	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf(`FROM %s
+	cli.BuildCmd(c, name2, build.WithDockerfile(fmt.Sprintf(`FROM %s
         ENTRYPOINT []`, name)))
 	res = inspectField(c, name2, "Config.Entrypoint")
 
@@ -1694,7 +1694,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyEntrypoint(c *testing.T) {
 	const name = "testbuildentrypoint"
 	expected := "[]"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
         ENTRYPOINT []`))
 
 	res := inspectField(c, name, "Config.Entrypoint")
@@ -1707,7 +1707,7 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypoint(c *testing.T) {
 	const name = "testbuildentrypoint"
 
 	expected := "[/bin/echo]"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         ENTRYPOINT ["/bin/echo"]`))
 
 	res := inspectField(c, name, "Config.Entrypoint")
@@ -1718,7 +1718,7 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypoint(c *testing.T) {
 
 // #6445 ensure ONBUILD triggers aren't committed to grandchildren
 func (s *DockerCLIBuildSuite) TestBuildOnBuildLimitedInheritance(c *testing.T) {
-	buildImageSuccessfully(c, "testonbuildtrigger1", build.WithDockerfile(`
+	cli.BuildCmd(c, "testonbuildtrigger1", build.WithDockerfile(`
 		FROM busybox
 		RUN echo "GRANDPARENT"
 		ONBUILD RUN echo "ONBUILD PARENT"
@@ -1742,11 +1742,11 @@ func (s *DockerCLIBuildSuite) TestBuildSameDockerfileWithAndWithoutCache(c *test
 		MAINTAINER dockerio
 		EXPOSE 5432
         ENTRYPOINT ["/bin/echo"]`
-	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, name, build.WithDockerfile(dockerfile))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, name, build.WithDockerfile(dockerfile))
 	id2 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 	id3 := getIDByName(c, name)
 	if id1 != id2 {
 		c.Fatal("The cache should have been used but hasn't.")
@@ -1860,13 +1860,13 @@ func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithCache(c *testing.T) {
 		"foo": "hello",
 	}))
 	defer ctx.Close()
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id1 := getIDByName(c, name)
 	// Check that adding file invalidate cache of "ADD ."
 	if err := ctx.Add("bar", "hello2"); err != nil {
 		c.Fatal(err)
 	}
-	buildImageSuccessfully(c, name2, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name2, build.WithExternalBuildContext(ctx))
 	id2 := getIDByName(c, name2)
 	if id1 == id2 {
 		c.Fatal("The cache should have been invalided but hasn't.")
@@ -1875,7 +1875,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithCache(c *testing.T) {
 	if err := ctx.Add("foo", "hello1"); err != nil {
 		c.Fatal(err)
 	}
-	buildImageSuccessfully(c, name3, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name3, build.WithExternalBuildContext(ctx))
 	id3 := getIDByName(c, name3)
 	if id2 == id3 {
 		c.Fatal("The cache should have been invalided but hasn't.")
@@ -1886,7 +1886,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithCache(c *testing.T) {
 	if err := ctx.Add("foo", "hello1"); err != nil {
 		c.Fatal(err)
 	}
-	buildImageSuccessfully(c, name4, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name4, build.WithExternalBuildContext(ctx))
 	id4 := getIDByName(c, name4)
 	if id3 != id4 {
 		c.Fatal("The cache should have been used but hasn't.")
@@ -1904,9 +1904,9 @@ func (s *DockerCLIBuildSuite) TestBuildAddCurrentDirWithoutCache(c *testing.T) {
 		"foo": "hello",
 	}))
 	defer ctx.Close()
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithoutCache, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithoutCache, build.WithExternalBuildContext(ctx))
 	id2 := getIDByName(c, name)
 	if id1 == id2 {
 		c.Fatal("The cache should have been invalided but hasn't.")
@@ -1996,11 +1996,11 @@ func (s *DockerCLIBuildSuite) TestBuildAddLocalAndRemoteFilesWithAndWithoutCache
 			"foo": "hello world",
 		}))
 	defer ctx.Close()
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 	id2 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithoutCache, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithoutCache, build.WithExternalBuildContext(ctx))
 	id3 := getIDByName(c, name)
 	if id1 != id2 {
 		c.Fatal("The cache should have been used but hasn't.")
@@ -2138,7 +2138,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumeOwnership(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildimg"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox:latest
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox:latest
         RUN mkdir /test && chown daemon:wheel /test && chmod 0600 /test
         VOLUME /test`))
 
@@ -2155,10 +2155,10 @@ func (s *DockerCLIBuildSuite) TestBuildWithVolumeOwnership(c *testing.T) {
 // utilizing cache
 func (s *DockerCLIBuildSuite) TestBuildEntrypointRunCleanup(c *testing.T) {
 	const name = "testbuildcmdcleanup"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
         RUN echo "hello"`))
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
         RUN echo "hello"
         ADD foo /foo
@@ -2188,11 +2188,11 @@ func (s *DockerCLIBuildSuite) TestBuildInheritance(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildinheritance"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM scratch
 		EXPOSE 2375`))
 	ports1 := inspectField(c, name, "Config.ExposedPorts")
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
+	cli.BuildCmd(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["/bin/echo"]`, name)))
 
 	res := inspectField(c, name, "Config.Entrypoint")
@@ -2216,9 +2216,9 @@ func (s *DockerCLIBuildSuite) TestBuildFails(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildOnBuild(c *testing.T) {
 	const name = "testbuildonbuild"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		ONBUILD RUN touch foobar`))
-	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
+	cli.BuildCmd(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		RUN [ -f foobar ]`, name)))
 }
 
@@ -2229,7 +2229,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddToSymlinkDest(c *testing.T) {
 		makeLink = `mklink /D C:\bar C:\foo`
 	}
 	const name = "testbuildaddtosymlinkdest"
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
 		RUN sh -c "mkdir /foo"
@@ -2244,7 +2244,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddToSymlinkDest(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildEscapeWhitespace(c *testing.T) {
 	const name = "testbuildescapewhitespace"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   # ESCAPE=\
   FROM busybox
   MAINTAINER "Docker \
@@ -2262,7 +2262,7 @@ func (s *DockerCLIBuildSuite) TestBuildVerifyIntString(c *testing.T) {
 	// Verify that strings that look like ints are still passed as strings
 	const name = "testbuildstringing"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
 	FROM busybox
 	MAINTAINER 123`))
 
@@ -2274,7 +2274,7 @@ func (s *DockerCLIBuildSuite) TestBuildVerifyIntString(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignore(c *testing.T) {
 	const name = "testbuilddockerignore"
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
 		 ADD . /bla
@@ -2312,7 +2312,7 @@ dir`),
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoreCleanPaths(c *testing.T) {
 	const name = "testbuilddockerignorecleanpaths"
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
         FROM busybox
         ADD . /tmp/
@@ -2326,7 +2326,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoreCleanPaths(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildDockerignoreExceptions(c *testing.T) {
 	const name = "testbuilddockerignoreexceptions"
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
 		ADD . /bla
@@ -2376,12 +2376,12 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringDockerfile(c *testing.T) {
 		ADD . /tmp/
 		RUN sh -c "! ls /tmp/Dockerfile"
 		RUN ls /tmp/.dockerignore`
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile(".dockerignore", "Dockerfile\n"),
 	))
 	// FIXME(vdemeester) why twice ?
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile(".dockerignore", "./Dockerfile\n"),
 	))
@@ -2395,13 +2395,13 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringRenamedDockerfile(c *testin
 		RUN ls /tmp/Dockerfile
 		RUN sh -c "! ls /tmp/MyDockerfile"
 		RUN ls /tmp/.dockerignore`
-	buildImageSuccessfully(c, name, cli.WithFlags("-f", "MyDockerfile"), build.WithBuildContext(c,
+	cli.BuildCmd(c, name, cli.WithFlags("-f", "MyDockerfile"), build.WithBuildContext(c,
 		build.WithFile("Dockerfile", "Should not use me"),
 		build.WithFile("MyDockerfile", dockerfile),
 		build.WithFile(".dockerignore", "MyDockerfile\n"),
 	))
 	// FIXME(vdemeester) why twice ?
-	buildImageSuccessfully(c, name, cli.WithFlags("-f", "MyDockerfile"), build.WithBuildContext(c,
+	cli.BuildCmd(c, name, cli.WithFlags("-f", "MyDockerfile"), build.WithBuildContext(c,
 		build.WithFile("Dockerfile", "Should not use me"),
 		build.WithFile("MyDockerfile", dockerfile),
 		build.WithFile(".dockerignore", "./MyDockerfile\n"),
@@ -2415,7 +2415,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringDockerignore(c *testing.T) 
 		ADD . /tmp/
 		RUN sh -c "! ls /tmp/.dockerignore"
 		RUN ls /tmp/Dockerfile`
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile(".dockerignore", ".dockerignore\n"),
 	))
@@ -2472,7 +2472,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringWholeDir(c *testing.T) {
 		RUN sh -c "[[ ! -e /.gitignore ]]"
 		RUN sh -c "[[ ! -e /Makefile ]]"`
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile(".dockerignore", "*\n"),
 		build.WithFile("Makefile", "all:"),
@@ -2489,7 +2489,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringOnlyDotfiles(c *testing.T) 
 		RUN sh -c "[[ ! -e /.gitignore ]]"
 		RUN sh -c "[[ -f /Makefile ]]"`
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile(".dockerignore", ".*"),
 		build.WithFile("Makefile", "all:"),
@@ -2525,7 +2525,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoringWildTopDir(c *testing.T) {
 
 	// All of these should result in ignoring all files
 	for _, variant := range []string{"**", "**/", "**/**", "*"} {
-		buildImageSuccessfully(c, "noname", build.WithBuildContext(c,
+		cli.BuildCmd(c, "noname", build.WithBuildContext(c,
 			build.WithFile("Dockerfile", dockerfile),
 			build.WithFile("file1", ""),
 			build.WithFile("dir/file1", ""),
@@ -2577,7 +2577,7 @@ dir1/dir3/**
 **/dir5/file.
 `
 
-	buildImageSuccessfully(c, "noname", build.WithBuildContext(c,
+	cli.BuildCmd(c, "noname", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile(".dockerignore", dockerignore),
 		build.WithFile("dir1/file0", ""),
@@ -2602,7 +2602,7 @@ dir1/dir3/**
 func (s *DockerCLIBuildSuite) TestBuildLineBreak(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildlinebreak"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM  busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM  busybox
 RUN    sh -c 'echo root:testpass \
 	> /tmp/passwd'
 RUN    mkdir -p /var/run/sshd
@@ -2613,7 +2613,7 @@ RUN    sh -c "[ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]"`))
 func (s *DockerCLIBuildSuite) TestBuildEOLInLine(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildeolinline"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM   busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM   busybox
 RUN    sh -c 'echo root:testpass > /tmp/passwd'
 RUN    echo "foo \n bar"; echo "baz"
 RUN    mkdir -p /var/run/sshd
@@ -2624,7 +2624,7 @@ RUN    sh -c "[ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]"`))
 func (s *DockerCLIBuildSuite) TestBuildCommentsShebangs(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildcomments"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 # This is an ordinary comment.
 RUN { echo '#!/bin/sh'; echo 'echo hello world'; } > /hello.sh
 RUN [ ! -x /hello.sh ]
@@ -2638,7 +2638,7 @@ RUN [ "$(/hello.sh)" = "hello world" ]`))
 func (s *DockerCLIBuildSuite) TestBuildUsersAndGroups(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildusers"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 
 # Make sure our defaults work
 RUN [ "$(id -u):$(id -g)/$(id -un):$(id -gn)" = '0:0/root:root' ]
@@ -2715,7 +2715,7 @@ ENV    abc=def
 ENV    ghi=$abc
 RUN    [ "$ghi" = "def" ]
 `
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile("hello/docker/world", "hello"),
 	))
@@ -2785,7 +2785,7 @@ ENV    eee4 'foo'
 RUN    [ "$eee1,$eee2,$eee3,$eee4" = 'foo,foo,foo,foo' ]
 
 `
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile("hello/docker/world", "hello"),
 	))
@@ -2801,7 +2801,7 @@ RUN ["chmod","+x","/test"]
 RUN ["/test"]
 RUN [ "$(cat /testfile)" = 'test!' ]`
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile("test", "#!/bin/sh\necho 'test!' > /testfile"),
 	))
@@ -2858,7 +2858,7 @@ RUN cat /existing-directory-trailing-slash/test/foo | grep Hi`
 	}()
 	defer ctx.Close()
 
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddBrokenTar(c *testing.T) {
@@ -2916,7 +2916,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddNonTar(c *testing.T) {
 	const name = "testbuildaddnontar"
 
 	// Should not try to extract test.tar
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
 		ADD test.tar /
@@ -2971,7 +2971,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddTarXz(c *testing.T) {
 
 	defer ctx.Close()
 
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildAddTarXzGz(c *testing.T) {
@@ -3023,7 +3023,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddTarXzGz(c *testing.T) {
 
 	defer ctx.Close()
 
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 }
 
 // FIXME(vdemeester) most of the from git tests could be moved to `docker/cli` e2e tests
@@ -3038,7 +3038,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromGit(c *testing.T) {
 	}, true)
 	defer git.Close()
 
-	buildImageSuccessfully(c, name, build.WithContextPath(git.RepoURL))
+	cli.BuildCmd(c, name, build.WithContextPath(git.RepoURL))
 
 	res := inspectField(c, name, "Author")
 	if res != "docker" {
@@ -3057,7 +3057,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromGitWithContext(c *testing.T) {
 	}, true)
 	defer git.Close()
 
-	buildImageSuccessfully(c, name, build.WithContextPath(fmt.Sprintf("%s#master:docker", git.RepoURL)))
+	cli.BuildCmd(c, name, build.WithContextPath(fmt.Sprintf("%s#master:docker", git.RepoURL)))
 
 	res := inspectField(c, name, "Author")
 	if res != "docker" {
@@ -3116,10 +3116,10 @@ func (s *DockerCLIBuildSuite) TestBuildFromRemoteTarball(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildCleanupCmdOnEntrypoint(c *testing.T) {
 	const name = "testbuildcmdcleanuponentrypoint"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
 		CMD ["test"]
 		ENTRYPOINT ["echo"]`))
-	buildImageSuccessfully(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
+	cli.BuildCmd(c, name, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["cat"]`, name)))
 
 	res := inspectField(c, name, "Config.Cmd")
@@ -3134,7 +3134,7 @@ func (s *DockerCLIBuildSuite) TestBuildCleanupCmdOnEntrypoint(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildClearCmd(c *testing.T) {
 	const name = "testbuildclearcmd"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
    ENTRYPOINT ["/bin/bash"]
    CMD []`))
 
@@ -3147,7 +3147,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyCmd(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	const name = "testbuildemptycmd"
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM "+minimalBaseImage()+"\nMAINTAINER quux\n"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	if res != "null" {
@@ -3157,7 +3157,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyCmd(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildOnBuildOutput(c *testing.T) {
 	const name = "testbuildonbuildparent"
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nONBUILD RUN echo foo\n"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nONBUILD RUN echo foo\n"))
 
 	buildImage(name, build.WithDockerfile("FROM "+name+"\nMAINTAINER quux\n")).Assert(c, icmd.Expected{
 		Out: "# Executing 1 build trigger",
@@ -3175,7 +3175,7 @@ func (s *DockerCLIBuildSuite) TestBuildInvalidTag(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildCmdShDashC(c *testing.T) {
 	const name = "testbuildcmdshc"
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD echo cmd\n"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nCMD echo cmd\n"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	expected := `["/bin/sh","-c","echo cmd"]`
@@ -3193,9 +3193,9 @@ func (s *DockerCLIBuildSuite) TestBuildCmdSpaces(c *testing.T) {
 	// look the same
 	const name = "testbuildcmdspaces"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo hi\"]\n"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo hi\"]\n"))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo\", \"hi\"]\n"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo\", \"hi\"]\n"))
 	id2 := getIDByName(c, name)
 
 	if id1 == id2 {
@@ -3203,9 +3203,9 @@ func (s *DockerCLIBuildSuite) TestBuildCmdSpaces(c *testing.T) {
 	}
 
 	// Now do the same with ENTRYPOINT
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT [\"echo hi\"]\n"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT [\"echo hi\"]\n"))
 	id1 = getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT [\"echo\", \"hi\"]\n"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT [\"echo\", \"hi\"]\n"))
 	id2 = getIDByName(c, name)
 
 	if id1 == id2 {
@@ -3215,7 +3215,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdSpaces(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildCmdJSONNoShDashC(c *testing.T) {
 	const name = "testbuildcmdjson"
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo\", \"cmd\"]"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nCMD [\"echo\", \"cmd\"]"))
 
 	res := inspectFieldJSON(c, name, "Config.Cmd")
 	expected := `["echo","cmd"]`
@@ -3225,7 +3225,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdJSONNoShDashC(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildEntrypointCanBeOverriddenByChild(c *testing.T) {
-	buildImageSuccessfully(c, "parent", build.WithDockerfile(`
+	cli.BuildCmd(c, "parent", build.WithDockerfile(`
     FROM busybox
     ENTRYPOINT exit 130
     `))
@@ -3234,7 +3234,7 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypointCanBeOverriddenByChild(c *testi
 		ExitCode: 130,
 	})
 
-	buildImageSuccessfully(c, "child", build.WithDockerfile(`
+	cli.BuildCmd(c, "child", build.WithDockerfile(`
     FROM parent
     ENTRYPOINT exit 5
     `))
@@ -3255,8 +3255,8 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypointCanBeOverriddenByChildInspect(c
 		expected = `["cmd /S /C echo quux"]`
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT /foo/bar"))
-	buildImageSuccessfully(c, name2, build.WithDockerfile(fmt.Sprintf("FROM %s\nENTRYPOINT echo quux", name)))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nENTRYPOINT /foo/bar"))
+	cli.BuildCmd(c, name2, build.WithDockerfile(fmt.Sprintf("FROM %s\nENTRYPOINT echo quux", name)))
 
 	res := inspectFieldJSON(c, name2, "Config.Entrypoint")
 	if res != expected {
@@ -3270,7 +3270,7 @@ func (s *DockerCLIBuildSuite) TestBuildEntrypointCanBeOverriddenByChildInspect(c
 
 func (s *DockerCLIBuildSuite) TestBuildRunShEntrypoint(c *testing.T) {
 	const name = "testbuildentrypoint"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
                                 ENTRYPOINT echo`))
 	cli.DockerCmd(c, "run", "--rm", name)
 }
@@ -3279,7 +3279,7 @@ func (s *DockerCLIBuildSuite) TestBuildExoticShellInterpolation(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildexoticshellinterpolation"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
 		FROM busybox
 
 		ENV SOME_VAR a.b.c
@@ -3309,7 +3309,7 @@ func (s *DockerCLIBuildSuite) TestBuildVerifySingleQuoteFails(c *testing.T) {
 	const name = "testbuildsinglequotefails"
 	expectedExitCode := 2
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		CMD [ '/bin/sh', '-c', 'echo hi' ]`))
 
 	icmd.RunCommand(dockerBinary, "run", "--rm", name).Assert(c, icmd.Expected{
@@ -3336,7 +3336,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithTabs(c *testing.T) {
 	skip.If(c, testEnv.UsingSnapshotter, "ContainerConfig is not filled in c8d")
 
 	const name = "testbuildwithtabs"
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nRUN echo\tone\t\ttwo"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nRUN echo\tone\t\ttwo"))
 	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
 	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
 	expected2 := `["/bin/sh","-c","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
@@ -3352,7 +3352,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithTabs(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildLabels(c *testing.T) {
 	const name = "testbuildlabel"
 	expected := `{"License":"GPL","Vendor":"Acme"}`
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme
                 LABEL License GPL`))
 	res := inspectFieldJSON(c, name, "Config.Labels")
@@ -3364,24 +3364,24 @@ func (s *DockerCLIBuildSuite) TestBuildLabels(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildLabelsCache(c *testing.T) {
 	const name = "testbuildlabelcache"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme`))
 	id1 := getIDByName(c, name)
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme`))
 	id2 := getIDByName(c, name)
 	if id1 != id2 {
 		c.Fatalf("Build 2 should have worked & used cache(%s,%s)", id1, id2)
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor=Acme1`))
 	id2 = getIDByName(c, name)
 	if id1 == id2 {
 		c.Fatalf("Build 3 should have worked & NOT used cache(%s,%s)", id1, id2)
 	}
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		LABEL Vendor Acme`))
 	id2 = getIDByName(c, name)
 	if id1 != id2 {
@@ -3389,10 +3389,10 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsCache(c *testing.T) {
 	}
 
 	// Now make sure the cache isn't used by mistake
-	buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithoutCache, build.WithDockerfile(`FROM busybox
        LABEL f1=b1 f2=b2`))
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
        LABEL f1=b1 f2=b2`))
 	id2 = getIDByName(c, name)
 	if id1 == id2 {
@@ -3620,7 +3620,7 @@ func (s *DockerCLIBuildSuite) TestBuildSymlinkBreakout(c *testing.T) {
 	w.Close()
 	f.Close()
 
-	buildImageSuccessfully(c, name, build.WithoutCache, build.WithExternalBuildContext(fakecontext.New(c, ctx)))
+	cli.BuildCmd(c, name, build.WithoutCache, build.WithExternalBuildContext(fakecontext.New(c, ctx)))
 	if _, err := os.Lstat(filepath.Join(tmpdir, "inject")); err == nil {
 		c.Fatal("symlink breakout - inject")
 	} else if !os.IsNotExist(err) {
@@ -3634,7 +3634,7 @@ func (s *DockerCLIBuildSuite) TestBuildXZHost(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuildxzhost"
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 FROM busybox
 ADD xz /usr/local/sbin/
@@ -3660,7 +3660,7 @@ func (s *DockerCLIBuildSuite) TestBuildVolumesRetainContents(c *testing.T) {
 		volName = "C:/foo"
 	}
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 FROM busybox
 COPY content /foo/file
@@ -3761,7 +3761,7 @@ func (s *DockerCLIBuildSuite) TestBuildFromOfficialNames(c *testing.T) {
 	}
 	for idx, fromName := range fromNames {
 		imgName := fmt.Sprintf("%s%d", name, idx)
-		buildImageSuccessfully(c, imgName, build.WithDockerfile("FROM "+fromName))
+		cli.BuildCmd(c, imgName, build.WithDockerfile("FROM "+fromName))
 		cli.DockerCmd(c, "rmi", imgName)
 	}
 }
@@ -3915,7 +3915,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmptyScratch(c *testing.T) {
 }
 
 func (s *DockerCLIBuildSuite) TestBuildDotDotFile(c *testing.T) {
-	buildImageSuccessfully(c, "sc", build.WithBuildContext(c,
+	cli.BuildCmd(c, "sc", build.WithBuildContext(c,
 		build.WithFile("Dockerfile", "FROM busybox\n"),
 		build.WithFile("..gitme", ""),
 	))
@@ -4029,7 +4029,7 @@ func (s *DockerCLIBuildSuite) TestBuildNullStringInAddCopyVolume(c *testing.T) {
 		volName = `C:\\nullvolume`
 	}
 
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `
 		FROM busybox
 
@@ -4045,7 +4045,7 @@ func (s *DockerCLIBuildSuite) TestBuildNullStringInAddCopyVolume(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildStopSignal(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Windows does not support STOPSIGNAL yet
 	imgName := "test_build_stop_signal"
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imgName, build.WithDockerfile(`FROM busybox
 		 STOPSIGNAL SIGKILL`))
 	res := inspectFieldJSON(c, imgName, "Config.StopSignal")
 	if res != `"SIGKILL"` {
@@ -4160,14 +4160,14 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgCacheHit(c *testing.T) {
 	dockerfile := fmt.Sprintf(`FROM busybox
 		ARG %s
 		RUN echo $%s`, envKey, envKey)
-	buildImageSuccessfully(c, imgName,
+	cli.BuildCmd(c, imgName,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
 		build.WithDockerfile(dockerfile),
 	)
 	origImgID := getIDByName(c, imgName)
 
 	imgNameCache := "bldargtestcachehit"
-	buildImageSuccessfully(c, imgNameCache,
+	cli.BuildCmd(c, imgNameCache,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
 		build.WithDockerfile(dockerfile),
 	)
@@ -4187,14 +4187,14 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgCacheMissExtraArg(c *testing.
 		ARG %s
 		ARG %s
 		RUN echo $%s`, envKey, extraEnvKey, envKey)
-	buildImageSuccessfully(c, imgName,
+	cli.BuildCmd(c, imgName,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
 		build.WithDockerfile(dockerfile),
 	)
 	origImgID := getIDByName(c, imgName)
 
 	imgNameCache := "bldargtestcachemiss"
-	buildImageSuccessfully(c, imgNameCache,
+	cli.BuildCmd(c, imgNameCache,
 		cli.WithFlags(
 			"--build-arg", fmt.Sprintf("%s=%s", envKey, envVal),
 			"--build-arg", fmt.Sprintf("%s=%s", extraEnvKey, extraEnvVal),
@@ -4216,14 +4216,14 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgCacheMissSameArgDiffVal(c *te
 	dockerfile := fmt.Sprintf(`FROM busybox
 		ARG %s
 		RUN echo $%s`, envKey, envKey)
-	buildImageSuccessfully(c, imgName,
+	cli.BuildCmd(c, imgName,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, envVal)),
 		build.WithDockerfile(dockerfile),
 	)
 	origImgID := getIDByName(c, imgName)
 
 	imgNameCache := "bldargtestcachemiss"
-	buildImageSuccessfully(c, imgNameCache,
+	cli.BuildCmd(c, imgNameCache,
 		cli.WithFlags("--build-arg", fmt.Sprintf("%s=%s", envKey, newEnvVal)),
 		build.WithDockerfile(dockerfile),
 	)
@@ -4311,7 +4311,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgExpansion(c *testing.T) {
 		wdVal = "C:\\tmp"
 	}
 
-	buildImageSuccessfully(c, imgName,
+	cli.BuildCmd(c, imgName,
 		cli.WithFlags(
 			"--build-arg", fmt.Sprintf("%s=%s", wdVar, wdVal),
 			"--build-arg", fmt.Sprintf("%s=%s", addVar, addVal),
@@ -4574,7 +4574,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgQuotedValVariants(c *testing.
 		RUN [ "$%s" != "$%s" ]`, envKey, envKey1, envKey2, envKey3,
 		envKey, envKey2, envKey, envKey3, envKey1, envKey2, envKey1, envKey3,
 		envKey2, envKey3)
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, imgName, build.WithDockerfile(dockerfile))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgEmptyValVariants(c *testing.T) {
@@ -4590,7 +4590,7 @@ func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgEmptyValVariants(c *testing.T
 		RUN [ "$%s" = "$%s" ]
 		RUN [ "$%s" = "$%s" ]
 		RUN [ "$%s" = "$%s" ]`, envKey, envKey1, envKey2, envKey, envKey1, envKey1, envKey2, envKey, envKey2)
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, imgName, build.WithDockerfile(dockerfile))
 }
 
 func (s *DockerCLIBuildSuite) TestBuildBuildTimeArgDefinitionWithNoEnvInjection(c *testing.T) {
@@ -4706,7 +4706,7 @@ func (s *DockerCLIBuildSuite) TestBuildTagEvent(c *testing.T) {
 	dockerFile := `FROM busybox
 	RUN echo events
 	`
-	buildImageSuccessfully(c, "test", build.WithDockerfile(dockerFile))
+	cli.BuildCmd(c, "test", build.WithDockerfile(dockerFile))
 
 	until := daemonUnixTime(c)
 	out := cli.DockerCmd(c, "events", "--since", since, "--until", until, "--filter", "type=image").Stdout()
@@ -4729,7 +4729,7 @@ func (s *DockerCLIBuildSuite) TestBuildMultipleTags(c *testing.T) {
 	FROM busybox
 	MAINTAINER test-15780
 	`
-	buildImageSuccessfully(c, "tag1", cli.WithFlags("-t", "tag2:v2", "-t", "tag1:latest", "-t", "tag1"), build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, "tag1", cli.WithFlags("-t", "tag2:v2", "-t", "tag1:latest", "-t", "tag1"), build.WithDockerfile(dockerfile))
 
 	id1 := getIDByName(c, "tag1")
 	id2 := getIDByName(c, "tag2:v2")
@@ -4889,7 +4889,7 @@ func (s *DockerCLIBuildSuite) TestBuildFailsGitNotCallable(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildWorkdirWindowsPath(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
 	const name = "testbuildworkdirwindowspath"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
 	FROM `+testEnv.PlatformDefaults.BaseImage+`
 	RUN mkdir C:\\work
 	WORKDIR C:\\work
@@ -4901,7 +4901,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabel(c *testing.T) {
 	const name = "testbuildlabel"
 	testLabel := "foo"
 
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", testLabel),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", testLabel),
 		build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
@@ -4916,7 +4916,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabel(c *testing.T) {
 
 func (s *DockerCLIBuildSuite) TestBuildLabelOneNode(c *testing.T) {
 	const name = "testbuildlabel"
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=bar"),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", "foo=bar"),
 		build.WithDockerfile("FROM busybox"))
 
 	var labels map[string]string
@@ -4932,11 +4932,11 @@ func (s *DockerCLIBuildSuite) TestBuildLabelCacheCommit(c *testing.T) {
 	const name = "testbuildlabelcachecommit"
 	testLabel := "foo"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
   `))
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", testLabel),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", testLabel),
 		build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
@@ -4960,7 +4960,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelMultiple(c *testing.T) {
 		labelArgs = append(labelArgs, "--label", k+"="+v)
 	}
 
-	buildImageSuccessfully(c, name, cli.WithFlags(labelArgs...),
+	cli.BuildCmd(c, name, cli.WithFlags(labelArgs...),
 		build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   LABEL default foo
@@ -4979,7 +4979,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildFromAuthenticatedRegistry(c *
 	cli.DockerCmd(c, "login", "-u", s.reg.Username(), "-p", s.reg.Password(), privateRegistryURL)
 	baseImage := privateRegistryURL + "/baseimage"
 
-	buildImageSuccessfully(c, baseImage, build.WithDockerfile(`
+	cli.BuildCmd(c, baseImage, build.WithDockerfile(`
 	FROM busybox
 	ENV env1 val1
 	`))
@@ -4987,7 +4987,7 @@ func (s *DockerRegistryAuthHtpasswdSuite) TestBuildFromAuthenticatedRegistry(c *
 	cli.DockerCmd(c, "push", baseImage)
 	cli.DockerCmd(c, "rmi", baseImage)
 
-	buildImageSuccessfully(c, baseImage, build.WithDockerfile(fmt.Sprintf(`
+	cli.BuildCmd(c, baseImage, build.WithDockerfile(fmt.Sprintf(`
 	FROM %s
 	ENV env2 val2
 	`, baseImage)))
@@ -5036,7 +5036,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 	// Command line option labels will always override
 	name := "scratchy"
 	expected := `{"bar":"from-flag","foo":"from-flag"}`
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
 		build.WithDockerfile(`FROM `+minimalBaseImage()+`
                 LABEL foo=from-dockerfile`))
 	res := inspectFieldJSON(c, name, "Config.Labels")
@@ -5046,7 +5046,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 
 	name = "from"
 	expected = `{"foo":"from-dockerfile"}`
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
                 LABEL foo from-dockerfile`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5056,7 +5056,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 	// Command line option label will override even via `FROM`
 	name = "new"
 	expected = `{"bar":"from-dockerfile2","foo":"new"}`
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=new"),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", "foo=new"),
 		build.WithDockerfile(`FROM from
                 LABEL bar from-dockerfile2`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
@@ -5068,7 +5068,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 	// will be treated as --label foo="", --label bar=""
 	name = "scratchy2"
 	expected = `{"bar":"","foo":""}`
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo", "--label", "bar="),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", "foo", "--label", "bar="),
 		build.WithDockerfile(`FROM `+minimalBaseImage()+`
                 LABEL foo=from-dockerfile`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
@@ -5081,7 +5081,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 	// This time is for inherited images
 	name = "new2"
 	expected = `{"bar":"","foo":""}`
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=", "--label", "bar"),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", "foo=", "--label", "bar"),
 		build.WithDockerfile(`FROM from
                 LABEL bar from-dockerfile2`))
 	res = inspectFieldJSON(c, name, "Config.Labels")
@@ -5092,7 +5092,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 	// Command line option labels with only `FROM`
 	name = "scratchy"
 	expected = `{"bar":"from-flag","foo":"from-flag"}`
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", "foo=from-flag", "--label", "bar=from-flag"),
 		build.WithDockerfile(`FROM `+minimalBaseImage()))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5102,7 +5102,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 	// Command line option labels with env var
 	name = "scratchz"
 	expected = `{"bar":"$PATH"}`
-	buildImageSuccessfully(c, name, cli.WithFlags("--label", "bar=$PATH"),
+	cli.BuildCmd(c, name, cli.WithFlags("--label", "bar=$PATH"),
 		build.WithDockerfile(`FROM `+minimalBaseImage()))
 	res = inspectFieldJSON(c, name, "Config.Labels")
 	if res != expected {
@@ -5113,7 +5113,7 @@ func (s *DockerCLIBuildSuite) TestBuildLabelsOverride(c *testing.T) {
 // Test case for #22855
 func (s *DockerCLIBuildSuite) TestBuildDeleteCommittedFile(c *testing.T) {
 	const name = "test-delete-committed-file"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo test > file
 		RUN test -e file
 		RUN rm file
@@ -5134,7 +5134,7 @@ func (s *DockerCLIBuildSuite) TestBuildDockerignoreComment(c *testing.T) {
         RUN sh -c "(ls -la /tmp/#1)"
         RUN sh -c "(! ls -la /tmp/#2)"
         RUN sh -c "(! ls /tmp/foo) && (! ls /tmp/foo2) && (ls /tmp/dir1/foo)"`
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile("foo", "foo"),
 		build.WithFile("foo2", "foo2"),
@@ -5159,7 +5159,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithUTF8BOM(c *testing.T) {
 	const name = "test-with-utf8-bom"
 	dockerfile := []byte(`FROM busybox`)
 	bomDockerfile := append([]byte{0xEF, 0xBB, 0xBF}, dockerfile...)
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", string(bomDockerfile)),
 	))
 }
@@ -5175,7 +5175,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithUTF8BOMDockerignore(c *testing.T) {
 		RUN ls /tmp/.dockerignore`
 	dockerignore := []byte("./Dockerfile\n")
 	bomDockerignore := append([]byte{0xEF, 0xBB, 0xBF}, dockerignore...)
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", dockerfile),
 		build.WithFile(".dockerignore", string(bomDockerignore)),
 	))
@@ -5188,7 +5188,7 @@ func (s *DockerCLIBuildSuite) TestBuildShellUpdatesConfig(c *testing.T) {
 
 	const name = "testbuildshellupdatesconfig"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
         SHELL ["foo", "-bar"]`))
 	expected := `["foo","-bar","#(nop) ","SHELL [foo -bar]"]`
 	res := inspectFieldJSON(c, name, "ContainerConfig.Cmd")
@@ -5241,7 +5241,7 @@ func (s *DockerCLIBuildSuite) TestBuildShellMultiple(c *testing.T) {
 func (s *DockerCLIBuildSuite) TestBuildShellEntrypoint(c *testing.T) {
 	const name = "testbuildshellentrypoint"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		SHELL ["ls"]
 		ENTRYPOINT -l`))
 	// A container started from the image uses the shell-form ENTRYPOINT.
@@ -5255,7 +5255,7 @@ func (s *DockerCLIBuildSuite) TestBuildShellEntrypoint(c *testing.T) {
 // #22489 Shell test to confirm shell is inherited in a subsequent build
 func (s *DockerCLIBuildSuite) TestBuildShellInherited(c *testing.T) {
 	const name1 = "testbuildshellinherited1"
-	buildImageSuccessfully(c, name1, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name1, build.WithDockerfile(`FROM busybox
         SHELL ["ls"]`))
 	const name2 = "testbuildshellinherited2"
 	buildImage(name2, build.WithDockerfile(`FROM `+name1+`
@@ -5317,7 +5317,7 @@ func (s *DockerCLIBuildSuite) TestBuildEscapeNotBackslashWordTest(c *testing.T) 
 func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
 	const name1 = "testbuildcmdshellescapedshellform"
-	buildImageSuccessfully(c, name1, build.WithDockerfile(`
+	cli.BuildCmd(c, name1, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   CMD "ipconfig"
   `))
@@ -5335,7 +5335,7 @@ func (s *DockerCLIBuildSuite) TestBuildCmdShellArgsEscaped(c *testing.T) {
 
 	// Now in JSON/exec-form
 	const name2 = "testbuildcmdshellescapedexecform"
-	buildImageSuccessfully(c, name2, build.WithDockerfile(`
+	cli.BuildCmd(c, name2, build.WithDockerfile(`
   FROM `+minimalBaseImage()+`
   CMD ["ipconfig"]
   `))
@@ -5558,7 +5558,7 @@ func (s *DockerCLIBuildSuite) TestBuildNetContainer(c *testing.T) {
 	id := cli.DockerCmd(c, "run", "--hostname", "foobar", "-d", "busybox", "nc", "-ll", "-p", "1234", "-e", "hostname").Stdout()
 
 	const name = "testbuildnetcontainer"
-	buildImageSuccessfully(c, name, cli.WithFlags("--network=container:"+strings.TrimSpace(id)),
+	cli.BuildCmd(c, name, cli.WithFlags("--network=container:"+strings.TrimSpace(id)),
 		build.WithDockerfile(`
   FROM busybox
   RUN nc localhost 1234 > /otherhost
@@ -5572,7 +5572,7 @@ func (s *DockerCLIBuildSuite) TestBuildWithExtraHost(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	const name = "testbuildwithextrahost"
-	buildImageSuccessfully(c, name,
+	cli.BuildCmd(c, name,
 		cli.WithFlags(
 			"--add-host", "foo:127.0.0.1",
 			"--add-host", "bar:127.0.0.1",
@@ -5984,7 +5984,7 @@ func (s *DockerCLIBuildSuite) TestBuildOpaqueDirectory(c *testing.T) {
 		`
 	// Test that build succeeds, last command fails if opaque directory
 	// was not handled correctly
-	buildImageSuccessfully(c, "testopaquedirectory", build.WithDockerfile(dockerFile))
+	cli.BuildCmd(c, "testopaquedirectory", build.WithDockerfile(dockerFile))
 }
 
 // Windows test for USER in dockerfile
@@ -6008,7 +6008,7 @@ func (s *DockerCLIBuildSuite) TestBuildWindowsUser(c *testing.T) {
 // Note 27545 was reverted in 28505, but a new fix was added subsequently in 28514.
 func (s *DockerCLIBuildSuite) TestBuildCopyFileDotWithWorkdir(c *testing.T) {
 	const name = "testbuildcopyfiledotwithworkdir"
-	buildImageSuccessfully(c, name, build.WithBuildContext(c,
+	cli.BuildCmd(c, name, build.WithBuildContext(c,
 		build.WithFile("Dockerfile", `FROM busybox
 WORKDIR /foo
 COPY file .
@@ -6022,7 +6022,7 @@ RUN ["cat", "/foo/file"]
 func (s *DockerCLIBuildSuite) TestBuildWindowsEnvCaseInsensitive(c *testing.T) {
 	testRequires(c, DaemonIsWindows)
 	const name = "testbuildwindowsenvcaseinsensitive"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
 		FROM `+testEnv.PlatformDefaults.BaseImage+`
 		ENV FOO=bar foo=baz
   `))
@@ -6035,7 +6035,7 @@ func (s *DockerCLIBuildSuite) TestBuildWindowsEnvCaseInsensitive(c *testing.T) {
 // Test case for 29667
 func (s *DockerCLIBuildSuite) TestBuildWorkdirImageCmd(c *testing.T) {
 	imgName := "testworkdirimagecmd"
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(`
+	cli.BuildCmd(c, imgName, build.WithDockerfile(`
 FROM busybox
 WORKDIR /foo/bar
 `))
@@ -6043,7 +6043,7 @@ WORKDIR /foo/bar
 	assert.Equal(c, strings.TrimSpace(out), `["sh"]`)
 
 	imgName = "testworkdirlabelimagecmd"
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(`
+	cli.BuildCmd(c, imgName, build.WithDockerfile(`
 FROM busybox
 WORKDIR /foo/bar
 LABEL a=b
@@ -6061,7 +6061,7 @@ func (s *DockerCLIBuildSuite) TestBuildWorkdirCmd(c *testing.T) {
                 FROM busybox
                 WORKDIR /
                 `
-	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
+	cli.BuildCmd(c, name, build.WithDockerfile(dockerFile))
 	result := buildImage(name, build.WithDockerfile(dockerFile))
 	result.Assert(c, icmd.Success)
 	assert.Equal(c, strings.Count(result.Combined(), "Using cache"), 1)
@@ -6125,11 +6125,11 @@ func (s *DockerCLIBuildSuite) TestBuildLineErrorWithComments(c *testing.T) {
 
 // #31957
 func (s *DockerCLIBuildSuite) TestBuildSetCommandWithDefinedShell(c *testing.T) {
-	buildImageSuccessfully(c, "build1", build.WithDockerfile(`
+	cli.BuildCmd(c, "build1", build.WithDockerfile(`
 FROM busybox
 SHELL ["/bin/sh", "-c"]
 `))
-	buildImageSuccessfully(c, "build2", build.WithDockerfile(`
+	cli.BuildCmd(c, "build2", build.WithDockerfile(`
 FROM build1
 CMD echo foo
 `))

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -115,7 +115,7 @@ func (s *DockerCLIBuildSuite) TestBuildAddChangeOwnership(c *testing.T) {
 
 	defer ctx.Close()
 
-	buildImageSuccessfully(c, name, build.WithExternalBuildContext(ctx))
+	cli.BuildCmd(c, name, build.WithExternalBuildContext(ctx))
 }
 
 // Test that an infinite sleep during a build is killed if the client disconnects.

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -175,7 +175,7 @@ func (s *DockerRegistrySuite) TestBuildByDigest(t *testing.T) {
 
 	// do the build
 	const name = "buildbydigest"
-	buildImageSuccessfully(t, name, build.WithDockerfile(fmt.Sprintf(
+	cli.BuildCmd(t, name, build.WithDockerfile(fmt.Sprintf(
 		`FROM %s
      CMD ["/bin/echo", "Hello World"]`, imageReference)))
 	assert.NilError(t, err)
@@ -403,7 +403,7 @@ func (s *DockerRegistrySuite) TestPsListContainersFilterAncestorImageByDigest(t 
 
 	// build an image from it
 	const imageName1 = "images_ps_filter_test"
-	buildImageSuccessfully(t, imageName1, build.WithDockerfile(fmt.Sprintf(
+	cli.BuildCmd(t, imageName1, build.WithDockerfile(fmt.Sprintf(
 		`FROM %s
 		 LABEL match me 1`, imageReference)))
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -178,7 +178,7 @@ func (s *DockerCLICreateSuite) TestCreateLabels(c *testing.T) {
 
 func (s *DockerCLICreateSuite) TestCreateLabelFromImage(c *testing.T) {
 	imageName := "testcreatebuildlabel"
-	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName, build.WithDockerfile(`FROM busybox
 		LABEL k1=v1 k2=v2`))
 
 	const name = "test_create_labels_from_image"

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -337,7 +337,7 @@ func (s *DockerCLIEventSuite) TestEventsFilterImageLabels(c *testing.T) {
 	label := "io.docker.testing=image"
 
 	// Build a test image.
-	buildImageSuccessfully(c, name,
+	cli.BuildCmd(c, name,
 		build.WithDockerfile("FROM busybox:latest\nLABEL "+label),
 		build.WithoutCache, // Make sure image is actually built
 	)
@@ -418,7 +418,7 @@ func (s *DockerCLIEventSuite) TestEventsCommit(c *testing.T) {
 
 func (s *DockerCLIEventSuite) TestEventsCopy(c *testing.T) {
 	// Build a test image.
-	buildImageSuccessfully(c, "cpimg", build.WithDockerfile(`
+	cli.BuildCmd(c, "cpimg", build.WithDockerfile(`
 		  FROM busybox
 		  RUN echo HI > /file`))
 	id := getIDByName(c, "cpimg")
@@ -560,7 +560,7 @@ func (s *DockerCLIEventSuite) TestEventsFilterType(c *testing.T) {
 	label := "io.docker.testing=image"
 
 	// Build a test image.
-	buildImageSuccessfully(c, name,
+	cli.BuildCmd(c, name,
 		build.WithDockerfile("FROM busybox:latest\nLABEL "+label),
 		build.WithoutCache, // Make sure image is actually built
 	)

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -312,7 +312,7 @@ func (s *DockerCLIEventSuite) TestEventsImageUntagDelete(c *testing.T) {
 	defer observer.Stop()
 
 	name := "testimageevents"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM scratch
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM scratch
 		MAINTAINER "docker"`))
 	imageID := getIDByName(c, name)
 	assert.NilError(c, deleteImages(name))

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -491,7 +491,7 @@ func (s *DockerCLIExecSuite) TestExecWithImageUser(c *testing.T) {
 	// Not applicable on Windows
 	testRequires(c, DaemonIsLinux)
 	const name = "testbuilduser"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		USER dockerio`))
 	cli.DockerCmd(c, "run", "-d", "--name", "dockerioexec", name, "top")

--- a/integration-cli/docker_cli_health_test.go
+++ b/integration-cli/docker_cli_health_test.go
@@ -56,7 +56,7 @@ func (s *DockerCLIHealthSuite) TestHealth(c *testing.T) {
 	existingContainers := ExistingContainerIDs(c)
 
 	imageName := "testhealth"
-	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName, build.WithDockerfile(`FROM busybox
 		RUN echo OK > /status
 		CMD ["/bin/sleep", "120"]
 		STOPSIGNAL SIGKILL
@@ -100,7 +100,7 @@ func (s *DockerCLIHealthSuite) TestHealth(c *testing.T) {
 	cli.DockerCmd(c, "rm", "noh")
 
 	// Disable the check with a new build
-	buildImageSuccessfully(c, "no_healthcheck", build.WithDockerfile(`FROM testhealth
+	cli.BuildCmd(c, "no_healthcheck", build.WithDockerfile(`FROM testhealth
 		HEALTHCHECK NONE`))
 
 	out = cli.DockerCmd(c, "inspect", "--format={{.Config.Healthcheck.Test}}", "no_healthcheck").Stdout()
@@ -144,7 +144,7 @@ func (s *DockerCLIHealthSuite) TestHealth(c *testing.T) {
 	cli.DockerCmd(c, "rm", "-f", "test")
 
 	// Check JSON-format
-	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName, build.WithDockerfile(`FROM busybox
 		RUN echo OK > /status
 		CMD ["/bin/sleep", "120"]
 		STOPSIGNAL SIGKILL
@@ -159,7 +159,7 @@ func (s *DockerCLIHealthSuite) TestUnsetEnvVarHealthCheck(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // busybox doesn't work on Windows
 
 	imageName := "testhealth"
-	buildImageSuccessfully(c, imageName, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName, build.WithDockerfile(`FROM busybox
 HEALTHCHECK --interval=1s --timeout=5s --retries=5 CMD /bin/sh -c "sleep 1"
 ENTRYPOINT /bin/sh -c "sleep 600"`))
 

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -30,7 +30,7 @@ func (s *DockerCLIHistorySuite) OnTimeout(t *testing.T) {
 // sort is not predictable it doesn't always fail.
 func (s *DockerCLIHistorySuite) TestBuildHistory(c *testing.T) {
 	const name = "testbuildhistory"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL label.A="A"
 LABEL label.B="B"
 LABEL label.C="C"

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -200,7 +200,7 @@ func assertImageList(out string, expected []string) bool {
 func (s *DockerCLIImagesSuite) TestImagesFilterSpaceTrimCase(c *testing.T) {
 	const imageName = "images_filter_test"
 	// Build a image and fail to build so that we have dangling images ?
-	buildImage(imageName, build.WithDockerfile(`FROM busybox
+	cli.Docker(cli.Args("build", "-t", imageName), build.WithDockerfile(`FROM busybox
                  RUN touch /test/foo
                  RUN touch /test/bar
                  RUN touch /test/baz`)).Assert(c, icmd.Expected{
@@ -275,7 +275,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureOnlyHeadsImagesShown(c *testing.T
         MAINTAINER docker
         ENV foo bar`
 	const name = "scratch-image"
-	result := buildImage(name, build.WithDockerfile(dockerfile))
+	result := cli.Docker(cli.Args("build", "-t", name), build.WithDockerfile(dockerfile))
 	result.Assert(c, icmd.Success)
 	id := getIDByName(c, name)
 

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -60,15 +60,15 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *tes
 }
 
 func (s *DockerCLIImagesSuite) TestImagesOrderedByCreationDate(c *testing.T) {
-	buildImageSuccessfully(c, "order:test_a", build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, "order:test_a", build.WithDockerfile(`FROM busybox
                 MAINTAINER dockerio1`))
 	id1 := getIDByName(c, "order:test_a")
 	time.Sleep(1 * time.Second)
-	buildImageSuccessfully(c, "order:test_c", build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, "order:test_c", build.WithDockerfile(`FROM busybox
                 MAINTAINER dockerio2`))
 	id2 := getIDByName(c, "order:test_c")
 	time.Sleep(1 * time.Second)
-	buildImageSuccessfully(c, "order:test_b", build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, "order:test_b", build.WithDockerfile(`FROM busybox
                 MAINTAINER dockerio3`))
 	id3 := getIDByName(c, "order:test_b")
 
@@ -89,15 +89,15 @@ func (s *DockerCLIImagesSuite) TestImagesFilterLabelMatch(c *testing.T) {
 	const imageName1 = "images_filter_test1"
 	const imageName2 = "images_filter_test2"
 	const imageName3 = "images_filter_test3"
-	buildImageSuccessfully(c, imageName1, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName1, build.WithDockerfile(`FROM busybox
                  LABEL match me`))
 	image1ID := getIDByName(c, imageName1)
 
-	buildImageSuccessfully(c, imageName2, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName2, build.WithDockerfile(`FROM busybox
                  LABEL match="me too"`))
 	image2ID := getIDByName(c, imageName2)
 
-	buildImageSuccessfully(c, imageName3, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName3, build.WithDockerfile(`FROM busybox
                  LABEL nomatch me`))
 	image3ID := getIDByName(c, imageName3)
 
@@ -128,13 +128,13 @@ func (s *DockerCLIImagesSuite) TestCommitWithFilterLabel(c *testing.T) {
 }
 
 func (s *DockerCLIImagesSuite) TestImagesFilterSinceAndBefore(c *testing.T) {
-	buildImageSuccessfully(c, "image:1", build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, "image:1", build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL number=1`))
 	imageID1 := getIDByName(c, "image:1")
-	buildImageSuccessfully(c, "image:2", build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, "image:2", build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL number=2`))
 	imageID2 := getIDByName(c, "image:2")
-	buildImageSuccessfully(c, "image:3", build.WithDockerfile(`FROM `+minimalBaseImage()+`
+	cli.BuildCmd(c, "image:3", build.WithDockerfile(`FROM `+minimalBaseImage()+`
 LABEL number=3`))
 	imageID3 := getIDByName(c, "image:3")
 
@@ -299,7 +299,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromScratchShown(c *testing
         MAINTAINER docker`
 
 	const name = "scratch-image"
-	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, name, build.WithDockerfile(dockerfile))
 	id := getIDByName(c, name)
 
 	out := cli.DockerCmd(c, "images").Stdout()
@@ -315,7 +315,7 @@ func (s *DockerCLIImagesSuite) TestImagesEnsureImagesFromBusyboxShown(c *testing
         MAINTAINER docker`
 	const name = "busybox-image"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, name, build.WithDockerfile(dockerfile))
 	id := getIDByName(c, name)
 
 	out := cli.DockerCmd(c, "images").Stdout()

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -323,17 +323,17 @@ func (s *DockerCLIPsSuite) TestPsListContainersFilterAncestorImage(c *testing.T)
 
 	// Build images
 	imageName1 := "images_ps_filter_test1"
-	buildImageSuccessfully(c, imageName1, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName1, build.WithDockerfile(`FROM busybox
 		 LABEL match me 1`))
 	imageID1 := getIDByName(c, imageName1)
 
 	imageName1Tagged := "images_ps_filter_test1:tag"
-	buildImageSuccessfully(c, imageName1Tagged, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, imageName1Tagged, build.WithDockerfile(`FROM busybox
 		 LABEL match me 1 tagged`))
 	imageID1Tagged := getIDByName(c, imageName1Tagged)
 
 	imageName2 := "images_ps_filter_test2"
-	buildImageSuccessfully(c, imageName2, build.WithDockerfile(fmt.Sprintf(`FROM %s
+	cli.BuildCmd(c, imageName2, build.WithDockerfile(fmt.Sprintf(`FROM %s
 		 LABEL match me 2`, imageName1)))
 	imageID2 := getIDByName(c, imageName2)
 

--- a/integration-cli/docker_cli_pull_local_test.go
+++ b/integration-cli/docker_cli_pull_local_test.go
@@ -58,7 +58,7 @@ func (s *DockerRegistrySuite) TestConcurrentPullWholeRepo(t *testing.T) {
 	var repos []string
 	for _, tag := range []string{"recent", "fresh", "todays"} {
 		repo := fmt.Sprintf("%v:%v", imgRepo, tag)
-		buildImageSuccessfully(t, repo, build.WithDockerfile(fmt.Sprintf(`
+		cli.BuildCmd(t, repo, build.WithDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
 		    ENV FOO foo
@@ -130,7 +130,7 @@ func (s *DockerRegistrySuite) TestConcurrentPullMultipleTags(t *testing.T) {
 	var repos []string
 	for _, tag := range []string{"recent", "fresh", "todays"} {
 		repo := fmt.Sprintf("%v:%v", imgRepo, tag)
-		buildImageSuccessfully(t, repo, build.WithDockerfile(fmt.Sprintf(`
+		cli.BuildCmd(t, repo, build.WithDockerfile(fmt.Sprintf(`
 		    FROM busybox
 		    ENTRYPOINT ["/bin/echo"]
 		    ENV FOO foo
@@ -176,7 +176,7 @@ func (s *DockerRegistrySuite) TestPullIDStability(t *testing.T) {
 	const derivedImage = privateRegistryURL + "/dockercli/id-stability"
 	const baseImage = "busybox"
 
-	buildImageSuccessfully(t, derivedImage, build.WithDockerfile(fmt.Sprintf(`
+	cli.BuildCmd(t, derivedImage, build.WithDockerfile(fmt.Sprintf(`
 	    FROM %s
 	    ENV derived true
 	    ENV asdf true
@@ -226,7 +226,7 @@ func (s *DockerRegistrySuite) TestPullIDStability(t *testing.T) {
 func (s *DockerRegistrySuite) TestPullNoLayers(t *testing.T) {
 	const imgRepo = privateRegistryURL + "/dockercli/scratch"
 
-	buildImageSuccessfully(t, imgRepo, build.WithDockerfile(`
+	cli.BuildCmd(t, imgRepo, build.WithDockerfile(`
 	FROM scratch
 	ENV foo bar`))
 	cli.DockerCmd(t, "push", imgRepo)

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -135,7 +135,7 @@ func (s *DockerRegistrySuite) TestConcurrentPush(c *testing.T) {
 	var repos []string
 	for _, tag := range []string{"push1", "push2", "push3"} {
 		repo := fmt.Sprintf("%v:%v", imgRepo, tag)
-		buildImageSuccessfully(c, repo, build.WithDockerfile(fmt.Sprintf("FROM busybox\nCMD echo hello from %s\n", repo)))
+		cli.BuildCmd(c, repo, build.WithDockerfile(fmt.Sprintf("FROM busybox\nCMD echo hello from %s\n", repo)))
 		repos = append(repos, repo)
 	}
 

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -154,7 +154,7 @@ func (s *DockerCLIRmiSuite) TestRmiImgIDForce(c *testing.T) {
 // See https://github.com/moby/moby/issues/14116
 func (s *DockerCLIRmiSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c *testing.T) {
 	dockerfile := "FROM busybox\nRUN echo test 14116\n"
-	buildImageSuccessfully(c, "test-14116", build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, "test-14116", build.WithDockerfile(dockerfile))
 	imgID := getIDByName(c, "test-14116")
 
 	newTag := "newtag"
@@ -212,7 +212,7 @@ func (s *DockerCLIRmiSuite) TestRmiForceWithMultipleRepositories(c *testing.T) {
 	tag1 := imageName + ":tag1"
 	tag2 := imageName + ":tag2"
 
-	buildImageSuccessfully(c, tag1, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, tag1, build.WithDockerfile(`FROM busybox
 		MAINTAINER "docker"`))
 	cli.DockerCmd(c, "tag", tag1, tag2)
 
@@ -240,7 +240,7 @@ func (s *DockerCLIRmiSuite) TestRmiContainerImageNotFound(c *testing.T) {
 	imageIds := make([]string, 2)
 	for i, name := range imageNames {
 		dockerfile := fmt.Sprintf("FROM busybox\nMAINTAINER %s\nRUN echo %s\n", name, name)
-		buildImageSuccessfully(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
+		cli.BuildCmd(c, name, build.WithoutCache, build.WithDockerfile(dockerfile))
 		id := getIDByName(c, name)
 		imageIds[i] = id
 	}
@@ -269,7 +269,7 @@ RUN echo 0 #layer0
 RUN echo 1 #layer1
 RUN echo 2 #layer2
 `
-	buildImageSuccessfully(c, imgName, build.WithoutCache, build.WithDockerfile(dockerfile))
+	cli.BuildCmd(c, imgName, build.WithoutCache, build.WithDockerfile(dockerfile))
 	out := cli.DockerCmd(c, "history", "-q", imgName).Stdout()
 	ids := strings.Split(out, "\n")
 	idToTag := ids[2]
@@ -306,7 +306,7 @@ RUN echo 2 #layer2
 func (*DockerCLIRmiSuite) TestRmiParentImageFail(c *testing.T) {
 	skip.If(c, testEnv.UsingSnapshotter(), "image are independent when using the containerd image store")
 
-	buildImageSuccessfully(c, "test", build.WithDockerfile(`
+	cli.BuildCmd(c, "test", build.WithDockerfile(`
 	FROM busybox
 	RUN echo hello`))
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -412,7 +412,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumesInSymlinkDir(c *testing.T) {
 		containerPath = "/test/test"
 		cmd = "true"
 	}
-	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
+	cli.BuildCmd(c, name, build.WithDockerfile(dockerFile))
 	cli.DockerCmd(c, "run", "-v", containerPath, name, cmd)
 }
 
@@ -437,7 +437,7 @@ func (s *DockerCLIRunSuite) TestRunCreateVolumesInSymlinkDir2(c *testing.T) {
 		containerPath = "/test/test"
 		cmd = "true"
 	}
-	buildImageSuccessfully(c, name, build.WithDockerfile(dockerFile))
+	cli.BuildCmd(c, name, build.WithDockerfile(dockerFile))
 	cli.DockerCmd(c, "run", "-v", containerPath, name, cmd)
 }
 
@@ -1582,7 +1582,7 @@ func (s *DockerCLIRunSuite) TestRunCopyVolumeUIDGID(c *testing.T) {
 	// Not applicable on Windows as it does not support uid or gid in this way
 	testRequires(c, DaemonIsLinux)
 	name := "testrunvolumesuidgid"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		RUN echo 'dockerio:x:1001:' >> /etc/group
 		RUN mkdir -p /hello && touch /hello/test && chown dockerio.dockerio /hello`))
@@ -1601,7 +1601,7 @@ func (s *DockerCLIRunSuite) TestRunCopyVolumeContent(c *testing.T) {
 	// that copies from the image to the volume.
 	testRequires(c, DaemonIsLinux)
 	name := "testruncopyvolumecontent"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		RUN mkdir -p /hello/local && echo hello > /hello/local/world`))
 
 	// Test that the content is copied from the image to the volume
@@ -1613,7 +1613,7 @@ func (s *DockerCLIRunSuite) TestRunCopyVolumeContent(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestRunCleanupCmdOnEntrypoint(c *testing.T) {
 	name := "testrunmdcleanuponentrypoint"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		ENTRYPOINT ["echo"]
 		CMD ["testingpoint"]`))
 
@@ -2073,7 +2073,7 @@ func (s *DockerCLIRunSuite) TestVolumesNoCopyData(c *testing.T) {
 	// are pre-populated such as is built in the dockerfile used in this test.
 	testRequires(c, DaemonIsLinux)
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	buildImageSuccessfully(c, "dataimage", build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, "dataimage", build.WithDockerfile(`FROM busybox
 		RUN ["mkdir", "-p", "/foo"]
 		RUN ["touch", "/foo/bar"]`))
 	cli.DockerCmd(c, "run", "--name", "test", "-v", prefix+slash+"foo", "busybox")
@@ -2104,7 +2104,7 @@ func (s *DockerCLIRunSuite) TestRunNoOutputFromPullInStdout(c *testing.T) {
 func (s *DockerCLIRunSuite) TestRunVolumesCleanPaths(c *testing.T) {
 	testRequires(c, testEnv.IsLocalDaemon)
 	prefix, slash := getPrefixAndSlashFromDaemonPlatform()
-	buildImageSuccessfully(c, "run_volumes_clean_paths", build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, "run_volumes_clean_paths", build.WithDockerfile(`FROM busybox
 		VOLUME `+prefix+`/foo/`))
 	cli.DockerCmd(c, "run", "-v", prefix+"/foo", "-v", prefix+"/bar/", "--name", "dark_helmet", "run_volumes_clean_paths")
 
@@ -3599,7 +3599,7 @@ func (s *DockerCLIRunSuite) TestRunInitLayerPathOwnership(c *testing.T) {
 	// Not applicable on Windows as it does not support Linux uid/gid ownership
 	testRequires(c, DaemonIsLinux)
 	name := "testetcfileownership"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 		RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
 		RUN echo 'dockerio:x:1001:' >> /etc/group
 		RUN chown dockerio:dockerio /etc`))
@@ -3651,7 +3651,7 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumeCopyImageData(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
 
 	testImg := "testvolumecopy"
-	buildImageSuccessfully(c, testImg, build.WithDockerfile(`
+	cli.BuildCmd(c, testImg, build.WithDockerfile(`
 	FROM busybox
 	RUN mkdir -p /foo && echo hello > /foo/hello
 	`))
@@ -3770,7 +3770,7 @@ func (s *DockerCLIRunSuite) TestRunVolumeWithOneCharacter(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestRunVolumeCopyFlag(c *testing.T) {
 	testRequires(c, DaemonIsLinux) // Windows does not support copying data from image to the volume
-	buildImageSuccessfully(c, "volumecopy", build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, "volumecopy", build.WithDockerfile(`FROM busybox
 		RUN mkdir /foo && echo hello > /foo/bar
 		CMD cat /foo/bar`))
 	cli.DockerCmd(c, "volume", "create", "test")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -794,7 +794,7 @@ func (s *DockerCLIRunSuite) TestRunTmpfsMounts(c *testing.T) {
 
 func (s *DockerCLIRunSuite) TestRunTmpfsMountsOverrideImageVolumes(c *testing.T) {
 	const name = "img-with-volumes"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`
+	cli.BuildCmd(c, name, build.WithDockerfile(`
     FROM busybox
     VOLUME /run
     RUN touch /run/stuff

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -300,7 +300,7 @@ func (s *DockerCLISaveLoadSuite) TestSaveLoadNoTag(c *testing.T) {
 
 	name := "saveloadnotag"
 
-	buildImageSuccessfully(c, name, build.WithDockerfile("FROM busybox\nENV foo=bar"))
+	cli.BuildCmd(c, name, build.WithDockerfile("FROM busybox\nENV foo=bar"))
 	id := inspectField(c, name, "Id")
 
 	// Test to make sure that save w/o name just shows imageID during load

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -78,7 +78,7 @@ func (s *DockerCLISaveLoadSuite) TestSaveAndLoadWithProgressBar(c *testing.T) {
 	skip.If(c, testEnv.UsingSnapshotter(), "TODO: Not implemented yet")
 
 	name := "test-load"
-	buildImageSuccessfully(c, name, build.WithDockerfile(`FROM busybox
+	cli.BuildCmd(c, name, build.WithDockerfile(`FROM busybox
 	RUN touch aa
 	`))
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -471,7 +471,7 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFrom(c *testing
 	testRequires(c, DaemonIsLinux)
 
 	const imgName = "vimage"
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(`
+	cli.BuildCmd(c, imgName, build.WithDockerfile(`
 		FROM busybox
 		VOLUME ["/tmp/data"]`))
 
@@ -512,7 +512,7 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFromAndBind(c *
 	testRequires(c, DaemonIsLinux)
 
 	const imgName = "vimage"
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(`
+	cli.BuildCmd(c, imgName, build.WithDockerfile(`
                 FROM busybox
                 VOLUME ["/tmp/data"]`))
 
@@ -554,7 +554,7 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFromAndMounts(c
 	testRequires(c, testEnv.IsLocalDaemon, DaemonIsLinux)
 
 	const imgName = "vimage"
-	buildImageSuccessfully(c, imgName, build.WithDockerfile(`
+	cli.BuildCmd(c, imgName, build.WithDockerfile(`
                 FROM busybox
                 VOLUME ["/tmp/data"]`))
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -133,12 +133,6 @@ func getIDByName(t *testing.T, name string) string {
 }
 
 // Deprecated: use cli.Docker
-func buildImageSuccessfully(t *testing.T, name string, cmdOperators ...cli.CmdOperator) {
-	t.Helper()
-	cli.Docker(cli.Args("build", "-t", name), cmdOperators...).Assert(t, icmd.Success)
-}
-
-// Deprecated: use cli.Docker
 func buildImage(name string, cmdOperators ...cli.CmdOperator) *icmd.Result {
 	return cli.Docker(cli.Args("build", "-t", name), cmdOperators...)
 }

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -132,11 +132,6 @@ func getIDByName(t *testing.T, name string) string {
 	return id
 }
 
-// Deprecated: use cli.Docker
-func buildImage(name string, cmdOperators ...cli.CmdOperator) *icmd.Result {
-	return cli.Docker(cli.Args("build", "-t", name), cmdOperators...)
-}
-
 // Write `content` to the file at path `dst`, creating it if necessary,
 // as well as any missing directories.
 // The file is truncated if it already exists.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/31608

### integration-cli: remove deprecated buildImageSuccessfully utility

This was deprecated in 50c4475df6304e0cf12ea95217eb00ab5d572e34, which introduced the cli test-utils package.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

