### PR TITLE
[28.x backport] dockerd-rootless.sh: reject DOCKERD_ROOTLESS_ROOTLESSKIT_NET=host

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -130,6 +130,10 @@ if [ -z "$net" ]; then
 		echo "One of slirp4netns (>= v0.4.0), pasta (passt >= 2023_12_04), or vpnkit needs to be installed"
 	fi
 fi
+if [ "$net" = host ]; then
+	echo "Unsupported RootlessKit network driver: $net"
+	exit 1
+fi
 if [ -z "$mtu" ]; then
 	if [ "$net" = slirp4netns -o "$net" = pasta ]; then
 		mtu=65520


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51379
- relates to https://github.com/moby/moby/issues/51363

-----
`rootlesskit --net=host` does not work with Docker.

Alternative ways to run Rootless Docker without the network overhead:
- Use https://github.com/rootless-containers/bypass4netns
- Or, use `docker run --net=host` with #47103 (WIP)

See:
- #51363

- - -

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Reject `DOCKERD_ROOTLESS_ROOTLESSKIT_NET=host`.

**- How I did it**

See the code

**- How to verify it**

```console
$ DOCKERD_ROOTLESS_ROOTLESSKIT_NET=host dockerd-rootless.sh
[...]
+ echo Unsupported RootlessKit network driver: host
Unsupported RootlessKit network driver: host
+ exit 1
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

