### PR TITLE
Refactor Daemon.create - prep for call to NRI plugin

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -143,7 +143,7 @@ func (daemon *Daemon) newContainer(name string, platform ocispec.Platform, confi
 	base.Path = entrypoint
 	base.Args = args // FIXME: de-duplicate from config
 	base.Config = config
-	base.HostConfig = &containertypes.HostConfig{}
+	base.HostConfig = hostConfig
 	base.ImageID = imgID
 	base.NetworkSettings = &network.Settings{}
 	base.Name = name
@@ -209,14 +209,6 @@ func (daemon *Daemon) setSecurityOptions(cfg *config.Config, container *containe
 	container.Lock()
 	defer container.Unlock()
 	return daemon.parseSecurityOpt(cfg, &container.SecurityOptions, hostConfig)
-}
-
-func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *containertypes.HostConfig) error {
-	container.Lock()
-	defer container.Unlock()
-
-	container.HostConfig = hostConfig
-	return nil
 }
 
 // verifyContainerSettings performs validation of the hostconfig and config

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -221,9 +221,6 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 	container.Lock()
 	defer container.Unlock()
 
-	if hostConfig != nil && hostConfig.NetworkMode == "" {
-		hostConfig.NetworkMode = networktypes.NetworkDefault
-	}
 	container.HostConfig = hostConfig
 	return nil
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -205,10 +205,10 @@ func (daemon *Daemon) GetDependentContainers(c *container.Container) []*containe
 	return append(dependentContainers, slices.Collect(maps.Values(daemon.linkIndex.children(c)))...)
 }
 
