### PR TITLE
fix: Correct typo in error message

### DIFF
--- a/daemon/libnetwork/service_linux.go
+++ b/daemon/libnetwork/service_linux.go
@@ -247,7 +247,7 @@ func (n *Network) rmLBBackend(ip net.IP, lb *loadBalancer, rmService bool, fullR
 		}
 		err := sb.osSbox.RemoveAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
 		if err != nil {
-			log.G(context.TODO()).Errorf("Failed add IP alias %s to network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
+			log.G(context.TODO()).Errorf("Failed to remove IP alias %s from network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Corrected an incorrect error message in `daemon/libnetwork/service_linux.go` where the log output referenced "Failed add IP alias" even though the code path executes `RemoveAliasIP`.
The message now accurately reflects the operation being performed (removal, not addition).

**- How I did it**
Identified the mismatch in `service_linux.go` at line 250, and updated the log string to indicate failure to remove an IP alias instead of failure to add one.
No functional code change was made; only the log message text was corrected.

**- How to verify it**
1. This issue was not encountered during runtime; it was identified through code review while inspecting the Swarm networking implementation.
1. Reproduce a scenario where `sb.osSbox.RemoveAliasIP` returns an error (e.g., attempting to remove a non-existent alias in a Swarm ingress network).
1. Inspect the Docker daemon logs.
1. Confirm that the emitted log now reports:
"Failed remove IP alias …"
instead of the outdated and misleading "Failed add IP alias …".


```markdown
Corrected an inaccurate log message in Docker Swarm networking to reflect failures when removing an IP alias instead of adding one.
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="250" height="309" alt="image" src="https://github.com/user-attachments/assets/bd10e84a-61ed-4670-8326-6759aaa6487f" />

