### PR TITLE
Fix spelling error in comments for names-generator.go

### DIFF
--- a/internal/namesgenerator/names-generator.go
+++ b/internal/namesgenerator/names-generator.go
@@ -793,7 +793,7 @@ var (
 		// Dorothy Vaughan was a NASA mathematician and computer programmer on the SCOUT launch vehicle program that put America's first satellites into space - https://en.wikipedia.org/wiki/Dorothy_Vaughan
 		"vaughan",
 
-		// Cédric Villani - French mathematician, won Fields Medal, Fermat Prize and Poincaré Price for his work in differential geometry and statistical mechanics. https://en.wikipedia.org/wiki/C%C3%A9dric_Villani
+		// Cédric Villani - French mathematician, won Fields Medal, Fermat Prize and Poincaré Prize for his work in differential geometry and statistical mechanics. https://en.wikipedia.org/wiki/C%C3%A9dric_Villani
 		"villani",
 
 		// Sir Mokshagundam Visvesvaraya - is a notable Indian engineer.  He is a recipient of the Indian Republic's highest honour, the Bharat Ratna, in 1955. On his birthday, 15 September is celebrated as Engineer's Day in India in his memory - https://en.wikipedia.org/wiki/Visvesvaraya


### PR DESCRIPTION
Corrected the spelling of 'Poincaré Prize' in comments.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBU3TING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Corrected a typographical error in the `internal/namesgenerator/names-generator.go` file:
- Changed "Poincaré Price" to "Poincaré Prize" in the comment describing Cédric Villani's achievements.

**- How I did it**
Located the relevant comment in the name list for scientists and mathematicians and updated "Price" to the correct term "Prize".

**- How to verify it**
Review the updated comment in `internal/namesgenerator/names-generator.go` and verify the spelling and context are now correct.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

**- A picture of a cute animal (My pet dog, Yuki)**

![yuki](https://github.com/user-attachments/assets/9496c9dc-b409-4763-8564-31229f59d7f7)
