### PR TITLE
[28.x backport] api/types/plugin: deprecate Config.DockerVersion field

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3142,10 +3142,15 @@ definitions:
           - Args
         properties:
           DockerVersion:
-            description: "Docker Version used to create the plugin"
+            description: |-
+              Docker Version used to create the plugin.
+
+              Depending on how the plugin was created, this field may be empty or omitted.
+
+              Deprecated: this field is no longer set, and will be removed in the next API version.
             type: "string"
             x-nullable: false
-            example: "17.06.0-ce"
+            x-omitempty: true
           Description:
             type: "string"
             x-nullable: false

--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -42,7 +42,11 @@ type PluginConfig struct {
 	// Required: true
 	Description string `json:"Description"`
 
-	// Docker Version used to create the plugin
+	// Docker Version used to create the plugin.
+	//
+	// Depending on how the plugin was created, this field may be empty or omitted.
+	//
+	// Deprecated: this field is no longer set, and will be removed in the next API version.
 	DockerVersion string `json:"DockerVersion,omitempty"`
 
 	// documentation

--- a/docs/api/v1.51.yaml
+++ b/docs/api/v1.51.yaml
@@ -3142,10 +3142,15 @@ definitions:
           - Args
         properties:
           DockerVersion:
-            description: "Docker Version used to create the plugin"
+            description: |-
+              Docker Version used to create the plugin.
+
+              Depending on how the plugin was created, this field may be empty or omitted.
+
+              Deprecated: this field is no longer set, and will be removed in the next API version.
             type: "string"
             x-nullable: false
-            example: "17.06.0-ce"
+            x-omitempty: true
           Description:
             type: "string"
             x-nullable: false

--- a/docs/api/version-history.md
+++ b/docs/api/version-history.md
@@ -33,6 +33,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   continues returning these fields when set for informational purposes, but
   they should not be depended on as they will be omitted once the legacy builder
   is removed.
+* Deprecated: the `Config.DockerVersion` field returned by the `GET /plugins`
+  and `GET /images/{name}/json` endpoints is deprecated. The field is no
+  longer set, and is omitted when empty.
 
 ## v1.50 API changes
 

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -700,7 +700,7 @@ func (pm *Manager) CreateFromContext(ctx context.Context, tarCtx io.ReadCloser, 
 		DiffIds: []string{rootFSBlob.Digest().String()},
 	}
 
-	config.DockerVersion = dockerversion.Version
+	config.DockerVersion = dockerversion.Version //nolint:staticcheck // ignore SA1019: field is deprecated.
 
 	configBlob, err := pm.blobStore.Writer(ctx, content.WithRef(name+"-config.json"))
 	if err != nil {


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51109

---

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/plugin: deprecate `Config.DockerVersion` field.
```

**- A picture of a cute animal (not mandatory but encouraged)**

