### PR TITLE
c8d/builder-next: Skip unpacking when push=true

### DIFF
--- a/daemon/internal/builder-next/exporter/wrapper.go
+++ b/daemon/internal/builder-next/exporter/wrapper.go
@@ -38,6 +38,20 @@ func NewWrapper(exp exporter.Exporter, callbacks BuildkitCallbacks) (exporter.Ex
 	}, nil
 }
 
+// shouldUnpack returns true if the image should be unpacked
+func shouldUnpack(exporterAttrs map[string]string) string {
+	if unpack, has := exporterAttrs[string(exptypes.OptKeyUnpack)]; has {
+		return unpack
+	}
+
+	if push, has := exporterAttrs[string(exptypes.OptKeyPush)]; has {
+		if push == "true" {
+			return "false"
+		}
+	}
+	return "true"
+}
+
 // Resolve applies moby specific attributes to the request.
 func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, id int, exporterAttrs map[string]string) (exporter.ExporterInstance, error) {
 	if exporterAttrs == nil {
@@ -49,9 +63,7 @@ func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, id int, exporter
 	}
 	exporterAttrs[string(exptypes.OptKeyName)] = strings.Join(reposAndTags, ",")
 
-	if _, has := exporterAttrs[string(exptypes.OptKeyUnpack)]; !has {
-		exporterAttrs[string(exptypes.OptKeyUnpack)] = "true"
-	}
+	exporterAttrs[string(exptypes.OptKeyUnpack)] = shouldUnpack(exporterAttrs)
 	if _, has := exporterAttrs[string(exptypes.OptKeyDanglingPrefix)]; !has {
 		exporterAttrs[string(exptypes.OptKeyDanglingPrefix)] = "moby-dangling"
 	}


### PR DESCRIPTION
- needs: https://github.com/moby/moby/pull/51493 (which is a bugfix, in contrast to **this** PR which is kind of an enhancement/feature)
- fixes: https://github.com/moby/moby/issues/51442

### c8d/builder-next: Skip unpacking when push=true

The image exporter wrapper was unconditionally setting `unpack=true` for
all build exports when no explicit unpack option was provided. This
caused unnecessary unpacking overhead when images were only being pushed
to a registry and not intended for local execution.

```markdown changelog
containerd image store: Images built with `docker build --push` will no longer be unpacked automatically. 
```