### PR TITLE
client: refactor `ContainerRename` to wrap options/result structs

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -66,7 +66,7 @@ type ContainerAPIClient interface {
 	ContainerLogs(ctx context.Context, container string, options ContainerLogsOptions) (io.ReadCloser, error)
 	ContainerPause(ctx context.Context, container string, options ContainerPauseOptions) (ContainerPauseResult, error)
 	ContainerRemove(ctx context.Context, container string, options ContainerRemoveOptions) (ContainerRemoveResult, error)
-	ContainerRename(ctx context.Context, container, newContainerName string) error
+	ContainerRename(ctx context.Context, container string, options ContainerRenameOptions) (ContainerRenameResult, error)
 	ContainerResize(ctx context.Context, container string, options ContainerResizeOptions) (ContainerResizeResult, error)
 	ContainerRestart(ctx context.Context, container string, options ContainerRestartOptions) (ContainerRestartResult, error)
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)

--- a/client/container_rename.go
+++ b/client/container_rename.go
@@ -5,16 +5,26 @@ import (
 	"net/url"
 )
 
+// ContainerRenameOptions represents the options for renaming a container.
+type ContainerRenameOptions struct {
+	NewName string
+}
+
+// ContainerRenameResult represents the result of a container rename operation.
+type ContainerRenameResult struct {
+	// This struct can be expanded in the future if needed
+}
+
 // ContainerRename changes the name of a given container.
-func (cli *Client) ContainerRename(ctx context.Context, containerID, newContainerName string) error {
+func (cli *Client) ContainerRename(ctx context.Context, containerID string, options ContainerRenameOptions) (ContainerRenameResult, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return err
+		return ContainerRenameResult{}, err
 	}
 
 	query := url.Values{}
-	query.Set("name", newContainerName)
+	query.Set("name", options.NewName)
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/rename", query, nil, nil)
 	defer ensureReaderClosed(resp)
-	return err
+	return ContainerRenameResult{}, err
 }

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -14,14 +14,14 @@ import (
 func TestContainerRenameError(t *testing.T) {
 	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
-	err = client.ContainerRename(context.Background(), "nothing", "newNothing")
+	_, err = client.ContainerRename(context.Background(), "nothing", ContainerRenameOptions{NewName: "newNothing"})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 
-	err = client.ContainerRename(context.Background(), "", "newNothing")
+	_, err = client.ContainerRename(context.Background(), "", ContainerRenameOptions{NewName: "newNothing"})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 
-	err = client.ContainerRename(context.Background(), "    ", "newNothing")
+	_, err = client.ContainerRename(context.Background(), "    ", ContainerRenameOptions{NewName: "newNothing"})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
 	assert.Check(t, is.ErrorContains(err, "value is empty"))
 }
@@ -40,6 +40,6 @@ func TestContainerRename(t *testing.T) {
 	}))
 	assert.NilError(t, err)
 
-	err = client.ContainerRename(context.Background(), "container_id", "newName")
+	_, err = client.ContainerRename(context.Background(), "container_id", ContainerRenameOptions{NewName: "newName"})
 	assert.NilError(t, err)
 }

