### PR TITLE
client/pkg/jsonmessage: refactor in terms of `api/types/jsonstream`

### DIFF
--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -9,13 +9,13 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client/internal"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 )
 
 type ImagePullResponse interface {
 	io.ReadCloser
-	JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error]
+	JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error]
 	Wait(ctx context.Context) error
 }
 

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client/internal"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -193,7 +193,7 @@ func TestImagePullResponse(t *testing.T) {
 	response := internal.NewJSONMessageStream(r)
 	ctx, cancel := context.WithCancel(t.Context())
 	messages := response.JSONMessages(ctx)
-	c := make(chan jsonmessage.JSONMessage)
+	c := make(chan jsonstream.Message)
 	go func() {
 		for message, err := range messages {
 			if err != nil {

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -12,14 +12,14 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client/internal"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 )
 
 type ImagePushResponse interface {
 	io.ReadCloser
-	JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error]
+	JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error]
 	Wait(ctx context.Context) error
 }
 

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -8,7 +8,7 @@ import (
 	"iter"
 	"sync"
 
-	"github.com/moby/moby/client/pkg/jsonmessage"
+	"github.com/moby/moby/api/types/jsonstream"
 )
 
 func NewJSONMessageStream(rc io.ReadCloser) stream {
@@ -44,15 +44,15 @@ func (r stream) Close() error {
 
 // JSONMessages decodes the response stream as a sequence of JSONMessages.
 // if stream ends or context is cancelled, the underlying [io.Reader] is closed.
-func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
+func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error] {
 	context.AfterFunc(ctx, func() {
 		_ = r.Close()
 	})
 	dec := json.NewDecoder(r)
-	return func(yield func(jsonmessage.JSONMessage, error) bool) {
+	return func(yield func(jsonstream.Message, error) bool) {
 		defer r.Close()
 		for {
-			var jm jsonmessage.JSONMessage
+			var jm jsonstream.Message
 			err := dec.Decode(&jm)
 			if errors.Is(err, io.EOF) {
 				break

--- a/integration/build/build_cgroupns_linux_test.go
+++ b/integration/build/build_cgroupns_linux_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/integration/internal/requirement"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
@@ -23,7 +23,7 @@ func getCgroupFromBuildOutput(buildOutput io.Reader) (string, error) {
 
 	dec := json.NewDecoder(buildOutput)
 	for {
-		m := jsonmessage.JSONMessage{}
+		m := jsonstream.Message{}
 		err := dec.Decode(&m)
 		if err == io.EOF {
 			return "", nil

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
 	"gotest.tools/v3/assert"
@@ -127,7 +127,7 @@ func buildContainerIdsFilter(buildOutput io.Reader) (client.Filters, error) {
 
 	dec := json.NewDecoder(buildOutput)
 	for {
-		m := jsonmessage.JSONMessage{}
+		m := jsonstream.Message{}
 		err := dec.Decode(&m)
 		if err == io.EOF {
 			return filter, nil
@@ -811,7 +811,7 @@ func readBuildImageIDs(t *testing.T, rd io.Reader) string {
 	t.Helper()
 	decoder := json.NewDecoder(rd)
 	for {
-		var jm jsonmessage.JSONMessage
+		var jm jsonstream.Message
 		if err := decoder.Decode(&jm); err != nil {
 			if err == io.EOF {
 				break

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -15,6 +15,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/integration/internal/container"
@@ -217,7 +218,7 @@ func makeTestImage(ctx context.Context, t *testing.T) (imageID string) {
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
-	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
+	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonstream.Message) {
 		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID
@@ -292,7 +293,7 @@ func TestCopyFromContainer(t *testing.T) {
 	defer resp.Body.Close()
 
 	var imageID string
-	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonmessage.JSONMessage) {
+	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonstream.Message) {
 		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID

--- a/integration/container/export_test.go
+++ b/integration/container/export_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
@@ -39,7 +39,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	// the image ID and match with the output from `docker images`.
 
 	dec := json.NewDecoder(importRes)
-	var jm jsonmessage.JSONMessage
+	var jm jsonstream.Message
 	err = dec.Decode(&jm)
 	assert.NilError(t, err)
 

--- a/integration/internal/build/build.go
+++ b/integration/internal/build/build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/protobuf/proto"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/internal/testutil/fakecontext"
@@ -36,7 +37,7 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 	buf := bytes.NewBuffer(nil)
 	dec := json.NewDecoder(body)
 	for {
-		var jm jsonmessage.JSONMessage
+		var jm jsonstream.Message
 		err := dec.Decode(&jm)
 		if err == io.EOF {
 			break
@@ -48,7 +49,7 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 		}
 
 		buf.Reset()
-		jm.Display(buf, false)
+		jsonmessage.Display(jm, buf, false, 0)
 		if buf.Len() == 0 {
 			continue
 		}
@@ -76,7 +77,7 @@ func GetImageIDFromBody(t *testing.T, body io.Reader) string {
 	return id
 }
 
-func processBuildkitAux(t *testing.T, jm *jsonmessage.JSONMessage, id *string) bool {
+func processBuildkitAux(t *testing.T, jm *jsonstream.Message, id *string) bool {
 	if jm.ID == "moby.buildkit.trace" {
 		var dt []byte
 		if err := json.Unmarshal(*jm.Aux, &dt); err != nil {

--- a/integration/internal/image/load.go
+++ b/integration/internal/image/load.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/moby/go-archive"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 	"github.com/moby/moby/v2/internal/testutil/specialimage"
 	"gotest.tools/v3/assert"
 )
@@ -46,7 +46,7 @@ func Load(ctx context.Context, t *testing.T, apiClient client.APIClient, imageFu
 
 	decoder := json.NewDecoder(bytes.NewReader(all))
 	for {
-		var msg jsonmessage.JSONMessage
+		var msg jsonstream.Message
 		err := decoder.Decode(&msg)
 		if errors.Is(err, io.EOF) {
 			break

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -16,6 +16,7 @@ import (
 	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/api/types/jsonstream"
 	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
@@ -142,7 +143,7 @@ func TestPluginInstall(t *testing.T) {
 		buf := &strings.Builder{}
 		assert.NilError(t, err)
 		var digest string
-		assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(pushResult, buf, 0, false, func(j jsonmessage.JSONMessage) {
+		assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(pushResult, buf, 0, false, func(j jsonstream.Message) {
 			if j.Aux != nil {
 				var r types.PushResult
 				assert.NilError(t, json.Unmarshal(*j.Aux, &r))

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -9,13 +9,13 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/client/internal"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 )
 
 type ImagePullResponse interface {
 	io.ReadCloser
-	JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error]
+	JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error]
 	Wait(ctx context.Context) error
 }
 

--- a/vendor/github.com/moby/moby/client/image_push.go
+++ b/vendor/github.com/moby/moby/client/image_push.go
@@ -12,14 +12,14 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/distribution/reference"
+	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client/internal"
-	"github.com/moby/moby/client/pkg/jsonmessage"
 )
 
 type ImagePushResponse interface {
 	io.ReadCloser
-	JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error]
+	JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error]
 	Wait(ctx context.Context) error
 }
 

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -8,7 +8,7 @@ import (
 	"iter"
 	"sync"
 
-	"github.com/moby/moby/client/pkg/jsonmessage"
+	"github.com/moby/moby/api/types/jsonstream"
 )
 
 func NewJSONMessageStream(rc io.ReadCloser) stream {
@@ -44,15 +44,15 @@ func (r stream) Close() error {
 
 // JSONMessages decodes the response stream as a sequence of JSONMessages.
 // if stream ends or context is cancelled, the underlying [io.Reader] is closed.
-func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
+func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error] {
 	context.AfterFunc(ctx, func() {
 		_ = r.Close()
 	})
 	dec := json.NewDecoder(r)
-	return func(yield func(jsonmessage.JSONMessage, error) bool) {
+	return func(yield func(jsonstream.Message, error) bool) {
 		defer r.Close()
 		for {
-			var jm jsonmessage.JSONMessage
+			var jm jsonstream.Message
 			err := dec.Decode(&jm)
 			if errors.Is(err, io.EOF) {
 				break


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Stacked on top of #51153 
- For #50575 

**- What I did**
Refactored client/pkg/jsonmessage to reference the API types, eliminating its separate definition.

**- How I did it**
By changing some methods and struct fields to functions and function arguments.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

