### PR TITLE
Don't try to remove a cleared docker_gwbridge endpoint

### DIFF
--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -567,6 +567,16 @@ func (ep *Endpoint) sbJoin(ctx context.Context, sb *Sandbox, options ...Endpoint
 		if err := sb.populateNetworkResources(ctx, ep); err != nil {
 			return err
 		}
+
+		// If the old gateway was in the docker_gwbridge network, it's already been removed if
+		// the new endpoint provides a gateway. Don't try to remove it again.
+		if gwepBefore4 != nil && sb.GetEndpoint(gwepBefore4.ID()) == nil {
+			gwepBefore4 = nil
+		}
+		if gwepBefore6 != nil && sb.GetEndpoint(gwepBefore6.ID()) == nil {
+			gwepBefore6 = nil
+		}
+
 		if err := ep.updateExternalConnectivity(ctx, sb, gwepBefore4, gwepBefore6); err != nil {
 			return err
 		}


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/51522
- (probably) intruduced by https://github.com/moby/moby/pull/50321

If a container is using a `docker_gwbridge` endpoint as its gateway, when it's connected to another network that provides a gateway, the `docker_gwbridge` endpoint is removed (in a recursive nightmare).

So, the "before" gateway for the container has been removed before the new gateway is updateExternalConnectivity'd, and an error is raised because it can't be removed again.

This will affect any container using `docker_gwbridge` - most won't ... the built-in ipvlan/macvlan drivers disable it, and non-internal bridge networks require IPv4 or IPv6. But I'm not sure if there's a way to provoke the error with Swarm.

**- How I did it**

Don't pass the old gateway to updateExternalConnectivity in that case, because the network driver's already forgotten about it.

**- How to verify it**

This needs a regression test - but wanted to get the fix in first (missed 29.0.1, but there will be a 29.0.2).

For now, manual repro ...

- create a network with a remote driver (I used https://github.com/KatharaFramework/NetworkPlugin/tree/main/bridge, modified not to set `DisableGatewayEndpoint` in its `Join` response).
- run a container connected to that network, with no IP addresses
- create a bridge network and connect it to the container
- see if it goes bang

**- Human readable description for the release notes**
```markdown changelog
Fix an issue that could lead to an "endpoint not found" error when creating a container with multiple network connections, when one of the networks is non-internal but does not have its own external IP connectivity.
```
