### PR TITLE
API compat: replace nil values when adding fields

### DIFF
--- a/daemon/internal/compat/compat.go
+++ b/daemon/internal/compat/compat.go
@@ -46,7 +46,7 @@ func appendFields(src, dst map[string]any) {
 				continue
 			}
 		}
-		if _, ok := dst[k]; !ok {
+		if existing, ok := dst[k]; !ok || existing == nil {
 			dst[k] = v
 		}
 	}


### PR DESCRIPTION
**- What I did**

I've a test that occasionally returns a nil `Config` field in an image inspect response, using API v1.51. That's two bugs:
- the inspect response shouldn't occasionally have nil fields
- `Config` should never be nil with API 1.51, because it adds extra fields that weren't previously `omitempty`.

This is a fix for the second problem, haven't investigated the first yet.

- introduced in https://github.com/moby/moby/pull/51097

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

