### PR TITLE
Allow configured address with no configured subnet

### DIFF
--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -4,7 +4,7 @@ set -e
 source hack/make/.integration-test-helpers
 
 # The commit or tag to use for testing
-: "${DOCKER_PY_COMMIT:=65f7f0c772577beb5e2cd6daac4e5ca806ccc4af}" # master (v7.2.0-dev)
+: "${DOCKER_PY_COMMIT:=df3f8e2abc5a03de482e37214dddef9e0cee1bb1}" # master (v7.2.0-dev)
 
 # custom options to pass py.test
 #

--- a/integration-cli/docker_cli_network_unix_test.go
+++ b/integration-cli/docker_cli_network_unix_test.go
@@ -1357,10 +1357,10 @@ func (s *DockerNetworkSuite) TestDockerNetworkUnsupportedRequiredIP(c *testing.T
 
 	out, _, err := dockerCmdWithError("run", "-d", "--ip", "172.28.99.88", "--net", "n0", "busybox", "top")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, is.Contains(out, "user specified IP address is supported only when connecting to networks with user configured subnets"))
+	assert.Assert(c, is.Contains(out, "no configured subnet contains IP address 172.28.99.88"))
 	out, _, err = dockerCmdWithError("run", "-d", "--ip6", "2001:db8:1234::9988", "--net", "n0", "busybox", "top")
 	assert.Assert(c, err != nil, "out: %s", out)
-	assert.Assert(c, is.Contains(out, "user specified IP address is supported only when connecting to networks with user configured subnets"))
+	assert.Assert(c, is.Contains(out, "no configured subnet contains IP address 2001:db8:1234::9988"))
 	cli.DockerCmd(c, "network", "rm", "n0")
 	assertNwNotAvailable(c, "n0")
 }


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/51569
- introduced by https://github.com/moby/moby/pull/51134
- depends on https://github.com/docker/docker-py/pull/3372
- depends on https://github.com/docker/docker-py/pull/3373

When a network is configured with no explicit `--subnet`, `daemon.validateEndpointIPAddress` tries to prevent a container from being started with a `--ip` address - with error "user specified IP address is supported only when connecting to networks with user configured subnets".

But the check didn't work in 28.x and older because, until https://github.com/moby/moby/pull/51134, IPAM config always contained a copy of the network's subnet - whether the user configured it, or it was allocated from the default pools.

So, it was possible to inspect (or guess!) a network's subnet and create a container with a specific address ... restore that behaviour.

**- How I did it**

- Use IPAM info instead of config to check whether a configured IP address is in one of a container's subnets.
- Remove the check that now prevents setting an IP address when the subnet was unspecified at network creation time.

**- How to verify it**

```
docker network create n1
docker network inspect n1
docker run --rm -ti --network n1 --ip <address in n1's subnet> alpine
```

New integration test that fails without the fix.

**- Human readable description for the release notes**
```markdown changelog
Allow creation of a container with a specific IP address when its networks were not configured with a specific subnet
```
