### PR TITLE
integration/network: TestServiceWithDefaultAddressPoolInit fix log

### DIFF
--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -445,7 +445,7 @@ func TestServiceWithDefaultAddressPoolInit(t *testing.T) {
 
 	res, err := cli.NetworkInspect(ctx, overlayID, client.NetworkInspectOptions{Verbose: true})
 	assert.NilError(t, err)
-	t.Logf("%s: NetworkInspect: %+v", t.Name(), res)
+	t.Logf("%s: NetworkInspect: %+v", t.Name(), res.Network)
 	assert.Assert(t, len(res.Network.IPAM.Config) > 0)
 	// As of docker/swarmkit#2890, the ingress network uses the default address
 	// pool (whereas before, the subnet for the ingress network was hard-coded.


### PR DESCRIPTION
This log was logging the whole inspect-response, including the "Raw" field;

    === RUN   TestServiceWithDefaultAddressPoolInit
        service_test.go:448: TestServiceWithDefaultAddressPoolInit: NetworkInspect: {Network:{Network:{Name:sthiraTestServiceWithDefaultAddressPoolInit ID:j4k7ql2dbyycbyew1i7fiyif3 Created:2025-10-21 19:00:32.418877317 +0000 UTC Scope:swarm Driver:overlay EnableIPv4:true EnableIPv6:false IPAM:{Driver:default Options:map[] Config:[{Subnet:20.20.1.0/24 IPRange:invalid Prefix Gateway:20.20.1.1 AuxAddress:map[]}]} Internal:false Attachable:false Ingress:false ConfigFrom:{Network:} ConfigOnly:false Options:map[com.docker.network.driver.overlay.vxlanid_list:4097] Labels:map[] Peers:[{Name:661bf7d013f3 IP:127.0.0.1}]} Containers:map[27af69f425142a8916c35f2d3a0ad4b7ea100db2d8309cfb8fb1fd65c1fd0bc1:{Name:TestServiceTestServiceWithDefaultAddressPoolInit.1.kss6lqx8nspg0o42evczitpda EndpointID:692933d4206760cd24b46a3df036dc2b3b8f87bc6f8fc711528a041f95fef084 MacAddress:02:42:14:14:01:03 IPv4Address:20.20.1.3/24 IPv6Address:invalid Prefix} lb-sthiraTestServiceWithDefaultAddressPoolInit:{Name:sthiraTestServiceWithDefaultAddressPoolInit-endpoint EndpointID:4685f15d277e748004bd963919fb34d9ea110415e7267ac68d5900f3dd8abb5d MacAddress:02:42:14:14:01:04 IPv4Address:20.20.1.4/24 IPv6Address:invalid Prefix}] Services:map[TestServiceTestServiceWithDefaultAddressPoolInit:{VIP:20.20.1.2 Ports:[] LocalLBIndex:256 Tasks:[{Name:TestServiceTestServiceWithDefaultAddressPoolInit.1.kss6lqx8nspg0o42evczitpda EndpointID:692933d4206760cd24b46a3df036dc2b3b8f87bc6f8fc711528a041f95fef084 EndpointIP:20.20.1.3 Info:map[Host IP:127.0.0.1]}]}] Status:0xc0001341d0} Raw:[123 34 78 97 109 101 34 58 34 115 116 104 105 114 97 84 101 115 116 83 101 114 118 105 99 101 87 105 116 104 68 101 102 97 117 108 116 65 100 100 114 101 115 115 80 111 111 108 73 110 105 116 34 44 34 73 100 34 58 34 106 52 107 55 113 108 50 100 98 121 121 99 98 121 101 119 49 105 55 102 105 121 105 102 51 34 44 34 67 114 101 97 116 101 100 34 58 34 50 48 50 53 45 49 48 45 50 49 84 49 57 58 48 48 58 51 50 46 52 49 56 56 55 55 51 49 55 90 34 44 34 83 99 111 112 101 34 58 34 115 119 97 114 109 34 44 34 68 114 105 118 101 114 34 58 34 111 118 101 114 108 97 121 34 44 34 69 110 97 98 108 101 73 80 118 52 34 58 116 114 117 101 44 34 69 110 97 98 108 101 73 80 118 54 34 58 102 97 108 115 101 44 34 73 80 65 77 34 58 123 34 68 114 105 118 101 114 34 58 34 100 101 102 97 117 108 116 34 44 34 79 112 116 105 111 110 115 34 58 110 117 108 108 44 34 67 111 110 102 105 103 34 58 91 123 34 83 117 98 110 101 116 34 58 34 50 48 46 50 48 46 49 46 48 47 50 52 34 44 34 73 80 82 97 110 103 101 34 58 34 34 44 34 71 97 116 101 119 97 121 34 58 34 50 48 46 50 48 46 49 46 49 34 125 93 125 44 34 73 110 116 101 114 110 97 108 34 58 102 97 108 115 101 44 34 65 116 116 97 99 104 97 98 108 101 34 58 102 97 108 115 101 44 34 73 110 103 114 101 115 115 34 58 102 97 108 115 101 44 34 67 111 110 102 105 103 70 114 111 109 34 58 123 34 78 101 116 119 111 114 107 34 58 34 34 125 44 34 67 111 110 102 105 103 79 110 108 121 34 58 102 97 108 115 101 44 34 79 112 116 105 111 110 115 34 58 123 34 99 111 109 46 100 111 99 107 101 114 46 110 101 116 119 111 114 107 46 100 114 105 118 101 114 46 111 118 101 114 108 97 121 46 118 120 108 97 110 105 100 95 108 105 115 116 34 58 34 52 48 57 55 34 125 44 34 76 97 98 101 108 115 34 58 123 125 44 34 80 101 101 114 115 34 58 91 123 34 78 97 109 101 34 58 34 54 54 49 98 102 55 100 48 49 51 102 51 34 44 34 73 80 34 58 34 49 50 55 46 48 46 48 46 49 34 125 93 44 34 67 111 110 116 97 105 110 101 114 115 34 58 123 34 50 55 97 102 54 57 102 52 50 53 49 52 50 97 56 57 49 54 99 51 53 102 50 100 51 97 48 97 100 52 98 55 101 97 49 48 48 100 98 50 100 56 51 48 57 99 102 98 56 102 98 49 102 100 54 53 99 49 102 100 48 98 99 49 34 58 123 34 78 97 109 101 34 58 34 84 101 115 116 83 101 114 118 105 99 101 84 101 115 116 83 101 114 118 105 99 101 87 105 116 104 68 101 102 97 117 108 116 65 100 100 114 101 115 115 80 111 111 108 73 110 105 116 46 49 46 107 115 115 54 108 113 120 56 110 115 112 103 48 111 52 50 101 118 99 122 105 116 112 100 97 34 44 34 69 110 100 112 111 105 110 116 73 68 34 58 34 54 57 50 57 51 51 100 52 50 48 54 55 54 48 99 100 50 52 98 52 54 97 51 100 102 48 51 54 100 99 50 98 51 98 56 102 56 55 98 99 54 102 56 102 99 55 49 49 53 50 56 97 48 52 49 102 57 53 102 101 102 48 56 52 34 44 34 77 97 99 65 100 100 114 101 115 115 34 58 34 48 50 58 52 50 58 49 52 58 49 52 58 48 49 58 48 51 34 44 34 73 80 118 52 65 100 100 114 101 115 115 34 58 34 50 48 46 50 48 46 49 46 51 47 50 52 34 44 34 73 80 118 54 65 100 100 114 101 115 115 34 58 34 34 125 44 34 108 98 45 115 116 104 105 114 97 84 101 115 116 83 101 114 118 105 99 101 87 105 116 104 68 101 102 97 117 108 116 65 100 100 114 101 115 115 80 111 111 108 73 110 105 116 34 58 123 34 78 97 109 101 34 58 34 115 116 104 105 114 97 84 101 115 116 83 101 114 118 105 99 101 87 105 116 104 68 101 102 97 117 108 116 65 100 100 114 101 115 115 80 111 111 108 73 110 105 116 45 101 110 100 112 111 105 110 116 34 44 34 69 110 100 112 111 105 110 116 73 68 34 58 34 52 54 56 53 102 49 53 100 50 55 55 101 55 52 56 48 48 52 98 100 57 54 51 57 49 57 102 98 51 52 100 57 101 97 49 49 48 52 49 53 101 55 50 54 55 97 99 54 56 100 53 57 48 48 102 51 100 100 56 97 98 98 53 100 34 44 34 77 97 99 65 100 100 114 101 115 115 34 58 34 48 50 58 52 50 58 49 52 58 49 52 58 48 49 58 48 52 34 44 34 73 80 118 52 65 100 100 114 101 115 115 34 58 34 50 48 46 50 48 46 49 46 52 47 50 52 34 44 34 73 80 118 54 65 100 100 114 101 115 115 34 58 34 34 125 125 44 34 83 101 114 118 105 99 101 115 34 58 123 34 84 101 115 116 83 101 114 118 105 99 101 84 101 115 116 83 101 114 118 105 99 101 87 105 116 104 68 101 102 97 117 108 116 65 100 100 114 101 115 115 80 111 111 108 73 110 105 116 34 58 123 34 86 73 80 34 58 34 50 48 46 50 48 46 49 46 50 34 44 34 80 111 114 116 115 34 58 91 93 44 34 76 111 99 97 108 76 66 73 110 100 101 120 34 58 50 53 54 44 34 84 97 115 107 115 34 58 91 123 34 78 97 109 101 34 58 34 84 101 115 116 83 101 114 118 105 99 101 84 101 115 116 83 101 114 118 105 99 101 87 105 116 104 68 101 102 97 117 108 116 65 100 100 114 101 115 115 80 111 111 108 73 110 105 116 46 49 46 107 115 115 54 108 113 120 56 110 115 112 103 48 111 52 50 101 118 99 122 105 116 112 100 97 34 44 34 69 110 100 112 111 105 110 116 73 68 34 58 34 54 57 50 57 51 51 100 52 50 48 54 55 54 48 99 100 50 52 98 52 54 97 51 100 102 48 51 54 100 99 50 98 51 98 56 102 56 55 98 99 54 102 56 102 99 55 49 49 53 50 56 97 48 52 49 102 57 53 102 101 102 48 56 52 34 44 34 69 110 100 112 111 105 110 116 73 80 34 58 34 50 48 46 50 48 46 49 46 51 34 44 34 73 110 102 111 34 58 123 34 72 111 115 116 32 73 80 34 58 34 49 50 55 46 48 46 48 46 49 34 125 125 93 125 125 44 34 83 116 97 116 117 115 34 58 123 34 73 80 65 77 34 58 123 34 83 117 98 110 101 116 115 34 58 123 34 50 48 46 50 48 46 49 46 48 47 50 52 34 58 123 34 73 80 115 73 110 85 115 101 34 58 53 44 34 68 121 110 97 109 105 99 73 80 115 65 118 97 105 108 97 98 108 101 34 58 50 53 49 125 125 125 125 125 10]}

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

