### PR TITLE
api/types/network: EndpointSettings: make MacAddress "operational data"

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -8,14 +8,10 @@ import (
 
 // EndpointSettings stores the network endpoint details
 type EndpointSettings struct {
-	// Configurations
+	// Configuration data
 	IPAMConfig *EndpointIPAMConfig
 	Links      []string
 	Aliases    []string // Aliases holds the list of extra, user-specified DNS names for this endpoint.
-	// MacAddress may be used to specify a MAC address when the container is created.
-	// Once the container is running, it becomes operational data (it may contain a
-	// generated address).
-	MacAddress string
 	DriverOpts map[string]string
 
 	// GwPriority determines which endpoint will provide the default gateway
@@ -23,17 +19,24 @@ type EndpointSettings struct {
 	// If multiple endpoints have the same priority, they are lexicographically
 	// sorted based on their network name, and the one that sorts first is picked.
 	GwPriority int
+
 	// Operational data
-	NetworkID           string
-	EndpointID          string
-	Gateway             netip.Addr
-	IPAddress           netip.Addr
+
+	NetworkID  string
+	EndpointID string
+	Gateway    netip.Addr
+	IPAddress  netip.Addr
+
+	// MacAddress may be used to specify a MAC address when the container is created.
+	// Once the container is running, it becomes operational data (it may contain a
+	// generated address).
+	MacAddress          string
 	IPPrefixLen         int
 	IPv6Gateway         netip.Addr
 	GlobalIPv6Address   netip.Addr
 	GlobalIPv6PrefixLen int
-	// DNSNames holds all the (non fully qualified) DNS names associated to this endpoint. First entry is used to
-	// generate PTR records.
+	// DNSNames holds all the (non fully qualified) DNS names associated to this
+	// endpoint. The first entry is used to generate PTR records.
 	DNSNames []string
 }
 

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -270,7 +270,7 @@ func TestMacAddressIsAppliedToMainNetworkWithShortID(t *testing.T) {
 
 	ctx := testutil.StartSpan(baseContext, t)
 
-	d := daemon.New(t)
+	d := daemon.New(t, daemon.WithEnvVars("DOCKER_MIN_API_VERSION=1.43"))
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 

--- a/vendor/github.com/moby/moby/api/types/network/endpoint.go
+++ b/vendor/github.com/moby/moby/api/types/network/endpoint.go
@@ -8,14 +8,10 @@ import (
 
 // EndpointSettings stores the network endpoint details
 type EndpointSettings struct {
-	// Configurations
+	// Configuration data
 	IPAMConfig *EndpointIPAMConfig
 	Links      []string
 	Aliases    []string // Aliases holds the list of extra, user-specified DNS names for this endpoint.
-	// MacAddress may be used to specify a MAC address when the container is created.
-	// Once the container is running, it becomes operational data (it may contain a
-	// generated address).
-	MacAddress string
 	DriverOpts map[string]string
 
 	// GwPriority determines which endpoint will provide the default gateway
@@ -23,17 +19,24 @@ type EndpointSettings struct {
 	// If multiple endpoints have the same priority, they are lexicographically
 	// sorted based on their network name, and the one that sorts first is picked.
 	GwPriority int
+
 	// Operational data
-	NetworkID           string
-	EndpointID          string
-	Gateway             netip.Addr
-	IPAddress           netip.Addr
+
+	NetworkID  string
+	EndpointID string
+	Gateway    netip.Addr
+	IPAddress  netip.Addr
+
+	// MacAddress may be used to specify a MAC address when the container is created.
+	// Once the container is running, it becomes operational data (it may contain a
+	// generated address).
+	MacAddress          string
 	IPPrefixLen         int
 	IPv6Gateway         netip.Addr
 	GlobalIPv6Address   netip.Addr
 	GlobalIPv6PrefixLen int
-	// DNSNames holds all the (non fully qualified) DNS names associated to this endpoint. First entry is used to
-	// generate PTR records.
+	// DNSNames holds all the (non fully qualified) DNS names associated to this
+	// endpoint. The first entry is used to generate PTR records.
 	DNSNames []string
 }
 


### PR DESCRIPTION
The MacAddress field currently reflects _either_ the user-specified (DesiredMacAddress) _or_ the actual / assigned MacAddress (when running).

Internal structs already have a separate DesiredMacAddres field, but this field is not (yet) reflected in the API response. The intent is to move towards better separation of config ("desired state") and operational ("actual state") data.

Let's move the MacAddress field under "operational" data; the field's description still describes its dual-personality, but potentially we can move towards separate fields in future.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

