### PR TITLE
api: remove / internalize LegacyDiskUsage

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -75,9 +75,11 @@ keywords: "API, Docker, rcli, REST, documentation"
   `BuildCacheUsage` fields with brief system disk usage data for each system object type.
   The endpoint supports the `?verbose=1` query to return verbose system disk usage information.
 * Deprecated: `GET /system/df` response fields `LayersSize`, `Images`, `Containers`,
-  `Volumes`, and `BuildCache` are deprecated in favor of the type specific usage fields.
-  The legacy fields will not be populated for new API versions that specify the `verbose`
-  query.
+  `Volumes`, and `BuildCache` have been removed in favor of the-type specific usage fields.
+  API v1.52 returns both the legacy and current fields to help existing integrations
+  to transition to the new response. The legacy fields are not populated if the
+  `verbose` query parameter is used. Starting with API v1.53, the legacy fields
+  will no longer be returned.
 
 ## v1.51 API changes
 

--- a/api/types/system/disk_usage.go
+++ b/api/types/system/disk_usage.go
@@ -24,27 +24,8 @@ const (
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {
-	LegacyDiskUsage
-
 	ImageUsage      *image.DiskUsage     `json:"ImageUsage,omitempty"`
 	ContainerUsage  *container.DiskUsage `json:"ContainerUsage,omitempty"`
 	VolumeUsage     *volume.DiskUsage    `json:"VolumeUsage,omitempty"`
 	BuildCacheUsage *build.DiskUsage     `json:"BuildCacheUsage,omitempty"`
-}
-
-type LegacyDiskUsage struct {
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.TotalSize] instead.
-	LayersSize int64 `json:"LayersSize,omitempty"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.Items] instead.
-	Images []image.Summary `json:"Images,omitzero"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ContainersDiskUsage.Items] instead.
-	Containers []container.Summary `json:"Containers,omitzero"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [VolumesDiskUsage.Items] instead.
-	Volumes []volume.Volume `json:"Volumes,omitzero"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [BuildCacheDiskUsage.Items] instead.
-	BuildCache []build.CacheRecord `json:"BuildCache,omitzero"`
 }

--- a/client/system_disk_usage_test.go
+++ b/client/system_disk_usage_test.go
@@ -139,11 +139,9 @@ func TestLegacyDiskUsage(t *testing.T) {
 				return nil, err
 			}
 
-			return mockJSONResponse(http.StatusOK, nil, system.DiskUsage{
-				LegacyDiskUsage: system.LegacyDiskUsage{
-					LayersSize: 4096,
-					Images:     []image.Summary{},
-				},
+			return mockJSONResponse(http.StatusOK, nil, &legacyDiskUsage{
+				LayersSize: 4096,
+				Images:     []image.Summary{},
 			})(req)
 		}))
 	assert.NilError(t, err)

--- a/daemon/server/router/system/disk_usage.go
+++ b/daemon/server/router/system/disk_usage.go
@@ -1,0 +1,27 @@
+package system
+
+import (
+	buildtypes "github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/system"
+	"github.com/moby/moby/api/types/volume"
+)
+
+// diskUsageCompat is used to provide API responses with backward-compatibility
+// for API < v1.52, which used a different format. For API v1.52, we return
+// both "old" and "new" responses if the client did not explicitly opt in to
+// using the new format (through the use of the "verbose" query-parameter).
+type diskUsageCompat struct {
+	*legacyDiskUsage
+	*system.DiskUsage
+}
+
+// legacyDiskUsage is the response as was used by API < v1.52.
+type legacyDiskUsage struct {
+	LayersSize int64                    `json:"LayersSize,omitempty"`
+	Images     []image.Summary          `json:"Images,omitzero"`
+	Containers []container.Summary      `json:"Containers,omitzero"`
+	Volumes    []volume.Volume          `json:"Volumes,omitzero"`
+	BuildCache []buildtypes.CacheRecord `json:"BuildCache,omitzero"`
+}

--- a/vendor/github.com/moby/moby/api/types/system/disk_usage.go
+++ b/vendor/github.com/moby/moby/api/types/system/disk_usage.go
@@ -24,27 +24,8 @@ const (
 // DiskUsage contains response of Engine API:
 // GET "/system/df"
 type DiskUsage struct {
-	LegacyDiskUsage
-
 	ImageUsage      *image.DiskUsage     `json:"ImageUsage,omitempty"`
 	ContainerUsage  *container.DiskUsage `json:"ContainerUsage,omitempty"`
 	VolumeUsage     *volume.DiskUsage    `json:"VolumeUsage,omitempty"`
 	BuildCacheUsage *build.DiskUsage     `json:"BuildCacheUsage,omitempty"`
-}
-
-type LegacyDiskUsage struct {
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.TotalSize] instead.
-	LayersSize int64 `json:"LayersSize,omitempty"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ImagesDiskUsage.Items] instead.
-	Images []image.Summary `json:"Images,omitzero"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [ContainersDiskUsage.Items] instead.
-	Containers []container.Summary `json:"Containers,omitzero"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [VolumesDiskUsage.Items] instead.
-	Volumes []volume.Volume `json:"Volumes,omitzero"`
-
-	// Deprecated: kept to maintain backwards compatibility with API < v1.52, use [BuildCacheDiskUsage.Items] instead.
-	BuildCache []build.CacheRecord `json:"BuildCache,omitzero"`
 }


### PR DESCRIPTION
- [x] follow-up to / stacked on https://github.com/moby/moby/pull/51436
- [x] follow-up to / stacked on https://github.com/moby/moby/pull/51438


-----

### api: remove / internalize LegacyDiskUsage

These fields have been removed from the API specification, and the struct
was only needed to produce legacy responses (server), or to unmarshal
legacy responses in the client.

As the API module only provides API definitions for the current API version,
we should remove these legacy structs, and keep them internal to the daemon
and client.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

