### PR TITLE
libnetwork: support custom DNS servers in Windows overlay driver

### DIFF
--- a/daemon/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
+++ b/daemon/libnetwork/drivers/windows/overlay/ov_endpoint_windows.go
@@ -124,12 +124,18 @@ func (d *driver) CreateEndpoint(ctx context.Context, nid, eid string, ifInfo dri
 
 	// Todo: Add port bindings and qos policies here
 
+	dnsServerList, err := windows.ParseDNSServers(epOptions)
+	if err != nil {
+		return err
+	}
+
 	hnsEndpoint := &hcsshim.HNSEndpoint{
 		Name:              eid,
 		VirtualNetwork:    n.hnsID,
 		IPAddress:         ep.addr.IP,
 		EnableInternalDNS: true,
 		GatewayAddress:    s.gwIP.String(),
+		DNSServerList:     dnsServerList,
 	}
 
 	if ep.mac != nil {


### PR DESCRIPTION
**- What I did**
Decision in #19474 seems to be that there is no option to disable embedded DNS but user can provide own DNS servers with `--dns` option. However that logic does not exist in Windows version of overlay driver so I fixed that.

**- How I did it**
Copy & paste logic from non-overlay driver:
https://github.com/moby/moby/blob/663aa7aeab85d007be756001691ebf5d0fe0ab53/daemon/libnetwork/drivers/windows/windows.go#L732

**- How to verify it**
Create attachable  test network:
```bash
docker network create --driver overlay --attachable test
```
Start test container:
```powershell
docker run -it --rm --network=test --dns=1.1.1.1 mcr.microsoft.com/windows/nanoserver:ltsc2025
```

**NOTE!** In Windows, gateway is always first DNS server inside of the container but internally DNS server(s) provided by user are used. That can be confirmed by testing with both valid and invalid DNS server IP addresses.

**- Human readable description for the release notes**
```markdown changelog
- The Windows overlay network driver now supports option `--dns`.
```
