### PR TITLE
Move container platform migration logic

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -79,16 +79,6 @@ func (daemon *Daemon) load(id string) (*container.Container, error) {
 	}
 	selinux.ReserveLabel(ctr.ProcessLabel)
 
-	if ctr.ImagePlatform.Architecture == "" {
-		migration := daemonPlatformReader{
-			imageService: daemon.imageService,
-		}
-		if daemon.containerdClient != nil {
-			migration.content = daemon.containerdClient.ContentStore()
-		}
-		migrateContainerOS(context.TODO(), migration, ctr)
-	}
-
 	if ctr.ID != id {
 		return ctr, fmt.Errorf("Container %s is stored at %s", ctr.ID, id)
 	}


### PR DESCRIPTION
Defer the logic to fill in the container platform information from the image service until container restore. During container restore the image backend is fully initialized and can be used to fill in the missing platform fields for older containers.

Fixes #51215

Did not add tests for this since it is deprecated functionality, the crash will be avoided by not accessing the image backend before it is initialized.