### PR TITLE
api/types/container: remove support for config mac address

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -54,6 +54,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * Removed the `KernelMemoryTCP` field from the `GET /info` endpoint.
 * `GET /events` supports content-type negotiation and can produce either `application/x-ndjson` 
   (Newline delimited JSON object stream) or `application/json-seq` (RFC7464).
+* Removed the container-wide `MacAddress` field in `Config` on `POST /containers/create` 
+  and `GET /containers/{id}/json` endpoints. Mac address assignments can be set using
+  endpoint configuration when connecting the container to a network.
 
 ## v1.51 API changes
 

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -1390,13 +1390,6 @@ definitions:
         description: "Disable networking for the container."
         type: "boolean"
         x-nullable: true
-      MacAddress:
-        description: |
-          MAC address of the container.
-
-          Deprecated: this field is deprecated in API v1.44 and up. Use EndpointSettings.MacAddress instead.
-        type: "string"
-        x-nullable: true
       OnBuild:
         description: |
           `ONBUILD` metadata that were defined in the image's `Dockerfile`.
@@ -7890,7 +7883,6 @@ paths:
                 /volumes/data: {}
               WorkingDir: ""
               NetworkDisabled: false
-              MacAddress: "12:34:56:78:9a:bc"
               ExposedPorts:
                 22/tcp: {}
               StopSignal: "SIGTERM"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1390,13 +1390,6 @@ definitions:
         description: "Disable networking for the container."
         type: "boolean"
         x-nullable: true
-      MacAddress:
-        description: |
-          MAC address of the container.
-
-          Deprecated: this field is deprecated in API v1.44 and up. Use EndpointSettings.MacAddress instead.
-        type: "string"
-        x-nullable: true
       OnBuild:
         description: |
           `ONBUILD` metadata that were defined in the image's `Dockerfile`.
@@ -7890,7 +7883,6 @@ paths:
                 /volumes/data: {}
               WorkingDir: ""
               NetworkDisabled: false
-              MacAddress: "12:34:56:78:9a:bc"
               ExposedPorts:
                 22/tcp: {}
               StopSignal: "SIGTERM"

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -42,13 +42,9 @@ type Config struct {
 	WorkingDir      string              // Current directory (PWD) in the command will be launched
 	Entrypoint      []string            // Entrypoint to run when starting the container
 	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
-	// Mac Address of the container.
-	//
-	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
-	MacAddress  string            `json:",omitempty"`
-	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
-	Labels      map[string]string // List of labels set to this container
-	StopSignal  string            `json:",omitempty"` // Signal to stop a container
-	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell       []string          `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+	OnBuild         []string            `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
+	Labels          map[string]string   // List of labels set to this container
+	StopSignal      string              `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           []string            `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -11,7 +11,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/api/types/versions"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -27,25 +26,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	if hostConfig != nil {
 		hostConfig.CapAdd = normalizeCapabilities(hostConfig.CapAdd)
 		hostConfig.CapDrop = normalizeCapabilities(hostConfig.CapDrop)
-	}
-
-	// FIXME(thaJeztah): remove this once we updated our (integration) tests;
-	//  some integration tests depend on this to test old API versions; see https://github.com/moby/moby/pull/51120#issuecomment-3376224865
-	if config.MacAddress != "" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		// Make sure we negotiated (if the client is configured to do so),
-		// as code below contains API-version specific handling of options.
-		//
-		// Normally, version-negotiation (if enabled) would not happen until
-		// the API request is made.
-		if err := cli.checkVersion(ctx); err != nil {
-			return response, err
-		}
-		if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.44") {
-			// Since API 1.44, the container-wide MacAddress is deprecated and triggers a WARNING if it's specified.
-			//
-			// FIXME(thaJeztah): remove the field from the API
-			config.MacAddress = "" //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		}
 	}
 
 	query := url.Values{}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -97,18 +97,6 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, ctr *container.Co
 	// We merge the Ulimits from hostConfig with daemon default
 	daemon.mergeUlimits(&hostConfig, daemonCfg)
 
