### PR TITLE
gha/validate: Don't fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,6 @@ jobs:
       - validate-prepare
       - build-dev
     strategy:
-      fail-fast: true
       matrix:
         script: ${{ fromJson(needs.validate-prepare.outputs.matrix) }}
     steps:


### PR DESCRIPTION
Allow other validate checks to finish even if one of them failed.

Sometimes a check is faulty and its failure is expected - in such case we want to ignore that one validation fail but still run all the others.
