### PR TITLE
daemon/config: export "min-api-version" through daemon.json

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -97,6 +97,9 @@ var skipValidateOptions = map[string]bool{
 	"features": true,
 	"builder":  true,
 
+	// Only available in daemon.json, no flags
+	"min-api-version": true,
+
 	// Deprecated options that are safe to ignore if present.
 	"deprecated-key-path":              true,
 	"allow-nondistributable-artifacts": true,
@@ -287,9 +290,9 @@ type CommonConfig struct {
 	//
 	// API versions older than [defaultMinAPIVersion] are deprecated and
 	// to be removed in a future release. The "DOCKER_MIN_API_VERSION" env
-	// var should only be used for exceptional cases, and the MinAPIVersion
-	// field is therefore not included in the JSON representation.
-	MinAPIVersion string `json:"-"`
+	// var and this configuration option should only be used for exceptional
+	// cases.
+	MinAPIVersion string `json:"min-api-version,omitempty"`
 
 	// FIXME(vdemeester) This part is not that clear and is mainly dependent on cli flags
 	// It should probably be handled outside this package.


### PR DESCRIPTION
Allows the minimum API version to be set through the daemon.json, e.g. "min-api-version": "1.24"

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

