### PR TITLE
client: change Raw fields to be json.RawMessage

### DIFF
--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/swarm"
 )
@@ -14,7 +15,7 @@ type ConfigInspectOptions struct {
 // ConfigInspectResult holds the result from the ConfigInspect method.
 type ConfigInspectResult struct {
 	Config swarm.Config
-	Raw    []byte
+	Raw    json.RawMessage
 }
 
 // ConfigInspect returns the config information with raw data

--- a/client/config_inspect.go
+++ b/client/config_inspect.go
@@ -25,7 +25,6 @@ func (cli *Client) ConfigInspect(ctx context.Context, id string, options ConfigI
 		return ConfigInspectResult{}, err
 	}
 	resp, err := cli.get(ctx, "/configs/"+id, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return ConfigInspectResult{}, err
 	}

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 
 	"github.com/moby/moby/api/types/network"
@@ -10,7 +11,7 @@ import (
 // NetworkInspectResult contains the result of a network inspection.
 type NetworkInspectResult struct {
 	Network network.Inspect
-	Raw     []byte
+	Raw     json.RawMessage
 }
 
 // NetworkInspect returns the information for a specific network configured in the docker host.

--- a/client/network_inspect.go
+++ b/client/network_inspect.go
@@ -29,7 +29,6 @@ func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options
 	}
 
 	resp, err := cli.get(ctx, "/networks/"+networkID, query, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return NetworkInspectResult{}, err
 	}

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -14,7 +14,7 @@ type NodeInspectOptions struct{}
 
 type NodeInspectResult struct {
 	Node swarm.Node
-	Raw  []byte
+	Raw  json.RawMessage
 }
 
 // NodeInspect returns the node information.

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -25,7 +25,6 @@ func (cli *Client) PluginInspect(ctx context.Context, name string, options Plugi
 		return PluginInspectResult{}, err
 	}
 	resp, err := cli.get(ctx, "/plugins/"+name+"/json", nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return PluginInspectResult{}, err
 	}

--- a/client/plugin_inspect.go
+++ b/client/plugin_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/plugin"
 )
@@ -13,8 +14,8 @@ type PluginInspectOptions struct {
 
 // PluginInspectResult holds the result from the [Client.PluginInspect] method.
 type PluginInspectResult struct {
-	Raw    []byte
 	Plugin plugin.Plugin
+	Raw    json.RawMessage
 }
 
 // PluginInspect inspects an existing plugin

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/swarm"
 )
@@ -14,7 +15,7 @@ type SecretInspectOptions struct {
 // SecretInspectResult holds the result from the [Client.SecretInspect]. method.
 type SecretInspectResult struct {
 	Secret swarm.Secret
-	Raw    []byte
+	Raw    json.RawMessage
 }
 
 // SecretInspect returns the secret information with raw data.

--- a/client/secret_inspect.go
+++ b/client/secret_inspect.go
@@ -25,7 +25,6 @@ func (cli *Client) SecretInspect(ctx context.Context, id string, options SecretI
 		return SecretInspectResult{}, err
 	}
 	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return SecretInspectResult{}, err
 	}

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -30,7 +30,6 @@ func (cli *Client) ServiceInspect(ctx context.Context, serviceID string, options
 	query := url.Values{}
 	query.Set("insertDefaults", fmt.Sprintf("%v", options.InsertDefaults))
 	resp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return ServiceInspectResult{}, err
 	}

--- a/client/service_inspect.go
+++ b/client/service_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -16,7 +17,7 @@ type ServiceInspectOptions struct {
 // ServiceInspectResult represents the result of a service inspect operation.
 type ServiceInspectResult struct {
 	Service swarm.Service
-	Raw     []byte
+	Raw     json.RawMessage
 }
 
 // ServiceInspect retrieves detailed information about a specific service by its ID.

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -26,7 +26,6 @@ func (cli *Client) TaskInspect(ctx context.Context, taskID string, options TaskI
 	}
 
 	resp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return TaskInspectResult{}, err
 	}

--- a/client/task_inspect.go
+++ b/client/task_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/swarm"
 )
