### PR TITLE
cmd/dockerd: minor cleanups / changes

### DIFF
--- a/cmd/dockerd/main.go
+++ b/cmd/dockerd/main.go
@@ -26,16 +26,14 @@ func main() {
 
 	// Set terminal emulation based on platform as required.
 	_, stdout, stderr := term.StdStreams()
-	onError := func(err error) {
-		_, _ = fmt.Fprintln(stderr, err)
-		os.Exit(1)
-	}
 
 	r, err := command.NewDaemonRunner(stdout, stderr)
 	if err != nil {
-		onError(err)
+		_, _ = fmt.Fprintln(stderr, err)
+		os.Exit(1)
 	}
 	if err := r.Run(ctx); err != nil {
-		onError(err)
+		_, _ = fmt.Fprintln(stderr, err)
+		os.Exit(1)
 	}
 }

--- a/daemon/command/docker.go
+++ b/daemon/command/docker.go
@@ -15,7 +15,7 @@ import (
 
 var honorXDG bool
 
-func newDaemonCommand(stderr io.Writer) (*cobra.Command, error) {
+func newDaemonCommand() (*cobra.Command, error) {
 	// FIXME(thaJeztah): config.New also looks up default binary-path, but this code is also executed when running "--version".
 	cfg, err := config.New()
 	if err != nil {
@@ -38,7 +38,10 @@ func newDaemonCommand(stderr io.Writer) (*cobra.Command, error) {
 			}
 			if opts.Validate {
 				// If config wasn't OK we wouldn't have made it this far.
-				_, _ = fmt.Fprintln(stderr, "configuration OK")
+				//
+				// We print this message on STDERR, not STDOUT, to align
+				// with other tools, such as "nginx -t" or "sshd -t".
+				cmd.PrintErrln("configuration OK")
 				return nil
 			}
 
@@ -104,11 +107,12 @@ func NewDaemonRunner(stdout, stderr io.Writer) (Runner, error) {
 
 	initLogging(stdout, stderr)
 
-	cmd, err := newDaemonCommand(stderr)
+	cmd, err := newDaemonCommand()
 	if err != nil {
 		return nil, err
 	}
 	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
 
 	return daemonRunner{cmd}, nil
 }


### PR DESCRIPTION
part of a branch where I was working on removing the `dockerversion` package; still incomplete, so let me get these already in;

### cmd/dockerd: main(): remove "onError" func

Remove the redundant abstraction; just inline it.

### daemon/command: NewDaemonRunner: set both stdout and stderr

Make sure Cobra is configured with the streams we use, and use
Cobra's utilities to print the validation messsage.

While updating, also add a short comment outlining why we're using
STDERR, not STDOUT for this message.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

