### PR TITLE
introduce ImagePushResponse

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -114,7 +114,7 @@ type ImageAPIClient interface {
 
 	ImageList(ctx context.Context, options ImageListOptions) ([]image.Summary, error)
 	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (ImagePullResponse, error)
-	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (io.ReadCloser, error)
+	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (ImagePushResponse, error)
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -2,83 +2,31 @@ package client
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"io"
 	"iter"
 	"net/url"
 	"strings"
-	"sync"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/client/internal"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 )
 
-func newImagePullResponse(rc io.ReadCloser) ImagePullResponse {
-	if rc == nil {
-		panic("nil io.ReadCloser")
-	}
-	return ImagePullResponse{
-		rc:    rc,
-		close: sync.OnceValue(rc.Close),
-	}
-}
-
-type ImagePullResponse struct {
-	rc    io.ReadCloser
-	close func() error
-}
-
-// Read implements io.ReadCloser
-func (r ImagePullResponse) Read(p []byte) (n int, err error) {
-	if r.rc == nil {
-		return 0, io.EOF
-	}
-	return r.rc.Read(p)
-}
-
-// Close implements io.ReadCloser
-func (r ImagePullResponse) Close() error {
-	if r.close == nil {
-		return nil
-	}
-	return r.close()
-}
-
-// JSONMessages decodes the response stream as a sequence of JSONMessages.
-// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
-func (r ImagePullResponse) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
-	context.AfterFunc(ctx, func() {
-		_ = r.Close()
-	})
-	dec := json.NewDecoder(r)
-	return func(yield func(jsonmessage.JSONMessage, error) bool) {
-		defer r.Close()
-		for {
-			var jm jsonmessage.JSONMessage
-			err := dec.Decode(&jm)
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if ctx.Err() != nil {
-				yield(jm, ctx.Err())
-				return
-			}
-			if !yield(jm, err) {
-				return
-			}
-		}
-	}
+type ImagePullResponse interface {
+	io.ReadCloser
+	JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error]
+	Wait(ctx context.Context) error
 }
 
 // ImagePull requests the docker host to pull an image from a remote registry.
 // It executes the privileged function if the operation is unauthorized
 // and it tries one more time.
-// Callers can use [ImagePullResponse.JSONMessages] to monitor pull progress as
-// a sequence of JSONMessages, [ImagePullResponse.Close] does not need to be
-// called in this case. Or, use the [io.Reader] interface and call
-// [ImagePullResponse.Close] after processing.
+// Callers can:
+// - use [ImagePullResponse.Wait] to wait for pull to complete
+// - use [ImagePullResponse.JSONMessages] to monitor pull progress as a sequence
+//   of JSONMessages, [ImagePullResponse.Close] does not need to be called in this case.
+// - use the [io.Reader] interface and call [ImagePullResponse.Close] after processing.
 func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePullOptions) (ImagePullResponse, error) {
 	// FIXME(vdemeester): there is currently used in a few way in docker/docker
 	// - if not in trusted content, ref is used to pass the whole reference, and tag is empty
@@ -88,7 +36,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 
 	ref, err := reference.ParseNormalizedNamed(refStr)
 	if err != nil {
-		return ImagePullResponse{}, err
+		return nil, err
 	}
 
 	query := url.Values{}
@@ -105,10 +53,10 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		resp, err = cli.tryImageCreate(ctx, query, options.PrivilegeFunc)
 	}
 	if err != nil {
-		return ImagePullResponse{}, err
+		return nil, err
 	}
 
