### PR TITLE
api/types/image: remove deprecated Summary.VirtualSize field

### DIFF
--- a/api/types/image/summary.go
+++ b/api/types/image/summary.go
@@ -3,7 +3,6 @@ package image
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 type Summary struct {
-
 	// Number of containers using this image. Includes both stopped and running
 	// containers.
 	//
@@ -93,9 +92,4 @@ type Summary struct {
 	//
 	// Required: true
 	Size int64 `json:"Size"`
-
-	// Total size of the image including all layers it is composed of.
-	//
-	// Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
-	VirtualSize int64 `json:"VirtualSize,omitempty"`
 }

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -501,7 +501,6 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 	}
 
 	useNone := versions.LessThan(version, "1.43")
-	withVirtualSize := versions.LessThan(version, "1.44")
 	noDescriptor := versions.LessThan(version, "1.48")
 	noContainers := versions.LessThan(version, "1.51")
 	for _, img := range images {
@@ -517,9 +516,6 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 			if img.RepoDigests == nil {
 				img.RepoDigests = []string{}
 			}
-		}
-		if withVirtualSize {
-			img.VirtualSize = img.Size //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
 		}
 		if noDescriptor {
 			img.Descriptor = nil

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -203,11 +203,6 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 			builderSize += b.Size
 		}
 	}
-	if versions.LessThan(version, "1.44") && systemDiskUsage != nil && systemDiskUsage.Images != nil {
-		for _, b := range systemDiskUsage.Images.Items {
-			b.VirtualSize = b.Size //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
-		}
-	}
 
 	du := backend.DiskUsage{}
 	if getBuildCache {

--- a/vendor/github.com/moby/moby/api/types/image/summary.go
+++ b/vendor/github.com/moby/moby/api/types/image/summary.go
@@ -3,7 +3,6 @@ package image
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 type Summary struct {
-
 	// Number of containers using this image. Includes both stopped and running
 	// containers.
 	//
@@ -93,9 +92,4 @@ type Summary struct {
 	//
 	// Required: true
 	Size int64 `json:"Size"`
-
-	// Total size of the image including all layers it is composed of.
-	//
-	// Deprecated: this field is omitted in API v1.44, but kept for backward compatibility. Use Size instead.
-	VirtualSize int64 `json:"VirtualSize,omitempty"`
 }


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/17924
- https://github.com/moby/moby/pull/45346
- https://github.com/moby/moby/pull/45469
- https://github.com/moby/moby/pull/51186
- https://github.com/moby/moby/pull/51119


### api/types/image: remove deprecated Summary.VirtualSize field

The `VirtualSize` field became redundant with the introduction of content- addressable images in docker v1.10 (4352da7803d182a6013a5238ce20a7c749db979a), after which the field was identical to the `Size` field. The field was marked to be deprecated, which happened in 1261fe69a3586bb102182aa885197822419c768c (API v1.43) and removed in API v1.44 (913b0f51cab18a56247a950f5f1e75ca79b63039).

Now that we stop supporting API versions older than v1.44, we can drop this field; it's a minor breakage of old API versions, but the same information is available in the "Size" field.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: api/types/image: remove deprecated Summary.VirtualSize field
```

**- A picture of a cute animal (not mandatory but encouraged)**

