### PR TITLE
NRI: allow plugins to add mounts

### DIFF
--- a/integration/daemon/nri/nri_test.go
+++ b/integration/daemon/nri/nri_test.go
@@ -1,10 +1,12 @@
 package nri
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/containerd/nri/pkg/api"
+	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -64,6 +66,126 @@ func TestNRIContainerCreateEnvVarMod(t *testing.T) {
 			inspect, err := c.ContainerInspect(ctx, ctrId, client.ContainerInspectOptions{})
 			if assert.Check(t, err) {
 				assert.Check(t, is.Contains(inspect.Container.Config.Env, tc.expEnv))
+			}
+		})
+	}
+}
+
+func TestNRIContainerCreateAddMount(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start a separate daemon with NRI enabled on Windows")
+	skip.If(t, testEnv.IsRootless)
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	sockPath := filepath.Join(t.TempDir(), "nri.sock")
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t,
+		"--nri-opts=enable=true,socket-path="+sockPath,
+		"--iptables=false", "--ip6tables=false",
+	)
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+
+	// Create and populate a directory for containers to mount.
+	dirToMount := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dirToMount, "testfile.txt"), []byte("hello\n"), 0o644); err != nil {
+		assert.NilError(t, err)
+	}
+	const (
+		mountPoint  = "/mountpoint"
+		ctrTestFile = "/mountpoint/testfile.txt"
+		exitOk      = 0
+		exitFail    = 1
+	)
+
+	// Create and populate a volume.
+	const volName = "nri-test-volume"
+	_, err := c.VolumeCreate(ctx, client.VolumeCreateOptions{Name: volName})
+	assert.NilError(t, err)
+	defer func() {
+		_, _ = c.VolumeRemove(ctx, volName, client.VolumeRemoveOptions{Force: true})
+	}()
+	// Populate the volume with a test file.
+	_ = container.Run(ctx, t, c,
+		container.WithAutoRemove,
+		container.WithMount(mount.Mount{Type: "volume", Source: volName, Target: mountPoint}),
+		container.WithCmd("sh", "-c", "echo hello > "+ctrTestFile),
+	)
+
+	tests := []struct {
+		name         string
+		ctrCreateAdj *api.ContainerAdjustment
+
+		expMountRead  int
+		expMountWrite int
+	}{
+		{
+			name: "mount/bind/ro",
+			ctrCreateAdj: &api.ContainerAdjustment{Mounts: []*api.Mount{{
+				Type:        "bind",
+				Source:      dirToMount,
+				Destination: mountPoint,
+				Options:     []string{"ro"},
+			}}},
+			expMountRead:  exitOk,
+			expMountWrite: exitFail,
+		},
+		{
+			name: "mount/bind/rw",
+			ctrCreateAdj: &api.ContainerAdjustment{Mounts: []*api.Mount{{
+				Type:        "bind",
+				Source:      dirToMount,
+				Destination: mountPoint,
+			}}},
+			expMountRead:  exitOk,
+			expMountWrite: exitOk,
+		},
+		{
+			name: "mount/volume/ro",
+			ctrCreateAdj: &api.ContainerAdjustment{Mounts: []*api.Mount{{
+				Type:        "volume",
+				Source:      volName,
+				Destination: mountPoint,
+				Options:     []string{"ro"},
+			}}},
+			expMountRead:  exitOk,
+			expMountWrite: exitFail,
+		},
+		{
+			name: "mount/volume/rw",
+			ctrCreateAdj: &api.ContainerAdjustment{Mounts: []*api.Mount{{
+				Type:        "volume",
+				Source:      volName,
+				Destination: mountPoint,
+			}}},
+			expMountRead:  exitOk,
+			expMountWrite: exitOk,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stopPlugin := startBuiltinPlugin(ctx, t, builtinPluginConfig{
+				pluginName:   "nri-test-plugin",
+				pluginIdx:    "00",
+				sockPath:     sockPath,
+				ctrCreateAdj: tc.ctrCreateAdj,
+			})
+			defer stopPlugin()
+
+			ctrId := container.Run(ctx, t, c)
+			defer func() { _, _ = c.ContainerRemove(ctx, ctrId, client.ContainerRemoveOptions{Force: true}) }()
+
+			res, err := container.Exec(ctx, c, ctrId, []string{"cat", ctrTestFile})
+			if assert.Check(t, err) {
+				assert.Check(t, is.Equal(res.ExitCode, tc.expMountRead))
+				assert.Check(t, is.Equal(res.Stdout(), "hello\n"))
+			}
+			res, err = container.Exec(ctx, c, ctrId, []string{"touch", ctrTestFile})
+			if assert.Check(t, err) {
+				assert.Check(t, is.Equal(res.ExitCode, tc.expMountWrite))
 			}
 		})
 	}


### PR DESCRIPTION
- stacked on https://github.com/moby/moby/pull/51636
- stacked on https://github.com/moby/moby/pull/51674

**- What I did**

- related to https://github.com/moby/moby/issues/51511

**- How I did it**

- Tell NRI plugins about container state, allow plugins to modify mounts.
- Added an integration test

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add experimental NRI support
```

**- A picture of a cute animal (not mandatory but encouraged)**

