### PR TITLE
[TBD] api/types/image: InspectResponse: deprecate `Author`

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -74,6 +74,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   continues returning these fields when set for informational purposes, but
   they should not be depended on as they will be omitted once the legacy builder
   is removed.
+* Deprecated: the `Author` fields returned by the `GET /images/{name}/json`
+  endpoint is deprecated. The `Author` field is set through the `MAINTAINER`
+  Dockerfile instruction, which is deprecated, and may not be set depending
+  on how the image was created. The API continues returning this field when
+  set for informational purposes, but is should not be depended on.
 
 ## v1.50 API changes
 

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -1980,6 +1980,10 @@ definitions:
         description: |
           Name of the author that was specified when committing the image, or as
           specified through MAINTAINER (deprecated) in the Dockerfile.
+
+          > **Deprecated**: This field is only set when using the deprecated
+          > MAINTAINER Dockerfile instruction. It is included in API responses
+          > for informational purposes, but should not be depended on.
         type: "string"
         x-nullable: false
         example: ""

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -1880,6 +1880,10 @@ definitions:
         description: |
           Name of the author that was specified when committing the image, or as
           specified through MAINTAINER (deprecated) in the Dockerfile.
+
+          > **Deprecated**: This field is only set when using the deprecated
+          > MAINTAINER Dockerfile instruction. It is included in API responses
+          > for informational purposes, but should not be depended on.
         type: "string"
         x-nullable: true
         example: ""

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1880,6 +1880,10 @@ definitions:
         description: |
           Name of the author that was specified when committing the image, or as
           specified through MAINTAINER (deprecated) in the Dockerfile.
+
+          > **Deprecated**: This field is only set when using the deprecated
+          > MAINTAINER Dockerfile instruction. It is included in API responses
+          > for informational purposes, but should not be depended on.
         type: "string"
         x-nullable: true
         example: ""

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -89,6 +89,8 @@ type InspectResponse struct {
 	// Author is the name of the author that was specified when committing the
 	// image, or as specified through MAINTAINER (deprecated) in the Dockerfile.
 	// This field is omitted if not set.
+	//
+	// Deprecated: this field is deprecated, and will be removed in the next release.
 	Author string `json:",omitempty"`
 	Config *dockerspec.DockerOCIImageConfig
 

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -100,7 +100,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 
 	if multi.Best != nil {
 		imgConfig := img.Config
-		resp.Author = img.Author
+		resp.Author = img.Author //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
 		resp.Config = &imgConfig
 		resp.Architecture = img.Architecture
 		resp.Variant = img.Variant

--- a/daemon/images/image_inspect.go
+++ b/daemon/images/image_inspect.go
@@ -64,7 +64,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts ba
 		Container:       img.Container,        //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
 		ContainerConfig: &img.ContainerConfig, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.45.
 		DockerVersion:   img.DockerVersion,    //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
-		Author:          img.Author,
+		Author:          img.Author,           //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
 		Config:          &imgConfig,
 		Architecture:    img.Architecture,
 		Variant:         img.Variant,

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -424,7 +424,7 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 			"Parent":        imageInspect.Parent, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present (built with legacy builder).
 			"Comment":       imageInspect.Comment,
 			"DockerVersion": imageInspect.DockerVersion, //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
-			"Author":        imageInspect.Author,
+			"Author":        imageInspect.Author,        //nolint:staticcheck // ignore SA1019: field is deprecated, but still included in response when present.
 		}))
 		if versions.LessThan(version, "1.50") {
 			legacyOptions = append(legacyOptions, compat.WithExtraFields(legacyConfigFields["v1.49"]))

--- a/vendor/github.com/moby/moby/api/types/image/image_inspect.go
+++ b/vendor/github.com/moby/moby/api/types/image/image_inspect.go
@@ -89,6 +89,8 @@ type InspectResponse struct {
 	// Author is the name of the author that was specified when committing the
 	// image, or as specified through MAINTAINER (deprecated) in the Dockerfile.
 	// This field is omitted if not set.
+	//
+	// Deprecated: this field is deprecated, and will be removed in the next release.
 	Author string `json:",omitempty"`
 	Config *dockerspec.DockerOCIImageConfig
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/51104

---


relates to:

- https://github.com/moby/moby/pull/28293
- https://github.com/moby/moby/pull/25466

### api/types/image: InspectResponse: deprecate `Author`

The `Author` field can be set through the `MAINTAINER` instruction in
Dockerfiles, and through the `--author` option on `docker commit`, but
is optional, and won't be set in most situations.

This patch deprecates the fields in the `InspectResponse` go struct. The
`Author` field can still be set but is deprecated in the Dockerfile syntax,
so should not be depended on. This field was implicitly deprecated when
the `MAINTAINER` command was deprecated in [moby@efb9e38] / [moby@6694974]
(docker 1.13, API v1.25), however the related API fields were kept so
that information of legacy images would not be discarded.

The API continues to return the field if set, allowing the client to
print the fields for informational purposes when printing the raw response,
but these fields should be considered "transitional", and not be depended
on; deprecating the fields helps raise awareness.

[moby@efb9e38]: https://github.com/moby/moby/commit/efb9e38ebab4b60a73e3295e3c468813182fd3ea
[moby@6694974]: https://github.com/moby/moby/commit/6694974c9e3532cdaf5333b0a8b19f5ca64c70f0



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/image: InspectResponse: deprecate `Author`
```

**- A picture of a cute animal (not mandatory but encouraged)**

