### PR TITLE
integration: increase timeout; gha/vm: update Lima to v2.0.2

### DIFF
--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -45,7 +45,7 @@ jobs:
         uses: lima-vm/lima-actions/setup@03b96d61959e83b2c737e44162c3088e81de0886  # v1.0.1
         id: lima-actions-setup
         with:
-          version: v1.2.2
+          version: v2.0.2
       -
         name: Cache ~/.cache/lima
         uses: actions/cache@v4

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -768,7 +768,7 @@ func TestCreateWithCustomMACs(t *testing.T) {
 
 	net.CreateNoError(ctx, t, apiClient, "testnet")
 
-	attachCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	res := testContainer.RunAttach(attachCtx, t, apiClient,
 		testContainer.WithCmd("ip", "-o", "link", "show"),

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -40,7 +40,7 @@ func TestCreateWithMultiNetworks(t *testing.T) {
 	network.CreateNoError(ctx, t, apiClient, "testnet2")
 	defer network.RemoveNoError(ctx, t, apiClient, "testnet2")
 
-	attachCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	attachCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	res := ctr.RunAttach(attachCtx, t, apiClient,
 		ctr.WithCmd("ip", "-o", "-4", "addr", "show"),

--- a/integration/network/network_linux_test.go
+++ b/integration/network/network_linux_test.go
@@ -392,7 +392,7 @@ func checkCtrRoutes(t *testing.T, ctx context.Context, apiClient client.APIClien
 		fam = "-6"
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	res, err := container.Exec(ctx, apiClient, ctrID, []string{"ip", "-o", fam, "route", "show"})
 	assert.NilError(t, err)


### PR DESCRIPTION
Revert:
- #51417 

The regression https://github.com/lima-vm/lima/issues/4313 in Lima v2.0.0 was addressed in Lima v2.0.1.
