### PR TITLE
[28.x backport] builder: use proper percentage calculations for default gc policy

### DIFF
--- a/builder/builder-next/worker/gc.go
+++ b/builder/builder-next/worker/gc.go
@@ -72,6 +72,6 @@ func DefaultGCPolicy(p string, reservedSpace, maxUsedSpace, minFreeSpace int64) 
 }
 
 func diskPercentage(dstat disk.DiskStat, percentage int64) int64 {
-	avail := dstat.Total / percentage
+	avail := dstat.Total * percentage / 100
 	return (avail/(1<<30) + 1) * 1e9 // round up
 }


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51125
- fixes https://github.com/moby/moby/issues/51122

The default gc policy calculations based on percentage were calculated
improperly. These were calculated correctly in buildkit, but the
calculation method was not copied over correctly when updating the
values.