### PR TITLE
Inspect: API v1.51 compatibility

### DIFF
--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -12,6 +12,7 @@ import (
 	"github.com/distribution/reference"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	imagetypes "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/storage"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/sliceutil"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -98,6 +99,9 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 			},
 		},
 		Parent: parent, // field is deprecated with the legacy builder, but returned by the API if present.
+
+		// GraphDriver is omitted in API v1.52 unless using a graphdriver.
+		GraphDriverLegacy: &storage.DriverData{Name: i.snapshotter},
 	}
 
 	if multi.Best != nil {

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -7,6 +7,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 	imagetypes "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/registry"
+	"github.com/moby/moby/api/types/storage"
 	"github.com/moby/moby/v2/daemon/internal/filters"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -92,4 +93,8 @@ type InspectData struct {
 	//
 	// This field is removed in API v1.45, but used for API <= v1.44 responses.
 	ContainerConfig *container.Config
+
+	// GraphDriverLegacy is used for API versions < v1.52, which included the
+	// name of the snapshotter the GraphDriver field.
+	GraphDriverLegacy *storage.DriverData
 }

--- a/daemon/server/router/container/inspect.go
+++ b/daemon/server/router/container/inspect.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/storage"
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/v2/daemon/internal/compat"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
@@ -68,6 +69,15 @@ func (c *containerRouter) getContainersByName(ctx context.Context, w http.Respon
 					"MacAddress": desiredMACAddress,
 				},
 			}))
+		}
+
+		// Restore the GraphDriver field, now omitted when a snapshotter is used.
+		// Remove the Storage field that replaced it.
+		if ctr.GraphDriver == nil && ctr.Storage != nil && ctr.Storage.RootFS != nil && ctr.Storage.RootFS.Snapshot != nil {
+			ctr.GraphDriver = &storage.DriverData{
+				Name: ctr.Storage.RootFS.Snapshot.Name,
+			}
+			ctr.Storage = nil
 		}
 	}
 

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -440,6 +440,11 @@ func (ir *imageRouter) getImagesByName(ctx context.Context, w http.ResponseWrite
 				"Config": legacyConfigFields["v1.50-v1.51"],
 			}))
 		}
+
+		// Restore the GraphDriver field, now omitted when a snapshotter is used.
+		if imageInspect.GraphDriver == nil && inspectData.GraphDriverLegacy != nil {
+			imageInspect.GraphDriver = inspectData.GraphDriverLegacy
+		}
 	} else {
 		if inspectData.Parent != "" {
 			// field is deprecated, but still included in response when present (built with legacy builder).

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -19,14 +19,8 @@ func (s *DockerAPISuite) TestInspectAPIContainerResponse(c *testing.T) {
 
 	keysBase := []string{
 		"Id", "State", "Created", "Path", "Args", "Config", "Image", "NetworkSettings",
-		"ResolvConfPath", "HostnamePath", "HostsPath", "LogPath", "Name", "Driver", "MountLabel", "ProcessLabel",
+		"ResolvConfPath", "HostnamePath", "HostsPath", "LogPath", "Name", "Driver", "MountLabel", "ProcessLabel", "GraphDriver",
 		"Mounts",
-	}
-
-	if testEnv.UsingSnapshotter() {
-		keysBase = append(keysBase, "Storage")
-	} else {
-		keysBase = append(keysBase, "GraphDriver")
 	}
 
 	cases := []struct {


### PR DESCRIPTION
**- What I did**

For API < v1.52:
- In container inspect:
  - Restore GraphDriver when a snapshotter is used.
  - Remove field Storage
  - Related to https://github.com/moby/moby/pull/50857
- In image inspect:
  - Restore GraphDriver when a snapshotter is used.
  - Related to https://github.com/moby/moby/pull/50893

Without this, an application using the new client but with its API version pinned to < 1.52 would panic when dereferencing an omitted `GraphDriver` field in a inspect response (in older clients, it wasn't a pointer, and was always filled in) ... in addition to old clients finding the field is now unpopulated.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

