### PR TITLE
Dockerfile: verify the git tags with the hashes

### DIFF
--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -102,7 +102,7 @@ jobs:
           EOF
           # TODO: use native packages for AlmaLinux: https://github.com/docker/packaging/pull/138
           lima sudo dnf config-manager --add-repo=https://download.docker.com/linux/rhel/docker-ce.repo
-          lima sudo dnf -q -y install --nobest docker-ce make
+          lima sudo dnf -q -y install --nobest docker-ce make git
           lima sudo systemctl enable --now docker
           lima docker info
       -

--- a/cmd/dockerd/winresources/Dockerfile
+++ b/cmd/dockerd/winresources/Dockerfile
@@ -1,10 +1,15 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.20.0@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
 
+# NOTE: the image digest is not pinned to a specific version,
+# as the image is frequently updated with apt security updates.
+#
+# TODO: consider pinning for better build reproducibility.
+# A reproduction build will need executing apt-get with snapshot mode.
 ARG DEBIAN_VERSION=bookworm
 
 # XX_VERSION specifies the version of the xx utility to use.
 # It must be a valid tag in the docker.io/tonistiigi/xx image repository.
-ARG XX_VERSION=1.7.0
+ARG XX_VERSION=1.7.0@sha256:010d4b66aed389848b0694f91c7aaee9df59a6f20be7f5d12e53663a37bd14e2
 
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/contrib/nnp-test/Dockerfile
+++ b/contrib/nnp-test/Dockerfile
@@ -1,5 +1,10 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.20.0@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
 
+# NOTE: the image digest is not pinned to a specific version,
+# as the image is frequently updated with apt security updates.
+#
+# TODO: consider pinning for better build reproducibility.
+# A reproduction build will need executing apt-get with snapshot mode.
 ARG BASE_DEBIAN_DISTRO=trixie
 
 FROM debian:${BASE_DEBIAN_DISTRO}-slim

--- a/contrib/syscall-test/Dockerfile
+++ b/contrib/syscall-test/Dockerfile
@@ -1,5 +1,10 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.20.0@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
 
+# NOTE: the image digest is not pinned to a specific version,
+# as the image is frequently updated with apt security updates.
+#
+# TODO: consider pinning for better build reproducibility.
+# A reproduction build will need executing apt-get with snapshot mode.
 ARG BASE_DEBIAN_DISTRO=trixie
 
 FROM debian:${BASE_DEBIAN_DISTRO}-slim

--- a/hack/dockerfile/cli.sh
+++ b/hack/dockerfile/cli.sh
@@ -2,8 +2,9 @@
 
 set -e
 version="$1"
-repository="$2"
-outdir="$3"
+commit="$2"
+repository="$3"
+outdir="$4"
 
 DOWNLOAD_URL="https://download.docker.com/linux/static/stable/$(xx-info march)/docker-${version#v}.tgz"
 
