### PR TITLE
client: remove ImageLoadResult.JSON

### DIFF
--- a/client/image_load.go
+++ b/client/image_load.go
@@ -47,36 +47,13 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...I
 	}
 	return ImageLoadResult{
 		body: resp.Body,
-		JSON: resp.Header.Get("Content-Type") == "application/json",
 	}, nil
 }
 
 // ImageLoadResult returns information to the client about a load process.
-//
-// TODO(thaJeztah): remove this type, and just use an io.ReadCloser
-//
-// This type was added in https://github.com/moby/moby/pull/18878, related
-// to https://github.com/moby/moby/issues/19177;
-//
-// Make docker load to output json when the response content type is json
-// Swarm hijacks the response from docker load and returns JSON rather
-// than plain text like the Engine does. This makes the API library to return
-// information to figure that out.
-//
-// However the "load" endpoint unconditionally returns JSON;
-// https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255
-//
-// PR https://github.com/moby/moby/pull/21959 made the response-type depend
-// on whether "quiet" was set, but this logic got changed in a follow-up
-// https://github.com/moby/moby/pull/25557, which made the JSON response-type
-// unconditionally, but the output produced depend on whether"quiet" was set.
-//
-// We should deprecated the "quiet" option, as it's really a client
-// responsibility.
 type ImageLoadResult struct {
 	// Body must be closed to avoid a resource leak
 	body io.ReadCloser
-	JSON bool
 }
 
 func (r ImageLoadResult) Read(p []byte) (n int, err error) {

--- a/vendor/github.com/moby/moby/client/image_load.go
+++ b/vendor/github.com/moby/moby/client/image_load.go
@@ -47,36 +47,13 @@ func (cli *Client) ImageLoad(ctx context.Context, input io.Reader, loadOpts ...I
 	}
 	return ImageLoadResult{
 		body: resp.Body,
-		JSON: resp.Header.Get("Content-Type") == "application/json",
 	}, nil
 }
 
 // ImageLoadResult returns information to the client about a load process.
-//
-// TODO(thaJeztah): remove this type, and just use an io.ReadCloser
-//
-// This type was added in https://github.com/moby/moby/pull/18878, related
-// to https://github.com/moby/moby/issues/19177;
-//
-// Make docker load to output json when the response content type is json
-// Swarm hijacks the response from docker load and returns JSON rather
-// than plain text like the Engine does. This makes the API library to return
-// information to figure that out.
-//
-// However the "load" endpoint unconditionally returns JSON;
-// https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255
-//
-// PR https://github.com/moby/moby/pull/21959 made the response-type depend
-// on whether "quiet" was set, but this logic got changed in a follow-up
-// https://github.com/moby/moby/pull/25557, which made the JSON response-type
-// unconditionally, but the output produced depend on whether"quiet" was set.
-//
-// We should deprecated the "quiet" option, as it's really a client
-// responsibility.
 type ImageLoadResult struct {
 	// Body must be closed to avoid a resource leak
 	body io.ReadCloser
-	JSON bool
 }
 
 func (r ImageLoadResult) Read(p []byte) (n int, err error) {


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/51296

----

relates to:

- https://github.com/moby/moby/pull/18878
    - https://github.com/moby/moby/issues/19177
- https://github.com/moby/moby/pull/21959
    - https://github.com/moby/moby/issues/21957
- https://github.com/moby/moby/pull/25557
    - https://github.com/moby/moby/issues/25529

### client: remove ImageLoadResult.JSON field

The JSON field was added in [moby@9fd2c0f], to address [moby#19177], which
reported an incompatibility with Classic (V1) Swarm, which produced a non-
standard response;

> Make docker load to output json when the response content type is json
> Swarm hijacks the response from docker load and returns JSON rather
> than plain text like the Engine does. This makes the API library to return
> information to figure that out.

A later change in [moby@96d7db6] added additional logic to make sure the
correct content-type was returned, depending on whether the `quiet` option
was set (which produced a non-JSON response). This caused inconsistency in
the API response, and [moby@2f27632] changed the endpoint to always produce
JSON (only skipping the "progress" output if `quiet` was set).

This means that the "load" endpoint ([`imageRouter.postImagesLoad`]) now
unconditionally returns JSON, making the `JSON` field fully redundant.

We should consider deprecating the "quiet" option, as it's really the client's
responsibility to show or hide progress-bars, but we can do this separately.

This patch removes the JSON field, as it's redundant, and the way it handles
the content-type is incorrect because it would not handle correct, but different
formatted response-headers (`application/json; charset=utf-8`), which could
result in malformed output on the client.


[moby@9fd2c0f]: https://github.com/moby/moby/commit/9fd2c0feb0c131d01d727d50baa7183b976c7bdc
[moby#19177]: https://github.com/moby/moby/issues/19177
[moby@96d7db6]: https://github.com/moby/moby/commit/96d7db665b06cc0bbede22d818c69dc5f6921f66
[moby@2f27632]: https://github.com/moby/moby/commit/2f27632cde2f0e514bd3a8de77cc1934e5193a83
[`imageRouter.postImagesLoad`]: https://github.com/moby/moby/blob/7b9d2ef6e5518a3d3f3cc418459f8df786cfbbd1/api/server/router/image/image_routes.go#L248-L255




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

