### PR TITLE
PublishAllPorts: don't crash with nil PortBindings

### DIFF
--- a/daemon/internal/runconfig/config.go
+++ b/daemon/internal/runconfig/config.go
@@ -42,6 +42,9 @@ func decodeCreateRequest(src io.Reader) (container.CreateRequest, error) {
 	if w.HostConfig == nil {
 		w.HostConfig = &container.HostConfig{}
 	}
+	if w.HostConfig.PortBindings == nil {
+		w.HostConfig.PortBindings = make(network.PortMap)
+	}
 	// Make sure NetworkMode has an acceptable value. We do this to ensure
 	// backwards compatible API behavior.
 	//

--- a/integration/internal/container/ops.go
+++ b/integration/internal/container/ops.go
@@ -72,6 +72,13 @@ func WithSysctls(sysctls map[string]string) func(*TestContainerConfig) {
 	}
 }
 
+// WithPublishAllPorts sets PublishAllPorts.
+func WithPublishAllPorts(publishAll bool) func(*TestContainerConfig) {
+	return func(c *TestContainerConfig) {
+		c.HostConfig.PublishAllPorts = publishAll
+	}
+}
+
 // WithExposedPorts sets the exposed ports of the container
 func WithExposedPorts(ports ...string) func(*TestContainerConfig) {
 	return func(c *TestContainerConfig) {


### PR DESCRIPTION
**- What I did**

- fix https://github.com/moby/moby/issues/51620
- Introduced by https://github.com/moby/moby/pull/51586

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Prevent a crash when making an API request with `HostConfig.PublishAllPorts` set (`-P`), and no port bindings
```

**- A picture of a cute animal (not mandatory but encouraged)**

