### PR TITLE
api/t/network: represent MAC addrs as byte slices

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2628,6 +2628,8 @@ definitions:
         type: "string"
         x-omitempty: false
         example: "02:42:ac:13:00:02"
+        x-go-type:
+          type: HardwareAddr
       IPv4Address:
         type: "string"
         x-omitempty: false
@@ -2914,6 +2916,8 @@ definitions:
           MAC address for the endpoint on this network. The network driver might ignore this parameter.
         type: "string"
         example: "02:42:ac:11:00:04"
+        x-go-type:
+          type: HardwareAddr
       Aliases:
         type: "array"
         items:

--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -30,7 +30,7 @@ type EndpointSettings struct {
 	// MacAddress may be used to specify a MAC address when the container is created.
 	// Once the container is running, it becomes operational data (it may contain a
 	// generated address).
-	MacAddress          string
+	MacAddress          HardwareAddr
 	IPPrefixLen         int
 	IPv6Gateway         netip.Addr
 	GlobalIPv6Address   netip.Addr

--- a/api/types/network/endpoint_resource.go
+++ b/api/types/network/endpoint_resource.go
@@ -24,7 +24,7 @@ type EndpointResource struct {
 
 	// mac address
 	// Example: 02:42:ac:13:00:02
-	MacAddress string `json:"MacAddress"`
+	MacAddress HardwareAddr `json:"MacAddress"`
 
 	// IPv4 address
 	// Example: 172.19.0.2/16

--- a/api/types/network/hwaddr.go
+++ b/api/types/network/hwaddr.go
@@ -1,0 +1,37 @@
+package network
+
+import (
+	"encoding"
+	"fmt"
+	"net"
+)
+
+// A HardwareAddr represents a physical hardware address.
+// It implements [encoding.TextMarshaler] and [encoding.TextUnmarshaler]
+// in the absence of go.dev/issue/29678.
+type HardwareAddr net.HardwareAddr
+
+var _ encoding.TextMarshaler = (HardwareAddr)(nil)
+var _ encoding.TextUnmarshaler = (*HardwareAddr)(nil)
+var _ fmt.Stringer = (HardwareAddr)(nil)
+
+func (m *HardwareAddr) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*m = nil
+		return nil
+	}
+	hw, err := net.ParseMAC(string(text))
+	if err != nil {
+		return err
+	}
+	*m = HardwareAddr(hw)
+	return nil
+}
+
+func (m HardwareAddr) MarshalText() ([]byte, error) {
+	return []byte(net.HardwareAddr(m).String()), nil
+}
+
+func (m HardwareAddr) String() string {
+	return net.HardwareAddr(m).String()
+}

--- a/api/types/network/hwaddr_test.go
+++ b/api/types/network/hwaddr_test.go
@@ -1,0 +1,87 @@
+package network_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/moby/moby/api/types/network"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestHardwareAddr_UnmarshalText(t *testing.T) {
+	cases := []struct {
+		in  string
+		out network.HardwareAddr
+		err string
+	}{
+		{"", nil, ""},
+		{"00:11:22:33:44:55", network.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, ""},
+		{"xx:xx:xx:xx:xx:xx", network.HardwareAddr{0xde, 0xad, 0xbe, 0xef}, "invalid MAC address"},
+	}
+	for _, c := range cases {
+		a := network.HardwareAddr{0xde, 0xad, 0xbe, 0xef}
+		err := a.UnmarshalText([]byte(c.in))
+		if (c.err == "") != (err == nil) {
+			t.Errorf("UnmarshalText(%q) error = %v, want %v", c.in, err, c.err)
+		}
+		assert.Check(t, is.DeepEqual(a, c.out), "UnmarshalText(%q)", c.in)
+	}
+}
+
+func TestHardwareAddr_MarshalText(t *testing.T) {
+	cases := []struct {
+		in  network.HardwareAddr
+		out string
+	}{
+		{nil, ""},
+		{network.HardwareAddr{}, ""},
+		{network.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, "00:11:22:33:44:55"},
+	}
+	for _, c := range cases {
+		out, err := c.in.MarshalText()
+		assert.Check(t, err, "MarshalText(%v)", c.in)
+		assert.Check(t, is.Equal(string(out), c.out), "MarshalText(%v)", c.in)
+	}
+}
+
+func TestHardwareAddr_MarshalJSON(t *testing.T) {
+	cases := []struct {
+		in  network.HardwareAddr
+		out string
+	}{
+		{nil, `{"mac":""}`},
+		{network.HardwareAddr{}, `{"mac":""}`},
+		{network.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, `{"mac":"00:11:22:33:44:55"}`},
+	}
+	for _, c := range cases {
+		s := struct {
+			Mac network.HardwareAddr `json:"mac"`
+		}{c.in}
+		got, err := json.Marshal(s)
+		assert.Check(t, err, "json.Marshal(network.HardwareAddr(%v))", c.in)
+		assert.Check(t, is.Equal(string(got), c.out), "json.Marshal(network.HardwareAddr(%v))", c.in)
+	}
+}
+
+func TestHardwareAddr_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		in  string
+		out network.HardwareAddr
+		err string
+	}{
+		{`{"mac":""}`, nil, ""},
+		{`{"mac":"00:11:22:33:44:55"}`, network.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, ""},
+		{`{"mac":"xx:xx:xx:xx:xx:xx"}`, network.HardwareAddr{0xde, 0xad, 0xbe, 0xef}, "invalid MAC address"},
+	}
+	for _, c := range cases {
+		s := struct {
+			Mac network.HardwareAddr `json:"mac"`
+		}{network.HardwareAddr{0xde, 0xad, 0xbe, 0xef}}
+		err := json.Unmarshal([]byte(c.in), &s)
+		if (c.err == "") != (err == nil) {
+			t.Errorf("json.Unmarshal(%q) error = %v, want %v", c.in, err, c.err)
+		}
+		assert.Check(t, is.DeepEqual(s.Mac, c.out), "json.Unmarshal(%q)", c.in)
+	}
+}

