### PR TITLE
test: migrate test api error not found json

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -50,14 +50,3 @@ func (s *DockerAPISuite) TestAPIErrorJSON(c *testing.T) {
 	assert.NilError(c, err)
 	assert.Check(c, is.Contains(getErrorMessage(c, b), "config cannot be empty"))
 }
-
-func (s *DockerAPISuite) TestAPIErrorNotFoundJSON(c *testing.T) {
-	// 404 is a different code path to normal errors, so test separately
-	httpResp, body, err := request.Get(testutil.GetContext(c), "/notfound", request.JSON)
-	assert.NilError(c, err)
-	assert.Equal(c, httpResp.StatusCode, http.StatusNotFound)
-	assert.Assert(c, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
-	b, err := request.ReadBody(body)
-	assert.NilError(c, err)
-	assert.Equal(c, getErrorMessage(c, b), "page not found")
-}

--- a/integration/system/api_test.go
+++ b/integration/system/api_test.go
@@ -1,0 +1,23 @@
+package system
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moby/moby/api/types/common"
+	"github.com/moby/moby/v2/internal/testutil/request"
+	"gotest.tools/v3/assert"
+)
+
+func TestAPIErrorNotFoundJSON(t *testing.T) {
+	ctx := setupTest(t)
+
+	// 404 is a different code path to normal errors, so test separately
+	httpResp, _, err := request.Get(ctx, "/notfound", request.JSON)
+	assert.NilError(t, err)
+	assert.Equal(t, httpResp.StatusCode, http.StatusNotFound)
+
+	var respErr common.ErrorResponse
+	assert.NilError(t, request.ReadJSONResponse(httpResp, &respErr))
+	assert.Error(t, respErr, "page not found")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Migrated the TestAPIErrorNotFoundJSON to integration tests in reference to the integration-cli migration epic https://github.com/moby/moby/issues/50159

**- How I did it**
Using test on integration-cli/docker_api_test.go

**- How to verify it**
Run the integration test

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
🐳