--- a/integration/container/rename_test.go
+++ b/integration/container/rename_test.go
@@ -27,7 +27,7 @@ func TestRenameLinkedContainer(t *testing.T) {
 	aID := container.Run(ctx, t, apiClient, container.WithName(aName))
 	bID := container.Run(ctx, t, apiClient, container.WithName(bName), container.WithLinks(aName))
 
-	err := apiClient.ContainerRename(ctx, aID, "a1"+t.Name())
+	_, err := apiClient.ContainerRename(ctx, aID, client.ContainerRenameOptions{NewName: "a1" + t.Name()})
 	assert.NilError(t, err)
 
 	container.Run(ctx, t, apiClient, container.WithName(aName))
@@ -54,7 +54,7 @@ func TestRenameStoppedContainer(t *testing.T) {
 	assert.Check(t, is.Equal("/"+oldName, inspect.Container.Name))
 
 	newName := "new_name" + cID // using cID as random suffix
-	err = apiClient.ContainerRename(ctx, oldName, newName)
+	_, err = apiClient.ContainerRename(ctx, oldName, client.ContainerRenameOptions{NewName: newName})
 	assert.NilError(t, err)
 
 	inspect, err = apiClient.ContainerInspect(ctx, cID, client.ContainerInspectOptions{})
@@ -70,7 +70,7 @@ func TestRenameRunningContainerAndReuse(t *testing.T) {
 	cID := container.Run(ctx, t, apiClient, container.WithName(oldName))
 
 	newName := "new_name" + cID // using cID as random suffix
-	err := apiClient.ContainerRename(ctx, oldName, newName)
+	_, err := apiClient.ContainerRename(ctx, oldName, client.ContainerRenameOptions{NewName: newName})
 	assert.NilError(t, err)
 
 	inspect, err := apiClient.ContainerInspect(ctx, cID, client.ContainerInspectOptions{})
@@ -94,7 +94,7 @@ func TestRenameInvalidName(t *testing.T) {
 	oldName := "first_name" + t.Name()
 	cID := container.Run(ctx, t, apiClient, container.WithName(oldName))
 
-	err := apiClient.ContainerRename(ctx, oldName, "new:invalid")
+	_, err := apiClient.ContainerRename(ctx, oldName, client.ContainerRenameOptions{NewName: "new:invalid"})
 	assert.Check(t, is.ErrorContains(err, "Invalid container name"))
 
 	inspect, err := apiClient.ContainerInspect(ctx, oldName, client.ContainerInspectOptions{})
@@ -125,7 +125,7 @@ func TestRenameAnonymousContainer(t *testing.T) {
 	})
 
 	container1Name := "container1" + t.Name()
-	err = apiClient.ContainerRename(ctx, cID, container1Name)
+	_, err = apiClient.ContainerRename(ctx, cID, client.ContainerRenameOptions{NewName: container1Name})
 	assert.NilError(t, err)
 	// Stop/Start the container to get registered
 	// FIXME(vdemeester) this is a really weird behavior as it fails otherwise
@@ -158,9 +158,9 @@ func TestRenameContainerWithSameName(t *testing.T) {
 
 	oldName := "old" + t.Name()
 	cID := container.Run(ctx, t, apiClient, container.WithName(oldName))
-	err := apiClient.ContainerRename(ctx, oldName, oldName)
+	_, err := apiClient.ContainerRename(ctx, oldName, client.ContainerRenameOptions{NewName: oldName})
 	assert.Check(t, is.ErrorContains(err, "Renaming a container with the same name"))
-	err = apiClient.ContainerRename(ctx, cID, oldName)
+	_, err = apiClient.ContainerRename(ctx, cID, client.ContainerRenameOptions{NewName: oldName})
 	assert.Check(t, is.ErrorContains(err, "Renaming a container with the same name"))
 }
 
@@ -183,7 +183,7 @@ func TestRenameContainerWithLinkedContainer(t *testing.T) {
 	app2Name := "app2" + t.Name()
 	container.Run(ctx, t, apiClient, container.WithName(app1Name), container.WithLinks(db1Name+":/mysql"))
 
-	err := apiClient.ContainerRename(ctx, app1Name, app2Name)
+	_, err := apiClient.ContainerRename(ctx, app1Name, client.ContainerRenameOptions{NewName: app2Name})
 	assert.NilError(t, err)
 
 	inspect, err := apiClient.ContainerInspect(ctx, app2Name+"/mysql", client.ContainerInspectOptions{})
@@ -204,11 +204,11 @@ func TestRenameContainerTwice(t *testing.T) {
 		})
 	}()
 
-	err := apiClient.ContainerRename(ctx, "c0", "c1")
+	_, err := apiClient.ContainerRename(ctx, "c0", client.ContainerRenameOptions{NewName: "c1"})
 	assert.NilError(t, err)
 	ctrName = "c1"
 
-	err = apiClient.ContainerRename(ctx, "c1", "c2")
+	_, err = apiClient.ContainerRename(ctx, "c1", client.ContainerRenameOptions{NewName: "c2"})
 	assert.NilError(t, err)
 	ctrName = "c2"
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -66,7 +66,7 @@ type ContainerAPIClient interface {
 	ContainerLogs(ctx context.Context, container string, options ContainerLogsOptions) (io.ReadCloser, error)
 	ContainerPause(ctx context.Context, container string, options ContainerPauseOptions) (ContainerPauseResult, error)
 	ContainerRemove(ctx context.Context, container string, options ContainerRemoveOptions) (ContainerRemoveResult, error)
-	ContainerRename(ctx context.Context, container, newContainerName string) error
+	ContainerRename(ctx context.Context, container string, options ContainerRenameOptions) (ContainerRenameResult, error)
 	ContainerResize(ctx context.Context, container string, options ContainerResizeOptions) (ContainerResizeResult, error)
 	ContainerRestart(ctx context.Context, container string, options ContainerRestartOptions) (ContainerRestartResult, error)
 	ContainerStatPath(ctx context.Context, container, path string) (container.PathStat, error)

--- a/vendor/github.com/moby/moby/client/container_rename.go
+++ b/vendor/github.com/moby/moby/client/container_rename.go
@@ -5,16 +5,26 @@ import (
 	"net/url"
 )
 
+// ContainerRenameOptions represents the options for renaming a container.
+type ContainerRenameOptions struct {
+	NewName string
+}
+
+// ContainerRenameResult represents the result of a container rename operation.
+type ContainerRenameResult struct {
+	// This struct can be expanded in the future if needed
+}
+
 // ContainerRename changes the name of a given container.
-func (cli *Client) ContainerRename(ctx context.Context, containerID, newContainerName string) error {
+func (cli *Client) ContainerRename(ctx context.Context, containerID string, options ContainerRenameOptions) (ContainerRenameResult, error) {
 	containerID, err := trimID("container", containerID)
 	if err != nil {
-		return err
+		return ContainerRenameResult{}, err
 	}
 
 	query := url.Values{}
-	query.Set("name", newContainerName)
+	query.Set("name", options.NewName)
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/rename", query, nil, nil)
 	defer ensureReaderClosed(resp)
-	return err
+	return ContainerRenameResult{}, err
 }


### PR DESCRIPTION
**- What I did**
https://github.com/moby/moby/issues/50965

This change refactors client `ContainerRename` implementation to take client module defined options and result structs to decouple the client module from API changes.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

