### PR TITLE
c8d/builder-next: Don't force unpack

### DIFF
--- a/daemon/internal/builder-next/exporter/wrapper.go
+++ b/daemon/internal/builder-next/exporter/wrapper.go
@@ -48,7 +48,10 @@ func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, id int, exporter
 		return nil, err
 	}
 	exporterAttrs[string(exptypes.OptKeyName)] = strings.Join(reposAndTags, ",")
-	exporterAttrs[string(exptypes.OptKeyUnpack)] = "true"
+
+	if _, has := exporterAttrs[string(exptypes.OptKeyUnpack)]; !has {
+		exporterAttrs[string(exptypes.OptKeyUnpack)] = "true"
+	}
 	if _, has := exporterAttrs[string(exptypes.OptKeyDanglingPrefix)]; !has {
 		exporterAttrs[string(exptypes.OptKeyDanglingPrefix)] = "moby-dangling"
 	}


### PR DESCRIPTION
- related to: https://github.com/moby/moby/issues/51442
- replaces https://github.com/moby/moby/pull/50853

### c8d/builder-next: Don't force unpack

The image exporter wrapper was unconditionally setting `unpack=true` for
all build exports, preventing users from controlling this behavior
through buildkit's output image exporter option.

```markdown changelog
containerd image store: Fix a bug causing `docker build` to ignore the explicitly set `unpack` image exporter option.
```