### PR TITLE
gha/bin-image: Fix dco running on non-v tags

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   validate-dco:
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     uses: ./.github/workflows/.dco.yml
 
   prepare:


### PR DESCRIPTION
bin-image workflow was failing for the new docker tags (`docker-v29.0.0-rc.2`) because it wasn't correctly picked up by the condition that should filter out tags.

Example failure: https://github.com/moby/moby/actions/runs/18981889069/job/54376614064