### PR TITLE
types/network: introduce MACAddress type (temporary placement)

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -1,10 +1,35 @@
 package network
 
 import (
+	"encoding/json"
 	"maps"
+	"net"
 	"net/netip"
 	"slices"
 )
+
+type MACAddress net.HardwareAddr
+
+func (m MACAddress) String() string {
+	return net.HardwareAddr(m).String()
+}
+
+func (m MACAddress) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.String())
+}
+
+func (m *MACAddress) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	addr, err := net.ParseMAC(s)
+	if err != nil {
+		return err
+	}
+	*m = MACAddress(addr)
+	return nil
+}
 
 // EndpointSettings stores the network endpoint details
 type EndpointSettings struct {
@@ -30,7 +55,7 @@ type EndpointSettings struct {
 	// MacAddress may be used to specify a MAC address when the container is created.
 	// Once the container is running, it becomes operational data (it may contain a
 	// generated address).
-	MacAddress          string
+    MacAddress          MACAddress `json:",omitempty"`
 	IPPrefixLen         int
 	IPv6Gateway         netip.Addr
 	GlobalIPv6Address   netip.Addr


### PR DESCRIPTION
Fixes #51146 

**- What I did**

Introduced a new `MACAddress` type that wraps `net.HardwareAddr` with custom JSON marshaling and unmarshaling logic to ensure consistent serialization/deserialization of MAC addresses.  
Currently added in `api/types/network/endpoint.go` **temporarily** for review and discussion on ideal placement.

**- How I did it**

- Defined a new `MACAddress` type with `String()`, `MarshalJSON()`, and `UnmarshalJSON()` methods.
- Replaced the `MacAddress` field in `EndpointSettings` with this new type.
- Rebuilt and ran `dockerd` from this branch.
- Created and inspected containers to confirm correct `MacAddress` serialization.
