### PR TITLE
internal/testutil/daemon: cleanup after successful tests

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -34,7 +34,7 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistry(c *testing.T) {
 	if err != nil && strings.Contains(err.Error(), "toomanyrequests") {
 		c.Skipf("XFAIL: %s", err.Error())
 	}
-	assert.NilError(c, err)
+	assert.NilError(c, err, out)
 	defer deleteImages("hello-world")
 
 	assert.Assert(c, strings.Contains(out, "Using default tag: latest"), "expected the 'latest' tag to be automatically assumed")

--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -33,6 +33,7 @@ func newDockerHubPullSuite() *DockerHubPullSuite {
 // SetUpSuite starts the suite daemon.
 func (s *DockerHubPullSuite) SetUpSuite(ctx context.Context, t *testing.T) {
 	testRequires(t, DaemonIsLinux, testEnv.IsLocalDaemon)
+	t.Logf("SETTING UP TEST")
 	s.d = daemon.New(t, dockerBinary, dockerdBinary, testdaemon.WithEnvironment(testEnv.Execution))
 	s.d.Start(t)
 }
@@ -66,7 +67,7 @@ func (s *DockerHubPullSuite) Cmd(t *testing.T, name string, arg ...string) strin
 	t.Helper()
 	args := append([]string{"--host", s.d.Sock(), name}, arg...)
 	out, err := exec.CommandContext(t.Context(), dockerBinary, args...).CombinedOutput()
-	assert.Assert(t, err == nil, "%q failed with errors: %s, %v", strings.Join(args, " "), string(out), err)
+	assert.Assert(t, err == nil, "%q failed with errors: %s %s, %v", dockerBinary, strings.Join(args, " "), string(out), err)
 	return string(out)
 }
 

--- a/internal/test/suite/suite.go
+++ b/internal/test/suite/suite.go
@@ -36,6 +36,7 @@ func Run(ctx context.Context, t *testing.T, suite any) {
 	}()
 
 	methodFinder := reflect.TypeOf(suite)
+	ts := t
 	for index := 0; index < methodFinder.NumMethod(); index++ {
 		method := methodFinder.Method(index)
 		if !methodFilter(method.Name, method.Type) {
@@ -58,11 +59,12 @@ func Run(ctx context.Context, t *testing.T, suite any) {
 			}
 
 			if setupTestSuite, ok := getSetupTestSuite(suite); ok {
-				setupTestSuite.SetUpTest(ctx, t)
+				setupTestSuite.SetUpTest(ctx, ts)
 			}
 			defer func() {
 				if tearDownTestSuite, ok := getTearDownTestSuite(suite); ok {
-					tearDownTestSuite.TearDownTest(ctx, t)
+					t.Logf("TEARDOWN TEST SUITE")
+					tearDownTestSuite.TearDownTest(ctx, ts)
 				}
 			}()
 

--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -239,6 +239,7 @@ func New(t testing.TB, ops ...Option) *Daemon {
 	}
 
 	t.Cleanup(func() {
+		t.Logf("Cleaning up daemon2: %s", d.id)
 		if err := d.Kill(); err != nil && !errors.Is(err, errDaemonNotStarted) {
 			t.Errorf("[%s] error while stopping the daemon during cleanup: %v", d.id, err)
 		}
@@ -325,6 +326,7 @@ func (d *Daemon) NewClient(extraOpts ...client.Opt) (*client.Client, error) {
 // Cleanup cleans the daemon files : exec root (network namespaces, ...), swarmkit files
 func (d *Daemon) Cleanup(t testing.TB) {
 	t.Helper()
+	t.Logf("Cleaning up daemon: %s", d.id)
 	if err := d.Kill(); err != nil && !errors.Is(err, errDaemonNotStarted) {
 		t.Errorf("[%s] error while stopping the daemon during cleanup: %v", d.id, err)
 	}


### PR DESCRIPTION
There's many daemons started during our integration tests, and currently those daemons may not be stopped, and their files not cleaned up. This also results in failures while producing test-reports:

    Run reportsName=ubuntu-22.04
      reportsName=ubuntu-22.04
    ...
      find bundles -path '*/root/*overlay2' -prune -o -type f \( -name '*-report.json' -o -name '*.log' -o -name '*.out' -o -name '*.prof' -o -name '*-report.xml' \) -print | xargs sudo tar -czf /tmp/reports.tar.gz
    ...

    find: ‘bundles/test-integration/TestDirectRoutingOpenPorts/da6750f8132d0/root’: Permission denied
    find: ‘bundles/test-integration/TestPruneDontDeleteUsedDangling/d53d74e126435/root’: Permission denied
    find: ‘bundles/test-integration/TestInfoAPIWarnings/dfd5dfc619efb/root’: Permission denied
    ...

This patch;

- Updates the list of files and directories to clean up, including the daemon's root-directory itself.
- Updates the `daemon.Cleanup` to kill the daemon before cleaning up.
- Sets up a `t.Cleanup` as part of `daemon.New` that kills the daemon, and (if tests were successful) deletes the daemon's state, except for the daemon logs, which may still be useful also on successful tests.

Before this change;

    make TEST_FILTER=TestPruneDontDeleteUsedDangling test-integration
    tree bundles/test-integration
    bundles/test-integration
    ├── TestPruneDontDeleteUsedDangling
    │   └── d6539b99effc9
    │       ├── docker.log
    │       └── root
    │           ├── buildkit
    │           │   ├── cache.db
    │           │   ├── containerd-native
    │           │   │   ├── cachemounts
    │           │   │   ├── metadata_v2.db
    │           │   │   └── workerid
    │           │   ├── executor
    │           │   └── history_c8d.db
    │           ├── containers
    │           │   └── cdd2e8a29403a81e03281cc0bd36284a4e0df9e5f80789b0f6d869104cbede05
    │           │       ├── checkpoints
    │           │       ├── config.v2.json
    │           │       └── hostconfig.json
    │           ├── engine-id
    │           ├── network
    │           │   └── files
    │           │       └── local-kv.db
    │           ├── plugins
    │           │   └── tmp
    │           ├── rootfs
    │           │   └── native
    │           ├── runtimes
    │           ├── swarm
    │           ├── tmp
    │           └── volumes
    │               ├── backingFsBlockDev
    │               └── metadata.db
    ├── arm64-integration-image-go-test-report.json
    ├── arm64-integration-image-junit-report.xml
    ├── docker.log
    ├── fake-HOME
    └── test.log

    22 directories, 15 files

With this patch:

    make TEST_FILTER=TestPruneDontDeleteUsedDangling test-integration
    tree bundles/test-integration
    bundles/test-integration
    ├── TestPruneDontDeleteUsedDangling
    │   └── d52d9f92a1d39
    │       └── docker.log
    ├── arm64-integration-image-go-test-report.json
    ├── arm64-integration-image-junit-report.xml
    ├── docker.log
    ├── fake-HOME
    └── test.log

    4 directories, 5 files

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

