### PR TITLE
integration-cli: migrate test api error json

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -41,16 +41,6 @@ func (s *DockerAPISuite) TestAPIGetEnabledCORS(c *testing.T) {
 	// assert.Equal(c, res.Header.Get("Access-Control-Allow-Headers"), "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
 }
 
-func (s *DockerAPISuite) TestAPIErrorJSON(c *testing.T) {
-	httpResp, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.JSONBody(struct{}{}))
-	assert.NilError(c, err)
-	assert.Equal(c, httpResp.StatusCode, http.StatusBadRequest)
-	assert.Assert(c, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
-	b, err := request.ReadBody(body)
-	assert.NilError(c, err)
-	assert.Check(c, is.Contains(getErrorMessage(c, b), "config cannot be empty"))
-}
-
 func (s *DockerAPISuite) TestAPIErrorNotFoundJSON(c *testing.T) {
 	// 404 is a different code path to normal errors, so test separately
 	httpResp, body, err := request.Get(testutil.GetContext(c), "/notfound", request.JSON)

--- a/integration/system/api_test.go
+++ b/integration/system/api_test.go
@@ -1,0 +1,21 @@
+package system
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moby/moby/v2/internal/testutil/request"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestAPIErrorJSON(t *testing.T) {
+	ctx := setupTest(t)
+	httpResp, body, err := request.Post(ctx, "/containers/create", request.JSONBody(struct{}{}))
+	assert.NilError(t, err)
+	assert.Equal(t, httpResp.StatusCode, http.StatusBadRequest)
+	assert.Assert(t, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
+	b, err := request.ReadBody(body)
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(getErrorMessage(t, b), "config cannot be empty"))
+}

--- a/integration/system/utils_test.go
+++ b/integration/system/utils_test.go
@@ -1,0 +1,18 @@
+package system
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/api/types/common"
+	"gotest.tools/v3/assert"
+)
+
+// getErrorMessage returns the error message from an error API response
+func getErrorMessage(t *testing.T, body []byte) string {
+	t.Helper()
+	var resp common.ErrorResponse
+	assert.NilError(t, json.Unmarshal(body, &resp))
+	return strings.TrimSpace(resp.Message)
+}


### PR DESCRIPTION
- What I did

Migrated the TestAPIErrorJSON to integration tests in reference to the integration-cli migration epic https://github.com/moby/moby/issues/50159

- How I did it

Using test on integration-cli/docker_api_test.go

- How to verify it

Run the integration test