### PR TITLE
[docker-29.x backport] daemon: disallow container port 0

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -335,7 +335,7 @@ func validateHealthCheck(healthConfig *containertypes.HealthConfig) error {
 
 func validatePortBindings(ports networktypes.PortMap) error {
 	for port := range ports {
-		if !port.IsValid() {
+		if !port.IsValid() || port.Num() == 0 {
 			return errors.Errorf("invalid port specification: %q", port.String())
 		}
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -300,6 +300,18 @@ func TestValidateContainerIsolation(t *testing.T) {
 	assert.Check(t, is.Error(err, "invalid isolation 'invalid' on "+runtime.GOOS))
 }
 
+func TestInvalidContainerPort0(t *testing.T) {
+	d := Daemon{}
+
+	hc := containertypes.HostConfig{
+		PortBindings: map[network.Port][]network.PortBinding{
+			network.MustParsePort("0/tcp"): {},
+		},
+	}
+	_, err := d.verifyContainerSettings(&configStore{}, &hc, nil, false)
+	assert.Error(t, err, `invalid port specification: "0/tcp"`)
+}
+
 func TestFindNetworkErrorType(t *testing.T) {
 	d := Daemon{}
 	_, err := d.FindNetwork("fakeNet")


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/51684

**- What I did**

Although container port 0 is invalid, it's currently accepted by the Engine. Users could mistakenly declare `-p 0:0` and end up with a port mapping that does nothing. In that case, the Engine would allocate an ephemeral host port and create an iptables / nftables rule that DNAT to container port 0. This is obviously wrong.

```
Chain DOCKER (2 references)
 pkts bytes target     prot opt in     out     source               destination
    0     0 DNAT       6    --  !docker0 *       0.0.0.0/0            0.0.0.0/0            tcp dpt:32768 to:172.18.0.2:0
```

Instead of failing silently, return an error message to the API client when it calls the `ContainerCreate` endpoint.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Return an error when a container is created with a port-mapping pointing to container port 0.
```
