### PR TITLE
client: rewrite prune functions to use option structs and result

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -88,7 +88,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, container.PathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options CopyToContainerOptions) error
-	ContainersPrune(ctx context.Context, pruneFilters Filters) (container.PruneReport, error)
+	ContainersPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error)
 }
 
 type ExecAPIClient interface {

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -200,7 +200,7 @@ type VolumeAPIClient interface {
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (volume.Volume, []byte, error)
 	VolumeList(ctx context.Context, options VolumeListOptions) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
-	VolumesPrune(ctx context.Context, pruneFilter Filters) (volume.PruneReport, error)
+	VolumesPrune(ctx context.Context, opts VolumePruneOptions) (VolumePruneResult, error)
 	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
 }
 

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -118,7 +118,7 @@ type ImageAPIClient interface {
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
-	ImagesPrune(ctx context.Context, pruneFilter Filters) (image.PruneReport, error)
+	ImagesPrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error)
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) ([]image.HistoryResponseItem, error)

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -135,7 +135,7 @@ type NetworkAPIClient interface {
 	NetworkInspectWithRaw(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, []byte, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
-	NetworksPrune(ctx context.Context, pruneFilter Filters) (network.PruneReport, error)
+	NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error)
 }
 
 // NodeAPIClient defines API client methods for the nodes

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -18,7 +18,7 @@ func TestContainersPruneError(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
-	_, err = client.ContainersPrune(context.Background(), Filters{})
+	_, err = client.ContainersPrune(context.Background(), ContainerPruneOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -99,9 +99,9 @@ func TestContainersPrune(t *testing.T) {
 		}))
 		assert.NilError(t, err)
 
-		report, err := client.ContainersPrune(context.Background(), listCase.filters)
+		req, err := client.ContainersPrune(context.Background(), ContainerPruneOptions{Filters: listCase.filters})
 		assert.NilError(t, err)
-		assert.Check(t, is.Len(report.ContainersDeleted, 2))
-		assert.Check(t, is.Equal(uint64(9999), report.SpaceReclaimed))
+		assert.Check(t, is.Len(req.Report.ContainersDeleted, 2))
+		assert.Check(t, is.Equal(uint64(9999), req.Report.SpaceReclaimed))
 	}
 }

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -19,7 +19,7 @@ func TestImagesPruneError(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
-	_, err = client.ImagesPrune(context.Background(), nil)
+	_, err = client.ImagesPrune(context.Background(), ImagePruneOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -96,9 +96,9 @@ func TestImagesPrune(t *testing.T) {
 		}))
 		assert.NilError(t, err)
 
-		report, err := client.ImagesPrune(context.Background(), listCase.filters)
+		res, err := client.ImagesPrune(context.Background(), ImagePruneOptions{Filters: listCase.filters})
 		assert.NilError(t, err)
-		assert.Check(t, is.Len(report.ImagesDeleted, 2))
-		assert.Check(t, is.Equal(uint64(9999), report.SpaceReclaimed))
+		assert.Check(t, is.Len(res.Report.ImagesDeleted, 2))
+		assert.Check(t, is.Equal(uint64(9999), res.Report.SpaceReclaimed))
 	}
 }

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -9,21 +9,31 @@ import (
 	"github.com/moby/moby/api/types/network"
 )
 
+// NetworkPruneOptions holds parameters to prune networks.
+type NetworkPruneOptions struct {
+	Filters Filters
+}
+
+// NetworkPruneResult holds the result from the [Client.NetworksPrune] method.
+type NetworkPruneResult struct {
+	Report network.PruneReport
+}
+
 // NetworksPrune requests the daemon to delete unused networks
-func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters Filters) (network.PruneReport, error) {
+func (cli *Client) NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error) {
 	query := url.Values{}
-	pruneFilters.updateURLValues(query)
+	opts.Filters.updateURLValues(query)
 
 	resp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return network.PruneReport{}, err
+		return NetworkPruneResult{}, err
 	}
 
 	var report network.PruneReport
 	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
