### PR TITLE
delete trivially redundant/incorrect cmd/dockerd/README.md

### DIFF
--- a/cmd/dockerd/README.md
+++ b/cmd/dockerd/README.md
@@ -1,3 +1,0 @@
-docker.go contains Docker daemon's main function.
-
-This file provides first line CLI argument parsing and environment variable setting.


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Delete trivially redundant/incorrect cmd/dockerd/README.md

The README was useful when it was pointing to `docker.go` and when `docker.go` contained the arg parsing and env setting code, but the structure was simplified by @dmcgowan in 33139da5225a4926383da76618784d877ed3d568

It seems pointless to update it to say the obvious:

> main.go contains Docker daemon's main function.

and this part is out of date

> This file provides first line CLI argument parsing and environment variable setting.

Since it seems redundant with the new simpler structure, I recommend deleting it.


**- A picture of a cute animal (not mandatory but encouraged)**

The world's tiniest frog [Paedophryne amauensis](https://www.science.org/content/article/scienceshot-smaller-dime-frog-worlds-tiniest-vertebrate) for one of the world's smallest PRs:

<img width="560" height="467" alt="image" src="https://github.com/user-attachments/assets/35e90b46-2dc2-4ebd-9e78-2233555819b3" />
