### PR TITLE
daemon: buildCreateEndpointOptions: fix panic with "publish all"

### DIFF
--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -647,7 +647,10 @@ func (container *Container) BackfillEmptyPBs() {
 	if container.HostConfig == nil {
 		return
 	}
-
+	if container.HostConfig.PortBindings == nil {
+		container.HostConfig.PortBindings = networktypes.PortMap{}
+		return
+	}
 	for portProto, pb := range container.HostConfig.PortBindings {
 		if len(pb) > 0 || pb == nil {
 			continue

--- a/daemon/network.go
+++ b/daemon/network.go
@@ -1038,10 +1038,13 @@ func buildPortsRelatedCreateEndpointOptions(c *container.Container, n *libnetwor
 	)
 
 	ports := c.HostConfig.PortBindings
-	if c.HostConfig.PublishAllPorts {
+	if c.HostConfig.PublishAllPorts && len(c.Config.ExposedPorts) > 0 {
 		// Add exposed ports to a copy of the map to make sure a "publishedPorts" entry is created
 		// for each exposed port, even if there's no specific binding.
 		ports = maps.Clone(c.HostConfig.PortBindings)
+		if ports == nil {
+			ports = networktypes.PortMap{}
+		}
 		for p := range c.Config.ExposedPorts {
 			if _, exists := ports[p]; !exists {
 				ports[p] = nil


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/pull/51586
- relates to / similar https://github.com/moby/moby/pull/51621
- fixes https://github.com/moby/moby/issues/51620#issuecomment-3639505600


This code was added in 85b260fba8785e7cb767f14c58c533f21843de5e, but didn't account for maps.Clone returning a `nil` map if the map cloned was `nil`.

This could lead to a panic, similar to the panic that was fixed in 7517464283d29969c4d3615397b369abd99ce395;

    panic: assignment to entry in nil map

    goroutine 498 [running]:

    github.com/moby/moby/v2/daemon.buildPortsRelatedCreateEndpointOptions(0x400042f348, 0xaaaabcc8f458?, 0x40006feb40)
        /root/build-deb/engine/daemon/network.go:1047 +0x844
    github.com/moby/moby/v2/daemon.buildCreateEndpointOptions(0x400042f348, 0x4001015040, 0x400027d320, 0x40006feb40, {0x0, 0x0, 0x4001506cb8?})
        /root/build-deb/engine/daemon/network.go:988 +0x20c
    github.com/moby/moby/v2/daemon.(*Daemon).connectToNetwork(0x4000898008, {0xaaaabe21d9f8, 0x4000f12b10}, 0x400089a008, 0x400042f348, {0x400077a9f0, 0x6}, 0x400027d320)
        /root/build-deb/engine/daemon/container_operations.go:738 +0x66c
    github.com/moby/moby/v2/daemon.(*Daemon).allocateNetwork(0x4000898008, {0xaaaabe21d9f8, 0x4000f12b10}, 0x400089a008, 0x400042f348)
        /root/build-deb/engine/daemon/container_operations.go:421 +0x298
    github.com/moby/moby/v2/daemon.(*Daemon).initializeCreatedTask(0x4000898008, {0xaaaabe21d9f8, 0x4000f12b10}, 0x400089a008, {0xaaaabe23dc60, 0x4000eb21c8}, 0x400042f348, 0xaaaabd4db3df?)
        /root/build-deb/engine/daemon/start_linux.go:37 +0x260
    github.com/moby/moby/v2/daemon.(*Daemon).containerStart(0x4000898008, {0xaaaabe21d9c0, 0xaaaabfa05300}, 0x400089a008, 0x400042f348, {0x0, 0x0}, {0x0, 0x0}, 0x1)
        /root/build-deb/engine/daemon/start.go:242 +0xba8
    github.com/moby/moby/v2/daemon.(*Daemon).restore.func4(0x400042f348, 0x400117f1f0)
        /root/build-deb/engine/daemon/daemon.go:633 +0x308
    created by github.com/moby/moby/v2/daemon.(*Daemon).restore in goroutine 1
        /root/build-deb/engine/daemon/daemon.go:607 +0x5ec

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Don't crash when starting a container created via the API before upgrade to v29.1.2, with `PublishAll` and a nil `PortBindings` map.
```

**- A picture of a cute animal (not mandatory but encouraged)**

