### PR TITLE
Add support for memory swap settings for services

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -57,6 +57,18 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `POST /containers/create` no longer supports configuring a container-wide MAC address
   via the container's `Config.MacAddress` field. A container's MAC address can now only 
   be configured via endpoint settings when connecting to a network.
+* `GET /services` now returns `SwapBytes` and `MemorySwappiness` fields as part
+  of the `Resource` requirements.
+* `GET /services/{id}` now returns `SwapBytes` and `MemorySwappiness` fields as
+  part of the `Resource` requirements.
+* `POST /services/create` now accepts `SwapBytes` and `MemorySwappiness` fields
+  as part of the `Resource` requirements.
+* `POST /services/{id}/update` now accepts `SwapBytes` and `MemorySwappiness`
+  fields as part of the `Resource` requirements.
+* `GET /tasks` now  returns `SwapBytes` and `MemorySwappiness` fields as part
+  of the `Resource` requirements.
+* `GET /tasks/{id}` now  returns `SwapBytes` and `MemorySwappiness` fields as
+  part of the `Resource` requirements.
 
 ## v1.51 API changes
 

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -4287,6 +4287,29 @@ definitions:
           Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
+          SwapBytes:
+            description: |
+              Amount of swap in bytes - can only be used together with a memory limit.
+              If not specified, the default behaviour is to grant a swap space twice
+              as big as the memory limit.
+              Set to -1 to enable unlimited swap.
+            type: "integer"
+            format: "int64"
+            minimum: -1
+            x-nullable: true
+            x-omitempty: true
+          MemorySwappiness:
+            description: |
+              Tune the service's containers' memory swappiness (0 to 100).
+              If not specified, defaults to the containers' OS' default, generally 60,
+              or whatever value was predefined in the image.
+              Set to -1 to unset a previously set value.
+            type: "integer"
+            format: "int64"
+            minimum: -1
+            maximum: 100
+            x-nullable: true
+            x-omitempty: true
       RestartPolicy:
         description: |
           Specification for the restart policy which applies to containers

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -4287,6 +4287,29 @@ definitions:
           Reservations:
             description: "Define resources reservation."
             $ref: "#/definitions/ResourceObject"
+          SwapBytes:
+            description: |
+              Amount of swap in bytes - can only be used together with a memory limit.
+              If not specified, the default behaviour is to grant a swap space twice
+              as big as the memory limit.
+              Set to -1 to enable unlimited swap.
+            type: "integer"
+            format: "int64"
+            minimum: -1
+            x-nullable: true
+            x-omitempty: true
+          MemorySwappiness:
+            description: |
+              Tune the service's containers' memory swappiness (0 to 100).
+              If not specified, defaults to the containers' OS' default, generally 60,
+              or whatever value was predefined in the image.
+              Set to -1 to unset a previously set value.
+            type: "integer"
+            format: "int64"
+            minimum: -1
+            maximum: 100
+            x-nullable: true
+            x-omitempty: true
       RestartPolicy:
         description: |
           Specification for the restart policy which applies to containers

