### PR TITLE
api: remove image inspect `Parent`, `DockerVersion` from swagger docs

### DIFF
--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -1831,21 +1831,6 @@ definitions:
         example:
           - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
           - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
-      Parent:
-        description: |
-          ID of the parent image.
-
-          Depending on how the image was created, this field may be empty and
-          is only set for images that were built/created locally. This field
-          is empty if the image was pulled from an image registry.
-
-          > **Deprecated**: This field is only set when using the deprecated
-          > legacy builder. It is included in API responses for informational
-          > purposes, but should not be depended on as it will be omitted
-          > once the legacy builder is removed.
-        type: "string"
-        x-nullable: true
-        example: ""
       Comment:
         description: |
           Optional message that was set when committing or importing the image.
@@ -1863,19 +1848,6 @@ definitions:
         format: "dateTime"
         x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
-      DockerVersion:
-        description: |
-          The version of Docker that was used to build the image.
-
-          Depending on how the image was created, this field may be empty.
-
-          > **Deprecated**: This field is only set when using the deprecated
-          > legacy builder. It is included in API responses for informational
-          > purposes, but should not be depended on as it will be omitted
-          > once the legacy builder is removed.
-        type: "string"
-        x-nullable: true
-        example: "27.0.1"
       Author:
         description: |
           Name of the author that was specified when committing the image, or as

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1831,21 +1831,6 @@ definitions:
         example:
           - "example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb"
           - "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"
-      Parent:
-        description: |
-          ID of the parent image.
-
-          Depending on how the image was created, this field may be empty and
-          is only set for images that were built/created locally. This field
-          is empty if the image was pulled from an image registry.
-
-          > **Deprecated**: This field is only set when using the deprecated
-          > legacy builder. It is included in API responses for informational
-          > purposes, but should not be depended on as it will be omitted
-          > once the legacy builder is removed.
-        type: "string"
-        x-nullable: true
-        example: ""
       Comment:
         description: |
           Optional message that was set when committing or importing the image.
@@ -1863,19 +1848,6 @@ definitions:
         format: "dateTime"
         x-nullable: true
         example: "2022-02-04T21:20:12.497794809Z"
-      DockerVersion:
-        description: |
-          The version of Docker that was used to build the image.
-
-          Depending on how the image was created, this field may be empty.
-
-          > **Deprecated**: This field is only set when using the deprecated
-          > legacy builder. It is included in API responses for informational
-          > purposes, but should not be depended on as it will be omitted
-          > once the legacy builder is removed.
-        type: "string"
-        x-nullable: true
-        example: "27.0.1"
       Author:
         description: |
           Name of the author that was specified when committing the image, or as


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/51103

**- What I did**

Follow-up to https://github.com/moby/moby/pull/51103/commits/f8d3c4e4a7cf8c8fa9e856dd072f2c7ffd43914b, this change removes the `Parent` and `DockerVersion` fields from the swagger documentation.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

