### PR TITLE
Fix TestHandleMACAddressBC

### DIFF
--- a/daemon/server/router/container/container_routes_test.go
+++ b/daemon/server/router/container/container_routes_test.go
@@ -68,39 +68,39 @@ func TestHandleMACAddressBC(t *testing.T) {
 			expCtrWideMAC:       network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 		},
 		{
-			name:        "new api no macs",
+			name:        "api 1.44 no macs",
 			apiVersion:  "1.44",
 			networkMode: "aNetId",
 			epConfig:    map[string]*network.EndpointSettings{"aNetName": {}},
 		},
 		{
-			name:        "new api ep specific mac",
+			name:        "api 1.44 ep specific mac",
 			apiVersion:  "1.44",
 			networkMode: "aNetName",
 			epConfig:    map[string]*network.EndpointSettings{"aNetName": {MacAddress: network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}}},
 		},
 		{
-			name:                "new api migrate ctr-wide mac to new ep",
+			name:                "api 1.44 migrate ctr-wide mac to new ep",
 			apiVersion:          "1.44",
 			ctrWideMAC:          network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 			networkMode:         "aNetName",
 			epConfig:            map[string]*network.EndpointSettings{},
 			expEpWithCtrWideMAC: "aNetName",
 			expWarning:          "The container-wide MacAddress field is now deprecated",
-			expCtrWideMAC:       nil,
+			expCtrWideMAC:       network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 		},
 		{
-			name:                "new api migrate ctr-wide mac to existing ep",
+			name:                "api 1.44 migrate ctr-wide mac to existing ep",
 			apiVersion:          "1.44",
 			ctrWideMAC:          network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 			networkMode:         "aNetName",
 			epConfig:            map[string]*network.EndpointSettings{"aNetName": {}},
 			expEpWithCtrWideMAC: "aNetName",
 			expWarning:          "The container-wide MacAddress field is now deprecated",
-			expCtrWideMAC:       nil,
+			expCtrWideMAC:       network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 		},
 		{
-			name:          "new api mode vs name mismatch",
+			name:          "api 1.44 mode vs name mismatch",
 			apiVersion:    "1.44",
 			ctrWideMAC:    network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 			networkMode:   "aNetId",
@@ -109,13 +109,21 @@ func TestHandleMACAddressBC(t *testing.T) {
 			expCtrWideMAC: network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 		},
 		{
-			name:          "new api mac mismatch",
+			name:          "api 1.44 mac mismatch",
 			apiVersion:    "1.44",
 			ctrWideMAC:    network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
 			networkMode:   "aNetName",
 			epConfig:      map[string]*network.EndpointSettings{"aNetName": {MacAddress: network.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}}},
 			expError:      "the container-wide MAC address must match the endpoint-specific MAC address",
 			expCtrWideMAC: network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
+		},
+		{
+			name:        "api 1.52 reject ctr-wide mac",
+			apiVersion:  "1.52",
+			ctrWideMAC:  network.HardwareAddr{0x11, 0x22, 0x33, 0x44, 0x55, 0x66},
+			networkMode: "aNetName",
+			epConfig:    map[string]*network.EndpointSettings{},
+			expError:    "container-wide MAC address no longer supported; use endpoint-specific MAC address instead",
 		},
 	}
 
@@ -147,7 +155,7 @@ func TestHandleMACAddressBC(t *testing.T) {
 			}
 			if tc.expEpWithCtrWideMAC != "" {
 				got := netCfg.EndpointsConfig[tc.expEpWithCtrWideMAC].MacAddress
-				assert.Check(t, is.DeepEqual(got, tc.ctrWideMAC, cmpopts.EquateEmpty()))
+				assert.Check(t, is.DeepEqual(got, tc.expCtrWideMAC, cmpopts.EquateEmpty()))
 			}
 			if tc.expEpWithNoMAC != "" {
 				got := netCfg.EndpointsConfig[tc.expEpWithNoMAC].MacAddress


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix TestHandleMACAddressBC:
- expCtrWideMAC was unused
- missing test for API 1.52

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

