### PR TITLE
libnet/pms/nat: don't bind IPv6 ports if not supported by port driver

### DIFF
--- a/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
+++ b/daemon/libnetwork/internal/rlkclient/rootlesskit_client_linux.go
@@ -75,13 +75,37 @@ func NewPortDriverClient(ctx context.Context) (*PortDriverClient, error) {
 	return pdc, nil
 }
 
+// proto normalizes the protocol to match what the rootlesskit API expects.
+func (c *PortDriverClient) proto(proto string, hostIP netip.Addr) string {
+	// proto is like "tcp", but we need to convert it to "tcp4" or "tcp6" explicitly
+	// for libnetwork >= 20201216
+	//
+	// See https://github.com/moby/libnetwork/pull/2604/files#diff-8fa48beed55dd033bf8e4f8c40b31cf69d0b2cc5d4bb53cde8594670ea6c938aR20
+	// See also https://github.com/rootless-containers/rootlesskit/issues/231
+	apiProto := proto
+	if !strings.HasSuffix(apiProto, "4") && !strings.HasSuffix(apiProto, "6") {
+		if hostIP.Is6() {
+			apiProto += "6"
+		} else {
+			apiProto += "4"
+		}
+	}
+	return apiProto
+}
+
 // ChildHostIP returns the address that must be used in the child network
 // namespace in place of hostIP, a host IP address. In particular, port
 // mappings from host IP addresses, and DNAT rules, must use this child
