### PR TITLE
api/types: use regular slices for disk usage types

### DIFF
--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -2096,7 +2096,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: Summary
 
@@ -2279,7 +2278,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: Volume
 
@@ -2893,7 +2891,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: CacheRecord
 
@@ -5617,7 +5614,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: Summary
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2096,7 +2096,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: Summary
 
@@ -2279,7 +2278,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: Volume
 
@@ -2893,7 +2891,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: CacheRecord
 
@@ -5617,7 +5614,6 @@ definitions:
         type: "array"
         x-omitempty: true
         items:
-          x-nullable: true
           x-go-type:
             type: Summary
 

--- a/api/types/build/disk_usage.go
+++ b/api/types/build/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of build cache records.
 	//
-	Items []*CacheRecord `json:"Items,omitempty"`
+	Items []CacheRecord `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing inactive build cache records.
 	//

--- a/api/types/container/disk_usage.go
+++ b/api/types/container/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of container summaries.
 	//
-	Items []*Summary `json:"Items,omitempty"`
+	Items []Summary `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing inactive containers.
 	//

--- a/api/types/image/disk_usage.go
+++ b/api/types/image/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of image summaries.
 	//
-	Items []*Summary `json:"Items,omitempty"`
+	Items []Summary `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing unused images.
 	//

--- a/api/types/system/disk_usage.go
+++ b/api/types/system/disk_usage.go
@@ -37,14 +37,14 @@ type LegacyDiskUsage struct {
 	LayersSize int64 `json:"LayersSize,omitempty"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.Items] instead.
-	Images []*image.Summary `json:"Images,omitempty"`
+	Images []image.Summary `json:"Images,omitzero"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ContainersDiskUsage.Items] instead.
-	Containers []*container.Summary `json:"Containers,omitempty"`
+	Containers []container.Summary `json:"Containers,omitzero"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [VolumesDiskUsage.Items] instead.
-	Volumes []*volume.Volume `json:"Volumes,omitempty"`
+	Volumes []volume.Volume `json:"Volumes,omitzero"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [BuildCacheDiskUsage.Items] instead.
-	BuildCache []*build.CacheRecord `json:"BuildCache,omitempty"`
+	BuildCache []build.CacheRecord `json:"BuildCache,omitzero"`
 }

--- a/api/types/volume/disk_usage.go
+++ b/api/types/volume/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of volumes.
 	//
-	Items []*Volume `json:"Items,omitempty"`
+	Items []Volume `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing inactive volumes.
 	//

--- a/client/system_disk_usage.go
+++ b/client/system_disk_usage.go
@@ -171,13 +171,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 
 		if options.Verbose {
-			r.Images.Items = slices.Collect(func(yield func(image.Summary) bool) {
-				for _, i := range du.Images {
-					if !yield(*i) {
-						return
-					}
-				}
-			})
+			r.Images.Items = du.Images
 		}
 	}
 
