### PR TITLE
libnetwork/discoverapi: use DiscoveryType for enum

### DIFF
--- a/daemon/libnetwork/discoverapi/discoverapi.go
+++ b/daemon/libnetwork/discoverapi/discoverapi.go
@@ -14,12 +14,9 @@ type Discover interface {
 type DiscoveryType int
 
 const (
-	// NodeDiscovery represents Node join/leave events provided by discovery
-	NodeDiscovery = iota + 1
-	// EncryptionKeysConfig represents the initial key(s) for performing datapath encryption
-	EncryptionKeysConfig
-	// EncryptionKeysUpdate represents an update to the datapath encryption key(s)
-	EncryptionKeysUpdate
+	NodeDiscovery        DiscoveryType = 1 // NodeDiscovery represents Node join/leave events provided by discovery.
+	EncryptionKeysConfig DiscoveryType = 2 // EncryptionKeysConfig represents the initial key(s) for performing datapath encryption.
+	EncryptionKeysUpdate DiscoveryType = 3 // EncryptionKeysUpdate represents an update to the datapath encryption key(s).
 )
 
 // NodeDiscoveryData represents the structure backing the node discovery data json string


### PR DESCRIPTION
This type describes the options defined as consts below it, so make those consts typed. While updating, I also removed the use of iota to prevent accidentally changing their values (and if this API is implemented elsewhere)

(but mostly because I'm not a fan of iota ':))

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

