### PR TITLE
api/container_inspect: Ensure Config is not nil in inspect response

### DIFF
--- a/daemon/server/router/container/inspect.go
+++ b/daemon/server/router/container/inspect.go
@@ -81,5 +81,8 @@ func (c *containerRouter) getContainersByName(ctx context.Context, w http.Respon
 		}
 	}
 
+	if ctr.Config == nil {
+		ctr.Config = &container.Config{}
+	}
 	return httputils.WriteJSON(w, http.StatusOK, compat.Wrap(ctr, wrapOpts...))
 }


### PR DESCRIPTION
Ensure that the JSON response for the `GET /containers/{name}/json` outputs an empty object instead of a nil config.

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

