### PR TITLE
client: tidy-up test/mock-utilities

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -452,11 +452,3 @@ func (cli *Client) dialer() func(context.Context) (net.Conn, error) {
 		}
 	}
 }
-
-// transportFunc allows us to inject a mock transport for testing. We define it
-// here so we can detect the tlsconfig and return nil for only this type.
-type transportFunc func(*http.Request) (*http.Response, error)
-
-func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return tf(req)
-}

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -30,7 +30,9 @@ func assertRequest(req *http.Request, expMethod string, expectedPath string) err
 	return nil
 }
 
-func transportEnsureBody(f transportFunc) transportFunc {
+// ensureBody makes sure the response has a Body, using [http.NoBody] if
+// none is present, and returns it as a testRoundTripper.
+func ensureBody(f func(req *http.Request) (*http.Response, error)) testRoundTripper {
 	return func(req *http.Request) (*http.Response, error) {
 		resp, err := f(req)
 		if resp != nil && resp.Body == nil {
@@ -43,7 +45,7 @@ func transportEnsureBody(f transportFunc) transportFunc {
 // WithMockClient is a test helper that allows you to inject a mock client for testing.
 func WithMockClient(doer func(*http.Request) (*http.Response, error)) Opt {
 	return WithHTTPClient(&http.Client{
-		Transport: transportEnsureBody(transportFunc(doer)),
+		Transport: ensureBody(doer),
 	})
 }
 

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -78,7 +78,7 @@ func TestSetHostHeader(t *testing.T) {
 // API versions < 1.24 returned plain text errors, but we may encounter
 // other situations where a non-JSON error is returned.
 func TestPlainTextError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(plainTextErrorMock(http.StatusInternalServerError, "Server error")))
+	client, err := NewClientWithOpts(WithMockClient(mockResponse(http.StatusInternalServerError, nil, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerList(context.Background(), ContainerListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -452,11 +452,3 @@ func (cli *Client) dialer() func(context.Context) (net.Conn, error) {
 		}
 	}
 }
-
-// transportFunc allows us to inject a mock transport for testing. We define it
-// here so we can detect the tlsconfig and return nil for only this type.
-type transportFunc func(*http.Request) (*http.Response, error)
-
-func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return tf(req)
-}


### PR DESCRIPTION
## client: tidy-up test/mock-utilities

### client: rename transportFunc -> testRoundTripper

Rename it so that it's clearer that it's intended for test-purposes,
and adding a `skipConfigureTransport()` method to the signature to
prevent IDEs considering is a redundant convert, and to be more explicit
on intent.

### client: tidy-up mock-utilities

- Add a `mockResponse` utility, and slightly enhance it to also include
  the request Headers and Status message, to be more closely to actual
  responses.
- Add a `mockJSONResponse` utility, implemented using `mockResponse`
- Remove `plainTextErrorMock` in favor of `mockResponse`


### client: remove roundTripFunc, bytesBufferClose

- Use the `mockResponse` instead
- `bytesBufferClose` was our own implementation of `io.NopCloser`


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