--- a/api/types/swarm/task.go
+++ b/api/types/swarm/task.go
@@ -138,6 +138,17 @@ type DiscreteGenericResource struct {
 type ResourceRequirements struct {
 	Limits       *Limit     `json:",omitempty"`
 	Reservations *Resources `json:",omitempty"`
+
+	// Amount of swap in bytes - can only be used together with a memory limit
+	// -1 means unlimited
+	// a null pointer keeps the default behaviour of granting twice the memory
+	// amount in swap
+	SwapBytes *int64 `json:"SwapBytes,omitzero"`
+
+	// Tune container memory swappiness (0 to 100) - if not specified, defaults
+	// to the container OS's default - generally 60, or the value predefined in
+	// the image; set to -1 to unset a previously set value
+	MemorySwappiness *int64 `json:MemorySwappiness,omitzero"`
 }
 
 // Placement represents orchestration parameters.

--- a/daemon/cluster/convert/service.go
+++ b/daemon/cluster/convert/service.go
@@ -178,13 +178,18 @@ func ServiceSpecToGRPC(s types.ServiceSpec) (swarmapi.ServiceSpec, error) {
 		taskNetworks = append(taskNetworks, netConfig)
 	}
 
+	resources, err := resourcesToGRPC(s.TaskTemplate.Resources)
+	if err != nil {
+		return swarmapi.ServiceSpec{}, err
+	}
+
 	spec := swarmapi.ServiceSpec{
 		Annotations: swarmapi.Annotations{
 			Name:   name,
 			Labels: s.Labels,
 		},
 		Task: swarmapi.TaskSpec{
-			Resources:   resourcesToGRPC(s.TaskTemplate.Resources),
+			Resources:   resources,
 			LogDriver:   driverToGRPC(s.TaskTemplate.LogDriver),
 			Networks:    taskNetworks,
 			ForceUpdate: s.TaskTemplate.ForceUpdate,
@@ -439,9 +444,18 @@ func resourcesFromGRPC(ts *swarmapi.TaskSpec) *types.ResourceRequirements {
 				GenericResources: GenericResourcesFromGRPC(res.Reservations.Generic),
 			}
 		}
+		resources.SwapBytes = int64PointerFromGRPC(res.SwapBytes)
+		resources.MemorySwappiness = int64PointerFromGRPC(res.MemorySwappiness)
 	}
 
 	return resources
+}
+
+func int64PointerFromGRPC(v *gogotypes.Int64Value) *int64 {
+	if v == nil {
+		return nil
+	}
+	return &v.Value
 }
 
 // GenericResourcesToGRPC converts a GenericResource to a GRPC GenericResource
@@ -462,7 +476,7 @@ func GenericResourcesToGRPC(genericRes []types.GenericResource) []*swarmapi.Gene
 	return generic
 }
 
-func resourcesToGRPC(res *types.ResourceRequirements) *swarmapi.ResourceRequirements {
+func resourcesToGRPC(res *types.ResourceRequirements) (*swarmapi.ResourceRequirements, error) {
 	var reqs *swarmapi.ResourceRequirements
 	if res != nil {
 		reqs = &swarmapi.ResourceRequirements{}
@@ -480,8 +494,21 @@ func resourcesToGRPC(res *types.ResourceRequirements) *swarmapi.ResourceRequirem
 				Generic:     GenericResourcesToGRPC(res.Reservations.GenericResources),
 			}
 		}
+		reqs.SwapBytes = int64PointerToGRPC(res.SwapBytes)
+		reqs.MemorySwappiness = int64PointerToGRPC(res.MemorySwappiness)
+
+		if reqs.SwapBytes != nil && (reqs.Limits == nil || reqs.Limits.MemoryBytes == 0) {
+			return nil, errors.New("memory swap provided, but no memory-limit was set")
+		}
 	}
