### PR TITLE
client: rename `ServiceListResult.Services` to `ServiceListResult.Items`

### DIFF
--- a/client/service_list.go
+++ b/client/service_list.go
@@ -19,7 +19,7 @@ type ServiceListOptions struct {
 
 // ServiceListResult represents the result of a service list operation.
 type ServiceListResult struct {
-	Services []swarm.Service
+	Items []swarm.Service
 }
 
 // ServiceList returns the list of services.
@@ -40,5 +40,5 @@ func (cli *Client) ServiceList(ctx context.Context, options ServiceListOptions) 
 
 	var services []swarm.Service
 	err = json.NewDecoder(resp.Body).Decode(&services)
-	return ServiceListResult{Services: services}, err
+	return ServiceListResult{Items: services}, err
 }

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -77,6 +77,6 @@ func TestServiceList(t *testing.T) {
 
 		list, err := client.ServiceList(context.Background(), listCase.options)
 		assert.NilError(t, err)
-		assert.Check(t, is.Len(list.Services, 2))
+		assert.Check(t, is.Len(list.Items, 2))
 	}
 }

--- a/integration/network/service_test.go
+++ b/integration/network/service_test.go
@@ -337,10 +337,10 @@ func noServices(ctx context.Context, apiClient client.ServiceAPIClient) func(log
 		switch {
 		case err != nil:
 			return poll.Error(err)
-		case len(result.Services) == 0:
+		case len(result.Items) == 0:
 			return poll.Success()
 		default:
-			return poll.Continue("waiting for all services to be removed: service count at %d", len(result.Services))
+			return poll.Continue("waiting for all services to be removed: service count at %d", len(result.Items))
 		}
 	}
 }

--- a/integration/service/list_test.go
+++ b/integration/service/list_test.go
@@ -80,16 +80,16 @@ func TestServiceListWithStatuses(t *testing.T) {
 	// now, let's do the list operation with no status arg set.
 	result, err := apiClient.ServiceList(ctx, client.ServiceListOptions{})
 	assert.NilError(t, err)
-	assert.Check(t, is.Len(result.Services, serviceCount))
-	for _, service := range result.Services {
+	assert.Check(t, is.Len(result.Items, serviceCount))
+	for _, service := range result.Items {
 		assert.Check(t, is.Nil(service.ServiceStatus))
 	}
 
 	// now try again, but with Status: true. This time, we should have statuses
 	result, err = apiClient.ServiceList(ctx, client.ServiceListOptions{Status: true})
 	assert.NilError(t, err)
-	assert.Check(t, is.Len(result.Services, serviceCount))
-	for _, service := range result.Services {
+	assert.Check(t, is.Len(result.Items, serviceCount))
+	for _, service := range result.Items {
 		replicas := *service.Spec.Mode.Replicated.Replicas
 
 		assert.Assert(t, service.ServiceStatus != nil)

--- a/internal/testutil/daemon/service.go
+++ b/internal/testutil/daemon/service.go
@@ -107,7 +107,7 @@ func (d *Daemon) ListServices(ctx context.Context, t testing.TB) []swarm.Service
 
 	res, err := cli.ServiceList(ctx, client.ServiceListOptions{})
 	assert.NilError(t, err)
-	return res.Services
+	return res.Items
 }
 
 // GetTask returns the swarm task identified by the specified id

--- a/vendor/github.com/moby/moby/client/service_list.go
+++ b/vendor/github.com/moby/moby/client/service_list.go
@@ -19,7 +19,7 @@ type ServiceListOptions struct {
 
 // ServiceListResult represents the result of a service list operation.
 type ServiceListResult struct {
-	Services []swarm.Service
+	Items []swarm.Service
 }
 
 // ServiceList returns the list of services.
@@ -40,5 +40,5 @@ func (cli *Client) ServiceList(ctx context.Context, options ServiceListOptions) 
 
 	var services []swarm.Service
 	err = json.NewDecoder(resp.Body).Decode(&services)
-	return ServiceListResult{Services: services}, err
+	return ServiceListResult{Items: services}, err
 }


### PR DESCRIPTION
**- What I did**
Part of https://github.com/moby/moby/issues/50965, follow-up to https://github.com/moby/moby/pull/51252

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

