### PR TITLE
Makefile: Add simple dev loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,10 @@ build: validate-bind-dir bundles
 shell: build  ## start a shell inside the build env
 	$(DOCKER_RUN_DOCKER) bash
 
+.PHONY: dev
+dev: build  ## start a dev mode inside the build env
+	$(DOCKER_RUN_DOCKER) hack/dev.sh
+
 .PHONY: test
 test: build test-unit ## run the unit, integration and docker-py tests
 	$(DOCKER_RUN_DOCKER) hack/make.sh dynbinary test-integration test-docker-py

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+while true; do
+	if ! ./hack/make.sh binary; then
+		# If the build fails, sleep for 5 seconds and continue
+		sleep 5
+		continue
+	fi
+	KEEPBUNDLE=1 ./hack/make.sh install-binary || continue
+
+	dockerd --debug || true
+	sleep 0.1
+done


### PR DESCRIPTION
Something I have been using since forever... but got tired of cherry-picking it for every branch I make

### Makefile: Add simple dev loop

Add a `dev` target which adds a convenient developer loop which
rebuilds and reruns the daemon after a SIGINT is received.

It can be exited by sending SIGINT (Ctrl+C) a couple times.


# Showcase

https://github.com/user-attachments/assets/abac2fc5-6504-4f82-a4b1-b3b31b143882

