### PR TITLE
client, api: update go.mod to go1.24

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/moby/api
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/docker/go-units v0.5.0

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/moby/client
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -973,7 +973,7 @@ github.com/moby/ipvs
 ## explicit; go 1.13
 github.com/moby/locker
 # github.com/moby/moby/api v1.52.0-rc.1 => ./api
-## explicit; go 1.23.0
+## explicit; go 1.24.0
 github.com/moby/moby/api/pkg/authconfig
 github.com/moby/moby/api/pkg/stdcopy
 github.com/moby/moby/api/types
@@ -995,7 +995,7 @@ github.com/moby/moby/api/types/swarm
 github.com/moby/moby/api/types/system
 github.com/moby/moby/api/types/volume
 # github.com/moby/moby/client v0.1.0-rc.1 => ./client
-## explicit; go 1.23.0
+## explicit; go 1.24.0
 github.com/moby/moby/client
 github.com/moby/moby/client/internal
 github.com/moby/moby/client/internal/timestamp


### PR DESCRIPTION
While go1.23 still works, it's already EOL, so it may be a better starting point to use that as minimum version for these modules, as they're brand new.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

