### PR TITLE
NRI: add daemon.json/command line options

### DIFF
--- a/daemon/command/config.go
+++ b/daemon/command/config.go
@@ -79,6 +79,8 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 
 	flags.Var(opts.NewNamedListOptsRef("cdi-spec-dirs", &conf.CDISpecDirs, nil), "cdi-spec-dir", "CDI specification directories to use")
 
+	flags.Var(opts.NewNamedNRIOptsRef(&conf.NRIOpts), "nri-opts", "Node Resource Interface configuration")
+
 	// Deprecated flags / options
 	flags.BoolVarP(&conf.AutoRestart, "restart", "r", true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	_ = flags.MarkDeprecated("restart", "Please use a restart policy on docker run")

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -88,6 +88,7 @@ var flatOptions = map[string]bool{
 	"default-ulimits":      true,
 	"features":             true,
 	"builder":              true,
+	"nri-opts":             true,
 }
 
 // skipValidateOptions contains configuration keys
@@ -283,6 +284,9 @@ type CommonConfig struct {
 
 	// CDISpecDirs is a list of directories in which CDI specifications can be found.
 	CDISpecDirs []string `json:"cdi-spec-dirs,omitempty"`
+
+	// NRIOpts defines configuration for NRI (Node Resource Interface).
+	NRIOpts opts.NRIOpts `json:"nri-opts,omitempty"`
 
 	// The minimum API version provided by the daemon. Defaults to [defaultMinAPIVersion].
 	//

--- a/daemon/pkg/opts/nri_opts.go
+++ b/daemon/pkg/opts/nri_opts.go
@@ -1,0 +1,94 @@
+package opts
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type NRIOpts struct {
+	Enable           bool   `json:"enable,omitempty"`
+	PluginPath       string `json:"plugin-path,omitempty"`
+	PluginConfigPath string `json:"plugin-config-path,omitempty"`
+	SocketPath       string `json:"socket-path,omitempty"`
+}
+
+func (c *NRIOpts) UnmarshalJSON(raw []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	type nc *NRIOpts // prevent recursion
+	if err := dec.Decode(nc(c)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// NamedNRIOpts is a NamedOption and flags.Value for NRI configuration parsing.
+type NamedNRIOpts struct {
+	Val *NRIOpts
+}
+
+func NewNamedNRIOptsRef(val *NRIOpts) *NamedNRIOpts {
+	return &NamedNRIOpts{Val: val}
+}
+
+func (p *NamedNRIOpts) Set(value string) error {
+	csvReader := csv.NewReader(strings.NewReader(value))
+	fields, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+
+	for _, field := range fields {
+		key, val, _ := strings.Cut(field, "=")
+		switch key {
+		case "enable":
+			// Assume "enable=true" if no value given, so that "--nri enable" works.
+			if val == "" {
+				val = "true"
+			}
+			en, err := strconv.ParseBool(val)
+			if err != nil {
+				return fmt.Errorf("invalid value for NRI enable %q: %w", val, err)
+			}
+			p.Val.Enable = en
+		case "plugin-path":
+			p.Val.PluginPath = val
+		case "plugin-config-path":
+			p.Val.PluginConfigPath = val
+		case "socket-path":
+			p.Val.SocketPath = val
+		default:
+			return fmt.Errorf("unexpected key '%s' in '%s'", key, field)
+		}
+	}
+	return nil
+}
+
+// Type returns the type of this option
+func (p *NamedNRIOpts) Type() string {
+	return "nri-opts"
+}
+
+// String returns a string repr of this option
+func (p *NamedNRIOpts) String() string {
+	vals := []string{fmt.Sprintf("enable=%v", p.Val.Enable)}
+	if p.Val.PluginPath != "" {
+		vals = append(vals, "plugin-path="+p.Val.PluginPath)
+	}
+	if p.Val.PluginConfigPath != "" {
+		vals = append(vals, "plugin-config-path="+p.Val.PluginConfigPath)
+	}
+	if p.Val.SocketPath != "" {
+		vals = append(vals, "socket-path="+p.Val.SocketPath)
+	}
+	return strings.Join(vals, ",")
+}
+
+// Name returns the flag name of this option
+func (p *NamedNRIOpts) Name() string {
+	return "nri-opts"
+}

--- a/daemon/pkg/opts/nri_opts_test.go
+++ b/daemon/pkg/opts/nri_opts_test.go
@@ -1,0 +1,117 @@
+package opts
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestNRIOptsJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		json   string
+		expErr string
+		expNRI NRIOpts
+	}{
+		{
+			name:   "no config",
+			expNRI: NRIOpts{},
+		},
+		{
+			name: "json enable",
+			json: `{"enable": true}`,
+			expNRI: NRIOpts{
+				Enable: true,
+			},
+		},
+		{
+			name: "json enable with paths",
+			json: `{"enable": true, "plugin-path": "/foo", "plugin-config-path": "/bar", "socket-path": "/baz"}`,
+			expNRI: NRIOpts{
+				Enable:           true,
+				PluginPath:       "/foo",
+				PluginConfigPath: "/bar",
+				SocketPath:       "/baz",
+			},
+		},
+		{
+			name:   "json unknown field",
+			json:   `{"foo": "bar"}`,
+			expErr: "unknown field \"foo\"",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var nc NRIOpts
+			if tc.json != "" {
+				err := nc.UnmarshalJSON([]byte(tc.json))
+				if tc.expErr != "" {
+					assert.Check(t, is.ErrorContains(err, tc.expErr))
+					return
+				}
+				assert.Check(t, err)
+			}
+			assert.Check(t, is.Equal(nc, tc.expNRI))
+		})
+	}
+}
+
+func TestNRIOptsCmd(t *testing.T) {
+	tests := []struct {
+		name      string
+		cmd       string
+		expErr    string
+		expNRI    NRIOpts
+		expString string
+	}{
+		{
+			name: "cmd enable",
+			cmd:  "enable=true",
+			expNRI: NRIOpts{
+				Enable: true,
+			},
+			expString: "enable=true",
+		},
+		{
+			name: "cmd enable with paths",
+			cmd:  "enable=true,plugin-path=/foo,plugin-config-path=/bar,socket-path=/baz",
+			expNRI: NRIOpts{
+				Enable:           true,
+				PluginPath:       "/foo",
+				PluginConfigPath: "/bar",
+				SocketPath:       "/baz",
+			},
+			expString: "enable=true,plugin-path=/foo,plugin-config-path=/bar,socket-path=/baz",
+		},
+		{
+			// "--nri-opts enable"
+			name: "cmd enable no value",
+			cmd:  `enable`,
+			expNRI: NRIOpts{
+				Enable: true,
+			},
+			expString: "enable=true",
+		},
+		{
+			name:   "cmd unknown field",
+			cmd:    `foo=bar`,
+			expErr: "unexpected key 'foo' in 'foo=bar'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var nc NRIOpts
+			nriOpt := NewNamedNRIOptsRef(&nc)
+			err := nriOpt.Set(tc.cmd)
+			if tc.expErr != "" {
+				assert.Check(t, is.ErrorContains(err, tc.expErr))
+				return
+			}
+			assert.Check(t, err)
+			assert.Check(t, is.Equal(nriOpt.String(), tc.expString))
+		})
+	}
+}


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/51511

