### PR TITLE
client: deprecate NewClientWithOpts in favor of New

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		panic(err)
 	}

--- a/client/checkpoint_create_test.go
+++ b/client/checkpoint_create_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCheckpointCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -42,7 +42,7 @@ func TestCheckpointCreate(t *testing.T) {
 		expectedURL          = "/containers/container_id/checkpoints"
 	)
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err

--- a/client/checkpoint_delete_test.go
+++ b/client/checkpoint_delete_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCheckpointDeleteError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -34,7 +34,7 @@ func TestCheckpointDeleteError(t *testing.T) {
 func TestCheckpointDelete(t *testing.T) {
 	const expectedURL = "/containers/container_id/checkpoints/checkpoint_id"
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 				return nil, err

--- a/client/checkpoint_list_test.go
+++ b/client/checkpoint_list_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCheckpointListError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -24,7 +24,7 @@ func TestCheckpointListError(t *testing.T) {
 func TestCheckpointList(t *testing.T) {
 	const expectedURL = "/containers/container_id/checkpoints"
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
@@ -42,7 +42,7 @@ func TestCheckpointList(t *testing.T) {
 }
 
 func TestCheckpointListContainerNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Server error")),
 	)
 	assert.NilError(t, err)

--- a/client/client.go
+++ b/client/client.go
@@ -6,7 +6,7 @@ https://docs.docker.com/reference/api/engine/
 
 # Usage
 
-You use the library by constructing a client object using [NewClientWithOpts]
+You use the library by constructing a client object using [New]
 and calling methods on it. The client can be configured from environment
 variables by passing the [FromEnv] option, and the [WithAPIVersionNegotiation]
 option to allow downgrading the API version used when connecting with an older
@@ -30,7 +30,7 @@ For example, to list running containers (the equivalent of "docker ps"):
 		// for configuration (DOCKER_HOST, DOCKER_API_VERSION), and does
 		// API-version negotiation to allow downgrading the API version
 		// when connecting with an older daemon version.
-		apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -160,7 +160,14 @@ func CheckRedirect(_ *http.Request, via []*http.Request) error {
 	return ErrRedirect
 }
 
-// NewClientWithOpts initializes a new API client with a default HTTPClient, and
+// NewClientWithOpts initializes a new API client.
+//
+// Deprecated: use New. This function will be removed in the next release.
+func NewClientWithOpts(ops ...Opt) (*Client, error) {
+	return New(ops...)
+}
+
+// New initializes a new API client with a default HTTPClient, and
 // default API host and version. It also initializes the custom HTTP headers to
 // add to each request.
 //
@@ -170,11 +177,11 @@ func CheckRedirect(_ *http.Request, via []*http.Request) error {
 // itself with values from environment variables ([FromEnv]), and has automatic
 // API version negotiation enabled ([WithAPIVersionNegotiation]).
 //
-//	cli, err := client.NewClientWithOpts(
+//	cli, err := client.New(
 //		client.FromEnv,
 //		client.WithAPIVersionNegotiation(),
 //	)
-func NewClientWithOpts(ops ...Opt) (*Client, error) {
+func New(ops ...Opt) (*Client, error) {
 	hostURL, err := ParseHostURL(DefaultDockerHost)
 	if err != nil {
 		return nil, err

--- a/client/client_example_test.go
+++ b/client/client_example_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/moby/moby/client"
 )
 
-func ExampleNewClientWithOpts() {
+func ExampleNew() {
 	// Create a new client that handles common environment variables
 	// for configuration (DOCKER_HOST, DOCKER_API_VERSION), and does
 	// API-version negotiation to allow downgrading the API version
 	// when connecting with an older daemon version.
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client/config_create_test.go
+++ b/client/config_create_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestConfigCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -23,7 +23,7 @@ func TestConfigCreateError(t *testing.T) {
 
 func TestConfigCreate(t *testing.T) {
 	const expectedURL = "/configs/create"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err

--- a/client/config_inspect_test.go
+++ b/client/config_inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestConfigInspectNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -23,7 +23,7 @@ func TestConfigInspectNotFound(t *testing.T) {
 }
 
 func TestConfigInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
 		}),
@@ -39,7 +39,7 @@ func TestConfigInspectWithEmptyID(t *testing.T) {
 }
 
 func TestConfigInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -49,7 +49,7 @@ func TestConfigInspectError(t *testing.T) {
 }
 
 func TestConfigInspectConfigNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -60,7 +60,7 @@ func TestConfigInspectConfigNotFound(t *testing.T) {
 
 func TestConfigInspect(t *testing.T) {
 	const expectedURL = "/configs/config_id"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err

--- a/client/config_list_test.go
+++ b/client/config_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestConfigListError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -47,7 +47,7 @@ func TestConfigList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(
+		client, err := New(
 			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 					return nil, err

--- a/client/config_remove_test.go
+++ b/client/config_remove_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestConfigRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -31,7 +31,7 @@ func TestConfigRemoveError(t *testing.T) {
 func TestConfigRemove(t *testing.T) {
 	const expectedURL = "/configs/config_id"
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 				return nil, err

--- a/client/config_update_test.go
+++ b/client/config_update_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestConfigUpdateError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -31,7 +31,7 @@ func TestConfigUpdateError(t *testing.T) {
 func TestConfigUpdate(t *testing.T) {
 	const expectedURL = "/configs/config_id/update"
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err

--- a/client/container_commit_test.go
+++ b/client/container_commit_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestContainerCommitError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -42,7 +42,7 @@ func TestContainerCommit(t *testing.T) {
 	)
 	expectedChanges := []string{"change1", "change2"}
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err

--- a/client/container_copy_test.go
+++ b/client/container_copy_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestContainerStatPathError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -37,7 +37,7 @@ func TestContainerStatPathError(t *testing.T) {
 }
 
 func TestContainerStatPathNotFoundError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Not found")),
 	)
 	assert.NilError(t, err)
@@ -47,7 +47,7 @@ func TestContainerStatPathNotFoundError(t *testing.T) {
 }
 
 func TestContainerStatPathNoHeaderError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(mockResponse(http.StatusOK, nil, "")),
 	)
 	assert.NilError(t, err)
@@ -61,7 +61,7 @@ func TestContainerStatPath(t *testing.T) {
 		expectedURL  = "/containers/container_id/archive"
 		expectedPath = "path/to/file"
 	)
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodHead, expectedURL); err != nil {
 				return nil, err
@@ -93,7 +93,7 @@ func TestContainerStatPath(t *testing.T) {
 }
 
 func TestCopyToContainerError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -120,7 +120,7 @@ func TestCopyToContainerError(t *testing.T) {
 }
 
 func TestCopyToContainerNotFoundError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Not found")),
 	)
 	assert.NilError(t, err)
@@ -135,7 +135,7 @@ func TestCopyToContainerNotFoundError(t *testing.T) {
 // TestCopyToContainerEmptyResponse verifies that no error is returned when a
 // "204 No Content" is returned by the API.
 func TestCopyToContainerEmptyResponse(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNoContent, "No content")),
 	)
 	assert.NilError(t, err)
@@ -152,7 +152,7 @@ func TestCopyToContainer(t *testing.T) {
 		expectedURL  = "/containers/container_id/archive"
 		expectedPath = "path/to/file"
 	)
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPut, expectedURL); err != nil {
 				return nil, err
@@ -192,7 +192,7 @@ func TestCopyToContainer(t *testing.T) {
 }
 
 func TestCopyFromContainerError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -210,7 +210,7 @@ func TestCopyFromContainerError(t *testing.T) {
 }
 
 func TestCopyFromContainerNotFoundError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Not found")),
 	)
 	assert.NilError(t, err)
@@ -222,7 +222,7 @@ func TestCopyFromContainerNotFoundError(t *testing.T) {
 // TestCopyFromContainerEmptyResponse verifies that no error is returned when a
 // "204 No Content" is returned by the API.
 func TestCopyFromContainerEmptyResponse(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			content, err := json.Marshal(container.PathStat{
 				Name: "path/to/file",
@@ -245,7 +245,7 @@ func TestCopyFromContainerEmptyResponse(t *testing.T) {
 }
 
 func TestCopyFromContainerNoHeaderError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(mockResponse(http.StatusOK, nil, "")),
 	)
 	assert.NilError(t, err)
@@ -259,7 +259,7 @@ func TestCopyFromContainer(t *testing.T) {
 		expectedURL  = "/containers/container_id/archive"
 		expectedPath = "path/to/file"
 	)
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestContainerCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -29,7 +29,7 @@ func TestContainerCreateError(t *testing.T) {
 }
 
 func TestContainerCreateImageNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "No such image")),
 	)
 	assert.NilError(t, err)
@@ -40,7 +40,7 @@ func TestContainerCreateImageNotFound(t *testing.T) {
 
 func TestContainerCreateWithName(t *testing.T) {
 	const expectedURL = "/containers/create"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
@@ -62,7 +62,7 @@ func TestContainerCreateWithName(t *testing.T) {
 }
 
 func TestContainerCreateAutoRemove(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			var config container.CreateRequest
 			if err := json.NewDecoder(req.Body).Decode(&config); err != nil {
@@ -88,7 +88,7 @@ func TestContainerCreateAutoRemove(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerCreate(context.Background(), ContainerCreateOptions{Config: &container.Config{Image: "test"}})
@@ -116,7 +116,7 @@ func TestContainerCreateCapabilities(t *testing.T) {
 		"CAP_CAPABILITY_D",
 	}
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			var config container.CreateRequest
 

--- a/client/container_diff_test.go
+++ b/client/container_diff_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContainerDiffError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -47,7 +47,7 @@ func TestContainerDiff(t *testing.T) {
 		},
 	}
 
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestExecCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -37,7 +37,7 @@ func TestExecCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestExecCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ExecCreate(context.Background(), "container_id", ExecCreateOptions{})
@@ -46,7 +46,7 @@ func TestExecCreateConnectionError(t *testing.T) {
 
 func TestExecCreate(t *testing.T) {
 	const expectedURL = "/containers/container_id/exec"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
@@ -77,7 +77,7 @@ func TestExecCreate(t *testing.T) {
 }
 
 func TestExecStartError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -88,7 +88,7 @@ func TestExecStartError(t *testing.T) {
 
 func TestExecStart(t *testing.T) {
 	const expectedURL = "/exec/exec_id/start"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
@@ -116,7 +116,7 @@ func TestExecStart(t *testing.T) {
 }
 
 func TestExecStartConsoleSize(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, nil
 		}),
@@ -133,7 +133,7 @@ func TestExecStartConsoleSize(t *testing.T) {
 }
 
 func TestExecInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -144,7 +144,7 @@ func TestExecInspectError(t *testing.T) {
 
 func TestExecInspect(t *testing.T) {
 	const expectedURL = "/exec/exec_id/json"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err

--- a/client/container_export_test.go
+++ b/client/container_export_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContainerExportError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -31,7 +31,7 @@ func TestContainerExportError(t *testing.T) {
 
 func TestContainerExport(t *testing.T) {
 	const expectedURL = "/containers/container_id/export"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err

--- a/client/container_inspect_test.go
+++ b/client/container_inspect_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContainerInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -30,7 +30,7 @@ func TestContainerInspectError(t *testing.T) {
 }
 
 func TestContainerInspectContainerNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -40,7 +40,7 @@ func TestContainerInspectContainerNotFound(t *testing.T) {
 }
 
 func TestContainerInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("should not make request")
 		}),
@@ -58,7 +58,7 @@ func TestContainerInspectWithEmptyID(t *testing.T) {
 
 func TestContainerInspect(t *testing.T) {
 	const expectedURL = "/containers/container_id/json"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err

--- a/client/container_kill_test.go
+++ b/client/container_kill_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestContainerKillError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -33,7 +33,7 @@ func TestContainerKillError(t *testing.T) {
 func TestContainerKill(t *testing.T) {
 	const expectedURL = "/containers/container_id/kill"
 	const expectedSignal = "SIG_SOMETHING"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestContainerListError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -27,7 +27,7 @@ func TestContainerList(t *testing.T) {
 		expectedURL     = "/containers/json"
 		expectedFilters = `{"before":{"container":true},"label":{"label1":true,"label2":true}}`
 	)
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestContainerLogsNotFoundError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusNotFound, "Not found")),
 	)
 	assert.NilError(t, err)
@@ -35,7 +35,7 @@ func TestContainerLogsNotFoundError(t *testing.T) {
 }
 
 func TestContainerLogsError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -135,7 +135,7 @@ func TestContainerLogs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(
+			client, err := New(
 				WithMockClient(func(req *http.Request) (*http.Response, error) {
 					if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 						return nil, err
@@ -167,10 +167,13 @@ func TestContainerLogs(t *testing.T) {
 }
 
 func ExampleClient_ContainerLogs_withTimeout() {
+	client, err := New(FromEnv, WithAPIVersionNegotiation())
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-
-	client, _ := NewClientWithOpts(FromEnv)
 	res, err := client.ContainerLogs(ctx, "container_id", ContainerLogsOptions{})
 	if err != nil {
 		log.Fatal(err)

--- a/client/container_pause_test.go
+++ b/client/container_pause_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestContainerPauseError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -21,7 +21,7 @@ func TestContainerPauseError(t *testing.T) {
 
 func TestContainerPause(t *testing.T) {
 	const expectedURL = "/containers/container_id/pause"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContainersPruneError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ContainersPrune(context.Background(), ContainerPruneOptions{})
@@ -73,7 +73,7 @@ func TestContainersPrune(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/container_remove_test.go
+++ b/client/container_remove_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestContainerRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerRemove(t.Context(), "container_id", ContainerRemoveOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -26,7 +26,7 @@ func TestContainerRemoveError(t *testing.T) {
 }
 
 func TestContainerRemoveNotFoundError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "no such container: container_id")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "no such container: container_id")))
 	assert.NilError(t, err)
 	_, err = client.ContainerRemove(t.Context(), "container_id", ContainerRemoveOptions{})
 	assert.Check(t, is.ErrorContains(err, "no such container: container_id"))
@@ -35,7 +35,7 @@ func TestContainerRemoveNotFoundError(t *testing.T) {
 
 func TestContainerRemove(t *testing.T) {
 	const expectedURL = "/containers/container_id"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/container_rename_test.go
+++ b/client/container_rename_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContainerRenameError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerRename(context.Background(), "nothing", ContainerRenameOptions{NewName: "newNothing"})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -28,7 +28,7 @@ func TestContainerRenameError(t *testing.T) {
 
 func TestContainerRename(t *testing.T) {
 	const expectedURL = "/containers/container_id/rename"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/container_resize_test.go
+++ b/client/container_resize_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestContainerResizeError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerResize(t.Context(), "container_id", ContainerResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -26,7 +26,7 @@ func TestContainerResizeError(t *testing.T) {
 }
 
 func TestExecResizeError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ExecResize(t.Context(), "exec_id", ExecResizeOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -67,7 +67,7 @@ func TestContainerResize(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)))
+			client, err := New(WithMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)))
 			assert.NilError(t, err)
 			_, err = client.ContainerResize(t.Context(), "container_id", tc.opts)
 			assert.NilError(t, err)
@@ -109,7 +109,7 @@ func TestExecResize(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)))
+			client, err := New(WithMockClient(resizeTransport(t, expectedURL, tc.expectedHeight, tc.expectedWidth)))
 			assert.NilError(t, err)
 			_, err = client.ExecResize(t.Context(), "exec_id", tc.opts)
 			assert.NilError(t, err)

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestContainerRestartError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerRestart(t.Context(), "nothing", ContainerRestartOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -30,7 +30,7 @@ func TestContainerRestartError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerRestartConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerRestart(t.Context(), "nothing", ContainerRestartOptions{})
@@ -39,7 +39,7 @@ func TestContainerRestartConnectionError(t *testing.T) {
 
 func TestContainerRestart(t *testing.T) {
 	const expectedURL = "/containers/container_id/restart"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/container_start_test.go
+++ b/client/container_start_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContainerStartError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerStart(t.Context(), "nothing", ContainerStartOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -28,7 +28,7 @@ func TestContainerStartError(t *testing.T) {
 
 func TestContainerStart(t *testing.T) {
 	const expectedURL = "/containers/container_id/start"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/container_stats_test.go
+++ b/client/container_stats_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestContainerStatsError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerStats(t.Context(), "nothing", ContainerStatsOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -43,7 +43,7 @@ func TestContainerStats(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestContainerStopError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerStop(t.Context(), "container_id", ContainerStopOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -30,7 +30,7 @@ func TestContainerStopError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerStopConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerStop(t.Context(), "container_id", ContainerStopOptions{})
@@ -39,7 +39,7 @@ func TestContainerStopConnectionError(t *testing.T) {
 
 func TestContainerStop(t *testing.T) {
 	const expectedURL = "/containers/container_id/stop"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/container_top_test.go
+++ b/client/container_top_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestContainerTopError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerTop(context.Background(), "nothing", ContainerTopOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -35,7 +35,7 @@ func TestContainerTop(t *testing.T) {
 	}
 	expectedTitles := []string{"title1", "title2"}
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/container_unpause_test.go
+++ b/client/container_unpause_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestContainerUnpauseError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerUnpause(t.Context(), "nothing", ContainerUnpauseOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -26,7 +26,7 @@ func TestContainerUnpauseError(t *testing.T) {
 
 func TestContainerUnpause(t *testing.T) {
 	const expectedURL = "/containers/container_id/unpause"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/container_update_test.go
+++ b/client/container_update_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestContainerUpdateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerUpdate(context.Background(), "nothing", ContainerUpdateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -29,7 +29,7 @@ func TestContainerUpdateError(t *testing.T) {
 func TestContainerUpdate(t *testing.T) {
 	const expectedURL = "/containers/container_id/update"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/distribution_inspect_test.go
+++ b/client/distribution_inspect_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDistributionInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)

--- a/client/hijack_test.go
+++ b/client/hijack_test.go
@@ -86,7 +86,7 @@ func TestTLSCloseWriter(t *testing.T) {
 	serverURL, err := url.Parse(ts.URL)
 	assert.NilError(t, err)
 
-	client, err := NewClientWithOpts(WithHost("tcp://"+serverURL.Host), WithHTTPClient(ts.Client()))
+	client, err := New(WithHost("tcp://"+serverURL.Host), WithHTTPClient(ts.Client()))
 	assert.NilError(t, err)
 
 	resp, err := client.postHijacked(context.Background(), "/asdf", url.Values{}, nil, map[string][]string{"Content-Type": {"text/plain"}})

--- a/client/image_build_test.go
+++ b/client/image_build_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestImageBuildError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ImageBuild(context.Background(), nil, ImageBuildOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -154,7 +154,7 @@ func TestImageBuild(t *testing.T) {
 	}
 	const expectedURL = "/build"
 	for _, buildCase := range buildCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/image_create_test.go
+++ b/client/image_create_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestImageCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ImageCreate(context.Background(), "reference", ImageCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -29,7 +29,7 @@ func TestImageCreate(t *testing.T) {
 		expectedRegistryAuth = "eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImRHOTBid289IiwiZW1haWwiOiJqb2huQGRvZS5jb20ifX0="
 	)
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/image_history_test.go
+++ b/client/image_history_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestImageHistoryError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ImageHistory(context.Background(), "nothing")
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -25,7 +25,7 @@ func TestImageHistory(t *testing.T) {
 		historyResponse  = `[{"Comment":"","Created":0,"CreatedBy":"","Id":"image_id1","Size":0,"Tags":["tag1","tag2"]},{"Comment":"","Created":0,"CreatedBy":"","Id":"image_id2","Size":0,"Tags":["tag1","tag2"]}]`
 		expectedPlatform = `{"architecture":"arm64","os":"linux","variant":"v8"}`
 	)
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		assert.Check(t, assertRequest(req, http.MethodGet, expectedURL))
 		assert.Check(t, is.Equal(req.URL.Query().Get("platform"), expectedPlatform))
 		return mockResponse(http.StatusOK, nil, historyResponse)(req)

--- a/client/image_import_test.go
+++ b/client/image_import_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestImageImportError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ImageImport(context.Background(), ImageImportSource{}, "image:tag", ImageImportOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -66,7 +66,7 @@ func TestImageImport(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, assertRequest(req, http.MethodPost, expectedURL))
 				query := req.URL.Query()
 				assert.Check(t, is.DeepEqual(query, tc.expectedQueryParams))

--- a/client/image_inspect_test.go
+++ b/client/image_inspect_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestImageInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageInspect(context.Background(), "nothing")
@@ -23,7 +23,7 @@ func TestImageInspectError(t *testing.T) {
 }
 
 func TestImageInspectImageNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageInspect(context.Background(), "unknown")
@@ -31,7 +31,7 @@ func TestImageInspectImageNotFound(t *testing.T) {
 }
 
 func TestImageInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)
@@ -42,7 +42,7 @@ func TestImageInspectWithEmptyID(t *testing.T) {
 func TestImageInspect(t *testing.T) {
 	const expectedURL = "/images/image_id/json"
 	expectedTags := []string{"tag1", "tag2"}
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func TestImageInspectWithPlatform(t *testing.T) {
 	expectedPlatform, err := encodePlatform(requestedPlatform)
 	assert.NilError(t, err)
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestImageListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageList(context.Background(), ImageListOptions{})
@@ -26,7 +26,7 @@ func TestImageListError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestImageListConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ImageList(context.Background(), ImageListOptions{})
@@ -73,7 +73,7 @@ func TestImageList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}
@@ -114,7 +114,7 @@ func TestImageListWithSharedSize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			var query url.Values
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				query = req.URL.Query()
 				return mockResponse(http.StatusOK, nil, "[]")(req)
 			}), WithVersion(tc.version))

--- a/client/image_load_test.go
+++ b/client/image_load_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestImageLoadError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageLoad(context.Background(), nil, ImageLoadWithQuiet(true))
@@ -71,7 +71,7 @@ func TestImageLoad(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, assertRequest(req, http.MethodPost, expectedURL))
 				assert.Check(t, is.Equal(req.Header.Get("Content-Type"), expectedContentType))
 				assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestImagesPruneError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImagesPrune(context.Background(), ImagePruneOptions{})
@@ -63,7 +63,7 @@ func TestImagesPrune(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestImagePullReferenceParseError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, nil
 	}))
 	assert.NilError(t, err)
@@ -28,21 +28,21 @@ func TestImagePullReferenceParseError(t *testing.T) {
 }
 
 func TestImagePullAnyError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ImagePull(context.Background(), "myimage", ImagePullOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestImagePullStatusUnauthorizedError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	_, err = client.ImagePull(context.Background(), "myimage", ImagePullOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
 }
 
 func TestImagePullWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	_, err = client.ImagePull(context.Background(), "myimage", ImagePullOptions{
 		PrivilegeFunc: func(_ context.Context) (string, error) {
@@ -53,7 +53,7 @@ func TestImagePullWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 }
 
 func TestImagePullWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	_, err = client.ImagePull(context.Background(), "myimage", ImagePullOptions{
 		PrivilegeFunc: staticAuth("a-auth-header"),
@@ -65,7 +65,7 @@ func TestImagePullWithPrivilegedFuncNoError(t *testing.T) {
 	const expectedURL = "/images/create"
 	const invalidAuth = "NotValid"
 	const validAuth = "IAmValid"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func TestImagePullWithoutErrors(t *testing.T) {
 	}
 	for _, pullCase := range pullCases {
 		t.Run(pullCase.reference, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 					return nil, err
 				}

--- a/client/image_push_test.go
+++ b/client/image_push_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestImagePushReferenceError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, nil
 	}))
 	assert.NilError(t, err)
@@ -28,21 +28,21 @@ func TestImagePushReferenceError(t *testing.T) {
 }
 
 func TestImagePushAnyError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ImagePush(context.Background(), "myimage", ImagePushOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestImagePushStatusUnauthorizedError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	_, err = client.ImagePush(context.Background(), "myimage", ImagePushOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
 }
 
 func TestImagePushWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", errors.New("error requesting privilege")
@@ -54,7 +54,7 @@ func TestImagePushWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 }
 
 func TestImagePushWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
@@ -69,7 +69,7 @@ func TestImagePushWithPrivilegedFuncNoError(t *testing.T) {
 	const expectedURL = "/images/docker.io/myname/myimage/push"
 	const invalidAuth = "NotValid"
 	const validAuth = "IAmValid"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func TestImagePushWithoutErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s,all-tags=%t", tc.reference, tc.all), func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				expectedURL := fmt.Sprintf(expectedURLFormat, tc.expectedImage)
 				if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 					return nil, err

--- a/client/image_remove_test.go
+++ b/client/image_remove_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestImageRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageRemove(context.Background(), "image_id", ImageRemoveOptions{})
@@ -22,7 +22,7 @@ func TestImageRemoveError(t *testing.T) {
 }
 
 func TestImageRemoveImageNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "no such image: unknown")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "no such image: unknown")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageRemove(context.Background(), "unknown", ImageRemoveOptions{})
@@ -65,7 +65,7 @@ func TestImageRemove(t *testing.T) {
 		},
 	}
 	for _, removeCase := range removeCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/image_save_test.go
+++ b/client/image_save_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestImageSaveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	armv64 := ocispec.Platform{Architecture: "arm64", OS: "linux", Variant: "v8"}
 	_, err = client.ImageSave(context.Background(), []string{"nothing"}, ImageSaveWithPlatforms(armv64))
@@ -63,7 +63,7 @@ func TestImageSave(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, assertRequest(req, http.MethodGet, expectedURL))
 				assert.Check(t, is.DeepEqual(req.URL.Query(), tc.expectedQueryParams))
 				return mockResponse(http.StatusOK, nil, expectedOutput)(req)

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -14,21 +14,21 @@ import (
 )
 
 func TestImageSearchAnyError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestImageSearchStatusUnauthorizedError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	_, err = client.ImageSearch(context.Background(), "some-image", ImageSearchOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsUnauthorized))
 }
 
 func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "", errors.New("Error requesting privilege")
@@ -40,7 +40,7 @@ func TestImageSearchWithUnauthorizedErrorAndPrivilegeFuncError(t *testing.T) {
 }
 
 func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
+	client, err := New(WithMockClient(errorMock(http.StatusUnauthorized, "Unauthorized error")))
 	assert.NilError(t, err)
 	privilegeFunc := func(_ context.Context) (string, error) {
 		return "a-auth-header", nil
@@ -53,7 +53,7 @@ func TestImageSearchWithUnauthorizedErrorAndAnotherUnauthorizedError(t *testing.
 
 func TestImageSearchWithPrivilegedFuncNoError(t *testing.T) {
 	const expectedURL = "/images/search"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func TestImageSearchWithoutErrors(t *testing.T) {
 	const expectedURL = "/images/search"
 	const expectedFilters = `{"is-automated":{"true":true},"stars":{"3":true}}`
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/image_tag_test.go
+++ b/client/image_tag_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestImageTagError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageTag(context.Background(), ImageTagOptions{Source: "image_id", Target: "repo:tag"})
@@ -23,7 +23,7 @@ func TestImageTagError(t *testing.T) {
 // Note: this is not testing all the InvalidReference as it's the responsibility
 // of distribution/reference package.
 func TestImageTagInvalidReference(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageTag(context.Background(), ImageTagOptions{Source: "image_id", Target: "aa/asdf$$^/aa"})
@@ -34,7 +34,7 @@ func TestImageTagInvalidReference(t *testing.T) {
 func TestImageTagInvalidSourceImageName(t *testing.T) {
 	ctx := context.Background()
 
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "client should not have made an API call")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "client should not have made an API call")))
 	assert.NilError(t, err)
 
 	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "aa/asdf$$^/aa"}
@@ -86,7 +86,7 @@ func generateRandomAlphaOnlyString(n int) string {
 }
 
 func TestImageTagHexSource(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(mockResponse(http.StatusOK, nil, "OK")))
+	client, err := New(WithMockClient(mockResponse(http.StatusOK, nil, "OK")))
 	assert.NilError(t, err)
 
 	_, err = client.ImageTag(context.Background(), ImageTagOptions{Source: "0d409d33b27e47423b049f7f863faa08655a8c901749c2b25b93ca67d01a470d", Target: "repo:tag"})
@@ -150,7 +150,7 @@ func TestImageTag(t *testing.T) {
 		},
 	}
 	for _, tagCase := range tagCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/network_connect_test.go
+++ b/client/network_connect_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNetworkConnectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkConnect(context.Background(), "network_id", NetworkConnectOptions{
@@ -37,7 +37,7 @@ func TestNetworkConnectError(t *testing.T) {
 func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
 	const expectedURL = "/networks/network_id/connect"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}
@@ -68,7 +68,7 @@ func TestNetworkConnectEmptyNilEndpointSettings(t *testing.T) {
 func TestNetworkConnect(t *testing.T) {
 	const expectedURL = "/networks/network_id/connect"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNetworkCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{})
@@ -24,7 +24,7 @@ func TestNetworkCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestNetworkCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkCreate(context.Background(), "mynetwork", NetworkCreateOptions{})
@@ -34,7 +34,7 @@ func TestNetworkCreateConnectionError(t *testing.T) {
 func TestNetworkCreate(t *testing.T) {
 	const expectedURL = "/networks/create"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/network_disconnect_test.go
+++ b/client/network_disconnect_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNetworkDisconnectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkDisconnect(context.Background(), "network_id", NetworkDisconnectOptions{
@@ -37,7 +37,7 @@ func TestNetworkDisconnectError(t *testing.T) {
 func TestNetworkDisconnect(t *testing.T) {
 	const expectedURL = "/networks/network_id/disconnect"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/network_inspect_test.go
+++ b/client/network_inspect_test.go
@@ -15,7 +15,7 @@ import (
 func TestNetworkInspect(t *testing.T) {
 	const expectedURL = "/networks/network_id"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Path == defaultAPIPath+"/networks/" {
 			return errorMock(http.StatusInternalServerError, "client should not make a request for empty IDs")(req)
 		}

--- a/client/network_list_test.go
+++ b/client/network_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNetworkListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkList(context.Background(), NetworkListOptions{})
@@ -54,7 +54,7 @@ func TestNetworkList(t *testing.T) {
 	}
 
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNetworksPruneError(t *testing.T) {
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
@@ -65,7 +65,7 @@ func TestNetworksPrune(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(
+		client, err := New(
 			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 					return nil, err

--- a/client/network_remove_test.go
+++ b/client/network_remove_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNetworkRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkRemove(context.Background(), "network_id", NetworkRemoveOptions{})
@@ -29,7 +29,7 @@ func TestNetworkRemoveError(t *testing.T) {
 func TestNetworkRemove(t *testing.T) {
 	const expectedURL = "/networks/network_id"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/node_inspect_test.go
+++ b/client/node_inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNodeInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NodeInspect(context.Background(), "nothing", NodeInspectOptions{})
@@ -21,7 +21,7 @@ func TestNodeInspectError(t *testing.T) {
 }
 
 func TestNodeInspectNodeNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NodeInspect(context.Background(), "unknown", NodeInspectOptions{})
@@ -29,7 +29,7 @@ func TestNodeInspectNodeNotFound(t *testing.T) {
 }
 
 func TestNodeInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)
@@ -44,7 +44,7 @@ func TestNodeInspectWithEmptyID(t *testing.T) {
 
 func TestNodeInspect(t *testing.T) {
 	const expectedURL = "/nodes/node_id"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/node_list_test.go
+++ b/client/node_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNodeListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NodeList(context.Background(), NodeListOptions{})
@@ -44,7 +44,7 @@ func TestNodeList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/node_remove_test.go
+++ b/client/node_remove_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNodeRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NodeRemove(context.Background(), "node_id", NodeRemoveOptions{Force: false})
@@ -44,7 +44,7 @@ func TestNodeRemove(t *testing.T) {
 	}
 
 	for _, removeCase := range removeCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNodeUpdateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.NodeUpdate(context.Background(), "node_id", NodeUpdateOptions{
@@ -39,7 +39,7 @@ func TestNodeUpdateError(t *testing.T) {
 func TestNodeUpdate(t *testing.T) {
 	const expectedURL = "/nodes/node_id/update"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestOptionWithHostFromEnv(t *testing.T) {
-	c, err := NewClientWithOpts(WithHostFromEnv())
+	c, err := New(WithHostFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
 	assert.Check(t, is.Equal(c.basePath, ""))
@@ -27,7 +27,7 @@ func TestOptionWithHostFromEnv(t *testing.T) {
 
 	t.Setenv("DOCKER_HOST", "tcp://foo.example.com:2376/test/")
 
-	c, err = NewClientWithOpts(WithHostFromEnv())
+	c, err = New(WithHostFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
 	assert.Check(t, is.Equal(c.basePath, "/test/"))
@@ -38,14 +38,14 @@ func TestOptionWithHostFromEnv(t *testing.T) {
 
 func TestOptionWithTimeout(t *testing.T) {
 	timeout := 10 * time.Second
-	c, err := NewClientWithOpts(WithTimeout(timeout))
+	c, err := New(WithTimeout(timeout))
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
 	assert.Check(t, is.Equal(c.client.Timeout, timeout))
 }
 
 func TestOptionWithVersionFromEnv(t *testing.T) {
-	c, err := NewClientWithOpts(WithVersionFromEnv())
+	c, err := New(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
 	assert.Check(t, is.Equal(c.version, MaxAPIVersion))
@@ -53,7 +53,7 @@ func TestOptionWithVersionFromEnv(t *testing.T) {
 
 	t.Setenv("DOCKER_API_VERSION", "2.9999")
 
-	c, err = NewClientWithOpts(WithVersionFromEnv())
+	c, err = New(WithVersionFromEnv())
 	assert.NilError(t, err)
 	assert.Check(t, c.client != nil)
 	assert.Check(t, is.Equal(c.version, "2.9999"))
@@ -63,7 +63,7 @@ func TestOptionWithVersionFromEnv(t *testing.T) {
 func TestWithUserAgent(t *testing.T) {
 	const userAgent = "Magic-Client/v1.2.3"
 	t.Run("user-agent", func(t *testing.T) {
-		c, err := NewClientWithOpts(
+		c, err := New(
 			WithUserAgent(userAgent),
 			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), userAgent))
@@ -76,7 +76,7 @@ func TestWithUserAgent(t *testing.T) {
 		assert.NilError(t, c.Close())
 	})
 	t.Run("user-agent and custom headers", func(t *testing.T) {
-		c, err := NewClientWithOpts(
+		c, err := New(
 			WithUserAgent(userAgent),
 			WithHTTPHeaders(map[string]string{"User-Agent": "should-be-ignored/1.0.0", "Other-Header": "hello-world"}),
 			WithMockClient(func(req *http.Request) (*http.Response, error) {
@@ -91,7 +91,7 @@ func TestWithUserAgent(t *testing.T) {
 		assert.NilError(t, c.Close())
 	})
 	t.Run("custom headers", func(t *testing.T) {
-		c, err := NewClientWithOpts(
+		c, err := New(
 			WithHTTPHeaders(map[string]string{"User-Agent": "from-custom-headers/1.0.0", "Other-Header": "hello-world"}),
 			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), "from-custom-headers/1.0.0"))
@@ -105,7 +105,7 @@ func TestWithUserAgent(t *testing.T) {
 		assert.NilError(t, c.Close())
 	})
 	t.Run("no user-agent set", func(t *testing.T) {
-		c, err := NewClientWithOpts(
+		c, err := New(
 			WithHTTPHeaders(map[string]string{"Other-Header": "hello-world"}),
 			WithMockClient(func(req *http.Request) (*http.Response, error) {
 				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), ""))
@@ -119,7 +119,7 @@ func TestWithUserAgent(t *testing.T) {
 		assert.NilError(t, c.Close())
 	})
 	t.Run("reset custom user-agent", func(t *testing.T) {
-		c, err := NewClientWithOpts(
+		c, err := New(
 			WithUserAgent(""),
 			WithHTTPHeaders(map[string]string{"User-Agent": "from-custom-headers/1.0.0", "Other-Header": "hello-world"}),
 			WithMockClient(func(req *http.Request) (*http.Response, error) {

--- a/client/ping_test.go
+++ b/client/ping_test.go
@@ -18,7 +18,7 @@ import (
 // panics.
 func TestPingFail(t *testing.T) {
 	var withHeader bool
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		var hdr http.Header
 		if withHeader {
 			hdr = http.Header{}
@@ -48,7 +48,7 @@ func TestPingFail(t *testing.T) {
 // TestPingWithError tests the case where there is a protocol error in the ping.
 // This test is mostly just testing that there are no panics in this code path.
 func TestPingWithError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("some connection error")
 	}))
 	assert.NilError(t, err)
@@ -64,7 +64,7 @@ func TestPingWithError(t *testing.T) {
 // TestPingSuccess tests that we are able to get the expected API headers/ping
 // details on success.
 func TestPingSuccess(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		hdr := http.Header{}
 		hdr.Set("Api-Version", "awesome")
 		hdr.Set("Docker-Experimental", "true")
@@ -109,7 +109,7 @@ func TestPingHeadFallback(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(http.StatusText(tc.status), func(t *testing.T) {
 			var reqs []string
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if !strings.HasPrefix(req.URL.Path, expectedPath) {
 					return nil, fmt.Errorf("expected URL '%s', got '%s'", expectedPath, req.URL.Path)
 				}

--- a/client/plugin_disable_test.go
+++ b/client/plugin_disable_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPluginDisableError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.PluginDisable(context.Background(), "plugin_name", PluginDisableOptions{})
@@ -29,7 +29,7 @@ func TestPluginDisableError(t *testing.T) {
 func TestPluginDisable(t *testing.T) {
 	const expectedURL = "/plugins/plugin_name/disable"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/plugin_enable_test.go
+++ b/client/plugin_enable_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPluginEnableError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.PluginEnable(context.Background(), "plugin_name", PluginEnableOptions{})
@@ -29,7 +29,7 @@ func TestPluginEnableError(t *testing.T) {
 func TestPluginEnable(t *testing.T) {
 	const expectedURL = "/plugins/plugin_name/enable"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/plugin_inspect_test.go
+++ b/client/plugin_inspect_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPluginInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.PluginInspect(t.Context(), "nothing", PluginInspectOptions{})
@@ -20,7 +20,7 @@ func TestPluginInspectError(t *testing.T) {
 }
 
 func TestPluginInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)
@@ -35,7 +35,7 @@ func TestPluginInspectWithEmptyID(t *testing.T) {
 
 func TestPluginInspect(t *testing.T) {
 	const expectedURL = "/plugins/plugin_name"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPluginListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.PluginList(context.Background(), PluginListOptions{})
@@ -53,7 +53,7 @@ func TestPluginList(t *testing.T) {
 	}
 
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/plugin_push_test.go
+++ b/client/plugin_push_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPluginPushError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.PluginPush(context.Background(), "plugin_name", PluginPushOptions{})
@@ -31,7 +31,7 @@ func TestPluginPushError(t *testing.T) {
 func TestPluginPush(t *testing.T) {
 	const expectedURL = "/plugins/plugin_name"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/plugin_remove_test.go
+++ b/client/plugin_remove_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPluginRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.PluginRemove(context.Background(), "plugin_name", PluginRemoveOptions{})
@@ -29,7 +29,7 @@ func TestPluginRemoveError(t *testing.T) {
 func TestPluginRemove(t *testing.T) {
 	const expectedURL = "/plugins/plugin_name"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/plugin_set_test.go
+++ b/client/plugin_set_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPluginSetError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.PluginSet(context.Background(), "plugin_name", PluginSetOptions{})
@@ -29,7 +29,7 @@ func TestPluginSetError(t *testing.T) {
 func TestPluginSet(t *testing.T) {
 	const expectedURL = "/plugins/plugin_name/set"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -50,7 +50,7 @@ func TestSetHostHeader(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.host, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if err := assertRequest(req, http.MethodGet, testEndpoint); err != nil {
 					return nil, err
 				}
@@ -74,7 +74,7 @@ func TestSetHostHeader(t *testing.T) {
 // API versions < 1.24 returned plain text errors, but we may encounter
 // other situations where a non-JSON error is returned.
 func TestPlainTextError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(mockResponse(http.StatusInternalServerError, nil, "Server error")))
+	client, err := New(WithMockClient(mockResponse(http.StatusInternalServerError, nil, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ContainerList(context.Background(), ContainerListOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -195,11 +195,11 @@ func TestResponseErrors(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				return mockResponse(http.StatusBadRequest, http.Header{"Content-Type": []string{tc.contentType}}, tc.response)(req)
 			}))
 			if tc.apiVersion != "" {
-				client, err = NewClientWithOpts(WithHTTPClient(client.client), WithVersion(tc.apiVersion))
+				client, err = New(WithHTTPClient(client.client), WithVersion(tc.apiVersion))
 			}
 			assert.NilError(t, err)
 			_, err = client.Ping(t.Context(), PingOptions{})
@@ -211,7 +211,7 @@ func TestResponseErrors(t *testing.T) {
 
 func TestInfiniteError(t *testing.T) {
 	infinitR := rand.New(rand.NewSource(42))
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		resp := &http.Response{
 			StatusCode: http.StatusInternalServerError,
 			Header:     http.Header{},
@@ -229,7 +229,7 @@ func TestInfiniteError(t *testing.T) {
 func TestCanceledContext(t *testing.T) {
 	const testEndpoint = "/test"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		assert.Check(t, is.ErrorType(req.Context().Err(), context.Canceled))
 		return nil, context.Canceled
 	}))
@@ -245,7 +245,7 @@ func TestCanceledContext(t *testing.T) {
 func TestDeadlineExceededContext(t *testing.T) {
 	const testEndpoint = "/test"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		assert.Check(t, is.ErrorType(req.Context().Err(), context.DeadlineExceeded))
 		return nil, context.DeadlineExceeded
 	}))

--- a/client/secret_create_test.go
+++ b/client/secret_create_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSecretCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.SecretCreate(context.Background(), SecretCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -20,7 +20,7 @@ func TestSecretCreateError(t *testing.T) {
 
 func TestSecretCreate(t *testing.T) {
 	const expectedURL = "/secrets/create"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/secret_inspect_test.go
+++ b/client/secret_inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSecretInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SecretInspect(context.Background(), "nothing", SecretInspectOptions{})
@@ -21,7 +21,7 @@ func TestSecretInspectError(t *testing.T) {
 }
 
 func TestSecretInspectSecretNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SecretInspect(context.Background(), "unknown", SecretInspectOptions{})
@@ -29,7 +29,7 @@ func TestSecretInspectSecretNotFound(t *testing.T) {
 }
 
 func TestSecretInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)
@@ -44,7 +44,7 @@ func TestSecretInspectWithEmptyID(t *testing.T) {
 
 func TestSecretInspect(t *testing.T) {
 	const expectedURL = "/secrets/secret_id"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/secret_list_test.go
+++ b/client/secret_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSecretListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SecretList(context.Background(), SecretListOptions{})
@@ -43,7 +43,7 @@ func TestSecretList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/secret_remove_test.go
+++ b/client/secret_remove_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSecretRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SecretRemove(context.Background(), "secret_id", SecretRemoveOptions{})
@@ -29,7 +29,7 @@ func TestSecretRemoveError(t *testing.T) {
 func TestSecretRemove(t *testing.T) {
 	const expectedURL = "/secrets/secret_id"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/secret_update_test.go
+++ b/client/secret_update_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSecretUpdateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SecretUpdate(context.Background(), "secret_id", SecretUpdateOptions{})
@@ -29,7 +29,7 @@ func TestSecretUpdateError(t *testing.T) {
 func TestSecretUpdate(t *testing.T) {
 	const expectedURL = "/secrets/secret_id/update"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestServiceCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ServiceCreate(t.Context(), ServiceCreateOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -29,7 +29,7 @@ func TestServiceCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestServiceCreateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceCreate(t.Context(), ServiceCreateOptions{})
@@ -38,7 +38,7 @@ func TestServiceCreateConnectionError(t *testing.T) {
 
 func TestServiceCreate(t *testing.T) {
 	const expectedURL = "/services/create"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}
@@ -54,7 +54,7 @@ func TestServiceCreate(t *testing.T) {
 }
 
 func TestServiceCreateCompatiblePlatforms(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if strings.HasPrefix(req.URL.Path, defaultAPIPath+"/services/create") {
 			var serviceSpec swarm.ServiceSpec
 
@@ -123,7 +123,7 @@ func TestServiceCreateDigestPinning(t *testing.T) {
 		{"cannotresolve", "cannotresolve:latest"},
 	}
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if strings.HasPrefix(req.URL.Path, defaultAPIPath+"/services/create") {
 			// reset and set image received by the service create endpoint
 			serviceCreateImage = ""

--- a/client/service_inspect_test.go
+++ b/client/service_inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestServiceInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceInspect(context.Background(), "nothing", ServiceInspectOptions{})
@@ -21,7 +21,7 @@ func TestServiceInspectError(t *testing.T) {
 }
 
 func TestServiceInspectServiceNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceInspect(context.Background(), "unknown", ServiceInspectOptions{})
@@ -29,7 +29,7 @@ func TestServiceInspectServiceNotFound(t *testing.T) {
 }
 
 func TestServiceInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)
@@ -44,7 +44,7 @@ func TestServiceInspectWithEmptyID(t *testing.T) {
 
 func TestServiceInspect(t *testing.T) {
 	const expectedURL = "/services/service_id"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/service_list_test.go
+++ b/client/service_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestServiceListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceList(context.Background(), ServiceListOptions{})
@@ -43,7 +43,7 @@ func TestServiceList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestServiceLogsError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.ServiceLogs(t.Context(), "service_id", ServiceLogsOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -99,7 +99,7 @@ func TestServiceLogs(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 					return nil, err
 				}
@@ -129,10 +129,13 @@ func TestServiceLogs(t *testing.T) {
 }
 
 func ExampleClient_ServiceLogs_withTimeout() {
+	client, err := New(FromEnv, WithAPIVersionNegotiation())
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-
-	client, _ := NewClientWithOpts(FromEnv)
 	res, err := client.ServiceLogs(ctx, "service_id", ServiceLogsOptions{})
 	if err != nil {
 		log.Fatal(err)

--- a/client/service_remove_test.go
+++ b/client/service_remove_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestServiceRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceRemove(context.Background(), "service_id", ServiceRemoveOptions{})
@@ -27,7 +27,7 @@ func TestServiceRemoveError(t *testing.T) {
 }
 
 func TestServiceRemoveNotFoundError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "no such service: service_id")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "no such service: service_id")))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceRemove(context.Background(), "service_id", ServiceRemoveOptions{})
@@ -38,7 +38,7 @@ func TestServiceRemoveNotFoundError(t *testing.T) {
 func TestServiceRemove(t *testing.T) {
 	const expectedURL = "/services/service_id"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestServiceUpdateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceUpdate(t.Context(), "service_id", ServiceUpdateOptions{})
@@ -32,7 +32,7 @@ func TestServiceUpdateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestServiceUpdateConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceUpdate(t.Context(), "service_id", ServiceUpdateOptions{})
@@ -64,7 +64,7 @@ func TestServiceUpdate(t *testing.T) {
 	}
 
 	for _, updateCase := range updateCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/swarm_get_unlock_key_test.go
+++ b/client/swarm_get_unlock_key_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSwarmGetUnlockKeyError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SwarmGetUnlockKey(context.Background())
@@ -25,7 +25,7 @@ func TestSwarmGetUnlockKey(t *testing.T) {
 		unlockKey   = "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeE"
 	)
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/swarm_init_test.go
+++ b/client/swarm_init_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSwarmInitError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SwarmInit(context.Background(), SwarmInitOptions{})
@@ -21,7 +21,7 @@ func TestSwarmInitError(t *testing.T) {
 func TestSwarmInit(t *testing.T) {
 	const expectedURL = "/swarm/init"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/swarm_inspect_test.go
+++ b/client/swarm_inspect_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSwarmInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SwarmInspect(t.Context(), SwarmInspectOptions{})
@@ -20,7 +20,7 @@ func TestSwarmInspectError(t *testing.T) {
 
 func TestSwarmInspect(t *testing.T) {
 	const expectedURL = "/swarm"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/swarm_join_test.go
+++ b/client/swarm_join_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSwarmJoinError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SwarmJoin(context.Background(), SwarmJoinOptions{})
@@ -21,7 +21,7 @@ func TestSwarmJoinError(t *testing.T) {
 func TestSwarmJoin(t *testing.T) {
 	const expectedURL = "/swarm/join"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/swarm_leave_test.go
+++ b/client/swarm_leave_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSwarmLeaveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SwarmLeave(context.Background(), SwarmLeaveOptions{})
@@ -36,7 +36,7 @@ func TestSwarmLeave(t *testing.T) {
 	}
 
 	for _, leaveCase := range leaveCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/swarm_unlock_test.go
+++ b/client/swarm_unlock_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSwarmUnlockError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SwarmUnlock(context.Background(), SwarmUnlockOptions{Key: "SWMKEY-1-y6guTZNTwpQeTL5RhUfOsdBdXoQjiB2GADHSRJvbXeU"})
@@ -21,7 +21,7 @@ func TestSwarmUnlockError(t *testing.T) {
 func TestSwarmUnlock(t *testing.T) {
 	const expectedURL = "/swarm/unlock"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/swarm_update_test.go
+++ b/client/swarm_update_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSwarmUpdateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.SwarmUpdate(t.Context(), SwarmUpdateOptions{})
@@ -20,7 +20,7 @@ func TestSwarmUpdateError(t *testing.T) {
 func TestSwarmUpdate(t *testing.T) {
 	const expectedURL = "/swarm/update"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDiskUsageError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.DiskUsage(context.Background(), DiskUsageOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
@@ -20,7 +20,7 @@ func TestDiskUsageError(t *testing.T) {
 
 func TestDiskUsage(t *testing.T) {
 	const expectedURL = "/system/df"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/system_events_test.go
+++ b/client/system_events_test.go
@@ -35,7 +35,7 @@ func TestEventsErrorInOptions(t *testing.T) {
 		},
 	}
 	for _, tc := range errorCases {
-		client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+		client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 		assert.NilError(t, err)
 		events := client.Events(context.Background(), tc.options)
 		err = <-events.Err
@@ -44,7 +44,7 @@ func TestEventsErrorInOptions(t *testing.T) {
 }
 
 func TestEventsErrorFromServer(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	events := client.Events(context.Background(), EventsListOptions{})
 	err = <-events.Err
@@ -106,7 +106,7 @@ func TestEvents(t *testing.T) {
 	}
 
 	for _, eventsCase := range eventsCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/system_info_test.go
+++ b/client/system_info_test.go
@@ -12,14 +12,14 @@ import (
 )
 
 func TestInfoServerError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 	_, err = client.Info(context.Background(), InfoOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
 func TestInfoInvalidResponseJSONError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(mockResponse(http.StatusOK, nil, "invalid json")))
+	client, err := New(WithMockClient(mockResponse(http.StatusOK, nil, "invalid json")))
 	assert.NilError(t, err)
 	_, err = client.Info(context.Background(), InfoOptions{})
 	assert.Check(t, is.ErrorContains(err, "invalid character"))
@@ -27,7 +27,7 @@ func TestInfoInvalidResponseJSONError(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	const expectedURL = "/info"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}
@@ -48,7 +48,7 @@ func TestInfo(t *testing.T) {
 
 func TestInfoWithDiscoveredDevices(t *testing.T) {
 	const expectedURL = "/info"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/task_inspect_test.go
+++ b/client/task_inspect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTaskInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.TaskInspect(context.Background(), "nothing", TaskInspectOptions{})
@@ -21,7 +21,7 @@ func TestTaskInspectError(t *testing.T) {
 }
 
 func TestTaskInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)
@@ -36,7 +36,7 @@ func TestTaskInspectWithEmptyID(t *testing.T) {
 
 func TestTaskInspect(t *testing.T) {
 	const expectedURL = "/tasks/task_id"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/task_list_test.go
+++ b/client/task_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTaskListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.TaskList(context.Background(), TaskListOptions{})
@@ -43,7 +43,7 @@ func TestTaskList(t *testing.T) {
 		},
 	}
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/volume_create_test.go
+++ b/client/volume_create_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestVolumeCreateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeCreate(context.Background(), VolumeCreateOptions{})
@@ -22,7 +22,7 @@ func TestVolumeCreateError(t *testing.T) {
 func TestVolumeCreate(t *testing.T) {
 	const expectedURL = "/volumes/create"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/volume_inspect_test.go
+++ b/client/volume_inspect_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestVolumeInspectError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeInspect(t.Context(), "nothing", VolumeInspectOptions{})
@@ -20,7 +20,7 @@ func TestVolumeInspectError(t *testing.T) {
 }
 
 func TestVolumeInspectNotFound(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusNotFound, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeInspect(t.Context(), "unknown", VolumeInspectOptions{})
@@ -28,7 +28,7 @@ func TestVolumeInspectNotFound(t *testing.T) {
 }
 
 func TestVolumeInspectWithEmptyID(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("should not make request")
 	}))
 	assert.NilError(t, err)
@@ -49,7 +49,7 @@ func TestVolumeInspect(t *testing.T) {
 		Mountpoint: "mountpoint",
 	}
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/volume_list_test.go
+++ b/client/volume_list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestVolumeListError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeList(context.Background(), VolumeListOptions{})
@@ -42,7 +42,7 @@ func TestVolumeList(t *testing.T) {
 	}
 
 	for _, listCase := range listCases {
-		client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+		client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
 				return nil, err
 			}

--- a/client/volume_prune_test.go
+++ b/client/volume_prune_test.go
@@ -63,7 +63,7 @@ func TestVolumePrune(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if err := assertRequest(req, http.MethodPost, expectedURL); err != nil {
 					return nil, err
 				}

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestVolumeRemoveError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeRemove(t.Context(), "volume_id", VolumeRemoveOptions{})
@@ -31,7 +31,7 @@ func TestVolumeRemoveError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestVolumeRemoveConnectionError(t *testing.T) {
-	client, err := NewClientWithOpts(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeRemove(t.Context(), "volume_id", VolumeRemoveOptions{})
@@ -41,7 +41,7 @@ func TestVolumeRemoveConnectionError(t *testing.T) {
 func TestVolumeRemove(t *testing.T) {
 	const expectedURL = "/volumes/volume_id"
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodDelete, expectedURL); err != nil {
 			return nil, err
 		}

--- a/client/volume_update_test.go
+++ b/client/volume_update_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestVolumeUpdateError(t *testing.T) {
-	client, err := NewClientWithOpts(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
+	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeUpdate(t.Context(), "volume", VolumeUpdateOptions{})
@@ -34,7 +34,7 @@ func TestVolumeUpdate(t *testing.T) {
 		expectedVersion = "version=10"
 	)
 
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+	client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 		if err := assertRequest(req, http.MethodPut, expectedURL); err != nil {
 			return nil, err
 		}

--- a/integration-cli/daemon/daemon.go
+++ b/integration-cli/daemon/daemon.go
@@ -85,7 +85,7 @@ func (d *Daemon) inspectFieldWithError(name, field string) (string, error) {
 func (d *Daemon) CheckActiveContainerCount(ctx context.Context) func(t *testing.T) (any, string) {
 	return func(t *testing.T) (any, string) {
 		t.Helper()
-		apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithHost(d.Sock()))
+		apiClient, err := client.New(client.FromEnv, client.WithHost(d.Sock()))
 		assert.NilError(t, err)
 
 		list, err := apiClient.ContainerList(ctx, client.ContainerListOptions{})

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -177,7 +177,7 @@ func (s *DockerAPISuite) TestPostContainersAttach(c *testing.T) {
 	expectTimeout(wc, br, "stdout")
 
 	// Test the client API
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -37,7 +37,7 @@ func (s *DockerAPISuite) TestContainerAPIGetAll(c *testing.T) {
 	const name = "getall"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "true")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -56,7 +56,7 @@ func (s *DockerAPISuite) TestContainerAPIGetJSONNoFieldsOmitted(c *testing.T) {
 	startCount := getContainerCount(c)
 	cli.DockerCmd(c, "run", "busybox", "true")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -99,7 +99,7 @@ func (s *DockerAPISuite) TestContainerAPIGetExport(c *testing.T) {
 	const name = "exportcontainer"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "touch", "/test")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -126,7 +126,7 @@ func (s *DockerAPISuite) TestContainerAPIGetChanges(c *testing.T) {
 	const name = "changescontainer"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "rm", "/etc/passwd")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -154,7 +154,7 @@ func (s *DockerAPISuite) TestGetContainerStats(c *testing.T) {
 
 	bc := make(chan b, 1)
 	go func() {
-		apiClient, err := client.NewClientWithOpts(client.FromEnv)
+		apiClient, err := client.New(client.FromEnv)
 		assert.NilError(c, err)
 		defer apiClient.Close()
 
@@ -190,7 +190,7 @@ func (s *DockerAPISuite) TestGetContainerStatsRmRunning(c *testing.T) {
 	buf := &ChannelBuffer{C: make(chan []byte, 1)}
 	defer buf.Close()
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -263,7 +263,7 @@ func (s *DockerAPISuite) TestGetContainerStatsStream(c *testing.T) {
 
 	bc := make(chan b, 1)
 	go func() {
-		apiClient, err := client.NewClientWithOpts(client.FromEnv)
+		apiClient, err := client.New(client.FromEnv)
 		assert.NilError(c, err)
 		defer apiClient.Close()
 
@@ -300,7 +300,7 @@ func (s *DockerAPISuite) TestGetContainerStatsNoStream(c *testing.T) {
 	cID := runSleepingContainer(c, "--name", name)
 	defer cli.DockerCmd(c, "rm", "-f", cID)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -328,7 +328,7 @@ func (s *DockerAPISuite) TestGetStoppedContainerStats(c *testing.T) {
 	cli.DockerCmd(c, "create", "--name", name, "busybox", "ps")
 	defer cli.DockerCmd(c, "rm", "-f", name)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -362,7 +362,7 @@ func (s *DockerAPISuite) TestContainerAPIPause(c *testing.T) {
 	out := cli.DockerCmd(c, "run", "-d", "busybox", "sleep", "30").Combined()
 	ContainerID := strings.TrimSpace(out)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -388,7 +388,7 @@ func (s *DockerAPISuite) TestContainerAPITop(c *testing.T) {
 	id := strings.TrimSpace(out)
 	cli.WaitRun(c, id)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -410,7 +410,7 @@ func (s *DockerAPISuite) TestContainerAPITopWindows(c *testing.T) {
 	id := runSleepingContainer(c, "-d")
 	cli.WaitRun(c, id)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -439,7 +439,7 @@ func (s *DockerAPISuite) TestContainerAPICommit(c *testing.T) {
 	const cName = "testapicommit"
 	cli.DockerCmd(c, "run", "--name="+cName, "busybox", "/bin/sh", "-c", "touch /test")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -461,7 +461,7 @@ func (s *DockerAPISuite) TestContainerAPICommitWithLabelInConfig(c *testing.T) {
 	const cName = "testapicommitwithconfig"
 	cli.DockerCmd(c, "run", "--name="+cName, "busybox", "/bin/sh", "-c", "touch /test")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -508,7 +508,7 @@ func (s *DockerAPISuite) TestContainerAPIBadPort(c *testing.T) {
 		},
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -526,7 +526,7 @@ func (s *DockerAPISuite) TestContainerAPICreate(c *testing.T) {
 		Cmd:   []string{"/bin/sh", "-c", "touch /test && ls /test"},
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -542,7 +542,7 @@ func (s *DockerAPISuite) TestContainerAPICreate(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestContainerAPICreateEmptyConfig(c *testing.T) {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -577,7 +577,7 @@ func UtilCreateNetworkMode(t *testing.T, networkMode container.NetworkMode) {
 		NetworkMode: networkMode,
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(t, err)
 	defer apiClient.Close()
 
@@ -608,7 +608,7 @@ func (s *DockerAPISuite) TestContainerAPICreateWithCpuSharesCpuset(c *testing.T)
 		},
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -709,7 +709,7 @@ func (s *DockerAPISuite) TestContainerAPIKill(c *testing.T) {
 	const name = "test-api-kill"
 	runSleepingContainer(c, "-i", "--name", name)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -725,7 +725,7 @@ func (s *DockerAPISuite) TestContainerAPIKill(c *testing.T) {
 func (s *DockerAPISuite) TestContainerAPIRestart(c *testing.T) {
 	const name = "test-api-restart"
 	runSleepingContainer(c, "-di", "--name", name)
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -743,7 +743,7 @@ func (s *DockerAPISuite) TestContainerAPIRestartNotimeoutParam(c *testing.T) {
 	id := runSleepingContainer(c, "-di", "--name", name)
 	cli.WaitRun(c, id)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -761,7 +761,7 @@ func (s *DockerAPISuite) TestContainerAPIStart(c *testing.T) {
 		OpenStdin: true,
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -789,7 +789,7 @@ func (s *DockerAPISuite) TestContainerAPIStop(c *testing.T) {
 	runSleepingContainer(c, "-i", "--name", name)
 	timeout := 30
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -816,7 +816,7 @@ func (s *DockerAPISuite) TestContainerAPIWait(c *testing.T) {
 	}
 	cli.DockerCmd(c, "run", "--name", name, "busybox", sleepCmd, "2")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -835,7 +835,7 @@ func (s *DockerAPISuite) TestContainerAPIDelete(c *testing.T) {
 	cli.WaitRun(c, id)
 	cli.DockerCmd(c, "stop", id)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -844,7 +844,7 @@ func (s *DockerAPISuite) TestContainerAPIDelete(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestContainerAPIDeleteNotExist(c *testing.T) {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -860,7 +860,7 @@ func (s *DockerAPISuite) TestContainerAPIDeleteForce(c *testing.T) {
 		Force: true,
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -886,7 +886,7 @@ func (s *DockerAPISuite) TestContainerAPIDeleteRemoveLinks(c *testing.T) {
 		RemoveLinks: true,
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -908,7 +908,7 @@ func (s *DockerAPISuite) TestContainerAPIDeleteRemoveVolume(c *testing.T) {
 	id := runSleepingContainer(c, "-v", testVol)
 	cli.WaitRun(c, id)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -957,7 +957,7 @@ func (s *DockerAPISuite) TestContainerAPIPostContainerStop(c *testing.T) {
 	containerID := runSleepingContainer(c)
 	cli.WaitRun(c, containerID)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -988,7 +988,7 @@ func (s *DockerAPISuite) TestPutContainerArchiveErrSymlinkInVolumeToReadOnlyRoot
 	// Attempt to extract to a symlink in the volume which points to a
 	// directory outside the volume. This should cause an error because the
 	// rootfs is read-only.
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 
 	_, err = apiClient.CopyToContainer(testutil.GetContext(c), cID, client.CopyToContainerOptions{DestinationPath: "/vol2/symlinkToAbsDir"})
@@ -999,7 +999,7 @@ func (s *DockerAPISuite) TestPostContainersCreateWithWrongCpusetValues(c *testin
 	// Not supported on Windows
 	testRequires(c, DaemonIsLinux)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -1045,7 +1045,7 @@ func (s *DockerAPISuite) TestPostContainersCreateMemorySwappinessHostConfigOmitt
 		Image: "busybox",
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -1075,7 +1075,7 @@ func (s *DockerAPISuite) TestPostContainersCreateWithOomScoreAdjInvalidRange(c *
 		OomScoreAdj: 1001,
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -1108,7 +1108,7 @@ func (s *DockerAPISuite) TestPostContainersCreateWithOomScoreAdjInvalidRange(c *
 
 // test case for #22210 where an empty container name caused panic.
 func (s *DockerAPISuite) TestContainerAPIDeleteWithEmptyName(c *testing.T) {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -1129,7 +1129,7 @@ func (s *DockerAPISuite) TestContainerAPIStatsWithNetworkDisabled(c *testing.T) 
 		NetworkDisabled: true,
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -1461,7 +1461,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsValidation(c *testing.T) {
 			},
 		}...)
 	}
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -1501,7 +1501,7 @@ func (s *DockerAPISuite) TestContainerAPICreateMountsBindRead(c *testing.T) {
 			{Type: "bind", Source: tmpDir, Target: destPath},
 		},
 	}
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -1747,7 +1747,7 @@ func (s *DockerAPISuite) TestContainersAPICreateMountsTmpfs(c *testing.T) {
 		},
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -60,7 +60,7 @@ func (s *DockerAPISuite) TestExecAPICreateContainerPaused(c *testing.T) {
 
 	cli.DockerCmd(c, "pause", name)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -124,7 +124,7 @@ func (s *DockerAPISuite) TestExecAPIStartWithDetach(c *testing.T) {
 
 	ctx := testutil.GetContext(c)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -37,7 +37,7 @@ func (s *DockerAPISuite) TestAPIImagesSaveAndLoad(c *testing.T) {
 }
 
 func (s *DockerAPISuite) TestAPIImagesDelete(c *testing.T) {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -109,7 +109,7 @@ func (s *DockerAPISuite) TestAPIImagesSizeCompatibility(c *testing.T) {
 		assert.Assert(c, img.Size != int64(-1))
 	}
 
-	apiclient, err = client.NewClientWithOpts(client.FromEnv, client.WithVersion("v1.24"))
+	apiclient, err = client.New(client.FromEnv, client.WithVersion("v1.24"))
 	assert.NilError(c, err)
 	defer apiclient.Close()
 

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -72,7 +72,7 @@ func (s *DockerAPISuite) TestInspectAPIContainerVolumeDriver(c *testing.T) {
 
 func (s *DockerAPISuite) TestInspectAPIImageResponse(c *testing.T) {
 	cli.DockerCmd(c, "tag", "busybox:latest", "busybox:mytag")
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -58,7 +58,7 @@ func (s *DockerAPISuite) TestLogsAPIWithStdout(c *testing.T) {
 func (s *DockerAPISuite) TestLogsAPINoStdoutNorStderr(c *testing.T) {
 	const name = "logs_test"
 	cli.DockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 
@@ -100,7 +100,7 @@ func (s *DockerAPISuite) TestLogsAPIUntilFutureFollow(c *testing.T) {
 	assert.NilError(c, err)
 	until := daemonTime(c).Add(untilDur)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func (s *DockerAPISuite) TestLogsAPIUntil(c *testing.T) {
 	const name = "logsuntil"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; sleep 1; done")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func (s *DockerAPISuite) TestLogsAPIUntilDefaultValue(c *testing.T) {
 	const name = "logsuntildefaultval"
 	cli.DockerCmd(c, "run", "--name", name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do echo log$i; done")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -180,7 +180,7 @@ func getNetworkStats(t *testing.T, id string) map[string]container.NetworkStats 
 
 func (s *DockerAPISuite) TestAPIStatsContainerNotFound(c *testing.T) {
 	testRequires(c, DaemonIsLinux)
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer func() { _ = apiClient.Close() }()
 

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -449,7 +449,7 @@ func (s *DockerCLIEventSuite) TestEventsResize(c *testing.T) {
 	cID := runSleepingContainer(c, "-d", "-t")
 	cli.WaitRun(c, cID)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -372,7 +372,7 @@ func (s *DockerCLIExecSuite) TestExecInspectID(c *testing.T) {
 	}
 
 	// But we should still be able to query the execID
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_cli_info_unix_test.go
+++ b/integration-cli/docker_cli_info_unix_test.go
@@ -18,7 +18,7 @@ func (s *DockerCLIInfoSuite) TestInfoSecurityOptions(c *testing.T) {
 		c.Skip("test requires Seccomp and/or AppArmor")
 	}
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 	result, err := apiClient.Info(testutil.GetContext(c), client.InfoOptions{})

--- a/integration-cli/docker_cli_plugins_logdriver_test.go
+++ b/integration-cli/docker_cli_plugins_logdriver_test.go
@@ -50,7 +50,7 @@ func (s *DockerCLIPluginLogDriverSuite) TestPluginLogDriverInfoList(c *testing.T
 
 	cli.DockerCmd(c, "plugin", "install", pluginName)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3685,7 +3685,7 @@ func (s *DockerCLIRunSuite) TestRunNamedVolumesFromNotRemoved(c *testing.T) {
 	cid := cli.DockerCmd(c, "run", "-d", "--name=parent", "-v", "test:"+prefix+"/foo", "-v", prefix+"/bar", "busybox", "true").Stdout()
 	cli.DockerCmd(c, "run", "--name=child", "--volumes-from=parent", "busybox", "true")
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -1558,7 +1558,7 @@ func (s *DockerCLIRunSuite) TestRunWithNanoCPUs(c *testing.T) {
 	out := cli.DockerCmd(c, "run", "--cpus", "0.5", "--name", "test", "busybox", "sh", "-c", fmt.Sprintf("cat %s && cat %s", file1, file2)).Combined()
 	assert.Equal(c, strings.TrimSpace(out), "50000\n100000")
 
-	clt, err := client.NewClientWithOpts(client.FromEnv)
+	clt, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	res, err := clt.ContainerInspect(testutil.GetContext(c), "test", client.ContainerInspectOptions{})
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_update_unix_test.go
+++ b/integration-cli/docker_cli_update_unix_test.go
@@ -264,7 +264,7 @@ func (s *DockerCLIUpdateSuite) TestUpdateWithNanoCPUs(c *testing.T) {
 	out = cli.DockerCmd(c, "exec", "top", "sh", "-c", fmt.Sprintf("cat %s && cat %s", file1, file2)).Combined()
 	assert.Equal(c, strings.TrimSpace(out), "50000\n100000")
 
-	clt, err := client.NewClientWithOpts(client.FromEnv)
+	clt, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	res, err := clt.ContainerInspect(testutil.GetContext(c), "top", client.ContainerInspectOptions{})
 	assert.NilError(c, err)

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -577,7 +577,7 @@ func (s *DockerCLIVolumeSuite) TestDuplicateMountpointsForVolumesFromAndMounts(c
 	assert.NilError(c, err)
 
 	// Mounts is available in API
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(c, err)
 	defer apiClient.Close()
 

--- a/integration-cli/docker_utils_test.go
+++ b/integration-cli/docker_utils_test.go
@@ -196,7 +196,7 @@ func daemonTime(t *testing.T) time.Time {
 	if testEnv.IsLocalDaemon() {
 		return time.Now()
 	}
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	assert.NilError(t, err)
 	defer apiClient.Close()
 
@@ -254,7 +254,7 @@ func waitInspect(name, expr, expected string, timeout time.Duration) error {
 
 func getInspectBody(t *testing.T, version, id string) json.RawMessage {
 	t.Helper()
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion(version))
+	apiClient, err := client.New(client.FromEnv, client.WithVersion(version))
 	assert.NilError(t, err)
 	defer apiClient.Close()
 	inspect, err := apiClient.ContainerInspect(testutil.GetContext(t), id, client.ContainerInspectOptions{})

--- a/integration-cli/requirements_test.go
+++ b/integration-cli/requirements_test.go
@@ -31,7 +31,7 @@ func DaemonIsLinux() bool {
 }
 
 func OnlyDefaultNetworks(ctx context.Context) bool {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	apiClient, err := client.New(client.FromEnv)
 	if err != nil {
 		return false
 	}

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -734,7 +734,7 @@ func TestCreateWithMultipleEndpointSettings(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run("with API v"+tc.apiVersion, func(t *testing.T) {
-			apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion(tc.apiVersion))
+			apiClient, err := client.New(client.FromEnv, client.WithVersion(tc.apiVersion))
 			assert.NilError(t, err)
 
 			config := container.Config{

--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -63,7 +63,7 @@ func TestContainerNetworkMountsNoChown(t *testing.T) {
 		},
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.New(client.FromEnv)
 	assert.NilError(t, err)
 	defer cli.Close()
 
@@ -524,7 +524,7 @@ func TestContainerBindMountReadOnlyDefault(t *testing.T) {
 			skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), minDaemonVersion), "requires API v"+minDaemonVersion)
 
 			if tc.clientVersion != "" {
-				c, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion(tc.clientVersion))
+				c, err := client.New(client.FromEnv, client.WithVersion(tc.clientVersion))
 				assert.NilError(t, err, "failed to create client with version v%s", tc.clientVersion)
 				apiClient = c
 			}

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -308,7 +308,7 @@ func TestStaticIPOutsideSubpool(t *testing.T) {
 	d.StartWithBusybox(ctx, t)
 	defer d.Stop(t)
 
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.43"))
+	apiClient, err := client.New(client.FromEnv, client.WithVersion("1.43"))
 	assert.NilError(t, err)
 
 	const netname = "subnet-range"

--- a/integration/plugin/authz/authz_plugin_test.go
+++ b/integration/plugin/authz/authz_plugin_test.go
@@ -149,7 +149,7 @@ func newTLSAPIClient(host, cacertPath, certPath, keyPath string) (client.APIClie
 		KeepAlive: 30 * time.Second,
 		Timeout:   30 * time.Second,
 	}
-	return client.NewClientWithOpts(
+	return client.New(
 		client.WithTLSClientConfig(cacertPath, certPath, keyPath),
 		client.WithDialContext(dialer.DialContext),
 		client.WithHost(host))

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -306,7 +306,7 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	assert.Check(t, is.Equal(len(report.VolumesDeleted), 2))
 
 	// Validate that older API versions still have the old behavior of pruning all local volumes
-	clientOld, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.41"))
+	clientOld, err := client.New(client.FromEnv, client.WithVersion("1.41"))
 	assert.NilError(t, err)
 	defer clientOld.Close()
 	assert.Equal(t, clientOld.ClientVersion(), "1.41")

--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -309,7 +309,7 @@ func (d *Daemon) NewClient(extraOpts ...client.Opt) (*client.Client, error) {
 	}
 	clientOpts = append(clientOpts, extraOpts...)
 
-	return client.NewClientWithOpts(clientOpts...)
+	return client.New(clientOpts...)
 }
 
 // Cleanup cleans the daemon files : exec root (network namespaces, ...), swarmkit files
@@ -873,7 +873,7 @@ func (d *Daemon) LoadBusybox(ctx context.Context, t testing.TB) {
 
 func (d *Daemon) LoadImage(ctx context.Context, t testing.TB, img string) {
 	t.Helper()
-	clientHost, err := client.NewClientWithOpts(client.FromEnv)
+	clientHost, err := client.New(client.FromEnv)
 	assert.NilError(t, err, "[%s] failed to create client", d.id)
 	defer clientHost.Close()
 

--- a/internal/testutil/environment/environment.go
+++ b/internal/testutil/environment/environment.go
@@ -36,7 +36,7 @@ type PlatformDefaults struct {
 // New creates a new Execution struct
 // This is configured using the env client (see client.FromEnv)
 func New(ctx context.Context) (*Execution, error) {
-	c, err := client.NewClientWithOpts(client.FromEnv)
+	c, err := client.New(client.FromEnv)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create client")
 	}

--- a/internal/testutil/request/request.go
+++ b/internal/testutil/request/request.go
@@ -27,7 +27,7 @@ import (
 func NewAPIClient(t testing.TB, ops ...client.Opt) client.APIClient {
 	t.Helper()
 	ops = append([]client.Opt{client.FromEnv}, ops...)
-	clt, err := client.NewClientWithOpts(ops...)
+	clt, err := client.New(ops...)
 	assert.NilError(t, err)
 	return clt
 }

--- a/vendor/github.com/moby/moby/client/README.md
+++ b/vendor/github.com/moby/moby/client/README.md
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -6,7 +6,7 @@ https://docs.docker.com/reference/api/engine/
 
 # Usage
 
-You use the library by constructing a client object using [NewClientWithOpts]
+You use the library by constructing a client object using [New]
 and calling methods on it. The client can be configured from environment
 variables by passing the [FromEnv] option, and the [WithAPIVersionNegotiation]
 option to allow downgrading the API version used when connecting with an older
@@ -30,7 +30,7 @@ For example, to list running containers (the equivalent of "docker ps"):
 		// for configuration (DOCKER_HOST, DOCKER_API_VERSION), and does
 		// API-version negotiation to allow downgrading the API version
 		// when connecting with an older daemon version.
-		apiClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -160,7 +160,14 @@ func CheckRedirect(_ *http.Request, via []*http.Request) error {
 	return ErrRedirect
 }
 
-// NewClientWithOpts initializes a new API client with a default HTTPClient, and
+// NewClientWithOpts initializes a new API client.
+//
+// Deprecated: use New. This function will be removed in the next release.
+func NewClientWithOpts(ops ...Opt) (*Client, error) {
+	return New(ops...)
+}
+
+// New initializes a new API client with a default HTTPClient, and
 // default API host and version. It also initializes the custom HTTP headers to
 // add to each request.
 //
@@ -170,11 +177,11 @@ func CheckRedirect(_ *http.Request, via []*http.Request) error {
 // itself with values from environment variables ([FromEnv]), and has automatic
 // API version negotiation enabled ([WithAPIVersionNegotiation]).
 //
-//	cli, err := client.NewClientWithOpts(
+//	cli, err := client.New(
 //		client.FromEnv,
 //		client.WithAPIVersionNegotiation(),
 //	)
-func NewClientWithOpts(ops ...Opt) (*Client, error) {
+func New(ops ...Opt) (*Client, error) {
 	hostURL, err := ParseHostURL(DefaultDockerHost)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- stacked on https://github.com/moby/moby/pull/51330

Use a more idiomatic name so that it can be used as `client.New()`.

We should look if we want `New()` to have different / updated defaults
i.e., enable `WithEnv` as default, and have an opt-out and have API-
version negotiation enabled by default (with an opt-out option).



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

