### PR TITLE
daemon/server: Close request body when request context is done

### DIFF
--- a/daemon/server/server.go
+++ b/daemon/server/server.go
@@ -60,6 +60,9 @@ func (s *Server) makeHTTPHandler(r router.Route) http.HandlerFunc {
 			vars = make(map[string]string)
 		}
 
+		// Close the body when the context is done
+		context.AfterFunc(ctx, func() { r.Body.Close() })
+
 		if err := handlerFunc(ctx, w, r, vars); err != nil {
 			statusCode := httpstatus.FromError(err)
 			if statusCode >= http.StatusInternalServerError {


### PR DESCRIPTION
Ensures that HTTP request bodies are properly closed when the request context is cancelled or times out, preventing potential resource leaks in long-running daemon operations.

This is particularly important for large request payloads where the body might not be fully consumed before the context expires.

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

