### PR TITLE
client: singularize prune methods

### DIFF
--- a/client/client_interfaces.go
+++ b/client/client_interfaces.go
@@ -72,7 +72,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string, options ContainerWaitOptions) ContainerWaitResult
 	CopyFromContainer(ctx context.Context, container string, options CopyFromContainerOptions) (CopyFromContainerResult, error)
 	CopyToContainer(ctx context.Context, container string, options CopyToContainerOptions) (CopyToContainerResult, error)
-	ContainersPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error)
+	ContainerPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error)
 }
 
 type ExecAPIClient interface {
@@ -101,7 +101,7 @@ type ImageAPIClient interface {
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) (ImageRemoveResult, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) (ImageSearchResult, error)
 	ImageTag(ctx context.Context, options ImageTagOptions) (ImageTagResult, error)
-	ImagesPrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error)
+	ImagePrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error)
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (ImageInspectResult, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) (ImageHistoryResult, error)
@@ -117,7 +117,7 @@ type NetworkAPIClient interface {
 	NetworkInspect(ctx context.Context, network string, options NetworkInspectOptions) (NetworkInspectResult, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) (NetworkListResult, error)
 	NetworkRemove(ctx context.Context, network string, options NetworkRemoveOptions) (NetworkRemoveResult, error)
-	NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error)
+	NetworkPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error)
 }
 
 // NodeAPIClient defines API client methods for the nodes
@@ -181,7 +181,7 @@ type VolumeAPIClient interface {
 	VolumeInspect(ctx context.Context, volumeID string, options VolumeInspectOptions) (VolumeInspectResult, error)
 	VolumeList(ctx context.Context, options VolumeListOptions) (VolumeListResult, error)
 	VolumeRemove(ctx context.Context, volumeID string, options VolumeRemoveOptions) (VolumeRemoveResult, error)
-	VolumesPrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error)
+	VolumePrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error)
 	VolumeUpdate(ctx context.Context, volumeID string, options VolumeUpdateOptions) (VolumeUpdateResult, error)
 }
 

--- a/client/container_prune.go
+++ b/client/container_prune.go
@@ -14,13 +14,13 @@ type ContainerPruneOptions struct {
 	Filters Filters
 }
 
-// ContainerPruneResult holds the result from the [Client.ContainersPrune] method.
+// ContainerPruneResult holds the result from the [Client.ContainerPrune] method.
 type ContainerPruneResult struct {
 	Report container.PruneReport
 }
 
