### PR TITLE
api/types/volume: move `UpdateOptions` to `client.VolumeUpdateOptions`

### DIFF
--- a/api/types/volume/volume_update.go
+++ b/api/types/volume/volume_update.go
@@ -1,7 +1,0 @@
-package volume
-
-// UpdateOptions is configuration to update a Volume with.
-type UpdateOptions struct {
-	// Spec is the ClusterVolumeSpec to update the volume to.
-	Spec *ClusterVolumeSpec `json:"Spec,omitempty"`
-}

--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -201,7 +201,7 @@ type VolumeAPIClient interface {
 	VolumeList(ctx context.Context, options VolumeListOptions) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	VolumesPrune(ctx context.Context, opts VolumePruneOptions) (VolumePruneResult, error)
-	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
+	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options VolumeUpdateOptions) error
 }
 
 // SecretAPIClient defines API client methods for secrets

--- a/client/volume_update.go
+++ b/client/volume_update.go
@@ -8,9 +8,14 @@ import (
 	"github.com/moby/moby/api/types/volume"
 )
 
+type VolumeUpdateOptions struct {
+	// Spec is the ClusterVolumeSpec to update the volume to.
+	Spec *volume.ClusterVolumeSpec `json:"Spec,omitempty"`
+}
+
 // VolumeUpdate updates a volume. This only works for Cluster Volumes, and
 // only some fields can be updated.
