### PR TITLE
builder: use proper percentage calculations for default gc policy

### DIFF
--- a/daemon/internal/builder-next/worker/gc.go
+++ b/daemon/internal/builder-next/worker/gc.go
@@ -72,6 +72,6 @@ func DefaultGCPolicy(p string, reservedSpace, maxUsedSpace, minFreeSpace int64) 
 }
 
 func diskPercentage(dstat disk.DiskStat, percentage int64) int64 {
-	avail := dstat.Total / percentage
+	avail := dstat.Total * percentage / 100
 	return (avail/(1<<30) + 1) * 1e9 // round up
 }


### PR DESCRIPTION
The default gc policy calculations based on percentage were calculated
improperly. These were calculated correctly in buildkit, but the
calculation method was not copied over correctly when updating the
values.

Fixes #51122.
