### PR TITLE
api/types/swarm: remove deprecated ServiceSpec.Networks field

### DIFF
--- a/api/types/swarm/service.go
+++ b/api/types/swarm/service.go
@@ -35,12 +35,7 @@ type ServiceSpec struct {
 	Mode           ServiceMode   `json:",omitempty"`
 	UpdateConfig   *UpdateConfig `json:",omitempty"`
 	RollbackConfig *UpdateConfig `json:",omitempty"`
-
-	// Networks specifies which networks the service should attach to.
-	//
-	// Deprecated: This field is deprecated since v1.44. The Networks field in TaskSpec should be used instead.
-	Networks     []NetworkAttachmentConfig `json:",omitempty"`
-	EndpointSpec *EndpointSpec             `json:",omitempty"`
+	EndpointSpec   *EndpointSpec `json:",omitempty"`
 }
 
 // ServiceMode represents the mode of a service.

--- a/daemon/cluster/networks.go
+++ b/daemon/cluster/networks.go
@@ -328,12 +328,7 @@ func (c *Cluster) RemoveNetwork(input string) error {
 }
 
 func (c *Cluster) populateNetworkID(ctx context.Context, client swarmapi.ControlClient, s *types.ServiceSpec) error {
-	// Always prefer NetworkAttachmentConfigs from TaskTemplate
-	// but fallback to service spec for backward compatibility
 	networks := s.TaskTemplate.Networks
-	if len(networks) == 0 {
-		networks = s.Networks //nolint:staticcheck // ignore SA1019: field is deprecated.
-	}
 	for i, nw := range networks {
 		apiNetwork, err := getNetwork(ctx, client, nw.Target, nil)
 		if err != nil {

--- a/daemon/server/router/swarm/helpers.go
+++ b/daemon/server/router/swarm/helpers.go
@@ -73,7 +73,7 @@ func (sr *swarmRouter) swarmLogs(ctx context.Context, w http.ResponseWriter, r *
 
 // adjustForAPIVersion takes a version and service spec and removes fields to
 // make the spec compatible with the specified version.
-func adjustForAPIVersion(cliVersion string, service *swarm.ServiceSpec) {
+func adjustForAPIVersion(cliVersion string, service *serviceWithLegacy) {
 	if cliVersion == "" {
 		return
 	}
@@ -142,6 +142,25 @@ func adjustForAPIVersion(cliVersion string, service *swarm.ServiceSpec) {
 				service.TaskTemplate.ContainerSpec.Healthcheck.StartInterval = 0
 			}
 		}
+
+		// Always prefer NetworkAttachmentConfigs from TaskTemplate
+		// but fallback to service spec for backward compatibility.
+		//
+		// The ServiceSpec.Networks field was deprecated in API v1.25, with
+		// the deprecation notice updated in API v1.44. We only consider this
+		// field on API < v1.44 and if the replacement TaskSpec.Networks is
+		// not set.
+		if len(service.TaskTemplate.Networks) == 0 && len(service.Networks) > 0 {
+			service.TaskTemplate.Networks = make([]swarm.NetworkAttachmentConfig, 0, len(service.Networks))
+			for _, n := range service.Networks {
+				service.TaskTemplate.Networks = append(service.TaskTemplate.Networks, swarm.NetworkAttachmentConfig{
+					Target:     n.Target,
+					Aliases:    n.Aliases,
+					DriverOpts: n.DriverOpts,
+				})
+			}
+		}
+
 	}
 
 	if versions.LessThan(cliVersion, "1.46") {

--- a/daemon/server/router/swarm/helpers_test.go
+++ b/daemon/server/router/swarm/helpers_test.go
@@ -14,7 +14,7 @@ func TestAdjustForAPIVersion(t *testing.T) {
 	// testing the negative -- does this leave everything else alone? -- is
 	// prohibitively time-consuming to write, because it would need an object
 	// with literally every field filled in.
-	spec := &swarm.ServiceSpec{
+	serviceSpec := swarm.ServiceSpec{
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: &swarm.ContainerSpec{
 				Sysctls: expectedSysctls,
@@ -70,6 +70,9 @@ func TestAdjustForAPIVersion(t *testing.T) {
 		},
 	}
 
+	spec := &serviceWithLegacy{
+		ServiceSpec: serviceSpec,
+	}
 	adjustForAPIVersion("1.46", spec)
 	if !reflect.DeepEqual(
 		spec.TaskTemplate.ContainerSpec.Mounts[0].TmpfsOptions.Options,

--- a/vendor/github.com/moby/moby/api/types/swarm/service.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/service.go
@@ -35,12 +35,7 @@ type ServiceSpec struct {
 	Mode           ServiceMode   `json:",omitempty"`
 	UpdateConfig   *UpdateConfig `json:",omitempty"`
 	RollbackConfig *UpdateConfig `json:",omitempty"`
-
-	// Networks specifies which networks the service should attach to.
-	//
-	// Deprecated: This field is deprecated since v1.44. The Networks field in TaskSpec should be used instead.
-	Networks     []NetworkAttachmentConfig `json:",omitempty"`
-	EndpointSpec *EndpointSpec             `json:",omitempty"`
+	EndpointSpec   *EndpointSpec `json:",omitempty"`
 }
 
 // ServiceMode represents the mode of a service.


### PR DESCRIPTION
relates to:

- https://github.com/docker-archive-public/docker.engine-api/pull/380
- https://github.com/moby/moby/pull/26200
- https://github.com/moby/moby/pull/25962
- [x] depends on / stacked on https://github.com/moby/moby/pull/51212


### api/types/swarm: remove deprecated ServiceSpec.Networks field

This field was deprecated in [engine-api@5c4b684], which got vendored into Moby in [moby@8f7a8c7] (API v1.25), and wired up in [moby@99a98cc].

[engine-api@5c4b684]: https://github.com/docker-archive-public/docker.engine-api/commit/5c4b684b2f2e836144951e96bbb52c66804498c3
[moby@8f7a8c7]: https://github.com/moby/moby/commit/8f7a8c75ae251f1260299892c5de7c83224b110e
[moby@99a98cc]: https://github.com/moby/moby/commit/99a98ccc14a9427be47c8006e130750710db0a16


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types/swarm: remove deprecated ServiceSpec.Networks field
```

**- A picture of a cute animal (not mandatory but encouraged)**

