### PR TITLE
Dockerfile: upgrade Delve to v1.25.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN git init . && git remote add origin "https://github.com/go-delve/delve.git"
 # from the https://github.com/go-delve/delve repository.
 # It can be used to run Docker with a possibility of
 # attaching debugger to it.
-ARG DELVE_VERSION=v1.25.0
+ARG DELVE_VERSION=v1.25.2
 RUN git fetch -q --depth 1 origin "${DELVE_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS delve-supported


### PR DESCRIPTION
To get rid of `WARNING: undefined behavior - version of Delve is too old for Go version go1.25.3 (maximum supported version 1.24)` ... although it's just cosmetic, https://github.com/go-delve/delve/pull/4046/commits/eeb5b05421429e49301a52e2fac1825735120b68


Update to the latest version:
- https://github.com/go-delve/delve/releases/tag/v1.25.2
- https://github.com/go-delve/delve/blob/v1.25.2/CHANGELOG.md#1252-2025-08-26

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