--- a/daemon/cluster/executor/backend.go
+++ b/daemon/cluster/executor/backend.go
@@ -43,7 +43,7 @@ type Backend interface {
 	ActivateContainerServiceBinding(containerName string) error
 	DeactivateContainerServiceBinding(containerName string) error
 	UpdateContainerServiceConfig(containerName string, serviceConfig *clustertypes.ServiceConfig) error
-	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (_ *container.InspectResponse, desiredMACAddress string, _ error)
+	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (_ *container.InspectResponse, desiredMACAddress network.HardwareAddr, _ error)
 	ContainerWait(ctx context.Context, name string, condition container.WaitCondition) (<-chan containerpkg.StateStatus, error)
 	ContainerRm(name string, config *backend.ContainerRmConfig) error
 	ContainerKill(name string, sig string) error

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"os"
 	"runtime"
@@ -545,13 +544,6 @@ func validateEndpointSettings(nw *libnetwork.Network, nwName string, epConfig *n
 		errs = validateIPAMConfigIsInRange(errs, ipamConfig, v4Configs, v6Configs)
 	}
 
-	if epConfig.MacAddress != "" {
-		_, err := net.ParseMAC(epConfig.MacAddress)
-		if err != nil {
-			return fmt.Errorf("invalid MAC address %s", epConfig.MacAddress)
-		}
-	}
-
 	if sysctls, ok := epConfig.DriverOpts[netlabel.EndpointSysctls]; ok {
 		for _, sysctl := range strings.Split(sysctls, ",") {
 			scname := strings.SplitN(sysctl, ".", 5)
@@ -647,7 +639,7 @@ func cleanOperationalData(es *network.EndpointSettings) {
 	es.IPv6Gateway = netip.Addr{}
 	es.GlobalIPv6Address = netip.Addr{}
 	es.GlobalIPv6PrefixLen = 0
-	es.MacAddress = ""
+	es.MacAddress = nil
 	if es.IPAMOperational {
 		es.IPAMConfig = nil
 	}

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -886,7 +886,7 @@ func buildEndpointResource(ep *libnetwork.Endpoint, info libnetwork.EndpointInfo
 		Name:       ep.Name(),
 	}
 	if iface := info.Iface(); iface != nil {
-		er.MacAddress = iface.MacAddress().String()
+		er.MacAddress = networktypes.HardwareAddr(iface.MacAddress())
 		er.IPv4Address = netiputil.Unmap(iface.Addr())
 		er.IPv6Address = iface.AddrIPv6()
 	}
@@ -955,12 +955,8 @@ func buildCreateEndpointOptions(c *container.Container, n *libnetwork.Network, e
 			createOptions = append(createOptions, libnetwork.EndpointOptionGeneric(options.Generic{k: v}))
 		}
 
-		if epConfig.DesiredMacAddress != "" {
-			mac, err := net.ParseMAC(epConfig.DesiredMacAddress)
-			if err != nil {
-				return nil, err
-			}
-			genericOptions[netlabel.MacAddress] = mac
+		if len(epConfig.DesiredMacAddress) != 0 {
+			genericOptions[netlabel.MacAddress] = net.HardwareAddr(epConfig.DesiredMacAddress)
 		}
 	}
 
@@ -1174,8 +1170,8 @@ func buildEndpointInfo(networkSettings *network.Settings, n *libnetwork.Network,
 		return nil
 	}
 
-	if iface.MacAddress() != nil {
-		networkSettings.Networks[nwName].MacAddress = iface.MacAddress().String()
+	if mac := iface.MacAddress(); mac != nil {
+		networkSettings.Networks[nwName].MacAddress = networktypes.HardwareAddr(mac)
 	}
 
 	if iface.Address() != nil {

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -28,7 +28,7 @@ type EndpointSettings struct {
 	IPAMOperational bool
 	// DesiredMacAddress is the configured value, it's copied from MacAddress (the
 	// API param field) when the container is created.
-	DesiredMacAddress string
+	DesiredMacAddress networktypes.HardwareAddr
 }
 
 // AttachmentStore stores the load balancer IP address for a network id.

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	containerpkg "github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/internal/filters"
 	"github.com/moby/moby/v2/daemon/server/backend"
@@ -48,7 +49,7 @@ type stateBackend interface {
 // monitorBackend includes functions to implement to provide containers monitoring functionality.
 type monitorBackend interface {
 	ContainerChanges(ctx context.Context, name string) ([]archive.Change, error)
-	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (_ *container.InspectResponse, desiredMACAddress string, _ error)
+	ContainerInspect(ctx context.Context, name string, options backend.ContainerInspectOptions) (_ *container.InspectResponse, desiredMACAddress network.HardwareAddr, _ error)
 	ContainerLogs(ctx context.Context, name string, config *backend.ContainerLogsOptions) (msgs <-chan *backend.LogMessage, tty bool, err error)
 	ContainerStats(ctx context.Context, name string, config *backend.ContainerStatsConfig) error
 	ContainerTop(name string, psArgs string) (*container.TopResponse, error)

--- a/daemon/server/router/container/inspect.go
+++ b/daemon/server/router/container/inspect.go
@@ -63,7 +63,7 @@ func (c *containerRouter) getContainersByName(ctx context.Context, w http.Respon
 		//
 		// This was deprecated in API v1.44, but kept in place until
 		// API v1.52, which removed this entirely.
-		if desiredMACAddress != "" {
+		if len(desiredMACAddress) != 0 {
 			wrapOpts = append(wrapOpts, compat.WithExtraFields(map[string]any{
 				"Config": map[string]any{
 					"MacAddress": desiredMACAddress,

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	containertypes "github.com/moby/moby/api/types/container"
+	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	net "github.com/moby/moby/v2/integration/internal/network"
@@ -295,7 +296,7 @@ func TestMacAddressIsAppliedToMainNetworkWithShortID(t *testing.T) {
 
 	c := container.Inspect(ctx, t, apiClient, cid)
 	assert.Assert(t, c.NetworkSettings.Networks["testnet"] != nil)
-	assert.Equal(t, c.NetworkSettings.Networks["testnet"].MacAddress, "02:42:08:26:a9:55")
+	assert.DeepEqual(t, c.NetworkSettings.Networks["testnet"].MacAddress, networktypes.HardwareAddr{0x02, 0x42, 0x08, 0x26, 0xa9, 0x55})
 }
 
 func TestStaticIPOutsideSubpool(t *testing.T) {

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"maps"
+	"net"
 	"net/netip"
 	"slices"
 	"strings"
@@ -151,6 +152,10 @@ func WithTmpfs(targetAndOpts string) func(config *TestContainerConfig) {
 }
 
 func WithMacAddress(networkName, mac string) func(config *TestContainerConfig) {
+	maddr, err := net.ParseMAC(mac)
+	if err != nil {
+		panic(err)
+	}
 	return func(c *TestContainerConfig) {
 		if c.NetworkingConfig.EndpointsConfig == nil {
 			c.NetworkingConfig.EndpointsConfig = map[string]*network.EndpointSettings{}
@@ -158,7 +163,7 @@ func WithMacAddress(networkName, mac string) func(config *TestContainerConfig) {
 		if v, ok := c.NetworkingConfig.EndpointsConfig[networkName]; !ok || v == nil {
 			c.NetworkingConfig.EndpointsConfig[networkName] = &network.EndpointSettings{}
 		}
-		c.NetworkingConfig.EndpointsConfig[networkName].MacAddress = mac
+		c.NetworkingConfig.EndpointsConfig[networkName].MacAddress = network.HardwareAddr(maddr)
 	}
 }
 

--- a/integration/networking/mac_addr_test.go
+++ b/integration/networking/mac_addr_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/netip"
+	"slices"
 	"testing"
 
 	containertypes "github.com/moby/moby/api/types/container"
@@ -82,7 +83,7 @@ func TestMACAddrOnRestart(t *testing.T) {
 	ctr2Inspect := container.Inspect(ctx, t, c, ctr2Name)
 	ctr2MAC := ctr2Inspect.NetworkSettings.Networks[netName].MacAddress
 
-	assert.Check(t, ctr1MAC != ctr2MAC,
+	assert.Check(t, !slices.Equal(ctr1MAC, ctr2MAC),
 		"expected containers to have different MAC addresses; got %q for both", ctr1MAC)
 }
 
@@ -120,7 +121,7 @@ func TestCfgdMACAddrOnRestart(t *testing.T) {
 
 	inspect := container.Inspect(ctx, t, c, ctr1Name)
 	gotMAC := inspect.NetworkSettings.Networks[netName].MacAddress
-	assert.Check(t, is.Equal(wantMAC, gotMAC))
+	assert.Check(t, is.Equal(wantMAC, gotMAC.String()))
 
 	startAndCheck := func() {
 		t.Helper()
@@ -128,7 +129,7 @@ func TestCfgdMACAddrOnRestart(t *testing.T) {
 		assert.Assert(t, is.Nil(err))
 		inspect = container.Inspect(ctx, t, c, ctr1Name)
 		gotMAC = inspect.NetworkSettings.Networks[netName].MacAddress
-		assert.Check(t, is.Equal(wantMAC, gotMAC))
+		assert.Check(t, is.Equal(wantMAC, gotMAC.String()))
 	}
 
 	// Restart the container, check that the MAC address is restored.
@@ -301,7 +302,7 @@ func TestWatchtowerCreate(t *testing.T) {
 	inspect := container.Inspect(ctx, t, c, ctrName)
 	netSettings := inspect.NetworkSettings.Networks[netName]
 	assert.Check(t, is.Equal(netSettings.IPAddress, netip.MustParseAddr(ctrIP)))
-	assert.Check(t, is.Equal(netSettings.MacAddress, ctrMAC))
+	assert.Check(t, is.Equal(netSettings.MacAddress.String(), ctrMAC))
 }
 
 type legacyCreateRequest struct {

--- a/vendor/github.com/moby/moby/api/types/network/endpoint.go
+++ b/vendor/github.com/moby/moby/api/types/network/endpoint.go
@@ -30,7 +30,7 @@ type EndpointSettings struct {
 	// MacAddress may be used to specify a MAC address when the container is created.
 	// Once the container is running, it becomes operational data (it may contain a
 	// generated address).
-	MacAddress          string
+	MacAddress          HardwareAddr
 	IPPrefixLen         int
 	IPv6Gateway         netip.Addr
 	GlobalIPv6Address   netip.Addr

--- a/vendor/github.com/moby/moby/api/types/network/endpoint_resource.go
+++ b/vendor/github.com/moby/moby/api/types/network/endpoint_resource.go
@@ -24,7 +24,7 @@ type EndpointResource struct {
 
 	// mac address
 	// Example: 02:42:ac:13:00:02
-	MacAddress string `json:"MacAddress"`
+	MacAddress HardwareAddr `json:"MacAddress"`
 
 	// IPv4 address
 	// Example: 172.19.0.2/16

--- a/vendor/github.com/moby/moby/api/types/network/hwaddr.go
+++ b/vendor/github.com/moby/moby/api/types/network/hwaddr.go
@@ -1,0 +1,37 @@
+package network
+
+import (
+	"encoding"
+	"fmt"
+	"net"
+)
+
+// A HardwareAddr represents a physical hardware address.
+// It implements [encoding.TextMarshaler] and [encoding.TextUnmarshaler]
+// in the absence of go.dev/issue/29678.
+type HardwareAddr net.HardwareAddr
+
+var _ encoding.TextMarshaler = (HardwareAddr)(nil)
+var _ encoding.TextUnmarshaler = (*HardwareAddr)(nil)
+var _ fmt.Stringer = (HardwareAddr)(nil)
+
+func (m *HardwareAddr) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*m = nil
+		return nil
+	}
+	hw, err := net.ParseMAC(string(text))
+	if err != nil {
+		return err
+	}
+	*m = HardwareAddr(hw)
+	return nil
+}
+
+func (m HardwareAddr) MarshalText() ([]byte, error) {
+	return []byte(net.HardwareAddr(m).String()), nil
+}
+
+func (m HardwareAddr) String() string {
+	return net.HardwareAddr(m).String()
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

- Fixes #51146 
- Closes #51319

**- What I did**
Make invalid states unrepresentable by moving away from stringly-typed MAC address values in API structs.

**- How I did it**
As https://go.dev/issue/29678 has not yet been implemented, provide our own HardwareAddr byte-slice type which implements TextMarshaler and TextUnmarshaler to retain compatibility with the API wire format.

When stdlib's net.HardwareAddr type implements TextMarshaler and TextUnmarshaler and GODEBUG=netmarshal becomes the default, we should be able to make the type a straight alias for stdlib net.HardwareAddr as a non-breaking change.

**- How to verify it**
CI.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Go-SDK: MAC address fields are represented as byte slices compatible with the standard library net.HardwareAddr type instead of strings.
```

**- A picture of a cute animal (not mandatory but encouraged)**

