### PR TITLE
client: rename VolumeListResult.List to VolumeListResult.Items

### DIFF
--- a/client/volume_list.go
+++ b/client/volume_list.go
@@ -15,7 +15,7 @@ type VolumeListOptions struct {
 
 // VolumeListResult holds the result from the [Client.VolumeList] method.
 type VolumeListResult struct {
-	List volume.ListResponse
+	Items volume.ListResponse
 }
 
 // VolumeList returns the volumes configured in the docker host.
@@ -29,7 +29,7 @@ func (cli *Client) VolumeList(ctx context.Context, options VolumeListOptions) (V
 		return VolumeListResult{}, err
 	}
 
-	var volumes volume.ListResponse
-	err = json.NewDecoder(resp.Body).Decode(&volumes)
-	return VolumeListResult{List: volumes}, err
+	var res VolumeListResult
+	err = json.NewDecoder(resp.Body).Decode(&res.Items)
+	return res, err
 }

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -74,6 +74,6 @@ func TestVolumeList(t *testing.T) {
 
 		result, err := client.VolumeList(context.Background(), VolumeListOptions{Filters: listCase.filters})
 		assert.NilError(t, err)
-		assert.Check(t, is.Len(result.List.Volumes, 1))
+		assert.Check(t, is.Len(result.Items.Volumes, 1))
 	}
 }

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -50,11 +50,10 @@ func TestVolumesCreateAndList(t *testing.T) {
 
 	res, err := apiClient.VolumeList(ctx, client.VolumeListOptions{})
 	assert.NilError(t, err)
-	volList := res.List
-	assert.Assert(t, len(volList.Volumes) > 0)
+	assert.Assert(t, len(res.Items.Volumes) > 0)
 
-	volumes := volList.Volumes[:0]
-	for _, v := range volList.Volumes {
+	volumes := res.Items.Volumes[:0]
+	for _, v := range res.Items.Volumes {
 		if v.Name == namedV.Name {
 			volumes = append(volumes, v)
 		}

--- a/internal/testutil/environment/clean.go
+++ b/internal/testutil/environment/clean.go
@@ -129,9 +129,8 @@ func deleteAllVolumes(ctx context.Context, t testing.TB, c client.VolumeAPIClien
 	t.Helper()
 	res, err := c.VolumeList(ctx, client.VolumeListOptions{})
 	assert.Check(t, err, "failed to list volumes")
-	volumeList := res.List
 
-	for _, v := range volumeList.Volumes {
+	for _, v := range res.Items.Volumes {
 		if _, ok := protectedVolumes[v.Name]; ok {
 			continue
 		}

--- a/internal/testutil/environment/protect.go
+++ b/internal/testutil/environment/protect.go
@@ -229,10 +229,9 @@ func getExistingVolumes(ctx context.Context, t testing.TB, testEnv *Execution) [
 	apiClient := testEnv.APIClient()
 	res, err := apiClient.VolumeList(ctx, client.VolumeListOptions{})
 	assert.NilError(t, err, "failed to list volumes")
-	volumeList := res.List
 
 	var volumes []string
-	for _, vol := range volumeList.Volumes {
+	for _, vol := range res.Items.Volumes {
 		volumes = append(volumes, vol.Name)
 	}
 	return volumes

--- a/vendor/github.com/moby/moby/client/volume_list.go
+++ b/vendor/github.com/moby/moby/client/volume_list.go
@@ -15,7 +15,7 @@ type VolumeListOptions struct {
 
 // VolumeListResult holds the result from the [Client.VolumeList] method.
 type VolumeListResult struct {
-	List volume.ListResponse
+	Items volume.ListResponse
 }
 
 // VolumeList returns the volumes configured in the docker host.
@@ -29,7 +29,7 @@ func (cli *Client) VolumeList(ctx context.Context, options VolumeListOptions) (V
 		return VolumeListResult{}, err
 	}
 
-	var volumes volume.ListResponse
-	err = json.NewDecoder(resp.Body).Decode(&volumes)
-	return VolumeListResult{List: volumes}, err
+	var res VolumeListResult
+	err = json.NewDecoder(resp.Body).Decode(&res.Items)
+	return res, err
 }


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/51210


Trying to find a common naming for these fields.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