-		return network.PruneReport{}, fmt.Errorf("Error retrieving network prune report: %v", err)
+		return NetworkPruneResult{}, fmt.Errorf("Error retrieving network prune report: %v", err)
 	}
 
-	return report, nil
+	return NetworkPruneResult{Report: report}, nil
 }

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -20,7 +20,7 @@ func TestNetworksPruneError(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	_, err = client.NetworksPrune(context.Background(), nil)
+	_, err = client.NetworksPrune(context.Background(), NetworkPruneOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -92,8 +92,8 @@ func TestNetworksPrune(t *testing.T) {
 		)
 		assert.NilError(t, err)
 
-		report, err := client.NetworksPrune(context.Background(), listCase.filters)
+		res, err := client.NetworksPrune(context.Background(), NetworkPruneOptions{Filters: listCase.filters})
 		assert.NilError(t, err)
-		assert.Check(t, is.Len(report.NetworksDeleted, 2))
+		assert.Check(t, is.Len(res.Report.NetworksDeleted, 2))
 	}
 }

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -110,7 +110,7 @@ func TestAuthZPluginV2RejectVolumeRequests(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
-	_, err = c.VolumesPrune(ctx, nil)
+	_, err = c.VolumesPrune(ctx, client.VolumePruneOptions{})
 	assert.Assert(t, err != nil)
 	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 }

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -270,10 +270,10 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Prune anonymous volumes
-	pruneReport, err := apiClient.VolumesPrune(ctx, nil)
+	res, err := apiClient.VolumesPrune(ctx, client.VolumePruneOptions{})
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(len(pruneReport.VolumesDeleted), 1))
-	assert.Check(t, is.Equal(pruneReport.VolumesDeleted[0], v.Name))
+	assert.Check(t, is.Equal(len(res.Report.VolumesDeleted), 1))
+	assert.Check(t, is.Equal(res.Report.VolumesDeleted[0], v.Name))
 
 	_, err = apiClient.VolumeInspect(ctx, vNamed.Name)
 	assert.NilError(t, err)
@@ -282,9 +282,11 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	_, err = apiClient.VolumeCreate(ctx, volume.CreateOptions{})
 	assert.NilError(t, err)
 
-	pruneReport, err = apiClient.VolumesPrune(ctx, make(client.Filters).Add("all", "1"))
+	res, err = apiClient.VolumesPrune(ctx, client.VolumePruneOptions{
+		Filters: make(client.Filters).Add("all", "1"),
+	})
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(len(pruneReport.VolumesDeleted), 2))
+	assert.Check(t, is.Equal(len(res.Report.VolumesDeleted), 2))
 
 	// Validate that older API versions still have the old behavior of pruning all local volumes
 	clientOld, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
@@ -297,11 +299,11 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	vNamed, err = apiClient.VolumeCreate(ctx, volume.CreateOptions{Name: "test-api141"})
 	assert.NilError(t, err)
 