Add config options for the (yet to be implemented) NRI component. (Getting the most contentious part out of the way first!)

For context, commits in the queue after this - https://github.com/moby/moby/compare/master...robmry:moby:nri?expand=1

**- How I did it**

In `daemon.json`, config looks like this ...
```
{
        "nri-opts": {
                "enable": true,
                "plugin-path": "/path/to/plugins",
                "plugin-config-path": "/path/to/plugin-config",
                "socket-path": "/path/to/nri.sock"
        },
        ...
```

These are:
- plugin-path - anything in this directory, named with a two-digit prefix (like "00-my-plugin"), will be started by dockerd as an NRI plugin when dockerd starts.
- plugin-config-path - config snippets that get passed to the plugin when dockerd starts it.
- socket-path - location of a listening socket, allowing plugins that aren't in `plugin-path` and started by the daemon to connect.

On the dockerd command line, the same config looks like this ...
```
--nri-opts enable=true,plugin-path=/path/to/plugins,plugin-config-path=/path/to/plugin-config,socket-path=/path/to/nri.sock
```

If there's an `"nri-opts"` in the JSON, and an `--nri-opts` on the command line, dockerd says ...
```
$ dockerd --nri-opts enable,plugin-path=/path/to/plugin/config
unable to configure the Docker daemon with file /etc/docker/daemon.json: the following directives are specified both as a flag and in the configuration file: nri-opts: (from flag: enable=true,plugin-path=/path/to/plugin/config, from file: map[enable:true plugin-path:/path/to/plugin/config])
```

**- How to verify it**

New unit tests. Integration tests coming along in a later PR.

**- Human readable description for the release notes**
```markdown changelog
Add experimental NRI support
```
