### PR TITLE
api/types/container: remove support for config mac address

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -54,6 +54,9 @@ keywords: "API, Docker, rcli, REST, documentation"
 * Removed the `KernelMemoryTCP` field from the `GET /info` endpoint.
 * `GET /events` supports content-type negotiation and can produce either `application/x-ndjson` 
   (Newline delimited JSON object stream) or `application/json-seq` (RFC7464).
+* `POST /containers/create` no longer supports configuring a container-wide MAC address
+  via the container's `Config.MacAddress` field. A container's MAC address can now only 
+  be configured via endpoint settings when connecting to a network.
 
 ## v1.51 API changes
 

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -1390,13 +1390,6 @@ definitions:
         description: "Disable networking for the container."
         type: "boolean"
         x-nullable: true
-      MacAddress:
-        description: |
-          MAC address of the container.
-
-          Deprecated: this field is deprecated in API v1.44 and up. Use EndpointSettings.MacAddress instead.
-        type: "string"
-        x-nullable: true
       OnBuild:
         description: |
           `ONBUILD` metadata that were defined in the image's `Dockerfile`.
@@ -7882,7 +7875,6 @@ paths:
                 /volumes/data: {}
               WorkingDir: ""
               NetworkDisabled: false
-              MacAddress: "12:34:56:78:9a:bc"
               ExposedPorts:
                 22/tcp: {}
               StopSignal: "SIGTERM"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1390,13 +1390,6 @@ definitions:
         description: "Disable networking for the container."
         type: "boolean"
         x-nullable: true
-      MacAddress:
-        description: |
-          MAC address of the container.
-
-          Deprecated: this field is deprecated in API v1.44 and up. Use EndpointSettings.MacAddress instead.
-        type: "string"
-        x-nullable: true
       OnBuild:
         description: |
           `ONBUILD` metadata that were defined in the image's `Dockerfile`.
@@ -7882,7 +7875,6 @@ paths:
                 /volumes/data: {}
               WorkingDir: ""
               NetworkDisabled: false
-              MacAddress: "12:34:56:78:9a:bc"
               ExposedPorts:
                 22/tcp: {}
               StopSignal: "SIGTERM"

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
 	// Mac Address of the container.
 	//
-	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
+	// Deprecated: this field is deprecated since API v1.44 and obsolete since v1.52. Use EndpointSettings.MacAddress instead.
 	MacAddress  string            `json:",omitempty"`
 	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
 	Labels      map[string]string // List of labels set to this container

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -760,6 +760,11 @@ func handleMACAddressBC(config *container.Config, hostConfig *container.HostConf
 	if deprecatedMacAddress == "" {
 		return "", nil
 	}
+
+	if versions.GreaterThanOrEqualTo(version, "1.52") {
+		return "", errdefs.InvalidParameter(errors.New("container-wide MAC address no longer supported; use endpoint-specific MAC address instead"))
+	}
+
 	var warning string
 	if hostConfig.NetworkMode.IsBridge() || hostConfig.NetworkMode.IsUserDefined() {
 		ep, err := epConfigForNetMode(version, hostConfig.NetworkMode, networkingConfig)

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
 	// Mac Address of the container.
 	//
-	// Deprecated: this field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
+	// Deprecated: this field is deprecated since API v1.44 and obsolete since v1.52. Use EndpointSettings.MacAddress instead.
 	MacAddress  string            `json:",omitempty"`
 	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
 	Labels      map[string]string // List of labels set to this container


### PR DESCRIPTION
**- What I did**
Alternative to #51152

This change stops daemon support for the container config MacAddress field. Clients specifying the field will now receive an error for API v1.52 and onwards.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/container: make the container config `MacAddress` obsolete for v1.52 and onwards. Use network endpoint settings instead.
```

**- A picture of a cute animal (not mandatory but encouraged)**

