### PR TITLE
PublishAllPorts: create port mappings for exposed ports

### DIFF
--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1036,7 +1036,20 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 		exposedPorts   []lntypes.TransportPort
 		publishedPorts []lntypes.PortBinding
 	)
-	for p, bindings := range c.HostConfig.PortBindings {
+
+	ports := c.HostConfig.PortBindings
+	if c.HostConfig.PublishAllPorts {
+		// Add exposed ports to a copy of the map to make sure a "publishedPorts" entry is created
+		// for each exposed port, even if there's no specific binding.
+		ports = maps.Clone(c.HostConfig.PortBindings)
+		for p := range c.Config.ExposedPorts {
+			if _, exists := ports[p]; !exists {
+				ports[p] = nil
+			}
+		}
+	}
+
+	for p, bindings := range ports {
 		protocol := lntypes.ParseProtocol(string(p.Proto()))
 		exposedPorts = append(exposedPorts, lntypes.TransportPort{
 			Proto: protocol,


### PR DESCRIPTION
**- What I did**

- introduced by https://github.com/moby/moby/pull/50705

The `-P` option to publish exposed ports doesn't work for Windows containers in 29.x.

Before 423980614ef60a3953517027070819d9f5932baa, `buildPortsRelatedCreateEndpointOptions` created `ports` entries for each of `c.Config.ExposedPorts`. So, they were included in the endpoint options if `c.HostConfig.PublishAllPorts`.

Restore that behaviour.

**- How I did it**

**- How to verify it**

Run a Windows container with exposed ports and `-P` ... check that `docker ps` shows the published ports.

(Needs an integration test.)

**- Human readable description for the release notes**
```markdown changelog
- fix `--publish-all` / `-P` for Windows containers
```