-	return reqs
+	return reqs, nil
+}
+
+func int64PointerToGRPC(v *int64) *gogotypes.Int64Value {
+	if v == nil {
+		return nil
+	}
+	return &gogotypes.Int64Value{Value: *v}
 }
 
 func restartPolicyFromGRPC(p *swarmapi.RestartPolicy) *types.RestartPolicy {

--- a/daemon/cluster/executor/container/container.go
+++ b/daemon/cluster/executor/container/container.go
@@ -527,6 +527,20 @@ func (c *containerConfig) resources() container.Resources {
 
 	if r.Limits.MemoryBytes > 0 {
 		resources.Memory = r.Limits.MemoryBytes
+
+		if r.SwapBytes != nil {
+			if swapBytes := r.SwapBytes.Value; swapBytes == -1 {
+				// means unlimited
+				resources.MemorySwap = -1
+			} else if swapBytes >= 0 {
+				// resources.MemorySwap is actually the sum of the memory + the swap
+				resources.MemorySwap = resources.Memory + swapBytes
+			}
+		}
+	}
+
+	if r.MemorySwappiness != nil {
+		resources.MemorySwappiness = &r.MemorySwappiness.Value
 	}
 
 	if r.Limits.NanoCPUs > 0 {

--- a/daemon/server/router/swarm/helpers.go
+++ b/daemon/server/router/swarm/helpers.go
@@ -77,6 +77,14 @@ func adjustForAPIVersion(cliVersion string, service *serviceWithLegacy) {
 	if cliVersion == "" {
 		return
 	}
+
+	if versions.LessThan(cliVersion, "1.52") {
+		if service.TaskTemplate.Resources != nil {
+			service.TaskTemplate.Resources.SwapBytes = nil
+			service.TaskTemplate.Resources.MemorySwappiness = nil
+		}
+	}
+
 	if versions.LessThan(cliVersion, "1.46") {
 		if service.TaskTemplate.ContainerSpec != nil {
 			for i, mount := range service.TaskTemplate.ContainerSpec.Mounts {

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -200,6 +200,21 @@ func ServiceWithPidsLimit(limit int64) ServiceSpecOpt {
 	}
 }
 
+func ServiceWithMemorySwap(swap *int64, memoryLimit int64) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureResources(spec)
+		spec.TaskTemplate.Resources.SwapBytes = swap
+		spec.TaskTemplate.Resources.Limits.MemoryBytes = memoryLimit
+	}
+}
+
+func ServiceWithMemorySwappiness(swappiness *int64) ServiceSpecOpt {
+	return func(spec *swarmtypes.ServiceSpec) {
+		ensureResources(spec)
+		spec.TaskTemplate.Resources.MemorySwappiness = swappiness
+	}
+}
+
 // GetRunningTasks gets the list of running tasks for a service
 func GetRunningTasks(ctx context.Context, t *testing.T, c client.ServiceAPIClient, serviceID string) []swarmtypes.Task {
 	t.Helper()

--- a/vendor/github.com/moby/moby/api/types/swarm/task.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/task.go
@@ -138,6 +138,17 @@ type DiscreteGenericResource struct {
 type ResourceRequirements struct {
 	Limits       *Limit     `json:",omitempty"`
 	Reservations *Resources `json:",omitempty"`
+
+	// Amount of swap in bytes - can only be used together with a memory limit
+	// -1 means unlimited
+	// a null pointer keeps the default behaviour of granting twice the memory
+	// amount in swap
+	SwapBytes *int64 `json:"SwapBytes,omitzero"`
+
+	// Tune container memory swappiness (0 to 100) - if not specified, defaults
+	// to the container OS's default - generally 60, or the value predefined in
+	// the image; set to -1 to unset a previously set value
+	MemorySwappiness *int64 `json:MemorySwappiness,omitzero"`
 }
 
 // Placement represents orchestration parameters.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- supersedes, closes https://github.com/moby/moby/pull/37872
- fixes https://github.com/moby/moby/issues/34654
- addresses https://github.com/moby/moby/issues/25303


**- What I did**

Updated #37872 to the latest master branch.

**- How I did it**

* Changed API version of the relevant settings to v1.52
* Update various segments to deal with bit rot

**- How to verify it**

Comes with integration tests!

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Add support for memory swappiness in Swarm services.
  * `GET /services` now returns `SwapBytes` and `MemorySwappiness` fields as part of the `Resource` requirements.
  * `GET /services/{id}` now returns `SwapBytes` and `MemorySwappiness` fields as part of the `Resource` requirements.
  * `POST /services/create` now accepts `SwapBytes` and `MemorySwappiness` fields as part of the `Resource` requirements.
  * `POST /services/{id}/update` now accepts `SwapBytes` and `MemorySwappiness` fields as part of the `Resource` requirements.
  * `GET /tasks` now returns `SwapBytes` and `MemorySwappiness` fields as part of the `Resource` requirements.
  * `GET /tasks/{id}` now returns `SwapBytes` and `MemorySwappiness` fields as part of the `Resource` requirements.
```