### PR TITLE
daemon: Daemon.stats: fill-in container ID and Name when collecting

### DIFF
--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -48,8 +48,6 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 	var preRead time.Time
 	getStatJSON := func(v any) *containertypes.StatsResponse {
 		ss := v.(containertypes.StatsResponse)
-		ss.Name = ctr.Name
-		ss.ID = ctr.ID
 		ss.PreCPUStats = preCPUStats
 		ss.PreRead = preRead
 		preCPUStats = ss.CPUStats

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -47,10 +47,11 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 		return nil, err
 	}
 	s := &containertypes.StatsResponse{
+		Name: c.Name,
+		ID:   c.ID,
 		Read: cs.Read,
 	}
-	stats := cs.Metrics
-	switch t := stats.(type) {
+	switch t := cs.Metrics.(type) {
 	case *statsV1.Metrics:
 		return daemon.statsV1(s, t)
 	case *statsV2.Metrics:

--- a/daemon/stats_windows.go
+++ b/daemon/stats_windows.go
@@ -28,6 +28,8 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 
 	// Start with an empty structure
 	s := &containertypes.StatsResponse{
+		Name:     c.Name,
+		ID:       c.ID,
 		Read:     stats.Read,
 		NumProcs: platform.NumProcs(),
 	}


### PR DESCRIPTION
Propagate these fields when collecting the data, instead of patching the result inside the router.

This also fixes a bug where the ID and Name fields were not set when using one-shot.

Before this patch, the "id" and "name" fields were not set in one-shot mode:

    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/foo/stats?stream=false' | jq .id
    "125d7f3df7919c33195fa4ec0636c27cdbe6d9b14339867d2920900565bcaf7e"
    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/foo/stats?stream=false' | jq .name
    "/foo"

    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/foo/stats?stream=false&one-shot=true' | jq .id
    null
    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/foo/stats?stream=false&one-shot=true' | jq .name
    null

With this patch, both are set:

    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/foo/stats?stream=false&one-shot=true' | jq .id
    "125d7f3df7919c33195fa4ec0636c27cdbe6d9b14339867d2920900565bcaf7e"
    curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/foo/stats?stream=false&one-shot=true' | jq .name
    "/foo"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix a bug where collecting container stats in "one-shot" mode would not include the container's ID and Name.
```

**- A picture of a cute animal (not mandatory but encouraged)**

