### PR TITLE
daemon: raise default minimum API version to v1.44

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -344,8 +344,11 @@ jobs:
               "--register-service"
           If ("${{ inputs.storage }}" -eq "graphdriver") {
             # Make the env-var visible to the service-managed dockerd, as there's no CLI flag for this option.
-            & reg add "HKLM\SYSTEM\CurrentControlSet\Services\docker" /v Environment /t REG_MULTI_SZ /s '@' /d TEST_INTEGRATION_USE_GRAPHDRIVER=1
+            & reg add "HKLM\SYSTEM\CurrentControlSet\Services\docker" /v Environment /t REG_MULTI_SZ /s '@' /d "DOCKER_MIN_API_VERSION=1.24@TEST_INTEGRATION_USE_GRAPHDRIVER=1"
             echo "TEST_INTEGRATION_USE_GRAPHDRIVER=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          } Else {
+            # Make the env-var visible to the service-managed dockerd, as there's no CLI flag for this option.
+            & reg add "HKLM\SYSTEM\CurrentControlSet\Services\docker" /v Environment /t REG_MULTI_SZ /s '@' /d DOCKER_MIN_API_VERSION=1.24
           }
           Write-Host "Starting service"
           Start-Service -Name docker

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -59,10 +59,12 @@ const (
 	//
 	// This version may be lower than the version of the api library module used.
 	MaxAPIVersion = "1.52"
-	// MinAPIVersion is the minimum API version supported by the API.
+	// defaultMinAPIVersion is the minimum API version supported by the API.
 	// This version can be overridden through the "DOCKER_MIN_API_VERSION"
-	// environment variable. It currently defaults to the minimum API version
-	// implemented in the API module.
+	// environment variable. The minimum allowed version is determined
+	// by [MinAPIVersion].
+	defaultMinAPIVersion = "1.44"
+	// MinAPIVersion is the minimum API version supported by the daemon.
 	MinAPIVersion = "1.24"
 	// SeccompProfileDefault is the built-in default seccomp profile.
 	SeccompProfileDefault = "builtin"
@@ -339,7 +341,7 @@ func New() (*Config, error) {
 			ContainerdPluginNamespace: DefaultPluginNamespace,
 			Features:                  make(map[string]bool),
 			DefaultRuntime:            StockRuntimeName,
-			MinAPIVersion:             MinAPIVersion,
+			MinAPIVersion:             defaultMinAPIVersion,
 		},
 	}
 

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -43,6 +43,9 @@ exec 41>&1 42>&2
 export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-native}
 export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
 
