### PR TITLE
Unmap() more netip.Addr vars created from slices

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -825,7 +825,7 @@ func migrateHostGatewayIP(config *Config) {
 	hgip := config.HostGatewayIP //nolint:staticcheck // ignore SA1019: migrating to HostGatewayIPs.
 	if hgip != nil {
 		addr, _ := netip.AddrFromSlice(hgip)
-		config.HostGatewayIPs = []netip.Addr{addr}
+		config.HostGatewayIPs = []netip.Addr{addr.Unmap()}
 		config.HostGatewayIP = nil //nolint:staticcheck // ignore SA1019: clearing old value.
 	}
 }

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -891,7 +891,7 @@ func setHostGatewayIP(controller *libnetwork.Controller, config *config.Config) 
 		v4Info, v6Info := n.IpamInfo()
 		if len(v4Info) > 0 {
 			addr, _ := netip.AddrFromSlice(v4Info[0].Gateway.IP)
-			config.HostGatewayIPs = append(config.HostGatewayIPs, addr)
+			config.HostGatewayIPs = append(config.HostGatewayIPs, addr.Unmap())
 		}
 		if len(v6Info) > 0 {
 			addr, _ := netip.AddrFromSlice(v6Info[0].Gateway.IP)

--- a/daemon/libnetwork/drivers/bridge/bridge_linux.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux.go
@@ -1796,10 +1796,12 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 			if !ok {
 				return fmt.Errorf("invalid parent endpoint IP: %s", parentEndpoint.addr.IP)
 			}
+			parentAddr = parentAddr.Unmap()
 			childAddr, ok := netip.AddrFromSlice(endpoint.addr.IP)
 			if !ok {
 				return fmt.Errorf("invalid parent endpoint IP: %s", endpoint.addr.IP)
 			}
+			childAddr = childAddr.Unmap()
 
 			if enable {
 				if err := network.firewallerNetwork.AddLink(context.TODO(), parentAddr, childAddr, ec.ExposedPorts); err != nil {
@@ -1826,10 +1828,12 @@ func (d *driver) link(network *bridgeNetwork, endpoint *bridgeEndpoint, enable b
 		if !ok {
 			return fmt.Errorf("invalid parent endpoint IP: %s", endpoint.addr.IP)
 		}
+		parentAddr = parentAddr.Unmap()
 		childAddr, ok := netip.AddrFromSlice(childEndpoint.addr.IP)
 		if !ok {
 			return fmt.Errorf("invalid parent endpoint IP: %s", childEndpoint.addr.IP)
 		}
+		childAddr = childAddr.Unmap()
 
 		if enable {
 			if err := network.firewallerNetwork.AddLink(context.TODO(), parentAddr, childAddr, childEndpoint.extConnConfig.ExposedPorts); err != nil {

--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -1010,7 +1010,7 @@ func (ep *Endpoint) getEtcHostsAddrs() []netip.Addr {
 	var addresses []netip.Addr
 	if ep.iface.addr != nil {
 		if addr, ok := netip.AddrFromSlice(ep.iface.addr.IP); ok {
-			addresses = append(addresses, addr)
+			addresses = append(addresses, addr.Unmap())
 		}
 	}
 	if ep.iface.addrv6 != nil {

--- a/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
+++ b/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
@@ -64,7 +64,7 @@ func NewPortDriverClient(ctx context.Context) (*PortDriverClient, error) {
 			return nil, fmt.Errorf("unable to use child IP %s from network driver (%q)",
 				info.NetworkDriver.ChildIP, info.NetworkDriver.Driver)
 		}
-		pdc.childIP = childIP
+		pdc.childIP = childIP.Unmap()
 	}
 
 	pdc.protos = make(map[string]struct{}, len(info.PortDriver.Protos))

--- a/daemon/libnetwork/networkdb/cluster.go
+++ b/daemon/libnetwork/networkdb/cluster.go
@@ -302,7 +302,7 @@ func (nDB *NetworkDB) rejoinClusterBootStrap() {
 					continue
 				}
 				nodeIP, _ := netip.AddrFromSlice(node.Addr)
-				if bootstrapIP == netip.AddrPortFrom(nodeIP, node.Port) {
+				if bootstrapIP == netip.AddrPortFrom(nodeIP.Unmap(), node.Port) {
 					// One of the bootstrap nodes (and not myself) is part of the cluster, return
 					nDB.RUnlock()
 					return

--- a/daemon/libnetwork/portallocator/osallocator_windows.go
+++ b/daemon/libnetwork/portallocator/osallocator_windows.go
@@ -64,7 +64,7 @@ func (pa *OSAllocator) AllocateHostPort(hostIP net.IP, proto types.Protocol, hos
 		return 0, fmt.Errorf("invalid HostIP: %s", hostIP)
 	}
 
-	hAddrPort := netip.AddrPortFrom(addr, uint16(allocatedHostPort))
+	hAddrPort := netip.AddrPortFrom(addr.Unmap(), uint16(allocatedHostPort))
 	if _, exists := pa.osListeners[proto][hAddrPort]; exists {
 		return 0, ErrPortMappedForIP
 	}
@@ -132,7 +132,7 @@ func (pa *OSAllocator) Deallocate(hostIP net.IP, proto types.Protocol, hostPort 
 		return ErrPortNotMapped
 	}
 
-	hAddrPort := netip.AddrPortFrom(addr, uint16(hostPort))
+	hAddrPort := netip.AddrPortFrom(addr.Unmap(), uint16(hostPort))
 	osListener, exists := pa.osListeners[proto][hAddrPort]
 	if !exists {
 		return ErrPortNotMapped

--- a/daemon/libnetwork/portmappers/nat/mapper_linux.go
+++ b/daemon/libnetwork/portmappers/nat/mapper_linux.go
@@ -95,7 +95,7 @@ func (pm PortMapper) MapPorts(ctx context.Context, cfg []portmapperapi.PortBindi
 		pb.PortBinding.HostPortEnd = pb.HostPort
 
 		childHIP, _ := netip.AddrFromSlice(cfg[i].ChildHostIP)
-		pb.NAT = netip.AddrPortFrom(childHIP, pb.PortBinding.HostPort)
+		pb.NAT = netip.AddrPortFrom(childHIP.Unmap(), pb.PortBinding.HostPort)
 
 		bindings = append(bindings, pb)
 	}
@@ -133,7 +133,7 @@ func setChildHostIP(pdc PortDriverClient, req portmapperapi.PortBindingReq) port
 		return req
 	}
 	hip, _ := netip.AddrFromSlice(req.HostIP)
-	req.ChildHostIP = pdc.ChildHostIP(hip).AsSlice()
+	req.ChildHostIP = pdc.ChildHostIP(hip.Unmap()).AsSlice()
 	return req
 }
 
@@ -153,7 +153,7 @@ func configPortDriver(ctx context.Context, pbs []portmapperapi.PortBinding, pdc 
 			if !ok {
 				return fmt.Errorf("invalid child host IP address %s in %s", b.ChildHostIP, b)
 			}
-			pbs[i].PortDriverRemove, err = pdc.AddPort(ctx, b.Proto.String(), hip, chip, int(b.HostPort))
+			pbs[i].PortDriverRemove, err = pdc.AddPort(ctx, b.Proto.String(), hip.Unmap(), chip.Unmap(), int(b.HostPort))
 			if err != nil {
 				var pErr *rlkclient.ProtocolUnsupportedError
 				if errors.As(err, &pErr) {

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1133,8 +1133,11 @@ func getEndpointPortMapInfo(pm networktypes.PortMap, ep *libnetwork.Endpoint) {
 			if pp.HostPort > 0 {
 				hp = strconv.Itoa(int(pp.HostPort))
 			}
-			natBndg := networktypes.PortBinding{HostPort: hp}
-			natBndg.HostIP, _ = netip.AddrFromSlice(pp.HostIP)
+			hip, _ := netip.AddrFromSlice(pp.HostIP)
+			natBndg := networktypes.PortBinding{
+				HostIP:   hip.Unmap(),
+				HostPort: hp,
+			}
 			pm[natPort] = append(pm[natPort], natBndg)
 		}
 	}


### PR DESCRIPTION
**- What I did**

- introduced by:
    - https://github.com/moby/moby/pull/50956 / https://github.com/moby/moby/commit/fd4329a6205eeb0c391f5383ccae5a90127b9028

In 29.x for Windows containers, with the default binding address `0.0.0.0`, the port mapping reported by `inspect` showed up as `::ffff:0.0.0.0`. For example ...

```
> docker ps
CONTAINER ID   IMAGE       COMMAND   CREATED         STATUS         PORTS                           NAMES
212a8af4131d   busybox80   "sh"      5 seconds ago   Up 3 seconds   [::ffff:0.0.0.0]:8080->80/tcp   c1
```

**- How I did it**

- The first commit fixes the specific issue.
- The second commit adds more Unmap calls, any/all of which may be unnecessary.
  - (I just did a trawl for calls to `netip.AddrFromSlice` that didn't have an obvious `Unmap`.)

**- How to verify it**

Run docker `inspect`/`ps` against a Windows container with published ports.

(Needs an integration test.)

**- Human readable description for the release notes**
```markdown changelog
- Windows containers: don't display an IPv6-mapped IPv4 address in port mappings. For example, `[::ffff:0.0.0.0]:8080->80/tcp` instead of `0.0.0.0:8080->80/tcp`.
```

