### PR TITLE
ci: update gha cache attributes

### DIFF
--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -89,7 +89,7 @@ jobs:
           targets: dev
           set: |
             *.cache-from=type=gha,scope=dev-arm64
-            *.cache-to=type=gha,scope=dev-arm64,mode=max
+            *.cache-to=type=gha,scope=dev-arm64
             *.output=type=cacheonly
 
   test-unit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         mode:
           - ""
           - systemd
+          - firewalld
     steps:
       -
         name: Prepare
@@ -65,7 +66,7 @@ jobs:
           targets: dev
           set: |
             *.cache-from=type=gha,scope=dev${{ matrix.mode }}
-            *.cache-to=type=gha,scope=dev${{ matrix.mode }},mode=max
+            *.cache-to=type=gha,scope=dev${{ matrix.mode }}
             *.output=type=cacheonly
 
   test:


### PR DESCRIPTION
* `mode=max` is not necessary since we update `bake-action` to v6 and therefore is using git context so git metadata don't invalidate the cache anymore.
* `firewalld` dev image was not built as prepare step, seems to be an oversight so adds it to the matrix.

Should be backported to other branches.

**- A picture of a cute animal (not mandatory but encouraged)**

