### PR TITLE
api/types/sytem: remove deprecated DiskUsage.BuilderSize

### DIFF
--- a/api/types/system/disk_usage.go
+++ b/api/types/system/disk_usage.go
@@ -24,10 +24,9 @@ const (
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {
-	LayersSize  int64
-	Images      []*image.Summary
-	Containers  []*container.Summary
-	Volumes     []*volume.Volume
-	BuildCache  []*build.CacheRecord
-	BuilderSize int64 `json:",omitempty"` // Deprecated: deprecated in API 1.38, and no longer used since API 1.40.
+	LayersSize int64
+	Images     []*image.Summary
+	Containers []*container.Summary
+	Volumes    []*volume.Volume
+	BuildCache []*build.CacheRecord
 }

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -246,7 +246,6 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 	if du.BuildCache != nil {
 		v.BuildCache = du.BuildCache.Items
 	}
-	v.BuilderSize = builderSize
 	return httputils.WriteJSON(w, http.StatusOK, v)
 }
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/32677
- https://github.com/moby/moby/pull/37151
- https://github.com/moby/moby/pull/42608


### api/types/sytem: remove deprecated DiskUsage.BuilderSize

The `DiskUsage.BuilderSize` field was added as part of the, then experimental, BuildKit builder in [moby@5c3d2d5] (API v1.31). It was deprecated in API v1.32 (through [moby@b225258]) but that change still returned the field. Commit [moby@31348af] removed it in API v1.42. This field was never documented, and part of an experimental feature, so we can remove it altogether.

[moby@5c3d2d5]: https://github.com/moby/moby/commit/5c3d2d552b0430672d5f481ab2d37036f6e92166
[moby@b225258]: https://github.com/moby/moby/commit/b225258496f3ec8b6906b3fc6a3a2c76e50502d9
[moby@31348af]: https://github.com/moby/moby/commit/31348afa194eaff0ef9639a0c5aefa6bce4ef4b1

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/sytem: remove deprecated `DiskUsage.BuilderSize`
```

**- A picture of a cute animal (not mandatory but encouraged)**

