### PR TITLE
api/types/plugin: remove deprecated Config.DockerVersion

### DIFF
--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -3337,16 +3337,6 @@ definitions:
           - Env
           - Args
         properties:
-          DockerVersion:
-            description: |-
-              Docker Version used to create the plugin.
-
-              Depending on how the plugin was created, this field may be empty or omitted.
-
-              Deprecated: this field is no longer set, and will be removed in the next API version.
-            type: "string"
-            x-nullable: false
-            x-omitempty: true
           Description:
             type: "string"
             x-nullable: false

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -3337,16 +3337,6 @@ definitions:
           - Env
           - Args
         properties:
-          DockerVersion:
-            description: |-
-              Docker Version used to create the plugin.
-
-              Depending on how the plugin was created, this field may be empty or omitted.
-
-              Deprecated: this field is no longer set, and will be removed in the next API version.
-            type: "string"
-            x-nullable: false
-            x-omitempty: true
           Description:
             type: "string"
             x-nullable: false

--- a/api/types/plugin/plugin.go
+++ b/api/types/plugin/plugin.go
@@ -51,13 +51,6 @@ type Config struct {
 	// Required: true
 	Description string `json:"Description"`
 
-	// Docker Version used to create the plugin.
-	//
-	// Depending on how the plugin was created, this field may be empty or omitted.
-	//
-	// Deprecated: this field is no longer set, and will be removed in the next API version.
-	DockerVersion string `json:"DockerVersion,omitempty"`
-
 	// documentation
 	// Example: https://docs.docker.com/engine/extend/plugins/
 	// Required: true

--- a/vendor/github.com/moby/moby/api/types/plugin/plugin.go
+++ b/vendor/github.com/moby/moby/api/types/plugin/plugin.go
@@ -51,13 +51,6 @@ type Config struct {
 	// Required: true
 	Description string `json:"Description"`
 
-	// Docker Version used to create the plugin.
-	//
-	// Depending on how the plugin was created, this field may be empty or omitted.
-	//
-	// Deprecated: this field is no longer set, and will be removed in the next API version.
-	DockerVersion string `json:"DockerVersion,omitempty"`
-
 	// documentation
 	// Example: https://docs.docker.com/engine/extend/plugins/
 	// Required: true


### PR DESCRIPTION
This was deprecated in c4fda95beaee750a21e2674f708fb39ad6810983, and already omitted.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/plugin: remove deprecated Config.DockerVersion
```

**- A picture of a cute animal (not mandatory but encouraged)**

