### PR TITLE
Suppress errors from gateway re-config when disconnecting a network

### DIFF
--- a/integration/networking/bridge_linux_test.go
+++ b/integration/networking/bridge_linux_test.go
@@ -2090,3 +2090,52 @@ func TestSetIPWithNoConfiguredSubnet(t *testing.T) {
 		assert.Check(t, is.Contains(res.Stdout.String(), ip6))
 	}
 }
+
+// Regression test for https://github.com/moby/moby/issues/51578
+func TestGatewayErrorOnNetDisconnect(t *testing.T) {
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+
+	network.CreateNoError(ctx, t, c, "n1")
+	defer network.RemoveNoError(ctx, t, c, "n1")
+	network.CreateNoError(ctx, t, c, "n2")
+	defer network.RemoveNoError(ctx, t, c, "n2")
+
+	// Run a container attached to both networks, with n1 providing the default gateway
+	// and n2's interface named "eth2".
+	ctrID := container.Run(ctx, t, c,
+		container.WithEndpointSettings("n1", &networktypes.EndpointSettings{GwPriority: 1}),
+		container.WithEndpointSettings("n2", &networktypes.EndpointSettings{DriverOpts: map[string]string{
+			netlabel.Ifname: "eth2",
+		}}),
+		container.WithCapability("NET_ADMIN"),
+	)
+	defer container.Remove(ctx, t, c, ctrID, client.ContainerRemoveOptions{Force: true})
+
+	// Break n2 so it can't be used as a gateway (there will be no route).
+	execRes := container.ExecT(ctx, t, c, ctrID, []string{"ip", "link", "set", "eth2", "down"})
+	assert.Assert(t, is.Equal(execRes.ExitCode, 0))
+
+	// Disconnect n1, n2 will be selected as the gateway and its config will fail.
+	// The error is only logged and the disconnect proceeds.
+	_, err := c.NetworkDisconnect(ctx, "n1", client.NetworkDisconnectOptions{Container: ctrID})
+	assert.Check(t, err)
+
+	// Check n1 can be reconnected.
+	_, err = c.NetworkConnect(ctx, "n1", client.NetworkConnectOptions{Container: ctrID})
+	assert.Check(t, err)
+
+	// Check the container can be restarted.
+	timeout := 0
+	_, err = c.ContainerRestart(ctx, ctrID, client.ContainerRestartOptions{Timeout: &timeout})
+	assert.Check(t, err)
+
+	// Both networks should be attached.
+	ctrInsp := container.Inspect(ctx, t, c, ctrID)
+	assert.Check(t, is.Len(ctrInsp.NetworkSettings.Networks, 2))
+	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, "n1"))
+	assert.Check(t, is.Contains(ctrInsp.NetworkSettings.Networks, "n2"))
+}


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/51578
- introduced by https://github.com/moby/moby/pull/50945 / https://github.com/moby/moby/commit/53390f85ddf238dea30c899355ef5b2299156f8f

When a network is disconnected from a container, if that network provides the container's default gateway, another gateway is selected from the remaining network endpoints (if there are any). That selection happens after the endpoint has been removed, but there's no proper rollback if the newly selected gateway doesn't work.

**- How I did it**

The first commit skips selection of a new gateway if the container is being deleted. So setup of a new gateway can't fail. This fixes the bug as-reported.

Prior to https://github.com/moby/moby/commit/53390f85ddf238dea30c899355ef5b2299156f8f, an error setting up the new gateway was only logged ... the second commit restores that behaviour for the `network disconnect` case, where the container is not being deleted. The container won't have a working gateway, but the `Network` will not be left with a broken reference to the disconnected `Endpoint`, so it can be reconnected.

**- How to verify it**

New integration test, following the repro steps outlined at https://github.com/moby/moby/issues/51578#issuecomment-3576104329.

Without the fixes, the new test fails with ...
```
=== RUN   TestGatewayErrorOnNetDisconnect
    bridge_linux_test.go:2093: assertion failed: error is not nil: Error response from daemon: container c081ced8f0a5658709ec6cb4571c01eb51d389e5858220c2babedee8eae35261 failed to leave network n1: updating gateway endpoint: failed to set gateway: route for the gateway 172.22.0.1 could not be found: network is unreachable
    bridge_linux_test.go:2097: assertion failed: error is not nil: Error response from daemon: endpoint with name nervous_morse already exists in network n1
    bridge_linux_test.go:2102: assertion failed: error is not nil: Error response from daemon: Cannot restart container c081ced8f0a5658709ec6cb4571c01eb51d389e5858220c2babedee8eae35261: failed to set up container networking: endpoint with name nervous_morse already exists in network n1
    bridge_linux_test.go:2109: assertion failed: error is not nil: Error response from daemon: error while removing network: network n1 has active endpoints (name:"nervous_morse" id:"8f477b1b9e52")
--- FAIL: TestGatewayErrorOnNetDisconnect (5.44s)
FAIL
```

With the fixes:
- restarting a container produces no warning in the log, because there's no attempt to select the new gateway. Release 28.x logged "Failed to clean up network resources on container disconnect".
- if gateway config fails when disconnecting an endpoint, the a warning is logged. For example:
  - `Configuring gateway after network disconnect  cid=5b73d9f67743 eid=f2df6ddb1ac5 ep=c1 error="failed to set gateway: route for the gateway 172.20.0.1 could not be found: network is unreachable" gw4=ce9bf8761a88 gw6= net=n1 nid=1a3331eaf7df sid=c44c4f4d7982`

**- Human readable description for the release notes**
```markdown changelog
- Fix an issue that prevented container restart or network reconnection when gateway configuration failed during container stop or network disconnect.
```

