### PR TITLE
fix(libnetwork): nil pointer will cause panic

### DIFF
--- a/daemon/libnetwork/ns/init_linux.go
+++ b/daemon/libnetwork/ns/init_linux.go
@@ -2,6 +2,7 @@ package ns
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"syscall"
 	"testing"
@@ -30,7 +31,8 @@ func initHandles() {
 	}
 	initNl, err = nlwrap.NewHandle(getSupportedNlFamilies()...)
 	if err != nil {
-		log.G(context.TODO()).Errorf("could not create netlink handle on initial namespace: %v", err)
+		// Fail fast to keep the invariant: NlHandle must be a valid handle
+		panic(fmt.Errorf("could not create netlink handle on initial (host) namespace: %w", err))
 	}
 	err = initNl.SetSocketTimeout(NetlinkSocketsTimeout)
 	if err != nil {


### PR DESCRIPTION
The panic log:
```
11月 12 11:00:55 test-pc dockerd[7618]: time="2025-11-12T11:00:55.921589100+08:00" level=info msg="Starting up"
11月 12 11:00:55 test-pc dockerd[7618]: time="2025-11-12T11:00:55.923922640+08:00" level=info msg="containerd not running, starting managed containerd"
11月 12 11:00:55 test-pc dockerd[7618]: time="2025-11-12T11:00:55.926598940+08:00" level=info msg="started new containerd process" address=/var/run/docker/containerd/containerd.sock module=libcontainerd pid=7641
11月 12 11:00:55 test-pc dockerd[7641]: time="2025-11-12T11:00:55.962856960+08:00" level=info msg="starting containerd" revision=ff6f75008afe6d75b3524bc2123dd4cfe3054358 version=1.7.6
11月 12 11:00:55 test-pc dockerd[7641]: time="2025-11-12T11:00:55.999083820+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.005622220+08:00" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.aufs\"..." error="aufs is not supported (modprobe aufs failed: exit status 1 \"modprobe: FATAL: Module aufs not found in directory /lib/modules/5.10.134-14.zncgsl6.aarch64\\n\"): skip plugin" type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.005704380+08:00" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.005775020+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.blockfile\"..." type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.005838880+08:00" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.blockfile\"..." error="no scratch file generator: skip plugin" type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.005873840+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.005934840+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.006237600+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.006279800+08:00" level=warning msg="failed to load plugin io.containerd.snapshotter.v1.devmapper" error="devmapper not configured"
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.006307380+08:00" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.006767320+08:00" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.zfs\"..." error="path /var/lib/docker/containerd/daemon/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.006817160+08:00" level=info msg="loading plugin \"io.containerd.metadata.v1.bolt\"..." type=io.containerd.metadata.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.006871440+08:00" level=warning msg="could not use snapshotter devmapper in metadata plugin" error="devmapper not configured"
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.006899280+08:00" level=info msg="metadata content store policy set" policy=shared
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007326720+08:00" level=info msg="loading plugin \"io.containerd.differ.v1.walking\"..." type=io.containerd.differ.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007400800+08:00" level=info msg="loading plugin \"io.containerd.event.v1.exchange\"..." type=io.containerd.event.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007445160+08:00" level=info msg="loading plugin \"io.containerd.gc.v1.scheduler\"..." type=io.containerd.gc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007511880+08:00" level=info msg="loading plugin \"io.containerd.lease.v1.manager\"..." type=io.containerd.lease.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007548420+08:00" level=info msg="loading plugin \"io.containerd.nri.v1.nri\"..." type=io.containerd.nri.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007596120+08:00" level=info msg="NRI interface is disabled by configuration."
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007627220+08:00" level=info msg="loading plugin \"io.containerd.runtime.v2.task\"..." type=io.containerd.runtime.v2
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007780700+08:00" level=info msg="loading plugin \"io.containerd.runtime.v2.shim\"..." type=io.containerd.runtime.v2
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007819320+08:00" level=info msg="loading plugin \"io.containerd.sandbox.store.v1.local\"..." type=io.containerd.sandbox.store.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007856960+08:00" level=info msg="loading plugin \"io.containerd.sandbox.controller.v1.local\"..." type=io.containerd.sandbox.controller.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007893280+08:00" level=info msg="loading plugin \"io.containerd.streaming.v1.manager\"..." type=io.containerd.streaming.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007938880+08:00" level=info msg="loading plugin \"io.containerd.service.v1.introspection-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.007974520+08:00" level=info msg="loading plugin \"io.containerd.service.v1.containers-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008009680+08:00" level=info msg="loading plugin \"io.containerd.service.v1.content-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008044880+08:00" level=info msg="loading plugin \"io.containerd.service.v1.diff-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008080960+08:00" level=info msg="loading plugin \"io.containerd.service.v1.images-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008113560+08:00" level=info msg="loading plugin \"io.containerd.service.v1.namespaces-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008147740+08:00" level=info msg="loading plugin \"io.containerd.service.v1.snapshots-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008176500+08:00" level=info msg="loading plugin \"io.containerd.runtime.v1.linux\"..." type=io.containerd.runtime.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008275300+08:00" level=info msg="loading plugin \"io.containerd.monitor.v1.cgroups\"..." type=io.containerd.monitor.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008903160+08:00" level=info msg="loading plugin \"io.containerd.service.v1.tasks-service\"..." type=io.containerd.service.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.008973940+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.introspection\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009013660+08:00" level=info msg="loading plugin \"io.containerd.transfer.v1.local\"..." type=io.containerd.transfer.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009070580+08:00" level=info msg="loading plugin \"io.containerd.internal.v1.restart\"..." type=io.containerd.internal.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009224540+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.containers\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009266080+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.content\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009300460+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.diff\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009331800+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.events\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009369420+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.healthcheck\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009402900+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.images\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009437680+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.leases\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009481640+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.namespaces\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009521380+08:00" level=info msg="loading plugin \"io.containerd.internal.v1.opt\"..." type=io.containerd.internal.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009608500+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.sandbox-controllers\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009648180+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.sandboxes\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009680260+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.snapshots\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009733660+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.streaming\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009766280+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.tasks\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009800540+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.transfer\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009836180+08:00" level=info msg="loading plugin \"io.containerd.grpc.v1.version\"..." type=io.containerd.grpc.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009866820+08:00" level=info msg="loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." type=io.containerd.tracing.processor.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009905180+08:00" level=info msg="skip loading plugin \"io.containerd.tracing.processor.v1.otlp\"..." error="no OpenTelemetry endpoint: skip plugin" type=io.containerd.tracing.processor.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009935160+08:00" level=info msg="loading plugin \"io.containerd.internal.v1.tracing\"..." type=io.containerd.internal.v1
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.009962700+08:00" level=info msg="skipping tracing processor initialization (no tracing plugin)" error="no OpenTelemetry endpoint: skip plugin"
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.010693060+08:00" level=info msg=serving... address=/var/run/docker/containerd/containerd-debug.sock
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.010856780+08:00" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock.ttrpc
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.010985860+08:00" level=info msg=serving... address=/var/run/docker/containerd/containerd.sock
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.011026280+08:00" level=info msg="containerd successfully booted in 0.049512s"
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.021031900+08:00" level=info msg="newEventServer exited with error: failed to listen on event.sock: listen unix /run/containerd/event.sock: bind: no such file or directory"
11月 12 11:00:56 test-pc dockerd[7618]: time="2025-11-12T11:00:56.023821920+08:00" level=info msg="[graphdriver] trying configured driver: overlay2"
11月 12 11:00:56 test-pc dockerd[7618]: time="2025-11-12T11:00:56.039025380+08:00" level=info msg="Loading containers: start."
11月 12 11:00:56 test-pc dockerd[7641]: time="2025-11-12T11:00:56.039626340+08:00" level=info msg="newEventServer exited with error: failed to listen on event.sock: listen unix /run/containerd/event.sock: bind: no such file or directory"
11月 12 11:00:56 test-pc dockerd[7618]: time="2025-11-12T11:00:56.174699600+08:00" level=error msg="could not create netlink handle on initial namespace: permission denied"
11月 12 11:00:56 test-pc dockerd[7618]: time="2025-11-12T11:00:56.174914960+08:00" level=info msg="stopping healthcheck following graceful shutdown" module=libcontainerd
11月 12 11:00:56 test-pc dockerd[7618]: time="2025-11-12T11:00:56.174921140+08:00" level=info msg="stopping event stream following graceful shutdown" error="context canceled" module=libcontainerd namespace=moby
11月 12 11:00:56 test-pc dockerd[7618]: time="2025-11-12T11:00:56.174922500+08:00" level=info msg="stopping event stream following graceful shutdown" error="context canceled" module=libcontainerd namespace=plugins.moby
11月 12 11:00:57 test-pc dockerd[7618]: panic: runtime error: invalid memory address or nil pointer dereference
11月 12 11:00:57 test-pc dockerd[7618]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xaaaaba53f864]
11月 12 11:00:57 test-pc dockerd[7618]: goroutine 1 [running, locked to thread]:
11月 12 11:00:57 test-pc dockerd[7618]: github.com/vishvananda/netlink.(*Handle).SetSocketTimeout(0xaaaabc73dc60?, 0xaaaa00000002?)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/vendor/github.com/vishvananda/netlink/handle_linux.go:63 +0x94
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork/ns.Init()
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/ns/init_linux.go:35 +0xfc
11月 12 11:00:57 test-pc dockerd[7618]: sync.(*Once).doSlow(0x4000ca23d8?, 0xaaaab9e16f30?)
11月 12 11:00:57 test-pc dockerd[7618]:         /usr/lib/golang/src/sync/once.go:74 +0x100
11月 12 11:00:57 test-pc dockerd[7618]: sync.(*Once).Do(...)
11月 12 11:00:57 test-pc dockerd[7618]:         /usr/lib/golang/src/sync/once.go:65
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork/ns.NlHandle(...)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/ns/init_linux.go:54
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork/drivers/bridge.(*driver).createNetwork(0x4000cb8b40, 0x40008f6b60)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/drivers/bridge/bridge.go:676 +0xe4
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork/drivers/bridge.(*driver).populateNetworks(0x4000cb8b40)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/drivers/bridge/bridge_store.go:65 +0x2d4
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork/drivers/bridge.(*driver).initStore(0x4000cb8b40, 0x0?)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/drivers/bridge/bridge_store.go:38 +0x150
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork/drivers/bridge.(*driver).configure(0x4000cb8b40, 0x0?)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/drivers/bridge/bridge.go:443 +0x814
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork/drivers/bridge.Register({0xaaaabb6abce0, 0x4000a3c110}, 0x6?)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/drivers/bridge/bridge.go:172 +0x94
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/libnetwork.New({0x40003cb500, 0x8, 0xe})
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/libnetwork/controller.go:144 +0x40c
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/daemon.(*Daemon).initNetworkController(0x4000b44000, 0x4000cc2e70)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/daemon/daemon_unix.go:853 +0x3c
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/daemon.(*Daemon).restore(0x4000b44000)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/daemon/daemon.go:514 +0x500
11月 12 11:00:57 test-pc dockerd[7618]: github.com/docker/docker/daemon.NewDaemon({0xaaaabb6cc8e0?, 0x400068e0a0}, 0x4000b7d900, 0x4000923860, 0x40005ae1c0)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/daemon/daemon.go:1141 +0x25f8
11月 12 11:00:57 test-pc dockerd[7618]: main.(*DaemonCli).start(0x4000b32d80, 0x4000338460)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/cmd/dockerd/daemon.go:232 +0x824
11月 12 11:00:57 test-pc dockerd[7618]: main.runDaemon(...)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/cmd/dockerd/docker_unix.go:14
11月 12 11:00:57 test-pc dockerd[7618]: main.newDaemonCommand.func1(0x4000a3ca00?, {0xaaaabc8052e0?, 0x7?, 0xaaaabacfc30d?})
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/cmd/dockerd/docker.go:39 +0x9c
11月 12 11:00:57 test-pc dockerd[7618]: github.com/spf13/cobra.(*Command).execute(0x4000a7f800, {0x400022a090, 0x0, 0x0})
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/vendor/github.com/spf13/cobra/command.go:916 +0x66c
11月 12 11:00:57 test-pc dockerd[7618]: github.com/spf13/cobra.(*Command).ExecuteC(0x4000a7f800)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/vendor/github.com/spf13/cobra/command.go:1044 +0x320
11月 12 11:00:57 test-pc dockerd[7618]: github.com/spf13/cobra.(*Command).Execute(...)
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/vendor/github.com/spf13/cobra/command.go:968
11月 12 11:00:57 test-pc dockerd[7618]: main.main()
11月 12 11:00:57 test-pc dockerd[7618]:         /builddir/build/BUILD/src/moby-24.0.9/cmd/dockerd/docker.go:109 +0x198
11月 12 11:00:57 test-pc systemd[1]: docker.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
11月 12 11:00:57 test-pc systemd[1]: docker.service: Failed with result 'exit-code'.
11月 12 11:00:57 test-pc systemd[1]: Failed to start Docker Application Container Engine.

```
if the `initNl, err = nlwrap.NewHandle(getSupportedNlFamilies()...)`  will not go on.
