### PR TITLE
migrate TestAPINetworkInspectWithScope to integration test

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/initca"
-	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
@@ -1018,23 +1017,4 @@ func (s *DockerSwarmSuite) TestSwarmRepeatedRootRotation(c *testing.T) {
 		assert.DeepEqual(c, m.GetNode(ctx, c, w.NodeID()).Description.TLSInfo, clusterTLSInfo)
 		currentTrustRoot = clusterTLSInfo.TrustRoot
 	}
-}
-
-func (s *DockerSwarmSuite) TestAPINetworkInspectWithScope(c *testing.T) {
-	ctx := testutil.GetContext(c)
-	d := s.AddDaemon(ctx, c, true, true)
-
-	name := "test-scoped-network"
-	apiclient := d.NewClientT(c)
-
-	create, err := apiclient.NetworkCreate(ctx, name, client.NetworkCreateOptions{Driver: "overlay"})
-	assert.NilError(c, err)
-
-	inspect, err := apiclient.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
-	assert.NilError(c, err)
-	assert.Check(c, is.Equal("swarm", inspect.Network.Scope))
-	assert.Check(c, is.Equal(create.ID, inspect.Network.ID))
-
-	_, err = apiclient.NetworkInspect(ctx, name, client.NetworkInspectOptions{Scope: "local"})
-	assert.Check(c, is.ErrorType(err, cerrdefs.IsNotFound))
 }


### PR DESCRIPTION
**- What I did**
Migrated the `TestAPINetworkInspectWithScope` test from `integration-cli/docker_api_swarm_test.go` to the new integration test framework under `integration/network/network_test.go`.