### PR TITLE
daemon: remove workaround for c8d client connection timeout

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -969,8 +969,6 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 	backoffConfig.MaxDelay = connTimeout
 	connParams := grpc.ConnectParams{
 		Backoff: backoffConfig,
-		// TODO: Remove after https://github.com/containerd/containerd/pull/11508
-		MinConnectTimeout: connTimeout,
 	}
 	gopts := []grpc.DialOption{
 		// ------------------------------------------------------------------

--- a/daemon/internal/libcontainerd/supervisor/remote_daemon.go
+++ b/daemon/internal/libcontainerd/supervisor/remote_daemon.go
@@ -280,19 +280,14 @@ func (r *remote) monitorDaemon(ctx context.Context) {
 				continue
 			}
 
-			const connTimeout = 60 * time.Second
 			client, err = containerd.New(
 				r.GRPC.Address,
-				containerd.WithTimeout(connTimeout),
+				containerd.WithTimeout(60*time.Second),
 				containerd.WithDialOpts([]grpc.DialOption{
 					grpc.WithTransportCredentials(insecure.NewCredentials()),
 					grpc.WithContextDialer(dialer.ContextDialer),
 					grpc.WithUnaryInterceptor(grpcerrors.UnaryClientInterceptor),
 					grpc.WithStreamInterceptor(grpcerrors.StreamClientInterceptor),
-					grpc.WithConnectParams(grpc.ConnectParams{
-						// TODO: Remove after https://github.com/containerd/containerd/pull/11508
-						MinConnectTimeout: connTimeout,
-					}),
 				}),
 			)
 			if err != nil {


### PR DESCRIPTION
relates to:

- https://github.com/containerd/containerd/pull/11508
- https://github.com/containerd/containerd/issues/11507
- https://github.com/containerd/containerd/pull/11508
- https://github.com/containerd/containerd/pull/11536



### daemon: remove workaround for c8d client connection timeout

This workaround was added in df519e9e1aa9aeb4c0d2aeac2db785346f6f904d, pending a fix in containerd;

> daemon: Fix giving up too early while connecting to containerd socket
>
> Explicitly set the gRPC connection params to take the timeout into
> account to workaround the containerd v2 client not passing down the
> stack.
>
> containerd v2 replaced usages of deprecated gRPC functions but didn't
> pass the timeout to the actual dial connection options.

A fix for this was merged in [containerd@ee574e7], which is part of containerd v2.1.0-beta.0, and backported to containerd v2.0.4 through [containerd@6b5efba].

[containerd@ee574e7]: https://github.com/containerd/containerd/commit/ee574e76e7f6bbe239298163eab6ccd8b94d73b3
[containerd@6b5efba]: https://github.com/containerd/containerd/commit/6b5efba83b2aa68b522ebfe73d3fed8e18a59429

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

