### PR TITLE
`daemon`: Use cgroup v2 parent to detect capabilities when not using systemd

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1081,6 +1081,8 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		return nil, err
 	}
 
+	createCGroup2Root(ctx, &cfgStore.Config)
+
 	// Check if Devices cgroup is mounted, it is hard requirement for container security,
 	// on Linux.
 	//

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1623,10 +1623,11 @@ func (daemon *Daemon) setupSeccompProfile(cfg *config.Config) error {
 
 func getSysInfo(cfg *config.Config) *sysinfo.SysInfo {
 	var siOpts []sysinfo.Opt
-	if cgroupDriver(cfg) == cgroupSystemdDriver {
-		if euid := os.Getenv("ROOTLESSKIT_PARENT_EUID"); euid != "" {
-			siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath("/user.slice/user-"+euid+".slice"))
-		}
+	if euid := os.Getenv("ROOTLESSKIT_PARENT_EUID"); cgroupDriver(cfg) == cgroupSystemdDriver && euid != "" {
+		siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath("/user.slice/user-"+euid+".slice"))
+	} else {
+		// Use container cgroup parent for effective capabilities detection
+		siOpts = append(siOpts, sysinfo.WithCgroup2GroupPath(getCgroupParent(cfg)))
 	}
 	si := sysinfo.New(siOpts...)
 
@@ -1695,4 +1696,19 @@ func createCGroup2Root(ctx context.Context, daemonConfiguration *config.Config) 
 			log.G(ctx).Errorf("Error activating controllers on cgroup v2 %s: %s", cGroup2Parent, err)
 		}
 	}