@@ -194,13 +188,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 	} else if du.Containers != nil && options.Verbose {
 		// Fallback for legacy response.
-		r.Containers.Items = slices.Collect(func(yield func(container.Summary) bool) {
-			for _, c := range du.Containers {
-				if !yield(*c) {
-					return
-				}
-			}
-		})
+		r.Containers.Items = du.Containers
 	}
 
 	if du.BuildCacheUsage != nil {
@@ -216,13 +204,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 	} else if du.BuildCache != nil && options.Verbose {
 		// Fallback for legacy response.
-		r.BuildCache.Items = slices.Collect(func(yield func(build.CacheRecord) bool) {
-			for _, b := range du.BuildCache {
-				if !yield(*b) {
-					return
-				}
-			}
-		})
+		r.BuildCache.Items = du.BuildCache
 	}
 
 	if du.VolumeUsage != nil {
@@ -238,13 +220,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 	} else if du.Volumes != nil && options.Verbose {
 		// Fallback for legacy response.
-		r.Volumes.Items = slices.Collect(func(yield func(volume.Volume) bool) {
-			for _, v := range du.Volumes {
-				if !yield(*v) {
-					return
-				}
-			}
-		})
+		r.Volumes.Items = du.Volumes
 	}
 
 	return r, nil

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -131,19 +131,22 @@ func TestDiskUsageWithOptions(t *testing.T) {
 }
 
 func TestLegacyDiskUsage(t *testing.T) {
+	const legacyVersion = "1.51"
 	const expectedURL = "/system/df"
-	client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
-		if err := assertRequest(req, http.MethodGet, expectedURL); err != nil {
-			return nil, err
-		}
+	client, err := NewClientWithOpts(
+		WithVersion(legacyVersion),
+		WithMockClient(func(req *http.Request) (*http.Response, error) {
+			if err := assertRequest(req, http.MethodGet, "/v"+legacyVersion+expectedURL); err != nil {
+				return nil, err
+			}
 
-		return mockJSONResponse(http.StatusOK, nil, system.DiskUsage{
-			LegacyDiskUsage: system.LegacyDiskUsage{
-				LayersSize: 4096,
-				Images:     []image.Summary{},
-			},
-		})(req)
-	}))
+			return mockJSONResponse(http.StatusOK, nil, system.DiskUsage{
+				LegacyDiskUsage: system.LegacyDiskUsage{
+					LayersSize: 4096,
+					Images:     []image.Summary{},
+				},
+			})(req)
+		}))
 	assert.NilError(t, err)
 
 	du, err := client.DiskUsage(context.Background(), DiskUsageOptions{})

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -33,7 +33,7 @@ func TestDiskUsage(t *testing.T) {
 				TotalImages:  0,
 				Reclaimable:  0,
 				TotalSize:    4096,
-				Items:        []*image.Summary{},
+				Items:        []image.Summary{},
 			},
 		})(req)
 	}))

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -140,7 +140,7 @@ func TestLegacyDiskUsage(t *testing.T) {
 		return mockJSONResponse(http.StatusOK, nil, system.DiskUsage{
 			LegacyDiskUsage: system.LegacyDiskUsage{
 				LayersSize: 4096,
-				Images:     []*image.Summary{},
+				Images:     []image.Summary{},
 			},
 		})(req)
 	}))

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/filters"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
+	"github.com/moby/moby/v2/internal/sliceutil"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -51,7 +52,7 @@ func (daemon *Daemon) containerDiskUsage(ctx context.Context, verbose bool) (*ba
 		du.ActiveCount = activeCount
 
 		if verbose {
-			du.Items = containers
+			du.Items = sliceutil.Deref(containers)
 		}
 
 		return du, nil
@@ -96,7 +97,7 @@ func (daemon *Daemon) imageDiskUsage(ctx context.Context, verbose bool) (*backen
 		du.ActiveCount = activeCount
 
 		if verbose {
-			du.Items = images
+			du.Items = sliceutil.Deref(images)
 		}
 
 		return du, nil
@@ -130,7 +131,7 @@ func (daemon *Daemon) localVolumesSize(ctx context.Context, verbose bool) (*back
 		du.ActiveCount = activeCount
 
 		if verbose {
-			du.Items = volumes
+			du.Items = sliceutil.Deref(volumes)
 		}
 
 		return du, nil

--- a/daemon/internal/builder-next/builder.go
+++ b/daemon/internal/builder-next/builder.go
@@ -150,15 +150,15 @@ func (b *Builder) Cancel(ctx context.Context, id string) error {
 }
 
 // DiskUsage returns a report about space used by build cache
-func (b *Builder) DiskUsage(ctx context.Context) ([]*build.CacheRecord, error) {
+func (b *Builder) DiskUsage(ctx context.Context) ([]build.CacheRecord, error) {
 	duResp, err := b.controller.DiskUsage(ctx, &controlapi.DiskUsageRequest{})
 	if err != nil {
 		return nil, err
 	}
 
-	var items []*build.CacheRecord
+	var items []build.CacheRecord
 	for _, r := range duResp.Record {
-		items = append(items, &build.CacheRecord{
+		items = append(items, build.CacheRecord{
 			ID:          r.ID,
 			Parents:     r.Parents,
 			Type:        r.RecordType,

--- a/daemon/server/backend/disk_usage.go
+++ b/daemon/server/backend/disk_usage.go
@@ -37,7 +37,7 @@ type BuildCacheDiskUsage struct {
 	TotalCount  int64
 	TotalSize   int64
 	Reclaimable int64
-	Items       []*build.CacheRecord
+	Items       []build.CacheRecord
 }
 
 // ContainerDiskUsage contains disk usage for containers.
@@ -46,7 +46,7 @@ type ContainerDiskUsage struct {
 	TotalCount  int64
 	TotalSize   int64
 	Reclaimable int64
-	Items       []*container.Summary
+	Items       []container.Summary
 }
 
 // ImageDiskUsage contains disk usage for images.
@@ -55,7 +55,7 @@ type ImageDiskUsage struct {
 	TotalCount  int64
 	TotalSize   int64
 	Reclaimable int64
-	Items       []*image.Summary
+	Items       []image.Summary
 }
 
 // VolumeDiskUsage contains disk usage for volumes.
@@ -64,5 +64,5 @@ type VolumeDiskUsage struct {
 	TotalCount  int64
 	TotalSize   int64
 	Reclaimable int64
-	Items       []*volume.Volume
+	Items       []volume.Volume
 }

--- a/daemon/server/router/system/backend.go
+++ b/daemon/server/router/system/backend.go
@@ -32,7 +32,7 @@ type ClusterBackend interface {
 
 // BuildBackend provides build specific system information.
 type BuildBackend interface {
-	DiskUsage(context.Context) ([]*build.CacheRecord, error)
+	DiskUsage(context.Context) ([]build.CacheRecord, error)
 }
 
 // StatusProvider provides methods to get the swarm status of the current node.

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"slices"
 	"strconv"
 	"time"
 
@@ -197,18 +196,13 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		})
 	}
 
-	var buildCache []*buildtypes.CacheRecord
+	var buildCache []buildtypes.CacheRecord
 	if getBuildCache {
 		eg.Go(func() error {
 			var err error
 			buildCache, err = s.builder.DiskUsage(ctx)
 			if err != nil {
 				return errors.Wrap(err, "error getting build cache usage")
-			}
-			if buildCache == nil {
-				// Ensure empty `BuildCache` field is represented as empty JSON array(`[]`)
-				// instead of `null` to be consistent with `Images`, `Containers` etc.
-				buildCache = []*buildtypes.CacheRecord{}
 			}
 			return nil
 		})
@@ -228,16 +222,10 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		}
 
 		if legacyFields {
-			v.LayersSize = systemDiskUsage.Images.TotalSize //nolint: staticcheck,SA1019: v.LayersSize is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.TotalSize] instead.
-			v.Images = systemDiskUsage.Images.Items         //nolint: staticcheck,SA1019: v.Images is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.Items] instead.
+			v.LayersSize = systemDiskUsage.Images.TotalSize      //nolint: staticcheck,SA1019: v.LayersSize is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.TotalSize] instead.
+			v.Images = nonNilSlice(systemDiskUsage.Images.Items) //nolint: staticcheck,SA1019: v.Images is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.Items] instead.
 		} else if verbose {
-			v.ImageUsage.Items = slices.Collect(func(yield func(image.Summary) bool) {
-				for _, i := range systemDiskUsage.Images.Items {
-					if !yield(*i) {
-						return
-					}
-				}
-			})
+			v.ImageUsage.Items = systemDiskUsage.Images.Items
 		}
 	}
 	if systemDiskUsage != nil && systemDiskUsage.Containers != nil {
@@ -249,15 +237,9 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		}
 
 		if legacyFields {
-			v.Containers = systemDiskUsage.Containers.Items //nolint: staticcheck,SA1019: v.Containers is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ContainersDiskUsage.Items] instead.
+			v.Containers = nonNilSlice(systemDiskUsage.Containers.Items) //nolint: staticcheck,SA1019: v.Containers is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ContainersDiskUsage.Items] instead.
 		} else if verbose {
-			v.ContainerUsage.Items = slices.Collect(func(yield func(container.Summary) bool) {
-				for _, c := range systemDiskUsage.Containers.Items {
-					if !yield(*c) {
-						return
-					}
-				}
-			})
+			v.ContainerUsage.Items = systemDiskUsage.Containers.Items
 		}
 	}
 	if systemDiskUsage != nil && systemDiskUsage.Volumes != nil {
@@ -269,15 +251,9 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		}
 
 		if legacyFields {
-			v.Volumes = systemDiskUsage.Volumes.Items //nolint: staticcheck,SA1019: v.Volumes is deprecated: kept to maintain backwards compatibility with API < v1.52, use [VolumesDiskUsage.Items] instead.
+			v.Volumes = nonNilSlice(systemDiskUsage.Volumes.Items) //nolint: staticcheck,SA1019: v.Volumes is deprecated: kept to maintain backwards compatibility with API < v1.52, use [VolumesDiskUsage.Items] instead.
 		} else if verbose {
-			v.VolumeUsage.Items = slices.Collect(func(yield func(volume.Volume) bool) {
-				for _, v := range systemDiskUsage.Volumes.Items {
-					if !yield(*v) {
-						return
-					}
-				}
-			})
+			v.VolumeUsage.Items = systemDiskUsage.Volumes.Items
 		}
 	}
 	if getBuildCache {
@@ -306,18 +282,21 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		v.BuildCacheUsage.Reclaimable = reclaimable
 
 		if legacyFields {
-			v.BuildCache = buildCache //nolint: staticcheck,SA1019: v.BuildCache is deprecated: kept to maintain backwards compatibility with API < v1.52, use [BuildCacheDiskUsage.Items] instead.
+			v.BuildCache = nonNilSlice(buildCache) //nolint: staticcheck,SA1019: v.BuildCache is deprecated: kept to maintain backwards compatibility with API < v1.52, use [BuildCacheDiskUsage.Items] instead.
 		} else if verbose {
-			v.BuildCacheUsage.Items = slices.Collect(func(yield func(buildtypes.CacheRecord) bool) {
-				for _, b := range buildCache {
-					if !yield(*b) {
-						return
-					}
-				}
-			})
+			v.BuildCacheUsage.Items = buildCache
 		}
 	}
 	return httputils.WriteJSON(w, http.StatusOK, v)
+}
+
+// nonNilSlice is used for the legacy fields, which are either omitted
+// entirely, or (if set), must return an empty slice in the response.
+func nonNilSlice[T any](s []T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return s
 }
 
 type invalidRequestError struct {

--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/moby/moby/api/types/build"
-	containertypes "github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/image"
-	"github.com/moby/moby/api/types/volume"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -56,19 +52,12 @@ func TestDiskUsage(t *testing.T) {
 				}
 
 				assert.DeepEqual(t, du, client.DiskUsageResult{
-					Containers: client.ContainersDiskUsage{
-						Items: []containertypes.Summary{},
-					},
+					Containers: client.ContainersDiskUsage{},
 					Images: client.ImagesDiskUsage{
 						TotalSize: expectedLayersSize,
-						Items:     []image.Summary{},
 					},
-					BuildCache: client.BuildCacheDiskUsage{
-						Items: []build.CacheRecord{},
-					},
-					Volumes: client.VolumesDiskUsage{
-						Items: []volume.Volume{},
-					},
+					BuildCache: client.BuildCacheDiskUsage{},
+					Volumes:    client.VolumesDiskUsage{},
 				})
 				return du
 			},
@@ -155,9 +144,9 @@ func TestDiskUsage(t *testing.T) {
 					},
 					expected: client.DiskUsageResult{
 						Containers: stepDU.Containers,
-						Images:     client.ImagesDiskUsage{Items: []image.Summary{}},
-						BuildCache: client.BuildCacheDiskUsage{Items: []build.CacheRecord{}},
-						Volumes:    client.VolumesDiskUsage{Items: []volume.Volume{}},
+						Images:     client.ImagesDiskUsage{},
+						BuildCache: client.BuildCacheDiskUsage{},
+						Volumes:    client.VolumesDiskUsage{},
 					},
 				},
 				{
@@ -167,10 +156,10 @@ func TestDiskUsage(t *testing.T) {
 						Verbose: true,
 					},
 					expected: client.DiskUsageResult{
-						Containers: client.ContainersDiskUsage{Items: []containertypes.Summary{}},
+						Containers: client.ContainersDiskUsage{},
 						Images:     stepDU.Images,
-						BuildCache: client.BuildCacheDiskUsage{Items: []build.CacheRecord{}},
-						Volumes:    client.VolumesDiskUsage{Items: []volume.Volume{}},
+						BuildCache: client.BuildCacheDiskUsage{},
+						Volumes:    client.VolumesDiskUsage{},
 					},
 				},
 				{
@@ -180,9 +169,9 @@ func TestDiskUsage(t *testing.T) {
 						Verbose: true,
 					},
 					expected: client.DiskUsageResult{
-						Containers: client.ContainersDiskUsage{Items: []containertypes.Summary{}},
-						Images:     client.ImagesDiskUsage{Items: []image.Summary{}},
-						BuildCache: client.BuildCacheDiskUsage{Items: []build.CacheRecord{}},
+						Containers: client.ContainersDiskUsage{},
+						Images:     client.ImagesDiskUsage{},
+						BuildCache: client.BuildCacheDiskUsage{},
 						Volumes:    stepDU.Volumes,
 					},
 				},
@@ -193,10 +182,10 @@ func TestDiskUsage(t *testing.T) {
 						Verbose:    true,
 					},
 					expected: client.DiskUsageResult{
-						Containers: client.ContainersDiskUsage{Items: []containertypes.Summary{}},
-						Images:     client.ImagesDiskUsage{Items: []image.Summary{}},
+						Containers: client.ContainersDiskUsage{},
+						Images:     client.ImagesDiskUsage{},
 						BuildCache: stepDU.BuildCache,
-						Volumes:    client.VolumesDiskUsage{Items: []volume.Volume{}},
+						Volumes:    client.VolumesDiskUsage{},
 					},
 				},
 				{
@@ -208,8 +197,8 @@ func TestDiskUsage(t *testing.T) {
 					},
 					expected: client.DiskUsageResult{
 						Containers: stepDU.Containers,
-						Images:     client.ImagesDiskUsage{Items: []image.Summary{}},
-						BuildCache: client.BuildCacheDiskUsage{Items: []build.CacheRecord{}},
+						Images:     client.ImagesDiskUsage{},
+						BuildCache: client.BuildCacheDiskUsage{},
 						Volumes:    stepDU.Volumes,
 					},
 				},
@@ -221,10 +210,10 @@ func TestDiskUsage(t *testing.T) {
 						Verbose:    true,
 					},
 					expected: client.DiskUsageResult{
-						Containers: client.ContainersDiskUsage{Items: []containertypes.Summary{}},
+						Containers: client.ContainersDiskUsage{},
 						Images:     stepDU.Images,
 						BuildCache: stepDU.BuildCache,
-						Volumes:    client.VolumesDiskUsage{Items: []volume.Volume{}},
+						Volumes:    client.VolumesDiskUsage{},
 					},
 				},
 				{
@@ -237,9 +226,7 @@ func TestDiskUsage(t *testing.T) {
 					},
 					expected: client.DiskUsageResult{
 						Containers: stepDU.Containers,
-						Images: client.ImagesDiskUsage{
-							Items: []image.Summary{},
-						},
+						Images:     client.ImagesDiskUsage{},
 						BuildCache: stepDU.BuildCache,
 						Volumes:    stepDU.Volumes,
 					},
@@ -253,9 +240,7 @@ func TestDiskUsage(t *testing.T) {
 						Verbose:    true,
 					},
 					expected: client.DiskUsageResult{
-						Containers: client.ContainersDiskUsage{
-							Items: []containertypes.Summary{},
-						},
+						Containers: client.ContainersDiskUsage{},
 						Images:     stepDU.Images,
 						BuildCache: stepDU.BuildCache,
 						Volumes:    stepDU.Volumes,
@@ -272,10 +257,8 @@ func TestDiskUsage(t *testing.T) {
 					expected: client.DiskUsageResult{
 						Containers: stepDU.Containers,
 						Images:     stepDU.Images,
-						BuildCache: client.BuildCacheDiskUsage{
-							Items: []build.CacheRecord{},
-						},
-						Volumes: stepDU.Volumes,
+						BuildCache: client.BuildCacheDiskUsage{},
+						Volumes:    stepDU.Volumes,
 					},
 				},
 				{

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,5 +1,18 @@
 package sliceutil
 
+func Deref[T any](slice []*T) []T {
+	if slice == nil {
+		return nil
+	}
+	out := make([]T, 0, len(slice))
+	for _, p := range slice {
+		if p != nil {
+			out = append(out, *p)
+		}
+	}
+	return out
+}
+
 func Dedup[T comparable](slice []T) []T {
 	keys := make(map[T]struct{})
 	out := make([]T, 0, len(slice))

--- a/vendor/github.com/moby/moby/api/types/build/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/build/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of build cache records.
 	//
-	Items []*CacheRecord `json:"Items,omitempty"`
+	Items []CacheRecord `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing inactive build cache records.
 	//

--- a/vendor/github.com/moby/moby/api/types/container/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/container/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of container summaries.
 	//
-	Items []*Summary `json:"Items,omitempty"`
+	Items []Summary `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing inactive containers.
 	//

--- a/vendor/github.com/moby/moby/api/types/image/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/image/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of image summaries.
 	//
-	Items []*Summary `json:"Items,omitempty"`
+	Items []Summary `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing unused images.
 	//

--- a/vendor/github.com/moby/moby/api/types/system/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/system/disk_usage.go
@@ -37,14 +37,14 @@ type LegacyDiskUsage struct {
 	LayersSize int64 `json:"LayersSize,omitempty"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.Items] instead.
-	Images []*image.Summary `json:"Images,omitempty"`
+	Images []image.Summary `json:"Images,omitzero"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ContainersDiskUsage.Items] instead.
-	Containers []*container.Summary `json:"Containers,omitempty"`
+	Containers []container.Summary `json:"Containers,omitzero"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [VolumesDiskUsage.Items] instead.
-	Volumes []*volume.Volume `json:"Volumes,omitempty"`
+	Volumes []volume.Volume `json:"Volumes,omitzero"`
 
 	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [BuildCacheDiskUsage.Items] instead.
-	BuildCache []*build.CacheRecord `json:"BuildCache,omitempty"`
+	BuildCache []build.CacheRecord `json:"BuildCache,omitzero"`
 }

--- a/vendor/github.com/moby/moby/api/types/volume/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/volume/disk_usage.go
@@ -17,7 +17,7 @@ type DiskUsage struct {
 
 	// List of volumes.
 	//
-	Items []*Volume `json:"Items,omitempty"`
+	Items []Volume `json:"Items,omitempty"`
 
 	// Disk space that can be reclaimed by removing inactive volumes.
 	//

--- a/vendor/github.com/moby/moby/client/system_disk_usage.go
+++ b/vendor/github.com/moby/moby/client/system_disk_usage.go
@@ -171,13 +171,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 
 		if options.Verbose {
-			r.Images.Items = slices.Collect(func(yield func(image.Summary) bool) {
-				for _, i := range du.Images {
-					if !yield(*i) {
-						return
-					}
-				}
-			})
+			r.Images.Items = du.Images
 		}
 	}
 
@@ -194,13 +188,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 	} else if du.Containers != nil && options.Verbose {
 		// Fallback for legacy response.
-		r.Containers.Items = slices.Collect(func(yield func(container.Summary) bool) {
-			for _, c := range du.Containers {
-				if !yield(*c) {
-					return
-				}
-			}
-		})
+		r.Containers.Items = du.Containers
 	}
 
 	if du.BuildCacheUsage != nil {
@@ -216,13 +204,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 	} else if du.BuildCache != nil && options.Verbose {
 		// Fallback for legacy response.
-		r.BuildCache.Items = slices.Collect(func(yield func(build.CacheRecord) bool) {
-			for _, b := range du.BuildCache {
-				if !yield(*b) {
-					return
-				}
-			}
-		})
+		r.BuildCache.Items = du.BuildCache
 	}
 
 	if du.VolumeUsage != nil {
@@ -238,13 +220,7 @@ func (cli *Client) DiskUsage(ctx context.Context, options DiskUsageOptions) (Dis
 		}
 	} else if du.Volumes != nil && options.Verbose {
 		// Fallback for legacy response.
-		r.Volumes.Items = slices.Collect(func(yield func(volume.Volume) bool) {
-			for _, v := range du.Volumes {
-				if !yield(*v) {
-					return
-				}
-			}
-		})
+		r.Volumes.Items = du.Volumes
 	}
 
 	return r, nil


### PR DESCRIPTION
**- What I did**
Follow-up to https://github.com/moby/moby/pull/51406 to use regular slices instead of pointers.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

