### PR TITLE
NRI: config reload

### DIFF
--- a/integration/daemon/nri/nri_test.go
+++ b/integration/daemon/nri/nri_test.go
@@ -3,6 +3,7 @@ package nri
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/containerd/nri/pkg/api"
@@ -13,6 +14,7 @@ import (
 	"github.com/moby/moby/v2/internal/testutil/daemon"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/skip"
 )
 
@@ -189,4 +191,81 @@ func TestNRIContainerCreateAddMount(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNRIReload(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start a separate daemon with NRI enabled on Windows")
+	skip.If(t, testEnv.IsRootless)
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	const pluginName = "00-nri-test-plugin"
+	const envVar = "NRI_TEST"
+
+	// Build and install a plugin.
+	pluginDir := t.TempDir()
+	res := icmd.RunCommand("go", "build", "-o", filepath.Join(pluginDir, pluginName), "./testdata/test_plugin.go")
+	res.Assert(t, icmd.Success)
+
+	// Location and update function for the plugin config file.
+	pluginConfigDir := t.TempDir()
+	configurePlugin := func(envVal string) {
+		t.Helper()
+		err := os.WriteFile(filepath.Join(pluginConfigDir, pluginName+".conf"),
+			[]byte(`{"env-var": "`+envVar+`", "env-val": "`+envVal+`"}`), 0o644)
+		assert.NilError(t, err)
+	}
+
+	// Location and update function for the daemon config file, with empty initial config.
+	daemonConfigDir := t.TempDir()
+	daemonConfigFile := filepath.Join(daemonConfigDir, "daemon.json")
+	configureDaemon := func(json string) {
+		t.Helper()
+		err := os.WriteFile(daemonConfigFile, []byte(json), 0o644)
+		assert.NilError(t, err)
+	}
+	configureDaemon("{}")
+
+	d := daemon.New(t)
+	d.StartWithBusybox(ctx, t, "--config-file", daemonConfigFile, "--iptables=false", "--ip6tables=false")
+	defer d.Stop(t)
+	c := d.NewClientT(t)
+
+	// Function to check envVar in a container has value expEnvVal, or is absent if expEnvVal is "".
+	checkEnvVar := func(expEnvVal string) {
+		t.Helper()
+		res := container.RunAttach(ctx, t, c, container.WithAutoRemove, container.WithCmd("env"))
+		if expEnvVal == "" {
+			assert.Check(t, !strings.Contains(res.Stdout.String(), envVar),
+				"unexpected %q in env:\n%s", envVar, res.Stdout.String())
+		} else {
+			assert.Check(t, is.Contains(res.Stdout.String(), envVar+"="+expEnvVal))
+		}
+	}
+
+	// Without NRI enabled, the env var should not be set.
+	checkEnvVar("")
+
+	// Enable NRI in the daemon config and reload.
+	configureDaemon(`{"nri-opts": {"enable": true, "plugin-path": "` + pluginDir + `", "plugin-config-path": "` + pluginConfigDir + `"}}`)
+	configurePlugin("1")
+	err := d.ReloadConfig()
+	assert.NilError(t, err)
+
+	// Now the env var should be set by the plugin.
+	checkEnvVar("1")
+
+	// Reconfigure the plugin, check the new config takes effect after reload.
+	configurePlugin("2")
+	checkEnvVar("1")
+	err = d.ReloadConfig()
+	assert.NilError(t, err)
+	checkEnvVar("2")
+
+	// Disable NRI by clearing the config and reloading.
+	configureDaemon("{}")
+	err = d.ReloadConfig()
+	assert.NilError(t, err)
+	checkEnvVar("")
 }

--- a/integration/daemon/nri/testdata/test_plugin.go
+++ b/integration/daemon/nri/testdata/test_plugin.go
@@ -1,0 +1,95 @@
+/*
+  Based on https://github.com/containerd/nri/blob/main/plugins/template/ - which is ...
+
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/containerd/nri/pkg/api"
+	"github.com/containerd/nri/pkg/stub"
+)
+
+type config struct {
+	EnvVar string `json:"env-var"`
+	EnvVal string `json:"env-val"`
+}
+
+type plugin struct {
+	stub stub.Stub
+	cfg  config
+}
+
+func (p *plugin) Configure(_ context.Context, config, runtime, version string) (stub.EventMask, error) {
+	if config == "" {
+		return 0, nil
+	}
+
+	err := json.Unmarshal([]byte(config), &p.cfg)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse configuration: %w", err)
+	}
+
+	return api.MustParseEventMask("CreateContainer"), nil
+}
+
+func (p *plugin) CreateContainer(_ context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+	env := []*api.KeyValue{{Key: "NRI_TEST_PLUGIN", Value: "wozere"}}
+	if p.cfg.EnvVar != "" {
+		env = append(env, &api.KeyValue{Key: p.cfg.EnvVar, Value: p.cfg.EnvVal})
+	}
+
+	adjustment := &api.ContainerAdjustment{Env: env}
+	updates := []*api.ContainerUpdate{}
+
+	return adjustment, updates, nil
+}
+
+func main() {
+	var (
+		pluginName string
+		pluginIdx  string
+		err        error
+	)
+
+	flag.StringVar(&pluginName, "name", "", "plugin name to register to NRI")
+	flag.StringVar(&pluginIdx, "idx", "", "plugin index to register to NRI")
+	flag.Parse()
+
+	p := &plugin{}
+	opts := []stub.Option{
+		stub.WithOnClose(func() { os.Exit(0) }),
+	}
+	if pluginName != "" {
+		opts = append(opts, stub.WithPluginName(pluginName))
+	}
+	if pluginIdx != "" {
+		opts = append(opts, stub.WithPluginIdx(pluginIdx))
+	}
+
+	if p.stub, err = stub.New(p, opts...); err != nil {
+		os.Exit(1)
+	}
+	if err = p.stub.Run(context.Background()); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
- stacked on https://github.com/moby/moby/pull/51675

**- What I did**

- related to https://github.com/moby/moby/issues/51511

Make NRI config reloadable.

**- How I did it**

With NRI enabled, a reload will always restart the NRI adaptation layer. That means daemon-started plugins will restart/resync, and so their config will be re-read. If any plugins started independently and connected via the daemon's socket, they'll be dropped and must reconnect/resync. Maybe that'll end up being too disruptive/slow, it depends on how long real plugins take to register and sync.

**- How to verify it**

New integration test.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add experimental NRI support
```

**- A picture of a cute animal (not mandatory but encouraged)**

