### PR TITLE
gha/vm: Force Lima v1.2.2

### DIFF
--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -44,6 +44,8 @@ jobs:
         name: Set up Lima
         uses: lima-vm/lima-actions/setup@03b96d61959e83b2c737e44162c3088e81de0886  # v1.0.1
         id: lima-actions-setup
+        with:
+          version: v1.2.2
       -
         name: Cache ~/.cache/lima
         uses: actions/cache@v4


### PR DESCRIPTION
- workaround: https://github.com/lima-vm/lima/issues/4313

Temporarily revert lima version from v2 to v1.

See: https://github.com/moby/moby/pull/51416