### PR TITLE
[28.x backport] Dockerfile: test containerd v2.1.5 (linux), v2.0.7 (windows)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v1.7.29
+ARG CONTAINERD_VERSION=v2.1.4
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -171,7 +171,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # When updating the binary version you may also need to update the vendor
 # version to pick up bug fixes or new APIs, however, usually the Go packages
 # are built from a commit from the master branch.
-ARG CONTAINERD_VERSION=v2.1.4
+ARG CONTAINERD_VERSION=v2.1.5
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -168,7 +168,10 @@ ARG GOTESTSUM_VERSION=v1.12.3
 
 # GOWINRES_VERSION is the version of go-winres to install.
 ARG GOWINRES_VERSION=v0.3.3
-ARG CONTAINERD_VERSION=v1.7.29
+
+# TODO: Update containerd version to match Linux version once
+# https://github.com/microsoft/hcsshim/issues/2488 is resolved.
+ARG CONTAINERD_VERSION=v2.0.6
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -171,7 +171,7 @@ ARG GOWINRES_VERSION=v0.3.3
 
 # TODO: Update containerd version to match Linux version once
 # https://github.com/microsoft/hcsshim/issues/2488 is resolved.
-ARG CONTAINERD_VERSION=v2.0.6
+ARG CONTAINERD_VERSION=v2.0.7
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v1.7.29}"
+: "${CONTAINERD_VERSION:=v2.1.4}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -15,7 +15,7 @@ set -e
 # the binary version you may also need to update the vendor version to pick up
 # bug fixes or new APIs, however, usually the Go packages are built from a
 # commit from the master branch.
-: "${CONTAINERD_VERSION:=v2.1.4}"
+: "${CONTAINERD_VERSION:=v2.1.5}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"


### PR DESCRIPTION
backport:

- https://github.com/moby/moby/pull/51409
- https://github.com/moby/moby/pull/47335


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update containerd (static binaries only) to [v2.1.5](https://github.com/containerd/containerd/releases/tag/v2.1.5)
```

**- A picture of a cute animal (not mandatory but encouraged)**

