### PR TITLE
migrate TestAPIImageImportBadSrc to integration test

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -2,39 +2,12 @@ package main
 
 import (
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
 )
-
-func (s *DockerAPISuite) TestAPIImagesImportBadSrc(c *testing.T) {
-	testRequires(c, Network, testEnv.IsLocalDaemon)
-
-	server := httptest.NewServer(http.NewServeMux())
-	defer server.Close()
-
-	tt := []struct {
-		statusExp int
-		fromSrc   string
-	}{
-		{http.StatusNotFound, server.URL + "/nofile.tar"},
-		{http.StatusNotFound, strings.TrimPrefix(server.URL, "http://") + "/nofile.tar"},
-		{http.StatusNotFound, strings.TrimPrefix(server.URL, "http://") + "%2Fdata%2Ffile.tar"},
-		{http.StatusInternalServerError, "%2Fdata%2Ffile.tar"},
-	}
-
-	ctx := testutil.GetContext(c)
-	for _, te := range tt {
-		res, _, err := request.Post(ctx, "/images/create?fromSrc="+te.fromSrc, request.JSON)
-		assert.NilError(c, err)
-		assert.Equal(c, res.StatusCode, te.statusExp)
-		assert.Equal(c, res.Header.Get("Content-Type"), "application/json")
-	}
-}
 
 // #14846
 func (s *DockerAPISuite) TestAPIImagesSearchJSONContentType(c *testing.T) {

--- a/integration/image/import_test.go
+++ b/integration/image/import_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"net/http/httptest"
 	"runtime"
 	"strconv"
 	"strings"
@@ -188,4 +189,58 @@ func TestImportWithCustomPlatformReject(t *testing.T) {
 			assert.Check(t, is.ErrorContains(err, tc.expectedErr))
 		})
 	}
+}
+
+func TestImageImportBadSrc(t *testing.T) {
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	skip.If(t, testEnv.IsRootless, "rootless daemon cannot access the test's HTTP server in the host's netns")
+
+	server := httptest.NewServer(nil)
+	defer server.Close()
+
+	trimmedHTTP := strings.TrimPrefix(server.URL, "http://")
+
+	tests := []struct {
+		name      string
+		fromSrc   string
+		expectErr func(error) bool
+	}{
+		{
+			name:      "missing file via full URL",
+			fromSrc:   server.URL + "/nofile.tar",
+			expectErr: cerrdefs.IsNotFound,
+		},
+		{
+			name:      "missing file via trimmed URL",
+			fromSrc:   trimmedHTTP + "/nofile.tar",
+			expectErr: cerrdefs.IsNotFound,
+		},
+		{
+			name:      "encoded path via trimmed URL",
+			fromSrc:   trimmedHTTP + "/%2Fdata%2Ffile.tar",
+			expectErr: cerrdefs.IsNotFound,
+		},
+		{
+			name:      "encoded absolute path",
+			fromSrc:   "%2Fdata%2Ffile.tar",
+			expectErr: cerrdefs.IsInvalidArgument,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := apiClient.ImageImport(ctx,
+				client.ImageImportSource{
+					SourceName: tc.fromSrc,
+				},
+				"import-bad-src:test",
+				client.ImageImportOptions{},
+			)
+
+			assert.Check(t, tc.expectErr(err))
+		})
+	}
+
 }


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/50159

**- What I did**
Migrated the `TestAPIImageImportBadSrc` test from `integration-cli/docker_api_image_test.go` to the new integration test framework under `integration/image/import_test.go`.


