### PR TITLE
Dockerfile: update runc binary to v1.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -254,7 +254,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # This version should usually match the version that is used by the containerd version
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged.
-ARG RUNC_VERSION=v1.3.2
+ARG RUNC_VERSION=v1.3.3
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -7,7 +7,7 @@ set -e
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: "${RUNC_VERSION:=v1.3.2}"
+: "${RUNC_VERSION:=v1.3.3}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -42,7 +42,7 @@ func (s *DockerCLIBuildSuite) TestBuildResourceConstraintsAreUsed(c *testing.T) 
 			"--cpuset-mems=0",
 			"--cpu-shares=100",
 			"--cpu-quota=8000",
-			"--ulimit", "nofile=42",
+			"--ulimit", "nofile=50",
 			"--label="+buildLabel,
 			"-t", name, "."),
 		cli.InDir(ctx.Dir),
@@ -74,7 +74,7 @@ func (s *DockerCLIBuildSuite) TestBuildResourceConstraintsAreUsed(c *testing.T) 
 	assert.Equal(c, c1.CPUShares, int64(100), "resource constraints not set properly for CPUShares")
 	assert.Equal(c, c1.CPUQuota, int64(8000), "resource constraints not set properly for CPUQuota")
 	assert.Equal(c, c1.Ulimits[0].Name, "nofile", "resource constraints not set properly for Ulimits")
-	assert.Equal(c, c1.Ulimits[0].Hard, int64(42), "resource constraints not set properly for Ulimits")
+	assert.Equal(c, c1.Ulimits[0].Hard, int64(50), "resource constraints not set properly for Ulimits")
 
 	// Make sure constraints aren't saved to image
 	cli.DockerCmd(c, "run", "--name=test", name)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -393,7 +393,7 @@ func deleteInterface(t *testing.T, ifName string) {
 }
 
 func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *testing.T) {
-	s.d.StartWithBusybox(testutil.GetContext(c), c, "--default-ulimit", "nofile=42:42", "--default-ulimit", "nproc=1024:1024")
+	s.d.StartWithBusybox(testutil.GetContext(c), c, "--default-ulimit", "nofile=50:50", "--default-ulimit", "nproc=1024:1024")
 
 	out, err := s.d.Cmd("run", "--ulimit", "nproc=2048", "--name=test", "busybox", "/bin/sh", "-c", "echo $(ulimit -n); echo $(ulimit -u)")
 	if err != nil {
@@ -407,15 +407,15 @@ func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *testing.T) {
 	nofile := strings.TrimSpace(outArr[0])
 	nproc := strings.TrimSpace(outArr[1])
 
-	if nofile != "42" {
-		c.Fatalf("expected `ulimit -n` to be `42`, got: %s", nofile)
+	if nofile != "50" {
+		c.Fatalf("expected `ulimit -n` to be `50`, got: %s", nofile)
 	}
 	if nproc != "2048" {
 		c.Fatalf("expected `ulimit -u` to be 2048, got: %s", nproc)
 	}
 
 	// Now restart daemon with a new default
-	s.d.Restart(c, "--default-ulimit", "nofile=43")
+	s.d.Restart(c, "--default-ulimit", "nofile=50")
 
 	out, err = s.d.Cmd("start", "-a", "test")
 	if err != nil {
@@ -429,8 +429,8 @@ func (s *DockerDaemonSuite) TestDaemonUlimitDefaults(c *testing.T) {
 	nofile = strings.TrimSpace(outArr[0])
 	nproc = strings.TrimSpace(outArr[1])
 
-	if nofile != "43" {
-		c.Fatalf("expected `ulimit -n` to be `43`, got: %s", nofile)
+	if nofile != "50" {
+		c.Fatalf("expected `ulimit -n` to be `50`, got: %s", nofile)
 	}
 	if nproc != "2048" {
 		c.Fatalf("expected `ulimit -u` to be 2048, got: %s", nproc)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3114,10 +3114,10 @@ func (s *DockerCLIRunSuite) TestRunWithUlimits(c *testing.T) {
 	// Not applicable on Windows as uses Unix specific functionality
 	testRequires(c, DaemonIsLinux)
 
-	out := cli.DockerCmd(c, "run", "--name=testulimits", "--ulimit", "nofile=42", "busybox", "/bin/sh", "-c", "ulimit -n").Combined()
+	out := cli.DockerCmd(c, "run", "--name=testulimits", "--ulimit", "nofile=50", "busybox", "/bin/sh", "-c", "ulimit -n").Combined()
 	ul := strings.TrimSpace(out)
-	if ul != "42" {
-		c.Fatalf("expected `ulimit -n` to be 42, got %s", ul)
+	if ul != "50" {
+		c.Fatalf("expected `ulimit -n` to be 50, got %s", ul)
 	}
 }
 
@@ -3939,13 +3939,13 @@ func (s *DockerDaemonSuite) TestRunWithUlimitAndDaemonDefault(c *testing.T) {
 	assert.NilError(c, err)
 	assert.Assert(c, is.Contains(out, "[nofile=65535:65535]"))
 	name = "test-B"
-	_, err = d.Cmd("run", "--name", name, "--ulimit=nofile=42", "-d", "busybox", "top")
+	_, err = d.Cmd("run", "--name", name, "--ulimit=nofile=50", "-d", "busybox", "top")
 	assert.NilError(c, err)
 	assert.NilError(c, d.WaitRun(name))
 
 	out, err = d.Cmd("inspect", "--format", "{{.HostConfig.Ulimits}}", name)
 	assert.NilError(c, err)
-	assert.Assert(c, is.Contains(out, "[nofile=42:42]"))
+	assert.Assert(c, is.Contains(out, "[nofile=50:50]"))
 }
 
 func (s *DockerCLIRunSuite) TestRunStoppedLoggingDriverNoLeak(c *testing.T) {


### PR DESCRIPTION
### Dockerfile: update runc binary to v1.3.3

Update the version used in CI and for the static binaries.

- release notes: https://github.com/opencontainers/runc/releases/tag/v1.3.3
- full diff: https://github.com/opencontainers/runc/compare/v1.3.2...v1.3.3

This release contains fixes for three high-severity security vulnerabilities in runc (CVE-2025-31133, CVE-2025-52565, and CVE-2025-52881).
All three vulnerabilities ultimately allow (through different methods) for full container breakouts by bypassing runc's restrictions for writing to arbitrary `/proc` files.

```markdown changelog
Update runc to [v1.3.3](https://github.com/opencontainers/runc/releases/tag/v1.3.3)
```