### PR TITLE
Remove restriction on anonymous read-only volumes

### DIFF
--- a/daemon/volume/mounts/linux_parser.go
+++ b/daemon/volume/mounts/linux_parser.go
@@ -112,9 +112,6 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 				return &errMountConfig{mnt, errInvalidSubpath}
 			}
 		}
-		if mnt.ReadOnly && anonymousVolume {
-			return &errMountConfig{mnt, errors.New("must not set ReadOnly mode when using anonymous volumes")}
-		}
 	case mount.TypeTmpfs:
 		if mnt.BindOptions != nil {
 			return &errMountConfig{mnt, errExtraField("BindOptions")}

--- a/daemon/volume/mounts/linux_parser_test.go
+++ b/daemon/volume/mounts/linux_parser_test.go
@@ -2,6 +2,7 @@ package mounts
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -252,6 +253,89 @@ func TestLinuxParseMountRawSplit(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.bind, func(t *testing.T) {
 			m, err := parser.ParseMountRaw(tc.bind, tc.driver)
+			if tc.expErr != "" {
+				assert.Check(t, is.Nil(m))
+				assert.Check(t, is.Error(err, tc.expErr))
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(*m, *tc.expected, cmpopts.IgnoreUnexported(MountPoint{})))
+		})
+	}
+}
+
+func TestLinuxValidateMounts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		doc      string
+		mount    mount.Mount
+		expected *MountPoint
+		expErr   string
+	}{
+		{
+			doc: "read-write",
+			mount: mount.Mount{
+				Source: tmpDir,
+				Target: "/tmp1",
+				Type:   mount.TypeBind,
+			},
+			expected: &MountPoint{
+				Source:      tmpDir,
+				Destination: "/tmp1",
+				RW:          true,
+				Type:        mount.TypeBind,
+				Propagation: "rprivate",
+				Spec: mount.Mount{
+					Source: tmpDir,
+					Target: "/tmp1",
+					Type:   mount.TypeBind,
+				},
+			},
+		},
+		{
+			doc: "read-only",
+			mount: mount.Mount{
+				Target:   "/data/anonymous-read-only-volume",
+				ReadOnly: true,
+				Type:     mount.TypeVolume,
+			},
+			expected: &MountPoint{
+				Destination: "/data/anonymous-read-only-volume",
+				Type:        mount.TypeVolume,
+				CopyData:    true,
+				Spec: mount.Mount{
+					Target:   "/data/anonymous-read-only-volume",
+					ReadOnly: true,
+					Type:     mount.TypeVolume,
+				},
+			},
+		},
+		{
+			doc: "invalid source path",
+			mount: mount.Mount{
+				Source: filepath.Join(tmpDir, "no-such-path"),
+				Target: "/data/anonymous-read-only-volume",
+				Type:   mount.TypeBind,
+			},
+			expErr: `invalid mount config for type "bind": bind source path does not exist: ` + filepath.Join(tmpDir, "no-such-path"),
+		},
+		{
+			doc: "invalid mount type",
+			mount: mount.Mount{
+				Target: "/data/invalid-type",
+				Type:   "invalid",
+			},
+			expErr: `invalid mount config for type "invalid": mount type unknown`,
+		},
+	}
+
+	parser := NewLinuxParser()
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			m, err := parser.ParseMountSpec(tc.mount)
 			if tc.expErr != "" {
 				assert.Check(t, is.Nil(m))
 				assert.Check(t, is.Error(err, tc.expErr))

--- a/daemon/volume/mounts/windows_parser.go
+++ b/daemon/volume/mounts/windows_parser.go
@@ -270,10 +270,6 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 			}
 		}
 
-		if anonymousVolume && mnt.ReadOnly {
-			return &errMountConfig{mnt, errors.New("must not set ReadOnly mode when using anonymous volumes")}
-		}
-
 		if mnt.Source != "" {
 			if err := p.ValidateVolumeName(mnt.Source); err != nil {
 				return &errMountConfig{mnt, err}


### PR DESCRIPTION
Remove restriction on anonymous read-only volumes.

This restriction is currently preventing the use of pre-populated volumes that should be accessed in a read-only manner in a container (e.g. an NFS volume containing data to be processed or served).

According to @neersighted the restriction may have originally been put in place with the assumption that pre-populated volumes would be exposed as a named volume by the volume driver.

In practice, NFS volumes are mounted using the docker `local` driver by supplying driver opts. Example that fails when `readonly` is specified but works without:

```
docker run --rm -it \
 --mount 'readonly,type=volume,dst=/data/dest,volume-driver=local,volume-opt=type=nfs,volume-opt=device=:/export/some-share,"volume-opt=o=nfsvers=4,addr=some.server"' \
  debian
```

Fixes #45297

**- What I did**
Removed restriction on anonymous read-only volumes.

**- How I did it**
Deleted simple checks for anonymous read-only volumes from Linux and Windows volume parsers.

**- How to verify it**
After changes, read only mount an NFS share using something like

```
docker run --rm -it \
 --mount 'readonly,type=volume,dst=/data/dest,volume-driver=local,volume-opt=type=nfs,volume-opt=device=:/export/some-share,"volume-opt=o=nfsvers=4,addr=some.server"' \
  debian
```

**- Human readable description for the release notes**
```markdown changelog
Remove restriction on anonymous read-only volumes
```

<img width="494" height="461" alt="image" src="https://github.com/user-attachments/assets/bf70cf50-e25a-4631-a641-f034d00d7f8e" />