### PR TITLE
Improve IP alias handling in service_linux.go

### DIFF
--- a/daemon/libnetwork/service_linux.go
+++ b/daemon/libnetwork/service_linux.go
@@ -118,8 +118,12 @@ func (n *Network) addLBBackend(ip net.IP, lb *loadBalancer) {
 		}
 		err := sb.osSbox.AddAliasIP(ifName, &net.IPNet{IP: lb.vip, Mask: net.CIDRMask(32, 32)})
 		if err != nil {
-			log.G(context.TODO()).Errorf("Failed add IP alias %s to network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
-			return
+			if errors.Is(err, syscall.EEXIST) {
+				log.G(context.TODO()).Debugf("IP alias %s already exists on network %s LB endpoint interface %s", lb.vip, n.ID(), ifName)
+			} else {
+				log.G(context.TODO()).Errorf("Failed add IP alias %s to network %s LB endpoint interface %s: %v", lb.vip, n.ID(), ifName, err)
+				return
+			}
 		}
 
 		if sb.ingress {


### PR DESCRIPTION


- Closes #51656

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Handled the case where `sb.osSbox.AddAliasIP` returns `EEXIST` (IP alias already exists) when attaching a VIP to a Swarm LB endpoint, preventing failure in service updates.

**- How I did it**
Wrapped the `AddAliasIP` call with a check for `syscall.EEXIST`.
Logged the occurrence at Debug level and avoided returning an error that blocks the stack update.


**- How to verify it**

1. Deploy a minimal Swarm stack with a service exposing a port (exposed 2 ports in this procedure to demonstrate that everything is lost)
```yaml
services:
  whoami:
    image: containous/whoami:latest
    deploy:
      update_config:
        order: start-first
    ports:
      - "8181:80"
      - "8881:80"
networks:
  default:
    driver: overlay
```
```bash
$ docker stack deploy -c /tmp/docker-compose.yml test
$ sudo netstat -tpnl|grep dockerd
tcp6       0      0 :::2377                 :::*                    LISTEN      2954664/dockerd     
tcp6       0      0 :::8881                 :::*                    LISTEN      2954664/dockerd     
tcp6       0      0 :::8181                 :::*                    LISTEN      2954664/dockerd     
tcp6       0      0 :::7946                 :::*                    LISTEN      2954664/dockerd     
```
2. change one of the published ports
```bash
$ sed -i 's/8181/8182/' /tmp/docker-compose.yml
```
3. Redeploy the stack with the change on the published port. Observe that there is no ports mapped anymore
```bash
$ docker stack deploy -c /tmp/docker-compose.yml test
# All published ports disappear after stack update without the patch.
$ sudo netstat -tpnl|grep dockerd
tcp6       0      0 :::2377                 :::*                    LISTEN      2954664/dockerd     
tcp6       0      0 :::7946                 :::*                    LISTEN      2954664/dockerd     
```
The logs also show:
```
level=error msg="Failed add IP alias 10.0.0.15 to network 2biqp5jrkarbk4z21e244kjv3 LB endpoint interface eth0: file exists"
```

### with the patch
```bash
$ docker stack rm test
$ sed -i 's/8182/8181/' /tmp/docker-compose.yml
$ docker stack deploy -c /tmp/docker-compose.yml test
$ sudo netstat -tpnl|grep dockerd
tcp6       0      0 :::2377                 :::*                    LISTEN      2964867/dockerd     
tcp6       0      0 :::8881                 :::*                    LISTEN      2964867/dockerd     
tcp6       0      0 :::8181                 :::*                    LISTEN      2964867/dockerd     
tcp6       0      0 :::7946                 :::*                    LISTEN      2964867/dockerd     
$ sed -i 's/8181/8182/' /tmp/docker-compose.yml
$ docker stack deploy -c /tmp/docker-compose.yml test
# we clearly see the rollout
$ sudo netstat -tpnl|grep dockerd
tcp6       0      0 :::2377                 :::*                    LISTEN      2967568/dockerd     
tcp6       0      0 :::8881                 :::*                    LISTEN      2967568/dockerd     
tcp6       0      0 :::8182                 :::*                    LISTEN      2967568/dockerd     
tcp6       0      0 :::8181                 :::*                    LISTEN      2967568/dockerd     
tcp6       0      0 :::7946                 :::*                    LISTEN      2967568/dockerd     
$ sudo netstat -tpnl|grep dockerd
tcp6       0      0 :::2377                 :::*                    LISTEN      2967568/dockerd     
tcp6       0      0 :::8881                 :::*                    LISTEN      2967568/dockerd     
tcp6       0      0 :::8182                 :::*                    LISTEN      2967568/dockerd     
tcp6       0      0 :::7946                 :::*                    LISTEN      2967568/dockerd     
```

The logs show our new message (as debug this time):
```
level=debug msg="IP alias 10.0.0.4 already exists on network 2biqp5jrkarbk4z21e244kjv3 LB endpoint interface eth0"
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix Swarm service updates failing due to "file exists" errors when a VIP IP alias already exists on the LB endpoint interface.
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="330" height="265" alt="image" src="https://github.com/user-attachments/assets/693e0758-a497-4f4a-9633-f09d8a873ddc" />