-func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error {
+func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options VolumeUpdateOptions) error {
 	volumeID, err := trimID("volume", volumeID)
 	if err != nil {
 		return err

--- a/client/volume_update_test.go
+++ b/client/volume_update_test.go
@@ -11,7 +11,6 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/swarm"
-	volumetypes "github.com/moby/moby/api/types/volume"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -20,14 +19,14 @@ func TestVolumeUpdateError(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
-	err = client.VolumeUpdate(context.Background(), "volume", swarm.Version{}, volumetypes.UpdateOptions{})
+	err = client.VolumeUpdate(context.Background(), "volume", swarm.Version{}, VolumeUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.VolumeUpdate(context.Background(), "", swarm.Version{}, volumetypes.UpdateOptions{})
+	err = client.VolumeUpdate(context.Background(), "", swarm.Version{}, VolumeUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.VolumeUpdate(context.Background(), "    ", swarm.Version{}, volumetypes.UpdateOptions{})
+	err = client.VolumeUpdate(context.Background(), "    ", swarm.Version{}, VolumeUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -52,6 +51,6 @@ func TestVolumeUpdate(t *testing.T) {
 	}))
 	assert.NilError(t, err)
 
-	err = client.VolumeUpdate(context.Background(), "test1", swarm.Version{Index: uint64(10)}, volumetypes.UpdateOptions{})
+	err = client.VolumeUpdate(context.Background(), "test1", swarm.Version{Index: uint64(10)}, VolumeUpdateOptions{})
 	assert.NilError(t, err)
 }

--- a/daemon/cluster/volumes.go
+++ b/daemon/cluster/volumes.go
@@ -107,7 +107,7 @@ func (c *Cluster) RemoveVolume(nameOrID string, force bool) error {
 }
 
 // UpdateVolume updates a volume in the swarm cluster.
-func (c *Cluster) UpdateVolume(nameOrID string, version uint64, volume volumetypes.UpdateOptions) error {
+func (c *Cluster) UpdateVolume(nameOrID string, version uint64, volume volumebackend.UpdateOptions) error {
 	return c.lockedManagerAction(context.TODO(), func(ctx context.Context, state nodeState) error {
 		v, err := getVolume(ctx, state.controlClient, nameOrID)
 		if err != nil {

--- a/daemon/server/router/volume/backend.go
+++ b/daemon/server/router/volume/backend.go
@@ -28,6 +28,6 @@ type ClusterBackend interface {
 	GetVolumes(options volumebackend.ListOptions) ([]*volume.Volume, error)
 	CreateVolume(volume volume.CreateOptions) (*volume.Volume, error)
 	RemoveVolume(nameOrID string, force bool) error
-	UpdateVolume(nameOrID string, version uint64, volume volume.UpdateOptions) error
+	UpdateVolume(nameOrID string, version uint64, volume volumebackend.UpdateOptions) error
 	IsManager() bool
 }

--- a/daemon/server/router/volume/volume_routes.go
+++ b/daemon/server/router/volume/volume_routes.go
@@ -147,7 +147,7 @@ func (v *volumeRouter) putVolumesUpdate(ctx context.Context, w http.ResponseWrit
 		return errdefs.InvalidParameter(err)
 	}
 
-	var req volume.UpdateOptions
+	var req volumebackend.UpdateOptions
 	if err := httputils.ReadJSON(r, &req); err != nil {
 		return err
 	}

--- a/daemon/server/router/volume/volume_routes_test.go
+++ b/daemon/server/router/volume/volume_routes_test.go
@@ -334,7 +334,7 @@ func TestUpdateVolume(t *testing.T) {
 		cluster: c,
 	}
 
-	volumeUpdate := volume.UpdateOptions{
+	volumeUpdate := volumebackend.UpdateOptions{
 		Spec: &volume.ClusterVolumeSpec{},
 	}
 
@@ -363,7 +363,7 @@ func TestUpdateVolumeNoSwarm(t *testing.T) {
 		cluster: c,
 	}
 
-	volumeUpdate := volume.UpdateOptions{
+	volumeUpdate := volumebackend.UpdateOptions{
 		Spec: &volume.ClusterVolumeSpec{},
 	}
 
@@ -395,7 +395,7 @@ func TestUpdateVolumeNotFound(t *testing.T) {
 		cluster: c,
 	}
 
-	volumeUpdate := volume.UpdateOptions{
+	volumeUpdate := volumebackend.UpdateOptions{
 		Spec: &volume.ClusterVolumeSpec{},
 	}
 
@@ -746,7 +746,7 @@ func (c *fakeClusterBackend) RemoveVolume(nameOrID string, force bool) error {
 	return nil
 }
 
-func (c *fakeClusterBackend) UpdateVolume(nameOrID string, version uint64, _ volume.UpdateOptions) error {
+func (c *fakeClusterBackend) UpdateVolume(nameOrID string, version uint64, _ volumebackend.UpdateOptions) error {
 	if err := c.checkSwarm(); err != nil {
 		return err
 	}

--- a/daemon/server/volumebackend/volume.go
+++ b/daemon/server/volumebackend/volume.go
@@ -1,7 +1,14 @@
 package volumebackend
 
-import "github.com/moby/moby/v2/daemon/internal/filters"
+import (
+	"github.com/moby/moby/api/types/volume"
+	"github.com/moby/moby/v2/daemon/internal/filters"
+)
 
 type ListOptions struct {
 	Filters filters.Args
+}
+
+type UpdateOptions struct {
+	Spec *volume.ClusterVolumeSpec `json:"Spec,omitempty"`
 }

--- a/vendor/github.com/moby/moby/api/types/volume/volume_update.go
+++ b/vendor/github.com/moby/moby/api/types/volume/volume_update.go
@@ -1,7 +1,0 @@
-package volume
-
-// UpdateOptions is configuration to update a Volume with.
-type UpdateOptions struct {
-	// Spec is the ClusterVolumeSpec to update the volume to.
-	Spec *ClusterVolumeSpec `json:"Spec,omitempty"`
-}

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -201,7 +201,7 @@ type VolumeAPIClient interface {
 	VolumeList(ctx context.Context, options VolumeListOptions) (volume.ListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
 	VolumesPrune(ctx context.Context, opts VolumePruneOptions) (VolumePruneResult, error)
-	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error
+	VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options VolumeUpdateOptions) error
 }
 
 // SecretAPIClient defines API client methods for secrets

--- a/vendor/github.com/moby/moby/client/volume_update.go
+++ b/vendor/github.com/moby/moby/client/volume_update.go
@@ -8,9 +8,14 @@ import (
 	"github.com/moby/moby/api/types/volume"
 )
 
+type VolumeUpdateOptions struct {
+	// Spec is the ClusterVolumeSpec to update the volume to.
+	Spec *volume.ClusterVolumeSpec `json:"Spec,omitempty"`
+}
+
 // VolumeUpdate updates a volume. This only works for Cluster Volumes, and
 // only some fields can be updated.
-func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options volume.UpdateOptions) error {
+func (cli *Client) VolumeUpdate(ctx context.Context, volumeID string, version swarm.Version, options VolumeUpdateOptions) error {
 	volumeID, err := trimID("volume", volumeID)
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**

fixes [volume_update.go #51206](https://github.com/moby/moby/issues/51206)

**- How I did it**
Lift and shift

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
api/types/volume: moved `UpdateOptions` into client module
```

**- A picture of a cute animal (not mandatory but encouraged)**

