### PR TITLE
project: add End-of-maintenance date for 25.0

### DIFF
--- a/project/BRANCHES-AND-TAGS.md
+++ b/project/BRANCHES-AND-TAGS.md
@@ -20,7 +20,7 @@ Currently (and previously) maintained release branches are documented in the tab
 | 27.x                        |                                                | Unmaintained          |                             |                                           |
 | 26.1                        |                                                | Unmaintained          |                             |                                           |
 | 26.0                        |                                                | Unmaintained          |                             |                                           |
-| 25.0                        | @corhere                                       | Maintained            | TBD                         | [Amazon][al2023], [Mirantis][mcr]         |
+| 25.0                        | @corhere                                       | Maintained            | [2026-12-04][mcr25-maint]   | [Amazon][al2023], [Mirantis][mcr]         |
 | 24.0                        |                                                | Unmaintained          |                             |                                           |
 | 23.0                        |                                                | Unmaintained          | [2025-05-19][mcr23-maint]   |                                           |
 | Older than 23.0             |                                                | Unmaintained          |                             |                                           |
@@ -28,6 +28,7 @@ Currently (and previously) maintained release branches are documented in the tab
 [al2023]: https://docs.aws.amazon.com/linux/
 [docker]: https://docker.com
 [mcr23-maint]: https://docs.mirantis.com/mcr/23.0/compat-matrix/maintenance-lifecycle.html
+[mcr25-maint]: https://docs.mirantis.com/mcr/25.0/compat-matrix/maintenance-lifecycle.html#mirantis-container-runtime-mcr
 [mcr]: https://www.mirantis.com/software/mirantis-container-runtime/
 [msft]: https://microsoft.com
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated the table in BRANCHES-AND-TAGS.md, setting the end-of-maintenance date for the 25.0 branch to the current end-of-life date for Mirantis Container Runtime 25.0.

**- How I did it**

**- How to verify it**
- [ ] Check in with the current Amazon Linux maintainers w.r.t. 25.0 branch maintenance. [AL2023 is in support until 2027/2029.](https://docs.aws.amazon.com/linux/al2023/ug/release-cadence.html)

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

