### PR TITLE
client: remove uses of deprecated NewClientWithOpts

### DIFF
--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -16,7 +15,7 @@ import (
 func TestDiskUsageError(t *testing.T) {
 	client, err := New(WithMockClient(errorMock(http.StatusInternalServerError, "Server error")))
 	assert.NilError(t, err)
-	_, err = client.DiskUsage(context.Background(), DiskUsageOptions{})
+	_, err = client.DiskUsage(t.Context(), DiskUsageOptions{})
 	assert.Check(t, is.ErrorType(err, cerrdefs.IsInternal))
 }
 
@@ -39,7 +38,7 @@ func TestDiskUsage(t *testing.T) {
 	}))
 	assert.NilError(t, err)
 
-	du, err := client.DiskUsage(context.Background(), DiskUsageOptions{})
+	du, err := client.DiskUsage(t.Context(), DiskUsageOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, du.Images.ActiveImages, int64(0))
 	assert.Equal(t, du.Images.TotalImages, int64(0))
@@ -116,7 +115,7 @@ func TestDiskUsageWithOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("options=%+v", tt.options), func(t *testing.T) {
-			client, err := NewClientWithOpts(WithMockClient(func(req *http.Request) (*http.Response, error) {
+			client, err := New(WithMockClient(func(req *http.Request) (*http.Response, error) {
 				if err := assertRequestWithQuery(req, http.MethodGet, expectedURL, tt.expectedQuery); err != nil {
 					return nil, err
 				}
@@ -133,7 +132,7 @@ func TestDiskUsageWithOptions(t *testing.T) {
 func TestLegacyDiskUsage(t *testing.T) {
 	const legacyVersion = "1.51"
 	const expectedURL = "/system/df"
-	client, err := NewClientWithOpts(
+	client, err := New(
 		WithVersion(legacyVersion),
 		WithMockClient(func(req *http.Request) (*http.Response, error) {
 			if err := assertRequest(req, http.MethodGet, "/v"+legacyVersion+expectedURL); err != nil {
@@ -149,7 +148,7 @@ func TestLegacyDiskUsage(t *testing.T) {
 		}))
 	assert.NilError(t, err)
 
-	du, err := client.DiskUsage(context.Background(), DiskUsageOptions{})
+	du, err := client.DiskUsage(t.Context(), DiskUsageOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, du.Images.ActiveImages, int64(0))
 	assert.Equal(t, du.Images.TotalImages, int64(0))


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

