### PR TITLE
libnetwork/osl/kernel: ApplyOSTweaks: don't log errors if not found

### DIFF
--- a/daemon/libnetwork/osl/kernel/knobs_linux.go
+++ b/daemon/libnetwork/osl/kernel/knobs_linux.go
@@ -32,14 +32,16 @@ func ApplyOSTweaks(osConfig map[string]*OSValue) {
 		// read the existing property from disk
 		oldv, err := readSystemProperty(k)
 		if err != nil {
-			log.G(context.TODO()).WithError(err).Errorf("error reading the kernel parameter %s", k)
+			if !os.IsNotExist(err) {
+				log.G(context.TODO()).WithError(err).Errorf("error reading the kernel parameter %s", k)
+			}
 			continue
 		}
 
 		if propertyIsValid(oldv, v.Value, v.CheckFn) {
 			// write new prop value to disk
 			if err := writeSystemProperty(k, v.Value); err != nil {
-				log.G(context.TODO()).WithError(err).Errorf("error setting the kernel parameter %s = %s, (leaving as %s)", k, v.Value, oldv)
+				log.G(context.TODO()).WithError(err).Warnf("error setting the kernel parameter %s = %s, (leaving as %s)", k, v.Value, oldv)
 				continue
 			}
 			log.G(context.TODO()).Debugf("updated kernel parameter %s = %s (was %s)", k, v.Value, oldv)


### PR DESCRIPTION
I noticed these errors logged inside the dev-container;

    ERRO[2025-10-14T16:15:46.603781797Z] error reading the kernel parameter net.ipv4.neigh.default.gc_thresh1  error="open /proc/sys/net/ipv4/neigh/default/gc_thresh1: no such file or directory"
    ERRO[2025-10-14T16:15:46.603808089Z] error reading the kernel parameter net.ipv4.neigh.default.gc_thresh2  error="open /proc/sys/net/ipv4/neigh/default/gc_thresh2: no such file or directory"
    ERRO[2025-10-14T16:15:46.603819922Z] error reading the kernel parameter net.ipv4.neigh.default.gc_thresh3  error="open /proc/sys/net/ipv4/neigh/default/gc_thresh3: no such file or directory"

Given that these happen during an initial check, we can probably ignore them if there's nothing to tweak.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

