### PR TITLE
daemon: add flag --default-subnet-size

### DIFF
--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -51,6 +51,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.Var(&conf.ShmSize, "default-shm-size", "Default shm size for containers")
 	flags.BoolVar(&conf.NoNewPrivileges, "no-new-privileges", false, "Set no-new-privileges by default for new containers")
 	flags.StringVar(&conf.IpcMode, "default-ipc-mode", conf.IpcMode, `Default mode for containers ipc ("shareable" | "private")`)
+	flags.IntVar(&conf.NetworkConfig.DefaultSubnetSize, "default-subnet-size", 24, "Default size for IPv4 subnets. This option is a no-op if the feature 'global-default-subnet-size' is not enabled")
 	flags.Var(&conf.NetworkConfig.DefaultAddressPools, "default-address-pool", "Default address pools for node specific local networks")
 	flags.StringVar(&conf.NetworkConfig.FirewallBackend, "firewall-backend", "", "Firewall backend to use, iptables or nftables")
 	// rootless needs to be explicitly specified for running "rootful" dockerd in rootless dockerd (#38702)

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -153,6 +153,9 @@ type commonBridgeConfig struct {
 type NetworkConfig struct {
 	// Default address pools for docker networks
 	DefaultAddressPools opts.PoolsOpt `json:"default-address-pools,omitempty"`
+	// DefaultSubnetSize is the default size used for dynamic IPv4 subnet allocation. In v29.x, this option is ignored
+	// unless the feature flag 'global-default-subnet-size' is enabled. For IPv6, the default size is hardcoded to /64.
+	DefaultSubnetSize int `json:"default-subnet-size,omitempty"`
 	// NetworkControlPlaneMTU allows to specify the control plane MTU, this will allow to optimize the network use in some components
 	NetworkControlPlaneMTU int `json:"network-control-plane-mtu,omitempty"`
 	// Default options for newly created networks

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1657,6 +1657,13 @@ func (daemon *Daemon) networkOptions(conf *config.Config, pg plugingetter.Plugin
 	}
 	options = append(options, nwconfig.OptionDefaultAddressPoolConfig(defaultAddressPools))
 
+	if enabled := conf.Features["global-default-subnet-size"]; enabled {
+		if conf.DefaultSubnetSize <= 0 || conf.DefaultSubnetSize >= 32 {
+			return nil, errors.New("default-subnet-size needs to be greater than 0 and less than 32")
+		}
+		options = append(options, nwconfig.OptionDefaultSubnetSize(conf.DefaultSubnetSize))
+	}
+
 	if conf.LiveRestoreEnabled && len(activeSandboxes) != 0 {
 		options = append(options, nwconfig.OptionActiveSandboxes(activeSandboxes))
 	}

--- a/daemon/libnetwork/cnmallocator/drivers_ipam.go
+++ b/daemon/libnetwork/cnmallocator/drivers_ipam.go
@@ -43,7 +43,7 @@ func initIPAMDrivers(r ipamapi.Registerer, netConfig *networkallocator.Config) e
 		log.G(context.TODO()).Info("Swarm initialized global default address pool to: " + str.String())
 	}
 
-	if err := ipams.Register(r, nil, nil, addressPool); err != nil {
+	if err := ipams.Register(r, nil, nil, addressPool, nil); err != nil {
 		return err
 	}
 

--- a/daemon/libnetwork/config/config.go
+++ b/daemon/libnetwork/config/config.go
@@ -36,13 +36,15 @@ type Config struct {
 	ClusterProvider        cluster.Provider
 	NetworkControlPlaneMTU int
 	DefaultAddressPool     []*ipamutils.NetworkToSplit
-	DatastoreBucket        string
-	ActiveSandboxes        map[string]any
-	PluginGetter           plugingetter.PluginGetter
-	FirewallBackend        string
-	Rootless               bool
-	EnableUserlandProxy    bool
-	UserlandProxyPath      string
+	// TODO(aker): make this a non-pointer once the feature flag 'global-default-subnet-size' is removed.
+	DefaultSubnetSize   *int
+	DatastoreBucket     string
+	ActiveSandboxes     map[string]any
+	PluginGetter        plugingetter.PluginGetter
+	FirewallBackend     string
+	Rootless            bool
+	EnableUserlandProxy bool
+	UserlandProxyPath   string
 }
 
 // New creates a new Config and initializes it with the given Options.
@@ -84,6 +86,15 @@ func OptionDefaultDriver(dd string) Option {
 func OptionDefaultAddressPoolConfig(addressPool []*ipamutils.NetworkToSplit) Option {
 	return func(c *Config) {
 		c.DefaultAddressPool = addressPool
+	}
+}
+
+// OptionDefaultSubnetSize defines a default subnet size that should be used for all dynamic subnet allocation. When
+// this option is not set, each address pool has its own default subnet size — dynamic subnet allocation doesn't yield
+// subnets of the same size across different address pools.
+func OptionDefaultSubnetSize(size int) Option {
+	return func(c *Config) {
+		c.DefaultSubnetSize = &size
 	}
 }
 

--- a/daemon/libnetwork/controller.go
+++ b/daemon/libnetwork/controller.go
@@ -192,7 +192,7 @@ func New(ctx context.Context, cfgOptions ...config.Option) (_ *Controller, retEr
 		return nil, err
 	}
 
-	if err := ipams.Register(&c.ipamRegistry, c.cfg.PluginGetter, c.cfg.DefaultAddressPool, nil); err != nil {
+	if err := ipams.Register(&c.ipamRegistry, c.cfg.PluginGetter, c.cfg.DefaultAddressPool, nil, c.cfg.DefaultSubnetSize); err != nil {
 		return nil, err
 	}
 

--- a/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_linux_test.go
@@ -251,7 +251,7 @@ func TestNetworkConfigurationMarshalling(t *testing.T) {
 func getIPv4Data(t *testing.T) []driverapi.IPAMData {
 	t.Helper()
 
-	a, _ := defaultipam.NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), nil)
+	a, _ := defaultipam.NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), nil, nil)
 	alloc, err := a.RequestPool(ipamapi.PoolRequest{
 		AddressSpace: "LocalDefault",
 		Exclude:      netutils.InferReservedNetworks(false),

--- a/daemon/libnetwork/drvregistry/ipams_test.go
+++ b/daemon/libnetwork/drvregistry/ipams_test.go
@@ -14,7 +14,7 @@ import (
 func getNewIPAMs(t *testing.T) *IPAMs {
 	r := &IPAMs{}
 
-	assert.Assert(t, ipams.Register(r, nil, nil, nil))
+	assert.Assert(t, ipams.Register(r, nil, nil, nil, nil))
 
 	return r
 }

--- a/daemon/libnetwork/ipams/defaultipam/allocator_test.go
+++ b/daemon/libnetwork/ipams/defaultipam/allocator_test.go
@@ -55,7 +55,7 @@ func TestKeyString(t *testing.T) {
 }
 
 func TestAddSubnets(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestAddSubnets(t *testing.T) {
 // TestDoublePoolRelease tests that releasing a pool which has already
 // been released raises an error.
 func TestDoublePoolRelease(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc1, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "10.0.0.0/8"})
@@ -131,7 +131,7 @@ func TestDoublePoolRelease(t *testing.T) {
 }
 
 func TestAddReleasePoolID(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	_, err = a.getAddrSpace(localAddressSpace, false)
@@ -259,7 +259,7 @@ func TestAddReleasePoolID(t *testing.T) {
 }
 
 func TestPredefinedPool(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc1, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace})
@@ -286,7 +286,7 @@ func TestPredefinedPool(t *testing.T) {
 }
 
 func TestPredefinedPoolWithPreferredSubnetSize(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc1, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "0.0.0.0/24"})
@@ -341,7 +341,7 @@ func TestPredefinedPoolWithPreferredSubnetSize(t *testing.T) {
 }
 
 func TestRemoveSubnet(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	reqs := []ipamapi.PoolRequest{
@@ -372,7 +372,7 @@ func TestRemoveSubnet(t *testing.T) {
 }
 
 func TestGetSameAddress(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "192.168.100.0/24"})
@@ -395,7 +395,7 @@ func TestGetSameAddress(t *testing.T) {
 // TestRequestFromSamePool verify the allocator implements the validation
 // inconsistencies described in https://github.com/moby/moby/issues/46756.
 func TestRequestFromSamePool(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	_, err = a.RequestPool(ipamapi.PoolRequest{
@@ -428,7 +428,7 @@ func TestRequestFromSamePool(t *testing.T) {
 }
 
 func TestGetAddressSubPoolEqualPool(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	// Requesting a subpool of same size of the master pool should not cause any problem on ip allocation
@@ -444,7 +444,7 @@ func TestGetAddressSubPoolEqualPool(t *testing.T) {
 }
 
 func TestRequestReleaseAddressFromSubPool(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "172.28.0.0/16", SubPool: "172.28.30.0/24"})
@@ -568,7 +568,7 @@ func TestSerializeRequestReleaseAddressFromSubPool(t *testing.T) {
 	opts := map[string]string{
 		ipamapi.AllocSerialPrefix: "true",
 	}
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: "172.28.0.0/16", SubPool: "172.28.30.0/24"})
@@ -708,7 +708,7 @@ func TestRequestSyntaxCheck(t *testing.T) {
 		subPool = "192.168.0.0/24"
 	)
 
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	_, err = a.RequestPool(ipamapi.PoolRequest{Pool: pool})
@@ -858,7 +858,7 @@ func TestOverlappingRequests(t *testing.T) {
 	}
 
 	for _, tc := range input {
-		a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+		a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 		assert.NilError(t, err)
 
 		// Set up some existing allocations.  This should always succeed.
@@ -895,7 +895,7 @@ func TestUnusualSubnets(t *testing.T) {
 		{"192.168.0.3"},
 	}
 
-	allocator, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	allocator, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -941,7 +941,7 @@ func TestUnusualSubnets(t *testing.T) {
 func TestRelease(t *testing.T) {
 	subnet := "192.168.0.0/23"
 
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: subnet})
@@ -1030,7 +1030,7 @@ func assertNRequests(t *testing.T, subnet string, numReq int, lastExpectedIP str
 	)
 
 	lastIP := net.ParseIP(lastExpectedIP)
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	assert.NilError(t, err)
 
 	alloc, err := a.RequestPool(ipamapi.PoolRequest{AddressSpace: localAddressSpace, Pool: subnet})
@@ -1072,7 +1072,7 @@ func BenchmarkRequest(b *testing.B) {
 	for _, subnet := range subnets {
 		name := fmt.Sprintf("%vSubnet", subnet)
 		b.Run(name, func(b *testing.B) {
-			a, _ := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+			a, _ := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 			benchmarkRequest(b, a, subnet)
 		})
 	}
@@ -1086,7 +1086,7 @@ func TestAllocateRandomDeallocate(t *testing.T) {
 }
 
 func testAllocateRandomDeallocate(t *testing.T, pool, subPool string, num int, store bool) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1180,7 +1180,7 @@ func runParallelTests(t *testing.T, instance int) {
 	// The first instance creates the allocator, gives the start
 	// and finally checks the pools each instance was assigned
 	if instance == first {
-		allocator, err = NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+		allocator, err = NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1213,7 +1213,7 @@ func runParallelTests(t *testing.T, instance int) {
 }
 
 func TestRequestReleaseAddressDuplicate(t *testing.T) {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/libnetwork/ipams/defaultipam/parallel_test.go
+++ b/daemon/libnetwork/ipams/defaultipam/parallel_test.go
@@ -35,7 +35,7 @@ type testContext struct {
 }
 
 func newTestContext(t *testing.T, mask int, options map[string]string) *testContext {
-	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks())
+	a, err := NewAllocator(ipamutils.GetLocalScopeDefaultNetworks(), ipamutils.GetGlobalScopeDefaultNetworks(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestDebug(t *testing.T) {
 func TestRequestPoolParallel(t *testing.T) {
 	a, err := NewAllocator([]*ipamutils.NetworkToSplit{
 		{Base: netip.MustParsePrefix("10.0.0.0/10"), Size: 24},
-	}, nil)
+	}, nil, nil)
 	assert.NilError(t, err)
 
 	var expected []string

--- a/daemon/libnetwork/ipams/drivers.go
+++ b/daemon/libnetwork/ipams/drivers.go
@@ -12,8 +12,8 @@ import (
 
 // Register registers all the builtin drivers (ie. default, windowsipam, null
 // and remote). 'pg' is nil here in case of non-managed plugins which Windows is using.
-func Register(r ipamapi.Registerer, pg plugingetter.PluginGetter, lAddrPools, gAddrPools []*ipamutils.NetworkToSplit) error {
-	if err := defaultipam.Register(r, lAddrPools, gAddrPools); err != nil {
+func Register(r ipamapi.Registerer, pg plugingetter.PluginGetter, lAddrPools, gAddrPools []*ipamutils.NetworkToSplit, defaultSubnetSize *int) error {
+	if err := defaultipam.Register(r, lAddrPools, gAddrPools, defaultSubnetSize); err != nil {
 		return err
 	}
 	if err := windowsipam.Register(r); err != nil {

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -1389,3 +1389,37 @@ func TestPreferredSubnetRestore(t *testing.T) {
 	assert.Check(t, is.Equal(dualv4after, dualv4), "expected same v4 subnet after restart")
 	assert.Check(t, is.Equal(dualv6after, dualv6), "expected same v6 subnet after restart")
 }
+
+func TestCreateNetworkWithGlobalDefaultSubnetSize(t *testing.T) {
+	ctx := setupTest(t)
+	d := daemon.New(t)
+	d.Start(t, "--default-subnet-size=24", "--feature=global-default-subnet-size=true")
+	defer d.Stop(t)
+
+	c := d.NewClientT(t)
+	defer c.Close()
+
+	nid, err := network.Create(ctx, c, "testnet",
+		network.WithIPv4(true),
+		network.WithIPv6())
+	assert.NilError(t, err)
+	defer network.RemoveNoError(ctx, t, c, nid)
+
+	inspect, err := c.NetworkInspect(ctx, nid, client.NetworkInspectOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(inspect.Network.IPAM.Config, 2))
+
+	var v4, v6 bool
+	for _, cfg := range inspect.Network.IPAM.Config {
+		if cfg.Subnet.Addr().Is4() {
+			v4 = true
+			assert.Equal(t, cfg.Subnet.Bits(), 24)
+		}
+		if cfg.Subnet.Addr().Is6() {
+			v6 = true
+			assert.Equal(t, cfg.Subnet.Bits(), 64)
+		}
+	}
+
+	assert.Assert(t, v4 && v6, "both IPv4 and IPv6 subnets should be present")
+}


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/47737
- Related to https://github.com/moby/moby/pull/50114

**- What I did**

This new flag allows to configure a daemon-wide default subnet size that will be applied to all dynamically allocated subnets. It defaults to /24 to give users more subnets from default address pools.

It's gated behind a feature flag named 'global-default-subnet-size'. This feature flag will be removed in v30.

**- How to verify it**

A new integration test has been added.

**- Human readable description for the release notes**

```markdown changelog
Introduce a new daemon flag that configures the default subnet size used for dynamic subnet allocations.
```

