### PR TITLE
quota: enable detect project quota for other filesystem.

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -185,16 +185,11 @@ func Init(home string, options []string, idMap user.IdentityMapping) (graphdrive
 
 	d.naiveDiff = graphdriver.NewNaiveDiffDriver(d, idMap)
 
-	if backingFs == "xfs" {
-		// Try to enable project quota support over xfs.
-		if d.quotaCtl, err = quota.NewControl(home); err == nil {
-			projectQuotaSupported = true
-		} else if opts.quota.Size > 0 {
-			return nil, fmt.Errorf("Storage option overlay2.size not supported. Filesystem does not support Project Quota: %v", err)
-		}
+	// Try to enable project quota support when fs project quota enabled.
+	if d.quotaCtl, err = quota.NewControl(home); err == nil {
+		projectQuotaSupported = true
 	} else if opts.quota.Size > 0 {
-		// if xfs is not the backing fs then error out if the storage-opt overlay2.size is used.
-		return nil, fmt.Errorf("Storage Option overlay2.size only supported for backingFS XFS. Found %v", backingFs)
+		return nil, fmt.Errorf("Storage option overlay2.size not supported. Filesystem does not support Project Quota: %v", err)
 	}
 
 	// figure out whether "index=off" option is recognized by the kernel


### PR DESCRIPTION
syscall for xfs apply to ext4 also

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

enable project quota detect for other filesystem, which enable storage-opt size limit on other filesystem

**- How I did it**

remove `if fs == "xfs"` before detect quota

**- How to verify it**

for ext4:
```
# quotaon -p /dev/vdb1 # or other block device for enable ext4 project quota
# dockerd --data-root /foo/docker # on ext4 device 
```
```
# docker run -it --rm --storage-opt size=100MB debian dd if=/dev/zero of=/abc
```
will produce like
```
dd: writing to '/abc': Disk quota exceeded
204745+0 records in
204744+0 records out
104828928 bytes (105 MB, 100 MiB) copied, 0.629145 s, 167 MB/s
```
**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

