### PR TITLE
api/types/swarm: fix EndpointVirtualIP.Addr type

### DIFF
--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -56,8 +56,8 @@ const (
 
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
-	NetworkID string     `json:",omitempty"`
-	Addr      netip.Addr `json:",omitempty"`
+	NetworkID string       `json:",omitempty"`
+	Addr      netip.Prefix `json:",omitempty"`
 }
 
 // Network represents a network.

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -130,7 +130,7 @@ func endpointFromGRPC(e *swarmapi.Endpoint) types.Endpoint {
 		}
 
 		for _, v := range e.VirtualIPs {
-			vip, _ := netip.ParseAddr(v.Addr)
+			vip, _ := netip.ParsePrefix(v.Addr)
 			endpoint.VirtualIPs = append(endpoint.VirtualIPs, types.EndpointVirtualIP{
 				NetworkID: v.NetworkID,
 				Addr:      vip,

--- a/vendor/github.com/moby/moby/api/types/swarm/network.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/network.go
@@ -56,8 +56,8 @@ const (
 
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
-	NetworkID string     `json:",omitempty"`
-	Addr      netip.Addr `json:",omitempty"`
+	NetworkID string       `json:",omitempty"`
+	Addr      netip.Prefix `json:",omitempty"`
 }
 
 // Network represents a network.


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixed https://github.com/moby/moby/pull/50956#discussion_r2415253891

**- How I did it**
The value returned from the Swarm API (and Moby <=v28) is a CIDR prefix string. Elsewhere in the code we assert that they are CIDR prefix strings. But it's incorrectly parsed and represented as an address in one place in the daemon and api, respectively. Change them to a netip.Prefix so as not to break compatibility.

**- How to verify it**
🤷 

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

