### PR TITLE
integration: Skip some tests as rootless

### DIFF
--- a/integration/build/build_cgroupns_linux_test.go
+++ b/integration/build/build_cgroupns_linux_test.go
@@ -71,6 +71,7 @@ func TestCgroupNamespacesBuild(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -84,6 +85,7 @@ func TestCgroupNamespacesBuildDaemonHostMode(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -34,6 +34,7 @@ const testNonExistingPlugin = "this-plugin-does-not-exist"
 func TestContainerNetworkMountsNoChown(t *testing.T) {
 	// chown only applies to Linux bind mounted volumes; must be same host to verify
 	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := setupTest(t)
 
@@ -549,6 +550,7 @@ func TestContainerBindMountReadOnlyDefault(t *testing.T) {
 func TestContainerBindMountRecursivelyReadOnly(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "requires API v1.44")
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := setupTest(t)
 

--- a/integration/container/pidmode_linux_test.go
+++ b/integration/container/pidmode_linux_test.go
@@ -15,6 +15,7 @@ import (
 func TestPIDModeHost(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	hostPid, err := os.Readlink("/proc/1/ns/pid")
 	assert.NilError(t, err)

--- a/integration/container/run_cgroupns_linux_test.go
+++ b/integration/container/run_cgroupns_linux_test.go
@@ -44,6 +44,7 @@ func TestCgroupNamespacesRun(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -71,6 +72,7 @@ func TestCgroupNamespacesRunDaemonHostMode(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -84,6 +86,7 @@ func TestCgroupNamespacesRunHostMode(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -97,6 +100,7 @@ func TestCgroupNamespacesRunPrivateMode(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -110,6 +114,7 @@ func TestCgroupNamespacesRunPrivilegedAndPrivate(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 
@@ -135,6 +140,7 @@ func TestCgroupNamespacesRunOlderClient(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
 	skip.If(t, !requirement.CgroupNamespacesEnabled())
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -132,6 +132,7 @@ func TestPrivilegedHostDevices(t *testing.T) {
 	// so needs to be same host.
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
@@ -204,6 +205,7 @@ func TestRunConsoleSize(t *testing.T) {
 func TestRunWithAlternativeContainerdShim(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, testEnv.IsRootless, "scenario doesn't work with rootless mode")
 
 	ctx := testutil.StartSpan(baseContext, t)
 


### PR DESCRIPTION
These tests fail as rootless when run on a VM.  I suspect they pass for you on `make test-integration` because they're run with docker via dind.

Environment: openSUSE Tumbleweed with docker 28.5.1
Other package versions: https://openqa.opensuse.org/tests/5401378/file/docker_engine-rpm-qa.txt

Logs:
https://openqa.opensuse.org/tests/5401378/file/docker_engine-integration-build.xml
https://openqa.opensuse.org/tests/5401378/file/docker_engine-integration-container.xml

```
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesBuild
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/12416/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesBuild (1.93s)
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesBuildDaemonHostMode
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/12766/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesBuildDaemonHostMode (1.90s)
			<failure message="Failed" type="">=== RUN   TestContainerNetworkMountsNoChown
    mounts_linux_test.go:89: assertion failed: 1000 (fi.Uid uint32) != 0 (uint32): bind mounted network file should not change ownership from root
--- FAIL: TestContainerNetworkMountsNoChown (0.26s)
			<failure message="Failed" type="">=== RUN   TestContainerBindMountRecursivelyReadOnly
    mounts_linux_test.go:565: mount /tmp/tmpdir2-154149550:/tmp/tmpdir1-2979097008/mnt, flags: 0x1000: operation not permitted
--- FAIL: TestContainerBindMountRecursivelyReadOnly (0.01s)
			<failure message="Failed" type="">=== RUN   TestPIDModeHost
    pidmode_linux_test.go:20: assertion failed: error is not nil: readlink /proc/1/ns/pid: permission denied
--- FAIL: TestPIDModeHost (0.00s)
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesRun
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/36061/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesRun (1.85s)
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesRunDaemonHostMode
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/36418/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesRunDaemonHostMode (1.87s)
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesRunHostMode
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/36775/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesRunHostMode (1.88s)
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesRunPrivateMode
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/37132/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesRunPrivateMode (1.87s)
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesRunPrivilegedAndPrivate
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/37487/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesRunPrivilegedAndPrivate (1.89s)
			<failure message="Failed" type="">=== RUN   TestCgroupNamespacesRunOlderClient
    daemon_linux.go:34: assertion failed: error is not nil: readlink /proc/38106/ns/cgroup: permission denied
--- FAIL: TestCgroupNamespacesRunOlderClient (1.87s)
			<failure message="Failed" type="">=== RUN   TestPrivilegedHostDevices
    run_linux_test.go:141: permission denied
--- FAIL: TestPrivilegedHostDevices (0.00s)
			<failure message="Failed" type="">=== RUN   TestRunWithAlternativeContainerdShim
    run_linux_test.go:226: assertion failed: error is not nil: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: mkdir /sys/fs/cgroup/user.slice/user-1000.slice/user.slice:docker:09ade8d74ba8806535ef3811a8d0e27fcab0fa01f4f9eccdccf906666317de0b: permission denied: unknown
--- FAIL: TestRunWithAlternativeContainerdShim (1.69s)
```

Notes:
- These directories were skipped: integration-cli, integration/network, integration/networking & integration/plugins