### PR TITLE
gha/labeler: Exclude client and api modules from dependencies label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -139,6 +139,9 @@ area/dependencies:
       - 'go.mod'
       - 'go.sum'
       - 'vendor/**'
+    - all-globs-to-all-files:
+      - '!client/**'
+      - '!api/**'
 
 area/ci:
   - changed-files:


### PR DESCRIPTION
Prevent applying `area/dependencies` when the `client` and `api` modules are changed.

Due to the replace rule present for these modules, we have to revendor them with each change which would trigger the previous rule.

This fixes the dependencies label being applied to PRs like:  https://github.com/moby/moby/pull/51236