### PR TITLE
introduce ability to expose engine socket to container

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -31,6 +31,9 @@ keywords: "API, Docker, rcli, REST, documentation"
   identity and origin information for the image.
 * Deprecated: The `POST /grpc` and `POST /session` endpoints are deprecated and
   will be removed in a future version.
+* `POST /containers/create` accepts a new `apisocket` Mount type to automatically expose engine socket inside container.
+  `access` let user select the mechanism used to expose the engine socket to container. `unconfined` mounts the engine
+  socket without any restriction.
 
 ## v1.52 API changes
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -236,6 +236,7 @@ definitions:
     description: |-
       The mount type. Available types:
 
+      - `apisocket` a mount of the engine API socket into the container.
       - `bind` a mount of a file or directory from the host into the container.
       - `cluster` a Swarm cluster volume.
       - `image` an OCI image.
@@ -244,6 +245,7 @@ definitions:
       - `volume` a docker volume with the given `Name`.
     type: "string"
     enum:
+      - "apisocket"
       - "bind"
       - "cluster"
       - "image"
@@ -262,6 +264,7 @@ definitions:
         description: |
           The mount type:
 
+          - `apisocket` a mount of the engine API socket into the container.
           - `bind` a mount of a file or directory from the host into the container.
           - `cluster` a Swarm cluster volume.
           - `image` an OCI image.
@@ -413,6 +416,7 @@ definitions:
         description: |
           The mount type. Available types:
 
+          - `apisocket` Mounts the engine API socket into the container.
           - `bind` Mounts a file or directory from the host into the container. The `Source` must exist prior to creating the container.
           - `cluster` a Swarm cluster volume
           - `image` Mounts an image.
@@ -529,6 +533,15 @@ definitions:
                 type: "string"
             example:
               [["noexec"]]
+      APISocketOptions:
+        description: |-
+          Optional configuration for the `apisocket` type.
+        type: object
+        required: ["access"]
+        properties:
+          access:
+            type: string
+            enum: ["unconfined"]
 
   RestartPolicy:
     description: |

--- a/api/types/mount/mount.go
+++ b/api/types/mount/mount.go
@@ -21,6 +21,8 @@ const (
 	TypeCluster Type = "cluster"
 	// TypeImage is the type for mounting another image's filesystem
 	TypeImage Type = "image"
+	// TypeAPISocket is the type for mounting the Docker engine socket
+	TypeAPISocket Type = "apisocket"
 )
 
 // Mount represents a mount (volume).
@@ -34,11 +36,12 @@ type Mount struct {
 	ReadOnly    bool        `json:",omitempty"` // attempts recursive read-only if possible
 	Consistency Consistency `json:",omitempty"`
 
-	BindOptions    *BindOptions    `json:",omitempty"`
-	VolumeOptions  *VolumeOptions  `json:",omitempty"`
-	ImageOptions   *ImageOptions   `json:",omitempty"`
-	TmpfsOptions   *TmpfsOptions   `json:",omitempty"`
-	ClusterOptions *ClusterOptions `json:",omitempty"`
+	BindOptions      *BindOptions      `json:",omitempty"`
+	VolumeOptions    *VolumeOptions    `json:",omitempty"`
+	ImageOptions     *ImageOptions     `json:",omitempty"`
+	TmpfsOptions     *TmpfsOptions     `json:",omitempty"`
+	ClusterOptions   *ClusterOptions   `json:",omitempty"`
+	APISocketOptions *APISocketOptions `json:",omitempty"`
 }
 
 // Propagation represents the propagation of a mount.
@@ -155,3 +158,10 @@ type TmpfsOptions struct {
 type ClusterOptions struct {
 	// intentionally empty
 }
+
+// APISocketOptions specifies options specific to mounts of type "apisocket".
+type APISocketOptions struct {
+	Access string `json:"acccess"`
+}
+
+const AccessUnconfined = "unconfined"

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -700,6 +700,14 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 			conf.Hosts = append(conf.Hosts, h)
 		}
 	}
