### PR TITLE
Dockerfile: update containerd binary to v2.1.4 (static binaries and CI only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,7 +163,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # integration tests. The distributed docker .deb and .rpm packages depend on a
 # separate (containerd.io) package, which may be a different version as is
 # specified here.
-ARG CONTAINERD_VERSION=v1.7.28
+ARG CONTAINERD_VERSION=v2.1.4
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,7 @@ ARG GOTESTSUM_VERSION=v1.13.0
 
 # GOWINRES_VERSION is the version of go-winres to install.
 ARG GOWINRES_VERSION=v0.3.3
-ARG CONTAINERD_VERSION=v1.7.28
+ARG CONTAINERD_VERSION=v2.1.4
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -10,7 +10,7 @@ set -e
 # as is specified here.
 #
 # Generally, the commit specified here should match a tagged release.
-: "${CONTAINERD_VERSION:=v1.7.28}"
+: "${CONTAINERD_VERSION:=v2.1.4}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
### Dockerfile: update containerd binary to v2.1.4 (static binaries and CI only)

Update the containerd binary that's used in CI and static binaries

- full diff: https://github.com/containerd/containerd/compare/v1.7.28...v2.1.4
- release notes: https://github.com/containerd/containerd/releases/tag/v2.1.4

```markdown changelog
Update containerd (static binaries only) to [v2.1.4](https://github.com/containerd/containerd/releases/tag/v2.1.4)
```