-func (daemon *Daemon) setSecurityOptions(cfg *config.Config, container *container.Container, hostConfig *containertypes.HostConfig) error {
+func (daemon *Daemon) setSecurityOptions(cfg *config.Config, container *container.Container) error {
 	container.Lock()
 	defer container.Unlock()
-	return daemon.parseSecurityOpt(cfg, &container.SecurityOptions, hostConfig)
+	return daemon.parseSecurityOpt(cfg, &container.SecurityOptions, container.HostConfig)
 }
 
 // verifyContainerSettings performs validation of the hostconfig and config

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -221,11 +221,6 @@ func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *
 	container.Lock()
 	defer container.Unlock()
 
-	// Register any links from the host config before starting the container
-	if err := daemon.registerLinks(container, hostConfig); err != nil {
-		return err
-	}
-
 	if hostConfig != nil && hostConfig.NetworkMode == "" {
 		hostConfig.NetworkMode = networktypes.NetworkDefault
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -211,13 +211,7 @@ func (daemon *Daemon) setSecurityOptions(cfg *config.Config, container *containe
 	return daemon.parseSecurityOpt(cfg, &container.SecurityOptions, hostConfig)
 }
 
-func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *containertypes.HostConfig, defaultReadOnlyNonRecursive bool) error {
-	// Do not lock while creating volumes since this could be calling out to external plugins
-	// Don't want to block other actions, like `docker ps` because we're waiting on an external plugin
-	if err := daemon.registerMountPoints(container, hostConfig, defaultReadOnlyNonRecursive); err != nil {
-		return err
-	}
-
+func (daemon *Daemon) setHostConfig(container *container.Container, hostConfig *containertypes.HostConfig) error {
 	container.Lock()
 	defer container.Unlock()
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -244,7 +244,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		return nil, err
 	}
 
-	if err := daemon.setHostConfig(ctr, opts.params.HostConfig, opts.params.DefaultReadOnlyNonRecursive); err != nil {
+	if err := daemon.setHostConfig(ctr, opts.params.HostConfig); err != nil {
 		return nil, err
 	}
 	if err := daemon.registerLinks(ctr); err != nil {
@@ -265,6 +265,9 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	}
 	daemon.updateContainerNetworkSettings(ctr, endpointsConfigs)
 
+	if err := daemon.registerMountPoints(ctr, opts.params.DefaultReadOnlyNonRecursive); err != nil {
+		return nil, err
+	}
 	if err := daemon.createContainerVolumesOS(ctx, ctr, opts.params.Config, opts.params.HostConfig); err != nil {
 		return nil, err
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -250,7 +250,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	if err := daemon.registerLinks(ctr); err != nil {
 		return nil, err
 	}
-	if err := daemon.createContainerOSSpecificSettings(ctx, ctr, opts.params.Config, opts.params.HostConfig); err != nil {
+	if err := daemon.createContainerOSSpecificSettings(ctx, ctr, opts.params.HostConfig); err != nil {
 		return nil, err
 	}
 
@@ -263,8 +263,12 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	if ctr.HostConfig != nil && ctr.HostConfig.NetworkMode == "" {
 		ctr.HostConfig.NetworkMode = networktypes.NetworkDefault
 	}
-
 	daemon.updateContainerNetworkSettings(ctr, endpointsConfigs)
+
+	if err := daemon.createContainerVolumesOS(ctx, ctr, opts.params.Config, opts.params.HostConfig); err != nil {
+		return nil, err
+	}
+
 	if err := daemon.register(ctx, ctr); err != nil {
 		return nil, err
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -221,7 +221,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		}
 	}()
 
-	if err := daemon.setSecurityOptions(daemonCfg, ctr, opts.params.HostConfig); err != nil {
+	if err := daemon.setSecurityOptions(daemonCfg, ctr); err != nil {
 		return nil, err
 	}
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -225,7 +225,6 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		return nil, err
 	}
 
-	ctr.HostConfig.StorageOpt = opts.params.HostConfig.StorageOpt
 	ctr.ImageManifest = imgManifest
 
 	// Set RWLayer for container after mount labels have been set
@@ -244,9 +243,6 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 		return nil, err
 	}
 
-	if err := daemon.setHostConfig(ctr, opts.params.HostConfig); err != nil {
-		return nil, err
-	}
 	if err := daemon.registerLinks(ctr); err != nil {
 		return nil, err
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -247,7 +247,9 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	if err := daemon.setHostConfig(ctr, opts.params.HostConfig, opts.params.DefaultReadOnlyNonRecursive); err != nil {
 		return nil, err
 	}
-
+	if err := daemon.registerLinks(ctr); err != nil {
+		return nil, err
+	}
 	if err := daemon.createContainerOSSpecificSettings(ctx, ctr, opts.params.Config, opts.params.HostConfig); err != nil {
 		return nil, err
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -246,7 +246,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	if err := daemon.registerLinks(ctr); err != nil {
 		return nil, err
 	}
-	if err := daemon.createContainerOSSpecificSettings(ctx, ctr, opts.params.HostConfig); err != nil {
+	if err := daemon.createContainerOSSpecificSettings(ctx, ctr); err != nil {
 		return nil, err
 	}
 
@@ -264,7 +264,7 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 	if err := daemon.registerMountPoints(ctr, opts.params.DefaultReadOnlyNonRecursive); err != nil {
 		return nil, err
 	}
-	if err := daemon.createContainerVolumesOS(ctx, ctr, opts.params.Config, opts.params.HostConfig); err != nil {
+	if err := daemon.createContainerVolumesOS(ctx, ctr, opts.params.Config); err != nil {
 		return nil, err
 	}
 

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -22,16 +22,7 @@ import (
 )
 
 // createContainerOSSpecificSettings performs host-OS specific container create functionality
-func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
-	if err := daemon.Mount(container); err != nil {
-		return err
-	}
-	defer daemon.Unmount(container)
-
-	if err := container.SetupWorkingDirectory(daemon.idMapping.RootPair()); err != nil {
-		return err
-	}
-
+func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, container *container.Container, hostConfig *containertypes.HostConfig) error {
 	// Set the default masked and readonly paths with regard to the host config options if they are not set.
 	if hostConfig.MaskedPaths == nil && !hostConfig.Privileged {
 		hostConfig.MaskedPaths = oci.DefaultSpec().Linux.MaskedPaths // Set it to the default if nil
@@ -40,6 +31,19 @@ func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, con
 	if hostConfig.ReadonlyPaths == nil && !hostConfig.Privileged {
 		hostConfig.ReadonlyPaths = oci.DefaultSpec().Linux.ReadonlyPaths // Set it to the default if nil
 		container.HostConfig.ReadonlyPaths = hostConfig.ReadonlyPaths
+	}
+	return nil
+}
+
+// createContainerVolumesOS performs host-OS specific volume creation
+func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
+	if err := daemon.Mount(container); err != nil {
+		return err
+	}
+	defer daemon.Unmount(container)
+
+	if err := container.SetupWorkingDirectory(daemon.idMapping.RootPair()); err != nil {
+		return err
 	}
 
 	for spec := range config.Volumes {

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -22,27 +22,25 @@ import (
 )
 
 // createContainerOSSpecificSettings performs host-OS specific container create functionality
-func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, container *container.Container, hostConfig *containertypes.HostConfig) error {
+func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, ctr *container.Container) error {
 	// Set the default masked and readonly paths with regard to the host config options if they are not set.
-	if hostConfig.MaskedPaths == nil && !hostConfig.Privileged {
-		hostConfig.MaskedPaths = oci.DefaultSpec().Linux.MaskedPaths // Set it to the default if nil
-		container.HostConfig.MaskedPaths = hostConfig.MaskedPaths
+	if ctr.HostConfig.MaskedPaths == nil && !ctr.HostConfig.Privileged {
+		ctr.HostConfig.MaskedPaths = oci.DefaultSpec().Linux.MaskedPaths // Set it to the default if nil
 	}
-	if hostConfig.ReadonlyPaths == nil && !hostConfig.Privileged {
-		hostConfig.ReadonlyPaths = oci.DefaultSpec().Linux.ReadonlyPaths // Set it to the default if nil
-		container.HostConfig.ReadonlyPaths = hostConfig.ReadonlyPaths
+	if ctr.HostConfig.ReadonlyPaths == nil && !ctr.HostConfig.Privileged {
+		ctr.HostConfig.ReadonlyPaths = oci.DefaultSpec().Linux.ReadonlyPaths // Set it to the default if nil
 	}
 	return nil
 }
 
 // createContainerVolumesOS performs host-OS specific volume creation
-func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
-	if err := daemon.Mount(container); err != nil {
+func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, ctr *container.Container, config *containertypes.Config) error {
+	if err := daemon.Mount(ctr); err != nil {
 		return err
 	}
-	defer daemon.Unmount(container)
+	defer daemon.Unmount(ctr)
 
-	if err := container.SetupWorkingDirectory(daemon.idMapping.RootPair()); err != nil {
+	if err := ctr.SetupWorkingDirectory(daemon.idMapping.RootPair()); err != nil {
 		return err
 	}
 
@@ -51,12 +49,12 @@ func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, container *c
 
 		// Skip volumes for which we already have something mounted on that
 		// destination because of a --volume-from.
-		if container.HasMountFor(destination) {
-			log.G(ctx).WithField("container", container.ID).WithField("destination", spec).Debug("mountpoint already exists, skipping anonymous volume")
+		if ctr.HasMountFor(destination) {
+			log.G(ctx).WithField("container", ctr.ID).WithField("destination", spec).Debug("mountpoint already exists, skipping anonymous volume")
 			// Not an error, this could easily have come from the image config.
 			continue
 		}
-		path, err := container.GetResourcePath(destination)
+		path, err := ctr.GetResourcePath(destination)
 		if err != nil {
 			return err
 		}
@@ -66,18 +64,18 @@ func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, container *c
 			return fmt.Errorf("cannot mount volume over existing file, file exists %s", path)
 		}
 
-		v, err := daemon.volumes.Create(context.TODO(), "", hostConfig.VolumeDriver, volumeopts.WithCreateReference(container.ID))
+		v, err := daemon.volumes.Create(context.TODO(), "", ctr.HostConfig.VolumeDriver, volumeopts.WithCreateReference(ctr.ID))
 		if err != nil {
 			return err
 		}
 
-		if err := label.Relabel(v.Mountpoint, container.MountLabel, true); err != nil {
+		if err := label.Relabel(v.Mountpoint, ctr.MountLabel, true); err != nil {
 			return err
 		}
 
-		container.AddMountPointWithVolume(destination, &volumeWrapper{v: v, s: daemon.volumes}, true)
+		ctr.AddMountPointWithVolume(destination, &volumeWrapper{v: v, s: daemon.volumes}, true)
 	}
-	return daemon.populateVolumes(ctx, container)
+	return daemon.populateVolumes(ctx, ctr)
 }
 
 // populateVolumes copies data from the container's rootfs into the volume for non-binds.

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -11,11 +11,16 @@ import (
 )
 
 // createContainerOSSpecificSettings performs host-OS specific container create functionality
-func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
+func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, container *container.Container, hostConfig *containertypes.HostConfig) error {
 	if containertypes.Isolation.IsDefault(hostConfig.Isolation) {
 		// Make sure the host config has the default daemon isolation if not specified by caller.
 		hostConfig.Isolation = daemon.defaultIsolation
 	}
+	return nil
+}
+
+// createContainerVolumesOS performs host-OS specific volume creation
+func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
 	parser := volumemounts.NewParser()
 	for spec := range config.Volumes {
 

--- a/daemon/create_windows.go
+++ b/daemon/create_windows.go
@@ -11,35 +11,33 @@ import (
 )
 
 // createContainerOSSpecificSettings performs host-OS specific container create functionality
-func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, container *container.Container, hostConfig *containertypes.HostConfig) error {
-	if containertypes.Isolation.IsDefault(hostConfig.Isolation) {
+func (daemon *Daemon) createContainerOSSpecificSettings(ctx context.Context, ctr *container.Container) error {
+	if containertypes.Isolation.IsDefault(ctr.HostConfig.Isolation) {
 		// Make sure the host config has the default daemon isolation if not specified by caller.
-		hostConfig.Isolation = daemon.defaultIsolation
+		ctr.HostConfig.Isolation = daemon.defaultIsolation
 	}
 	return nil
 }
 
 // createContainerVolumesOS performs host-OS specific volume creation
-func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
+func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, ctr *container.Container, config *containertypes.Config) error {
 	parser := volumemounts.NewParser()
 	for spec := range config.Volumes {
 
-		mp, err := parser.ParseMountRaw(spec, hostConfig.VolumeDriver)
+		mp, err := parser.ParseMountRaw(spec, ctr.HostConfig.VolumeDriver)
 		if err != nil {
 			return fmt.Errorf("Unrecognised volume spec: %v", err)
 		}
 
 		// Skip volumes for which we already have something mounted on that
 		// destination because of a --volume-from.
-		if container.IsDestinationMounted(mp.Destination) {
+		if ctr.IsDestinationMounted(mp.Destination) {
 			continue
 		}
 
-		volumeDriver := hostConfig.VolumeDriver
-
 		// Create the volume in the volume driver. If it doesn't exist,
 		// a new one will be created.
-		v, err := daemon.volumes.Create(ctx, "", volumeDriver, volumeopts.WithCreateReference(container.ID))
+		v, err := daemon.volumes.Create(ctx, "", ctr.HostConfig.VolumeDriver, volumeopts.WithCreateReference(ctr.ID))
 		if err != nil {
 			return err
 		}
@@ -75,7 +73,7 @@ func (daemon *Daemon) createContainerVolumesOS(ctx context.Context, container *c
 		//	}
 
 		// Add it to container.MountPoints
-		container.AddMountPointWithVolume(mp.Destination, &volumeWrapper{v: v, s: daemon.volumes}, mp.RW)
+		ctr.AddMountPointWithVolume(mp.Destination, &volumeWrapper{v: v, s: daemon.volumes}, mp.RW)
 	}
 	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -592,7 +592,7 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 		go func(c *container.Container) {
 			_ = sem.Acquire(context.Background(), 1)
 
-			if err := daemon.registerLinks(c, c.HostConfig); err != nil {
+			if err := daemon.registerLinks(c); err != nil {
 				log.G(ctx).WithField("container", c.ID).WithError(err).Error("failed to register link for container")
 			}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1504,12 +1504,12 @@ func getUnmountOnShutdownPath(config *config.Config) string {
 
 // registerLinks registers network links between container and other containers
 // with the daemon using the specification in hostConfig.
-func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *containertypes.HostConfig) error {
-	if hostConfig == nil || hostConfig.NetworkMode.IsUserDefined() {
+func (daemon *Daemon) registerLinks(ctr *container.Container) error {
+	if ctr.HostConfig == nil || ctr.HostConfig.NetworkMode.IsUserDefined() {
 		return nil
 	}
 
-	for _, l := range hostConfig.Links {
+	for _, l := range ctr.HostConfig.Links {
 		name, alias, err := opts.ParseLink(l)
 		if err != nil {
 			return err
@@ -1542,7 +1542,7 @@ func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *
 		if child.HostConfig.NetworkMode.IsHost() {
 			return cerrdefs.ErrInvalidArgument.WithMessage("conflicting options: host type networking can't be used with links. This would result in undefined behavior")
 		}
-		if err := daemon.registerLink(container, child, alias); err != nil {
+		if err := daemon.registerLink(ctr, child, alias); err != nil {
 			return err
 		}
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -464,7 +464,7 @@ func initBridgeDriver(controller *libnetwork.Controller, config config.BridgeCon
 
 // registerLinks sets up links between containers and writes the
 // configuration out for persistence. As of Windows TP4, links are not supported.
-func (daemon *Daemon) registerLinks(container *container.Container, hostConfig *containertypes.HostConfig) error {
+func (daemon *Daemon) registerLinks(container *container.Container) error {
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/51511

For NRI, the daemon will need to call a plugin with a container's config, and the plugin may modify the container - including its mount points.

So, set up the container's config before processing mount options and finding volumes to make it possible to call NRI first.

Plus some refactoring ...
- `Daemon.create` called `setHostConfig` to assign `opts.params.HostConfig` directly to `ctr.HostConfig`, after the container was constructed.
- It looked like `opts.params.HostConfig` and `ctr.HostConfig` were different, but they weren't.
- `setHostConfig` did stuff that wasn't setting host config.

**- How I did it**

See individual commits.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```
