### PR TITLE
client/container_exec: Wrap options and result

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -90,11 +90,11 @@ type ContainerAPIClient interface {
 }
 
 type ExecAPIClient interface {
-	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
-	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
-	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
-	ContainerExecInspect(ctx context.Context, execID string) (ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
+	ExecCreate(ctx context.Context, container string, options ExecCreateOptions) (ExecCreateResult, error)
+	ExecStart(ctx context.Context, execID string, options ExecStartOptions) (ExecStartResult, error)
+	ExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (ExecAttachResult, error)
+	ExecInspect(ctx context.Context, execID string, options ExecInspectOptions) (ExecInspectResult, error)
+	ExecResize(ctx context.Context, execID string, options ExecResizeOptions) (ExecResizeResult, error)
 }
 
 // DistributionAPIClient defines API client methods for the registry

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -15,37 +15,37 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestContainerExecCreateError(t *testing.T) {
+func TestExecCreateError(t *testing.T) {
 	client, err := NewClientWithOpts(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
 
-	_, err = client.ContainerExecCreate(context.Background(), "container_id", ExecCreateOptions{})
+	_, err = client.ExecCreate(context.Background(), "container_id", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	_, err = client.ContainerExecCreate(context.Background(), "", ExecCreateOptions{})
+	_, err = client.ExecCreate(context.Background(), "", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	_, err = client.ContainerExecCreate(context.Background(), "    ", ExecCreateOptions{})
+	_, err = client.ExecCreate(context.Background(), "    ", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
 
-// TestContainerExecCreateConnectionError verifies that connection errors occurring
+// TestExecCreateConnectionError verifies that connection errors occurring
 // during API-version negotiation are not shadowed by API-version errors.
 //
 // Regression test for https://github.com/docker/cli/issues/4890
-func TestContainerExecCreateConnectionError(t *testing.T) {
+func TestExecCreateConnectionError(t *testing.T) {
 	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
-	_, err = client.ContainerExecCreate(context.Background(), "container_id", ExecCreateOptions{})
+	_, err = client.ExecCreate(context.Background(), "container_id", ExecCreateOptions{})
 	assert.Check(t, is.ErrorType(err, IsErrConnectionFailed))
 }
 
-func TestContainerExecCreate(t *testing.T) {
+func TestExecCreate(t *testing.T) {
 	const expectedURL = "/containers/container_id/exec"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
@@ -77,24 +77,24 @@ func TestContainerExecCreate(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	r, err := client.ContainerExecCreate(context.Background(), "container_id", ExecCreateOptions{
+	r, err := client.ExecCreate(context.Background(), "container_id", ExecCreateOptions{
 		User: "user",
 	})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(r.ID, "exec_id"))
 }
 
-func TestContainerExecStartError(t *testing.T) {
+func TestExecStartError(t *testing.T) {
 	client, err := NewClientWithOpts(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
 
-	err = client.ContainerExecStart(context.Background(), "nothing", ExecStartOptions{})
+	_, err = client.ExecStart(context.Background(), "nothing", ExecStartOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
-func TestContainerExecStart(t *testing.T) {
+func TestExecStart(t *testing.T) {
 	const expectedURL = "/exec/exec_id/start"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
@@ -120,24 +120,24 @@ func TestContainerExecStart(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	err = client.ContainerExecStart(context.Background(), "exec_id", ExecStartOptions{
+	_, err = client.ExecStart(context.Background(), "exec_id", ExecStartOptions{
 		Detach: true,
 		Tty:    false,
 	})
 	assert.NilError(t, err)
 }
 
-func TestContainerExecInspectError(t *testing.T) {
+func TestExecInspectError(t *testing.T) {
 	client, err := NewClientWithOpts(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
 
-	_, err = client.ContainerExecInspect(context.Background(), "nothing")
+	_, err = client.ExecInspect(context.Background(), "nothing", ExecInspectOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
-func TestContainerExecInspect(t *testing.T) {
+func TestExecInspect(t *testing.T) {
 	const expectedURL = "/exec/exec_id/json"
 	client, err := NewClientWithOpts(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
@@ -159,7 +159,7 @@ func TestContainerExecInspect(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	inspect, err := client.ContainerExecInspect(context.Background(), "exec_id")
+	inspect, err := client.ExecInspect(context.Background(), "exec_id", ExecInspectOptions{})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(inspect.ExecID, "exec_id"))
 	assert.Check(t, is.Equal(inspect.ContainerID, "container_id"))

--- a/client/container_resize.go
+++ b/client/container_resize.go
@@ -23,13 +23,21 @@ func (cli *Client) ContainerResize(ctx context.Context, containerID string, opti
 	return cli.resize(ctx, "/containers/"+containerID, options.Height, options.Width)
 }
 
-// ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error {
+// ExecResizeOptions holds options for resizing a container exec TTY.
+type ExecResizeOptions ContainerResizeOptions
+
+// ExecResizeResult holds the result of resizing a container exec TTY.
+type ExecResizeResult struct {
+}
+
+// ExecResize changes the size of the tty for an exec process running inside a container.
+func (cli *Client) ExecResize(ctx context.Context, execID string, options ExecResizeOptions) (ExecResizeResult, error) {
 	execID, err := trimID("exec", execID)
 	if err != nil {
-		return err
+		return ExecResizeResult{}, err
 	}
-	return cli.resize(ctx, "/exec/"+execID, options.Height, options.Width)
+	err = cli.resize(ctx, "/exec/"+execID, options.Height, options.Width)
+	return ExecResizeResult{}, err
 }
 
 func (cli *Client) resize(ctx context.Context, basePath string, height, width uint) error {

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -28,10 +28,10 @@ func TestContainerResizeError(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
 
-func TestContainerExecResizeError(t *testing.T) {
+func TestExecResizeError(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
-	err = client.ContainerExecResize(context.Background(), "exec_id", ContainerResizeOptions{})
+	_, err = client.ExecResize(context.Background(), "exec_id", ExecResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -78,22 +78,22 @@ func TestContainerResize(t *testing.T) {
 	}
 }
 
-func TestContainerExecResize(t *testing.T) {
+func TestExecResize(t *testing.T) {
 	const expectedURL = "/exec/exec_id/resize"
 	tests := []struct {
 		doc                           string
-		opts                          ContainerResizeOptions
+		opts                          ExecResizeOptions
 		expectedHeight, expectedWidth string
 	}{
 		{
 			doc:            "zero width height", // valid, but not very useful
-			opts:           ContainerResizeOptions{},
+			opts:           ExecResizeOptions{},
 			expectedWidth:  "0",
 			expectedHeight: "0",
 		},
 		{
 			doc: "valid resize",
-			opts: ContainerResizeOptions{
+			opts: ExecResizeOptions{
 				Height: 500,
 				Width:  600,
 			},
@@ -102,7 +102,7 @@ func TestContainerExecResize(t *testing.T) {
 		},
 		{
 			doc: "larger than maxint64",
-			opts: ContainerResizeOptions{
+			opts: ExecResizeOptions{
 				Height: math.MaxInt64 + 1,
 				Width:  math.MaxInt64 + 2,
 			},
@@ -114,7 +114,7 @@ func TestContainerExecResize(t *testing.T) {
 		t.Run(tc.doc, func(t *testing.T) {
 			client, err := NewClientWithOpts(WithMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)))
 			assert.NilError(t, err)
-			err = client.ContainerExecResize(context.Background(), "exec_id", tc.opts)
+			_, err = client.ExecResize(context.Background(), "exec_id", tc.opts)
 			assert.NilError(t, err)
 		})
 	}

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -64,7 +64,7 @@ func (s *DockerAPISuite) TestExecAPICreateContainerPaused(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	_, err = apiClient.ContainerExecCreate(testutil.GetContext(c), name, client.ExecCreateOptions{
+	_, err = apiClient.ExecCreate(testutil.GetContext(c), name, client.ExecCreateOptions{
 		Cmd: []string{"true"},
 	})
 	assert.ErrorContains(c, err, "Container "+name+" is paused, unpause the container before exec", "Expected message when creating exec command with Container %s is paused", name)
@@ -128,7 +128,7 @@ func (s *DockerAPISuite) TestExecAPIStartWithDetach(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	createResp, err := apiClient.ContainerExecCreate(ctx, name, client.ExecCreateOptions{
+	createResp, err := apiClient.ExecCreate(ctx, name, client.ExecCreateOptions{
 		Cmd:          []string{"true"},
 		AttachStderr: true,
 	})

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -376,7 +376,7 @@ func (s *DockerCLIExecSuite) TestExecInspectID(c *testing.T) {
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
-	_, err = apiClient.ContainerExecInspect(testutil.GetContext(c), execID)
+	_, err = apiClient.ExecInspect(testutil.GetContext(c), execID, client.ExecInspectOptions{})
 	assert.NilError(c, err)
 
 	// Now delete the container and then an 'inspect' on the exec should
@@ -384,7 +384,7 @@ func (s *DockerCLIExecSuite) TestExecInspectID(c *testing.T) {
 	res := cli.DockerCmd(c, "rm", "-f", id)
 	assert.Equal(c, res.ExitCode, 0, "error removing container: %s", res.Combined())
 
-	_, err = apiClient.ContainerExecInspect(testutil.GetContext(c), execID)
+	_, err = apiClient.ExecInspect(testutil.GetContext(c), execID, client.ExecInspectOptions{})
 	assert.ErrorContains(c, err, "No such exec instance")
 }
 

--- a/integration/internal/container/exec.go
+++ b/integration/internal/container/exec.go
@@ -58,26 +58,26 @@ func Exec(ctx context.Context, apiClient client.APIClient, id string, cmd []stri
 		op(&execOptions)
 	}
 
-	cresp, err := apiClient.ContainerExecCreate(ctx, id, execOptions)
+	cresp, err := apiClient.ExecCreate(ctx, id, execOptions)
 	if err != nil {
 		return ExecResult{}, err
 	}
 	execID := cresp.ID
 
 	// run it, with stdout/stderr attached
-	aresp, err := apiClient.ContainerExecAttach(ctx, execID, client.ExecAttachOptions{})
+	aresp, err := apiClient.ExecAttach(ctx, execID, client.ExecAttachOptions{})
 	if err != nil {
 		return ExecResult{}, err
 	}
 
 	// read the output
-	s, err := demultiplexStreams(ctx, aresp)
+	s, err := demultiplexStreams(ctx, aresp.HijackedResponse)
 	if err != nil {
 		return ExecResult{}, err
 	}
 
 	// get the exit code
-	iresp, err := apiClient.ContainerExecInspect(ctx, execID)
+	iresp, err := apiClient.ExecInspect(ctx, execID, client.ExecInspectOptions{})
 	if err != nil {
 		return ExecResult{}, err
 	}

--- a/integration/internal/swarm/service.go
+++ b/integration/internal/swarm/service.go
@@ -220,12 +220,12 @@ func ExecTask(ctx context.Context, t *testing.T, d *daemon.Daemon, task swarmtyp
 	apiClient := d.NewClientT(t)
 	defer apiClient.Close()
 
-	resp, err := apiClient.ContainerExecCreate(ctx, task.Status.ContainerStatus.ContainerID, options)
+	resp, err := apiClient.ExecCreate(ctx, task.Status.ContainerStatus.ContainerID, options)
 	assert.NilError(t, err, "error creating exec")
 
-	attach, err := apiClient.ContainerExecAttach(ctx, resp.ID, client.ExecAttachOptions{})
+	attach, err := apiClient.ExecAttach(ctx, resp.ID, client.ExecAttachOptions{})
 	assert.NilError(t, err, "error attaching to exec")
-	return attach
+	return attach.HijackedResponse
 }
 
 func ensureResources(spec *swarmtypes.ServiceSpec) {

--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -25,7 +25,7 @@ func TestEventsExecDie(t *testing.T) {
 
 	cID := container.Run(ctx, t, apiClient)
 
-	id, err := apiClient.ContainerExecCreate(ctx, cID, client.ExecCreateOptions{
+	id, err := apiClient.ExecCreate(ctx, cID, client.ExecCreateOptions{
 		Cmd: []string{"echo", "hello"},
 	})
 	assert.NilError(t, err)
@@ -34,7 +34,7 @@ func TestEventsExecDie(t *testing.T) {
 		Filters: make(client.Filters).Add("container", cID).Add("event", string(events.ActionExecDie)),
 	})
 
-	err = apiClient.ContainerExecStart(ctx, id.ID, client.ExecStartOptions{
+	_, err = apiClient.ExecStart(ctx, id.ID, client.ExecStartOptions{
 		Detach: true,
 		Tty:    false,
 	})

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -90,11 +90,11 @@ type ContainerAPIClient interface {
 }
 
 type ExecAPIClient interface {
-	ContainerExecCreate(ctx context.Context, container string, options ExecCreateOptions) (container.ExecCreateResponse, error)
-	ContainerExecStart(ctx context.Context, execID string, options ExecStartOptions) error
-	ContainerExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (HijackedResponse, error)
-	ContainerExecInspect(ctx context.Context, execID string) (ExecInspect, error)
-	ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error
+	ExecCreate(ctx context.Context, container string, options ExecCreateOptions) (ExecCreateResult, error)
+	ExecStart(ctx context.Context, execID string, options ExecStartOptions) (ExecStartResult, error)
+	ExecAttach(ctx context.Context, execID string, options ExecAttachOptions) (ExecAttachResult, error)
+	ExecInspect(ctx context.Context, execID string, options ExecInspectOptions) (ExecInspectResult, error)
+	ExecResize(ctx context.Context, execID string, options ExecResizeOptions) (ExecResizeResult, error)
 }
 
 // DistributionAPIClient defines API client methods for the registry

--- a/vendor/github.com/moby/moby/client/container_resize.go
+++ b/vendor/github.com/moby/moby/client/container_resize.go
@@ -23,13 +23,21 @@ func (cli *Client) ContainerResize(ctx context.Context, containerID string, opti
 	return cli.resize(ctx, "/containers/"+containerID, options.Height, options.Width)
 }
 
-// ContainerExecResize changes the size of the tty for an exec process running inside a container.
-func (cli *Client) ContainerExecResize(ctx context.Context, execID string, options ContainerResizeOptions) error {
+// ExecResizeOptions holds options for resizing a container exec TTY.
+type ExecResizeOptions ContainerResizeOptions
+
+// ExecResizeResult holds the result of resizing a container exec TTY.
+type ExecResizeResult struct {
+}
+
+// ExecResize changes the size of the tty for an exec process running inside a container.
+func (cli *Client) ExecResize(ctx context.Context, execID string, options ExecResizeOptions) (ExecResizeResult, error) {
 	execID, err := trimID("exec", execID)
 	if err != nil {
-		return err
+		return ExecResizeResult{}, err
 	}
-	return cli.resize(ctx, "/exec/"+execID, options.Height, options.Width)
+	err = cli.resize(ctx, "/exec/"+execID, options.Height, options.Width)
+	return ExecResizeResult{}, err
 }
 
 func (cli *Client) resize(ctx context.Context, basePath string, height, width uint) error {


### PR DESCRIPTION
```markdown changelog
`client`: `ContainerExec...` methods were renamed to `Exec...`.