### PR TITLE
gha/vm: Adjust lima template locators

### DIFF
--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -22,6 +22,7 @@ on:
 env:
   GO_VERSION: "1.25.5"
   TESTSTAT_VERSION: v0.1.25
+  TEMPLATE_NAME: ${{ inputs.template }}
 
 jobs:
   integration:
@@ -147,7 +148,8 @@ jobs:
         run: |
           set -eux -o pipefail
           limactl cp -v -r default:/tmp/docker/bundles . || true
-          reportsName="$(basename ${{ inputs.template }})"
+          reportsName="${{ env.TEMPLATE_NAME }}"
+          reportsName="${reportsName#template:}"
           if [ -n "${{ matrix.mode }}" ]; then
             reportsName="$reportsName-${{ matrix.mode }}"
           fi
@@ -189,7 +191,10 @@ jobs:
           cache: false
       -
         name: Prepare reports
-        run: echo "TESTREPORTS_NAME=$(basename ${{ inputs.template }})*" >> $GITHUB_ENV
+        run: |
+          TEMPLATE="${{ env.TEMPLATE_NAME }}"
+          TEMPLATE="${TEMPLATE#template:}"
+          echo "TESTREPORTS_NAME=${TEMPLATE}*" >> $GITHUB_ENV
       -
         name: Download reports
         uses: actions/download-artifact@v6

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -40,7 +40,7 @@ jobs:
           # FIXME: use almalinux-8, then probably no need to keep oraclelinux-8 here.
           # On almalinux-8, port forwarding tests are failing:
           # https://github.com/moby/moby/pull/49819#issuecomment-2815676000
-          - template://oraclelinux-8  # Oracle's kernel 5.15
-          # - template://almalinux-8  # kernel 4.18
+          - template:oraclelinux-8  # Oracle's kernel 5.15
+          # - template:almalinux-8  # kernel 4.18
     with:
       template: ${{ matrix.template }}


### PR DESCRIPTION
Fixes:
```
Run # --plain is set because the built-in containerd support conflicts with Docker
time="2025-11-06T11:22:30Z" level=warning msg="Template locator \"template://oraclelinux-8\" should be written \"template:oraclelinux-8\" since Lima v2.0"
time="2025-11-06T11:22:30Z" level=fatal msg="template \"_images/oraclelinux-8.yaml\" not found"
```

observed in: https://github.com/moby/moby/actions/runs/19133930630/job/54681245416?pr=51390

https://github.com/moby/moby/pull/51390
