### PR TITLE
daemon: clean up dead containers on start

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -643,18 +643,25 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 	}
 	group.Wait()
 
-	for id := range removeContainers {
+	for id, c := range removeContainers {
 		group.Add(1)
-		go func(cid string) {
+		go func(cid string, c *container.Container) {
 			_ = sem.Acquire(context.Background(), 1)
+			defer group.Done()
+			defer sem.Release(1)
+
+			if c.State.IsDead() {
+				if err := daemon.cleanupContainer(c, backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
+					log.G(ctx).WithField("container", cid).WithError(err).Error("failed to remove dead container")
+				}
+				return
+			}
 
 			if err := daemon.containerRm(&cfg.Config, cid, &backend.ContainerRmConfig{ForceRemove: true, RemoveVolume: true}); err != nil {
 				log.G(ctx).WithField("container", cid).WithError(err).Error("failed to remove container")
 			}
 
-			sem.Release(1)
-			group.Done()
-		}(id)
+		}(id, c)
 	}
 	group.Wait()
 


### PR DESCRIPTION
- Fixes / addresses https://github.com/docker/desktop-linux/issues/309
- fixes / addresses https://github.com/docker/desktop-feedback/issues/253


**- What I did**

Stopping the Engine while a container with autoremove set is running may leave behind dead containers on disk. These containers aren't reclaimed on next start, appear as "dead" in `docker ps -a` and can't be inspected or removed by the user.

This bug has existed since a long time but became user visible with https://github.com/moby/moby/commit/9f5f4f5a4273e920d5d77c1e73db8bebe65982bb. Prior to that commit, containers with no rwlayer weren't added to the in-memory viewdb, so they weren't visible in `docker ps -a`. However, some dangling files would still live on disk (e.g. folder in /var/lib/docker/containers, mount points, etc).

The underlying issue is that when the daemon stops, it tries to stop all running containers and then closes the containerd client. This leaves a small window of time where the Engine might receive 'task stop' events from containerd, and trigger autoremove. If the containerd client is closed in parallel, the Engine is unable to complete the removal, leaving the container in 'dead' state. In such case, the Engine logs the following error:

    cannot remove container "bcbc98b4f5c2b072eb3c4ca673fa1c222d2a8af00bf58eae0f37085b9724ea46": Canceled: grpc: the client connection is closing: context canceled

Solving the underlying issue would require complex changes to the shutdown sequence. Moreover, the same issue could also happen if the daemon crashes while it deletes a container. Thus, add a cleanup step on daemon startup to remove these dead containers.

**- How to verify it**

A new integration test has been added.

**- Human readable description for the release notes**

```markdown changelog
Fix a bug that could cause the Engine to leave containers with autoremove set in 'dead' state on shutdown, and never reclaim them.
```
