### PR TITLE
system: df: fix SharedUsage on non-containerd

### DIFF
--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -103,8 +103,7 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 	}
 
 	var (
-		summaries     = make([]imagetypes.Summary, 0, len(selectedImages))
-		summaryMap    = make(map[*image.Image]imagetypes.Summary, len(selectedImages))
+		summaryMap    = make(map[*image.Image]*imagetypes.Summary, len(selectedImages))
 		allContainers []*container.Container
 	)
 	for id, img := range selectedImages {
@@ -210,8 +209,7 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 			}
 		}
 		summary.Containers = containersCount
-		summaryMap[img] = *summary
-		summaries = append(summaries, *summary)
+		summaryMap[img] = summary
 	}
 
 	if opts.SharedSize {
@@ -257,6 +255,10 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 		}
 	}
 
+	summaries := make([]imagetypes.Summary, 0, len(summaryMap))
+	for _, summary := range summaryMap {
+		summaries = append(summaries, *summary)
+	}
 	sort.Sort(sort.Reverse(byCreated(summaries)))
 
 	return summaries, nil


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/pull/51425
- fixes / addresses https://github.com/docker/cli/issues/6686


The value was calculated, but due to 0af2962fddc0030a7ab97c3a46368ec04b44a7d7 changing to a non-pointer, the value was not written back to the resulting slice.

Before this patch:

    docker pull nginx:alpine
    docker pull alpine

    docker system df -v
    Images space usage:

    REPOSITORY   TAG       IMAGE ID       CREATED       SIZE      SHARED SIZE   UNIQUE SIZE   CONTAINERS
    nginx        alpine    cbad6347cca2   4 weeks ago   53.4MB    N/A           N/A           0
    alpine       latest    171e65262c80   7 weeks ago   8.51MB    N/A           N/A           0

With this patch:

    docker system df -v
    Images space usage:

    REPOSITORY   TAG       IMAGE ID       CREATED       SIZE      SHARED SIZE   UNIQUE SIZE   CONTAINERS
    nginx        alpine    cbad6347cca2   4 weeks ago   53.4MB    8.512MB       44.91MB       0
    alpine       latest    171e65262c80   7 weeks ago   8.51MB    8.512MB       0B            0

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker system df` showing `N/A` for shared size and unique size when using graph-drivers as storage.
```

**- A picture of a cute animal (not mandatory but encouraged)**

