### PR TITLE
daemon: initialize volumes if nil on decode

### DIFF
--- a/daemon/internal/runconfig/config.go
+++ b/daemon/internal/runconfig/config.go
@@ -36,7 +36,7 @@ func decodeCreateRequest(src io.Reader) (container.CreateRequest, error) {
 	if w.Config == nil {
 		return container.CreateRequest{}, validationError("config cannot be empty in order to create a container")
 	}
-	if w.Config == nil {
+	if w.Config.Volumes == nil {
 		w.Config.Volumes = make(map[string]struct{})
 	}
 	if w.HostConfig == nil {


### PR DESCRIPTION
**- What I did**
Fixed a backend initialization on create container request unmarshalling when no volumes are specified. Not a bug per-se other parts are likely handling this already but certainly was not the intent of the code and is currently a dead branch.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

