### PR TITLE
quota: support disk quota when containerd-snapshotter is enabled

### DIFF
--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -12,9 +12,11 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/docker/go-units"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/layer"
+	"github.com/moby/moby/v2/daemon/internal/quota"
 	"github.com/moby/moby/v2/daemon/snapshotter"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/image-spec/identity"
@@ -48,6 +50,9 @@ func (i *ImageService) CreateLayerFromImage(img *image.Image, layerName string, 
 
 func (i *ImageService) createLayer(descriptor *ocispec.Descriptor, layerName string, rwLayerOpts *layer.CreateRWLayerOpts, initFunc layer.MountInit) (container.RWLayer, error) {
 	ctx := context.TODO()
+	if _, ok := rwLayerOpts.StorageOpt["size"]; ok && i.quotaCtl == nil {
+		return nil, errors.New("--storage-opt is not supported only by underlay fs")
+	}
 	var parentSnapshot string
 	if descriptor != nil {
 		snapshot, err := i.getImageSnapshot(ctx, descriptor)
@@ -85,6 +90,31 @@ func (i *ImageService) createLayer(descriptor *ocispec.Descriptor, layerName str
 
 	if err != nil {
 		return nil, err
+	}
+
+	// set quota
+	mounts, err := sn.Mounts(ctx, layerName)
+	if rwLayerOpts.StorageOpt != nil && len(rwLayerOpts.StorageOpt) > 0 {
+		var upperdir string
+		for _, m := range mounts {
+			for _, option := range m.Options {
+				if strings.HasPrefix(option, "upperdir=") {
+					upperdir = strings.TrimPrefix(option, "upperdir=")
+					break
+				}
+			}
+		}
+		size, err := parseStorageOpt(rwLayerOpts.StorageOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		if size > 0 {
+			// Set container disk quota limit
+			if err = i.quotaCtl.SetQuota(upperdir, quota.Quota{Size: size}); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return &rwLayer{
@@ -260,6 +290,26 @@ func (i *ImageService) ReleaseLayer(rwlayer container.RWLayer) error {
 		}
 	}
 	return nil
+}
+
+// Parse overlay storage options
+func parseStorageOpt(storageOpt map[string]string) (uint64, error) {
+	// Read size to set the disk project quota per container
+	for key, val := range storageOpt {
+		key = strings.ToLower(key)
+		switch key {
+		case "size":
+			size, err := units.RAMInBytes(val)
+			if err != nil {
+				return 0, err
+			}
+			return uint64(size), nil
+		default:
+			return 0, fmt.Errorf("Unknown option %s", key)
+		}
+	}
+
+	return 0, nil
 }
 
 func (i *ImageService) prepareInitLayer(ctx context.Context, id string, parent string, setupInit func(string) error) error {

--- a/daemon/containerd/image_snapshot.go
+++ b/daemon/containerd/image_snapshot.go
@@ -12,9 +12,11 @@ import (
 	"github.com/containerd/containerd/v2/core/snapshots"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/docker/go-units"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/layer"
+	"github.com/moby/moby/v2/daemon/internal/quota"
 	"github.com/moby/moby/v2/daemon/snapshotter"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/opencontainers/image-spec/identity"
@@ -48,6 +50,9 @@ func (i *ImageService) CreateLayerFromImage(img *image.Image, layerName string, 
 
 func (i *ImageService) createLayer(descriptor *ocispec.Descriptor, layerName string, rwLayerOpts *layer.CreateRWLayerOpts, initFunc layer.MountInit) (container.RWLayer, error) {
 	ctx := context.TODO()
+	if _, ok := rwLayerOpts.StorageOpt["size"]; ok && i.quotaCtl == nil {
+		return nil, errors.New("--storage-opt is not supported only by underlay fs")
+	}
 	var parentSnapshot string
 	if descriptor != nil {
 		snapshot, err := i.getImageSnapshot(ctx, descriptor)
@@ -85,6 +90,31 @@ func (i *ImageService) createLayer(descriptor *ocispec.Descriptor, layerName str
 
 	if err != nil {
 		return nil, err
+	}
+
+	// set quota
+	mounts, err := sn.Mounts(ctx, layerName)
+	if rwLayerOpts.StorageOpt != nil && len(rwLayerOpts.StorageOpt) > 0 {
+		var upperdir string
+		for _, m := range mounts {
+			for _, option := range m.Options {
+				if strings.HasPrefix(option, "upperdir=") {
+					upperdir = strings.TrimPrefix(option, "upperdir=")
+					break
+				}
+			}
+		}
+		size, err := parseStorageOpt(rwLayerOpts.StorageOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		if size > 0 && upperdir != "" {
+			// Set container disk quota limit
+			if err = i.quotaCtl.SetQuota(upperdir, quota.Quota{Size: size}); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return &rwLayer{
@@ -260,6 +290,26 @@ func (i *ImageService) ReleaseLayer(rwlayer container.RWLayer) error {
 		}
 	}
 	return nil
+}
+
+// Parse overlay storage options
+func parseStorageOpt(storageOpt map[string]string) (uint64, error) {
+	// Read size to set the disk project quota per container
+	for key, val := range storageOpt {
+		key = strings.ToLower(key)
+		switch key {
+		case "size":
+			size, err := units.RAMInBytes(val)
+			if err != nil {
+				return 0, err
+			}
+			return uint64(size), nil
+		default:
+			return 0, fmt.Errorf("Unknown option %s", key)
+		}
+	}
+
+	return 0, nil
 }
 
 func (i *ImageService) prepareInitLayer(ctx context.Context, id string, parent string, setupInit func(string) error) error {

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -19,6 +19,7 @@ import (
 	daemonevents "github.com/moby/moby/v2/daemon/events"
 	dimages "github.com/moby/moby/v2/daemon/images"
 	"github.com/moby/moby/v2/daemon/internal/distribution"
+	"github.com/moby/moby/v2/daemon/internal/quota"
 	"github.com/moby/moby/v2/daemon/snapshotter"
 	"github.com/moby/moby/v2/errdefs"
 	policyverifier "github.com/moby/policy-helpers"
@@ -47,6 +48,7 @@ type ImageService struct {
 
 	// defaultPlatformOverride is used in tests to override the host platform.
 	defaultPlatformOverride platforms.MatchComparer
+	quotaCtl                *quota.Control
 }
 
 type ImageServiceConfig struct {
@@ -54,6 +56,7 @@ type ImageServiceConfig struct {
 	Containers             container.Store
 	Snapshotter            string
 	IdentityCacheBackend   identitycache.Backend
+	RootDir	 			   string
 	RegistryHosts          docker.RegistryHosts
 	Registry               distribution.RegistryResolver
 	EventsService          *daemonevents.Events
@@ -64,6 +67,10 @@ type ImageServiceConfig struct {
 
 // NewService creates a new ImageService.
 func NewService(config ImageServiceConfig) *ImageService {
+	var quotaCtl *quota.Control
+	if config.RootDir != "" {
+		quotaCtl, _ = quota.NewControl(config.RootDir)
+	}
 	service := &ImageService{
 		client:  config.Client,
 		images:  config.Client.ImageService(),
@@ -88,6 +95,7 @@ func NewService(config ImageServiceConfig) *ImageService {
 				return identitycache.NewNopBackend()
 			}(),
 		},
+		quotaCtl:        quotaCtl,
 	}
 	service.startImageIdentityCacheRefresh()
 	return service

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -19,6 +19,7 @@ import (
 	daemonevents "github.com/moby/moby/v2/daemon/events"
 	dimages "github.com/moby/moby/v2/daemon/images"
 	"github.com/moby/moby/v2/daemon/internal/distribution"
+	"github.com/moby/moby/v2/daemon/internal/quota"
 	"github.com/moby/moby/v2/daemon/snapshotter"
 	"github.com/moby/moby/v2/errdefs"
 	policyverifier "github.com/moby/policy-helpers"
@@ -56,6 +57,7 @@ type ImageService struct {
 
 	// defaultPlatformOverride is used in tests to override the host platform.
 	defaultPlatformOverride *ocispec.Platform
+	quotaCtl                *quota.Control
 }
 
 func newTransferLimiter(maxConcurrent int) *semaphore.Weighted {
@@ -70,6 +72,7 @@ type ImageServiceConfig struct {
 	Containers             container.Store
 	Snapshotter            string
 	IdentityCacheBackend   identitycache.Backend
+	RootDir	 			   string
 	RegistryHosts          docker.RegistryHosts
 	Registry               distribution.RegistryResolver
 	EventsService          *daemonevents.Events
@@ -85,6 +88,10 @@ func NewService(config ImageServiceConfig) *ImageService {
 	log.G(context.TODO()).Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	log.G(context.TODO()).Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
 
+	var quotaCtl *quota.Control
+	if config.RootDir != "" {
+		quotaCtl, _ = quota.NewControl(config.RootDir)
+	}
 	service := &ImageService{
 		client:  config.Client,
 		images:  config.Client.ImageService(),
@@ -109,6 +116,7 @@ func NewService(config ImageServiceConfig) *ImageService {
 				return identitycache.NewNopBackend()
 			}(),
 		},
+		quotaCtl:        quotaCtl,
 	}
 	service.setTransferLimits(config.MaxConcurrentDownloads, config.MaxConcurrentUploads)
 	service.startImageIdentityCacheRefresh()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/containerd/containerd/api/services/introspection/v1"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/defaults"
 	cerrdefs "github.com/containerd/errdefs"
@@ -1274,13 +1275,13 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		if resp == nil || len(resp.Plugins) == 0 {
 			return nil, fmt.Errorf("failed to get containerd plugins response: %w", cerrdefs.ErrUnavailable)
 		}
-		availableDrivers := map[string]struct{}{}
+		availableDrivers := map[string]*introspection.Plugin{}
 		for _, p := range resp.Plugins {
 			if p == nil || p.Type != "io.containerd.snapshotter.v1" {
 				continue
 			}
 			if p.InitErr == nil {
-				availableDrivers[p.ID] = struct{}{}
+				availableDrivers[p.ID] = p
 			} else if (p.ID == driverName) || (driverName == "" && p.ID == defaults.DefaultSnapshotter) {
 				log.G(ctx).WithField("message", p.InitErr.Message).Warn("Preferred snapshotter not available in containerd")
 			}
@@ -1315,6 +1316,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			Containers:             d.containers,
 			Snapshotter:            driverName,
 			IdentityCacheBackend:   identityCacheBackend,
+			RootDir:                availableDrivers[driverName].Exports["root"],
 			RegistryHosts:          d.RegistryHosts,
 			Registry:               d.registryService,
 			EventsService:          d.EventsService,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/containerd/containerd/api/services/introspection/v1"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/defaults"
 	cerrdefs "github.com/containerd/errdefs"
@@ -1308,13 +1309,13 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		if resp == nil || len(resp.Plugins) == 0 {
 			return nil, fmt.Errorf("failed to get containerd plugins response: %w", cerrdefs.ErrUnavailable)
 		}
-		availableDrivers := map[string]struct{}{}
+		availableDrivers := map[string]*introspection.Plugin{}
 		for _, p := range resp.Plugins {
 			if p == nil || p.Type != "io.containerd.snapshotter.v1" {
 				continue
 			}
 			if p.InitErr == nil {
-				availableDrivers[p.ID] = struct{}{}
+				availableDrivers[p.ID] = p
 			} else if (p.ID == driverName) || (driverName == "" && p.ID == defaults.DefaultSnapshotter) {
 				log.G(ctx).WithField("message", p.InitErr.Message).Warn("Preferred snapshotter not available in containerd")
 			}
@@ -1349,6 +1350,7 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 			Containers:             d.containers,
 			Snapshotter:            driverName,
 			IdentityCacheBackend:   identityCacheBackend,
+			RootDir:                availableDrivers[driverName].Exports["root"],
 			RegistryHosts:          d.RegistryHosts,
 			Registry:               d.registryService,
 			EventsService:          d.EventsService,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Support `--storage-opt size=1G` when `containerd-snapshotter=true`

**- How I did it**

try create `quota.Control` in ctrd.NewServer.
set quota when creating rw layer

**- How to verify it**

start dockerd and bundled containerd with data-dir in a quota-supported fs
```
$ docker run -it --rm --storage-opt size=10MB debian dd if=/dev/zero of=/data3 bs=1MB count=1024
dd: error writing '/data3': Disk quota exceeded
11+0 records in
10+0 records out
10469376 bytes (10 MB, 10 MiB) copied, 0.0148708 s, 704 MB/s
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

