### PR TITLE
integration-cli: move some tests to integration

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 type DockerAPISuite struct {
@@ -39,14 +38,4 @@ func (s *DockerAPISuite) TestAPIGetEnabledCORS(c *testing.T) {
 	// c.Log(res.Header)
 	// assert.Equal(c, res.Header.Get("Access-Control-Allow-Origin"), "*")
 	// assert.Equal(c, res.Header.Get("Access-Control-Allow-Headers"), "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
-}
-
-func (s *DockerAPISuite) TestAPIErrorJSON(c *testing.T) {
-	httpResp, body, err := request.Post(testutil.GetContext(c), "/containers/create", request.JSONBody(struct{}{}))
-	assert.NilError(c, err)
-	assert.Equal(c, httpResp.StatusCode, http.StatusBadRequest)
-	assert.Assert(c, is.Contains(httpResp.Header.Get("Content-Type"), "application/json"))
-	b, err := request.ReadBody(body)
-	assert.NilError(c, err)
-	assert.Check(c, is.Contains(getErrorMessage(c, b), "config cannot be empty"))
 }


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/50159
- supersedes, closes https://github.com/moby/moby/pull/51176

Migrates:

- TestAPIErrorJSON
- TestContainerAPIInvalidPortSyntax
- TestContainerAPIRestartPolicyInvalidPolicyName
- TestContainerAPIRestartPolicyRetryMismatch
- TestContainerAPIRestartPolicyNegativeRetryCount
- TestContainerAPIRestartPolicyDefaultRetryCount
- TestCreateWithTooLowMemoryLimit

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

