### PR TITLE
api/types/swarm: add documentation to clarify virtual IP address type

### DIFF
--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -56,8 +56,12 @@ const (
 
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
-	NetworkID string       `json:",omitempty"`
-	Addr      netip.Prefix `json:",omitempty"`
+	NetworkID string `json:",omitempty"`
+
+	// Addr is the virtual ip address.
+	// This field accepts CIDR notation, for example `10.0.0.1/24`, to maintain backwards
+	// compatibility, but only the IP address is used.
+	Addr netip.Prefix `json:",omitempty"`
 }
 
 // Network represents a network.
@@ -91,7 +95,11 @@ type NetworkAttachmentConfig struct {
 
 // NetworkAttachment represents a network attachment.
 type NetworkAttachment struct {
-	Network   Network        `json:",omitempty"`
+	Network Network `json:",omitempty"`
+
+	// Addresses contains the IP addresses associated with the endpoint in the network.
+	// This field accepts CIDR notation, for example `10.0.0.1/24`, to maintain backwards
+	// compatibility, but only the IP address is used.
 	Addresses []netip.Prefix `json:",omitempty"`
 }
 

--- a/vendor/github.com/moby/moby/api/types/swarm/network.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/network.go
@@ -56,8 +56,12 @@ const (
 
 // EndpointVirtualIP represents the virtual ip of a port.
 type EndpointVirtualIP struct {
-	NetworkID string       `json:",omitempty"`
-	Addr      netip.Prefix `json:",omitempty"`
+	NetworkID string `json:",omitempty"`
+
+	// Addr is the virtual ip address.
+	// This field accepts CIDR notation, for example `10.0.0.1/24`, to maintain backwards
+	// compatibility, but only the IP address is used.
+	Addr netip.Prefix `json:",omitempty"`
 }
 
 // Network represents a network.
@@ -91,7 +95,11 @@ type NetworkAttachmentConfig struct {
 
 // NetworkAttachment represents a network attachment.
 type NetworkAttachment struct {
-	Network   Network        `json:",omitempty"`
+	Network Network `json:",omitempty"`
+
+	// Addresses contains the IP addresses associated with the endpoint in the network.
+	// This field accepts CIDR notation, for example `10.0.0.1/24`, to maintain backwards
+	// compatibility, but only the IP address is used.
 	Addresses []netip.Prefix `json:",omitempty"`
 }
 


### PR DESCRIPTION
**- What I did**

Added documentation for the swarm endpoint virtual IP address and network attachment addresses fields to clarify CIDR notation is accepted primarily for backwards compatibility with older clients but only the IP address is used.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

