### PR TITLE
Dockerfile: update runc binary to v1.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -254,7 +254,7 @@ RUN git init . && git remote add origin "https://github.com/opencontainers/runc.
 # This version should usually match the version that is used by the containerd version
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged.
-ARG RUNC_VERSION=v1.3.3
+ARG RUNC_VERSION=v1.3.4
 RUN git fetch -q --depth 1 origin "${RUNC_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS runc-build

--- a/hack/dockerfile/install/runc.installer
+++ b/hack/dockerfile/install/runc.installer
@@ -7,7 +7,7 @@ set -e
 # The version of runc should match the version that is used by the containerd
 # version that is used. If you need to update runc, open a pull request in
 # the containerd project first, and update both after that is merged.
-: "${RUNC_VERSION:=v1.3.3}"
+: "${RUNC_VERSION:=v1.3.4}"
 
 install_runc() {
 	RUNC_BUILDTAGS="${RUNC_BUILDTAGS:-"seccomp"}"


### PR DESCRIPTION
This version bump aims to fix a regression in runc v1.3.3, which caused `/dev/shm` to have inappropriate permissions exposed to containers:
* https://github.com/opencontainers/runc/issues/4971
* https://github.com/opencontainers/runc/pull/4976

Fixes https://github.com/docker/for-mac/issues/7804

- runc release notes: https://github.com/opencontainers/runc/releases/tag/v1.3.4
- runc full diff: https://github.com/opencontainers/runc/compare/v1.3.3...v1.3.4

```markdown changelog
Update runc (in static binaries) to [v1.3.4](https://github.com/opencontainers/runc/releases/tag/v1.3.4)
```