+# Allow testing old API versions
+export DOCKER_MIN_API_VERSION=1.24
+
 # example usage: DOCKER_STORAGE_OPTS="dm.basesize=20G,dm.loopdatasize=200G"
 storage_params=""
 if [ -n "$DOCKER_STORAGE_OPTS" ]; then

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -26,7 +26,7 @@ type Daemon struct {
 // The daemon will not automatically start.
 func New(t testing.TB, dockerBinary string, dockerdBinary string, ops ...daemon.Option) *Daemon {
 	t.Helper()
-	ops = append(ops, daemon.WithDockerdBinary(dockerdBinary))
+	ops = append(ops, daemon.WithDockerdBinary(dockerdBinary), daemon.WithEnvVars("DOCKER_MIN_API_VERSION=1.24"))
 	d := daemon.New(t, ops...)
 	return &Daemon{
 		Daemon:       d,

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -138,7 +138,7 @@ func TestCgroupNamespacesRunOlderClient(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t, daemon.WithDefaultCgroupNamespaceMode("private"))
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_MIN_API_VERSION=1.39"), daemon.WithDefaultCgroupNamespaceMode("private"))
 	apiClient := d.NewClientT(t, client.WithVersion("1.39"))
 
 	d.StartWithBusybox(ctx, t)

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
-	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/integration/internal/container"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -255,7 +253,7 @@ func TestAPIImagesListManifests(t *testing.T) {
 
 	t.Run("unsupported before 1.47", func(t *testing.T) {
 		// TODO: Remove when MinAPIVersion >= 1.47
-		c := d.NewClientT(t, client.WithVersion(config.MinAPIVersion))
+		c := d.NewClientT(t, client.WithVersion("1.46"))
 
 		images, err := c.ImageList(ctx, client.ImageListOptions{Manifests: true})
 		assert.NilError(t, err)
@@ -263,8 +261,6 @@ func TestAPIImagesListManifests(t *testing.T) {
 		assert.Assert(t, is.Len(images, 1))
 		assert.Check(t, is.Nil(images[0].Manifests))
 	})
-
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.47"))
 
 	api147 := d.NewClientT(t, client.WithVersion("1.47"))
 

--- a/integration/networking/mac_addr_test.go
+++ b/integration/networking/mac_addr_test.go
@@ -146,7 +146,7 @@ func TestInspectCfgdMAC(t *testing.T) {
 
 	ctx := setupTest(t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_MIN_API_VERSION=1.43"))
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
@@ -241,7 +241,7 @@ func TestWatchtowerCreate(t *testing.T) {
 
 	ctx := setupTest(t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_MIN_API_VERSION=1.25"))
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 

--- a/integration/service/network_linux_test.go
+++ b/integration/service/network_linux_test.go
@@ -28,7 +28,7 @@ import (
 func TestDockerNetworkConnectAliasPreV144(t *testing.T) {
 	ctx := setupTest(t)
 
-	d := swarm.NewSwarm(ctx, t, testEnv)
+	d := swarm.NewSwarm(ctx, t, testEnv, daemon.WithEnvVars("DOCKER_MIN_API_VERSION=1.43"))
 	defer d.Stop(t)
 	apiClient := d.NewClientT(t, client.WithVersion("1.43"))
 	defer apiClient.Close()


### PR DESCRIPTION
- relates to 96b29f5a1f7fc5e5d8b2b4dbd130e215bbb92ae9 https://github.com/moby/moby/pull/51119
- similar to 08e4e88482d640b9543d4ba6332109e6b6f2495d https://github.com/moby/moby/pull/46887

The daemon currently provides support for API versions all the way back to v1.24, which is the version of the API that shipped with docker 1.12.0 (released in 2016).

Such old versions of the client are rare, and supporting older API versions has accumulated significant amounts of code to remain backward-compatible (which is largely untested, and a "best-effort" at most).

This patch updates the minimum API version to v1.44, matching the minimum version of the client, and matching the API version of docker v25.0, which is the oldest supported version (through Mirantis MCR).

The intent is to start deprecating older API versions when daemons implementing them reach EOL. This patch does not yet remove backward-compatibility code for older API versions, and the DOCKER_MIN_API_VERSION environment variable allows overriding the minimum version (to allow restoring the behavior from before this patch), however, API versions below v1.44 should be considered "best effort", and we may remove compatibility code to provide "degraded" support.

With this patch the daemon defaults to API v1.44 as minimum:

    docker version
    Client:
     Version:           28.5.0
     API version:       1.51
     Go version:        go1.24.7
     Git commit:        887030f
     Built:             Thu Oct  2 14:54:39 2025
     OS/Arch:           linux/arm64
     Context:           default

    Server:
     Engine:
      Version:          dev
      API version:      1.52 (minimum version 1.44)
    ....

Trying to use an older version of the API produces an error:

    DOCKER_API_VERSION=1.43 docker version
    Client:
     Version:           28.5.0
     API version:       1.43 (downgraded from 1.51)
     Go version:        go1.24.7
     Git commit:        887030f
     Built:             Thu Oct  2 14:54:39 2025
     OS/Arch:           linux/arm64
     Context:           default
    Error response from daemon: client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version

To restore the previous minimum, users can start the daemon with the DOCKER_MIN_API_VERSION environment variable set:

    DOCKER_MIN_API_VERSION=1.24 dockerd

API 1.24 is the oldest supported API version;

    docker version
    Client:
     Version:           28.5.0
     API version:       1.24 (downgraded from 1.51)
     Go version:        go1.24.7
     Git commit:        887030f
     Built:             Thu Oct  2 14:54:39 2025
     OS/Arch:           linux/arm64
     Context:           default

    Server:
     Engine:
      Version:          dev
      API version:      1.52 (minimum version 1.24)
    ....

When using the `DOCKER_MIN_API_VERSION` with a version of the API that is not supported, an error is produced when starting the daemon;

    DOCKER_MIN_API_VERSION=1.23 dockerd --validate
    invalid DOCKER_MIN_API_VERSION: minimum supported API version is 1.24: 1.23

    DOCKER_MIN_API_VERSION=1.99 dockerd --validate
    invalid DOCKER_MIN_API_VERSION: maximum supported API version is 1.52: 1.99

Specifying a malformed API version also produces the same error;

    DOCKER_MIN_API_VERSION=hello dockerd --validate
    invalid DOCKER_MIN_API_VERSION: minimum supported API version is 1.24: hello

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
daemon: raise default minimum API version to v1.44
```

**- A picture of a cute animal (not mandatory but encouraged)**

