### PR TITLE
daemon: consolidate "log-level" and "log-format" options and flags

### DIFF
--- a/daemon/command/config.go
+++ b/daemon/command/config.go
@@ -1,8 +1,10 @@
 package command
 
 import (
+	"fmt"
 	"runtime"
 
+	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/config"
 	dopts "github.com/moby/moby/v2/daemon/internal/opts"
 	"github.com/moby/moby/v2/daemon/pkg/opts"
@@ -44,7 +46,11 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")
 	_ = flags.MarkHidden("network-diagnostic-port")
 
-	flags.BoolVar(&conf.RawLogs, "raw-logs", false, "Full timestamps without ANSI coloring")
+	// Daemon log config
+	flags.BoolVar(&conf.DaemonLogConfig.RawLogs, "raw-logs", conf.DaemonLogConfig.RawLogs, "Full timestamps without ANSI coloring")
+	flags.StringVarP(&conf.DaemonLogConfig.LogLevel, "log-level", "l", conf.DaemonLogConfig.LogLevel, `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
+	flags.Var(&stringVar[log.OutputFormat]{val: &conf.DaemonLogConfig.LogFormat}, "log-format", fmt.Sprintf(`Set the logging format (%q|%q)`, log.TextFormat, log.JSONFormat))
+
 	flags.Var(dopts.NewNamedIPListOptsRef("dns", &conf.DNS), "dns", "DNS server to use")
 	flags.Var(opts.NewNamedListOptsRef("dns-opts", &conf.DNSOptions, nil), "dns-opt", "DNS options to use")
 	flags.Var(opts.NewListOptsRef(&conf.DNSSearch, opts.ValidateDNSSearch), "dns-search", "DNS search domains to use")
@@ -81,3 +87,20 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	_ = flags.MarkDeprecated("restart", "Please use a restart policy on docker run")
 }
+
+// stringVar is a bare-bones implementation of a [pflag.Value] using
+// generics to create flags for typed string values / enums.
+type stringVar[T ~string] struct{ val *T }
+
+func (v *stringVar[T]) Set(s string) error {
+	*v.val = T(s)
+	return nil
+}
+
+func (v *stringVar[T]) String() string {
+	return string(*v.val)
+}
+
+func (v *stringVar[T]) Type() string { return "string" }
+
+var _ pflag.Value = (*stringVar[string])(nil)

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -101,7 +101,7 @@ func newDaemonCLI(opts *daemonOptions) (*daemonCLI, error) {
 }
 
 func (cli *daemonCLI) start(ctx context.Context) (err error) {
-	configureProxyEnv(cli.Config)
+	configureProxyEnv(ctx, cli.Config.Proxies)
 	configureDaemonLogs(cli.Config)
 
 	log.G(ctx).Info("Starting up")
@@ -994,24 +994,24 @@ func configureDaemonLogs(conf *config.Config) {
 	}
 }
 
-func configureProxyEnv(cfg *config.Config) {
+func configureProxyEnv(ctx context.Context, cfg config.Proxies) {
 	if p := cfg.HTTPProxy; p != "" {
-		overrideProxyEnv("HTTP_PROXY", p)
-		overrideProxyEnv("http_proxy", p)
+		overrideProxyEnv(ctx, "HTTP_PROXY", p)
+		overrideProxyEnv(ctx, "http_proxy", p)
 	}
 	if p := cfg.HTTPSProxy; p != "" {
-		overrideProxyEnv("HTTPS_PROXY", p)
-		overrideProxyEnv("https_proxy", p)
+		overrideProxyEnv(ctx, "HTTPS_PROXY", p)
+		overrideProxyEnv(ctx, "https_proxy", p)
 	}
 	if p := cfg.NoProxy; p != "" {
-		overrideProxyEnv("NO_PROXY", p)
-		overrideProxyEnv("no_proxy", p)
+		overrideProxyEnv(ctx, "NO_PROXY", p)
+		overrideProxyEnv(ctx, "no_proxy", p)
 	}
 }
 
-func overrideProxyEnv(name, val string) {
+func overrideProxyEnv(ctx context.Context, name, val string) {
 	if oldVal := os.Getenv(name); oldVal != "" && oldVal != val {
-		log.G(context.TODO()).WithFields(log.Fields{
+		log.G(ctx).WithFields(log.Fields{
 			"name":      name,
 			"old-value": config.MaskCredentials(oldVal),
 			"new-value": config.MaskCredentials(val),

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -557,8 +557,6 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	flags := opts.flags
 	conf.Debug = opts.Debug
 	conf.Hosts = opts.Hosts
-	conf.LogLevel = opts.LogLevel
-	conf.LogFormat = log.OutputFormat(opts.LogFormat)
 
 	// The DOCKER_MIN_API_VERSION env-var allows overriding the minimum API
 	// version provided by the daemon within constraints of the minimum and

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -758,10 +758,10 @@ func getContainerdDaemonOpts(cfg *config.Config) ([]supervisor.DaemonOpt, error)
 	if cfg.Debug {
 		opts = append(opts, supervisor.WithLogLevel("debug"))
 	} else {
-		opts = append(opts, supervisor.WithLogLevel(cfg.LogLevel))
+		opts = append(opts, supervisor.WithLogLevel(cfg.DaemonLogConfig.LogLevel))
 	}
 
-	if logFormat := cfg.LogFormat; logFormat != "" {
+	if logFormat := cfg.DaemonLogConfig.LogFormat; logFormat != "" {
 		opts = append(opts, supervisor.WithLogFormat(logFormat))
 	}
 

--- a/daemon/command/daemon_test.go
+++ b/daemon/command/daemon_test.go
@@ -157,7 +157,7 @@ func TestLoadDaemonCliConfigWithLogFormat(t *testing.T) {
 	loadedConfig, err := loadDaemonCliConfig(opts)
 	assert.NilError(t, err)
 	assert.Assert(t, loadedConfig != nil)
-	assert.Check(t, is.Equal(log.JSONFormat, loadedConfig.LogFormat))
+	assert.Check(t, is.Equal(log.JSONFormat, loadedConfig.DaemonLogConfig.LogFormat))
 }
 
 func TestLoadDaemonCliConfigWithInvalidLogFormat(t *testing.T) {

--- a/daemon/command/daemon_test.go
+++ b/daemon/command/daemon_test.go
@@ -198,17 +198,18 @@ func TestLoadDaemonConfigWithRegistryOptions(t *testing.T) {
 }
 
 func TestConfigureDaemonLogs(t *testing.T) {
-	conf := &config.Config{}
-	configureDaemonLogs(conf)
+	ctx := t.Context()
+	err := configureDaemonLogs(ctx, config.DaemonLogConfig{})
+	assert.NilError(t, err)
 	assert.Check(t, is.Equal(log.InfoLevel, log.GetLevel()))
 
 	// log level should not be changed when passing an invalid value
-	conf.LogLevel = "foobar"
-	configureDaemonLogs(conf)
+	err = configureDaemonLogs(ctx, config.DaemonLogConfig{LogLevel: "foobar"})
+	assert.NilError(t, err)
 	assert.Check(t, is.Equal(log.InfoLevel, log.GetLevel()))
 
-	conf.LogLevel = "warn"
-	configureDaemonLogs(conf)
+	err = configureDaemonLogs(ctx, config.DaemonLogConfig{LogLevel: "warn"})
+	assert.NilError(t, err)
 	assert.Check(t, is.Equal(log.WarnLevel, log.GetLevel()))
 }
 

--- a/daemon/command/daemon_unix_test.go
+++ b/daemon/command/daemon_unix_test.go
@@ -17,7 +17,7 @@ func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
 
 	opts := defaultOptions(t, tempFile.Path())
 	opts.Debug = true
-	opts.LogLevel = "info"
+	opts.daemonConfig.DaemonLogConfig.LogLevel = "info"
 	assert.Check(t, opts.flags.Set("selinux-enabled", "true"))
 
 	loadedConfig, err := loadDaemonCliConfig(opts)
@@ -25,7 +25,7 @@ func TestLoadDaemonCliConfigWithDaemonFlags(t *testing.T) {
 	assert.Assert(t, loadedConfig != nil)
 
 	assert.Check(t, loadedConfig.Debug)
-	assert.Check(t, is.Equal("info", loadedConfig.LogLevel))
+	assert.Check(t, is.Equal("info", loadedConfig.DaemonLogConfig.LogLevel))
 	assert.Check(t, loadedConfig.EnableSelinuxSupport)
 	assert.Check(t, is.Equal("json-file", loadedConfig.LogConfig.Type))
 	assert.Check(t, is.Equal("1k", loadedConfig.LogConfig.Config["max-size"]))

--- a/daemon/command/options.go
+++ b/daemon/command/options.go
@@ -1,11 +1,9 @@
 package command
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/log"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/pkg/opts"
@@ -73,8 +71,6 @@ type daemonOptions struct {
 	flags        *pflag.FlagSet
 	Debug        bool
 	Hosts        []string
-	LogLevel     string
-	LogFormat    string
 	TLS          bool
 	TLSVerify    bool
 	TLSOptions   *tlsconfig.Options
@@ -107,8 +103,6 @@ func (o *daemonOptions) installFlags(flags *pflag.FlagSet) {
 
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
 	flags.BoolVar(&o.Validate, "validate", false, "Validate daemon configuration and exit")
-	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
-	flags.StringVar(&o.LogFormat, "log-format", string(log.TextFormat), fmt.Sprintf(`Set the logging format (%q|%q)`, log.TextFormat, log.JSONFormat))
 	flags.BoolVar(&o.TLS, FlagTLS, DefaultTLSValue, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&o.TLSVerify, FlagTLSVerify, dockerTLSVerify || DefaultTLSValue, "Use TLS and verify the remote")
 

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -166,7 +166,7 @@ type TLSOptions struct {
 	KeyFile  string `json:"tlskey,omitempty"`
 }
 
-// DNSConfig defines the DNS configurations.
+// DNSConfig defines default DNS options for containers.
 type DNSConfig struct {
 	DNS            []netip.Addr `json:"dns,omitempty"`
 	DNSOptions     []string     `json:"dns-opts,omitempty"`
@@ -224,10 +224,6 @@ type CommonConfig struct {
 	TLS       *bool            `json:"tls,omitempty"`
 	TLSVerify *bool            `json:"tlsverify,omitempty"`
 
-	// Embedded structs that allow config
-	// deserialization without the full struct.
-	TLSOptions
-
 	// SwarmDefaultAdvertiseAddr is the default host/IP or network interface
 	// to use if a wildcard address is specified in the ListenAddr value
 	// given to the /swarm/init endpoint and no advertise address is
@@ -246,15 +242,14 @@ type CommonConfig struct {
 
 	MetricsAddress string `json:"metrics-addr"`
 
-	DNSConfig
-	LogConfig
-	BridgeConfig // BridgeConfig holds bridge network specific configuration.
-	NetworkConfig
-	registry.ServiceOptions
+	// Embedded structs that allow config deserialization without the full struct.
 
-	// FIXME(vdemeester) This part is not that clear and is mainly dependent on cli flags
-	// It should probably be handled outside this package.
-	ValuesSet map[string]any `json:"-"`
+	TLSOptions              // TLSOptions defines TLS configuration for the API server.
+	DNSConfig               // DNSConfig defines default DNS options for containers.
+	LogConfig               // LogConfig defines default log configuration for containers.
+	BridgeConfig            // BridgeConfig holds bridge network specific configuration.
+	NetworkConfig           // NetworkConfig stores the daemon-wide networking configurations.
+	registry.ServiceOptions // TODO(thaJeztah): define this type in daemon/config and either import into pkg/registry, or convert when using.
 
 	Experimental bool `json:"experimental"` // Experimental indicates whether experimental features should be exposed or not
 
@@ -295,6 +290,10 @@ type CommonConfig struct {
 	// var should only be used for exceptional cases, and the MinAPIVersion
 	// field is therefore not included in the JSON representation.
 	MinAPIVersion string `json:"-"`
+
+	// FIXME(vdemeester) This part is not that clear and is mainly dependent on cli flags
+	// It should probably be handled outside this package.
+	ValuesSet map[string]any `json:"-"`
 }
 
 // Proxies holds the proxies that are configured for the daemon.

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -327,6 +327,10 @@ func New() (*Config, error) {
 			LogConfig: LogConfig{
 				Config: make(map[string]string),
 			},
+			DaemonLogConfig: DaemonLogConfig{
+				LogLevel:  "info",
+				LogFormat: log.TextFormat,
+			},
 			MaxConcurrentDownloads: DefaultMaxConcurrentDownloads,
 			MaxConcurrentUploads:   DefaultMaxConcurrentUploads,
 			MaxDownloadAttempts:    DefaultDownloadAttempts,

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -189,7 +189,6 @@ type CommonConfig struct {
 	Labels                []string `json:"labels,omitempty"`
 	NetworkDiagnosticPort int      `json:"network-diagnostic-port,omitempty"`
 	Pidfile               string   `json:"pidfile,omitempty"`
-	RawLogs               bool     `json:"raw-logs,omitempty"`
 	Root                  string   `json:"data-root,omitempty"`
 	ExecRoot              string   `json:"exec-root,omitempty"`
 	SocketGroup           string   `json:"group,omitempty"`
@@ -217,12 +216,10 @@ type CommonConfig struct {
 	// to stop when daemon is being shutdown
 	ShutdownTimeout int `json:"shutdown-timeout,omitempty"`
 
-	Debug     bool             `json:"debug,omitempty"`
-	Hosts     []string         `json:"hosts,omitempty"`
-	LogLevel  string           `json:"log-level,omitempty"`
-	LogFormat log.OutputFormat `json:"log-format,omitempty"`
-	TLS       *bool            `json:"tls,omitempty"`
-	TLSVerify *bool            `json:"tlsverify,omitempty"`
+	Debug     bool     `json:"debug,omitempty"`
+	Hosts     []string `json:"hosts,omitempty"`
+	TLS       *bool    `json:"tls,omitempty"`
+	TLSVerify *bool    `json:"tlsverify,omitempty"`
 
 	// SwarmDefaultAdvertiseAddr is the default host/IP or network interface
 	// to use if a wildcard address is specified in the ListenAddr value
@@ -244,6 +241,7 @@ type CommonConfig struct {
 
 	// Embedded structs that allow config deserialization without the full struct.
 
+	DaemonLogConfig         // DaemonLogConfig holds options for configuring the daemon's logging.
 	TLSOptions              // TLSOptions defines TLS configuration for the API server.
 	DNSConfig               // DNSConfig defines default DNS options for containers.
 	LogConfig               // LogConfig defines default log configuration for containers.
@@ -294,6 +292,13 @@ type CommonConfig struct {
 	// FIXME(vdemeester) This part is not that clear and is mainly dependent on cli flags
 	// It should probably be handled outside this package.
 	ValuesSet map[string]any `json:"-"`
+}
+
+// DaemonLogConfig holds options for configuring the daemon's logging.
+type DaemonLogConfig struct {
+	LogLevel  string           `json:"log-level,omitempty"`
+	LogFormat log.OutputFormat `json:"log-format,omitempty"`
+	RawLogs   bool             `json:"raw-logs,omitempty"`
 }
 
 // Proxies holds the proxies that are configured for the daemon.

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -367,7 +367,7 @@ func TestValidateConfigurationErrors(t *testing.T) {
 			name: "with invalid log-level",
 			config: &Config{
 				CommonConfig: CommonConfig{
-					LogLevel: "foobar",
+					DaemonLogConfig: DaemonLogConfig{LogLevel: "foobar"},
 				},
 			},
 			expectedErr: "invalid logging level: foobar",
@@ -575,7 +575,7 @@ func TestValidateConfiguration(t *testing.T) {
 			field: "LogLevel",
 			config: &Config{
 				CommonConfig: CommonConfig{
-					LogLevel: "warn",
+					DaemonLogConfig: DaemonLogConfig{LogLevel: "warn"},
 				},
 			},
 		},


### PR DESCRIPTION
### daemon/config: slight cleanup of Config struct

Move embedded types together, and add some minimal godoc.

### daemon/command: configureProxyEnv: accept smaller struct

Also pass through the context

### daemon/config: move daemon log-config to a separate struct

### daemon/config: add validateDaemonLogConfig function

extract validation of the log-config to a separate function.

### daemon/command: configureDaemonLogs: don't panic

Return an error instead of panicking. 

### daemon: consolidate "log-level" and "log-format" options and flags

The `LogLevel` and `LogFormat` options were defined in two locations;

- in the `daemon/commands.daemonOptions` struct.
- in the `daemon/config.Config` (`CommonConfig`) struct.

While we may need some options-struct to initialize the daemon, we currently
don't and the separate structs means they have to be kept in sync, and for
flags to be distributed across multiple places.

Note that some flags will not be configurable in the config-file (such as
the path of the config-file itself), so those options will need to have a
separate struct (which may still live in the `daemon/config` package).


This patch;

- Removes the `LogLevel` and `LogFormat` from `daemon/commands.daemonOptions`
  to `daemon/config.CommonConfig`.
- Adds a bare-bones `stringVar` implementation using generics to allow using
  strong-typed string values to be used for flags.
- Moves the flags together with the other flags in `installCommonConfigFlags`.
- Sets the default options in the `Config` struct.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

