### PR TITLE
api, client: don't use a pointer-slice for plugins

### DIFF
--- a/api/types/plugin/plugin_responses.go
+++ b/api/types/plugin/plugin_responses.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ListResponse contains the response for the Engine API
-type ListResponse []*Plugin
+type ListResponse []Plugin
 
 // Privilege describes a permission the user has to accept
 // upon installing a plugin.

--- a/client/plugin_list.go
+++ b/client/plugin_list.go
@@ -15,7 +15,7 @@ type PluginListOptions struct {
 
 // PluginListResult represents the result of a plugin list operation.
 type PluginListResult struct {
-	Items []*plugin.Plugin
+	Items []plugin.Plugin
 }
 
 // PluginList returns the installed plugins

--- a/client/plugin_list_test.go
+++ b/client/plugin_list_test.go
@@ -64,7 +64,7 @@ func TestPluginList(t *testing.T) {
 					return nil, fmt.Errorf("%s not set in URL query properly. Expected '%s', got %s", key, expected, actual)
 				}
 			}
-			return mockJSONResponse(http.StatusOK, nil, []*plugin.Plugin{
+			return mockJSONResponse(http.StatusOK, nil, []plugin.Plugin{
 				{ID: "plugin_id1"},
 				{ID: "plugin_id2"},
 			})(req)

--- a/vendor/github.com/moby/moby/api/types/plugin/plugin_responses.go
+++ b/vendor/github.com/moby/moby/api/types/plugin/plugin_responses.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ListResponse contains the response for the Engine API
-type ListResponse []*Plugin
+type ListResponse []Plugin
 
 // Privilege describes a permission the user has to accept
 // upon installing a plugin.

--- a/vendor/github.com/moby/moby/client/plugin_list.go
+++ b/vendor/github.com/moby/moby/client/plugin_list.go
@@ -15,7 +15,7 @@ type PluginListOptions struct {
 
 // PluginListResult represents the result of a plugin list operation.
 type PluginListResult struct {
-	Items []*plugin.Plugin
+	Items []plugin.Plugin
 }
 
 // PluginList returns the installed plugins


### PR DESCRIPTION
The backend and router don't use a pointer-slice (the server actually doesn't use the `plugin.ListResponse` type and a straight slice); https://github.com/moby/moby/blob/778e5bfad3098bcc1b1457634e14c1c204ebf851/daemon/server/router/plugin/backend.go#L20 https://github.com/moby/moby/blob/6baf274fa3e90731ac653967cb0cea38e82b5e36/daemon/server/router/plugin/plugin_routes.go#L276-L280

Align the type in the API to match, and update the type defined in the client accordingly.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/plugin: change ListResponse to a non-pointer slice
client: PluginListResult: change Items field to a non-pointer slice
```

**- A picture of a cute animal (not mandatory but encouraged)**

