### PR TITLE
client: export fallbackAPIVersion as MinAPIVersion

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -110,10 +110,9 @@ const DummyHost = "api.moby.localhost"
 // This version may be lower than the version of the api library module used.
 const MaxAPIVersion = "1.52"
 
-// fallbackAPIVersion is the version to fall back to if API-version negotiation
-// fails. API versions below this version are not supported by the client,
-// and not considered when negotiating.
-const fallbackAPIVersion = "1.44"
+// MinAPIVersion is the minimum API version supported by the client. API versions
+// below this version are not considered when performing API-version negotiation.
+const MinAPIVersion = "1.44"
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}
@@ -312,9 +311,9 @@ func (cli *Client) negotiateAPIVersion(pingVersion string) error {
 	pingVersion = strings.TrimPrefix(pingVersion, "v")
 	if pingVersion == "" {
 		// TODO(thaJeztah): consider returning an error on empty value or not falling back; see https://github.com/moby/moby/pull/51119#discussion_r2413148487
-		pingVersion = fallbackAPIVersion
-	} else if versions.LessThan(pingVersion, fallbackAPIVersion) {
-		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, fallbackAPIVersion))
+		pingVersion = MinAPIVersion
+	} else if versions.LessThan(pingVersion, MinAPIVersion) {
+		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, MinAPIVersion))
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -254,7 +254,7 @@ func TestNegotiateAPIVersionEmpty(t *testing.T) {
 
 	// if no version from server, expect the earliest
 	// version before APIVersion was implemented
-	const expected = fallbackAPIVersion
+	const expected = MinAPIVersion
 
 	client, err := New(FromEnv,
 		WithAPIVersionNegotiation(),
@@ -306,7 +306,7 @@ func TestNegotiateAPIVersion(t *testing.T) {
 			// a version.
 			doc:             "downgrade legacy",
 			pingVersion:     "",
-			expectedVersion: fallbackAPIVersion,
+			expectedVersion: MinAPIVersion,
 		},
 		{
 			// client should not downgrade to the version reported by the daemon
@@ -314,7 +314,7 @@ func TestNegotiateAPIVersion(t *testing.T) {
 			doc:             "no downgrade old",
 			pingVersion:     "1.19",
 			expectedVersion: MaxAPIVersion,
-			expectedErr:     "API version 1.19 is not supported by this client: the minimum supported API version is " + fallbackAPIVersion,
+			expectedErr:     "API version 1.19 is not supported by this client: the minimum supported API version is " + MinAPIVersion,
 		},
 		{
 			// client should not upgrade to a newer version if a version was set,

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -110,10 +110,9 @@ const DummyHost = "api.moby.localhost"
 // This version may be lower than the version of the api library module used.
 const MaxAPIVersion = "1.52"
 
-// fallbackAPIVersion is the version to fall back to if API-version negotiation
-// fails. API versions below this version are not supported by the client,
-// and not considered when negotiating.
-const fallbackAPIVersion = "1.44"
+// MinAPIVersion is the minimum API version supported by the client. API versions
+// below this version are not considered when performing API-version negotiation.
+const MinAPIVersion = "1.44"
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}
@@ -312,9 +311,9 @@ func (cli *Client) negotiateAPIVersion(pingVersion string) error {
 	pingVersion = strings.TrimPrefix(pingVersion, "v")
 	if pingVersion == "" {
 		// TODO(thaJeztah): consider returning an error on empty value or not falling back; see https://github.com/moby/moby/pull/51119#discussion_r2413148487
-		pingVersion = fallbackAPIVersion
-	} else if versions.LessThan(pingVersion, fallbackAPIVersion) {
-		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, fallbackAPIVersion))
+		pingVersion = MinAPIVersion
+	} else if versions.LessThan(pingVersion, MinAPIVersion) {
+		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, MinAPIVersion))
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version


### PR DESCRIPTION
Export the const and rename it to better reflect its intent.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
add `MinAPIVersion` const, which contains the lowest API version supported by the client.
```

**- A picture of a cute animal (not mandatory but encouraged)**

