### PR TITLE
integration/container: Make tests runnable on SELinux enabled daemon

### DIFF
--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -361,7 +361,7 @@ func TestContainerVolumesMountedAsSlave(t *testing.T) {
 	topCmd := []string{"top"}
 
 	apiClient := testEnv.APIClient()
-	containerID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithMount(slaveMount), container.WithCmd(topCmd...))
+	containerID := container.Run(ctx, t, apiClient, container.WithTty(true), container.WithMount(slaveMount), container.WithCmd(topCmd...), container.WithSecurityOpt("label=disable"))
 
 	// Bind mount tmpDir2/ onto tmpDir1/mnt1. If mount propagates inside
 	// container then contents of tmpDir2/slave-testfile should become
@@ -608,15 +608,15 @@ func TestContainerBindMountRecursivelyReadOnly(t *testing.T) {
 	apiClient := testEnv.APIClient()
 
 	containers := []string{
-		container.Run(ctx, t, apiClient, container.WithMount(ro), container.WithCmd(roVerifier...)),
-		container.Run(ctx, t, apiClient, container.WithBindRaw(roAsStr), container.WithCmd(roVerifier...)),
+		container.Run(ctx, t, apiClient, container.WithMount(ro), container.WithCmd(roVerifier...), container.WithSecurityOpt("label=disable")),
+		container.Run(ctx, t, apiClient, container.WithBindRaw(roAsStr), container.WithCmd(roVerifier...), container.WithSecurityOpt("label=disable")),
 
-		container.Run(ctx, t, apiClient, container.WithMount(nonRecursive), container.WithCmd(nonRecursiveVerifier...)),
+		container.Run(ctx, t, apiClient, container.WithMount(nonRecursive), container.WithCmd(nonRecursiveVerifier...), container.WithSecurityOpt("label=disable")),
 	}
 
 	if rroSupported {
 		containers = append(containers,
-			container.Run(ctx, t, apiClient, container.WithMount(forceRecursive), container.WithCmd(forceRecursiveVerifier...)),
+			container.Run(ctx, t, apiClient, container.WithMount(forceRecursive), container.WithCmd(forceRecursiveVerifier...), container.WithSecurityOpt("label=disable")),
 		)
 	}
 

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -422,13 +422,13 @@ func TestCgroupRW(t *testing.T) {
 		},
 		{
 			name: "writable",
-			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups")},
+			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups"), container.WithSecurityOpt("label=disable")},
 			// no err msg, because this is correct key=bool
 			expectedExitCode: 0,
 		},
 		{
 			name: "writable=true",
-			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=true")},
+			ops:  []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=true"), container.WithSecurityOpt("label=disable")},
 			// no err msg, because this is correct key=value
 			expectedExitCode: 0,
 		},
@@ -445,7 +445,7 @@ func TestCgroupRW(t *testing.T) {
 		},
 		{
 			name:           "writable=1",
-			ops:            []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=1")},
+			ops:            []func(*container.TestContainerConfig){container.WithSecurityOpt("writable-cgroups=1"), container.WithSecurityOpt("label=disable")},
 			expectedErrMsg: `Error response from daemon: invalid --security-opt 2: "writable-cgroups=1"`,
 		},
 		{


### PR DESCRIPTION
Make tests runnable on SELinux enabled daemon.

Otherwise I get failures like these: https://openqa.opensuse.org/tests/5393787/file/docker_engine-report.txt

```
=== RUN   TestCgroupRW/writable
    run_linux_test.go:484: assertion failed: 
        --- ←
        +++ →
        @@ -1,2 +1 @@
        -mkdir: can't create directory '/sys/fs/cgroup/foo': Permission denied
         
        
--- FAIL: TestCgroupRW/writable (0.17s)
=== RUN   TestCgroupRW/writable=true
    run_linux_test.go:484: assertion failed: 
        --- ←
        +++ →
        @@ -1,2 +1 @@
        -mkdir: can't create directory '/sys/fs/cgroup/foo': Permission denied
         
        
--- FAIL: TestCgroupRW/writable=true (0.17s)
=== RUN   TestCgroupRW/writable=1
    run_linux_test.go:484: assertion failed: 
        --- ←
        +++ →
        @@ -1,2 +1 @@
        -mkdir: can't create directory '/sys/fs/cgroup/foo': Permission denied
         
        
--- FAIL: TestCgroupRW/writable=1 (0.18s)
=== FAIL: integration/container TestContainerVolumesMountedAsSlave (0.17s)
    mounts_linux_test.go:382: Bind mount under slave volume did not propagate to container

=== FAIL: integration/container TestContainerBindMountRecursivelyReadOnly (0.70s)
    mounts_linux_test.go:624: polling check failed: expected exit code 0, got 1

=== FAIL: integration/container TestCgroupRW/writable (0.17s)
    run_linux_test.go:484: assertion failed: 
        --- ←
        +++ →
        @@ -1,2 +1 @@
        -mkdir: can't create directory '/sys/fs/cgroup/foo': Permission denied
         
        

=== FAIL: integration/container TestCgroupRW/writable=true (0.17s)
    run_linux_test.go:484: assertion failed: 
        --- ←
        +++ →
        @@ -1,2 +1 @@
        -mkdir: can't create directory '/sys/fs/cgroup/foo': Permission denied
         
        

=== FAIL: integration/container TestCgroupRW/writable=1 (0.18s)
    run_linux_test.go:484: assertion failed: 
        --- ←
        +++ →
        @@ -1,2 +1 @@
        -mkdir: can't create directory '/sys/fs/cgroup/foo': Permission denied
         
        

=== FAIL: integration/container TestCgroupRW (1.35s)
```