-	pruneReport, err = clientOld.VolumesPrune(ctx, nil)
+	res, err = clientOld.VolumesPrune(ctx, client.VolumePruneOptions{})
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(len(pruneReport.VolumesDeleted), 2))
-	assert.Check(t, is.Contains(pruneReport.VolumesDeleted, v.Name))
-	assert.Check(t, is.Contains(pruneReport.VolumesDeleted, vNamed.Name))
+	assert.Check(t, is.Equal(len(res.Report.VolumesDeleted), 2))
+	assert.Check(t, is.Contains(res.Report.VolumesDeleted, v.Name))
+	assert.Check(t, is.Contains(res.Report.VolumesDeleted, vNamed.Name))
 }
 
 func TestVolumePruneAnonFromImage(t *testing.T) {
@@ -332,7 +334,7 @@ VOLUME ` + volDest
 	err = apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{})
 	assert.NilError(t, err)
 
-	pruneReport, err := apiClient.VolumesPrune(ctx, nil)
+	res, err := apiClient.VolumesPrune(ctx, client.VolumePruneOptions{})
 	assert.NilError(t, err)
-	assert.Assert(t, is.Contains(pruneReport.VolumesDeleted, volumeName))
+	assert.Assert(t, is.Contains(res.Report.VolumesDeleted, volumeName))
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -88,7 +88,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string, condition container.WaitCondition) (<-chan container.WaitResponse, <-chan error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, container.PathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options CopyToContainerOptions) error
-	ContainersPrune(ctx context.Context, pruneFilters Filters) (container.PruneReport, error)
+	ContainersPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error)
 }
 
 type ExecAPIClient interface {

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -200,7 +200,7 @@ type VolumeAPIClient interface {
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (volume.Volume, []byte, error)
 	VolumeList(ctx context.Context, options VolumeListOptions) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
-	VolumesPrune(ctx context.Context, pruneFilter Filters) (volume.PruneReport, error)
+	VolumesPrune(ctx context.Context, opts VolumePruneOptions) (VolumePruneResult, error)
 	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
 }
 

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -118,7 +118,7 @@ type ImageAPIClient interface {
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) ([]image.DeleteResponse, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageTag(ctx context.Context, image, ref string) error
-	ImagesPrune(ctx context.Context, pruneFilter Filters) (image.PruneReport, error)
+	ImagesPrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error)
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (image.InspectResponse, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) ([]image.HistoryResponseItem, error)

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -135,7 +135,7 @@ type NetworkAPIClient interface {
 	NetworkInspectWithRaw(ctx context.Context, network string, options NetworkInspectOptions) (network.Inspect, []byte, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
-	NetworksPrune(ctx context.Context, pruneFilter Filters) (network.PruneReport, error)
+	NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error)
 }
 
 // NodeAPIClient defines API client methods for the nodes

--- a/vendor/github.com/moby/moby/client/network_prune.go
+++ b/vendor/github.com/moby/moby/client/network_prune.go
@@ -9,21 +9,31 @@ import (
 	"github.com/moby/moby/api/types/network"
 )
 
+// NetworkPruneOptions holds parameters to prune networks.
+type NetworkPruneOptions struct {
+	Filters Filters
+}
+
+// NetworkPruneResult holds the result from the [Client.NetworksPrune] method.
+type NetworkPruneResult struct {
+	Report network.PruneReport
+}
+
 // NetworksPrune requests the daemon to delete unused networks
-func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters Filters) (network.PruneReport, error) {
+func (cli *Client) NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error) {
 	query := url.Values{}
-	pruneFilters.updateURLValues(query)
+	opts.Filters.updateURLValues(query)
 
 	resp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return network.PruneReport{}, err
+		return NetworkPruneResult{}, err
 	}
 
 	var report network.PruneReport
 	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
-		return network.PruneReport{}, fmt.Errorf("Error retrieving network prune report: %v", err)
+		return NetworkPruneResult{}, fmt.Errorf("Error retrieving network prune report: %v", err)
 	}
 
-	return report, nil
+	return NetworkPruneResult{Report: report}, nil
 }


### PR DESCRIPTION
- addresses parts of https://github.com/moby/moby/issues/50965
- supersedes, closes https://github.com/moby/moby/pull/45370


### client: rewrite prune functions to use option structs and result

- client: ContainersPrune: rewrite to use option structs and result
- client: ImagesPrune: rewrite to use option structs and result
- client: NetworksPrune: rewrite to use option structs and result
- client: VolumesPrune: rewrite to use option structs and result


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: ContainersPrune: rewrite to use option structs and result
client: ImagesPrune: rewrite to use option structs and result
client: NetworksPrune: rewrite to use option structs and result
client: VolumesPrune: rewrite to use option structs and result
```

**- A picture of a cute animal (not mandatory but encouraged)**

