### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/daemon/internal/image/tarexport/load.go
+++ b/daemon/internal/image/tarexport/load.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 
 	"github.com/containerd/containerd/v2/pkg/tracing"
 	"github.com/containerd/log"
@@ -78,7 +79,7 @@ func (l *tarexporter) Load(ctx context.Context, inTar io.ReadCloser, outStream i
 	}
 
 	var parentLinks []parentLink
-	var imageIDsStr string
+	var imageIDsStr strings.Builder
 	var imageRefCount int
 
 	for _, m := range manifest {
@@ -142,7 +143,7 @@ func (l *tarexporter) Load(ctx context.Context, inTar io.ReadCloser, outStream i
 		if err != nil {
 			return err
 		}
-		imageIDsStr += fmt.Sprintf("Loaded image ID: %s\n", imgID)
+		imageIDsStr.WriteString(fmt.Sprintf("Loaded image ID: %s\n", imgID))
 
 		imageRefCount = 0
 		for _, repoTag := range m.RepoTags {
@@ -172,7 +173,7 @@ func (l *tarexporter) Load(ctx context.Context, inTar io.ReadCloser, outStream i
 	}
 
 	if imageRefCount == 0 {
-		outStream.Write([]byte(imageIDsStr))
+		outStream.Write([]byte(imageIDsStr.String()))
 	}
 
 	return nil

--- a/daemon/libnetwork/diagnostic/server.go
+++ b/daemon/libnetwork/diagnostic/server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -154,13 +155,13 @@ func (s *Server) help(w http.ResponseWriter, r *http.Request) {
 		"url":       r.URL.String(),
 	}).Info("help done")
 
-	var result string
+	var result strings.Builder
 	s.mu.Lock()
 	for path := range s.handlers {
-		result += fmt.Sprintf("%s\n", path)
+		result.WriteString(fmt.Sprintf("%s\n", path))
 	}
 	s.mu.Unlock()
-	_, _ = HTTPReply(w, CommandSucceed(&StringCmd{Info: result}), jsonOutput)
+	_, _ = HTTPReply(w, CommandSucceed(&StringCmd{Info: result.String()}), jsonOutput)
 }
 
 func ready(w http.ResponseWriter, r *http.Request) {

--- a/daemon/libnetwork/diagnostic/types.go
+++ b/daemon/libnetwork/diagnostic/types.go
@@ -3,6 +3,7 @@ package diagnostic
 import (
 	"fmt"
 	"net/netip"
+	"strings"
 )
 
 // StringInterface interface that has to be implemented by messages
@@ -82,11 +83,12 @@ type TableObj struct {
 }
 
 func (t *TableObj) String() string {
-	output := fmt.Sprintf("total entries: %d\n", t.Length)
+	var output strings.Builder
+	output.WriteString(fmt.Sprintf("total entries: %d\n", t.Length))
 	for _, e := range t.Elements {
-		output += e.String()
+		output.WriteString(e.String())
 	}
-	return output
+	return output.String()
 }
 
 // PeerEntryObj entry in the networkdb peer table

--- a/daemon/libnetwork/internal/resolvconf/resolvconf_test.go
+++ b/daemon/libnetwork/internal/resolvconf/resolvconf_test.go
@@ -199,19 +199,19 @@ func TestRCModify(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc := tc
-			var input string
+			var input strings.Builder
 			if len(tc.inputNS) != 0 {
 				for _, ns := range tc.inputNS {
-					input += "nameserver " + ns + "\n"
+					input.WriteString("nameserver " + ns + "\n")
 				}
 			}
 			if len(tc.inputSearch) != 0 {
-				input += "search " + strings.Join(tc.inputSearch, " ") + "\n"
+				input.WriteString("search " + strings.Join(tc.inputSearch, " ") + "\n")
 			}
 			if len(tc.inputOptions) != 0 {
-				input += "options " + strings.Join(tc.inputOptions, " ") + "\n"
+				input.WriteString("options " + strings.Join(tc.inputOptions, " ") + "\n")
 			}
-			rc, err := Parse(bytes.NewBufferString(input), "")
+			rc, err := Parse(bytes.NewBufferString(input.String()), "")
 			assert.NilError(t, err)
 			assert.Check(t, is.DeepEqual(a2s(rc.NameServers()), tc.inputNS, cmpopts.EquateEmpty()))
 			assert.Check(t, is.DeepEqual(rc.Search(), tc.inputSearch))

--- a/dockerversion/useragent.go
+++ b/dockerversion/useragent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/moby/moby/v2/pkg/parsers/kernel"
@@ -80,19 +81,19 @@ const charsToEscape = `();\`
 
 // escapeStr returns s with every rune in charsToEscape escaped by a backslash
 func escapeStr(s string) string {
-	var ret string
+	var ret strings.Builder
 	for _, currRune := range s {
 		appended := false
 		for _, escapableRune := range charsToEscape {
 			if currRune == escapableRune {
-				ret += `\` + string(currRune)
+				ret.WriteString(`\` + string(currRune))
 				appended = true
 				break
 			}
 		}
 		if !appended {
-			ret += string(currRune)
+			ret.WriteString(string(currRune))
 		}
 	}
-	return ret
+	return ret.String()
 }

--- a/pkg/plugins/pluginrpc-gen/template.go
+++ b/pkg/plugins/pluginrpc-gen/template.go
@@ -16,19 +16,20 @@ func printArgs(args []fnArg) string {
 }
 
 func buildImports(specs []importSpec) string {
-	imports := `
+	var imports strings.Builder
+	imports.WriteString(`
 import(
 	"errors"
 	"time"
 
 	"github.com/moby/moby/v2/pkg/plugins"
-`
+`)
 	for _, i := range specs {
-		imports += "\t" + i.String() + "\n"
+		imports.WriteString("\t" + i.String() + "\n")
 	}
-	imports += `)
-`
-	return imports
+	imports.WriteString(`)
+`)
+	return imports.String()
 }
 
 func marshalType(t string) string {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)



**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

![4a51a0214f0f46aa71197fdd4ca06a38](https://github.com/user-attachments/assets/3e7e4d8c-b075-410a-b015-b59e8663b8a1)


