### PR TITLE
daemon: stats: cleanup and remove "OneShot" error

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -58,6 +58,7 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 	)
 
 	enc := json.NewEncoder(config.OutStream())
+	enc.SetEscapeHTML(false)
 	for {
 		select {
 		case v, ok := <-updates:


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/51293#discussion_r2463050437
- [x] depends on / stacked on https://github.com/moby/moby/pull/51302


### daemon: Daemon.ContainerStats: inline getStatJSON closure

Inline the code that handles preserving the previous read and putting
it in the next read, and rename some variables for clarity.


### daemon: Daemon.ContainerStats: combine some conditions and remove error

When streaming stats, the `OneShot` option is implied; streaming results
never populate the Pre* fields on the first result, so instead of producing
an error, we may as well ignore the option.

While updating this, also combine some of the conditions for non-streaming
results in an attempt to make the logic (early return on non-streaming,
one-shot requests) slightly clearer.

### daemon: Daemon.ContainerStats: don't escape HTML in responses

We have no need for it, and keeps the response more readable in case
it would ever contain any values that need escaping; it also would save
some cycles to check for such characters.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

