### PR TITLE
docker/save: stable timestamp for blobs/digest dir

### DIFF
--- a/daemon/internal/image/tarexport/save.go
+++ b/daemon/internal/image/tarexport/save.go
@@ -264,14 +264,14 @@ func (s *saveSession) save(ctx context.Context, outStream io.Writer) error {
 		if err := mkdirAllWithChtimes(filepath.Dir(mFile), 0o755, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
 			return errors.Wrap(err, "error creating blob directory")
 		}
-		if err := system.Chtimes(filepath.Dir(mFile), time.Unix(0, 0), time.Unix(0, 0)); err != nil {
-			return errors.Wrap(err, "error setting blob directory timestamps")
-		}
 		if err := os.WriteFile(mFile, data, 0o644); err != nil {
 			return errors.Wrap(err, "error writing oci manifest file")
 		}
 		if err := system.Chtimes(mFile, time.Unix(0, 0), time.Unix(0, 0)); err != nil {
-			return errors.Wrap(err, "error setting blob directory timestamps")
+			return errors.Wrap(err, "error setting oci manifest timestamp")
+		}
+		if err := system.Chtimes(filepath.Dir(mFile), time.Unix(0, 0), time.Unix(0, 0)); err != nil {
+			return errors.Wrap(err, "error setting blob digest directory timestamp")
 		}
 
 		untaggedMfstDesc := ocispec.Descriptor{


### PR DESCRIPTION
**- What I did**

Fixes #51364: files generated by `docker save` with the `overlay2` storage driver are now consistent across time.

**- How I did it**

This change moves the call to `system.Chtimes` to set the mtime of the blobs/digest directory to 0 **after** writing the OCI manifest file.

**- How to verify it**

Generate a tar with `docker save` after applying the patch:

```
$ docker pull ubuntu:24.04
$ docker save ubuntu:24.04 > save.tar
$ tar tvf save.tar
  drwxr-xr-x 0/0               0 2025-10-01 13:01 blobs/
> drwxr-xr-x 0/0               0 1970-01-01 00:00 blobs/sha256/
  -rw-r--r-- 0/0        80634368 2025-10-01 13:01 blobs/sha256/073ec47a8c22dcaa4d6e5758799ccefe2f9bde943685830b1bf6fd2395f5eabc
  -rw-r--r-- 0/0            1288 2025-10-01 13:01 blobs/sha256/8346eb021ab33bee3b3a4a2022f8274dd4581aec2b5dad83a156b0a272907030
  -rw-r--r-- 0/0            2297 2025-10-01 13:01 blobs/sha256/97bed23a34971024aa8d254abbe67b7168772340d1f494034773bc464e8dd5b6
  -rw-r--r-- 0/0             402 1970-01-01 00:00 blobs/sha256/a80ae87142a0ae1f9e02e3561844d7004a28886aaca46db5392dd556df7326f2
  -rw-r--r-- 0/0             360 1970-01-01 00:00 index.json
  -rw-r--r-- 0/0             457 1970-01-01 00:00 manifest.json
  -rw-r--r-- 0/0              31 1970-01-01 00:00 oci-layout
  -rw-r--r-- 0/0              88 1970-01-01 00:00 repositories
```

**- Human readable description for the release notes**

```markdown changelog
`docker save`: Fixed inconsistent tar member timestamps when exporting images with the overlay2 storage driver.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Please enjoy this picture of Daisy Doodle, our toy poodle:

![daisy_doodle](https://github.com/user-attachments/assets/72978d62-03d2-431c-b0f7-3d305f8695ec)



