### PR TITLE
client: Filters: add Clone method

### DIFF
--- a/client/filters.go
+++ b/client/filters.go
@@ -30,6 +30,19 @@ func (f Filters) Add(term string, values ...string) Filters {
 	return f
 }
 
+// Clone returns a deep copy of f.
+func (f Filters) Clone() Filters {
+	out := make(Filters, len(f))
+	for term, values := range f {
+		inner := make(map[string]bool, len(values))
+		for v, ok := range values {
+			inner[v] = ok
+		}
+		out[term] = inner
+	}
+	return out
+}
+
 // updateURLValues sets the "filters" key in values to the marshalled value of
 // f, replacing any existing values. When f is empty, any existing "filters" key
 // is removed.

--- a/client/filters_test.go
+++ b/client/filters_test.go
@@ -46,3 +46,26 @@ func TestFilters_UpdateURLValues(t *testing.T) {
 	Filters{"foo": map[string]bool{"bar": true}}.updateURLValues(v)
 	assert.Check(t, is.DeepEqual(v, url.Values{"filters": []string{`{"foo":{"bar":true}}`}}))
 }
+
+func TestFilters_Clone(t *testing.T) {
+	f1 := make(Filters).Add("foo", "one")
+	f2 := f1.Clone()
+
+	f2.Add("foo", "f2-extra").Add("f2", "f2-value")
+	assert.Check(t, is.DeepEqual(f1, Filters{"foo": {"one": true}}))
+	assert.Check(t, is.DeepEqual(f2, Filters{
+		"foo": {"one": true, "f2-extra": true},
+		"f2":  {"f2-value": true},
+	}))
+
+	f1.Add("foo", "f1-extra").Add("f1", "f1-value")
+	assert.Check(t, is.DeepEqual(f1, Filters{
+		"foo": {"one": true, "f1-extra": true},
+		"f1":  {"f1-value": true},
+	}))
+
+	assert.Check(t, is.DeepEqual(f2, Filters{
+		"foo": {"one": true, "f2-extra": true},
+		"f2":  {"f2-value": true},
+	}))
+}

--- a/vendor/github.com/moby/moby/client/filters.go
+++ b/vendor/github.com/moby/moby/client/filters.go
@@ -30,6 +30,19 @@ func (f Filters) Add(term string, values ...string) Filters {
 	return f
 }
 
+// Clone returns a deep copy of f.
+func (f Filters) Clone() Filters {
+	out := make(Filters, len(f))
+	for term, values := range f {
+		inner := make(map[string]bool, len(values))
+		for v, ok := range values {
+			inner[v] = ok
+		}
+		out[term] = inner
+	}
+	return out
+}
+
 // updateURLValues sets the "filters" key in values to the marshalled value of
 // f, replacing any existing values. When f is empty, any existing "filters" key
 // is removed.


### PR DESCRIPTION
This method returns a deep-copy of the filter, which can be used in situations where the original filter must not be mutated, but additional filters need to be added for a specific request.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

