### PR TITLE
client: remove support for negotiating API version < v1.44 (docker 25.0)

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -253,11 +253,11 @@ func TestNegotiateAPIVersionEmpty(t *testing.T) {
 	assert.NilError(t, err)
 
 	// set our version to something new
-	client.version = "1.25"
+	client.version = "1.51"
 
 	// if no version from server, expect the earliest
 	// version before APIVersion was implemented
-	const expected = "1.24"
+	const expected = fallbackAPIVersion
 
 	// test downgrade
 	client.NegotiateAPIVersionPing(types.Ping{})
@@ -276,16 +276,16 @@ func TestNegotiateAPIVersion(t *testing.T) {
 		{
 			// client should downgrade to the version reported by the daemon.
 			doc:             "downgrade from default",
-			pingVersion:     "1.21",
-			expectedVersion: "1.21",
+			pingVersion:     "1.50",
+			expectedVersion: "1.50",
 		},
 		{
 			// client should not downgrade to the version reported by the
 			// daemon if a custom version was set.
 			doc:             "no downgrade from custom version",
-			clientVersion:   "1.25",
-			pingVersion:     "1.21",
-			expectedVersion: "1.25",
+			clientVersion:   "1.51",
+			pingVersion:     "1.50",
+			expectedVersion: "1.51",
 		},
 		{
 			// client should downgrade to the last version before version
@@ -293,7 +293,7 @@ func TestNegotiateAPIVersion(t *testing.T) {
 			// a version.
 			doc:             "downgrade legacy",
 			pingVersion:     "",
-			expectedVersion: "1.24",
+			expectedVersion: fallbackAPIVersion,
 		},
 		{
 			// client should downgrade to the version reported by the daemon.
@@ -308,9 +308,9 @@ func TestNegotiateAPIVersion(t *testing.T) {
 			// client should not upgrade to a newer version if a version was set,
 			// even if both the daemon and the client support it.
 			doc:             "no upgrade",
-			clientVersion:   "1.20",
-			pingVersion:     "1.21",
-			expectedVersion: "1.20",
+			clientVersion:   "1.50",
+			pingVersion:     "1.51",
+			expectedVersion: "1.50",
 		},
 	}
 
@@ -380,14 +380,14 @@ func TestNegotiateAPIVersionAutomatic(t *testing.T) {
 	assert.Check(t, is.Equal(client.ClientVersion(), expected))
 
 	// First request should trigger negotiation
-	pingVersion = "1.35"
-	expected = "1.35"
+	pingVersion = "1.50"
+	expected = "1.50"
 	_, _ = client.Info(ctx)
 	assert.Check(t, is.Equal(client.ClientVersion(), expected))
 
 	// Once successfully negotiated, subsequent requests should not re-negotiate
-	pingVersion = "1.25"
-	expected = "1.35"
+	pingVersion = "1.49"
+	expected = "1.50"
 	_, _ = client.Info(ctx)
 	assert.Check(t, is.Equal(client.ClientVersion(), expected))
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -82,6 +82,13 @@ func TestNewClientWithOpsFromEnv(t *testing.T) {
 			},
 			expectedVersion: "1.50",
 		},
+		{
+			doc: "override with unsupported api version",
+			envs: map[string]string{
+				"DOCKER_API_VERSION": "1.0",
+			},
+			expectedVersion: "1.0",
+		},
 	}
 
 	for _, tc := range testcases {
@@ -296,13 +303,11 @@ func TestNegotiateAPIVersion(t *testing.T) {
 			expectedVersion: fallbackAPIVersion,
 		},
 		{
-			// client should downgrade to the version reported by the daemon.
-			// version negotiation was added in API 1.25, so this is theoretical,
-			// but it should negotiate to versions before that if the daemon
-			// gives that as a response.
-			doc:             "downgrade old",
+			// client should not downgrade to the version reported by the daemon
+			// if the version is not supported.
+			doc:             "no downgrade old",
 			pingVersion:     "1.19",
-			expectedVersion: "1.19",
+			expectedVersion: MaxAPIVersion,
 		},
 		{
 			// client should not upgrade to a newer version if a version was set,

--- a/client/request.go
+++ b/client/request.go
@@ -303,9 +303,8 @@ func checkResponseErr(serverResp *http.Response) (retErr error) {
 			daemonErr = errors.New(strings.TrimSpace(errorResponse.Message))
 		}
 	} else {
-		// Fall back to returning the response as-is for API versions < 1.24
-		// that didn't support JSON error responses, and for situations
-		// where a plain text error is returned. This branch may also catch
+		// Fall back to returning the response as-is for situations where a
+		// plain text error is returned. This branch may also catch
 		// situations where a proxy is involved, returning a HTML response.
 		daemonErr = errors.New(strings.TrimSpace(string(body)))
 	}

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -74,9 +74,9 @@ func TestSetHostHeader(t *testing.T) {
 	}
 }
 
-// TestPlainTextError tests the server returning an error in plain text for
-// backwards compatibility with API versions <1.24. All other tests use
-// errors returned as JSON
+// TestPlainTextError tests the server returning an error in plain text.
+// API versions < 1.24 returned plain text errors, but we may encounter
+// other situations where a non-JSON error is returned.
 func TestPlainTextError(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(plainTextErrorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -303,9 +303,8 @@ func checkResponseErr(serverResp *http.Response) (retErr error) {
 			daemonErr = errors.New(strings.TrimSpace(errorResponse.Message))
 		}
 	} else {
-		// Fall back to returning the response as-is for API versions < 1.24
-		// that didn't support JSON error responses, and for situations
-		// where a plain text error is returned. This branch may also catch
+		// Fall back to returning the response as-is for situations where a
+		// plain text error is returned. This branch may also catch
 		// situations where a proxy is involved, returning a HTML response.
 		daemonErr = errors.New(strings.TrimSpace(string(body)))
 	}


### PR DESCRIPTION
### client: remove support for negotiating API version < v1.44 (docker 25.0)

Docker versions below 25.0 have reached EOL; 25.0 is currently maintained
as an LTS version by Mirantis, and we want to allow current versions of the
CLI to be able to connect to such setups.

This patch raises the fallback API version to API v1.44; when negotiating an API
version with a daemon, this will be the lowest version negotiated.

Currently, it still allows manually overriding the version to versions that
are not supported (`WithVersion`, `WithVersionFromEnv`), and no code has
been removed yet that adjusts the client for old API versions, but this
can be done in a follow-up.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: remove support for negotiating API version < v1.44 (docker 25.0)
```

**- A picture of a cute animal (not mandatory but encouraged)**

