### PR TITLE
test-fixes in preparation of debian trixie update

### DIFF
--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/nftabler_test.go
@@ -98,11 +98,18 @@ func testNftabler(t *testing.T, tn string, config firewaller.Config, netConfig f
 	checkResults := func(family, name string, en bool) {
 		t.Helper()
 		res := icmd.RunCommand("nft", "list", "table", family, dockerTable)
+		out := res.Combined()
 		if !en {
-			assert.Assert(t, is.Contains(res.Combined(), "No such file or directory"))
+			assert.Assert(t, is.Contains(out, "No such file or directory"))
 			return
 		}
-		out := strings.ReplaceAll(res.Combined(), "type nat hook output priority -100", "type nat hook output priority dstnat")
+		// nftables before v1.0.9 don't stringify the dstnat priority for an
+		// output hook, and print its numeric value (-100) instead. Normalize the
+		// output for stable test results.
+		//
+		// - https://git.netfilter.org/nftables/commit/?id=8beafab74c391130fbb9111bfccab8613644e3b9
+		// - https://github.com/moby/moby/pull/50745 / https://github.com/moby/moby/commit/fbde2bcb9a8a8fcf06cc6fe1675560cf46237e7b
+		out = strings.ReplaceAll(out, "type nat hook output priority -100", "type nat hook output priority dstnat")
 		assert.Assert(t, res.Error, out)
 		golden.Assert(t, out, name+"__"+family+".golden")
 	}

--- a/daemon/libnetwork/firewall_linux_test.go
+++ b/daemon/libnetwork/firewall_linux_test.go
@@ -33,7 +33,7 @@ func TestUserChain(t *testing.T) {
 	res := icmd.RunCommand("iptables", "--version")
 	assert.NilError(t, res.Error)
 	noChainErr := "No chain/target/match by that name"
-	iptVerLt := versionLt(t, res.Combined(), 1, 8, 11)
+	iptVerLt := versionLt(t, res.Combined(), 1, 8, 10)
 	t.Logf("iptables version < v1.8.11: %t", iptVerLt)
 	if strings.Contains(res.Combined(), "nf_tables") && iptVerLt {
 		// Prior to v1.8.11, iptables-nft "-S <chain>" reports the following for a non-existent chain:

--- a/daemon/libnetwork/firewall_linux_test.go
+++ b/daemon/libnetwork/firewall_linux_test.go
@@ -33,7 +33,9 @@ func TestUserChain(t *testing.T) {
 	res := icmd.RunCommand("iptables", "--version")
 	assert.NilError(t, res.Error)
 	noChainErr := "No chain/target/match by that name"
-	if strings.Contains(res.Combined(), "nf_tables") && versionLt(t, res.Combined(), 1, 8, 11) {
+	iptVerLt := versionLt(t, res.Combined(), 1, 8, 11)
+	t.Logf("iptables version < v1.8.11: %t", iptVerLt)
+	if strings.Contains(res.Combined(), "nf_tables") && iptVerLt {
 		// Prior to v1.8.11, iptables-nft "-S <chain>" reports the following for a non-existent chain:
 		//
 		//   ip6tables v1.8.9 (nf_tables): chain `<chain>' in table `filter' is incompatible, use 'nft' tool.
@@ -150,22 +152,17 @@ func resetIptables(t *testing.T) {
 // versionLt returns true if the iptables version returned by `iptables --version`
 // is less than the `<major>.<minor>.<patch>` version passed in as argument.
 func versionLt(t *testing.T, ver string, major, minor, patch int) bool {
-	match := regexp.MustCompile(`iptables v([0-9]+)\.([0-9]+)\.([0-9]+)`).FindStringSubmatch(ver)
-	assert.Assert(t, len(match) != 4, "could not determine iptables version from %q", ver)
+	t.Helper()
 
-	parsedMajor, err := strconv.Atoi(match[1])
-	assert.NilError(t, err)
-	if parsedMajor >= major {
-		return false
-	}
+	matches := regexp.MustCompile(`iptables v([0-9]+)\.([0-9]+)\.([0-9]+)`).FindStringSubmatch(ver)
+	assert.Assert(t, len(matches) == 4, "could not determine iptables version from %q", ver)
 
-	parsedMinor, err := strconv.Atoi(match[2])
+	parsedMajor, err := strconv.Atoi(matches[1])
 	assert.NilError(t, err)
-	if parsedMinor >= minor {
-		return false
-	}
+	parsedMinor, err := strconv.Atoi(matches[2])
+	assert.NilError(t, err)
+	parsedPatch, err := strconv.Atoi(matches[3])
+	assert.NilError(t, err)
 
-	parsedPatch, err := strconv.Atoi(match[3])
-	assert.NilError(t, err)
-	return parsedPatch < patch
+	return parsedMajor <= major && parsedMinor <= minor && parsedPatch < patch
 }

--- a/daemon/libnetwork/firewall_linux_test.go
+++ b/daemon/libnetwork/firewall_linux_test.go
@@ -34,9 +34,9 @@ func TestUserChain(t *testing.T) {
 	assert.NilError(t, res.Error)
 	noChainErr := "No chain/target/match by that name"
 	iptVerLt := versionLt(t, res.Combined(), 1, 8, 10)
-	t.Logf("iptables version < v1.8.11: %t", iptVerLt)
+	t.Logf("iptables version < v1.8.10: %t", iptVerLt)
 	if strings.Contains(res.Combined(), "nf_tables") && iptVerLt {
-		// Prior to v1.8.11, iptables-nft "-S <chain>" reports the following for a non-existent chain:
+		// Prior to v1.8.10, iptables-nft "-S <chain>" reports the following for a non-existent chain:
 		//
 		//   ip6tables v1.8.9 (nf_tables): chain `<chain>' in table `filter' is incompatible, use 'nft' tool.
 		//

--- a/daemon/libnetwork/firewall_linux_test.go
+++ b/daemon/libnetwork/firewall_linux_test.go
@@ -3,8 +3,6 @@ package libnetwork
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -16,7 +14,6 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
-	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
 
@@ -32,18 +29,6 @@ func TestUserChain(t *testing.T) {
 	const testName = "TestUserChain"
 	iptable4 := iptables.GetIptable(iptables.IPv4)
 	iptable6 := iptables.GetIptable(iptables.IPv6)
-
-	res := icmd.RunCommand("iptables", "--version")
-	assert.NilError(t, res.Error)
-	noChainErr := "No chain/target/match by that name"
-	if strings.Contains(res.Combined(), "nf_tables") && versionLt(t, res.Combined(), 1, 8, 10) {
-		// Prior to v1.8.10, iptables-nft "-S <chain>" reports the following for a non-existent chain:
-		//
-		//   ip6tables v1.8.9 (nf_tables): chain `<chain>' in table `filter' is incompatible, use 'nft' tool.
-		//
-		// This was fixed in this commit: https://git.netfilter.org/iptables/commit/?id=82ccfb488eeac5507471099b9b4e6d136cc06e3b
-		noChainErr = "incompatible, use 'nft' tool"
-	}
 
 	tests := []struct {
 		iptables bool
@@ -123,9 +108,9 @@ func TestUserChain(t *testing.T) {
 					fmt.Sprintf("%s/iptables-%v_append-%v_usrafter6.golden", testName, tc.iptables, tc.append))
 			} else {
 				_, err := iptable4.Raw("-S", usrChainName)
-				assert.Check(t, is.ErrorContains(err, noChainErr), "ipv4 chain %v: created unexpectedly", usrChainName)
+				assert.Check(t, isMissingChainError(err), "ipv4 chain %v: created unexpectedly", usrChainName)
 				_, err = iptable6.Raw("-S", usrChainName)
-				assert.Check(t, is.ErrorContains(err, noChainErr), "ipv6 chain %v: created unexpectedly", usrChainName)
+				assert.Check(t, isMissingChainError(err), "ipv6 chain %v: created unexpectedly", usrChainName)
 			}
 		})
 	}
@@ -150,20 +135,27 @@ func resetIptables(t *testing.T) {
 	}
 }
 
-// versionLt returns true if the iptables version returned by `iptables --version`
-// is less than the `<major>.<minor>.<patch>` version passed in as argument.
-func versionLt(t *testing.T, ver string, major, minor, patch int) bool {
-	t.Helper()
-
-	matches := regexp.MustCompile(`iptables v([0-9]+)\.([0-9]+)\.([0-9]+)`).FindStringSubmatch(ver)
-	assert.Assert(t, len(matches) == 4, "could not determine iptables version from %q", ver)
-
-	parsedMajor, err := strconv.Atoi(matches[1])
-	assert.NilError(t, err)
-	parsedMinor, err := strconv.Atoi(matches[2])
-	assert.NilError(t, err)
-	parsedPatch, err := strconv.Atoi(matches[3])
-	assert.NilError(t, err)
-
-	return parsedMajor < major || (parsedMajor == major && parsedMinor < minor) || (parsedMajor == major && parsedMinor == minor && parsedPatch < patch)
+// isMissingChainError succeeds if err indicates that "iptables -S <chain>"
+// could not find the requested chain.
+//
+// Before iptables v1.8.10, iptables-nft "-S <chain>" could report a
+// non-existent chain as incompatible:
+//
+//	ip6tables v1.8.9 (nf_tables): chain `<chain>' in table `filter' is incompatible, use 'nft' tool.
+//
+// This was fixed in iptables v1.8.10. Debian 13 ships v1.8.11 and therefore
+// returns the usual "No chain/target/match by that name" diagnostic.
+//
+// Fixed by: https://git.netfilter.org/iptables/commit/?id=82ccfb488eeac5507471099b9b4e6d136cc06e3b
+func isMissingChainError(err error) is.Comparison {
+	return func() is.Result {
+		if err == nil {
+			return is.ResultFailure("expected a missing-chain error, got nil")
+		}
+		if strings.Contains(err.Error(), "No chain/target/match by that name") ||
+			strings.Contains(err.Error(), "incompatible, use 'nft' tool") {
+			return is.ResultSuccess
+		}
+		return is.ResultFailure(fmt.Sprintf("expected a missing-chain error, got %v", err))
+	}
 }

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -417,7 +417,7 @@ func runNftables(t *testing.T, host networking.Host) map[string]string {
 	var sb strings.Builder
 	for line := range lines(out) {
 		if line == "\n" || (line != "" && line[0] == '}') {
-			block := sb.String()
+			block := strings.ReplaceAll(sb.String(), "type nat hook output priority -100", "type nat hook output priority dstnat")
 			sb.Reset()
 			if keyEnd := strings.Index(block, " {"); keyEnd > 0 {
 				res[strings.TrimSpace(block[:keyEnd])] = block

--- a/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
+++ b/integration/network/bridge/nftablesdoc/nftablesdoc_linux_test.go
@@ -380,6 +380,13 @@ func pollService(ctx context.Context, t *testing.T, c *client.Client, host netwo
 func runNftables(t *testing.T, host networking.Host) map[string]string {
 	res := map[string]string{}
 	out := host.MustRun(t, "nft", "-s", "list", "table", "ip", "docker-bridges")
+
+	// nftables before v1.0.9 don't stringify the dstnat priority for an
+	// output hook, and print its numeric value (-100) instead. Normalize the
+	// output for stable test results.
+	//
+	// - https://git.netfilter.org/nftables/commit/?id=8beafab74c391130fbb9111bfccab8613644e3b9
+	// - https://github.com/moby/moby/pull/50745 / https://github.com/moby/moby/commit/fbde2bcb9a8a8fcf06cc6fe1675560cf46237e7b
 	out = strings.ReplaceAll(out, "type nat hook output priority -100", "type nat hook output priority dstnat")
 	// Indent the result, so that it's treated as preformatted markdown.
 	res["Ruleset4"] = "    " + strings.ReplaceAll(out, "\n", "\n    ")


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50726
- relates to https://github.com/moby/moby/pull/50745
- relates to https://github.com/moby/moby/pull/50841

### nftablesdoc,nftabler: document dstnat priority normalization

Add comments explaining why nft output normalizes
`type nat hook output priority -100` to `priority dstnat`.

Different nft versions format the dstnat priority for an output hook
differently, so keep the normalization documented to avoid it looking
like an obsolete or accidental workaround.

Include an upstream nftables source reference showing the corresponding
priority handling.

updates fbde2bcb9a8a8fcf06cc6fe1675560cf46237e7b


### d/libnet: TestUserChain: fix incorrect version-dependent error matching

Commit 8839f5317595 ("d/libnet: TestUserChain: fix error matching for
nonexistent chains") added version-dependent matching for an iptables-nft
behavior change, but used the wrong version boundary.

The upstream fix was released in iptables v1.8.11, not v1.8.10. Debian
13 ships v1.8.11, so the test still expected the older "incompatible,
use 'nft' tool" diagnostic instead of:

    ip6tables: No chain/target/match by that name.

Rather than selecting the expected diagnostic based on the reported
iptables version, accept either known missing-chain diagnostic. This
also handles distributions that backport the upstream fix independently
of the iptables version.

updates: https://github.com/moby/moby/commit/8839f5317595812c67fc71dc142e6e29c46760c3
ref: https://git.netfilter.org/iptables/commit/?id=82ccfb488eeac5507471099b9b4e6d136cc06e3b




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