@@ -17,6 +18,7 @@ else
 	git remote add origin "${repository}"
 	git fetch -q --depth 1 origin "${version}" +refs/tags/*:refs/tags/*
 	git checkout -fq "${version}"
+	[ "$(git rev-parse HEAD)" = "${commit}" ]
 	if [ -d ./components/cli ]; then
 		mv ./components/cli/* ./
 		CGO_ENABLED=0 xx-go build -o "${outdir}/docker" ./cmd/docker

--- a/hack/dockerfile/install/containerd.installer
+++ b/hack/dockerfile/install/containerd.installer
@@ -11,12 +11,14 @@ set -e
 #
 # Generally, the commit specified here should match a tagged release.
 : "${CONTAINERD_VERSION:=v2.2.0}"
+: "${CONTAINERD_COMMIT:=1c4457e00facac03ce1d75f7b6777a7a851e5c41}"
 
 install_containerd() (
 	echo "Install containerd version $CONTAINERD_VERSION"
 	git clone https://github.com/containerd/containerd.git "$GOPATH/src/github.com/containerd/containerd"
 	cd "$GOPATH/src/github.com/containerd/containerd"
 	git checkout -q "$CONTAINERD_VERSION"
+	[ "$(git rev-parse HEAD)" = "$CONTAINERD_COMMIT" ]
 
 	export BUILDTAGS='netgo osusergo static_build'
 	export EXTRA_FLAGS=${GO_BUILDMODE}

--- a/hack/dockerfile/install/dockercli.installer
+++ b/hack/dockerfile/install/dockercli.installer
@@ -2,6 +2,7 @@
 
 : ${DOCKERCLI_CHANNEL:=stable}
 : ${DOCKERCLI_VERSION:=18.06.3-ce}
+: ${DOCKERCLI_COMMIT:=c1ea761867553cea4e70d09e30bbba44ca1fc2ed}
 
 install_dockercli() {
 	echo "Install docker/cli version $DOCKERCLI_VERSION from $DOCKERCLI_CHANNEL"
@@ -24,6 +25,7 @@ build_dockercli() {
 	git clone https://github.com/docker/docker-ce "$GOPATH/tmp/docker-ce"
 	cd "$GOPATH/tmp/docker-ce"
 	git checkout -q "v$DOCKERCLI_VERSION"
+	[ "$(git rev-parse HEAD)" = "$DOCKERCLI_COMMIT" ]
 	mkdir -p "$GOPATH/src/github.com/docker"
 	mv components/cli "$GOPATH/src/github.com/docker/cli"
 	go build ${GO_BUILDMODE} -o "${PREFIX}/docker" "github.com/docker/cli/cmd/docker"

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -2,6 +2,7 @@
 
 # When updating, also update go.mod and Dockerfile accordingly.
 : "${ROOTLESSKIT_VERSION:=v2.3.5}"
+: "${ROOTLESSKIT_COMMIT:=0cc0811acc6e4daee71817383e62fb811590bc13}"
 
 install_rootlesskit() {
 	case "$1" in
@@ -27,5 +28,6 @@ install_rootlesskit_dynamic() {
 
 _install_rootlesskit() (
 	echo "Install rootlesskit version ${ROOTLESSKIT_VERSION}"
-	GOBIN="${PREFIX}" go install ${BUILD_MODE} -ldflags="$ROOTLESSKIT_LDFLAGS" "github.com/rootless-containers/rootlesskit/v2/cmd/rootlesskit@${ROOTLESSKIT_VERSION}"
+	GOBIN="${PREFIX}" go install ${BUILD_MODE} -ldflags="$ROOTLESSKIT_LDFLAGS" "github.com/rootless-containers/rootlesskit/v2/cmd/rootlesskit@${ROOTLESSKIT_COMMIT}"
+	[ "$("${GOBIN}/rootlesskit" --version)" = "rootlesskit version ${ROOTLESSKIT_VERSION#v}" ]
 )

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -8,6 +8,7 @@ set -e
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
 : "${RUNC_VERSION:=v1.3.3}"
+: "${RUNC_COMMIT:=d842d7719497cc3b774fd71620278ac9e17710e0}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"
@@ -16,6 +17,7 @@ install_runc() {
 	git clone https://github.com/opencontainers/runc.git "$GOPATH/src/github.com/opencontainers/runc"
 	cd "$GOPATH/src/github.com/opencontainers/runc"
 	git checkout -q "$RUNC_VERSION"
+	[ "$(git rev-parse HEAD)" = "$RUNC_COMMIT" ]
 	if [ -z "$1" ]; then
 		target=static
 	else

--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -4,12 +4,14 @@
 # from the https://github.com/krallin/tini repository. This binary is used
 # when starting containers with the `--init` option.
 : "${TINI_VERSION:=v0.19.0}"
+: "${TINI_COMMIT:=de40ad007797e0dcd8b7126f27bb87401d224240}"
 
 install_tini() {
 	echo "Install tini version $TINI_VERSION"
 	git clone https://github.com/krallin/tini.git "$GOPATH/tini"
 	cd "$GOPATH/tini"
 	git checkout -q "$TINI_VERSION"
+	[ "$(git rev-parse HEAD)" = "$TINI_COMMIT" ]
 	cmake .
 	make tini-static
 	mkdir -p "${PREFIX}"

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -1,5 +1,10 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.20.0@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
 
+# NOTE: the image digest is not pinned to a specific version,
+# as the image is frequently updated with apt security updates.
+#
+# TODO: consider pinning for better build reproducibility.
+# A reproduction build will need executing apt-get with snapshot mode.
 ARG GO_VERSION=1.25.4
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG PROTOC_VERSION=3.11.4
@@ -8,6 +13,7 @@ ARG PROTOC_VERSION=3.11.4
 FROM golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO} AS base
 RUN apt-get update && apt-get --no-install-recommends install -y git unzip
 ARG PROTOC_VERSION
+# TODO: validate the checksum of the zip file
 ARG TARGETOS
 ARG TARGETARCH
 ENV GOTOOLCHAIN=local

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,16 +1,25 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.20.0@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
 
+# NOTE: the image digest is not pinned to a specific version,
+# as the image is frequently updated with apt security updates.
+#
+# TODO: consider pinning for better build reproducibility.
+# A reproduction build will need executing apt-get with snapshot mode.
 ARG GO_VERSION=1.25.4
 ARG GOVULNCHECK_VERSION=v1.1.4
+ARG GOVULNCHECK_COMMIT=d1f380186385b4f64e00313f31743df8e4b89a77
 ARG FORMAT=text
 
 FROM golang:${GO_VERSION}-alpine AS base
 WORKDIR /go/src/github.com/moby/moby
 RUN apk add --no-cache jq moreutils
 ARG GOVULNCHECK_VERSION
+ARG GOVULNCHECK_COMMIT
+# Checkout and discard the source; we only need it to verify the commit hash.
+ADD https://github.com/golang/vuln.git?tag=${GOVULNCHECK_VERSION}&checksum=${GOVULNCHECK_COMMIT} /tmp/discarded
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \
-    go install golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION
+    go install golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_COMMIT
 
 FROM base AS run
 ARG FORMAT


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Verify the tags of containerd*, runc, tini, and rootlesskit with their commit hashes for tolerance to compromise of the tags.

These binaries are depeneded by docker-ce-packaging here: https://github.com/docker/docker-ce-packaging/blob/7e726fa319c261676d06b6ae10c04a3df80e4c48/static/Makefile#L43-L58

Replaces:
- #49674

Unlike the previous PR, this commit does not need the `git-checkout-tag-with-hash.sh` helper script.


**- How I did it**

By using `ADD ${URL}?tag=${TAG}&checksum=${COMMIT}`.

Available since Dockerfile v1.18: https://docs.docker.com/build/buildkit/dockerfile-release-notes/#1180

**- How to verify it**

- `make` passes
- `make` fails after modifying some hash

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