-// ContainersPrune requests the daemon to delete unused data
-func (cli *Client) ContainersPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error) {
+// ContainerPrune requests the daemon to delete unused data
+func (cli *Client) ContainerPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error) {
 	query := url.Values{}
 	opts.Filters.updateURLValues(query)
 

--- a/client/container_prune_test.go
+++ b/client/container_prune_test.go
@@ -11,15 +11,15 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestContainersPruneError(t *testing.T) {
+func TestContainerPruneError(t *testing.T) {
 	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
-	_, err = client.ContainersPrune(context.Background(), ContainerPruneOptions{})
+	_, err = client.ContainerPrune(context.Background(), ContainerPruneOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
-func TestContainersPrune(t *testing.T) {
+func TestContainerPrune(t *testing.T) {
 	const expectedURL = "/containers/prune"
 
 	listCases := []struct {
@@ -89,7 +89,7 @@ func TestContainersPrune(t *testing.T) {
 		}))
 		assert.NilError(t, err)
 
-		req, err := client.ContainersPrune(context.Background(), ContainerPruneOptions{Filters: listCase.filters})
+		req, err := client.ContainerPrune(context.Background(), ContainerPruneOptions{Filters: listCase.filters})
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(req.Report.ContainersDeleted, 2))
 		assert.Check(t, is.Equal(uint64(9999), req.Report.SpaceReclaimed))

--- a/client/image_prune.go
+++ b/client/image_prune.go
@@ -14,13 +14,13 @@ type ImagePruneOptions struct {
 	Filters Filters
 }
 
-// ImagePruneResult holds the result from the [Client.ImagesPrune] method.
+// ImagePruneResult holds the result from the [Client.ImagePrune] method.
 type ImagePruneResult struct {
 	Report image.PruneReport
 }
 
-// ImagesPrune requests the daemon to delete unused data
-func (cli *Client) ImagesPrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error) {
+// ImagePrune requests the daemon to delete unused data
+func (cli *Client) ImagePrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error) {
 	query := url.Values{}
 	opts.Filters.updateURLValues(query)
 

--- a/client/image_prune_test.go
+++ b/client/image_prune_test.go
@@ -12,15 +12,15 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestImagesPruneError(t *testing.T) {
+func TestImagePruneError(t *testing.T) {
 	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
 
-	_, err = client.ImagesPrune(context.Background(), ImagePruneOptions{})
+	_, err = client.ImagePrune(context.Background(), ImagePruneOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
-func TestImagesPrune(t *testing.T) {
+func TestImagePrune(t *testing.T) {
 	const expectedURL = "/images/prune"
 
 	listCases := []struct {
@@ -83,7 +83,7 @@ func TestImagesPrune(t *testing.T) {
 		}))
 		assert.NilError(t, err)
 
-		res, err := client.ImagesPrune(context.Background(), ImagePruneOptions{Filters: listCase.filters})
+		res, err := client.ImagePrune(context.Background(), ImagePruneOptions{Filters: listCase.filters})
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(res.Report.ImagesDeleted, 2))
 		assert.Check(t, is.Equal(uint64(9999), res.Report.SpaceReclaimed))

--- a/client/network_prune.go
+++ b/client/network_prune.go
@@ -14,13 +14,13 @@ type NetworkPruneOptions struct {
 	Filters Filters
 }
 
-// NetworkPruneResult holds the result from the [Client.NetworksPrune] method.
+// NetworkPruneResult holds the result from the [Client.NetworkPrune] method.
 type NetworkPruneResult struct {
 	Report network.PruneReport
 }
 
-// NetworksPrune requests the daemon to delete unused networks
-func (cli *Client) NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error) {
+// NetworkPrune requests the daemon to delete unused networks
+func (cli *Client) NetworkPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error) {
 	query := url.Values{}
 	opts.Filters.updateURLValues(query)
 

--- a/client/network_prune_test.go
+++ b/client/network_prune_test.go
@@ -11,17 +11,17 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestNetworksPruneError(t *testing.T) {
+func TestNetworkPruneError(t *testing.T) {
 	client, err := New(
 		WithMockClient(errorMock(http.StatusInternalServerError, "Server error")),
 	)
 	assert.NilError(t, err)
 
-	_, err = client.NetworksPrune(context.Background(), NetworkPruneOptions{})
+	_, err = client.NetworkPrune(context.Background(), NetworkPruneOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
-func TestNetworksPrune(t *testing.T) {
+func TestNetworkPrune(t *testing.T) {
 	const expectedURL = "/networks/prune"
 
 	listCases := []struct {
@@ -82,7 +82,7 @@ func TestNetworksPrune(t *testing.T) {
 		)
 		assert.NilError(t, err)
 
-		res, err := client.NetworksPrune(context.Background(), NetworkPruneOptions{Filters: listCase.filters})
+		res, err := client.NetworkPrune(context.Background(), NetworkPruneOptions{Filters: listCase.filters})
 		assert.NilError(t, err)
 		assert.Check(t, is.Len(res.Report.NetworksDeleted, 2))
 	}

--- a/client/volume_prune.go
+++ b/client/volume_prune.go
@@ -20,13 +20,13 @@ type VolumePruneOptions struct {
 	Filters Filters
 }
 
-// VolumePruneResult holds the result from the [Client.VolumesPrune] method.
+// VolumePruneResult holds the result from the [Client.VolumePrune] method.
 type VolumePruneResult struct {
 	Report volume.PruneReport
 }
 
-// VolumesPrune requests the daemon to delete unused data
-func (cli *Client) VolumesPrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error) {
+// VolumePrune requests the daemon to delete unused data
+func (cli *Client) VolumePrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error) {
 	if options.All {
 		if _, ok := options.Filters["all"]; ok {
 			return VolumePruneResult{}, errdefs.ErrInvalidArgument.WithMessage(`conflicting options: cannot specify both "all" and "all" filter`)

--- a/client/volume_prune_test.go
+++ b/client/volume_prune_test.go
@@ -79,7 +79,7 @@ func TestVolumePrune(t *testing.T) {
 			}))
 			assert.NilError(t, err)
 
-			_, err = client.VolumesPrune(t.Context(), tc.opts)
+			_, err = client.VolumePrune(t.Context(), tc.opts)
 			if tc.expectedError != "" {
 				assert.Check(t, is.ErrorType(err, errdefs.IsInvalidArgument))
 				assert.Check(t, is.Error(err, tc.expectedError))

--- a/daemon/containerd/image_prune.go
+++ b/daemon/containerd/image_prune.go
@@ -33,8 +33,8 @@ var imagesAcceptedFilters = map[string]bool{
 // one is in progress
 var errPruneRunning = errdefs.Conflict(errors.New("a prune operation is already running"))
 
-// ImagesPrune removes unused images
-func (i *ImageService) ImagesPrune(ctx context.Context, fltrs filters.Args) (*image.PruneReport, error) {
+// ImagePrune removes unused images
+func (i *ImageService) ImagePrune(ctx context.Context, fltrs filters.Args) (*image.PruneReport, error) {
 	if !i.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}

--- a/daemon/image_service.go
+++ b/daemon/image_service.go
@@ -36,7 +36,7 @@ type ImageService interface {
 	Images(ctx context.Context, opts imagebackend.ListOptions) ([]*imagetype.Summary, error)
 	LogImageEvent(ctx context.Context, imageID, refName string, action events.Action)
 	CountImages(ctx context.Context) int
-	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*imagetype.PruneReport, error)
+	ImagePrune(ctx context.Context, pruneFilters filters.Args) (*imagetype.PruneReport, error)
 	ImportImage(ctx context.Context, ref reference.Named, platform *ocispec.Platform, msg string, layerReader io.Reader, changes []string) (image.ID, error)
 	TagImage(ctx context.Context, imageID image.ID, newTag reference.Named) error
 	GetImage(ctx context.Context, refOrID string, options imagebackend.GetImageOpts) (*image.Image, error)

--- a/daemon/images/image_prune.go
+++ b/daemon/images/image_prune.go
@@ -31,8 +31,8 @@ var imagesAcceptedFilters = map[string]bool{
 // one is in progress
 var errPruneRunning = errdefs.Conflict(errors.New("a prune operation is already running"))
 
-// ImagesPrune removes unused images
-func (i *ImageService) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*imagetypes.PruneReport, error) {
+// ImagePrune removes unused images
+func (i *ImageService) ImagePrune(ctx context.Context, pruneFilters filters.Args) (*imagetypes.PruneReport, error) {
 	if !i.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}
@@ -148,7 +148,7 @@ deleteImagesLoop:
 	}
 
 	if canceled {
-		log.G(ctx).Debugf("ImagesPrune operation cancelled: %#v", *rep)
+		log.G(ctx).Debugf("ImagePrune operation cancelled: %#v", *rep)
 	}
 	i.eventsService.Log(events.ActionPrune, events.ImageEventType, events.Actor{
 		Attributes: map[string]string{

--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -31,8 +31,8 @@ var (
 	}
 )
 
-// ContainersPrune removes unused containers
-func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error) {
+// ContainerPrune removes unused containers
+func (daemon *Daemon) ContainerPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error) {
 	if !daemon.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}
@@ -56,7 +56,7 @@ func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.
 	for _, c := range allContainers {
 		select {
 		case <-ctx.Done():
-			log.G(ctx).Debugf("ContainersPrune operation cancelled: %#v", *rep)
+			log.G(ctx).Debugf("ContainerPrune operation cancelled: %#v", *rep)
 			return rep, nil
 		default:
 		}
@@ -90,8 +90,8 @@ func (daemon *Daemon) ContainersPrune(ctx context.Context, pruneFilters filters.
 	return rep, nil
 }
 
-// localNetworksPrune removes unused local networks
-func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters dnetwork.Filter) *network.PruneReport {
+// localNetworkPrune removes unused local networks
+func (daemon *Daemon) localNetworkPrune(ctx context.Context, pruneFilters dnetwork.Filter) *network.PruneReport {
 	rep := &network.PruneReport{}
 
 	// When the function returns true, the walk will stop.
@@ -126,8 +126,8 @@ func (daemon *Daemon) localNetworksPrune(ctx context.Context, pruneFilters dnetw
 
 var networkIsInUse = lazyregexp.New(`network ([[:alnum:]]+) is in use`)
 
-// clusterNetworksPrune removes unused cluster networks
-func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters dnetwork.Filter) (*network.PruneReport, error) {
+// clusterNetworkPrune removes unused cluster networks
+func (daemon *Daemon) clusterNetworkPrune(ctx context.Context, pruneFilters dnetwork.Filter) (*network.PruneReport, error) {
 	rep := &network.PruneReport{}
 
 	cluster := daemon.GetCluster()
@@ -168,8 +168,8 @@ func (daemon *Daemon) clusterNetworksPrune(ctx context.Context, pruneFilters dne
 	return rep, nil
 }
 
-// NetworksPrune removes unused networks
-func (daemon *Daemon) NetworksPrune(ctx context.Context, filterArgs filters.Args) (*network.PruneReport, error) {
+// NetworkPrune removes unused networks
+func (daemon *Daemon) NetworkPrune(ctx context.Context, filterArgs filters.Args) (*network.PruneReport, error) {
 	if !daemon.pruneRunning.CompareAndSwap(false, true) {
 		return nil, errPruneRunning
 	}
@@ -181,16 +181,16 @@ func (daemon *Daemon) NetworksPrune(ctx context.Context, filterArgs filters.Args
 	}
 
 	rep := &network.PruneReport{}
-	if clusterRep, err := daemon.clusterNetworksPrune(ctx, pruneFilters); err == nil {
+	if clusterRep, err := daemon.clusterNetworkPrune(ctx, pruneFilters); err == nil {
 		rep.NetworksDeleted = append(rep.NetworksDeleted, clusterRep.NetworksDeleted...)
 	}
 
-	localRep := daemon.localNetworksPrune(ctx, pruneFilters)
+	localRep := daemon.localNetworkPrune(ctx, pruneFilters)
 	rep.NetworksDeleted = append(rep.NetworksDeleted, localRep.NetworksDeleted...)
 
 	select {
 	case <-ctx.Done():
-		log.G(ctx).Debugf("NetworksPrune operation cancelled: %#v", *rep)
+		log.G(ctx).Debugf("NetworkPrune operation cancelled: %#v", *rep)
 		return rep, nil
 	default:
 	}

--- a/daemon/server/router/container/backend.go
+++ b/daemon/server/router/container/backend.go
@@ -63,7 +63,7 @@ type attachBackend interface {
 
 // systemBackend includes functions to implement to provide system wide containers functionality
 type systemBackend interface {
-	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error)
+	ContainerPrune(ctx context.Context, pruneFilters filters.Args) (*container.PruneReport, error)
 }
 
 type commitBackend interface {

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -1160,7 +1160,7 @@ func (c *containerRouter) postContainersPrune(ctx context.Context, w http.Respon
 		return err
 	}
 
-	pruneReport, err := c.backend.ContainersPrune(ctx, pruneFilters)
+	pruneReport, err := c.backend.ContainerPrune(ctx, pruneFilters)
 	if err != nil {
 		return err
 	}

--- a/daemon/server/router/image/backend.go
+++ b/daemon/server/router/image/backend.go
@@ -28,7 +28,7 @@ type imageBackend interface {
 	GetImage(ctx context.Context, refOrID string, options imagebackend.GetImageOpts) (*dockerimage.Image, error)
 	ImageInspect(ctx context.Context, refOrID string, options imagebackend.ImageInspectOpts) (*imagebackend.InspectData, error)
 	TagImage(ctx context.Context, id dockerimage.ID, newRef reference.Named) error
-	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (*image.PruneReport, error)
+	ImagePrune(ctx context.Context, pruneFilters filters.Args) (*image.PruneReport, error)
 }
 
 type importExportBackend interface {

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -630,7 +630,7 @@ func (ir *imageRouter) postImagesPrune(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
-	pruneReport, err := ir.backend.ImagesPrune(ctx, pruneFilters)
+	pruneReport, err := ir.backend.ImagePrune(ctx, pruneFilters)
 	if err != nil {
 		return err
 	}

--- a/daemon/server/router/network/backend.go
+++ b/daemon/server/router/network/backend.go
@@ -18,7 +18,7 @@ type Backend interface {
 	ConnectContainerToNetwork(ctx context.Context, containerName, networkName string, endpointConfig *network.EndpointSettings) error
 	DisconnectContainerFromNetwork(containerName string, networkName string, force bool) error
 	DeleteNetwork(networkID string) error
-	NetworksPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error)
+	NetworkPrune(ctx context.Context, pruneFilters filters.Args) (*network.PruneReport, error)
 }
 
 // ClusterBackend is all the methods that need to be implemented

--- a/daemon/server/router/network/network.go
+++ b/daemon/server/router/network/network.go
@@ -36,7 +36,7 @@ func (n *networkRouter) initRoutes() {
 		router.NewPostRoute("/networks/create", n.postNetworkCreate),
 		router.NewPostRoute("/networks/{id:.*}/connect", n.postNetworkConnect),
 		router.NewPostRoute("/networks/{id:.*}/disconnect", n.postNetworkDisconnect),
-		router.NewPostRoute("/networks/prune", n.postNetworksPrune, router.WithMinimumAPIVersion("1.25")),
+		router.NewPostRoute("/networks/prune", n.postNetworkPrune, router.WithMinimumAPIVersion("1.25")),
 		// DELETE
 		router.NewDeleteRoute("/networks/{id:.*}", n.deleteNetwork),
 	}

--- a/daemon/server/router/network/network_routes.go
+++ b/daemon/server/router/network/network_routes.go
@@ -334,7 +334,7 @@ func (n *networkRouter) deleteNetwork(ctx context.Context, w http.ResponseWriter
 	return nil
 }
 
-func (n *networkRouter) postNetworksPrune(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (n *networkRouter) postNetworkPrune(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
@@ -344,7 +344,7 @@ func (n *networkRouter) postNetworksPrune(ctx context.Context, w http.ResponseWr
 		return err
 	}
 
-	pruneReport, err := n.backend.NetworksPrune(ctx, pruneFilters)
+	pruneReport, err := n.backend.NetworkPrune(ctx, pruneFilters)
 	if err != nil {
 		return err
 	}

--- a/integration/image/prune_test.go
+++ b/integration/image/prune_test.go
@@ -38,7 +38,7 @@ func TestPruneDontDeleteUsedDangling(t *testing.T) {
 		container.WithImage(danglingID),
 		container.WithCmd("sleep", "60"))
 
-	res, err := apiClient.ImagesPrune(ctx, client.ImagePruneOptions{
+	res, err := apiClient.ImagePrune(ctx, client.ImagePruneOptions{
 		Filters: make(client.Filters).Add("dangling", "true"),
 	})
 	assert.NilError(t, err)
@@ -87,7 +87,7 @@ func TestPruneLexographicalOrder(t *testing.T) {
 	cid := container.Create(ctx, t, apiClient, container.WithImage(id))
 	defer container.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
 
-	res, err := apiClient.ImagesPrune(ctx, client.ImagePruneOptions{
+	res, err := apiClient.ImagePrune(ctx, client.ImagePruneOptions{
 		Filters: make(client.Filters).Add("dangling", "false"),
 	})
 	assert.NilError(t, err)
@@ -219,7 +219,7 @@ func TestPruneDontDeleteUsedImage(t *testing.T) {
 				defer container.Remove(ctx, t, apiClient, cid, client.ContainerRemoveOptions{Force: true})
 
 				// dangling=false also prunes unused images
-				res, err := apiClient.ImagesPrune(ctx, client.ImagePruneOptions{
+				res, err := apiClient.ImagePrune(ctx, client.ImagePruneOptions{
 					Filters: make(client.Filters).Add("dangling", "false"),
 				})
 				assert.NilError(t, err)

--- a/integration/plugin/authz/authz_plugin_v2_test.go
+++ b/integration/plugin/authz/authz_plugin_v2_test.go
@@ -109,7 +109,7 @@ func TestAuthZPluginV2RejectVolumeRequests(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 
-	_, err = c.VolumesPrune(ctx, client.VolumePruneOptions{})
+	_, err = c.VolumePrune(ctx, client.VolumePruneOptions{})
 	assert.Assert(t, err != nil)
 	assert.ErrorContains(t, err, fmt.Sprintf("Error response from daemon: plugin %s failed with error:", authzPluginNameWithTag))
 }

--- a/integration/volume/volume_test.go
+++ b/integration/volume/volume_test.go
@@ -273,7 +273,7 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	namedV := created.Volume
 
 	// Prune anonymous volumes
-	prune, err := apiClient.VolumesPrune(ctx, client.VolumePruneOptions{})
+	prune, err := apiClient.VolumePrune(ctx, client.VolumePruneOptions{})
 	assert.NilError(t, err)
 	report := prune.Report
 	assert.Check(t, is.Equal(len(report.VolumesDeleted), 1))
@@ -285,7 +285,7 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	// Prune all volumes
 	_, err = apiClient.VolumeCreate(ctx, client.VolumeCreateOptions{})
 	assert.NilError(t, err)
-	prune, err = apiClient.VolumesPrune(ctx, client.VolumePruneOptions{
+	prune, err = apiClient.VolumePrune(ctx, client.VolumePruneOptions{
 		All: true,
 	})
 	assert.NilError(t, err)
@@ -297,7 +297,7 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	_, err = apiClient.VolumeCreate(ctx, client.VolumeCreateOptions{Name: "test"})
 	assert.NilError(t, err)
 
-	prune, err = apiClient.VolumesPrune(ctx, client.VolumePruneOptions{
+	prune, err = apiClient.VolumePrune(ctx, client.VolumePruneOptions{
 		All: true,
 	})
 
@@ -318,7 +318,7 @@ func TestVolumePruneAnonymous(t *testing.T) {
 	assert.NilError(t, err)
 	namedV = created.Volume
 
-	prune, err = clientOld.VolumesPrune(ctx, client.VolumePruneOptions{})
+	prune, err = clientOld.VolumePrune(ctx, client.VolumePruneOptions{})
 	assert.NilError(t, err)
 	report = prune.Report
 	assert.Check(t, is.Equal(len(report.VolumesDeleted), 2))
@@ -354,7 +354,7 @@ VOLUME ` + volDest
 	_, err = apiClient.ContainerRemove(ctx, id, client.ContainerRemoveOptions{})
 	assert.NilError(t, err)
 
-	res, err := apiClient.VolumesPrune(ctx, client.VolumePruneOptions{})
+	res, err := apiClient.VolumePrune(ctx, client.VolumePruneOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, is.Contains(res.Report.VolumesDeleted, volumeName))
 }

--- a/vendor/github.com/moby/moby/client/client_interfaces.go
+++ b/vendor/github.com/moby/moby/client/client_interfaces.go
@@ -72,7 +72,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string, options ContainerWaitOptions) ContainerWaitResult
 	CopyFromContainer(ctx context.Context, container string, options CopyFromContainerOptions) (CopyFromContainerResult, error)
 	CopyToContainer(ctx context.Context, container string, options CopyToContainerOptions) (CopyToContainerResult, error)
-	ContainersPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error)
+	ContainerPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error)
 }
 
 type ExecAPIClient interface {
@@ -101,7 +101,7 @@ type ImageAPIClient interface {
 	ImageRemove(ctx context.Context, image string, options ImageRemoveOptions) (ImageRemoveResult, error)
 	ImageSearch(ctx context.Context, term string, options ImageSearchOptions) (ImageSearchResult, error)
 	ImageTag(ctx context.Context, options ImageTagOptions) (ImageTagResult, error)
-	ImagesPrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error)
+	ImagePrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error)
 
 	ImageInspect(ctx context.Context, image string, _ ...ImageInspectOption) (ImageInspectResult, error)
 	ImageHistory(ctx context.Context, image string, _ ...ImageHistoryOption) (ImageHistoryResult, error)
@@ -117,7 +117,7 @@ type NetworkAPIClient interface {
 	NetworkInspect(ctx context.Context, network string, options NetworkInspectOptions) (NetworkInspectResult, error)
 	NetworkList(ctx context.Context, options NetworkListOptions) (NetworkListResult, error)
 	NetworkRemove(ctx context.Context, network string, options NetworkRemoveOptions) (NetworkRemoveResult, error)
-	NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error)
+	NetworkPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error)
 }
 
 // NodeAPIClient defines API client methods for the nodes
@@ -181,7 +181,7 @@ type VolumeAPIClient interface {
 	VolumeInspect(ctx context.Context, volumeID string, options VolumeInspectOptions) (VolumeInspectResult, error)
 	VolumeList(ctx context.Context, options VolumeListOptions) (VolumeListResult, error)
 	VolumeRemove(ctx context.Context, volumeID string, options VolumeRemoveOptions) (VolumeRemoveResult, error)
-	VolumesPrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error)
+	VolumePrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error)
 	VolumeUpdate(ctx context.Context, volumeID string, options VolumeUpdateOptions) (VolumeUpdateResult, error)
 }
 

--- a/vendor/github.com/moby/moby/client/container_prune.go
+++ b/vendor/github.com/moby/moby/client/container_prune.go
@@ -14,13 +14,13 @@ type ContainerPruneOptions struct {
 	Filters Filters
 }
 
-// ContainerPruneResult holds the result from the [Client.ContainersPrune] method.
+// ContainerPruneResult holds the result from the [Client.ContainerPrune] method.
 type ContainerPruneResult struct {
 	Report container.PruneReport
 }
 
-// ContainersPrune requests the daemon to delete unused data
-func (cli *Client) ContainersPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error) {
+// ContainerPrune requests the daemon to delete unused data
+func (cli *Client) ContainerPrune(ctx context.Context, opts ContainerPruneOptions) (ContainerPruneResult, error) {
 	query := url.Values{}
 	opts.Filters.updateURLValues(query)
 

--- a/vendor/github.com/moby/moby/client/image_prune.go
+++ b/vendor/github.com/moby/moby/client/image_prune.go
@@ -14,13 +14,13 @@ type ImagePruneOptions struct {
 	Filters Filters
 }
 
-// ImagePruneResult holds the result from the [Client.ImagesPrune] method.
+// ImagePruneResult holds the result from the [Client.ImagePrune] method.
 type ImagePruneResult struct {
 	Report image.PruneReport
 }
 
-// ImagesPrune requests the daemon to delete unused data
-func (cli *Client) ImagesPrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error) {
+// ImagePrune requests the daemon to delete unused data
+func (cli *Client) ImagePrune(ctx context.Context, opts ImagePruneOptions) (ImagePruneResult, error) {
 	query := url.Values{}
 	opts.Filters.updateURLValues(query)
 

--- a/vendor/github.com/moby/moby/client/network_prune.go
+++ b/vendor/github.com/moby/moby/client/network_prune.go
@@ -14,13 +14,13 @@ type NetworkPruneOptions struct {
 	Filters Filters
 }
 
-// NetworkPruneResult holds the result from the [Client.NetworksPrune] method.
+// NetworkPruneResult holds the result from the [Client.NetworkPrune] method.
 type NetworkPruneResult struct {
 	Report network.PruneReport
 }
 
-// NetworksPrune requests the daemon to delete unused networks
-func (cli *Client) NetworksPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error) {
+// NetworkPrune requests the daemon to delete unused networks
+func (cli *Client) NetworkPrune(ctx context.Context, opts NetworkPruneOptions) (NetworkPruneResult, error) {
 	query := url.Values{}
 	opts.Filters.updateURLValues(query)
 

--- a/vendor/github.com/moby/moby/client/volume_prune.go
+++ b/vendor/github.com/moby/moby/client/volume_prune.go
@@ -20,13 +20,13 @@ type VolumePruneOptions struct {
 	Filters Filters
 }
 
-// VolumePruneResult holds the result from the [Client.VolumesPrune] method.
+// VolumePruneResult holds the result from the [Client.VolumePrune] method.
 type VolumePruneResult struct {
 	Report volume.PruneReport
 }
 
-// VolumesPrune requests the daemon to delete unused data
-func (cli *Client) VolumesPrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error) {
+// VolumePrune requests the daemon to delete unused data
+func (cli *Client) VolumePrune(ctx context.Context, options VolumePruneOptions) (VolumePruneResult, error) {
 	if options.All {
 		if _, ok := options.Filters["all"]; ok {
 			return VolumePruneResult{}, errdefs.ErrInvalidArgument.WithMessage(`conflicting options: cannot specify both "all" and "all" filter`)


### PR DESCRIPTION
All methods are singular; while pruning will impact multiple items, it's more consistent to use singular for all operations.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

