### PR TITLE
integration-cli: TestDockerCLIBuildSuite/TestBuildEmitsEvents: reduce…

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6242,9 +6242,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 					build.WithDockerfile("FROM busybox\nRUN echo hi >/hello"),
 					build.WithBuildkit(builder.buildkit),
 				)
-				b.Assert(t, icmd.Success)
-				t.Log(b.Stdout())
-				t.Log(b.Stderr())
+				assert.NilError(t, b.Compare(icmd.Success), b.Combined())
 
 				cmd := cli.Docker(
 					cli.Args("events",
@@ -6255,10 +6253,7 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 					cli.WithEnvironmentVariables("DOCKER_API_VERSION=v1.46"), // FIXME(thaJeztah): integration-cli runs docker CLI 18.06; we're "upgrading" the API version to a version it doesn't support here ;)
 				)
 
-				stdout := cmd.Stdout()
-				t.Log(stdout)
-
-				tc.check(t, stdout)
+				tc.check(t, cmd.Stdout())
 			})
 		}
 	}


### PR DESCRIPTION
… logs

This test was always logging build output and output of the events stream;

    === RUN   TestDockerCLIBuildSuite/TestBuildEmitsEvents/buildkit=false/no_tag
        docker_cli_build_test.go:6246: Sending build context to Docker daemon  2.048kB
            Step 1/2 : FROM busybox
             ---> c004456a6868
            Step 2/2 : RUN echo hi >/hello
             ---> Running in dd4f3ec8bd9e
             ---> Removed intermediate container dd4f3ec8bd9e
             ---> 25ee0d9e2b4a
            Successfully built 25ee0d9e2b4a

        docker_cli_build_test.go:6247:
        docker_cli_build_test.go:6259: 2025-10-16T12:28:34.113785300Z image create sha256:25ee0d9e2b4af90101abc6f2f3339807e7bcd0bfe5af6113c3a71c9edff6e858 (name=sha256:25ee0d9e2b4af90101abc6f2f3339807e7bcd0bfe5af6113c3a71c9edff6e858)

    --- PASS: TestDockerCLIBuildSuite/TestBuildEmitsEvents/buildkit=false/no_tag (6.56s)

This patch:

- Uses a manual assert to check if the build succeeded; on failure, it prints the combined output (stdout, stderr)
- Removes the log for the events output; the `assert` function used in the test already asserts the output, which would print the output when the assertion fails.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

