### PR TITLE
daemon: refactor disk-usage endpoint

### DIFF
--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -26,30 +26,27 @@ func (daemon *Daemon) containerDiskUsage(ctx context.Context, verbose bool) (*ba
 			return nil, fmt.Errorf("failed to retrieve container list: %v", err)
 		}
 
-		// Remove image manifest descriptor from the result as it should not be included.
-		// https://github.com/moby/moby/pull/49407#discussion_r1954396666
-		for _, c := range containers {
-			c.ImageManifestDescriptor = nil
-		}
-
 		isActive := func(ctr *container.Summary) bool {
 			return ctr.State == container.StateRunning ||
 				ctr.State == container.StatePaused ||
 				ctr.State == container.StateRestarting
 		}
 
-		activeCount := int64(len(containers))
-
-		du := &backend.ContainerDiskUsage{TotalCount: activeCount}
+		du := &backend.ContainerDiskUsage{
+			ActiveCount: int64(len(containers)),
+			TotalCount:  int64(len(containers)),
+		}
 		for _, ctr := range containers {
 			du.TotalSize += ctr.SizeRw
 			if !isActive(ctr) {
 				du.Reclaimable += ctr.SizeRw
-				activeCount--
+				du.ActiveCount--
 			}
-		}
 
-		du.ActiveCount = activeCount
+			// Remove image manifest descriptor from the result as it should not be included.
+			// https://github.com/moby/moby/pull/49407#discussion_r1954396666
+			ctr.ImageManifestDescriptor = nil
+		}
 
 		if verbose {
 			du.Items = sliceutil.Deref(containers)
@@ -73,28 +70,28 @@ func (daemon *Daemon) imageDiskUsage(ctx context.Context, verbose bool) (*backen
 			return nil, errors.Wrap(err, "failed to retrieve image list")
 		}
 
-		reclaimable, _, err := daemon.usageLayer.Do(ctx, struct{}{}, func(ctx context.Context) (int64, error) {
+		totalSize, _, err := daemon.usageLayer.Do(ctx, struct{}{}, func(ctx context.Context) (int64, error) {
 			return daemon.imageService.ImageDiskUsage(ctx)
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to calculate image disk usage")
 		}
 
-		activeCount := int64(len(images))
-
-		du := &backend.ImageDiskUsage{TotalCount: activeCount, TotalSize: reclaimable}
+		du := &backend.ImageDiskUsage{
+			ActiveCount: int64(len(images)),
+			Reclaimable: totalSize,
+			TotalCount:  int64(len(images)),
+			TotalSize:   totalSize,
+		}
 		for _, i := range images {
 			if i.Containers == 0 {
-				activeCount--
+				du.ActiveCount--
 				if i.Size == -1 || i.SharedSize == -1 {
 					continue
 				}
-				reclaimable -= i.Size - i.SharedSize
+				du.Reclaimable -= i.Size - i.SharedSize
 			}
 		}
-
-		du.Reclaimable = reclaimable
-		du.ActiveCount = activeCount
 
 		if verbose {
 			du.Items = sliceutil.Deref(images)
@@ -115,20 +112,19 @@ func (daemon *Daemon) localVolumesSize(ctx context.Context, verbose bool) (*back
 			return nil, err
 		}
 
-		activeCount := int64(len(volumes))
-
-		du := &backend.VolumeDiskUsage{TotalCount: activeCount}
+		du := &backend.VolumeDiskUsage{
+			ActiveCount: int64(len(volumes)),
+			TotalCount:  int64(len(volumes)),
+		}
 		for _, v := range volumes {
 			if v.UsageData.Size != -1 {
+				du.TotalSize += v.UsageData.Size
 				if v.UsageData.RefCount == 0 {
 					du.Reclaimable += v.UsageData.Size
-					activeCount--
+					du.ActiveCount--
 				}
-				du.TotalSize += v.UsageData.Size
 			}
 		}
-
-		du.ActiveCount = activeCount
 
 		if verbose {
 			du.Items = sliceutil.Deref(volumes)

--- a/daemon/server/backend/disk_usage.go
+++ b/daemon/server/backend/disk_usage.go
@@ -28,41 +28,14 @@ type DiskUsage struct {
 	Images     *ImageDiskUsage
 	Containers *ContainerDiskUsage
 	Volumes    *VolumeDiskUsage
-	BuildCache *BuildCacheDiskUsage
-}
-
-// BuildCacheDiskUsage contains disk usage for the build cache.
-type BuildCacheDiskUsage struct {
-	ActiveCount int64
-	TotalCount  int64
-	TotalSize   int64
-	Reclaimable int64
-	Items       []build.CacheRecord
+	BuildCache *build.DiskUsage
 }
 
 // ContainerDiskUsage contains disk usage for containers.
-type ContainerDiskUsage struct {
-	ActiveCount int64
-	TotalCount  int64
-	TotalSize   int64
-	Reclaimable int64
-	Items       []container.Summary
-}
+type ContainerDiskUsage = container.DiskUsage
 
 // ImageDiskUsage contains disk usage for images.
-type ImageDiskUsage struct {
-	ActiveCount int64
-	TotalCount  int64
-	TotalSize   int64
-	Reclaimable int64
-	Items       []image.Summary
-}
+type ImageDiskUsage = image.DiskUsage
 
 // VolumeDiskUsage contains disk usage for volumes.
-type VolumeDiskUsage struct {
-	ActiveCount int64
-	TotalCount  int64
-	TotalSize   int64
-	Reclaimable int64
-	Items       []volume.Volume
-}
+type VolumeDiskUsage = volume.DiskUsage

--- a/daemon/server/buildbackend/build.go
+++ b/daemon/server/buildbackend/build.go
@@ -11,6 +11,13 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/filters"
 )
 
+type DiskUsageOptions struct {
+	Verbose bool
+}
+
+// DiskUsage contains disk usage for the build cache.
+type DiskUsage = build.DiskUsage
+
 type CachePruneOptions struct {
 	All           bool
 	ReservedSpace int64

--- a/daemon/server/router/system/backend.go
+++ b/daemon/server/router/system/backend.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/v2/daemon/internal/filters"
 	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/buildbackend"
 )
 
 // Backend is the methods that need to be implemented to provide
@@ -32,7 +32,7 @@ type ClusterBackend interface {
 
 // BuildBackend provides build specific system information.
 type BuildBackend interface {
-	DiskUsage(context.Context) ([]build.CacheRecord, error)
+	DiskUsage(context.Context, buildbackend.DiskUsageOptions) (*buildbackend.DiskUsage, error)
 }
 
 // StatusProvider provides methods to get the swarm status of the current node.

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -183,11 +183,11 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 
 	eg, ctx := errgroup.WithContext(ctx)
 
-	var systemDiskUsage *backend.DiskUsage
+	var diskUsage *backend.DiskUsage
 	if getContainers || getImages || getVolumes {
 		eg.Go(func() error {
 			var err error
-			systemDiskUsage, err = s.backend.SystemDiskUsage(ctx, backend.DiskUsageOptions{
+			diskUsage, err = s.backend.SystemDiskUsage(ctx, backend.DiskUsageOptions{
 				Containers: getContainers,
 				Images:     getImages,
 				Volumes:    getVolumes,
@@ -214,47 +214,47 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	var v system.DiskUsage
-	if systemDiskUsage != nil && systemDiskUsage.Images != nil {
+	if diskUsage != nil && diskUsage.Images != nil {
 		v.ImageUsage = &image.DiskUsage{
-			ActiveCount: systemDiskUsage.Images.ActiveCount,
-			Reclaimable: systemDiskUsage.Images.Reclaimable,
-			TotalCount:  systemDiskUsage.Images.TotalCount,
-			TotalSize:   systemDiskUsage.Images.TotalSize,
+			ActiveCount: diskUsage.Images.ActiveCount,
+			Reclaimable: diskUsage.Images.Reclaimable,
+			TotalCount:  diskUsage.Images.TotalCount,
+			TotalSize:   diskUsage.Images.TotalSize,
 		}
 
 		if legacyFields {
-			v.LayersSize = systemDiskUsage.Images.TotalSize      //nolint: staticcheck,SA1019: v.LayersSize is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.TotalSize] instead.
-			v.Images = nonNilSlice(systemDiskUsage.Images.Items) //nolint: staticcheck,SA1019: v.Images is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.Items] instead.
+			v.LayersSize = diskUsage.Images.TotalSize      //nolint: staticcheck,SA1019: kept to maintain backwards compatibility with API < v1.52.
+			v.Images = nonNilSlice(diskUsage.Images.Items) //nolint: staticcheck,SA1019: kept to maintain backwards compatibility with API < v1.52.
 		} else if verbose {
-			v.ImageUsage.Items = systemDiskUsage.Images.Items
+			v.ImageUsage.Items = diskUsage.Images.Items
 		}
 	}
-	if systemDiskUsage != nil && systemDiskUsage.Containers != nil {
+	if diskUsage != nil && diskUsage.Containers != nil {
 		v.ContainerUsage = &container.DiskUsage{
-			ActiveCount: systemDiskUsage.Containers.ActiveCount,
-			Reclaimable: systemDiskUsage.Containers.Reclaimable,
-			TotalCount:  systemDiskUsage.Containers.TotalCount,
-			TotalSize:   systemDiskUsage.Containers.TotalSize,
+			ActiveCount: diskUsage.Containers.ActiveCount,
+			Reclaimable: diskUsage.Containers.Reclaimable,
+			TotalCount:  diskUsage.Containers.TotalCount,
+			TotalSize:   diskUsage.Containers.TotalSize,
 		}
 
 		if legacyFields {
-			v.Containers = nonNilSlice(systemDiskUsage.Containers.Items) //nolint: staticcheck,SA1019: v.Containers is deprecated: kept to maintain backwards compatibility with API < v1.52, use [ContainersDiskUsage.Items] instead.
+			v.Containers = nonNilSlice(diskUsage.Containers.Items) //nolint: staticcheck,SA1019: kept to maintain backwards compatibility with API < v1.52.
 		} else if verbose {
-			v.ContainerUsage.Items = systemDiskUsage.Containers.Items
+			v.ContainerUsage.Items = diskUsage.Containers.Items
 		}
 	}
-	if systemDiskUsage != nil && systemDiskUsage.Volumes != nil {
+	if diskUsage != nil && diskUsage.Volumes != nil {
 		v.VolumeUsage = &volume.DiskUsage{
-			ActiveCount: systemDiskUsage.Volumes.ActiveCount,
-			TotalSize:   systemDiskUsage.Volumes.TotalSize,
-			Reclaimable: systemDiskUsage.Volumes.Reclaimable,
-			TotalCount:  systemDiskUsage.Volumes.TotalCount,
+			ActiveCount: diskUsage.Volumes.ActiveCount,
+			TotalSize:   diskUsage.Volumes.TotalSize,
+			Reclaimable: diskUsage.Volumes.Reclaimable,
+			TotalCount:  diskUsage.Volumes.TotalCount,
 		}
 
 		if legacyFields {
-			v.Volumes = nonNilSlice(systemDiskUsage.Volumes.Items) //nolint: staticcheck,SA1019: v.Volumes is deprecated: kept to maintain backwards compatibility with API < v1.52, use [VolumesDiskUsage.Items] instead.
+			v.Volumes = nonNilSlice(diskUsage.Volumes.Items) //nolint: staticcheck,SA1019: kept to maintain backwards compatibility with API < v1.52.
 		} else if verbose {
-			v.VolumeUsage.Items = systemDiskUsage.Volumes.Items
+			v.VolumeUsage.Items = diskUsage.Volumes.Items
 		}
 	}
 	if getBuildCache {
@@ -283,7 +283,7 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		v.BuildCacheUsage.Reclaimable = reclaimable
 
 		if legacyFields {
-			v.BuildCache = nonNilSlice(buildCache) //nolint: staticcheck,SA1019: v.BuildCache is deprecated: kept to maintain backwards compatibility with API < v1.52, use [BuildCacheDiskUsage.Items] instead.
+			v.BuildCache = nonNilSlice(buildCache) //nolint: staticcheck,SA1019: kept to maintain backwards compatibility with API < v1.52.
 		} else if verbose {
 			v.BuildCacheUsage.Items = buildCache
 		}


### PR DESCRIPTION
### daemon/server/router/system: slightly rewrite logic for legacy

Rewrite the logic to have a better separation between producing legacy
fields, and verbose. We need to preserve / include all items in the
response _either_ if a API >= v1.52 client requested "verbose" _or_
if we're about to produce legacy fields.

Also switch to using the `httputils.BoolValue` utility; while we lose
the error for invalid values (which we probably should have as a utility
in `httputils`), it aligns with values accepted for other boolean values.

### daemon/server/router/system: use shorter names and comments

### daemon/server/backend: align DiskUsage types with api

Make the "per-object" types aliases for the API type, and remove
the BuildBackend type, as it's not currently used

### daemon: align build.DiskUsage() with other disk-usages

Move calculation of the data to the builder backend, to align with
the other type of objects. This also allows us to skip the verbose
data if it's not used.

### daemon: remove intermediate vars when collecting diskUsage

Set values directly on the DiskUsage objects instead of using some
intermediate vars, some of which were named slightly confusing due
to them being used both for "totalSize" and "reclaimableSize".

### daemon/server/router/system: use early return for disk-usage

Use early return for legacy response. When using API < v1.52, we'd
never return the new fields, so we can return early, and produce the
legacy-fields only.

### daemon/server/router/system: simplify constructing response

Now that we separated the legacy response from non-legacy responses,
we can consume the data produced by the backend as-is; the backend
takes care of omitting "verbose" data (leaving the `Items` slices
empty), and with an early return for the legacy responses, we won't
end up with returning _both_ responses on API < v1.52, but (TBD) still
return both responses for API v1.52.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

