### PR TITLE
[25.0 backport] gha: update to windows 2022 / 2025

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -32,8 +32,8 @@ env:
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore
-  WINDOWS_BASE_TAG_2019: ltsc2019
   WINDOWS_BASE_TAG_2022: ltsc2022
+  WINDOWS_BASE_TAG_2025: ltsc2025
   TEST_IMAGE_NAME: moby:test
   TEST_CTN_NAME: moby
   DOCKER_BUILDKIT: 0
@@ -65,8 +65,8 @@ jobs:
         run: |
           New-Item -ItemType "directory" -Path "${{ github.workspace }}\go-build"
           New-Item -ItemType "directory" -Path "${{ github.workspace }}\go\pkg\mod"
-          If ("${{ inputs.os }}" -eq "windows-2019") {
-            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          If ("${{ inputs.os }}" -eq "windows-2025") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2025 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           } ElseIf ("${{ inputs.os }}" -eq "windows-2022") {
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
@@ -145,8 +145,8 @@ jobs:
           New-Item -ItemType "directory" -Path "${{ github.workspace }}\go-build"
           New-Item -ItemType "directory" -Path "${{ github.workspace }}\go\pkg\mod"
           New-Item -ItemType "directory" -Path "bundles"
-          If ("${{ inputs.os }}" -eq "windows-2019") {
-            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          If ("${{ inputs.os }}" -eq "windows-2025") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2025 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           } ElseIf ("${{ inputs.os }}" -eq "windows-2022") {
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }
@@ -319,8 +319,8 @@ jobs:
         name: Init
         run: |
           New-Item -ItemType "directory" -Path "bundles"
-          If ("${{ inputs.os }}" -eq "windows-2019") {
-            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2019 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          If ("${{ inputs.os }}" -eq "windows-2025") {
+            echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2025 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           } ElseIf ("${{ inputs.os }}" -eq "windows-2022") {
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2022 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           }

--- a/.github/workflows/windows-2022.yml
+++ b/.github/workflows/windows-2022.yml
@@ -14,12 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  schedule:
+    - cron: '0 10 * * *'
   workflow_dispatch:
-  push:
-    branches:
-      - 'master'
-      - '[0-9]+.[0-9]+'
-  pull_request:
 
 jobs:
   validate-dco:

--- a/.github/workflows/windows-2025.yml
+++ b/.github/workflows/windows-2025.yml
@@ -1,4 +1,4 @@
-name: windows-2019
+name: windows-2025
 
 # Default to 'contents: read', which grants actions to read commits.
 #
@@ -37,6 +37,6 @@ jobs:
       matrix:
         storage: ${{ fromJson(needs.test-prepare.outputs.matrix) }}
     with:
-      os: windows-2019
+      os: windows-2025
       storage: ${{ matrix.storage }}
       send_coverage: false

--- a/.github/workflows/windows-2025.yml
+++ b/.github/workflows/windows-2025.yml
@@ -14,9 +14,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  schedule:
-    - cron: '0 10 * * *'
   workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
+  pull_request:
 
 jobs:
   validate-dco:

--- a/integration/networking/bridge_test.go
+++ b/integration/networking/bridge_test.go
@@ -238,7 +238,7 @@ func TestBridgeICCWindows(t *testing.T) {
 			pingCmd := []string{"ping", "-n", "1", "-w", "3000", ctr1Name}
 
 			const ctr2Name = "ctr2"
-			attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			attachCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
 			res := container.RunAttach(attachCtx, t, c,
 				container.WithName(ctr2Name),


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/50179
- backport: https://github.com/moby/moby/pull/50189

The hosted Windows 2019 runners reach EOL on June 30; https://github.com/actions/runner-images/issues/12045

**- A picture of a cute animal (not mandatory but encouraged)**