-	// Migrate the container's default network's MacAddress to the top-level
-	// Config.MacAddress field for older API versions (< 1.44). We set it here
-	// unconditionally, to keep backward compatibility with clients that use
-	// unversioned API endpoints.
-	if ctr.Config != nil && ctr.Config.MacAddress == "" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		if nwm := hostConfig.NetworkMode; nwm.IsBridge() || nwm.IsUserDefined() {
-			if epConf, ok := ctr.NetworkSettings.Networks[nwm.NetworkName()]; ok {
-				ctr.Config.MacAddress = epConf.DesiredMacAddress //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-			}
-		}
-	}
-
 	var containerHealth *containertypes.Health
 	if ctr.State.Health != nil {
 		containerHealth = &containertypes.Health{

--- a/daemon/internal/runconfig/config_test.go
+++ b/daemon/internal/runconfig/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/pkg/sysinfo"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -127,7 +128,7 @@ func TestDecodeCreateRequestIsolation(t *testing.T) {
 			if tc.invalid {
 				assert.Check(t, is.ErrorContains(err, tc.expectedErr))
 				assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
-				assert.Check(t, is.DeepEqual(req, container.CreateRequest{}))
+				assert.Check(t, is.DeepEqual(req, backend.CreateContainerRequest{}))
 			} else {
 				assert.NilError(t, err)
 			}
@@ -147,7 +148,7 @@ func TestDecodeCreateRequestPrivileged(t *testing.T) {
 		const expected = "invalid option: privileged mode is not supported for Windows containers"
 		assert.Check(t, is.Error(err, expected))
 		assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
-		assert.Check(t, is.DeepEqual(req, container.CreateRequest{}))
+		assert.Check(t, is.DeepEqual(req, backend.CreateContainerRequest{}))
 	} else {
 		assert.NilError(t, err)
 	}

--- a/daemon/server/backend/backend.go
+++ b/daemon/server/backend/backend.go
@@ -12,6 +12,12 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+type CreateContainerRequest struct {
+	ContainerConfig
+	HostConfig       *container.HostConfig     `json:"HostConfig,omitempty"`
+	NetworkingConfig *network.NetworkingConfig `json:"NetworkingConfig,omitempty"`
+}
+
 // ContainerCreateConfig is the parameter set to ContainerCreate()
 type ContainerCreateConfig struct {
 	Name                        string
@@ -20,6 +26,16 @@ type ContainerCreateConfig struct {
 	NetworkingConfig            *network.NetworkingConfig
 	Platform                    *ocispec.Platform
 	DefaultReadOnlyNonRecursive bool
+}
+
+type ContainerConfig struct {
+	*container.Config
+
+	// MacAddress sets the container's network interface MAC address.
+	// This option was deprecated in API v1.44 and removed in v1.52.
+	// It is added here to keep compatibility with older API versions.
+	// New code should use NetworkingConfig.EndpointsConfig[networkName].MacAddress instead.
+	MacAddress string `json:"MacAddress,omitempty"`
 }
 
 // ContainerRmConfig holds arguments for the container remove

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -360,12 +360,6 @@ func WithStopSignal(stopSignal string) func(c *TestContainerConfig) {
 	}
 }
 
-func WithContainerWideMacAddress(address string) func(c *TestContainerConfig) {
-	return func(c *TestContainerConfig) {
-		c.Config.MacAddress = address //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-	}
-}
-
 // WithHostConfig sets a custom [container.HostConfig] for the container.
 func WithHostConfig(hc *container.HostConfig) func(c *TestContainerConfig) {
 	return func(c *TestContainerConfig) {

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -42,13 +42,9 @@ type Config struct {
 	WorkingDir      string              // Current directory (PWD) in the command will be launched
 	Entrypoint      []string            // Entrypoint to run when starting the container
 	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
-	// Mac Address of the container.
-	//
-	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
-	MacAddress  string            `json:",omitempty"`
-	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
-	Labels      map[string]string // List of labels set to this container
-	StopSignal  string            `json:",omitempty"` // Signal to stop a container
-	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell       []string          `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+	OnBuild         []string            `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
+	Labels          map[string]string   // List of labels set to this container
+	StopSignal      string              `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           []string            `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/vendor/github.com/moby/moby/client/container_create.go
+++ b/vendor/github.com/moby/moby/client/container_create.go
@@ -11,7 +11,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/api/types/versions"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -27,25 +26,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	if hostConfig != nil {
 		hostConfig.CapAdd = normalizeCapabilities(hostConfig.CapAdd)
 		hostConfig.CapDrop = normalizeCapabilities(hostConfig.CapDrop)
-	}
-
-	// FIXME(thaJeztah): remove this once we updated our (integration) tests;
-	//  some integration tests depend on this to test old API versions; see https://github.com/moby/moby/pull/51120#issuecomment-3376224865
-	if config.MacAddress != "" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		// Make sure we negotiated (if the client is configured to do so),
-		// as code below contains API-version specific handling of options.
-		//
-		// Normally, version-negotiation (if enabled) would not happen until
-		// the API request is made.
-		if err := cli.checkVersion(ctx); err != nil {
-			return response, err
-		}
-		if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.44") {
-			// Since API 1.44, the container-wide MacAddress is deprecated and triggers a WARNING if it's specified.
-			//
-			// FIXME(thaJeztah): remove the field from the API
-			config.MacAddress = "" //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		}
 	}
 
 	query := url.Values{}


### PR DESCRIPTION
**- What I did**
Dropped support for the container wide MacAddress in container configuration.

Deprecated in API v1.44; the MacAddress field is no longer supported starting with API v1.52. Newer clients will no longer be able to send the field even when specifying the lower API versions. The daemon will continue to migrate the field when using API v1.44 - v1.51. Specifying the field will now result in an error for v1.52 and onwards.

**- How I did it**
🧹 ... 🗑️ 

**- How to verify it**


**- Human readable description for the release notes**
```markdown changelog
api/types/container: removed support for container wide MAC address. Use endpoint settings when connecting a container to a network for MAC address assignments.
```

**- A picture of a cute animal (not mandatory but encouraged)**

