### PR TITLE
feat:Add an environment variable switch for file mount checks

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -433,6 +433,14 @@ func ensureShared(path string) error {
 
 // Ensure mount point on which path is mounted, is either shared or slave.
 func ensureSharedOrSlave(path string) error {
+	// Skip mount check if SKIP_MOUNT_CHECK env is set to true.
+	// This is useful for testing environments where / is not a shared mount.
+	// Some minimalist Linux/Unix systems cannot pass this detection mechanism when using k8s, so you can choose to allow it.
+	// e.g. some CI systems, or when running inside a container.
+	skipMountCheck := strings.ToLower(os.Getenv("SKIP_MOUNT_CHECK"))
+	if skipMountCheck == "true" || skipMountCheck == "1" {
+		return nil
+	}
 	sourceMount, optionalOpts, err := getSourceMount(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Introduced the environment variable `SKIP_MOUNT_CHECK` to bypass the validation of whether the host path mount point is shared or slave.

**- How I did it**

Added a conditional check in the mount propagation validation logic. If the environment variable `SKIP_MOUNT_CHECK` is set to `"true"` or `"1"`, the validation is skipped.

**- How to verify it**

1. Set the environment variable before starting containerd:
   ```bash
   export SKIP_MOUNT_CHECK=true
   ```
2. Run a container with volume mounts on a system where `/` is not a shared mount.
3. Confirm that the container starts successfully without triggering mount propagation errors.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add SKIP_MOUNT_CHECK environment variable to bypass mount propagation validation for volume mounts
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="213" height="159" alt="image" src="https://github.com/user-attachments/assets/9e716b06-6adf-4bc4-ab5a-3446b6b1f46e" />
---

### Necessity
    When using HostToContainer or bidirectional mount propagation to mount volumes, containerd verifies that the underlying host mount has the correct propagation flags (such as rslave or rshared). This check is crucial for ensuring that volume mounts operate as expected according to the CRI specification. 
    However, in some systems, this verification may fail because by default, the root file system (/) is not configured as a shared mount or the system does not have a mount propagation mechanism. This situation is more common in some minimalist Linux distributions, certain CI/CD environments, and other operating systems such as HarmonyOS/OpenHarmonyOS. Some systems lack this mechanism, so containers with volume mounts can start smoothly and mount serial devices and folders without the need for detection. On these platforms, this check will prevent containers with volume mounts from starting. 
    By setting the environment variable SKIP_MOUNT_CHECK to true or 1, users can disable this validation. This provides a necessary workaround for these specific environments, allowing containers to run successfully. It should be used by users who understand the implications of mount propagation in their environment.

### 📎 Related issues

- [kubernetes/kubernetes#61058](https://github.com/kubernetes/kubernetes/issues/61058)
- [CSDN article on mount propagation limitations](https://devpress.csdn.net/cloudnative/66d54f190bfad230b8b362f2.html)
