### PR TITLE
integration: skip TestBuildWithHugeFile

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -475,6 +475,7 @@ RUN [ ! -f foo ]
 // #37581
 // #40444 (Windows Containers only)
 func TestBuildWithHugeFile(t *testing.T) {
+	t.Skip("Test is flaky, and often causes out of space issues on GitHub Actions")
 	ctx := setupTest(t)
 
 	var dockerfile string


### PR DESCRIPTION
We've seen various failures recently where GitHub actions runners are running out of space. Skip this test for now.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

