### PR TITLE
client: remove NegotiateAPIVersion, NegotiateAPIVersionPing

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -32,8 +32,6 @@ type stableAPIClient interface {
 	ClientVersion() string
 	DaemonHost() string
 	ServerVersion(ctx context.Context) (types.Version, error)
-	NegotiateAPIVersion(ctx context.Context)
-	NegotiateAPIVersionPing(PingResult)
 	HijackDialer
 	Dialer() func(context.Context) (net.Conn, error)
 	Close() error

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -32,8 +32,6 @@ type stableAPIClient interface {
 	ClientVersion() string
 	DaemonHost() string
 	ServerVersion(ctx context.Context) (types.Version, error)
-	NegotiateAPIVersion(ctx context.Context)
-	NegotiateAPIVersionPing(PingResult)
 	HijackDialer
 	Dialer() func(context.Context) (net.Conn, error)
 	Close() error


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/50968

Remove these methods in favor of adding negotiation options to the Ping method.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

