### PR TITLE
api/types/container: omit `Config.OnBuild` when empty

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ keywords: "API, Docker, rcli, REST, documentation"
   longer set when using BuildKit. The `Author` field is set through the
   `MAINTAINER` Dockerfile instruction, which is deprecated, and the `Comment`
   field is option, and may not be set depending on how the image was created.
+* `GET /container/{id}/json` now omits `Config.OnBuild` if its value is empty.
 * `GET /containers/{id}/json`: the `NetworkSettings` no longer returns the deprecated
   `Bridge`, `HairpinMode`, `LinkLocalIPv6Address`, `LinkLocalIPv6PrefixLen`,
   `SecondaryIPAddresses`, `SecondaryIPv6Addresses`, `EndpointID`, `Gateway`,

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	//
 	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
 	MacAddress  string            `json:",omitempty"`
-	OnBuild     []string          // ONBUILD metadata that were defined on the image Dockerfile
+	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
 	Labels      map[string]string // List of labels set to this container
 	StopSignal  string            `json:",omitempty"` // Signal to stop a container
 	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container

--- a/api/types/container/config_test.go
+++ b/api/types/container/config_test.go
@@ -1,0 +1,24 @@
+package container
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMarshalConfig(t *testing.T) {
+	omitted := []byte(`{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":null,"Image":"","Volumes":null,"WorkingDir":"","Entrypoint":null,"Labels":null}`)
+
+	bytes, err := json.Marshal(Config{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(bytes), string(omitted))
+
+	empty := Config{
+		OnBuild: []string{},
+	}
+
+	bytes, err = json.Marshal(empty)
+	assert.NilError(t, err)
+	assert.Equal(t, string(bytes), string(omitted))
+}

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -46,7 +46,7 @@ type Config struct {
 	//
 	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
 	MacAddress  string            `json:",omitempty"`
-	OnBuild     []string          // ONBUILD metadata that were defined on the image Dockerfile
+	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
 	Labels      map[string]string // List of labels set to this container
 	StopSignal  string            `json:",omitempty"` // Signal to stop a container
 	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container


### PR DESCRIPTION
**- What I did**
Added omit annotations for container configuration `OnBuild` field.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/container: `OnBuild` will now be omitted if its value is empty or zero.
```

**- A picture of a cute animal (not mandatory but encouraged)**