+}
+
+// Returns the cgroup parent cgroup
+func getCgroupParent(config *config.Config) string {
+	parent := "/docker"
+	if UsingSystemd(config) {
+		parent = "system.slice"
+		if config.Rootless {
+			parent = "user.slice"
+		}
+	}
+	if config.CgroupParent != "" {
+		parent = config.CgroupParent
+	}
+	return parent
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/netip"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/containerd/cgroups/v3"
+	"github.com/containerd/cgroups/v3/cgroup2"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/moby/moby/api/types/blkiodev"
@@ -1644,4 +1646,53 @@ func getSysInfo(cfg *config.Config) *sysinfo.SysInfo {
 
 func recursiveUnmount(target string) error {
 	return mount.RecursiveUnmount(target)
+}
+
+// Create cgroup v2 parent group based on daemon configuration
+func createCGroup2Root(ctx context.Context, daemonConfiguration *config.Config) {
+	if cgroups.Mode() != cgroups.Unified || UsingSystemd(daemonConfiguration) {
+		return
+	}
+
+	cGroup2Parent := getCgroupParent(daemonConfiguration)
+	cGroupManager, err := cgroup2.Load(cGroup2Parent)
+	if err != nil {
+		log.G(ctx).Errorf("Error loading cgroup v2 manager for group %s: %s", cGroup2Parent, err)
+		return
+	}
+
+	// cgroup2.Load does not check for cgroup v2 existence
+	// Cf. https://github.com/containerd/cgroups/pull/384
+	// Checking controllers will do so
+	_, err = cGroupManager.Controllers()
+	if err == nil {
+		log.G(ctx).Debugf("cgroup v2 already exists: %s", cGroup2Parent)
+	} else {
+		if !errors.Is(err, fs.ErrNotExist) {
+			log.G(ctx).Errorf("Error checking cgroup v2 %s existence: %s", cGroup2Parent, err)
+			return
+		}
+		cGroupResources := cgroup2.Resources{}
+		cGroupManager, err = cgroup2.NewManager(
+			"/sys/fs/cgroup",
+			cGroup2Parent,
+			&cGroupResources,
+		)
+		if err != nil {
+			log.G(ctx).Errorf("Error creating cgroup v2 %s: %s", cGroup2Parent, err)
+			return
+		} else {
+			log.G(ctx).Infof("Created cgroup v2: %s", cGroup2Parent)
+		}
+
+		rootControllers, err := cGroupManager.RootControllers()
+		if err != nil {
+			log.G(ctx).Errorf("Error gathering cgroup v2 hierarchy root controllers: %s", err)
+			return
+		}
+		err = cGroupManager.ToggleControllers(rootControllers, cgroup2.Enable)
+		if err != nil {
+			log.G(ctx).Errorf("Error activating controllers on cgroup v2 %s: %s", cGroup2Parent, err)
+		}
+	}
 }

--- a/daemon/daemon_unsupported.go
+++ b/daemon/daemon_unsupported.go
@@ -21,3 +21,5 @@ func getSysInfo(_ *Daemon) *sysinfo.SysInfo {
 func (daemon *Daemon) runInNetNS(f func() error) error {
 	return f()
 }
+
+func createCGroup2Root(_ context.Context, _ *config.Config) {}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -574,3 +574,5 @@ func getSysInfo(*config.Config) *sysinfo.SysInfo {
 func (daemon *Daemon) runInNetNS(f func() error) error {
 	return f()
 }
+
+func createCGroup2Root(_ context.Context, _ *config.Config) {}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -778,19 +778,13 @@ func withCgroups(daemon *Daemon, daemonCfg *dconfig.Config, c *container.Contain
 	return func(ctx context.Context, _ coci.Client, _ *containers.Container, s *coci.Spec) error {
 		var cgroupsPath string
 		scopePrefix := "docker"
-		parent := "/docker"
 		useSystemd := UsingSystemd(daemonCfg)
-		if useSystemd {
-			parent = "system.slice"
-			if daemonCfg.Rootless {
-				parent = "user.slice"
-			}
-		}
+		// Get parent cgroup from daemon configuration
+		parent := getCgroupParent(daemonCfg)
 
 		if c.HostConfig.CgroupParent != "" {
+			// Override parent cgroup from container configuration
 			parent = c.HostConfig.CgroupParent
-		} else if daemonCfg.CgroupParent != "" {
-			parent = daemonCfg.CgroupParent
 		}
 
 		if useSystemd {

--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/containerd/cgroups/v3"
 	cgroupsV2 "github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/containerd/log"
 	"github.com/moby/sys/userns"
@@ -57,18 +56,15 @@ func newV2(options ...Opt) *SysInfo {
 	return sysInfo
 }
 
-func getSwapLimitV2() bool {
-	_, g, err := cgroups.ParseCgroupFileUnified("/proc/self/cgroup")
-	if err != nil {
-		return false
-	}
+func getSwapLimitV2(info *SysInfo) bool {
+	g := info.cg2GroupPath
 
 	if g == "" {
 		return false
 	}
 
 	cGroupPath := path.Join("/sys/fs/cgroup", g, "memory.swap.max")
-	if _, err = os.Stat(cGroupPath); os.IsNotExist(err) {
+	if _, err := os.Stat(cGroupPath); os.IsNotExist(err) {
 		return false
 	}
 	return true
@@ -81,7 +77,7 @@ func applyMemoryCgroupInfoV2(info *SysInfo) {
 	}
 
 	info.MemoryLimit = true
-	info.SwapLimit = getSwapLimitV2()
+	info.SwapLimit = getSwapLimitV2(info)
 	info.MemoryReservation = true
 	info.OomKillDisable = false
 	info.MemorySwappiness = false


### PR DESCRIPTION
**- What I did**
Fixes #51480 

**- How I did it**
By default, all applications run in no particular namespace (for instance SysVInit services started from system initialisation) end up in the root `/sys/fs/cgroup` cgroup with cgroup v2.
The containers are created in another cgroup, defaulting to a `cgroup-parent` configuration setting, defaulting to `/docker` when using cgroup v2 without systemd.

The idea here is merely to make Docker use that parent cgroup to detect containers' capabilities when using cgroup v2 without systemd.
Since this parent cgroup is only created on container start, some additions were required to:
- make that parent cgroup be created on daemon startup
- make capabilities detection based on parent cgroup, the one which will actually be used for containers
This could be seen as an independent fix, because detecting capabilities based on another cgroup than the one the containers will actually use makes no sense.

**- How to verify it**
- `/sys/fs/cgroup<parent group>` gets created if non-existent on a fresh daemon startup with no container having ever run
- Debug messages indicate parent group detection/creation on daemon startup
- Integration tests pass

**- Human readable description for the release notes**

**- A picture of a cute animal (not mandatory but encouraged)**

