### PR TITLE
client/pkg/security: simplify

### DIFF
--- a/client/pkg/security/security_opts.go
+++ b/client/pkg/security/security_opts.go
@@ -1,8 +1,6 @@
 package security
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 )
 
@@ -19,22 +17,14 @@ type KeyValue struct {
 
 // DecodeOptions decodes a security options string slice to a
 // type-safe [Option].
-func DecodeOptions(opts []string) ([]Option, error) {
-	so := []Option{}
+func DecodeOptions(opts []string) []Option {
+	so := make([]Option, 0, len(opts))
 	for _, opt := range opts {
-		// support output from a < 1.13 docker daemon
-		if !strings.Contains(opt, "=") {
-			so = append(so, Option{Name: opt})
-			continue
-		}
 		secopt := Option{}
 		for _, s := range strings.Split(opt, ",") {
-			k, v, ok := strings.Cut(s, "=")
-			if !ok {
-				return nil, fmt.Errorf("invalid security option %q", s)
-			}
-			if k == "" || v == "" {
-				return nil, errors.New("invalid empty security option")
+			k, v, _ := strings.Cut(s, "=")
+			if k == "" {
+				continue
 			}
 			if k == "name" {
 				secopt.Name = v
@@ -42,7 +32,9 @@ func DecodeOptions(opts []string) ([]Option, error) {
 			}
 			secopt.Options = append(secopt.Options, KeyValue{Key: k, Value: v})
 		}
-		so = append(so, secopt)
+		if secopt.Name != "" {
+			so = append(so, secopt)
+		}
 	}
-	return so, nil
+	return so
 }

--- a/client/pkg/security/security_opts_test.go
+++ b/client/pkg/security/security_opts_test.go
@@ -10,10 +10,9 @@ import (
 
 func TestDecode(t *testing.T) {
 	tests := []struct {
-		name    string
-		opts    []string
-		want    []Option
-		wantErr string
+		name string
+		opts []string
+		want []Option
 	}{
 		{
 			name: "empty options",
@@ -24,13 +23,6 @@ func TestDecode(t *testing.T) {
 			name: "nil options",
 			opts: nil,
 			want: []Option{},
-		},
-		{
-			name: "legacy format without equals",
-			opts: []string{"apparmor:unconfined"},
-			want: []Option{
-				{Name: "apparmor:unconfined"},
-			},
 		},
 		{
 			name: "single option with name only",
@@ -74,34 +66,6 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			name: "mixed legacy and new format",
-			opts: []string{
-				"label:disable",
-				"name=apparmor,profile=custom",
-			},
-			want: []Option{
-				{Name: "label:disable"},
-				{
-					Name: "apparmor",
-					Options: []KeyValue{
-						{Key: "profile", Value: "custom"},
-					},
-				},
-			},
-		},
-		{
-			name: "option without name key",
-			opts: []string{"profile=custom,type=container_t"},
-			want: []Option{
-				{
-					Options: []KeyValue{
-						{Key: "profile", Value: "custom"},
-						{Key: "type", Value: "container_t"},
-					},
-				},
-			},
-		},
-		{
 			name: "option with equals in value",
 			opts: []string{"name=selinux,level=s0:c1=c2"},
 			want: []Option{
@@ -114,34 +78,52 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		{
-			name:    "invalid option without equals in comma-separated list",
-			opts:    []string{"name=apparmor,invalid"},
-			wantErr: `invalid security option "invalid"`,
+			name: "invalid option without equals in comma-separated list",
+			opts: []string{"name=apparmor,invalid"},
+			want: []Option{
+				{
+					Name: "apparmor",
+					Options: []KeyValue{
+						{Key: "invalid"},
+					},
+				},
+			},
 		},
 		{
-			name:    "empty key",
-			opts:    []string{"=value"},
-			wantErr: "invalid empty security option",
+			name: "empty key",
+			opts: []string{"=value"},
+			want: []Option{},
 		},
 		{
-			name:    "empty value",
-			opts:    []string{"key="},
-			wantErr: "invalid empty security option",
+			name: "empty value",
+			opts: []string{"key="},
+			want: []Option{},
 		},
 		{
-			name:    "empty key and value",
-			opts:    []string{"="},
-			wantErr: "invalid empty security option",
+			name: "empty key and value",
+			opts: []string{"="},
+			want: []Option{},
 		},
 		{
-			name:    "empty key in middle",
-			opts:    []string{"name=apparmor,=value"},
-			wantErr: "invalid empty security option",
+			name: "empty key in middle",
+			opts: []string{"name=apparmor,=value"},
+			want: []Option{
+				{
+					Name: "apparmor",
+				},
+			},
 		},
 		{
-			name:    "empty value in middle",
-			opts:    []string{"name=apparmor,key="},
-			wantErr: "invalid empty security option",
+			name: "empty value in middle",
+			opts: []string{"name=apparmor,key="},
+			want: []Option{
+				{
+					Name: "apparmor",
+					Options: []KeyValue{
+						{Key: "key", Value: ""},
+					},
+				},
+			},
 		},
 		{
 			name: "complex real-world example",
@@ -178,15 +160,8 @@ func TestDecode(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := DecodeOptions(tc.opts)
-
-			if tc.wantErr == "" {
-				assert.NilError(t, err)
-				assert.Check(t, cmp.DeepEqual(got, tc.want))
-			} else {
-				assert.Check(t, err != nil, "expected error but got none")
-				assert.ErrorContains(t, err, tc.wantErr)
-			}
+			got := DecodeOptions(tc.opts)
+			assert.Check(t, cmp.DeepEqual(got, tc.want))
 		})
 	}
 }
@@ -196,31 +171,11 @@ func BenchmarkDecode(b *testing.B) {
 		"name=selinux,user=system_u,role=system_r,type=container_t,level=s0:c1.c2",
 		"name=apparmor,profile=/usr/bin/docker",
 		"name=seccomp,profile=builtin",
-		"legacy:format",
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := DecodeOptions(opts)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkDecodeLegacy(b *testing.B) {
-	opts := []string{
-		"apparmor:unconfined",
-		"label:disable",
-		"seccomp:unconfined",
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := DecodeOptions(opts)
-		if err != nil {
-			b.Fatal(err)
-		}
+		_ = DecodeOptions(opts)
 	}
 }
 
@@ -232,9 +187,6 @@ func BenchmarkDecodeComplex(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := DecodeOptions(opts)
-		if err != nil {
-			b.Fatal(err)
-		}
+		_ = DecodeOptions(opts)
 	}
 }


### PR DESCRIPTION
This utility is used to split the SecurityOptions field from the "/info" response into a slice of security.Option. It's effectively only used by the CLI to present the `docker info` output, but has a use in buildx to parse the response.

We can assume the daemon returns a valid response, remove the error- conditions and fallback for legacy daemon versions (< 1.13), and limit it to parsing the response only.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

