### PR TITLE
cdi: read XDG_CONFIG_HOME/cdi and XDG_RUNTIME_DIR/cdi for rootless

### DIFF
--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -190,24 +190,6 @@ if [ -z "$_DOCKERD_ROOTLESS_CHILD" ]; then
 else
 	[ "$_DOCKERD_ROOTLESS_CHILD" = 1 ]
 
-	# The Container Device Interface (CDI) specs can be found by default
-	# under {/etc,/var/run}/cdi. More information at:
-	# https://github.com/cncf-tags/container-device-interface
-	#
-	# In order to use the Container Device Interface (CDI) integration,
-	# the CDI paths need to exist before the Docker daemon is started in
-	# order for it to read the CDI specification files. Otherwise, a
-	# Docker daemon restart will be required for the daemon to discover
-	# them.
-	#
-	# If another set of CDI paths (other than the default /etc/cdi and
-	# /var/run/cdi) are configured through the Docker configuration file
-	# (using "cdi-spec-dirs"), they need to be bind mounted in rootless
-	# mode; otherwise the Docker daemon won't have access to the CDI
-	# specification files.
-	mount_directory /etc/cdi
-	mount_directory /var/run/cdi
-
 	# remove the symlinks for the existing files in the parent namespace if any,
 	# so that we can create our own files in our mount namespace.
 	rm -f /run/docker /run/containerd /run/xtables.lock

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -656,6 +656,18 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	if conf.CDISpecDirs == nil {
 		// If the CDISpecDirs is not set at this stage, we set it to the default.
 		conf.CDISpecDirs = append([]string(nil), cdi.DefaultSpecDirs...)
+		if rootless.RunningWithRootlessKit() {
+			// In rootless mode, we add the user-specific CDI spec directory.
+			xch, err := homedir.GetConfigHome()
+			if err != nil {
+				return nil, err
+			}
+			xrd, err := homedir.GetRuntimeDir()
+			if err != nil {
+				return nil, err
+			}
+			conf.CDISpecDirs = append(conf.CDISpecDirs, filepath.Join(xch, "cdi"), filepath.Join(xrd, "cdi"))
+		}
 	} else if len(conf.CDISpecDirs) == 1 && conf.CDISpecDirs[0] == "" {
 		// If CDISpecDirs is set to an empty string, we clear it to ensure that CDI is disabled.
 		conf.CDISpecDirs = nil


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
#### Commit 1:  `cdi: read XDG_CONFIG_HOME/cdi and XDG_RUNTIME_DIR/cdi for rootless`

Fix #51601

#### Commit 2: `cdi: skip scanning non-readable dirs`

This simplifies `dockerd-rootless.sh` by removing the workaround for `CDI: Error associated with spec file /etc/cdi: failed to monitor for changes: permission denied`.

**- How I did it**

See the commits

**- How to verify it**

For commit 1 `cdi: read XDG_CONFIG_HOME/cdi and XDG_RUNTIME_DIR/cdi for rootless`, create `~/.config/cdi/foo.yaml` as follows, and run `docker run --rm --device example.com/foo=foo alpine ls -l /dev/null2`

```yaml
cdiVersion: "0.6.0"
kind: "example.com/foo"
devices:
- name: foo
  containerEdits:
    mounts:
    - hostPath: /dev/null
      containerPath: /dev/null2
      options: [bind]
```

Try the same with `/run/user/$UID/cdi`, `/etc/cdi`, and `/var/run/cdi` too.

For commit 2 `cdi: skip scanning non-readable dirs`:

```bash
sudo mkdir -p -m /etc/cdi
dockerd-rootless-setuptool.sh install
docker info
# no error
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Rootless: Consider `$XDG_CONFIG_HOME/cdi` and `$XDG_RUNTIME_DIR/cdi` when looking for CDI devices
```

**- A picture of a cute animal (not mandatory but encouraged)**

