### PR TITLE
api/pkg/stdcopy: move stdWriter to daemon/internal

### DIFF
--- a/api/pkg/stdcopy/stdcopy.go
+++ b/api/pkg/stdcopy/stdcopy.go
@@ -1,12 +1,10 @@
 package stdcopy
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"sync"
 )
 
 // StdType is the type of standard stream
@@ -27,71 +25,6 @@ const (
 
 	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
 )
-
-var bufPool = &sync.Pool{New: func() any { return bytes.NewBuffer(nil) }}
-
-// stdWriter is wrapper of io.Writer with extra customized info.
-type stdWriter struct {
-	io.Writer
-	prefix byte
-}
-
-// Write sends the buffer to the underlying writer.
-// It inserts the prefix header before the buffer,
-// so [StdCopy] knows where to multiplex the output.
-//
-// It implements [io.Writer].
-func (w *stdWriter) Write(p []byte) (int, error) {
-	if w == nil || w.Writer == nil {
-		return 0, errors.New("writer not instantiated")
-	}
-	if p == nil {
-		return 0, nil
-	}
-
-	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
-	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Write(header[:])
-	buf.Write(p)
-
-	n, err := w.Writer.Write(buf.Bytes())
-	n -= stdWriterPrefixLen
-	if n < 0 {
-		n = 0
-	}
-
-	buf.Reset()
-	bufPool.Put(buf)
-	return n, err
-}
-
-// NewStdWriter instantiates a new writer using a custom format to multiplex
-// multiple streams to a single writer. All messages written using this writer
-// are encapsulated using a custom format, and written to the underlying
-// stream "w".
-//
-// Writers created through NewStdWriter allow for multiple write streams
-// (e.g., stdout ([Stdout]) and stderr ([Stderr]) to be multiplexed into a
-// single connection. "streamType" indicates the type of stream to encapsulate,
-// commonly, [Stdout] or [Stderr]. The [Systemerr] stream can be used to
-// include server-side errors in the stream. Information on this stream
-// is returned as an error by [StdCopy] and terminates processing the
-// stream.
-//
-// The [Stdin] stream is present for completeness and should generally
-// NOT be used. It is output on [Stdout] when reading the stream with
-// [StdCopy].
-//
-// All streams must share the same underlying [io.Writer] to ensure proper
-// multiplexing. Each call to NewStdWriter wraps that shared writer with
-// a header indicating the target stream.
-func NewStdWriter(w io.Writer, streamType StdType) io.Writer {
-	return &stdWriter{
-		Writer: w,
-		prefix: byte(streamType),
-	}
-}
 
 // StdCopy is a modified version of [io.Copy] to de-multiplex messages
 // from "multiplexedSource" and copy them to destination streams

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -10,6 +10,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/internal/stdcopymux"
 	"github.com/moby/moby/v2/daemon/internal/stream"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/server/backend"
@@ -74,8 +75,8 @@ func (daemon *Daemon) ContainerAttach(prefixOrName string, req *backend.Containe
 	defer inStream.Close()
 
 	if multiplexed {
-		errStream = stdcopy.NewStdWriter(errStream, stdcopy.Stderr)
-		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
+		errStream = stdcopymux.NewStdWriter(errStream, stdcopy.Stderr)
+		outStream = stdcopymux.NewStdWriter(outStream, stdcopy.Stdout)
 	}
 
 	if cfg.UseStdin {

--- a/daemon/internal/stdcopymux/stdcopy_example_test.go
+++ b/daemon/internal/stdcopymux/stdcopy_example_test.go
@@ -1,4 +1,4 @@
-package stdcopy_test
+package stdcopymux_test
 
 import (
 	"errors"
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/v2/daemon/internal/stdcopymux"
 )
 
 func ExampleNewStdWriter() {
@@ -25,9 +26,9 @@ func ExampleNewStdWriter() {
 	}()
 
 	// daemon writing to stdout, stderr, and systemErr.
-	stdout := stdcopy.NewStdWriter(muxStream, stdcopy.Stdout)
-	stderr := stdcopy.NewStdWriter(muxStream, stdcopy.Stderr)
-	systemErr := stdcopy.NewStdWriter(muxStream, stdcopy.Systemerr)
+	stdout := stdcopymux.NewStdWriter(muxStream, stdcopy.Stdout)
+	stderr := stdcopymux.NewStdWriter(muxStream, stdcopy.Stderr)
+	systemErr := stdcopymux.NewStdWriter(muxStream, stdcopy.Systemerr)
 
 	for range 10 {
 		_, _ = fmt.Fprintln(stdout, "hello from stdout")

--- a/daemon/internal/stdcopymux/writer.go
+++ b/daemon/internal/stdcopymux/writer.go
@@ -1,0 +1,82 @@
+package stdcopymux
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/moby/moby/api/pkg/stdcopy"
+)
+
+const (
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+)
+
+var bufPool = &sync.Pool{New: func() any { return bytes.NewBuffer(nil) }}
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underlying writer.
+// It inserts the prefix header before the buffer,
+// so [StdCopy] knows where to multiplex the output.
+//
+// It implements [io.Writer].
+func (w *stdWriter) Write(p []byte) (int, error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("writer not instantiated")
+	}
+	if p == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Write(header[:])
+	buf.Write(p)
+
+	n, err := w.Writer.Write(buf.Bytes())
+	n -= stdWriterPrefixLen
+	if n < 0 {
+		n = 0
+	}
+
+	buf.Reset()
+	bufPool.Put(buf)
+	return n, err
+}
+
+// NewStdWriter instantiates a new writer using a custom format to multiplex
+// multiple streams to a single writer. All messages written using this writer
+// are encapsulated using a custom format, and written to the underlying
+// stream "w".
+//
+// Writers created through NewStdWriter allow for multiple write streams
+// (e.g., stdout ([Stdout]) and stderr ([Stderr]) to be multiplexed into a
+// single connection. "streamType" indicates the type of stream to encapsulate,
+// commonly, [Stdout] or [Stderr]. The [Systemerr] stream can be used to
+// include server-side errors in the stream. Information on this stream
+// is returned as an error by [StdCopy] and terminates processing the
+// stream.
+//
+// The [Stdin] stream is present for completeness and should generally
+// NOT be used. It is output on [Stdout] when reading the stream with
+// [StdCopy].
+//
+// All streams must share the same underlying [io.Writer] to ensure proper
+// multiplexing. Each call to NewStdWriter wraps that shared writer with
+// a header indicating the target stream.
+func NewStdWriter(w io.Writer, streamType stdcopy.StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(streamType),
+	}
+}

--- a/daemon/server/httputils/write_log_stream.go
+++ b/daemon/server/httputils/write_log_stream.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/v2/daemon/internal/stdcopymux"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/pkg/ioutils"
 )
