### PR TITLE
stream formatter without stream

### DIFF
--- a/api/pkg/streamformatter/streamformatter.go
+++ b/api/pkg/streamformatter/streamformatter.go
@@ -20,7 +20,7 @@ import (
 //
 // It is a reduced set of [jsonmessage.JSONMessage].
 type jsonMessage struct {
-	Stream   string               `json:"stream,omitempty"`
+	Stream   string               `json:"-"`
 	Status   string               `json:"status,omitempty"`
 	Progress *jsonstream.Progress `json:"progressDetail,omitempty"`
 	ID       string               `json:"id,omitempty"`

--- a/api/pkg/streamformatter/streamwriter.go
+++ b/api/pkg/streamformatter/streamwriter.go
@@ -3,6 +3,7 @@ package streamformatter
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 type streamWriter struct {
@@ -20,7 +21,8 @@ func (sw *streamWriter) Write(buf []byte) (int, error) {
 }
 
 func (sw *streamWriter) format(buf []byte) []byte {
-	msg := &jsonMessage{Stream: sw.lineFormat(buf)}
+	// Remove any trailing newlines (CR, LF, CRLF)
+	msg := &jsonMessage{Status: strings.TrimRight(sw.lineFormat(buf), streamNewline)}
 	b, err := json.Marshal(msg)
 	if err != nil {
 		return FormatError(err)

--- a/api/pkg/streamformatter/streamwriter_test.go
+++ b/api/pkg/streamformatter/streamwriter_test.go
@@ -17,7 +17,7 @@ func TestStreamWriterStdout(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(content), size))
 
-	expected := `{"stream":"content"}` + streamNewline
+	expected := `{"status":"content"}` + streamNewline
 	assert.Check(t, is.Equal(expected, buffer.String()))
 }
 
@@ -30,6 +30,6 @@ func TestStreamWriterStderr(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(len(content), size))
 
-	expected := `{"stream":"\u001b[91mcontent\u001b[0m"}` + streamNewline
+	expected := `{"status":"\u001b[91mcontent\u001b[0m"}` + streamNewline
 	assert.Check(t, is.Equal(expected, buffer.String()))
 }

--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -124,7 +124,7 @@ func (p *JSONProgress) width() int {
 // the created time, where it from, status, ID of the
 // message. It's used for docker events.
 type JSONMessage struct {
-	Stream   string            `json:"stream,omitempty"`
+	Stream   string            `json:"-"`
 	Status   string            `json:"status,omitempty"`
 	Progress *JSONProgress     `json:"progressDetail,omitempty"`
 	ID       string            `json:"id,omitempty"`

--- a/integration/build/build_cgroupns_linux_test.go
+++ b/integration/build/build_cgroupns_linux_test.go
@@ -31,8 +31,8 @@ func getCgroupFromBuildOutput(buildOutput io.Reader) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if ix := strings.Index(m.Stream, prefix); ix == 0 {
-			return strings.TrimSpace(m.Stream), nil
+		if ix := strings.Index(m.Status, prefix); ix == 0 {
+			return strings.TrimSpace(m.Status), nil
 		}
 	}
 }

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -135,8 +135,8 @@ func buildContainerIdsFilter(buildOutput io.Reader) (client.Filters, error) {
 		if err != nil {
 			return filter, err
 		}
-		if ix := strings.Index(m.Stream, intermediateContainerPrefix); ix != -1 {
-			filter.Add("id", strings.TrimSpace(m.Stream[ix+len(intermediateContainerPrefix):]))
+		if ix := strings.Index(m.Status, intermediateContainerPrefix); ix != -1 {
+			filter.Add("id", strings.TrimSpace(m.Status[ix+len(intermediateContainerPrefix):]))
 		}
 	}
 }

--- a/integration/internal/image/load.go
+++ b/integration/internal/image/load.go
@@ -53,12 +53,12 @@ func Load(ctx context.Context, t *testing.T, apiClient client.APIClient, imageFu
 		}
 		assert.NilError(t, err)
 
-		msg.Stream = strings.TrimSpace(msg.Stream)
+		msg.Status = strings.TrimSpace(msg.Status)
 
-		if _, imageID, hasID := strings.Cut(msg.Stream, "Loaded image ID: "); hasID {
+		if _, imageID, hasID := strings.Cut(msg.Status, "Loaded image ID: "); hasID {
 			return imageID
 		}
-		if _, imageRef, hasRef := strings.Cut(msg.Stream, "Loaded image: "); hasRef {
+		if _, imageRef, hasRef := strings.Cut(msg.Status, "Loaded image: "); hasRef {
 			return imageRef
 		}
 	}

--- a/vendor/github.com/moby/moby/api/pkg/streamformatter/streamformatter.go
+++ b/vendor/github.com/moby/moby/api/pkg/streamformatter/streamformatter.go
@@ -20,7 +20,7 @@ import (
 //
 // It is a reduced set of [jsonmessage.JSONMessage].
 type jsonMessage struct {
-	Stream   string               `json:"stream,omitempty"`
+	Stream   string               `json:"-"`
 	Status   string               `json:"status,omitempty"`
 	Progress *jsonstream.Progress `json:"progressDetail,omitempty"`
 	ID       string               `json:"id,omitempty"`

--- a/vendor/github.com/moby/moby/api/pkg/streamformatter/streamwriter.go
+++ b/vendor/github.com/moby/moby/api/pkg/streamformatter/streamwriter.go
@@ -3,6 +3,7 @@ package streamformatter
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 type streamWriter struct {
@@ -20,7 +21,8 @@ func (sw *streamWriter) Write(buf []byte) (int, error) {
 }
 
 func (sw *streamWriter) format(buf []byte) []byte {
-	msg := &jsonMessage{Stream: sw.lineFormat(buf)}
+	// Remove any trailing newlines (CR, LF, CRLF)
+	msg := &jsonMessage{Status: strings.TrimRight(sw.lineFormat(buf), streamNewline)}
 	b, err := json.Marshal(msg)
 	if err != nil {
 		return FormatError(err)

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -124,7 +124,7 @@ func (p *JSONProgress) width() int {
 // the created time, where it from, status, ID of the
 // message. It's used for docker events.
 type JSONMessage struct {
-	Stream   string            `json:"stream,omitempty"`
+	Stream   string            `json:"-"`
 	Status   string            `json:"status,omitempty"`
 	Progress *JSONProgress     `json:"progressDetail,omitempty"`
 	ID       string            `json:"id,omitempty"`


### PR DESCRIPTION
Just a quick experiment; current state is that;

- docker pull / push uses the JSONMessage, using the `id` and `status` fields, in addition to the progress-status (and "aux").
- docker build with the classic builder uses the `stream` field, in addition to the `aux` for the final message.
- if a `docker pull` happens during the build, those use the fields produced by `docker pull`.

However, the `jsonmessage` package have various fallbackes; they check if the `stream` field is set, in which case it's printed as-is. If that's not the case, it prints the status field, adding its own newline.

So, as a fun experiment; what if we'd drop the stream field, and use status instead?

```bash
mkdir build_curl && cd build_curl

cat > Dockerfile <<'EOF'
FROM ubuntu
RUN apt-get update
RUN apt-get install -y curl nano
EOF

tar cf - ./ | curl -s --unix-socket /var/run/docker.sock -X POST   "http://localhost/build" -H "Content-Type: application/json" --data-binary @-
```

Migrating it to the `Status` field:

```bash
tar cf - ./ | curl -s --unix-socket /var/run/docker.sock -X POST   "http://localhost/build" -H "Content-Type: application/json" --data-binary @-
```

```json lines
{"status":"Step 1/3 : FROM ubuntu"}
{"status":"\n"}
{"status":"Pulling from library/ubuntu","id":"latest"}
{"status":"Pulling fs layer","progressDetail":{},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":1048576,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":6291456,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":23068672,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":28861712,"total":28861712},"id":"b8a35db46e38"}
{"status":"Download complete","progressDetail":{"hidecounts":true},"id":"b8a35db46e38"}
{"status":"Extracting","progressDetail":{"current":1,"units":"s"},"id":"b8a35db46e38"}
{"status":"Extracting","progressDetail":{"current":1,"units":"s"},"id":"b8a35db46e38"}
{"status":"Pull complete","progressDetail":{"hidecounts":true},"id":"b8a35db46e38"}
{"status":"Digest: sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252"}
{"status":"Status: Downloaded newer image for ubuntu:latest"}
{"status":" ---\u003e 66460d557b25\n"}
{"status":"Step 2/3 : RUN apt-get update"}
{"status":"\n"}
{"status":" ---\u003e Running in 244bc195e5ae\n"}
{"status":"Get:1 http://ports.ubuntu.com/ubuntu-ports noble InRelease [256 kB]\n"}
{"status":"Get:2 http://ports.ubuntu.com/ubuntu-ports noble-updates InRelease [126 kB]\n"}
{"status":"Get:3 http://ports.ubuntu.com/ubuntu-ports noble-backports InRelease [126 kB]\n"}
{"status":"Get:18 http://ports.ubuntu.com/ubuntu-ports noble-security/multiverse arm64 Packages [34.3 kB]\n"}
{"status":"Fetched 36.0 MB in 2s (16.6 MB/s)\nReading package lists..."}
{"status":"\n"}
{"status":" ---\u003e Removed intermediate container 244bc195e5ae\n"}
{"status":" ---\u003e 284f773d2a15\n"}
{"status":"Step 3/3 : RUN apt-get install -y curl nano"}
{"status":"\n"}
{"status":" ---\u003e Running in 55d77a551ae0\n"}
{"status":"Reading package lists..."}
{"status":"\n"}
{"status":"Building dependency tree..."}
{"status":"\nReading state information...\n"}
{"status":"The following additional packages will be installed:\n"}
{"status":"  ca-certificates krb5-locales libbrotli1 libcurl4t64 libgssapi-krb5-2\n  libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-common libldap2\n"}
{"status":"  libnghttp2-14 libpsl5t64 librtmp1 libsasl2-2 libsasl2-modules\n"}
{"status":"Get:21 http://ports.ubuntu.com/ubuntu-ports noble-updates/main arm64 libldap-common all 2.6.7+dfsg-1~exp1ubuntu8.2 [31.7 kB]\n"}
{"status":"(Reading database ... 90%\r"}
{"status":"(Reading database ... 95%\r"}
{"status":"(Reading database ... 100%\r(Reading database ... 4376 files and directories currently installed.)\r\n"}
{"status":"Preparing to unpack .../00-openssl_3.0.13-0ubuntu3.6_arm64.deb ...\r\n"}
{"status":"Preparing to unpack .../09-libpsl5t64_0.21.2-1.1build1_arm64.deb ...\r\n"}
{"status":"Unpacking libpsl5t64:arm64 (0.21.2-1.1build1) ...\r\n"}
{"status":"Processing triggers for ca-certificates (20240203) ...\r\n"}
{"status":"Updating certificates in /etc/ssl/certs...\r\n"}
{"status":"0 added, 0 removed; done.\r\nRunning hooks in /etc/ca-certificates/update.d...\r\n"}
{"status":"done.\r\n"}
{"status":" ---\u003e Removed intermediate container 55d77a551ae0\n"}
{"status":" ---\u003e 868b27c76555\n"}
{"aux":{"ID":"sha256:868b27c765550433ec73b474532e8ea690d123a45d55ca95ab814de4f6274c72"}}
{"status":"Successfully built 868b27c76555\n"}
```

Which ... mostly works with existing CLIs at least, but looks like they're adding additional newlines;

```console
docker build -t foo .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  2.048kB
Step 1/3 : FROM ubuntu

latest: Pulling from library/ubuntu
b8a35db46e38: Pulling fs layer
b8a35db46e38: Download complete
b8a35db46e38: Pull complete
Digest: sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252
Status: Downloaded newer image for ubuntu:latest
 ---> 66460d557b25

Step 2/3 : RUN apt-get update

 ---> Running in 0a3fe091b57a

Get:1 http://ports.ubuntu.com/ubuntu-ports noble InRelease [256 kB]

Get:2 http://ports.ubuntu.com/ubuntu-ports noble-updates InRelease [126 kB]

Get:3 http://ports.ubuntu.com/ubuntu-ports noble-backports InRelease [126 kB]

Get:4 http://ports.ubuntu.com/ubuntu-ports noble-security InRelease [126 kB]

Fetched 36.0 MB in 3s (10.6 MB/s)
Reading package lists...

 ---> Removed intermediate container 0a3fe091b57a

 ---> e58fb8440203

Step 3/3 : RUN apt-get install -y curl nano

 ---> Running in 3568b4160d5e

Reading package lists...

Building dependency tree...

Reading state information...

The following additional packages will be installed:
  ca-certificates krb5-locales libbrotli1 libcurl4t64 libgssapi-krb5-2
  libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-common libldap2

Processing triggers for ca-certificates (20240203) ...

Updating certificates in /etc/ssl/certs...

0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...

done.

 ---> Removed intermediate container 3568b4160d5e

 ---> dc8884ef94b1

Successfully built dc8884ef94b1

Successfully tagged foo:latest

```

Trimming trailing whitespace .. makes that work;

```json lines
{"status":"Step 1/3 : FROM ubuntu"}
{}
{"status":"Pulling from library/ubuntu","id":"latest"}
{"status":"Pulling fs layer","progressDetail":{},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":3145728,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":7340032,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":13631488,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":20971520,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":22020096,"total":28861712},"id":"b8a35db46e38"}
{"status":"Downloading","progressDetail":{"current":28861712,"total":28861712},"id":"b8a35db46e38"}
{"status":"Download complete","progressDetail":{"hidecounts":true},"id":"b8a35db46e38"}
{"status":"Extracting","progressDetail":{"current":1,"units":"s"},"id":"b8a35db46e38"}
{"status":"Extracting","progressDetail":{"current":1,"units":"s"},"id":"b8a35db46e38"}
{"status":"Extracting","progressDetail":{"current":1,"units":"s"},"id":"b8a35db46e38"}
{"status":"Extracting","progressDetail":{"current":1,"units":"s"},"id":"b8a35db46e38"}
{"status":"Extracting","progressDetail":{"current":1,"units":"s"},"id":"b8a35db46e38"}
{"status":"Pull complete","progressDetail":{"hidecounts":true},"id":"b8a35db46e38"}
{"status":"Digest: sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252"}
{"status":"Status: Downloaded newer image for ubuntu:latest"}
{"status":" ---\u003e 66460d557b25"}
{"status":"Step 2/3 : RUN apt-get update"}
{}
{"status":" ---\u003e Running in 64ba0ed9732f"}
{"status":"Get:1 http://ports.ubuntu.com/ubuntu-ports noble InRelease [256 kB]"}
{"status":"Get:2 http://ports.ubuntu.com/ubuntu-ports noble-updates InRelease [126 kB]"}
{"status":"Get:3 http://ports.ubuntu.com/ubuntu-ports noble-backports InRelease [126 kB]"}
{"status":"Get:4 http://ports.ubuntu.com/ubuntu-ports noble-security InRelease [126 kB]"}
{"status":"Get:5 http://ports.ubuntu.com/ubuntu-ports noble/main arm64 Packages [1776 kB]"}
{"status":"Get:6 http://ports.ubuntu.com/ubuntu-ports noble/restricted arm64 Packages [113 kB]"}
{"status":"Get:7 http://ports.ubuntu.com/ubuntu-ports noble/universe arm64 Packages [19.0 MB]"}
{"status":"Get:8 http://ports.ubuntu.com/ubuntu-ports noble/multiverse arm64 Packages [274 kB]"}
{"status":"Get:9 http://ports.ubuntu.com/ubuntu-ports noble-updates/restricted arm64 Packages [3711 kB]"}
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

