### PR TITLE
api/types/container: remove deprecated Config.MacAddress

### DIFF
--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -42,13 +42,9 @@ type Config struct {
 	WorkingDir      string              // Current directory (PWD) in the command will be launched
 	Entrypoint      []string            // Entrypoint to run when starting the container
 	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
-	// Mac Address of the container.
-	//
-	// Deprecated: this field is deprecated since API v1.44 and obsolete since v1.52. Use EndpointSettings.MacAddress instead.
-	MacAddress  string            `json:",omitempty"`
-	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
-	Labels      map[string]string // List of labels set to this container
-	StopSignal  string            `json:",omitempty"` // Signal to stop a container
-	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell       []string          `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+	OnBuild         []string            `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
+	Labels          map[string]string   // List of labels set to this container
+	StopSignal      string              `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           []string            `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/client/container_create.go
+++ b/client/container_create.go
@@ -11,7 +11,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/api/types/versions"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -27,25 +26,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	if hostConfig != nil {
 		hostConfig.CapAdd = normalizeCapabilities(hostConfig.CapAdd)
 		hostConfig.CapDrop = normalizeCapabilities(hostConfig.CapDrop)
-	}
-
-	// FIXME(thaJeztah): remove this once we updated our (integration) tests;
-	//  some integration tests depend on this to test old API versions; see https://github.com/moby/moby/pull/51120#issuecomment-3376224865
-	if config.MacAddress != "" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		// Make sure we negotiated (if the client is configured to do so),
-		// as code below contains API-version specific handling of options.
-		//
-		// Normally, version-negotiation (if enabled) would not happen until
-		// the API request is made.
-		if err := cli.checkVersion(ctx); err != nil {
-			return response, err
-		}
-		if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.44") {
-			// Since API 1.44, the container-wide MacAddress is deprecated and triggers a WARNING if it's specified.
-			//
-			// FIXME(thaJeztah): remove the field from the API
-			config.MacAddress = "" //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		}
 	}
 
 	query := url.Values{}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -43,7 +43,7 @@ type Backend interface {
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
-	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (*container.InspectResponse, error)
+	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (_ *container.InspectResponse, desiredMACAddress string, _ error)
 	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	ContainerRm(name string, config *backend.ContainerRmConfig) error
 	ContainerKill(name string, sig string) error

--- a/daemon/cluster/executor/container/adapter.go
+++ b/daemon/cluster/executor/container/adapter.go
@@ -375,7 +375,7 @@ func (c *containerAdapter) start(ctx context.Context) error {
 }
 
 func (c *containerAdapter) inspect(ctx context.Context) (containertypes.InspectResponse, error) {
-	cs, err := c.backend.ContainerInspect(ctx, c.container.name(), backend.ContainerInspectOptions{})
+	cs, _, err := c.backend.ContainerInspect(ctx, c.container.name(), backend.ContainerInspectOptions{})
 	if ctx.Err() != nil {
 		return containertypes.InspectResponse{}, ctx.Err()
 	}

--- a/daemon/inspect_test.go
+++ b/daemon/inspect_test.go
@@ -26,10 +26,10 @@ func TestGetInspectData(t *testing.T) {
 	cfg := &configStore{}
 	d.configStore.Store(cfg)
 
-	_, err := d.getInspectData(&cfg.Config, c)
+	_, _, err := d.getInspectData(&cfg.Config, c)
 	assert.Check(t, is.ErrorContains(err, "RWLayer of container inspect-me is unexpectedly nil"))
 
 	c.State.Dead = true
-	_, err = d.getInspectData(&cfg.Config, c)
+	_, _, err = d.getInspectData(&cfg.Config, c)
 	assert.Check(t, err)
 }

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -48,7 +48,7 @@ type stateBackend interface {
 // monitorBackend includes functions to implement to provide containers monitoring functionality.
 type monitorBackend interface {
 	ContainerChanges(ctx context.Context, name string) ([]archive.Change, error)
-	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (*container.InspectResponse, error)
+	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (_ *container.InspectResponse, desiredMACAddress string, _ error)
 	ContainerLogs(ctx context.Context, name string, config *backend.ContainerLogsOptions) (msgs <-chan *backend.LogMessage, tty bool, err error)
 	ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error
 	ContainerTop(name string, psArgs string) (*container.TopResponse, error)

--- a/daemon/server/router/container/container_routes_test.go
+++ b/daemon/server/router/container/container_routes_test.go
@@ -120,9 +120,6 @@ func TestHandleMACAddressBC(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := &container.Config{
-				MacAddress: tc.ctrWideMAC, //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-			}
 			hostCfg := &container.HostConfig{
 				NetworkMode: tc.networkMode,
 			}
@@ -135,7 +132,7 @@ func TestHandleMACAddressBC(t *testing.T) {
 				EndpointsConfig: epConfig,
 			}
 
-			warning, err := handleMACAddressBC(cfg, hostCfg, netCfg, tc.apiVersion)
+			warning, err := handleMACAddressBC(hostCfg, netCfg, tc.apiVersion, tc.ctrWideMAC)
 
 			if tc.expError == "" {
 				assert.Check(t, err)
@@ -155,8 +152,6 @@ func TestHandleMACAddressBC(t *testing.T) {
 				got := netCfg.EndpointsConfig[tc.expEpWithNoMAC].MacAddress
 				assert.Check(t, is.Equal(got, ""))
 			}
-			gotCtrWideMAC := cfg.MacAddress //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-			assert.Check(t, is.Equal(gotCtrWideMAC, tc.expCtrWideMAC))
 		})
 	}
 }

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -360,12 +360,6 @@ func WithStopSignal(stopSignal string) func(c *TestContainerConfig) {
 	}
 }
 
-func WithContainerWideMacAddress(address string) func(c *TestContainerConfig) {
-	return func(c *TestContainerConfig) {
-		c.Config.MacAddress = address //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-	}
-}
-
 // WithHostConfig sets a custom [container.HostConfig] for the container.
 func WithHostConfig(hc *container.HostConfig) func(c *TestContainerConfig) {
 	return func(c *TestContainerConfig) {

--- a/integration/networking/mac_addr_test.go
+++ b/integration/networking/mac_addr_test.go
@@ -287,13 +287,15 @@ func TestWatchtowerCreate(t *testing.T) {
 	const ctrName = "ctr1"
 	const ctrIP = "172.30.0.2"
 	const ctrMAC = "02:42:ac:11:00:42"
-	id := container.Run(ctx, t, c,
+	opts := []func(*container.TestContainerConfig){
 		container.WithName(ctrName),
 		container.WithNetworkMode(netId),
-		container.WithContainerWideMacAddress(ctrMAC),
 		container.WithIPv4(netName, ctrIP),
-	)
+	}
+	id := createLegacyContainer(ctx, t, c, ctrMAC, opts...)
 	defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true})
+	err := c.ContainerStart(ctx, id, client.ContainerStartOptions{})
+	assert.NilError(t, err)
 
 	// Check that the container got the expected addresses.
 	inspect := container.Inspect(ctx, t, c, ctrName)

--- a/integration/networking/mac_addr_test.go
+++ b/integration/networking/mac_addr_test.go
@@ -1,15 +1,20 @@
 package networking
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
 	"net/netip"
 	"testing"
 
+	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/integration/internal/network"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
+	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/skip"
@@ -189,6 +194,8 @@ func TestInspectCfgdMAC(t *testing.T) {
 			var copts []client.Opt
 			if tc.ctrWide {
 				copts = append(copts, client.WithVersion("1.43"))
+			} else {
+				copts = append(copts, client.WithVersion("1.51"))
 			}
 			c := d.NewClientT(t, copts...)
 			defer c.Close()
@@ -213,21 +220,35 @@ func TestInspectCfgdMAC(t *testing.T) {
 			if tc.netName != "bridge" {
 				opts = append(opts, container.WithNetworkMode(tc.netName))
 			}
+			var id string
 			if tc.desiredMAC != "" {
 				if tc.ctrWide {
-					opts = append(opts, container.WithContainerWideMacAddress(tc.desiredMAC))
+					id = createLegacyContainer(ctx, t, c, tc.desiredMAC, opts...)
 				} else {
 					opts = append(opts, container.WithMacAddress(tc.netName, tc.desiredMAC))
+					id = container.Create(ctx, t, c, opts...)
 				}
+			} else {
+				id = container.Create(ctx, t, c, opts...)
 			}
-			id := container.Create(ctx, t, c, opts...)
 			defer c.ContainerRemove(ctx, id, client.ContainerRemoveOptions{
 				Force: true,
 			})
 
-			inspect := container.Inspect(ctx, t, c, ctrName)
-			configMAC := inspect.Config.MacAddress //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-			assert.Check(t, is.DeepEqual(configMAC, tc.desiredMAC))
+			_, raw, err := c.ContainerInspectWithRaw(ctx, id, false)
+			assert.NilError(t, err)
+			var inspect struct {
+				Config struct {
+					// Mac Address of the container.
+					//
+					// MacAddress field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
+					MacAddress string `json:",omitempty"`
+				}
+			}
+			err = json.Unmarshal(raw, &inspect)
+			assert.NilError(t, err, string(raw))
+			configMAC := inspect.Config.MacAddress
+			assert.Check(t, is.DeepEqual(configMAC, tc.desiredMAC), string(raw))
 		})
 	}
 }
@@ -279,4 +300,37 @@ func TestWatchtowerCreate(t *testing.T) {
 	netSettings := inspect.NetworkSettings.Networks[netName]
 	assert.Check(t, is.Equal(netSettings.IPAddress, netip.MustParseAddr(ctrIP)))
 	assert.Check(t, is.Equal(netSettings.MacAddress, ctrMAC))
+}
+
+type legacyCreateRequest struct {
+	containertypes.CreateRequest
+	// Mac Address of the container.
+	//
+	// MacAddress field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
+	MacAddress string `json:",omitempty"`
+}
+
+func createLegacyContainer(ctx context.Context, t *testing.T, apiClient client.APIClient, desiredMAC string, ops ...func(*container.TestContainerConfig)) string {
+	t.Helper()
+	config := container.NewTestConfig(ops...)
+	ep := "/v" + apiClient.ClientVersion() + "/containers/create"
+	if config.Name != "" {
+		ep += "?name=" + config.Name
+	}
+	res, _, err := request.Post(ctx, ep, request.Host(apiClient.DaemonHost()), request.JSONBody(&legacyCreateRequest{
+		CreateRequest: containertypes.CreateRequest{
+			Config:           config.Config,
+			HostConfig:       config.HostConfig,
+			NetworkingConfig: config.NetworkingConfig,
+		},
+		MacAddress: desiredMAC,
+	}))
+	assert.NilError(t, err)
+	buf, err := request.ReadBody(res.Body)
+	assert.NilError(t, err)
+	assert.Equal(t, res.StatusCode, http.StatusCreated, string(buf))
+	var resp containertypes.CreateResponse
+	err = json.Unmarshal(buf, &resp)
+	assert.NilError(t, err)
+	return resp.ID
 }

--- a/vendor/github.com/moby/moby/api/types/container/config.go
+++ b/vendor/github.com/moby/moby/api/types/container/config.go
@@ -42,13 +42,9 @@ type Config struct {
 	WorkingDir      string              // Current directory (PWD) in the command will be launched
 	Entrypoint      []string            // Entrypoint to run when starting the container
 	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
-	// Mac Address of the container.
-	//
-	// Deprecated: this field is deprecated since API v1.44 and obsolete since v1.52. Use EndpointSettings.MacAddress instead.
-	MacAddress  string            `json:",omitempty"`
-	OnBuild     []string          `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
-	Labels      map[string]string // List of labels set to this container
-	StopSignal  string            `json:",omitempty"` // Signal to stop a container
-	StopTimeout *int              `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell       []string          `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+	OnBuild         []string            `json:",omitempty"` // ONBUILD metadata that were defined on the image Dockerfile
+	Labels          map[string]string   // List of labels set to this container
+	StopSignal      string              `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           []string            `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/vendor/github.com/moby/moby/client/container_create.go
+++ b/vendor/github.com/moby/moby/client/container_create.go
@@ -11,7 +11,6 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/api/types/versions"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -27,25 +26,6 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	if hostConfig != nil {
 		hostConfig.CapAdd = normalizeCapabilities(hostConfig.CapAdd)
 		hostConfig.CapDrop = normalizeCapabilities(hostConfig.CapDrop)
-	}
-
-	// FIXME(thaJeztah): remove this once we updated our (integration) tests;
-	//  some integration tests depend on this to test old API versions; see https://github.com/moby/moby/pull/51120#issuecomment-3376224865
-	if config.MacAddress != "" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		// Make sure we negotiated (if the client is configured to do so),
-		// as code below contains API-version specific handling of options.
-		//
-		// Normally, version-negotiation (if enabled) would not happen until
-		// the API request is made.
-		if err := cli.checkVersion(ctx); err != nil {
-			return response, err
-		}
-		if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.44") {
-			// Since API 1.44, the container-wide MacAddress is deprecated and triggers a WARNING if it's specified.
-			//
-			// FIXME(thaJeztah): remove the field from the API
-			config.MacAddress = "" //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
-		}
 	}
 
 	query := url.Values{}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50846
- [x] depends on / stacked on https://github.com/moby/moby/pull/51201

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

