### PR TITLE
api: fix swarm network field from addr to prefix

### DIFF
--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -56,8 +56,8 @@ const (
 
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
-	NetworkID string     `json:",omitempty"`
-	Addr      netip.Addr `json:",omitempty"`
+	NetworkID string       `json:",omitempty"`
+	Addr      netip.Prefix `json:",omitempty"`
 }
 
 // Network represents a network.
@@ -91,8 +91,8 @@ type NetworkAttachmentConfig struct {
 
 // NetworkAttachment represents a network attachment.
 type NetworkAttachment struct {
-	Network   Network      `json:",omitempty"`
-	Addresses []netip.Addr `json:",omitempty"`
+	Network   Network        `json:",omitempty"`
+	Addresses []netip.Prefix `json:",omitempty"`
 }
 
 // IPAMOptions represents ipam options.

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -22,7 +22,7 @@ func networkAttachmentFromGRPC(na *swarmapi.NetworkAttachment) types.NetworkAtta
 	if na != nil {
 		return types.NetworkAttachment{
 			Network:   networkFromGRPC(na.Network),
-			Addresses: sliceutil.Map(na.Addresses, func(s string) netip.Addr { a, _ := netip.ParseAddr(s); return a }),
+			Addresses: sliceutil.Map(na.Addresses, func(s string) netip.Prefix { a, _ := netip.ParsePrefix(s); return a }),
 		}
 	}
 	return types.NetworkAttachment{}
@@ -130,7 +130,7 @@ func endpointFromGRPC(e *swarmapi.Endpoint) types.Endpoint {
 		}
 
 		for _, v := range e.VirtualIPs {
-			vip, _ := netip.ParseAddr(v.Addr)
+			vip, _ := netip.ParsePrefix(v.Addr)
 			endpoint.VirtualIPs = append(endpoint.VirtualIPs, types.EndpointVirtualIP{
 				NetworkID: v.NetworkID,
 				Addr:      vip,

--- a/vendor/github.com/moby/moby/api/types/swarm/network.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/network.go
@@ -56,8 +56,8 @@ const (
 
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
-	NetworkID string     `json:",omitempty"`
-	Addr      netip.Addr `json:",omitempty"`
+	NetworkID string       `json:",omitempty"`
+	Addr      netip.Prefix `json:",omitempty"`
 }
 
 // Network represents a network.
@@ -91,8 +91,8 @@ type NetworkAttachmentConfig struct {
 
 // NetworkAttachment represents a network attachment.
 type NetworkAttachment struct {
-	Network   Network      `json:",omitempty"`
-	Addresses []netip.Addr `json:",omitempty"`
+	Network   Network        `json:",omitempty"`
+	Addresses []netip.Prefix `json:",omitempty"`
 }
 
 // IPAMOptions represents ipam options.


### PR DESCRIPTION
**- What I did**
* Fixes https://github.com/moby/moby/pull/50956#discussion_r2415253891
  - issue found during https://github.com/docker/cli/pull/6545

The swarm network endpoint virtual IP Addr and network attach Addresses fields previously accepted CIDR notation. While `ipnet.Addr` makes more sense here, we are hamstrung by backwards compatibility with older clients if we stop accepting wires with `/xx`

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

