### PR TITLE
integration: remove some version-gates for API < v1.44

### DIFF
--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -696,7 +696,6 @@ func TestCreateWithMultipleEndpointSettings(t *testing.T) {
 
 func TestCreateWithCustomMACs(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "requires API v1.44")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/container/exec_linux_test.go
+++ b/integration/container/exec_linux_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"gotest.tools/v3/assert"
@@ -13,7 +12,6 @@ import (
 
 func TestExecConsoleSize(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.42"), "skip test from new feature")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -301,7 +300,6 @@ func TestDaemonIpcModeShareableFromConfig(t *testing.T) {
 // by default, even when the daemon default is private.
 func TestIpcModeOlderClient(t *testing.T) {
 	apiClient := testEnv.APIClient()
-	skip.If(t, versions.LessThan(apiClient.ClientVersion(), "1.40"), "requires client API >= 1.40")
 
 	t.Parallel()
 

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	containertypes "github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	net "github.com/moby/moby/v2/integration/internal/network"
@@ -174,7 +173,6 @@ func TestPrivilegedHostDevices(t *testing.T) {
 
 func TestRunConsoleSize(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.42"), "skip test from new feature")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/integration/internal/container"
@@ -263,8 +262,6 @@ func TestAPIImagesListManifests(t *testing.T) {
 		assert.Assert(t, is.Len(images, 1))
 		assert.Check(t, is.Nil(images[0].Manifests))
 	})
-
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.47"))
 
 	api147 := d.NewClientT(t, client.WithVersion("1.47"))
 

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cpuguy83/tar2go"
 	"github.com/moby/go-archive/compression"
-	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
@@ -91,8 +90,6 @@ func TestSaveCheckTimes(t *testing.T) {
 
 // Regression test for https://github.com/moby/moby/issues/47065
 func TestSaveOCI(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "OCI layout support was introduced in v25")
-
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
@@ -32,8 +31,6 @@ import (
 )
 
 func TestCreateWithMultiNetworks(t *testing.T) {
-	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "requires API v1.44")
-
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 


### PR DESCRIPTION
We don't run these tests against older daemons, but if we would, we no longer have to consider API < v1.44 as versions of the daemon below v25.0 reached EOL.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

