### PR TITLE
[28.x backport] ci: fix cache for go modules

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Download reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -265,7 +265,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Download reports
         uses: actions/download-artifact@v4
@@ -297,7 +297,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Install gotestlist
         run:
@@ -454,7 +454,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Download reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -71,18 +71,6 @@ jobs:
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
       -
-        name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~\go\pkg\mod
-            ${{ github.workspace }}\go-build
-            ${{ env.GOPATH }}\pkg\mod
-          key: ${{ inputs.os }}-${{ github.job }}-${{ hashFiles('**/vendor.sum') }}
-          restore-keys: |
-            ${{ inputs.os }}-${{ github.job }}-
-      -
         name: Docker info
         run: |
           docker info
@@ -98,8 +86,6 @@ jobs:
         name: Build binaries
         run: |
           & docker run --name ${{ env.TEST_CTN_NAME }} -e "DOCKER_GITCOMMIT=${{ github.sha }}" `
-              -v "${{ github.workspace }}\go-build:C:\Users\ContainerAdministrator\AppData\Local\go-build" `
-              -v "${{ github.workspace }}\go\pkg\mod:C:\gopath\pkg\mod" `
               ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -Daemon -Client
       -
         name: Copy artifacts
@@ -150,18 +136,6 @@ jobs:
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
       -
-        name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~\go\pkg\mod
-            ${{ github.workspace }}\go-build
-            ${{ env.GOPATH }}\pkg\mod
-          key: ${{ inputs.os }}-${{ github.job }}-${{ hashFiles('**/vendor.sum') }}
-          restore-keys: |
-            ${{ inputs.os }}-${{ github.job }}-
-      -
         name: Docker info
         run: |
           docker info
@@ -177,8 +151,6 @@ jobs:
         name: Test
         run: |
           & docker run --name ${{ env.TEST_CTN_NAME }} -e "DOCKER_GITCOMMIT=${{ github.sha }}" `
-            -v "${{ github.workspace }}\go-build:C:\Users\ContainerAdministrator\AppData\Local\go-build" `
-            -v "${{ github.workspace }}\go\pkg\mod:C:\gopath\pkg\mod" `
             -v "${{ env.GOPATH }}\src\github.com\docker\docker\bundles:C:\gopath\src\github.com\docker\docker\bundles" `
             ${{ env.TEST_IMAGE_NAME }} hack\make.ps1 -TestUnit
       -
@@ -212,7 +184,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Download artifacts
         uses: actions/download-artifact@v4
@@ -242,7 +214,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Install gotestlist
         run:
@@ -295,6 +267,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ${{ env.GOPATH }}/src/github.com/docker/docker
+      -
+        name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
       -
         name: Set up Jaeger
         run: |
@@ -427,12 +405,6 @@ jobs:
         env:
           DOCKER_HOST: npipe:////./pipe/docker_engine
       -
-        name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
-      -
         name: Test integration
         if: matrix.test == './...'
         run: |
@@ -525,7 +497,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Download reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -165,7 +165,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Download reports
         uses: actions/download-artifact@v4
@@ -268,7 +268,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: Download reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
       -
         name: BuildKit ref
         run: |
@@ -191,6 +191,7 @@ jobs:
       - name: Env
         run: |
           Get-ChildItem Env: | Out-String
+
       - name: Moby - Init
         run: |
           New-Item -ItemType "directory" -Path "${{ github.workspace }}\go-build"
@@ -201,18 +202,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~\go\pkg\mod
-            ${{ github.workspace }}\go-build
-            ${{ env.GOPATH }}\pkg\mod
-          key: ${{ inputs.os }}-${{ github.job }}-${{ hashFiles('**/vendor.sum') }}
-          restore-keys: |
-            ${{ inputs.os }}-${{ github.job }}-
+          cache: false
 
       - name: Docker info
         run: |
@@ -312,22 +302,27 @@ jobs:
             disabledFeatures="${disabledFeatures},merge_diff"
           fi
           echo "BUILDKIT_TEST_DISABLE_FEATURES=${disabledFeatures}" >> $GITHUB_ENV
+
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           path: moby
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: vendor.sum
+          cache: false
+
       - name: BuildKit ref
         shell: bash
         run: |
           echo "$(./hack/buildkit-ref)" >> $GITHUB_ENV
         working-directory: moby
+
       - name: Checkout BuildKit ${{ env.BUILDKIT_REF }}
         uses: actions/checkout@v4
         with:
@@ -362,6 +357,7 @@ jobs:
            testFlags="${testFlags} --run=TestIntegration/$testSliceOffset.*/worker=${{ matrix.worker }}"
           fi
           echo "TESTFLAGS=${testFlags}" >> $GITHUB_ENV
+
       - name: Test
         shell: bash
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,9 @@ on:
     #        * * * * *
     - cron: '0 9 * * 4'
 
+env:
+  GO_VERSION: "1.24.7"
+
 jobs:
   codeql:
     runs-on: ubuntu-24.04
@@ -55,10 +58,11 @@ jobs:
         run: |
           ln -s vendor.mod go.mod
           ln -s vendor.sum go.sum
-      - name: Update Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.7"
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/51124

We don't need to cache go modules when we setup go as we already have vendoring in our working tree.

**- A picture of a cute animal (not mandatory but encouraged)**

