### PR TITLE
Improve description of tmpfs mode

### DIFF
--- a/api/docs/v1.25.yaml
+++ b/api/docs/v1.25.yaml
@@ -319,7 +319,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
   RestartPolicy:
     description: |

--- a/api/docs/v1.26.yaml
+++ b/api/docs/v1.26.yaml
@@ -319,7 +319,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
   RestartPolicy:
     description: |

--- a/api/docs/v1.27.yaml
+++ b/api/docs/v1.27.yaml
@@ -321,7 +321,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
   RestartPolicy:
     description: |

--- a/api/docs/v1.28.yaml
+++ b/api/docs/v1.28.yaml
@@ -321,7 +321,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
   RestartPolicy:
     description: |

--- a/api/docs/v1.29.yaml
+++ b/api/docs/v1.29.yaml
@@ -324,7 +324,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
   RestartPolicy:
     description: |

--- a/api/docs/v1.30.yaml
+++ b/api/docs/v1.30.yaml
@@ -325,7 +325,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
   RestartPolicy:
     description: |

--- a/api/docs/v1.31.yaml
+++ b/api/docs/v1.31.yaml
@@ -325,7 +325,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
   RestartPolicy:
     description: |

--- a/api/docs/v1.32.yaml
+++ b/api/docs/v1.32.yaml
@@ -327,7 +327,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.33.yaml
+++ b/api/docs/v1.33.yaml
@@ -331,7 +331,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.34.yaml
+++ b/api/docs/v1.34.yaml
@@ -333,7 +333,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.35.yaml
+++ b/api/docs/v1.35.yaml
@@ -343,7 +343,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.36.yaml
+++ b/api/docs/v1.36.yaml
@@ -343,7 +343,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.37.yaml
+++ b/api/docs/v1.37.yaml
@@ -343,7 +343,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.38.yaml
+++ b/api/docs/v1.38.yaml
@@ -344,7 +344,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.39.yaml
+++ b/api/docs/v1.39.yaml
@@ -370,7 +370,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.40.yaml
+++ b/api/docs/v1.40.yaml
@@ -413,7 +413,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.41.yaml
+++ b/api/docs/v1.41.yaml
@@ -413,7 +413,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.42.yaml
+++ b/api/docs/v1.42.yaml
@@ -421,7 +421,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.43.yaml
+++ b/api/docs/v1.43.yaml
@@ -421,7 +421,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.44.yaml
+++ b/api/docs/v1.44.yaml
@@ -431,7 +431,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.45.yaml
+++ b/api/docs/v1.45.yaml
@@ -439,7 +439,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
 
   RestartPolicy:

--- a/api/docs/v1.46.yaml
+++ b/api/docs/v1.46.yaml
@@ -439,7 +439,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |

--- a/api/docs/v1.47.yaml
+++ b/api/docs/v1.47.yaml
@@ -439,7 +439,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |

--- a/api/docs/v1.48.yaml
+++ b/api/docs/v1.48.yaml
@@ -451,7 +451,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |

--- a/api/docs/v1.49.yaml
+++ b/api/docs/v1.49.yaml
@@ -451,7 +451,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |

--- a/api/docs/v1.50.yaml
+++ b/api/docs/v1.50.yaml
@@ -451,7 +451,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -451,7 +451,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -467,7 +467,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -467,7 +467,10 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: "The permission mode for the tmpfs mount in an integer."
+            description: |
+              The permission mode for the tmpfs mount in an integer.
+              The value must not be in octal format (e.g. 755) but rather
+              the decimal representation of the octal value (e.g. 493).
             type: "integer"
           Options:
             description: |


### PR DESCRIPTION
**- What I did**
I recently had a great time to find out why the tmpfs mode provided did not work until I found out that the API does not expect octal values but decimal ones.

Therefore, this PR will hopefully clarify the logic and prevent user questions in the future

**- How I did it**
Updating the description 

**- How to verify it**
n/a

**- A picture of a cute animal (not mandatory but encouraged)**