@@ -33,9 +34,9 @@ func WriteLogStream(_ context.Context, w http.ResponseWriter, msgs <-chan *backe
 	errStream := outStream
 	sysErrStream := errStream
 	if mux {
-		sysErrStream = stdcopy.NewStdWriter(outStream, stdcopy.Systemerr)
-		errStream = stdcopy.NewStdWriter(outStream, stdcopy.Stderr)
-		outStream = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
+		sysErrStream = stdcopymux.NewStdWriter(outStream, stdcopy.Systemerr)
+		errStream = stdcopymux.NewStdWriter(outStream, stdcopy.Stderr)
+		outStream = stdcopymux.NewStdWriter(outStream, stdcopy.Stdout)
 	}
 
 	for {

--- a/daemon/server/router/container/exec.go
+++ b/daemon/server/router/container/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/versions"
+	"github.com/moby/moby/v2/daemon/internal/stdcopymux"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
 	"github.com/moby/moby/v2/errdefs"
@@ -130,8 +131,8 @@ func (c *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		if options.Tty {
 			stdout = outStream
 		} else {
-			stderr = stdcopy.NewStdWriter(outStream, stdcopy.Stderr)
-			stdout = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
+			stderr = stdcopymux.NewStdWriter(outStream, stdcopy.Stderr)
+			stdout = stdcopymux.NewStdWriter(outStream, stdcopy.Stdout)
 		}
 	}
 

--- a/vendor/github.com/moby/moby/api/pkg/stdcopy/stdcopy.go
+++ b/vendor/github.com/moby/moby/api/pkg/stdcopy/stdcopy.go
@@ -1,12 +1,10 @@
 package stdcopy
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"sync"
 )
 
 // StdType is the type of standard stream
@@ -27,71 +25,6 @@ const (
 
 	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
 )
-
-var bufPool = &sync.Pool{New: func() any { return bytes.NewBuffer(nil) }}
-
-// stdWriter is wrapper of io.Writer with extra customized info.
-type stdWriter struct {
-	io.Writer
-	prefix byte
-}
-
-// Write sends the buffer to the underlying writer.
-// It inserts the prefix header before the buffer,
-// so [StdCopy] knows where to multiplex the output.
-//
-// It implements [io.Writer].
-func (w *stdWriter) Write(p []byte) (int, error) {
-	if w == nil || w.Writer == nil {
-		return 0, errors.New("writer not instantiated")
-	}
-	if p == nil {
-		return 0, nil
-	}
-
-	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
-	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Write(header[:])
-	buf.Write(p)
-
-	n, err := w.Writer.Write(buf.Bytes())
-	n -= stdWriterPrefixLen
-	if n < 0 {
-		n = 0
-	}
-
-	buf.Reset()
-	bufPool.Put(buf)
-	return n, err
-}
-
-// NewStdWriter instantiates a new writer using a custom format to multiplex
-// multiple streams to a single writer. All messages written using this writer
-// are encapsulated using a custom format, and written to the underlying
-// stream "w".
-//
-// Writers created through NewStdWriter allow for multiple write streams
-// (e.g., stdout ([Stdout]) and stderr ([Stderr]) to be multiplexed into a
-// single connection. "streamType" indicates the type of stream to encapsulate,
-// commonly, [Stdout] or [Stderr]. The [Systemerr] stream can be used to
-// include server-side errors in the stream. Information on this stream
-// is returned as an error by [StdCopy] and terminates processing the
-// stream.
-//
-// The [Stdin] stream is present for completeness and should generally
-// NOT be used. It is output on [Stdout] when reading the stream with
-// [StdCopy].
-//
-// All streams must share the same underlying [io.Writer] to ensure proper
-// multiplexing. Each call to NewStdWriter wraps that shared writer with
-// a header indicating the target stream.
-func NewStdWriter(w io.Writer, streamType StdType) io.Writer {
-	return &stdWriter{
-		Writer: w,
-		prefix: byte(streamType),
-	}
-}
 
 // StdCopy is a modified version of [io.Copy] to de-multiplex messages
 // from "multiplexedSource" and copy them to destination streams


### PR DESCRIPTION
Clients have no need for muxing streams using our StdCopy wire format.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Moved stdWriter out of api into daemon/internal.

**- How I did it**
I moved all the tests into the new daemon/internal/stdcopymux package verbatim, so there is still test coverage on the `stdcopy.StdCopy` function, albeit more like an integration test.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

