### PR TITLE
api/types: remove PushResult type, and move internal

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -43,12 +43,3 @@ type Version struct {
 	Experimental  bool   `json:",omitempty"`
 	BuildTime     string `json:",omitempty"`
 }
-
-// PushResult contains the tag, manifest digest, and manifest size from the
-// push. It's used to signal this information to the trust code in the client
-// so it can sign the manifest if necessary.
-type PushResult struct {
-	Tag    string
-	Digest string
-	Size   int
-}

--- a/daemon/pkg/plugin/backend_linux.go
+++ b/daemon/pkg/plugin/backend_linux.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/moby/go-archive/chrootarchive"
-	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/plugin"
 	"github.com/moby/moby/api/types/registry"
@@ -464,8 +463,19 @@ func (pm *Manager) Push(ctx context.Context, name string, metaHeader http.Header
 		progress.Update(out, pj.names[j], "Upload complete")
 	}
 
+	// pushResult contains the tag, manifest digest, and manifest size from the
+	// push. It's used to signal this information to the trust code in the client
+	// so it can sign the manifest if necessary.
+	//
+	// TODO(thaJeztah): this aux-type is only present for docker content trust, which is deprecated.
+	type pushResult struct {
+		Tag    string
+		Digest string
+		Size   int
+	}
+
 	// Signal the client for content trust verification
-	progress.Aux(out, types.PushResult{Tag: ref.(reference.Tagged).Tag(), Digest: desc.Digest.String(), Size: int(desc.Size)})
+	progress.Aux(out, pushResult{Tag: ref.(reference.Tagged).Tag(), Digest: desc.Digest.String(), Size: int(desc.Size)})
 
 	return nil
 }

--- a/vendor/github.com/moby/moby/api/types/types.go
+++ b/vendor/github.com/moby/moby/api/types/types.go
@@ -43,12 +43,3 @@ type Version struct {
 	Experimental  bool   `json:",omitempty"`
 	BuildTime     string `json:",omitempty"`
 }
-
-// PushResult contains the tag, manifest digest, and manifest size from the
-// push. It's used to signal this information to the trust code in the client
-// so it can sign the manifest if necessary.
-type PushResult struct {
-	Tag    string
-	Digest string
-	Size   int
-}


### PR DESCRIPTION
This type was used as Aux message for docker push, was not documented, and only present for Docker Content Trust (which is deprecated).

This patch removes it from the API module, and moves the type internal. We can stop sending this Aux message once DCT is fully phased out.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