+	if runtime.GOOS != "windows" {
+		// Always create a socket for bind-mounting into containers.
+		h, err := getAPISocket(honorXDG)
+		if err != nil {
+			return nil, err
+		}
+		conf.Hosts = append(conf.Hosts, h)
+	}
 
 	if err := normalizeHosts(conf); err != nil {
 		return nil, err
@@ -798,6 +806,20 @@ func defaultAPISocketPath(honorXDG bool) (string, error) {
 
 	// default unix-socket (Linux) or named pipe (Windows).
 	return dopts.DefaultHost, nil
+}
+
+// getAPISocket returns the address for the API-socket to use for mounting into containers.
+func getAPISocket(defaultToUnixXDG bool) (string, error) {
+	if defaultToUnixXDG {
+		// For rootless mode, the default is to listen on an unprivileged socket
+		// in XDG_RUNTIME_DIR.
+		runtimeDir, err := homedir.GetRuntimeDir()
+		if err != nil {
+			return "", err
+		}
+		return "unix://" + filepath.Join(runtimeDir, "docker-api.sock"), nil
+	}
+	return "unix://" + dopts.APISocket, nil
 }
 
 // normalizeHosts normalizes the configured config.Hosts and removes duplicates.

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -249,9 +249,12 @@ func (daemon *Daemon) apiSocket(_ string, options *mounttypes.APISocketOptions) 
 	}
 	switch accessType {
 	case mounttypes.AccessUnconfined:
+		// FIXME(thaJeztah): This patch needs to be aware of rootless (XDG) vs non-rootless.
 		return opts.APISocket, nil
 	case "":
-		return "", errors.New("API socket access option is not set")
+		// FIXME(thaJeztah): CLI needs updating to recognize this option (and to allow empty target).
+		return opts.APISocket, nil
+		// return "", errors.New("API socket access option is not set")
 	default:
 		return "", fmt.Errorf("API socket access %q is not supported", accessType)
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/containerd/log"
 	containertypes "github.com/moby/moby/api/types/container"
+	mounttypes "github.com/moby/moby/api/types/mount"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/container"
@@ -24,6 +25,7 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/options"
 	"github.com/moby/moby/v2/daemon/libnetwork/scope"
 	"github.com/moby/moby/v2/daemon/network"
+	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/parsers/operatingsystem"
 	"github.com/moby/moby/v2/pkg/sysinfo"
 	"github.com/moby/sys/user"
@@ -569,4 +571,8 @@ func setupResolvConf(config *config.Config) {}
 
 func getSysInfo(*config.Config) *sysinfo.SysInfo {
 	return sysinfo.New()
+}
+
+func (daemon *Daemon) apiSocket(string, *mounttypes.APISocketOptions) (string, error) {
+	return "", errdefs.NotImplemented(fmt.Errorf("API socket mounts are not supported on this platform"))
 }

--- a/daemon/pkg/opts/hosts.go
+++ b/daemon/pkg/opts/hosts.go
@@ -25,6 +25,8 @@ const (
 	DefaultTLSHost = "tcp://" + DefaultHTTPHost + ":2376"
 	// DefaultNamedPipe defines the default named pipe used by docker on Windows
 	DefaultNamedPipe = `//./pipe/docker_engine`
+	// APISocket Path for the socket used to expose API socket to containers by mount type apisocket;access=unconfined
+	APISocket = "/var/run/docker-api.sock"
 	// HostGatewayName is the string value that can be passed
 	// to the IPAddr section in --add-host that is replaced by
 	// the value of HostGatewayIP daemon config value

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -717,6 +717,14 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 		}
 	}
 
