### PR TITLE
seccomp: Take unshare() out of CAP_SYS_ADMIN gate

### DIFF
--- a/vendor/github.com/moby/profiles/seccomp/default_linux.go
+++ b/vendor/github.com/moby/profiles/seccomp/default_linux.go
@@ -398,6 +398,7 @@ func DefaultProfile() *Seccomp {
 					"uname",
 					"unlink",
 					"unlinkat",
+					"unshare",
 					"uretprobe", // kernel v6.11, libseccomp v2.6.0
 					"utime",
 					"utimensat",
@@ -618,7 +619,6 @@ func DefaultProfile() *Seccomp {
 					"syslog",
 					"umount",
 					"umount2",
-					"unshare",
 				},
 				Action: specs.ActAllow,
 			},


### PR DESCRIPTION
I'm a maintainer and author of passt (https://passt.top/), a user-mode networking implementation, that's used to connect containers, with pasta(1), and virtual machines, with passt(1), in an unprivileged way, without creating network interfaces.

By the way, Moby optionally uses pasta(1) to connect rootless containers via rootlesskit:
* https://github.com/rootless-containers/rootlesskit/blob/236f31ec2258a1da1b1a9b62b168dd5f9a840f83/pkg/network/pasta/pasta.go

Given that these tools deal with network packets from untrusted workloads, we pay particular attention to their security posture.

The project implements a rather substantial sandboxing mechanism, so that, once the initialisation phase completes, passt(1) and pasta(1) only have access to an empty filesystem with a zero-size limit, and relinquish access possibilities to any resources they don't need, by means of detaching namespaces:
* https://passt.top/passt/tree/isolation.c
* https://passt.top/#security

Users report that they can't use passt(1) in Docker containers, with one notable example at:
* https://bugs.passt.top/show_bug.cgi?id=116

and resort to run modified builds of passt:
* https://bugs.passt.top/show_bug.cgi?id=116#c6

with **sandboxing features entirely disabled**. This is of course not something we support, so it's not a particular concern in terms of maintainability, but still **it forces users to disable important security features, and it's a rather alarming trend**.

As a side note, Flatpak has a similar issue:
* https://github.com/flatpak/flatpak/issues/5921

and, same there, users routinely run custom builds of applications that ship strict native sandboxing features (including passt, Chromium, and Firefox) with those features disabled. This is not in the best interest of security and surely not in the best interest of those users.

To fix this, **enable unshare() regardless of the CAP_SYS_ADMIN capability, so that unprivileged applications can perform appropriate, strict sandboxing**.

I'm well aware of CVE-2022-0185 and CVE-2022-0492, but, since then, there have been significant hardening efforts going on in the affected portions of the kernel and the current situation appears substantially different, now.

Despite the original intention, a blanket ban on unprivileged unshare() appears nowadays to be detrimental to the security of containerised application, instead of contributing to it, as an increased number of applications finally start using namespaces for their own sandboxing, which is generally stricter than what any container runtime can provide.

Link: https://bugs.passt.top/show_bug.cgi?id=116
Reported-by: simonvanderlans@gmail.com
Signed-off-by: Stefano Brivio <sbrivio@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I took unshare(2), the system call, out of the CAP_SYS_ADMIN gate in the default seccomp profile.

**- How I did it**
I did it proudly, with a keyboard. I used so-called shortcuts that allowed me to conceptually cut one line of text file and paste it to another location.

**- How to verify it**
Run passt in a Docker container.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
The unshare(2) system call is now permitted in the default seccomp profile, enabling users to run applications that provide native sandboxing capabilities based on Linux namespaces.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Inspired from a submission at https://user.xmission.com/~emailbox/ascii_cats.htm:

```
fsc              ._
              .-'  `-.
           .-'        \
          ;    .-'\    ;
          `._.'    ;   |
                   |   |
                   ;   :
                  ;   :
                  ;   :
                 /   /
                ;   :                   ,
                ;   |               .-"7|
              .-'"  :            .-' .' :
           .-'       \         .'  .'   `.
         .'           `-. ""-.-'`""    `",`-._..--"7
         ;    .          `-.J `-,    ;"`.;|,_,    ;
       _.'    |         `"" `. ."""--. o \:.-. _.'
    .""       :            ,--`;   ,  `--/}o,' ;
    ;   .___.'        /     ,--.`-. `-..7_.-  /_
     \   :   `..__.._;    .'__;    `---..__.-'-.`"-,
     .'   `--. |   \_;    \'   `-._.-")     \\  `-,
     `.   -.`_):      `.   `-"""`.   ;__.' ;/ ;   "
       `-.__7"  `-..._.'`7     -._;'  ``"-''
                         `--.,__.'  let me run unshare() or isolation code in passt will face GRAVITY
                         
```
