### PR TITLE
gha/labeler: disable sync-labels to preserve human-added labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Labels
         uses: actions/labeler@v6
         with:
-          sync-labels: true
+          sync-labels: false


### PR DESCRIPTION
The sync-labels option was causing the labeler action to remove labels that were manually added by humans.