### PR TITLE
client: use http.NoBody if there's no body to send

### DIFF
--- a/client/ping.go
+++ b/client/ping.go
@@ -99,7 +99,7 @@ func (cli *Client) ping(ctx context.Context) (PingResult, error) {
 	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
 	// because ping requests are used during API version negotiation, so we want
 	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
-	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
+	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), http.NoBody, nil)
 	if err != nil {
 		return PingResult{}, err
 	}

--- a/client/request.go
+++ b/client/request.go
@@ -97,6 +97,9 @@ func prepareJSONRequest(body any, headers http.Header) (io.Reader, http.Header, 
 }
 
 func (cli *Client) buildRequest(ctx context.Context, method, path string, body io.Reader, headers http.Header) (*http.Request, error) {
+	if body == nil {
+		body = http.NoBody
+	}
 	req, err := http.NewRequestWithContext(ctx, method, path, body)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/moby/moby/client/ping.go
+++ b/vendor/github.com/moby/moby/client/ping.go
@@ -99,7 +99,7 @@ func (cli *Client) ping(ctx context.Context) (PingResult, error) {
 	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
 	// because ping requests are used during API version negotiation, so we want
 	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
-	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
+	req, err := cli.buildRequest(ctx, http.MethodHead, path.Join(cli.basePath, "/_ping"), http.NoBody, nil)
 	if err != nil {
 		return PingResult{}, err
 	}

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -97,6 +97,9 @@ func prepareJSONRequest(body any, headers http.Header) (io.Reader, http.Header, 
 }
 
 func (cli *Client) buildRequest(ctx context.Context, method, path string, body io.Reader, headers http.Header) (*http.Request, error) {
+	if body == nil {
+		body = http.NoBody
+	}
 	req, err := http.NewRequestWithContext(ctx, method, path, body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There's various code-paths that may attempt to handle the request, which may panic during tests if a nil-body is used.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