-// address in place of the real host address.
-func (c *PortDriverClient) ChildHostIP(hostIP netip.Addr) netip.Addr {
+// address in place of the real host address. It may return an invalid
+// netip.Addr if the proto and IP family aren't supported.
+func (c *PortDriverClient) ChildHostIP(proto string, hostIP netip.Addr) netip.Addr {
 	if c == nil {
 		return hostIP
+	}
+	if _, ok := c.protos[c.proto(proto, hostIP)]; !ok {
+		// This happens when apiProto="tcp6", portDriverName="slirp4netns",
+		// because "slirp4netns" port driver does not support listening on IPv6 yet.
+		return netip.Addr{}
 	}
 	if c.childIP.IsValid() {
 		return c.childIP
@@ -117,20 +141,8 @@ func (c *PortDriverClient) AddPort(
 	if c == nil {
 		return func() error { return nil }, nil
 	}
-	// proto is like "tcp", but we need to convert it to "tcp4" or "tcp6" explicitly
-	// for libnetwork >= 20201216
-	//
-	// See https://github.com/moby/libnetwork/pull/2604/files#diff-8fa48beed55dd033bf8e4f8c40b31cf69d0b2cc5d4bb53cde8594670ea6c938aR20
-	// See also https://github.com/rootless-containers/rootlesskit/issues/231
-	apiProto := proto
-	if !strings.HasSuffix(apiProto, "4") && !strings.HasSuffix(apiProto, "6") {
-		if hostIP.Is6() {
-			apiProto += "6"
-		} else {
-			apiProto += "4"
-		}
-	}
 
+	apiProto := c.proto(proto, hostIP)
 	if _, ok := c.protos[apiProto]; !ok {
 		// This happens when apiProto="tcp6", portDriverName="slirp4netns",
 		// because "slirp4netns" port driver does not support listening on IPv6 yet.

--- a/daemon/libnetwork/portmapper/proxy_linux.go
+++ b/daemon/libnetwork/portmapper/proxy_linux.go
@@ -135,6 +135,7 @@ func StartProxy(pb types.PortBinding,
 			return nil
 		}
 		stopped.Store(true)
+		log.G(context.Background()).WithField("pb", pb).Debug("Stopping userland proxy")
 		if err := cmd.Process.Signal(os.Interrupt); err != nil {
 			return err
 		}

--- a/daemon/libnetwork/portmappers/nat/mapper_linux.go
+++ b/daemon/libnetwork/portmappers/nat/mapper_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"strconv"
 
 	"github.com/containerd/log"
@@ -13,12 +14,13 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/portallocator"
 	"github.com/moby/moby/v2/daemon/libnetwork/portmapperapi"
 	"github.com/moby/moby/v2/daemon/libnetwork/types"
+	"github.com/moby/moby/v2/internal/sliceutil"
 )
 
 const driverName = "nat"
 
 type PortDriverClient interface {
-	ChildHostIP(hostIP netip.Addr) netip.Addr
+	ChildHostIP(proto string, hostIP netip.Addr) netip.Addr
 	AddPort(ctx context.Context, proto string, hostIP, childIP netip.Addr, hostPort int) (func() error, error)
 }
 
@@ -73,11 +75,17 @@ func (pm PortMapper) MapPorts(ctx context.Context, cfg []portmapperapi.PortBindi
 		}
 	}()
 
-	addrs := make([]net.IP, 0, len(cfg))
-	for i := range cfg {
-		cfg[i] = setChildHostIP(pm.pdc, cfg[i])
-		addrs = append(addrs, cfg[i].ChildHostIP)
+	for i := len(cfg) - 1; i >= 0; i-- {
+		var supported bool
+		if cfg[i], supported = setChildHostIP(pm.pdc, cfg[i]); !supported {
+			cfg = slices.Delete(cfg, i, i+1)
+			continue
+		}
 	}
+
+	addrs := sliceutil.Map(cfg, func(req portmapperapi.PortBindingReq) net.IP {
+		return req.ChildHostIP
+	})
 
 	pa := portallocator.NewOSAllocator()
 	allocatedPort, socks, err := pa.RequestPortsInRange(addrs, proto, int(hostPort), int(hostPortEnd))
@@ -127,14 +135,21 @@ func (pm PortMapper) UnmapPorts(ctx context.Context, pbs []portmapperapi.PortBin
 	return errors.Join(errs...)
 }
 
-func setChildHostIP(pdc PortDriverClient, req portmapperapi.PortBindingReq) portmapperapi.PortBindingReq {
+// setChildHostIP returns a modified PortBindingReq that contains the IP
+// address that should be used for port allocation, firewall rules, etc. It
+// returns false when the PortBindingReq isn't supported by the PortDriverClient.
+func setChildHostIP(pdc PortDriverClient, req portmapperapi.PortBindingReq) (portmapperapi.PortBindingReq, bool) {
 	if pdc == nil {
 		req.ChildHostIP = req.HostIP
-		return req
+		return req, true
 	}
 	hip, _ := netip.AddrFromSlice(req.HostIP)
-	req.ChildHostIP = pdc.ChildHostIP(hip.Unmap()).AsSlice()
-	return req
+	chip := pdc.ChildHostIP(req.Proto.String(), hip.Unmap())
+	if !chip.IsValid() {
+		return req, false
+	}
+	req.ChildHostIP = chip.AsSlice()
+	return req, true
 }
 
 // configPortDriver passes the port binding's details to rootlesskit, and updates the


### PR DESCRIPTION
- Fixes https://github.com/moby/moby/issues/51591
- Related to https://github.com/moby/moby/pull/50691

**- What I did**

In rootless mode, the Engine needs to call the rootless port driver to know which IP address it should bind to inside of its network namespace.

The slirp4netns port drivers doesn't support binding to IPv6 address, so we need to detect that before listening on the port.

Before commit 201968cc0, this wasn't a problem because the Engine was binding the port, then calling rootless port driver to learn whether the proto/IP family was supported, and listen on the port if so.

Starting with that commit, the Engine does bind + listen in one go, and then calls the port driver — this is too late. Fix the bug by checking if the port driver supports the PortBindingReq, and only allocate the port if so.

**- How to verify it**

Start a rootless daemon with `DOCKERD_ROOTLESS_ROOTLESSKIT_NET=slirp4netns DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=slirp4netns`, then `docker run -p 80:80 alpine`.

**- Human readable description for the release notes**

```markdown changelog
Fix a bug preventing port mappings in rootless mode when slirp4netns is used
```