### PR TITLE
daemon/server/router/container: fix back-filling of top-level network fields

### DIFF
--- a/daemon/server/router/container/inspect.go
+++ b/daemon/server/router/container/inspect.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/v2/daemon/internal/compat"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
@@ -36,23 +35,27 @@ func (c *containerRouter) getContainersByName(ctx context.Context, w http.Respon
 		ctr.ImageManifestDescriptor = nil
 	}
 
-	var bridgeNw network.EndpointSettings
-	if v := ctr.NetworkSettings.Networks["bridge"]; v != nil {
-		bridgeNw = *v
-	}
-
 	var wrapOpts []compat.Option
 	if versions.LessThan(version, "1.52") {
-		wrapOpts = append(wrapOpts, compat.WithExtraFields(map[string]any{
-			"EndpointID":          bridgeNw.EndpointID,
-			"Gateway":             bridgeNw.Gateway,
-			"GlobalIPv6Address":   bridgeNw.GlobalIPv6Address,
-			"GlobalIPv6PrefixLen": bridgeNw.GlobalIPv6PrefixLen,
-			"IPAddress":           bridgeNw.IPAddress,
-			"IPPrefixLen":         bridgeNw.IPPrefixLen,
-			"IPv6Gateway":         bridgeNw.IPv6Gateway,
-			"MacAddress":          bridgeNw.MacAddress,
-		}))
+		if bridgeNw := ctr.NetworkSettings.Networks["bridge"]; bridgeNw != nil {
+			// Old API versions showed the bridge's configuration as top-level
+			// fields in "NetworkConfig".
+			//
+			// This was deprecated in API v1.44, but kept in place until
+			// API v1.52, which removes this entirely.
+			wrapOpts = append(wrapOpts, compat.WithExtraFields(map[string]any{
+				"NetworkSettings": map[string]any{
+					"EndpointID":          bridgeNw.EndpointID,
+					"Gateway":             bridgeNw.Gateway,
+					"GlobalIPv6Address":   bridgeNw.GlobalIPv6Address,
+					"GlobalIPv6PrefixLen": bridgeNw.GlobalIPv6PrefixLen,
+					"IPAddress":           bridgeNw.IPAddress,
+					"IPPrefixLen":         bridgeNw.IPPrefixLen,
+					"IPv6Gateway":         bridgeNw.IPv6Gateway,
+					"MacAddress":          bridgeNw.MacAddress,
+				},
+			}))
+		}
 	}
 
 	return httputils.WriteJSON(w, http.StatusOK, compat.Wrap(ctr, wrapOpts...))

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -274,8 +274,7 @@ func TestMacAddressIsAppliedToMainNetworkWithShortID(t *testing.T) {
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.43"))
-	assert.NilError(t, err)
+	apiClient := d.NewClientT(t, client.WithVersion("1.43"))
 
 	n := net.CreateNoError(ctx, t, apiClient, "testnet", net.WithIPAM("192.168.101.0/24", "192.168.101.1"))
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50846
- needed for https://github.com/moby/moby/pull/51194

This was introduced in fc1ff44bc2c2ffa4070efbde76fe5daa1333c98a, which
back-filled the top-level network-properties for the bridge network,
but the fields ended up at the top-level of the response, not the top-level
of the NetworkSettings.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

