### PR TITLE
Remote nw driver: restore missing nwEndpointsMu.Lock

### DIFF
--- a/daemon/libnetwork/drivers/remote/driver.go
+++ b/daemon/libnetwork/drivers/remote/driver.go
@@ -415,6 +415,7 @@ func (d *driver) ProgramExternalConnectivity(_ context.Context, nid, eid string,
 
 // revokeExternalConnectivity method is invoked to remove any external connectivity programming related to the endpoint.
 func (d *driver) revokeExternalConnectivity(nid, eid string) error {
+	d.nwEndpointsMu.Lock()
 	ep, ok := d.nwEndpoints[eid]
 	d.nwEndpointsMu.Unlock()
 	if !ok {


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/51554
- introduced by:
  - https://github.com/moby/moby/pull/50321 
  - 4f7afb8 (Remove libnet's logic to track a driver's port mapping state)

`revokeExternalConnectivity` unlocked `d.nwEndpointsMu.Lock()` without locking it.

We're clearly missing some test coverage here - but let's get the fix in, and I'll follow up with that when I get a bit more time.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix an issue that caused daemon crash when using a remote network driver plugin
```

**- A picture of a cute animal (not mandatory but encouraged)**

