### PR TITLE
Dockerfile: update runc binary to v1.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,10 +250,11 @@ RUN --mount=source=hack/dockerfile/cli.sh,target=/download-or-build-cli.sh \
 FROM base AS runc-src
 WORKDIR /usr/src/runc
 RUN git init . && git remote add origin "https://github.com/opencontainers/runc.git"
-# RUNC_VERSION should match the version that is used by the containerd version
+# RUNC_VERSION sets the version of runc to install in the dev-container.
+# This version should usually match the version that is used by the containerd version
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged.
-ARG RUNC_VERSION=v1.3.0
+ARG RUNC_VERSION=v1.3.2
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -7,7 +7,7 @@ set -e
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: "${RUNC_VERSION:=v1.3.0}"
+: "${RUNC_VERSION:=v1.3.2}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
Update the version used in CI and for the static binaries.

- release notes: https://github.com/opencontainers/runc/releases/tag/v1.3.2
- full diff: https://github.com/opencontainers/runc/compare/v1.3.0...v1.3.2

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update `runc` to [v1.3.2](https://github.com/opencontainers/runc/releases/tag/v1.3.2)
```

**- A picture of a cute animal (not mandatory but encouraged)**

