### PR TITLE
api/types/build: remove deprecated BuildCache.Parent field

### DIFF
--- a/api/types/build/cache.go
+++ b/api/types/build/cache.go
@@ -8,10 +8,6 @@ import (
 type CacheRecord struct {
 	// ID is the unique ID of the build cache record.
 	ID string
-	// Parent is the ID of the parent build cache record.
-	//
-	// Deprecated: deprecated in API v1.42 and up, as it was deprecated in BuildKit; use Parents instead.
-	Parent string `json:"Parent,omitempty"`
 	// Parents is the list of parent build cache record IDs.
 	Parents []string `json:" Parents,omitempty"`
 	// Type is the cache record type.

--- a/daemon/internal/builder-next/builder.go
+++ b/daemon/internal/builder-next/builder.go
@@ -160,7 +160,6 @@ func (b *Builder) DiskUsage(ctx context.Context) ([]*build.CacheRecord, error) {
 	for _, r := range duResp.Record {
 		items = append(items, &build.CacheRecord{
 			ID:          r.ID,
-			Parent:      r.Parent, //nolint:staticcheck // ignore SA1019 (Parent field is deprecated)
 			Parents:     r.Parents,
 			Type:        r.RecordType,
 			Description: r.Description,

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -201,15 +201,6 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 	if versions.LessThan(version, "1.42") {
 		for _, b := range buildCache {
 			builderSize += b.Size
-			// Parents field was added in API 1.42 to replace the Parent field.
-			b.Parents = nil
-		}
-	}
-	if versions.GreaterThanOrEqualTo(version, "1.42") {
-		for _, b := range buildCache {
-			// Parent field is deprecated in API v1.42 and up, as it is deprecated
-			// in BuildKit. Empty the field to omit it in the API response.
-			b.Parent = "" //nolint:staticcheck // ignore SA1019 (Parent field is deprecated)
 		}
 	}
 	if versions.LessThan(version, "1.44") && systemDiskUsage != nil && systemDiskUsage.Images != nil {

--- a/vendor/github.com/moby/moby/api/types/build/cache.go
+++ b/vendor/github.com/moby/moby/api/types/build/cache.go
@@ -8,10 +8,6 @@ import (
 type CacheRecord struct {
 	// ID is the unique ID of the build cache record.
 	ID string
-	// Parent is the ID of the parent build cache record.
-	//
-	// Deprecated: deprecated in API v1.42 and up, as it was deprecated in BuildKit; use Parents instead.
-	Parent string `json:"Parent,omitempty"`
 	// Parents is the list of parent build cache record IDs.
 	Parents []string `json:" Parents,omitempty"`
 	// Type is the cache record type.


### PR DESCRIPTION
relates to

- https://github.com/moby/moby/pull/43631
- https://github.com/moby/buildkit/pull/2335



The BuildCache.Parent field was removed in API v1.42 in [moby@e0db820]. While we had to keep the Go struct field around to backfill the field for older API versions, it's no longer part of API v1.42 and up (using the "omitempty" is just an implementation detail).

Older clients unconditionally use the `Parents` field if set, and usage of this field is very limited, so let's remove the field without back- filling, and have clients use the replacement field; https://github.com/docker/cli/blob/v28.5.1/cli/command/formatter/buildcache.go

[moby@e0db820]: https://github.com/moby/moby/commit/e0db8207f3b84d030a71f41db70fc7fbf0535b9f

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types/build: remove deprecated BuildCache.Parent field
```

**- A picture of a cute animal (not mandatory but encouraged)**

