### PR TITLE
use mime-type application/jsonl to align with openapi 3.2

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 * `GET /info` now includes an `NRI` field. If the Node Resource Interface (NRI)
   is enabled, this field contains information describing it.
+* `GET /events` now also supports [`application/jsonl`](https://jsonlines.org/)
+  when negotiating content-type.
 * Deprecated: The `POST /grpc` and `POST /session` endpoints are deprecated and
   will be removed in a future version.
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10463,6 +10463,7 @@ paths:
 
       operationId: "SystemEvents"
       produces:
+        - "application/jsonl"
         - "application/x-ndjson"
         - "application/json-seq"
       responses:

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -10,8 +10,11 @@ const (
 	// MediaTypeJSON is the MIME-Type for JSON objects.
 	MediaTypeJSON = "application/json"
 
-	// MediaTypeNDJSON is the MIME-Type for Newline Delimited JSON objects streams.
+	// MediaTypeNDJSON is the MIME-Type for Newline Delimited JSON objects streams (https://github.com/ndjson/ndjson-spec).
 	MediaTypeNDJSON = "application/x-ndjson"
+
+	// MediaTypeJSONLines is the MIME-Type for JSONLines objects streams (https://jsonlines.org/).
+	MediaTypeJSONLines = "application/jsonl"
 
 	// MediaTypeJSONSequence is the MIME-Type for JSON Text Sequences (RFC7464).
 	MediaTypeJSONSequence = "application/json-seq"

--- a/client/internal/json-stream.go
+++ b/client/internal/json-stream.go
@@ -17,7 +17,7 @@ func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
 	switch contentType {
 	case types.MediaTypeJSONSequence:
 		return json.NewDecoder(NewRSFilterReader(r)).Decode
-	case types.MediaTypeJSON, types.MediaTypeNDJSON:
+	case types.MediaTypeJSON, types.MediaTypeNDJSON, types.MediaTypeJSONLines:
 		fallthrough
 	default:
 		return json.NewDecoder(r).Decode

--- a/client/system_events.go
+++ b/client/system_events.go
@@ -46,6 +46,7 @@ func (cli *Client) Events(ctx context.Context, options EventsListOptions) Events
 
 		headers := http.Header{}
 		headers.Add("Accept", types.MediaTypeJSONSequence)
+		headers.Add("Accept", types.MediaTypeJSONLines)
 		headers.Add("Accept", types.MediaTypeNDJSON)
 		resp, err := cli.get(ctx, "/events", query, headers)
 		if err != nil {

--- a/daemon/server/httputils/json-seq.go
+++ b/daemon/server/httputils/json-seq.go
@@ -21,7 +21,7 @@ func NewJSONStreamEncoder(w io.Writer, contentType string) EncoderFn {
 			json: jsonEncoder,
 		}
 		return jseq.Encode
-	case types.MediaTypeNDJSON, types.MediaTypeJSON:
+	case types.MediaTypeNDJSON, types.MediaTypeJSON, types.MediaTypeJSONLines:
 		fallthrough
 	default:
 		return jsonEncoder.Encode

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -311,6 +311,7 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	contentType := httputil.NegotiateContentType(r, []string{
+		types.MediaTypeJSONLines,
 		types.MediaTypeNDJSON,
 		types.MediaTypeJSONSequence,
 	}, types.MediaTypeJSON) // output isn't actually JSON but API used to  this content-type

--- a/vendor/github.com/moby/moby/api/types/types.go
+++ b/vendor/github.com/moby/moby/api/types/types.go
@@ -10,8 +10,11 @@ const (
 	// MediaTypeJSON is the MIME-Type for JSON objects.
 	MediaTypeJSON = "application/json"
 
-	// MediaTypeNDJSON is the MIME-Type for Newline Delimited JSON objects streams.
+	// MediaTypeNDJSON is the MIME-Type for Newline Delimited JSON objects streams (https://github.com/ndjson/ndjson-spec).
 	MediaTypeNDJSON = "application/x-ndjson"
+
+	// MediaTypeJSONLines is the MIME-Type for JSONLines objects streams (https://jsonlines.org/).
+	MediaTypeJSONLines = "application/jsonl"
 
 	// MediaTypeJSONSequence is the MIME-Type for JSON Text Sequences (RFC7464).
 	MediaTypeJSONSequence = "application/json-seq"

--- a/vendor/github.com/moby/moby/client/internal/json-stream.go
+++ b/vendor/github.com/moby/moby/client/internal/json-stream.go
@@ -17,7 +17,7 @@ func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
 	switch contentType {
 	case types.MediaTypeJSONSequence:
 		return json.NewDecoder(NewRSFilterReader(r)).Decode
-	case types.MediaTypeJSON, types.MediaTypeNDJSON:
+	case types.MediaTypeJSON, types.MediaTypeNDJSON, types.MediaTypeJSONLines:
 		fallthrough
 	default:
 		return json.NewDecoder(r).Decode

--- a/vendor/github.com/moby/moby/client/system_events.go
+++ b/vendor/github.com/moby/moby/client/system_events.go
@@ -46,6 +46,7 @@ func (cli *Client) Events(ctx context.Context, options EventsListOptions) Events
 
 		headers := http.Header{}
 		headers.Add("Accept", types.MediaTypeJSONSequence)
+		headers.Add("Accept", types.MediaTypeJSONLines)
 		headers.Add("Accept", types.MediaTypeNDJSON)
 		resp, err := cli.get(ctx, "/events", query, headers)
 		if err != nil {


### PR DESCRIPTION
**- What I did**

while json-lines isn't (yet) an official Mime type (https://github.com/wardi/jsonlines/issues/19), [OpenAPI 3.2 support for JSON streams](https://www.openapis.org/blog/2025/09/23/announcing-openapi-v3-2#sequential-and-streaming-data refers to "application/jsonl" as a commonly used mime type.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`GET /events` now also supports [`application/jsonl`](https://jsonlines.org/) when negotiating content-type.
```

**- A picture of a cute animal (not mandatory but encouraged)**

