### PR TITLE
Add the word "bytes" to `docker push` output line

### DIFF
--- a/daemon/containerd/image_push.go
+++ b/daemon/containerd/image_push.go
@@ -135,7 +135,7 @@ func (i *ImageService) pushRef(ctx context.Context, targetRef reference.Named, p
 		finishProgress()
 		if retErr == nil {
 			if tagged, ok := targetRef.(reference.Tagged); ok {
-				progress.Messagef(out, "", "%s: digest: %s size: %d", tagged.Tag(), target.Digest, target.Size)
+				progress.Messagef(out, "", "%s: digest: %s size: %d bytes", tagged.Tag(), target.Digest, target.Size)
 			}
 		}
 	}()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes https://github.com/moby/moby/issues/24444

**- How I did it**

I added the word "bytes" to the end of the push output, as proposed by https://github.com/moby/moby/issues/24444#issuecomment-231723612

There is potentially a lot of room for further improvement, but given the lack of discussion I wanted to implement something simple that is undoubtedly better than what we have right now. At least it ensures users are not going to mistake this for the image size or anything similar.

**- How to verify it**

`docker push` any image to any registry

**- Human readable description for the release notes**

Not sure if this is worth a changelog item, let me know if I should add some, or just go ahead:)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

## Note

This might be considered a breaking change, if we assume some tools may parse this line. It might be worth waiting a full major with this. Given that the ticket has been open for 9 years, I think we can afford it 😇 