### PR TITLE
hack: disable go telemetry in integration tests

### DIFF
--- a/hack/make/.integration-test-helpers
+++ b/hack/make/.integration-test-helpers
@@ -188,6 +188,13 @@ test_env() {
 	(
 		set -e
 		[ -n "$TESTDEBUG" ] && set -x
+
+		# Disable collecting local telemetry, as collected by Go and Delve;
+		#
+		# - https://github.com/go-delve/delve/blob/v1.24.1/CHANGELOG.md#1231-2024-09-23
+		# - https://go.dev/doc/telemetry#background
+		HOME="$ABS_DEST/fake-HOME" go telemetry off
+
 		env -i \
 			DEST="$ABS_DEST" \
 			DOCKER_API_VERSION="$DOCKER_API_VERSION" \

--- a/hack/test/e2e-run.sh
+++ b/hack/test/e2e-run.sh
@@ -40,6 +40,13 @@ test_env() {
 	(
 		set -e +u
 		[ -n "$TESTDEBUG" ] && set -x
+
+		# Disable collecting local telemetry, as collected by Go and Delve;
+		#
+		# - https://github.com/go-delve/delve/blob/v1.24.1/CHANGELOG.md#1231-2024-09-23
+		# - https://go.dev/doc/telemetry#background
+		HOME="$ABS_DEST/fake-HOME" go telemetry off
+
 		env -i \
 			DOCKER_API_VERSION="$DOCKER_API_VERSION" \
 			DOCKER_INTEGRATION_DAEMON_DEST="$DOCKER_INTEGRATION_DAEMON_DEST" \


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/49688

commit 081987b647b724b628f68bc68084341b3990d804 updated the Dockerfile to disable go's telemetry in our dev / test-environment; as collecting this data doesn't serve much purpose.

However, the configuration to disable telemetry is tied to the user's home-directory (HOME); and disabling telemetry writs a config-file to the user's home-directory (`~/.config/go/telemetry/mode`). While go provides env-vars about the mode and location (`GOTELEMETRY` and `GOTELEMETRYDIR`), those env-vars are read-only and cannot be used to either disable telemetry or to set the location;

> Information about telemetry configuration is also available via read-only Go environment variables:
>
>  go env GOTELEMETRY reports the telemetry mode.
> go env GOTELEMETRYDIR reports the directory holding telemetry configuration and data.

Some steps in our CI set up a different home-directory, which is not configured to disable telemetry, which means that CI currently leaves behind a bunch of files related to this;

    make TEST_FILTER=TestPruneDontDeleteUsedDangling test-integration
    tree -a bundles/test-integration/fake-HOME/
    bundles/test-integration/fake-HOME/
    └── .config
        └── go
            └── telemetry
                ├── local
                │   ├── asm@go1.25.3-go1.25.3-linux-arm64-2025-10-21.v1.count
                │   ├── compile@go1.25.3-go1.25.3-linux-arm64-2025-10-21.v1.count
                │   ├── go@go1.25.3-go1.25.3-linux-arm64-2025-10-21.v1.count
                │   ├── link@go1.25.3-go1.25.3-linux-arm64-2025-10-21.v1.count
                │   ├── test2json@go1.25.3-go1.25.3-linux-arm64-2025-10-21.v1.count
                │   ├── upload.token
                │   └── weekends
                └── upload

    6 directories, 7 files

This patch disables go telemetry also for this home-directory to prevent those files from being created, and to prevent go from producing the telemetry.

With this patch, only the file to disable telemetry is produced:

    make TEST_FILTER=TestPruneDontDeleteUsedDangling test-integration
    tree -a bundles/test-integration/fake-HOME/
    bundles/test-integration/fake-HOME/
    └── .config
        └── go
            └── telemetry
                └── mode

    4 directories, 1 file

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

