### PR TITLE
Fix some faulty defers in tests

### DIFF
--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -78,7 +78,9 @@ func TestImageImport(t *testing.T) {
 				SourceName: "image_source",
 			}, "repository_name:imported", tc.options)
 			assert.NilError(t, err)
-			defer assert.NilError(t, result.Close())
+			defer func() {
+				assert.NilError(t, result.Close())
+			}()
 
 			body, err := io.ReadAll(result)
 			assert.NilError(t, err)

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -71,7 +71,9 @@ func TestImageSave(t *testing.T) {
 			assert.NilError(t, err)
 			resp, err := client.ImageSave(context.Background(), []string{"image_id1", "image_id2"}, tc.options...)
 			assert.NilError(t, err)
-			defer assert.NilError(t, resp.Close())
+			defer func() {
+				assert.NilError(t, resp.Close())
+			}()
 
 			body, err := io.ReadAll(resp)
 			assert.NilError(t, err)

--- a/daemon/logger/loggertest/logreader.go
+++ b/daemon/logger/loggertest/logreader.go
@@ -292,7 +292,9 @@ func (tr Reader) TestFollow(t *testing.T) {
 		}()
 
 		expected := logMessages(t, l, mm)[:2]
-		defer assert.NilError(t, l.Close()) // Reading should end before the logger is closed.
+		defer func() {
+			assert.NilError(t, l.Close()) // Reading should end before the logger is closed.
+		}()
 		<-doneReading
 		assert.DeepEqual(t, logs, expected, compareLog)
 	})
@@ -317,7 +319,9 @@ func (tr Reader) TestFollow(t *testing.T) {
 		}()
 
 		expected := logMessages(t, l, mm)[1:2]
-		defer assert.NilError(t, l.Close()) // Reading should end before the logger is closed.
+		defer func() {
+			assert.NilError(t, l.Close()) // Reading should end before the logger is closed.
+		}()
 		<-doneReading
 		assert.DeepEqual(t, logs, expected, compareLog)
 	})

--- a/daemon/volume/local/local_linux_test.go
+++ b/daemon/volume/local/local_linux_test.go
@@ -235,13 +235,15 @@ func TestVolCreateValidation(t *testing.T) {
 			}
 			v, err := r.Create(tc.name, tc.opts)
 			if v != nil {
-				defer assert.Check(t, r.Remove(v))
+				defer func() {
+					assert.Check(t, r.Remove(v))
+				}()
 			}
 			if tc.expectedErr == "" {
 				assert.NilError(t, err)
 			} else {
 				assert.Check(t, cerrdefs.IsInvalidArgument(err), "got: %T", err)
-				assert.ErrorContains(t, err, tc.expectedErr)
+				assert.Check(t, is.ErrorContains(err, tc.expectedErr))
 			}
 		})
 	}

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -322,7 +322,9 @@ func TestAccessPublishedPortFromHost(t *testing.T) {
 	revertIPv6OnAll := enableIPv6OnAll(t)
 	defer revertIPv6OnAll()
 	assert.NilError(t, exec.Command("ip", "addr", "add", "fdfb:5cbb:29bf::2/64", "dev", "eth0", "nodad").Run())
-	defer assert.NilError(t, exec.Command("ip", "addr", "del", "fdfb:5cbb:29bf::2/64", "dev", "eth0").Run())
+	defer func() {
+		assert.NilError(t, exec.Command("ip", "addr", "del", "fdfb:5cbb:29bf::2/64", "dev", "eth0").Run())
+	}()
 
 	testcases := []struct {
 		ulpEnabled bool


### PR DESCRIPTION
Calling "defer assert.NilError(t, someCommand())" executes "someCommand()" immediately, but doesn't assert the error until the defer. https://go.dev/play/p/EO--y7OYerg

    package main

    import (
        "errors"
        "testing"

        "gotest.tools/v3/assert"
    )

    func TestDefer(t *testing.T) {
        doSomething := func() error {
            t.Log("doSomething failed with an error!")
            return errors.New("foo error")
        }

        defer assert.NilError(t, doSomething())

        t.Log("running test")
        t.Log("running test")
        t.Log("running test")
    }

Produces:

    === RUN   TestDefer
        prog_test.go:12: doSomething failed with an error!
        prog_test.go:18: running test
        prog_test.go:19: running test
        prog_test.go:20: running test
        prog_test.go:21: assertion failed: error is not nil: foo error
    --- FAIL: TestDefer (0.00s)
    FAIL

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

