### PR TITLE
migrate TestAPIOptionsRoute to integration test

### DIFF
--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -2,12 +2,7 @@ package main
 
 import (
 	"context"
-	"net/http"
 	"testing"
-
-	"github.com/moby/moby/v2/internal/testutil"
-	"github.com/moby/moby/v2/internal/testutil/request"
-	"gotest.tools/v3/assert"
 )
 
 type DockerAPISuite struct {
@@ -20,10 +15,4 @@ func (s *DockerAPISuite) TearDownTest(ctx context.Context, t *testing.T) {
 
 func (s *DockerAPISuite) OnTimeout(t *testing.T) {
 	s.ds.OnTimeout(t)
-}
-
-func (s *DockerAPISuite) TestAPIOptionsRoute(c *testing.T) {
-	resp, _, err := request.Do(testutil.GetContext(c), "/", request.Method(http.MethodOptions))
-	assert.NilError(c, err)
-	assert.Equal(c, resp.StatusCode, http.StatusOK)
 }


### PR DESCRIPTION

**- What I did**

Migrated the `TestAPIOptionsRoute` test from `integration-cli/docker_api_test.go` to the new integration test framework under `integration/system/api_test.go`.
