### PR TITLE
integration: migrate TestAPIImagesSizeCompatibility to integration test

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
@@ -46,29 +45,4 @@ func (s *DockerAPISuite) TestAPIImagesSearchJSONContentType(c *testing.T) {
 	b.Close()
 	assert.Equal(c, res.StatusCode, http.StatusOK)
 	assert.Equal(c, res.Header.Get("Content-Type"), "application/json")
-}
-
-// Test case for 30027: image size reported as -1 in v1.12 client against v1.13 daemon.
-// This test checks to make sure both v1.12 and v1.13 client against v1.13 daemon get correct `Size` after the fix.
-func (s *DockerAPISuite) TestAPIImagesSizeCompatibility(c *testing.T) {
-	apiclient := testEnv.APIClient()
-	defer apiclient.Close()
-
-	imageList, err := apiclient.ImageList(testutil.GetContext(c), client.ImageListOptions{})
-	assert.NilError(c, err)
-	assert.Assert(c, len(imageList.Items) != 0)
-	for _, img := range imageList.Items {
-		assert.Assert(c, img.Size != int64(-1))
-	}
-
-	apiclient, err = client.New(client.FromEnv, client.WithAPIVersion("v1.24"))
-	assert.NilError(c, err)
-	defer apiclient.Close()
-
-	v124Images, err := apiclient.ImageList(testutil.GetContext(c), client.ImageListOptions{})
-	assert.NilError(c, err)
-	assert.Assert(c, len(v124Images.Items) != 0)
-	for _, img := range v124Images.Items {
-		assert.Assert(c, img.Size != int64(-1))
-	}
 }

--- a/integration/image/size_test.go
+++ b/integration/image/size_test.go
@@ -1,0 +1,41 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/moby/moby/client"
+	"gotest.tools/v3/assert"
+)
+
+// Test case for 30027: image size reported as -1
+// in v1.12 client against v1.13 daemon.
+func TestImagesSizeCompatibility(t *testing.T) {
+	ctx := setupTest(t)
+
+	testCases := []struct {
+		name       string
+		apiVersion string
+	}{
+		{name: "LatestAPIVersion", apiVersion: ""},
+		{name: "MinimumAPIVersion", apiVersion: client.MinAPIVersion},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cli, err := client.New(
+				client.FromEnv,
+				client.WithAPIVersion(tc.apiVersion),
+			)
+			assert.NilError(t, err)
+			defer cli.Close()
+
+			images, err := cli.ImageList(ctx, client.ImageListOptions{})
+			assert.NilError(t, err)
+			assert.Assert(t, len(images.Items) > 0)
+
+			for _, img := range images.Items {
+				assert.Check(t, img.Size >= 0)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/50159
- replaces part of https://github.com/moby/moby/pull/50494

**- What I did**
Migrated the `TestAPIImagesSizeCompatibility` test from `integration-cli/docker_api_image_test.go` to the new integration test framework under `integration/image/size_test.go`.