@@ -14,7 +15,7 @@ type TaskInspectOptions struct {
 // TaskInspectResult contains the result of a task inspection.
 type TaskInspectResult struct {
 	Task swarm.Task
-	Raw  []byte
+	Raw  json.RawMessage
 }
 
 // TaskInspect returns the task information and its raw representation.

--- a/client/utils.go
+++ b/client/utils.go
@@ -70,7 +70,7 @@ func encodePlatform(platform *ocispec.Platform) (string, error) {
 	return string(p), nil
 }
 
-func decodeWithRaw[T any](resp *http.Response, out *T) (raw []byte, _ error) {
+func decodeWithRaw[T any](resp *http.Response, out *T) (raw json.RawMessage, _ error) {
 	if resp == nil || resp.Body == nil {
 		return nil, errors.New("empty response")
 	}

--- a/client/utils.go
+++ b/client/utils.go
@@ -74,7 +74,7 @@ func decodeWithRaw[T any](resp *http.Response, out *T) (raw json.RawMessage, _ e
 	if resp == nil || resp.Body == nil {
 		return nil, errors.New("empty response")
 	}
-	defer resp.Body.Close()
+	defer ensureReaderClosed(resp)
 
 	var buf bytes.Buffer
 	tr := io.TeeReader(resp.Body, &buf)

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -26,7 +26,6 @@ func (cli *Client) VolumeInspect(ctx context.Context, volumeID string, options V
 	}
 
 	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return VolumeInspectResult{}, err
 	}

--- a/client/volume_inspect.go
+++ b/client/volume_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/volume"
 )
@@ -13,8 +14,8 @@ type VolumeInspectOptions struct {
 
 // VolumeInspectResult holds the result from the [Client.VolumeInspect] method.
 type VolumeInspectResult struct {
-	Raw    []byte
 	Volume volume.Volume
+	Raw    json.RawMessage
 }
 
 // VolumeInspect returns the information about a specific volume in the docker host.

--- a/vendor/github.com/moby/moby/client/config_inspect.go
+++ b/vendor/github.com/moby/moby/client/config_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/swarm"
 )
@@ -14,7 +15,7 @@ type ConfigInspectOptions struct {
 // ConfigInspectResult holds the result from the ConfigInspect method.
 type ConfigInspectResult struct {
 	Config swarm.Config
-	Raw    []byte
+	Raw    json.RawMessage
 }
 
 // ConfigInspect returns the config information with raw data

--- a/vendor/github.com/moby/moby/client/config_inspect.go
+++ b/vendor/github.com/moby/moby/client/config_inspect.go
@@ -25,7 +25,6 @@ func (cli *Client) ConfigInspect(ctx context.Context, id string, options ConfigI
 		return ConfigInspectResult{}, err
 	}
 	resp, err := cli.get(ctx, "/configs/"+id, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return ConfigInspectResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/network_inspect.go
+++ b/vendor/github.com/moby/moby/client/network_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 
 	"github.com/moby/moby/api/types/network"
@@ -10,7 +11,7 @@ import (
 // NetworkInspectResult contains the result of a network inspection.
 type NetworkInspectResult struct {
 	Network network.Inspect
-	Raw     []byte
+	Raw     json.RawMessage
 }
 
 // NetworkInspect returns the information for a specific network configured in the docker host.

--- a/vendor/github.com/moby/moby/client/network_inspect.go
+++ b/vendor/github.com/moby/moby/client/network_inspect.go
@@ -29,7 +29,6 @@ func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options
 	}
 
 	resp, err := cli.get(ctx, "/networks/"+networkID, query, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return NetworkInspectResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/node_inspect.go
+++ b/vendor/github.com/moby/moby/client/node_inspect.go
@@ -14,7 +14,7 @@ type NodeInspectOptions struct{}
 
 type NodeInspectResult struct {
 	Node swarm.Node
-	Raw  []byte
+	Raw  json.RawMessage
 }
 
 // NodeInspect returns the node information.

--- a/vendor/github.com/moby/moby/client/plugin_inspect.go
+++ b/vendor/github.com/moby/moby/client/plugin_inspect.go
@@ -25,7 +25,6 @@ func (cli *Client) PluginInspect(ctx context.Context, name string, options Plugi
 		return PluginInspectResult{}, err
 	}
 	resp, err := cli.get(ctx, "/plugins/"+name+"/json", nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return PluginInspectResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/plugin_inspect.go
+++ b/vendor/github.com/moby/moby/client/plugin_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/plugin"
 )
@@ -13,8 +14,8 @@ type PluginInspectOptions struct {
 
 // PluginInspectResult holds the result from the [Client.PluginInspect] method.
 type PluginInspectResult struct {
-	Raw    []byte
 	Plugin plugin.Plugin
+	Raw    json.RawMessage
 }
 
 // PluginInspect inspects an existing plugin

--- a/vendor/github.com/moby/moby/client/secret_inspect.go
+++ b/vendor/github.com/moby/moby/client/secret_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/swarm"
 )
@@ -14,7 +15,7 @@ type SecretInspectOptions struct {
 // SecretInspectResult holds the result from the [Client.SecretInspect]. method.
 type SecretInspectResult struct {
 	Secret swarm.Secret
-	Raw    []byte
+	Raw    json.RawMessage
 }
 
 // SecretInspect returns the secret information with raw data.

--- a/vendor/github.com/moby/moby/client/secret_inspect.go
+++ b/vendor/github.com/moby/moby/client/secret_inspect.go
@@ -25,7 +25,6 @@ func (cli *Client) SecretInspect(ctx context.Context, id string, options SecretI
 		return SecretInspectResult{}, err
 	}
 	resp, err := cli.get(ctx, "/secrets/"+id, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return SecretInspectResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/service_inspect.go
+++ b/vendor/github.com/moby/moby/client/service_inspect.go
@@ -30,7 +30,6 @@ func (cli *Client) ServiceInspect(ctx context.Context, serviceID string, options
 	query := url.Values{}
 	query.Set("insertDefaults", fmt.Sprintf("%v", options.InsertDefaults))
 	resp, err := cli.get(ctx, "/services/"+serviceID, query, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return ServiceInspectResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/service_inspect.go
+++ b/vendor/github.com/moby/moby/client/service_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -16,7 +17,7 @@ type ServiceInspectOptions struct {
 // ServiceInspectResult represents the result of a service inspect operation.
 type ServiceInspectResult struct {
 	Service swarm.Service
-	Raw     []byte
+	Raw     json.RawMessage
 }
 
 // ServiceInspect retrieves detailed information about a specific service by its ID.

--- a/vendor/github.com/moby/moby/client/task_inspect.go
+++ b/vendor/github.com/moby/moby/client/task_inspect.go
@@ -26,7 +26,6 @@ func (cli *Client) TaskInspect(ctx context.Context, taskID string, options TaskI
 	}
 
 	resp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return TaskInspectResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/task_inspect.go
+++ b/vendor/github.com/moby/moby/client/task_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/swarm"
 )
@@ -14,7 +15,7 @@ type TaskInspectOptions struct {
 // TaskInspectResult contains the result of a task inspection.
 type TaskInspectResult struct {
 	Task swarm.Task
-	Raw  []byte
+	Raw  json.RawMessage
 }
 
 // TaskInspect returns the task information and its raw representation.

--- a/vendor/github.com/moby/moby/client/utils.go
+++ b/vendor/github.com/moby/moby/client/utils.go
@@ -70,7 +70,7 @@ func encodePlatform(platform *ocispec.Platform) (string, error) {
 	return string(p), nil
 }
 
-func decodeWithRaw[T any](resp *http.Response, out *T) (raw []byte, _ error) {
+func decodeWithRaw[T any](resp *http.Response, out *T) (raw json.RawMessage, _ error) {
 	if resp == nil || resp.Body == nil {
 		return nil, errors.New("empty response")
 	}

--- a/vendor/github.com/moby/moby/client/utils.go
+++ b/vendor/github.com/moby/moby/client/utils.go
@@ -74,7 +74,7 @@ func decodeWithRaw[T any](resp *http.Response, out *T) (raw json.RawMessage, _ e
 	if resp == nil || resp.Body == nil {
 		return nil, errors.New("empty response")
 	}
-	defer resp.Body.Close()
+	defer ensureReaderClosed(resp)
 
 	var buf bytes.Buffer
 	tr := io.TeeReader(resp.Body, &buf)

--- a/vendor/github.com/moby/moby/client/volume_inspect.go
+++ b/vendor/github.com/moby/moby/client/volume_inspect.go
@@ -26,7 +26,6 @@ func (cli *Client) VolumeInspect(ctx context.Context, volumeID string, options V
 	}
 
 	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
-	defer ensureReaderClosed(resp)
 	if err != nil {
 		return VolumeInspectResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/volume_inspect.go
+++ b/vendor/github.com/moby/moby/client/volume_inspect.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/moby/moby/api/types/volume"
 )
@@ -13,8 +14,8 @@ type VolumeInspectOptions struct {
 
 // VolumeInspectResult holds the result from the [Client.VolumeInspect] method.
 type VolumeInspectResult struct {
-	Raw    []byte
 	Volume volume.Volume
+	Raw    json.RawMessage
 }
 
 // VolumeInspect returns the information about a specific volume in the docker host.


### PR DESCRIPTION
These fields store the raw JSON data that we received, and should never container bytes that are non-JSON (as we'd error out when failing to unmarshal).

Change the type to a json.RawMessage, which:

- Is more explicit on intent
- Can still be used as a regular []byte in all cases

And, while it's not expected to be marshaled to JSON, doing so will also print the output in a readable format instead of base64 encoding;

    package main

    import (
        "encoding/json"
        "fmt"
    )

    func main() {
        foo := struct {
            Bytes []byte
            Raw   json.RawMessage
        }{
            Bytes: []byte(`{"hello": "world"}`),
            Raw:   json.RawMessage(`{"hello": "world"}`),
        }

        out, _ := json.MarshalIndent(foo, "", "  ")
        fmt.Println(string(out))
    }

Will print:

    {
      "Bytes": "eyJoZWxsbyI6ICJ3b3JsZCJ9",
      "Raw": {
        "hello": "world"
      }
    }

### client: remove redundant closing and draining of response

For methods using the decodeWithRaw utility, we were handling closing
of the body twice. The ensureReaderClosed utility also drains the
response to let the transport reuse the connnection. Let's use that
utility in decodeWithRaw as well.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

