### PR TITLE
client: ImagePullResponse: don't panic without reader

### DIFF
--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -29,6 +29,9 @@ type ImagePullResponse struct {
 
 // Read implements io.ReadCloser
 func (r ImagePullResponse) Read(p []byte) (n int, err error) {
+	if r.rc == nil {
+		return 0, io.EOF
+	}
 	return r.rc.Read(p)
 }
 
@@ -50,7 +53,7 @@ func (r ImagePullResponse) Close() error {
 // if stream ends or context is cancelled, the underlying [io.Reader] is closed.
 func (r ImagePullResponse) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
 	context.AfterFunc(ctx, func() {
-		r.Close()
+		_ = r.Close()
 	})
 	dec := json.NewDecoder(r)
 	return func(yield func(jsonmessage.JSONMessage, error) bool) {

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -29,6 +29,9 @@ type ImagePullResponse struct {
 
 // Read implements io.ReadCloser
 func (r ImagePullResponse) Read(p []byte) (n int, err error) {
+	if r.rc == nil {
+		return 0, io.EOF
+	}
 	return r.rc.Read(p)
 }
 
@@ -50,7 +53,7 @@ func (r ImagePullResponse) Close() error {
 // if stream ends or context is cancelled, the underlying [io.Reader] is closed.
 func (r ImagePullResponse) JSONMessages(ctx context.Context) iter.Seq2[jsonmessage.JSONMessage, error] {
 	context.AfterFunc(ctx, func() {
-		r.Close()
+		_ = r.Close()
 	})
 	dec := json.NewDecoder(r)
 	return func(yield func(jsonmessage.JSONMessage, error) bool) {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6545#discussion_r2417987918

When stubbing a client for tests, and there's no reader set, we just return an io.EOF, instead of panic.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