+	if versions.LessThan(version, "1.53") {
+		for _, m := range hostConfig.Mounts {
+			if m.Type == mount.TypeAPISocket {
+				return errdefs.InvalidParameter(errors.New(`Mount type "APISocket" needs API v1.53 or newer`))
+			}
+		}
+	}
+
 	if warn, err := handleSysctlBC(hostConfig, networkingConfig, version); err != nil {
 		return err
 	} else if warn != "" {

--- a/daemon/volume/mounts/linux_parser.go
+++ b/daemon/volume/mounts/linux_parser.go
@@ -49,17 +49,8 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 	if err := validateExclusiveOptions(mnt); err != nil {
 		return &errMountConfig{mount: mnt, err: err}
 	}
-
-	if mnt.Target == "" {
-		return &errMountConfig{mnt, errMissingField("Target")}
-	}
-
-	if err := linuxValidateNotRoot(mnt.Target); err != nil {
-		return &errMountConfig{mnt, err}
-	}
-
-	if err := linuxValidateAbsolute(mnt.Target); err != nil {
-		return &errMountConfig{mnt, err}
+	if err := validateMountTarget(mnt); err != nil {
+		return err
 	}
 
 	switch mnt.Type {
@@ -120,8 +111,30 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 				return &errMountConfig{mnt, errInvalidSubpath}
 			}
 		}
+	case mount.TypeAPISocket:
+		if mnt.Source != "" {
+			return &errMountConfig{mnt, errExtraField("Source")}
+		}
 	default:
 		return &errMountConfig{mnt, errors.New("mount type unknown")}
+	}
+	return nil
+}
+
+func validateMountTarget(mnt *mount.Mount) error {
+	if mnt.Target == "" {
+		if mnt.Type == mount.TypeAPISocket {
+			return nil
+		}
+		return &errMountConfig{mnt, errMissingField("Target")}
+	}
+
+	if err := linuxValidateNotRoot(mnt.Target); err != nil {
+		return &errMountConfig{mnt, err}
+	}
+
+	if err := linuxValidateAbsolute(mnt.Target); err != nil {
+		return &errMountConfig{mnt, err}
 	}
 	return nil
 }
@@ -359,6 +372,10 @@ func (p *linuxParser) parseMountSpec(cfg mount.Mount, validateBindSourceExists b
 		// Propagation is currently not configurable for image mounts.
 		// See https://github.com/moby/moby/issues/51980#issuecomment-3848407167
 		mp.Propagation = linuxDefaultPropagationMode
+	case mount.TypeAPISocket:
+		if cfg.Target == "" {
+			mp.Destination = "/var/run/docker.sock"
+		}
 	default:
 		// TODO(thaJeztah): make switch exhaustive: anything to do for mount.TypeNamedPipe, mount.TypeCluster ?
 	}

--- a/daemon/volume/mounts/linux_parser.go
+++ b/daemon/volume/mounts/linux_parser.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/log"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/v2/daemon/volume"
 )
@@ -376,6 +377,8 @@ func (p *linuxParser) parseMountSpec(cfg mount.Mount, validateBindSourceExists b
 		if cfg.Target == "" {
 			mp.Destination = "/var/run/docker.sock"
 		}
+		log.L.Errorf("linuxParser.parseMountSpec: mount api socket: %+v", mp)
+
 	default:
 		// TODO(thaJeztah): make switch exhaustive: anything to do for mount.TypeNamedPipe, mount.TypeCluster ?
 	}

--- a/daemon/volume/mounts/validate.go
+++ b/daemon/volume/mounts/validate.go
@@ -46,5 +46,8 @@ func validateExclusiveOptions(mnt *mount.Mount) error {
 	if mnt.Type != mount.TypeCluster && mnt.ClusterOptions != nil {
 		return errExtraField("ClusterOptions")
 	}
+	if mnt.Type != mount.TypeAPISocket && mnt.APISocketOptions != nil {
+		return errExtraField("APISocketOptions")
+	}
 	return nil
 }

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -282,6 +282,12 @@ func (daemon *Daemon) registerMountPoints(ctr *container.Container, defaultReadO
 			mp.Source = srcPath
 			mp.Layer = imgLayer
 			mp.RW = false
+		case mounttypes.TypeAPISocket:
+			socket, err := daemon.apiSocket(ctr.ID, cfg.APISocketOptions)
+			if err != nil {
+				return err
+			}
+			mp.Source = socket
 		case mounttypes.TypeTmpfs, mounttypes.TypeCluster, mounttypes.TypeNamedPipe:
 			// nothing to do
 		}

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -288,6 +288,7 @@ func (daemon *Daemon) registerMountPoints(ctr *container.Container, defaultReadO
 				return err
 			}
 			mp.Source = socket
