### PR TITLE
[docker-29.x backport] rootless: ignore error when enabling IPv6 forwarding

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -228,9 +228,10 @@ else
 	# When running with --firewall-backend=nftables, IP forwarding needs to be enabled
 	# because the daemon won't enable it. IP forwarding is harmless in the rootless
 	# netns, there's only a single external interface and only Docker uses the netns.
-	# So, always enable IPv4 and IPv6 forwarding.
+	# So, always enable IPv4 and IPv6 forwarding. But ignore failure to enable IPv6
+	# forwarding, for hosts with IPv6 disabled.
 	sysctl -w net.ipv4.ip_forward=1
-	sysctl -w net.ipv6.conf.all.forwarding=1
+	sysctl -w net.ipv6.conf.all.forwarding=1 || true
 
 	exec "$dockerd" "$@"
 fi


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51542

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- fix https://github.com/moby/moby/issues/51541

In `dockerd-rootless.sh` - ignore error when enabling IPv6 forwarding, hosts with IPv6 disabled.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix an issue that prevented rootless Docker from starting on a host with IPv6 disabled
```

**- A picture of a cute animal (not mandatory but encouraged)**

