### PR TITLE
client: client.Ping: allow ForceNegotiate with manual override

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -437,19 +437,28 @@ func TestNegotiateAPIVersionWithEmptyVersion(t *testing.T) {
 // TestNegotiateAPIVersionWithFixedVersion asserts that initializing a client
 // with a fixed version disables API-version negotiation
 func TestNegotiateAPIVersionWithFixedVersion(t *testing.T) {
-	const customVersion = "1.50"
+	const (
+		customVersion = "1.50"
+		pingVersion   = "1.49"
+	)
 	client, err := New(
 		WithAPIVersion(customVersion),
-		WithMockClient(mockResponse(http.StatusOK, http.Header{"Api-Version": []string{"1.49"}}, "OK")),
+		WithMockClient(mockResponse(http.StatusOK, http.Header{"Api-Version": []string{pingVersion}}, "OK")),
 	)
 	assert.NilError(t, err)
+
+	_, err = client.Ping(t.Context(), PingOptions{
+		NegotiateAPIVersion: true,
+	})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(client.ClientVersion(), customVersion))
 
 	_, err = client.Ping(t.Context(), PingOptions{
 		NegotiateAPIVersion: true,
 		ForceNegotiate:      true,
 	})
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal(client.ClientVersion(), customVersion))
+	assert.Check(t, is.Equal(client.ClientVersion(), pingVersion))
 }
 
 // TestCustomAPIVersion tests initializing the client with a custom

--- a/client/ping.go
+++ b/client/ping.go
@@ -29,9 +29,8 @@ type PingOptions struct {
 	NegotiateAPIVersion bool
 
 	// ForceNegotiate forces the client to re-negotiate the API version, even if
-	// API-version negotiation already happened. This option cannot be
-	// used if the client is configured with a fixed version using (using
-	// [WithAPIVersion] or [WithAPIVersionFromEnv]).
+	// API-version negotiation already happened or it the client is configured
+	// with a fixed version (using [WithAPIVersion] or [WithAPIVersionFromEnv]).
 	//
 	// This option has no effect if NegotiateAPIVersion is not set.
 	ForceNegotiate bool
@@ -72,7 +71,8 @@ type SwarmStatus struct {
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
 func (cli *Client) Ping(ctx context.Context, options PingOptions) (PingResult, error) {
-	if cli.manualOverride {
+	if (cli.manualOverride || cli.negotiated.Load()) && !options.ForceNegotiate {
+		// API version was already negotiated or manually set.
 		return cli.ping(ctx)
 	}
 	if !options.NegotiateAPIVersion && !cli.negotiateVersion {

--- a/vendor/github.com/moby/moby/client/ping.go
+++ b/vendor/github.com/moby/moby/client/ping.go
@@ -29,9 +29,8 @@ type PingOptions struct {
 	NegotiateAPIVersion bool
 
 	// ForceNegotiate forces the client to re-negotiate the API version, even if
-	// API-version negotiation already happened. This option cannot be
-	// used if the client is configured with a fixed version using (using
-	// [WithAPIVersion] or [WithAPIVersionFromEnv]).
+	// API-version negotiation already happened or it the client is configured
+	// with a fixed version (using [WithAPIVersion] or [WithAPIVersionFromEnv]).
 	//
 	// This option has no effect if NegotiateAPIVersion is not set.
 	ForceNegotiate bool
@@ -72,7 +71,8 @@ type SwarmStatus struct {
 // for other non-success status codes, failing to connect to the API, or failing
 // to parse the API response.
 func (cli *Client) Ping(ctx context.Context, options PingOptions) (PingResult, error) {
-	if cli.manualOverride {
+	if (cli.manualOverride || cli.negotiated.Load()) && !options.ForceNegotiate {
+		// API version was already negotiated or manually set.
 		return cli.ping(ctx)
 	}
 	if !options.NegotiateAPIVersion && !cli.negotiateVersion {


### PR DESCRIPTION
While a manual overridden version shouldn't perform automatic version negotiation, the "ForceNegotiate" option could still be used to (re) negotiate a version. This allows a client to be configured with an initial API version, then triggered to perform API-version negotiation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client.Ping: allow `ForceNegotiate` on clients configured with a manual version.
```

**- A picture of a cute animal (not mandatory but encouraged)**

