### PR TITLE
migrate TestAPIImagesSearchJSONContentType to integration test

### DIFF
--- a/integration/image/search_test.go
+++ b/integration/image/search_test.go
@@ -1,0 +1,22 @@
+package image
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moby/moby/v2/internal/testutil/request"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// https://github.com/moby/moby/issues/14846
+func TestImagesSearchJSONContentType(t *testing.T) {
+	ctx := setupTest(t)
+
+	res, body, err := request.Get(ctx, "/images/search?term=test", request.JSON)
+	assert.NilError(t, err)
+	body.Close()
+
+	assert.Check(t, is.Equal(res.StatusCode, http.StatusOK))
+	assert.Check(t, is.Equal(res.Header.Get("Content-type"), "application/json"))
+}


### PR DESCRIPTION

**- What I did**
Migrated the `TestAPIImagesSearchJSONContentType` test from `integration-cli/docker_api_image_test.go` to the new integration test framework under `integration/image/search_test.go`.