### PR TITLE
daemon: improve validation for container rename

### DIFF
--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -18,7 +18,9 @@ import (
 // to find the container. An error is returned if newName is already
 // reserved.
 func (daemon *Daemon) ContainerRename(oldName, newName string) (retErr error) {
-	if oldName == "" || newName == "" {
+	oldName = strings.TrimSpace(oldName)
+	newName = strings.TrimSpace(newName)
+	if strings.TrimPrefix(oldName, "/") == "" || strings.TrimPrefix(newName, "/") == "" {
 		return errdefs.InvalidParameter(errors.New("Neither old nor new names may be empty"))
 	}
 


### PR DESCRIPTION
Improve validation for empty name; while the daemon already handled empty strings, it didn't account for the "canonical" name with "/" prefix, for which it would produce an obscure error:

    Error response from daemon: Error when allocating new name: Invalid container name (/ ), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed

Before this change:

    curl -XPOST --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/old/rename?name='
    {"message":"Neither old nor new names may be empty"}

    curl -XPOST --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/old/rename?name=/'
    {"message":"Error when allocating new name: Invalid container name (/), only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed"}

    curl -XPOST --unix-socket /var/run/docker.sock 'http://localhost/v1.51/containers/old/rename?name=/hello'
    # OK

A check was added in the client as well for situations where an older daemon is used; the same code currently was implemented in the CLI.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