+			log.L.Errorf("daemon.registerMountPoints: mount api socket: %+v", mp)
 		case mounttypes.TypeTmpfs, mounttypes.TypeCluster, mounttypes.TypeNamedPipe:
 			// nothing to do
 		}

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -14,6 +14,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/common"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/stringid"
@@ -835,4 +836,44 @@ func TestContainerdContainerImageInfo(t *testing.T) {
 		// This field is not set when not using containerd backed storage.
 		assert.Equal(t, ctr.Image, "")
 	}
+}
+
+func TestCreateWithAPISocket(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	config := container.Config{
+		Image: "busybox",
+	}
+	ctr, err := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config:           &config,
+		NetworkingConfig: &network.NetworkingConfig{},
+		HostConfig: &container.HostConfig{
+			Mounts: []mount.Mount{
+				{
+					Type: mount.TypeAPISocket,
+					APISocketOptions: &mount.APISocketOptions{
+						Access: mount.AccessUnconfined,
+					},
+				},
+			},
+		},
+	})
+	assert.NilError(t, err)
+
+	inspect, err := apiClient.ContainerInspect(ctx, ctr.ID, client.ContainerInspectOptions{})
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, inspect.Container.HostConfig.Mounts, []mount.Mount{
+		{
+			Type:   mount.TypeAPISocket,
+			Source: "/var/run/docker-api.sock",
+			Target: "/var/run/docker.sock",
+			APISocketOptions: &mount.APISocketOptions{
+				Access: mount.AccessUnconfined,
+			},
+		},
+	})
 }

--- a/vendor/github.com/moby/moby/api/types/mount/mount.go
+++ b/vendor/github.com/moby/moby/api/types/mount/mount.go
@@ -21,6 +21,8 @@ const (
 	TypeCluster Type = "cluster"
 	// TypeImage is the type for mounting another image's filesystem
 	TypeImage Type = "image"
+	// TypeAPISocket is the type for mounting the Docker engine socket
+	TypeAPISocket Type = "apisocket"
 )
 
 // Mount represents a mount (volume).
@@ -34,11 +36,12 @@ type Mount struct {
 	ReadOnly    bool        `json:",omitempty"` // attempts recursive read-only if possible
 	Consistency Consistency `json:",omitempty"`
 
-	BindOptions    *BindOptions    `json:",omitempty"`
-	VolumeOptions  *VolumeOptions  `json:",omitempty"`
-	ImageOptions   *ImageOptions   `json:",omitempty"`
-	TmpfsOptions   *TmpfsOptions   `json:",omitempty"`
-	ClusterOptions *ClusterOptions `json:",omitempty"`
+	BindOptions      *BindOptions      `json:",omitempty"`
+	VolumeOptions    *VolumeOptions    `json:",omitempty"`
+	ImageOptions     *ImageOptions     `json:",omitempty"`
+	TmpfsOptions     *TmpfsOptions     `json:",omitempty"`
+	ClusterOptions   *ClusterOptions   `json:",omitempty"`
+	APISocketOptions *APISocketOptions `json:",omitempty"`
 }
 
 // Propagation represents the propagation of a mount.
@@ -155,3 +158,10 @@ type TmpfsOptions struct {
 type ClusterOptions struct {
 	// intentionally empty
 }
+
+// APISocketOptions specifies options specific to mounts of type "apisocket".
+type APISocketOptions struct {
+	Access string `json:"acccess"`
+}
+
+const AccessUnconfined = "unconfined"


### PR DESCRIPTION
**- What I did**

introduced ability to opt-in for engine socket to be exposed in container.
this offers an alternative implementation for docker/cli `--use-api-socket`

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
- Add new mount type `apisocket` to expose the Docker Engine API socket to containers. Containers with an `apisocket` mount automatically receive the `DOCKER_HOST` environment variable pointing to the mounted socket. 
```

**- A picture of a cute animal (not mandatory but encouraged)**

