### PR TITLE
daemon/server: remove some fallbacks for API < v1.44

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -168,6 +168,12 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 			if !opts.Manifests && !opts.Identity {
 				image.Manifests = nil
 			}
+			if image.RepoTags == nil {
+				image.RepoTags = []string{}
+			}
+			if image.RepoDigests == nil {
+				image.RepoDigests = []string{}
+			}
 			resultsMut.Lock()
 			summaries = append(summaries, *image)
 

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -272,6 +272,12 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 
 	summaries := make([]imagetypes.Summary, 0, len(summaryMap))
 	for _, summary := range summaryMap {
+		if summary.RepoTags == nil {
+			summary.RepoTags = []string{}
+		}
+		if summary.RepoDigests == nil {
+			summary.RepoDigests = []string{}
+		}
 		summaries = append(summaries, *summary)
 	}
 	sort.Sort(sort.Reverse(byCreated(summaries)))

--- a/daemon/server/router/container/exec.go
+++ b/daemon/server/router/container/exec.go
@@ -49,12 +49,6 @@ func (c *containerRouter) postContainerExecCreate(ctx context.Context, w http.Re
 		return execCommandError{}
 	}
 
-	version := httputils.VersionFromContext(ctx)
-	if versions.LessThan(version, "1.42") {
-		// Not supported by API versions before 1.42
-		execConfig.ConsoleSize = nil
-	}
-
 	// Register an instance of Exec in container.
 	id, err := c.backend.ContainerExecCreate(vars["name"], execConfig)
 	if err != nil {
@@ -88,18 +82,9 @@ func (c *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		return err
 	}
 
-	if options.ConsoleSize != nil {
-		version := httputils.VersionFromContext(ctx)
-
-		// Not supported before 1.42
-		if versions.LessThan(version, "1.42") {
-			options.ConsoleSize = nil
-		}
-
+	if !options.Tty {
 		// No console without tty
-		if !options.Tty {
-			options.ConsoleSize = nil
-		}
+		options.ConsoleSize = nil
 	}
 
 	if !options.Detach {

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -510,24 +510,20 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
+	addVirtualSize := versions.LessThan(version, "1.44")
 	noDescriptor := versions.LessThan(version, "1.48")
 	noContainers := versions.LessThan(version, "1.51")
-	for i := range images {
-		if images[i].RepoTags == nil {
-			images[i].RepoTags = []string{}
-		}
-		if images[i].RepoDigests == nil {
-			images[i].RepoDigests = []string{}
-		}
-		if noDescriptor {
-			images[i].Descriptor = nil
-		}
-		if noContainers {
-			images[i].Containers = -1
+	if noDescriptor || noContainers {
+		for i := range images {
+			if noDescriptor {
+				images[i].Descriptor = nil
+			}
+			if noContainers {
+				images[i].Containers = -1
+			}
 		}
 	}
-
-	if versions.LessThan(version, "1.44") {
+	if addVirtualSize {
 		wrapped := make([]*compat.Wrapper, len(images))
 		for i := range images {
 			wrapped[i] = compat.Wrap(&images[i], compat.WithExtraFields(map[string]any{

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -486,12 +486,6 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		}
 	}
 
-	var sharedSize bool
-	if versions.GreaterThanOrEqualTo(version, "1.42") {
-		// NOTE: Support for the "shared-size" parameter was added in API 1.42.
-		sharedSize = httputils.BoolValue(r, "shared-size")
-	}
-
 	var manifests bool
 	if versions.GreaterThanOrEqualTo(version, "1.47") {
 		manifests = httputils.BoolValue(r, "manifests")
@@ -508,7 +502,7 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 	images, err := ir.backend.Images(ctx, imagebackend.ListOptions{
 		All:        httputils.BoolValue(r, "all"),
 		Filters:    imageFilters,
-		SharedSize: sharedSize,
+		SharedSize: httputils.BoolValue(r, "shared-size"),
 		Manifests:  manifests,
 		Identity:   identity,
 	})
@@ -516,22 +510,14 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	useNone := versions.LessThan(version, "1.43")
 	noDescriptor := versions.LessThan(version, "1.48")
 	noContainers := versions.LessThan(version, "1.51")
 	for i := range images {
-		if useNone {
-			if len(images[i].RepoTags) == 0 && len(images[i].RepoDigests) == 0 {
-				images[i].RepoTags = append(images[i].RepoTags, "<none>:<none>")
-				images[i].RepoDigests = append(images[i].RepoDigests, "<none>@<none>")
-			}
-		} else {
-			if images[i].RepoTags == nil {
-				images[i].RepoTags = []string{}
-			}
-			if images[i].RepoDigests == nil {
-				images[i].RepoDigests = []string{}
-			}
+		if images[i].RepoTags == nil {
+			images[i].RepoTags = []string{}
+		}
+		if images[i].RepoDigests == nil {
+			images[i].RepoDigests = []string{}
 		}
 		if noDescriptor {
 			images[i].Descriptor = nil


### PR DESCRIPTION
- Stop producing `<none>:<none>` tags for images that have no tags
- Remove the version-gate for shared-size, assuming no old client would be aware of it, so won't be using it.
- Remove version-gate for console-size on "docker exec". Old clients wouldn't set this and there's no harm if they would.


**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

