### PR TITLE
client: enable API-version negotiation by default

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -27,7 +27,7 @@ func main() {
 	// for configuration (DOCKER_HOST, DOCKER_API_VERSION), and does
 	// API-version negotiation to allow downgrading the API version
 	// when connecting with an older daemon version.
-	apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
+	apiClient, err := client.New(client.FromEnv)
 	if err != nil {
 		panic(err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ You use the library by constructing a client object using [New]
 and calling methods on it. The client can be configured from environment
 variables by passing the [FromEnv] option, and the [WithAPIVersionNegotiation]
 option to allow downgrading the API version used when connecting with an older
-daemon version. Other options cen be configured manually by passing any of
+daemon version. Other options can be configured manually by passing any of
 the available [Opt] options.
 
 For example, to list running containers (the equivalent of "docker ps"):

--- a/client/client.go
+++ b/client/client.go
@@ -313,19 +313,12 @@ func (cli *Client) ClientVersion() string {
 }
 
 // negotiateAPIVersion updates the version to match the API version from
-// the ping response. It falls back to the lowest version supported if the
-// API version is empty.
+// the ping response.
 //
 // It returns an error if version is invalid, or lower than the minimum
 // supported API version in which case the client's API version is not
 // updated, and negotiation is not marked as completed.
 func (cli *Client) negotiateAPIVersion(pingVersion string) error {
-	pingVersion = strings.TrimPrefix(pingVersion, "v")
-	if pingVersion == "" {
-		// TODO(thaJeztah): consider returning an error on empty value or not falling back; see https://github.com/moby/moby/pull/51119#discussion_r2413148487
-		pingVersion = MinAPIVersion
-	}
-
 	var err error
 	pingVersion, err = parseAPIVersion(pingVersion)
 	if err != nil {

--- a/client/client_example_test.go
+++ b/client/client_example_test.go
@@ -13,7 +13,7 @@ func ExampleNew() {
 	// for configuration (DOCKER_HOST, DOCKER_API_VERSION), and does
 	// API-version negotiation to allow downgrading the API version
 	// when connecting with an older daemon version.
-	apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
+	apiClient, err := client.New(client.FromEnv)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client/client_options.go
+++ b/client/client_options.go
@@ -55,12 +55,6 @@ type clientConfig struct {
 	// takes precedence. Either field disables API-version negotiation.
 	envAPIVersion string
 
-	// negotiateVersion indicates if the client should automatically negotiate
-	// the API version to use when making requests. API version negotiation is
-	// performed on the first request, after which negotiated is set to "true"
-	// so that subsequent requests do not re-negotiate.
-	negotiateVersion bool
-
 	// traceOpts is a list of options to configure the tracing span.
 	traceOpts []otelhttp.Option
 }
@@ -325,9 +319,11 @@ func WithVersionFromEnv() Opt {
 // With this option enabled, the client automatically negotiates the API version
 // to use when making requests. API version negotiation is performed on the first
 // request; subsequent requests do not re-negotiate.
+//
+// Deprecated: API-version negotiation is now enabled by default. Use [WithAPIVersion]
+// or [WithAPIVersionFromEnv] to disable API version negotiation.
 func WithAPIVersionNegotiation() Opt {
 	return func(c *clientConfig) error {
-		c.negotiateVersion = true
 		return nil
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -257,7 +257,6 @@ func TestNegotiateAPIVersionEmpty(t *testing.T) {
 	const expected = MinAPIVersion
 
 	client, err := New(FromEnv,
-		WithAPIVersionNegotiation(),
 		WithBaseMockClient(mockPingResponse(http.StatusOK, PingResult{APIVersion: expected})),
 	)
 	assert.NilError(t, err)
@@ -330,7 +329,6 @@ func TestNegotiateAPIVersion(t *testing.T) {
 		t.Run(tc.doc, func(t *testing.T) {
 			opts := []Opt{
 				FromEnv,
-				WithAPIVersionNegotiation(),
 				WithBaseMockClient(mockPingResponse(http.StatusOK, PingResult{APIVersion: tc.pingVersion})),
 			}
 
@@ -396,7 +394,6 @@ func TestNegotiateAPIVersionAutomatic(t *testing.T) {
 		WithBaseMockClient(func(req *http.Request) (*http.Response, error) {
 			return mockPingResponse(http.StatusOK, PingResult{APIVersion: pingVersion})(req)
 		}),
-		WithAPIVersionNegotiation(),
 	)
 	assert.NilError(t, err)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -300,12 +300,10 @@ func TestNegotiateAPIVersion(t *testing.T) {
 			expectedVersion: "1.51",
 		},
 		{
-			// client should downgrade to the last version before version
-			// negotiation was added (1.24) if the daemon does not report
-			// a version.
+			// client should not downgrade if the daemon didn't report a version.
 			doc:             "downgrade legacy",
 			pingVersion:     "",
-			expectedVersion: MinAPIVersion,
+			expectedVersion: MaxAPIVersion,
 		},
 		{
 			// client should not downgrade to the version reported by the daemon

--- a/client/container_create_test.go
+++ b/client/container_create_test.go
@@ -87,7 +87,7 @@ func TestContainerCreateAutoRemove(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerCreateConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerCreate(t.Context(), ContainerCreateOptions{Config: &container.Config{Image: "test"}})

--- a/client/container_exec_test.go
+++ b/client/container_exec_test.go
@@ -36,7 +36,7 @@ func TestExecCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestExecCreateConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ExecCreate(t.Context(), "container_id", ExecCreateOptions{})

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -167,7 +167,7 @@ func TestContainerLogs(t *testing.T) {
 }
 
 func ExampleClient_ContainerLogs_withTimeout() {
-	client, err := New(FromEnv, WithAPIVersionNegotiation())
+	client, err := New(FromEnv)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client/container_restart_test.go
+++ b/client/container_restart_test.go
@@ -30,7 +30,7 @@ func TestContainerRestartError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerRestartConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerRestart(t.Context(), "nothing", ContainerRestartOptions{})

--- a/client/container_stop_test.go
+++ b/client/container_stop_test.go
@@ -30,7 +30,7 @@ func TestContainerStopError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestContainerStopConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ContainerStop(t.Context(), "container_id", ContainerStopOptions{})

--- a/client/container_wait_test.go
+++ b/client/container_wait_test.go
@@ -41,7 +41,7 @@ func TestContainerWaitConnectionError(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	wait := client.ContainerWait(ctx, "nothing", ContainerWaitOptions{})

--- a/client/hijack_test.go
+++ b/client/hijack_test.go
@@ -105,7 +105,7 @@ func TestTLSCloseWriter(t *testing.T) {
 
 	httpClient := ts.Client()
 	defer httpClient.CloseIdleConnections()
-	client, err := New(WithHost("tcp://"+serverURL.Host), WithHTTPClient(httpClient), WithAPIVersionNegotiation())
+	client, err := New(WithHost("tcp://"+serverURL.Host), WithHTTPClient(httpClient))
 	assert.NilError(t, err)
 
 	resp, err := client.postHijacked(ctx, "/asdf", url.Values{}, nil, map[string][]string{"Content-Type": {"text/plain"}})

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -24,7 +24,7 @@ func TestImageListError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestImageListConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ImageList(t.Context(), ImageListOptions{})

--- a/client/network_create_test.go
+++ b/client/network_create_test.go
@@ -23,7 +23,7 @@ func TestNetworkCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestNetworkCreateConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.NetworkCreate(t.Context(), "mynetwork", NetworkCreateOptions{})

--- a/client/ping.go
+++ b/client/ping.go
@@ -71,11 +71,12 @@ type SwarmStatus struct {
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
 func (cli *Client) Ping(ctx context.Context, options PingOptions) (PingResult, error) {
-	if cli.negotiated.Load() && !options.ForceNegotiate {
-		// API version was already negotiated or manually set.
+	if !options.NegotiateAPIVersion {
+		// No API version negotiation needed; just return ping response.
 		return cli.ping(ctx)
 	}
-	if !options.NegotiateAPIVersion && !cli.negotiateVersion {
+	if cli.negotiated.Load() && !options.ForceNegotiate {
+		// API version was already negotiated or manually set.
 		return cli.ping(ctx)
 	}
 

--- a/client/ping.go
+++ b/client/ping.go
@@ -97,6 +97,11 @@ func (cli *Client) Ping(ctx context.Context, options PingOptions) (PingResult, e
 		return ping, nil
 	}
 
+	if ping.APIVersion == "" {
+		cli.setAPIVersion(MaxAPIVersion)
+		return ping, nil
+	}
+
 	return ping, cli.negotiateAPIVersion(ping.APIVersion)
 }
 

--- a/client/service_create_test.go
+++ b/client/service_create_test.go
@@ -29,7 +29,7 @@ func TestServiceCreateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestServiceCreateConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceCreate(t.Context(), ServiceCreateOptions{})

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -129,7 +129,7 @@ func TestServiceLogs(t *testing.T) {
 }
 
 func ExampleClient_ServiceLogs_withTimeout() {
-	client, err := New(FromEnv, WithAPIVersionNegotiation())
+	client, err := New(FromEnv)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client/service_update_test.go
+++ b/client/service_update_test.go
@@ -32,7 +32,7 @@ func TestServiceUpdateError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestServiceUpdateConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.ServiceUpdate(t.Context(), "service_id", ServiceUpdateOptions{})

--- a/client/volume_remove_test.go
+++ b/client/volume_remove_test.go
@@ -31,7 +31,7 @@ func TestVolumeRemoveError(t *testing.T) {
 //
 // Regression test for https://github.com/docker/cli/issues/4890
 func TestVolumeRemoveConnectionError(t *testing.T) {
-	client, err := New(WithAPIVersionNegotiation(), WithHost("tcp://no-such-host.invalid"))
+	client, err := New(WithHost("tcp://no-such-host.invalid"))
 	assert.NilError(t, err)
 
 	_, err = client.VolumeRemove(t.Context(), "volume_id", VolumeRemoveOptions{})

--- a/vendor/github.com/moby/moby/client/README.md
+++ b/vendor/github.com/moby/moby/client/README.md
@@ -27,7 +27,7 @@ func main() {
 	// for configuration (DOCKER_HOST, DOCKER_API_VERSION), and does
 	// API-version negotiation to allow downgrading the API version
 	// when connecting with an older daemon version.
-	apiClient, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
+	apiClient, err := client.New(client.FromEnv)
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -10,7 +10,7 @@ You use the library by constructing a client object using [New]
 and calling methods on it. The client can be configured from environment
 variables by passing the [FromEnv] option, and the [WithAPIVersionNegotiation]
 option to allow downgrading the API version used when connecting with an older
-daemon version. Other options cen be configured manually by passing any of
+daemon version. Other options can be configured manually by passing any of
 the available [Opt] options.
 
 For example, to list running containers (the equivalent of "docker ps"):

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -313,19 +313,12 @@ func (cli *Client) ClientVersion() string {
 }
 
 // negotiateAPIVersion updates the version to match the API version from
-// the ping response. It falls back to the lowest version supported if the
-// API version is empty.
+// the ping response.
 //
 // It returns an error if version is invalid, or lower than the minimum
 // supported API version in which case the client's API version is not
 // updated, and negotiation is not marked as completed.
 func (cli *Client) negotiateAPIVersion(pingVersion string) error {
-	pingVersion = strings.TrimPrefix(pingVersion, "v")
-	if pingVersion == "" {
-		// TODO(thaJeztah): consider returning an error on empty value or not falling back; see https://github.com/moby/moby/pull/51119#discussion_r2413148487
-		pingVersion = MinAPIVersion
-	}
-
 	var err error
 	pingVersion, err = parseAPIVersion(pingVersion)
 	if err != nil {

--- a/vendor/github.com/moby/moby/client/client_options.go
+++ b/vendor/github.com/moby/moby/client/client_options.go
@@ -55,12 +55,6 @@ type clientConfig struct {
 	// takes precedence. Either field disables API-version negotiation.
 	envAPIVersion string
 
-	// negotiateVersion indicates if the client should automatically negotiate
-	// the API version to use when making requests. API version negotiation is
-	// performed on the first request, after which negotiated is set to "true"
-	// so that subsequent requests do not re-negotiate.
-	negotiateVersion bool
-
 	// traceOpts is a list of options to configure the tracing span.
 	traceOpts []otelhttp.Option
 }
@@ -325,9 +319,11 @@ func WithVersionFromEnv() Opt {
 // With this option enabled, the client automatically negotiates the API version
 // to use when making requests. API version negotiation is performed on the first
 // request; subsequent requests do not re-negotiate.
+//
+// Deprecated: API-version negotiation is now enabled by default. Use [WithAPIVersion]
+// or [WithAPIVersionFromEnv] to disable API version negotiation.
 func WithAPIVersionNegotiation() Opt {
 	return func(c *clientConfig) error {
-		c.negotiateVersion = true
 		return nil
 	}
 }

--- a/vendor/github.com/moby/moby/client/ping.go
+++ b/vendor/github.com/moby/moby/client/ping.go
@@ -71,11 +71,12 @@ type SwarmStatus struct {
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
 func (cli *Client) Ping(ctx context.Context, options PingOptions) (PingResult, error) {
-	if cli.negotiated.Load() && !options.ForceNegotiate {
-		// API version was already negotiated or manually set.
+	if !options.NegotiateAPIVersion {
+		// No API version negotiation needed; just return ping response.
 		return cli.ping(ctx)
 	}
-	if !options.NegotiateAPIVersion && !cli.negotiateVersion {
+	if cli.negotiated.Load() && !options.ForceNegotiate {
+		// API version was already negotiated or manually set.
 		return cli.ping(ctx)
 	}
 

--- a/vendor/github.com/moby/moby/client/ping.go
+++ b/vendor/github.com/moby/moby/client/ping.go
@@ -97,6 +97,11 @@ func (cli *Client) Ping(ctx context.Context, options PingOptions) (PingResult, e
 		return ping, nil
 	}
 
+	if ping.APIVersion == "" {
+		cli.setAPIVersion(MaxAPIVersion)
+		return ping, nil
+	}
+
 	return ping, cli.negotiateAPIVersion(ping.APIVersion)
 }
 


### PR DESCRIPTION
- [x] stacked on https://github.com/moby/moby/pull/51499
- [x] stacked on https://github.com/moby/moby/pull/51500
- [x] stacked on https://github.com/moby/moby/pull/51512
- [x] stacked on https://github.com/moby/moby/pull/51530
- [x] stacked on https://github.com/moby/moby/pull/51533
- [x] stacked on https://github.com/moby/moby/pull/51539


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Enable API-version negotiation by default and deprecate `WithAPIVersionNegotiation`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

