### PR TITLE
client/container_exec: Separate structs for Start and Attach

### DIFF
--- a/integration/system/event_test.go
+++ b/integration/system/event_test.go
@@ -36,7 +36,7 @@ func TestEventsExecDie(t *testing.T) {
 
 	_, err = apiClient.ExecStart(ctx, res.ID, client.ExecStartOptions{
 		Detach: true,
-		Tty:    false,
+		TTY:    false,
 	})
 	assert.NilError(t, err)
 


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/50965