### PR TITLE
gha/test-validate: Reuse the dev image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,14 @@ jobs:
           set: |
             *.cache-from=type=gha,scope=dev${{ matrix.mode }}
             *.cache-to=type=gha,scope=dev${{ matrix.mode }}
-            *.output=type=cacheonly
+            ${{ matrix.mode == '' && '*.output=type=docker,dest=/tmp/dev-image.tar' || '*.output=type=cacheonly' }}
+      -
+        name: Cache dev image
+        if: matrix.mode == ''
+        uses: actions/cache/save@v4
+        with:
+          key: dev-image-${{ github.run_id }}
+          path: /tmp/dev-image.tar
 
   test:
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
@@ -122,7 +129,6 @@ jobs:
       - validate-prepare
       - build-dev
     strategy:
-      fail-fast: false
       matrix:
         script: ${{ fromJson(needs.validate-prepare.outputs.matrix) }}
     steps:
@@ -139,15 +145,19 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           version: ${{ env.SETUP_BUILDX_VERSION }}
-          driver-opts: image=${{ env.SETUP_BUILDKIT_IMAGE }}
+          driver: docker
           buildkitd-flags: --debug
       -
-        name: Build dev image
-        uses: docker/bake-action@v6
+        name: Restore dev image
+        uses: actions/cache/restore@v4
         with:
-          targets: dev
-          set: |
-            dev.cache-from=type=gha,scope=dev
+          key: dev-image-${{ github.run_id }}
+          path: /tmp/dev-image.tar
+          fail-on-cache-miss: true
+      -
+        name: Load dev image
+        run: |
+          docker load -i /tmp/dev-image.tar
       -
         name: Validate
         run: |


### PR DESCRIPTION
Don't build the dev image separately for each validation.

Build it once and then cache it so the validations can reuse it.

This reduces the overhead for the more lightweight validations.