-	return newImagePullResponse(resp.Body), nil
+	return internal.NewJSONMessageStream(resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -12,6 +12,7 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/registry"
+	"github.com/moby/moby/client/internal"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -199,7 +200,7 @@ func TestImagePullWithoutErrors(t *testing.T) {
 
 func TestImagePullResponse(t *testing.T) {
 	r, w := io.Pipe()
-	response := newImagePullResponse(r)
+	response := internal.NewJSONMessageStream(r)
 	ctx, cancel := context.WithCancel(context.TODO())
 	messages := response.JSONMessages(ctx)
 	c := make(chan jsonmessage.JSONMessage)

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"iter"
+	"sync"
+
+	"github.com/moby/moby/client/pkg/jsonmessage"
+)
+
+func NewJSONMessageStream(rc io.ReadCloser) stream {
+	if rc == nil {
+		panic("nil io.ReadCloser")
+	}
+	return stream{
+		rc:    rc,
+		close: sync.OnceValue(rc.Close),
+	}
+}
+
+type stream struct {
+	rc    io.ReadCloser
+	close func() error
+}
+
+// Read implements io.ReadCloser
+func (r stream) Read(p []byte) (n int, err error) {
+	if r.rc == nil {
+		return 0, io.EOF
+	}
+	return r.rc.Read(p)
+}
+
+// Close implements io.ReadCloser
+func (r stream) Close() error {
+	if r.close == nil {
+		return nil
+	}
+	return r.close()
+}
+
+// JSONMessages decodes the response stream as a sequence of JSONMessages.
+// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
+func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
+	context.AfterFunc(ctx, func() {
+		_ = r.Close()
+	})
+	dec := json.NewDecoder(r)
+	return func(yield func(jsonmessage.JSONMessage, error) bool) {
+		defer r.Close()
+		for {
+			var jm jsonmessage.JSONMessage
+			err := dec.Decode(&jm)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if ctx.Err() != nil {
+				yield(jm, ctx.Err())
+				return
+			}
+			if !yield(jm, err) {
+				return
+			}
+		}
+	}
+}
+
+// Wait waits for operation to complete and detects errors reported as JSONMessage
+func (r stream) Wait(ctx context.Context) error {
+	for _, err := range r.JSONMessages(ctx) {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -153,7 +153,9 @@ func TestImagePullStoredDigestForOtherRepo(t *testing.T) {
 
 	// Now, pull a totally different repo with a the same digest
 	rdr, err = apiClient.ImagePull(ctx, path.Join(registry.DefaultURL, "other:image@"+desc.Digest.String()), client.ImagePullOptions{})
-	assert.Check(t, rdr.Close())
+	if rdr != nil {
+		assert.Check(t, rdr.Close())
+	}
 	assert.Assert(t, err != nil, "Expected error, got none: %v", err)
 	assert.Assert(t, cerrdefs.IsNotFound(err), err)
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -114,7 +114,7 @@ type ImageAPIClient interface {
 
 	ImageList(ctx context.Context, options ImageListOptions) ([]image.Summary, error)
 	ImagePull(ctx context.Context, ref string, options ImagePullOptions) (ImagePullResponse, error)
-	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (io.ReadCloser, error)
+	ImagePush(ctx context.Context, ref string, options ImagePushOptions) (ImagePushResponse, error)
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -2,83 +2,31 @@ package client
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"io"
 	"iter"
 	"net/url"
 	"strings"
-	"sync"
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/client/internal"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 )
 
-func newImagePullResponse(rc io.ReadCloser) ImagePullResponse {
-	if rc == nil {
-		panic("nil io.ReadCloser")
-	}
-	return ImagePullResponse{
-		rc:    rc,
-		close: sync.OnceValue(rc.Close),
-	}
-}
-
-type ImagePullResponse struct {
-	rc    io.ReadCloser
-	close func() error
-}
-
-// Read implements io.ReadCloser
-func (r ImagePullResponse) Read(p []byte) (n int, err error) {
-	if r.rc == nil {
-		return 0, io.EOF
-	}
-	return r.rc.Read(p)
-}
-
-// Close implements io.ReadCloser
-func (r ImagePullResponse) Close() error {
-	if r.close == nil {
-		return nil
-	}
-	return r.close()
-}
-
-// JSONMessages decodes the response stream as a sequence of JSONMessages.
-// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
-func (r ImagePullResponse) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
-	context.AfterFunc(ctx, func() {
-		_ = r.Close()
-	})
-	dec := json.NewDecoder(r)
-	return func(yield func(jsonmessage.JSONMessage, error) bool) {
-		defer r.Close()
-		for {
-			var jm jsonmessage.JSONMessage
-			err := dec.Decode(&jm)
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if ctx.Err() != nil {
-				yield(jm, ctx.Err())
-				return
-			}
-			if !yield(jm, err) {
-				return
-			}
-		}
-	}
+type ImagePullResponse interface {
+	io.ReadCloser
+	JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error]
+	Wait(ctx context.Context) error
 }
 
 // ImagePull requests the docker host to pull an image from a remote registry.
 // It executes the privileged function if the operation is unauthorized
 // and it tries one more time.
-// Callers can use [ImagePullResponse.JSONMessages] to monitor pull progress as
-// a sequence of JSONMessages, [ImagePullResponse.Close] does not need to be
-// called in this case. Or, use the [io.Reader] interface and call
-// [ImagePullResponse.Close] after processing.
+// Callers can:
+// - use [ImagePullResponse.Wait] to wait for pull to complete
+// - use [ImagePullResponse.JSONMessages] to monitor pull progress as a sequence
+//   of JSONMessages, [ImagePullResponse.Close] does not need to be called in this case.
+// - use the [io.Reader] interface and call [ImagePullResponse.Close] after processing.
 func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePullOptions) (ImagePullResponse, error) {
 	// FIXME(vdemeester): there is currently used in a few way in docker/docker
 	// - if not in trusted content, ref is used to pass the whole reference, and tag is empty
@@ -88,7 +36,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 
 	ref, err := reference.ParseNormalizedNamed(refStr)
 	if err != nil {
-		return ImagePullResponse{}, err
+		return nil, err
 	}
 
 	query := url.Values{}
@@ -105,10 +53,10 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		resp, err = cli.tryImageCreate(ctx, query, options.PrivilegeFunc)
 	}
 	if err != nil {
-		return ImagePullResponse{}, err
+		return nil, err
 	}
 
-	return newImagePullResponse(resp.Body), nil
+	return internal.NewJSONMessageStream(resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"iter"
+	"sync"
+
+	"github.com/moby/moby/client/pkg/jsonmessage"
+)
+
+func NewJSONMessageStream(rc io.ReadCloser) stream {
+	if rc == nil {
+		panic("nil io.ReadCloser")
+	}
+	return stream{
+		rc:    rc,
+		close: sync.OnceValue(rc.Close),
+	}
+}
+
+type stream struct {
+	rc    io.ReadCloser
+	close func() error
+}
+
+// Read implements io.ReadCloser
+func (r stream) Read(p []byte) (n int, err error) {
+	if r.rc == nil {
+		return 0, io.EOF
+	}
+	return r.rc.Read(p)
+}
+
+// Close implements io.ReadCloser
+func (r stream) Close() error {
+	if r.close == nil {
+		return nil
+	}
+	return r.close()
+}
+
+// JSONMessages decodes the response stream as a sequence of JSONMessages.
+// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
+func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
+	context.AfterFunc(ctx, func() {
+		_ = r.Close()
+	})
+	dec := json.NewDecoder(r)
+	return func(yield func(jsonmessage.JSONMessage, error) bool) {
+		defer r.Close()
+		for {
+			var jm jsonmessage.JSONMessage
+			err := dec.Decode(&jm)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if ctx.Err() != nil {
+				yield(jm, ctx.Err())
+				return
+			}
+			if !yield(jm, err) {
+				return
+			}
+		}
+	}
+}
+
+// Wait waits for operation to complete and detects errors reported as JSONMessage
+func (r stream) Wait(ctx context.Context) error {
+	for _, err := range r.JSONMessages(ctx) {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**- What I did**

follow-up for https://github.com/moby/moby/pull/50935
introduce ImagePushResponse with utility method `JSONMessages` to manage json messages stream 

**- How I did it**

made `ImagePullResponse` a general purpose type as `jsonmessage.Stream` type to be used as both `ImagePullResponse` and `ImagePushResponse` (avoid code duplication)

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
`ImagePush` now returns an object with `JSONMessages` method returning iterator over the message objects.
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="736" height="581" alt="image" src="https://github.com/user-attachments/assets/9a7cf648-b7ad-46a7-b445-b06e9b89b3a6" />

