### PR TITLE
[docker-29.x backport] libnet: create DNS records on sbJoin (if not agent node)

### DIFF
--- a/daemon/libnetwork/sandbox.go
+++ b/daemon/libnetwork/sandbox.go
@@ -348,10 +348,8 @@ func (sb *Sandbox) populateNetworkResources(ctx context.Context, ep *Endpoint) (
 
 	// Populate DNS records.
 	n := ep.getNetwork()
-	if !n.getController().isAgent() {
-		if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
-			n.updateSvcRecord(context.WithoutCancel(ctx), ep, true)
-		}
+	if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
+		n.updateSvcRecord(context.WithoutCancel(ctx), ep, true)
 	}
 
 	if err := ep.addDriverInfoToCluster(); err != nil {

--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -1092,7 +1092,7 @@ func TestDisableIPv6OnInterface(t *testing.T) {
 			// There should not be an IPv6 DNS or /etc/hosts entry.
 			runRes := container.RunAttach(ctx, t, c,
 				container.WithNetworkMode(tc.netName),
-				container.WithCmd("ping", "-6", ctrName),
+				container.WithCmd("ping", "-6", "-c1", ctrName),
 			)
 			assert.Check(t, is.Equal(runRes.ExitCode, 1))
 			assert.Check(t, is.Contains(runRes.Stderr.String(), "bad address"))


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/51495

- Fixes https://github.com/moby/moby/issues/51491
- Related to https://github.com/moby/moby/pull/48971

**- What I did**

Commit https://github.com/moby/moby/commit/a8b9eff902903246aed22a0e49fbc713abcb6a94 removed a call to Network.updateSvcRecord from Network.createEndpoint on the grounds that:

> all callers of Network.createEndpoint follow up with an Endpoint.Join, which also sets up the DNS entry.

However, the original call in Network.createEndpoint was gated by:

```golang
if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
	n.updateSvcRecord(context.WithoutCancel(ctx), ep, true)
}
```

whereas the call in Endpoint.sbJoin() (invoked by Endpoint.Join()) is gated by:

```golang
if !n.getController().isAgent() {
    if !n.getController().isSwarmNode() || n.Scope() != scope.Swarm || !n.driverIsMultihost() {
	    n.updateSvcRecord(context.WithoutCancel(ctx), ep, true)
    }
}
```

As a result, once a node has joined a Swarm cluster, no DNS entries are created for non swarm-scoped networks.

Change the condition used by `sbJoin` to match the original condition used in `createEndpoint`, and add an integration test.

**- Human readable description for the release notes**

```markdown changelog
Fix a bug preventing DNS resolution of containers attached to non swarm-scoped networks once the node has joined a Swarm cluster
```
