### PR TITLE
daemon/internal/netiputil: make "MaybeXXX" functions a function, not var

### DIFF
--- a/daemon/internal/netiputil/netiputil.go
+++ b/daemon/internal/netiputil/netiputil.go
@@ -122,8 +122,14 @@ func MaybeParse[T any](parse func(string) (T, error)) func(string) (T, error) {
 	}
 }
 
-var (
-	MaybeParseAddr   = MaybeParse(netip.ParseAddr)
-	MaybeParsePrefix = MaybeParse(netip.ParsePrefix)
-	MaybeParseCIDR   = MaybeParse(ParseCIDR)
-)
+func MaybeParseAddr(addr string) (netip.Addr, error) {
+	return MaybeParse(netip.ParseAddr)(addr)
+}
+
+func MaybeParsePrefix(prefix string) (netip.Prefix, error) {
+	return MaybeParse(netip.ParsePrefix)(prefix)
+}
+
+func MaybeParseCIDR(cidr string) (netip.Prefix, error) {
+	return MaybeParse(ParseCIDR)(cidr)
+}


### PR DESCRIPTION
This make it ever so slightly more clear (also when viewing docs).

Before:

<img width="603" height="652" alt="Screenshot 2025-10-10 at 10 18 39" src="https://github.com/user-attachments/assets/2980b4e6-2416-473f-9f3b-d09f5d9b3ce4" />



After

<img width="604" height="568" alt="Screenshot 2025-10-10 at 10 18 17" src="https://github.com/user-attachments/assets/ef193060-8c44-4221-870b-75c915d1f64b" />



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

