### PR TITLE
integration/plugin: try prevent panics during cleanup

### DIFF
--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -61,7 +61,7 @@ func setupTestV1(t *testing.T) context.Context {
 	ctx := setupTest(t)
 
 	// reset fields between tests
-	ctrl.Reset()
+	ctrl = &authorizationController{}
 
 	err := os.MkdirAll("/etc/docker/plugins", 0o755)
 	assert.NilError(t, err)

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -35,10 +35,7 @@ const (
 	serverVersionAPI    = "/version"
 )
 
-var (
-	alwaysAllowed = []string{"/_ping", "/info"}
-	ctrl          *authorizationController
-)
+var alwaysAllowed = []string{"/_ping", "/info"}
 
 type authorizationController struct {
 	reqRes          authorization.Response // reqRes holds the plugin response to the initial client request
@@ -50,10 +47,21 @@ type authorizationController struct {
 	resUser         string
 }
 
+func (ac *authorizationController) Reset() {
+	ac.resRes = authorization.Response{}
+	ac.resRes = authorization.Response{}
+	ac.versionReqCount = 0
+	ac.versionResCount = 0
+	ac.reqUser = ""
+	ac.resUser = ""
+	ac.requestsURIs = []string{}
+}
+
 func setupTestV1(t *testing.T) context.Context {
 	ctx := setupTest(t)
 
-	ctrl = &authorizationController{}
+	// reset fields between tests
+	ctrl.Reset()
 
 	err := os.MkdirAll("/etc/docker/plugins", 0o755)
 	assert.NilError(t, err)
@@ -65,7 +73,6 @@ func setupTestV1(t *testing.T) context.Context {
 	t.Cleanup(func() {
 		err := os.RemoveAll("/etc/docker/plugins")
 		assert.NilError(t, err)
-		ctrl = nil
 	})
 	return ctx
 }


### PR DESCRIPTION
Various AuthZ tests would panic when `t.Cleanup` kicked in and removed the controller; try to avoid this by keeping the controller, but resetting it.

    === RUN   TestAuthZPluginAllowEventStream
    2025/10/06 13:30:39 http: panic serving 127.0.0.1:39140: runtime error: invalid memory address or nil pointer dereference
    goroutine 181 [running]:
    net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1947 +0xbe
    panic({0x1061260?, 0x1c826b0?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
    go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:467 +0x25
    go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0003fe3c0, {0x0, 0x0, 0xc0001acc40?})
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:506 +0xb6e
    panic({0x1061260?, 0x1c826b0?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
    github.com/moby/moby/v2/integration/plugin/authz.setupSuite.func3({0x13c13e0, 0xc0004e4060}, 0xc0003cf6f8?)
        /go/src/github.com/docker/docker/integration/plugin/authz/main_test.go:159 +0x19d
    net/http.HandlerFunc.ServeHTTP(0xc0001da6c0?, {0x13c13e0?, 0xc0004e4060?}, 0xc0003cf720?)
        /usr/local/go/src/net/http/server.go:2294 +0x29
    net/http.(*ServeMux).ServeHTTP(0x13c73f0?, {0x13c13e0, 0xc0004e4060}, 0xc00024edc0)
        /usr/local/go/src/net/http/server.go:2822 +0x1c4
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0xc000288300, {0x13c0060, 0xc0004920e0}, 0xc00024eb40, {0x13b4200, 0xc0001da6c0})
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:179 +0x12fa
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x13c0060?, 0xc0004920e0?}, 0x0?)
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:67 +0x35
    net/http.HandlerFunc.ServeHTTP(0x41a185?, {0x13c0060?, 0xc0004920e0?}, 0xc000492001?)
        /usr/local/go/src/net/http/server.go:2294 +0x29
    net/http.serverHandler.ServeHTTP({0x13bbde0?}, {0x13c0060?, 0xc0004920e0?}, 0x1?)
        /usr/local/go/src/net/http/server.go:3301 +0x8e
    net/http.(*conn).serve(0xc0004adc20, {0x13c73f0, 0xc00047e660})
        /usr/local/go/src/net/http/server.go:2102 +0x625
    created by net/http.(*Server).Serve in goroutine 20
        /usr/local/go/src/net/http/server.go:3454 +0x485
    2025/10/06 13:30:40 http: panic serving 127.0.0.1:34954: could not unmarshal json for /AuthZPlugin.AuthZRes: unexpected end of JSON input
    goroutine 134 [running]:
    net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1947 +0xbe
    panic({0xff2ec0?, 0xc000116f70?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
    go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:467 +0x25
    go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0003fe5a0, {0x0, 0x0, 0xc0001acc40?})
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:506 +0xb6e
    panic({0xff2ec0?, 0xc000116f70?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
    github.com/moby/moby/v2/integration/plugin/authz.setupSuite.func3({0x13c13e0, 0xc0004e4120}, 0xc0003cf6f8?)
        /go/src/github.com/docker/docker/integration/plugin/authz/main_test.go:149 +0x3c5
    net/http.HandlerFunc.ServeHTTP(0xc0001da6c0?, {0x13c13e0?, 0xc0004e4120?}, 0xc0003cf720?)
        /usr/local/go/src/net/http/server.go:2294 +0x29
    net/http.(*ServeMux).ServeHTTP(0x13c73f0?, {0x13c13e0, 0xc0004e4120}, 0xc00024f040)
        /usr/local/go/src/net/http/server.go:2822 +0x1c4
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0xc000288300, {0x13c0060, 0xc0004921c0}, 0xc00024ef00, {0x13b4200, 0xc0001da6c0})
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:179 +0x12fa
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x13c0060?, 0xc0004921c0?}, 0x0?)
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:67 +0x35
    net/http.HandlerFunc.ServeHTTP(0x476979?, {0x13c0060?, 0xc0004921c0?}, 0xc000328b70?)
        /usr/local/go/src/net/http/server.go:2294 +0x29
    net/http.serverHandler.ServeHTTP({0xc000591ce0?}, {0x13c0060?, 0xc0004921c0?}, 0x1?)
        /usr/local/go/src/net/http/server.go:3301 +0x8e
    net/http.(*conn).serve(0xc00038c510, {0x13c73f0, 0xc00047e660})
        /usr/local/go/src/net/http/server.go:2102 +0x625
    created by net/http.(*Server).Serve in goroutine 20
        /usr/local/go/src/net/http/server.go:3454 +0x485
    2025/10/06 13:30:42 http: panic serving 127.0.0.1:34970: could not unmarshal json for /AuthZPlugin.AuthZRes: unexpected end of JSON input
    goroutine 136 [running]:
    net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1947 +0xbe
    panic({0xff2ec0?, 0xc0001170d0?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
    go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:467 +0x25
    go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0003fe780, {0x0, 0x0, 0xc0001acc40?})
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/otel/sdk/trace/span.go:506 +0xb6e
    panic({0xff2ec0?, 0xc0001170d0?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
    github.com/moby/moby/v2/integration/plugin/authz.setupSuite.func3({0x13c13e0, 0xc0004e41e0}, 0xc0003cf6f8?)
        /go/src/github.com/docker/docker/integration/plugin/authz/main_test.go:149 +0x3c5
    net/http.HandlerFunc.ServeHTTP(0xc0001da6c0?, {0x13c13e0?, 0xc0004e41e0?}, 0xc0003cf720?)
        /usr/local/go/src/net/http/server.go:2294 +0x29
    net/http.(*ServeMux).ServeHTTP(0x13c73f0?, {0x13c13e0, 0xc0004e41e0}, 0xc00024f2c0)
        /usr/local/go/src/net/http/server.go:2822 +0x1c4
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0xc000288300, {0x13c0060, 0xc0004922a0}, 0xc00024f180, {0x13b4200, 0xc0001da6c0})
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:179 +0x12fa
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x13c0060?, 0xc0004922a0?}, 0x0?)
        /go/src/github.com/docker/docker/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:67 +0x35
    net/http.HandlerFunc.ServeHTTP(0x476979?, {0x13c0060?, 0xc0004922a0?}, 0xc000328b70?)
        /usr/local/go/src/net/http/server.go:2294 +0x29
    net/http.serverHandler.ServeHTTP({0xc000591e90?}, {0x13c0060?, 0xc0004922a0?}, 0x1?)
        /usr/local/go/src/net/http/server.go:3301 +0x8e
    net/http.(*conn).serve(0xc00038c6c0, {0x13c73f0, 0xc00047e660})
        /usr/local/go/src/net/http/server.go:2102 +0x625
    created by net/http.(*Server).Serve in goroutine 20
        /usr/local/go/src/net/http/server.go:3454 +0x485
    --- PASS: TestAuthZPluginAllowEventStream (6.09s)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

