### PR TITLE
api/types/container: StatsResponse: add OSType field, remove client.ContainerStatsResult.OSType

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -69,6 +69,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   of the `Resource` requirements.
 * `GET /tasks/{id}` now  returns `SwapBytes` and `MemorySwappiness` fields as
   part of the `Resource` requirements.
+* `GET /containers/{id}/stats` now returns an `os_type` field to allow platform-
+  specific handling of the stats.
 
 ## v1.51 API changes
 

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -5639,6 +5639,13 @@ definitions:
         type: "string"
         x-nullable: true
         example: "boring_wozniak"
+      os_type:
+        description: |
+          OSType is the OS of the container ("linux" or "windows") to allow
+          platform-specific handling of stats.
+        type: "string"
+        x-nullable: true
+        example: "linux"
       read:
         description: |
           Date and time at which this sample was collected.

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5639,6 +5639,13 @@ definitions:
         type: "string"
         x-nullable: true
         example: "boring_wozniak"
+      os_type:
+        description: |
+          OSType is the OS of the container ("linux" or "windows") to allow
+          platform-specific handling of stats.
+        type: "string"
+        x-nullable: true
+        example: "linux"
       read:
         description: |
           Date and time at which this sample was collected.

--- a/api/types/container/stats.go
+++ b/api/types/container/stats.go
@@ -155,6 +155,10 @@ type StatsResponse struct {
 	// Name is the name of the container for which the stats were collected.
 	Name string `json:"name,omitempty"`
 
+	// OSType is the OS of the container ("linux" or "windows") to allow
+	// platform-specific handling of stats.
+	OSType string `json:"os_type,omitempty"`
+
 	// Read is the date and time at which this sample was collected.
 	Read time.Time `json:"read"`
 

--- a/client/container_stats.go
+++ b/client/container_stats.go
@@ -36,12 +36,8 @@ type ContainerStatsOptions struct {
 // It wraps an [io.ReadCloser] that provides one or more [container.StatsResponse]
 // objects for a container, as produced by the "GET /containers/{id}/stats" endpoint.
 // If streaming is disabled, the stream contains a single record.
-//
-// The OSType field reports the daemon's operating system, allowing platform-specific
-// handling of the response.
 type ContainerStatsResult struct {
-	Body   io.ReadCloser
-	OSType string // TODO(thaJeztah): consider moving OSType into [container.StatsResponse].
+	Body io.ReadCloser
 }
 
 // ContainerStats retrieves live resource usage statistics for the specified
@@ -72,7 +68,6 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, optio
 	}
 
 	return ContainerStatsResult{
-		Body:   resp.Body,
-		OSType: resp.Header.Get("Ostype"),
+		Body: resp.Body,
 	}, nil
 }

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -29,8 +29,9 @@ func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, c
 		if !ctr.State.IsRunning() || ctr.State.IsRestarting() {
 			// The container is either not running or restarting, return an empty stats.
 			return json.NewEncoder(config.OutStream()).Encode(&containertypes.StatsResponse{
-				Name: ctr.Name,
-				ID:   ctr.ID,
+				ID:     ctr.ID,
+				Name:   ctr.Name,
+				OSType: runtime.GOOS,
 			})
 		}
 		if config.OneShot {
@@ -133,8 +134,9 @@ done:
 		if cerrdefs.IsNotFound(err) || cerrdefs.IsConflict(err) {
 			// return empty stats containing only name and ID if not running or not found
 			return &containertypes.StatsResponse{
-				Name: ctr.Name,
-				ID:   ctr.ID,
+				ID:     ctr.ID,
+				Name:   ctr.Name,
+				OSType: runtime.GOOS,
 			}, nil
 		}
 		log.G(context.TODO()).Errorf("collecting stats for container %s: %v", ctr.Name, err)

--- a/daemon/stats/collector.go
+++ b/daemon/stats/collector.go
@@ -1,6 +1,7 @@
 package stats
 
 import (
+	"runtime"
 	"sync"
 	"time"
 
@@ -109,8 +110,9 @@ func (s *Collector) Run() {
 			stats, err := s.supervisor.GetContainerStats(pair.container)
 			if err != nil {
 				stats = &containertypes.StatsResponse{
-					Name: pair.container.Name,
-					ID:   pair.container.ID,
+					ID:     pair.container.ID,
+					Name:   pair.container.Name,
+					OSType: runtime.GOOS,
 				}
 			}
 			pair.publisher.Publish(*stats)

--- a/daemon/stats_unix.go
+++ b/daemon/stats_unix.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -47,9 +48,10 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 		return nil, err
 	}
 	s := &containertypes.StatsResponse{
-		Name: c.Name,
-		ID:   c.ID,
-		Read: cs.Read,
+		ID:     c.ID,
+		Name:   c.Name,
+		OSType: runtime.GOOS,
+		Read:   cs.Read,
 	}
 	switch t := cs.Metrics.(type) {
 	case *statsV1.Metrics:

--- a/daemon/stats_windows.go
+++ b/daemon/stats_windows.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"runtime"
 
 	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/moby/moby/api/types/container"
@@ -28,8 +29,9 @@ func (daemon *Daemon) stats(c *container.Container) (*containertypes.StatsRespon
 
 	// Start with an empty structure
 	s := &containertypes.StatsResponse{
-		Name:     c.Name,
 		ID:       c.ID,
+		Name:     c.Name,
+		OSType:   runtime.GOOS,
 		Read:     stats.Read,
 		NumProcs: platform.NumProcs(),
 	}

--- a/vendor/github.com/moby/moby/api/types/container/stats.go
+++ b/vendor/github.com/moby/moby/api/types/container/stats.go
@@ -155,6 +155,10 @@ type StatsResponse struct {
 	// Name is the name of the container for which the stats were collected.
 	Name string `json:"name,omitempty"`
 
+	// OSType is the OS of the container ("linux" or "windows") to allow
+	// platform-specific handling of stats.
+	OSType string `json:"os_type,omitempty"`
+
 	// Read is the date and time at which this sample was collected.
 	Read time.Time `json:"read"`
 

--- a/vendor/github.com/moby/moby/client/container_stats.go
+++ b/vendor/github.com/moby/moby/client/container_stats.go
@@ -36,12 +36,8 @@ type ContainerStatsOptions struct {
 // It wraps an [io.ReadCloser] that provides one or more [container.StatsResponse]
 // objects for a container, as produced by the "GET /containers/{id}/stats" endpoint.
 // If streaming is disabled, the stream contains a single record.
-//
-// The OSType field reports the daemon's operating system, allowing platform-specific
-// handling of the response.
 type ContainerStatsResult struct {
-	Body   io.ReadCloser
-	OSType string // TODO(thaJeztah): consider moving OSType into [container.StatsResponse].
+	Body io.ReadCloser
 }
 
 // ContainerStats retrieves live resource usage statistics for the specified
@@ -72,7 +68,6 @@ func (cli *Client) ContainerStats(ctx context.Context, containerID string, optio
 	}
 
 	return ContainerStatsResult{
-		Body:   resp.Body,
-		OSType: resp.Header.Get("Ostype"),
+		Body: resp.Body,
 	}, nil
 }


### PR DESCRIPTION
### api/types/container: StatsResponse: add OSType field

Adds a per-stats OSType field to allow handle the platform-specific fields.
Before this change, the client had to get the OSType field from the server's
API response header and copy it to each record.

Older daemon versions don't have this field, so the client still needs to
handle fallbacks.

### client: remove ContainerStatsResult.OSType field

The API now includes this information per record, and clients can
get this information using the `Ping` method if needed as fallback.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/container: StatsResponse: add OSType field
client: remove client.ContainerStatsResult.OSType field.
```

**- A picture of a cute animal (not mandatory but encouraged)**

