### PR TITLE
NRI: report config in "docker info"

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -13,6 +13,11 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.53 API changes
+
+* `GET /info` now includes an `NRI` field. If the Node Resource Interface (NRI)
+  is enabled, this field contains information describing it.
+
 ## v1.52 API changes
 
 * `GET /images/{name}/get` now accepts multiple `platform` query-arguments

--- a/api/docs/v1.53.yaml
+++ b/api/docs/v1.53.yaml
@@ -2943,6 +2943,31 @@ definitions:
           The unique identifier for the device within its source driver.
           For CDI devices, this would be an FQDN like "vendor.com/gpu=0".
 
+  NRIInfo:
+    description: |
+      Information about the Node Resource Interface (NRI).
+
+      This field is only present if NRI is enabled.
+    type: "object"
+    x-nullable: true
+    properties:
+      Info:
+        description: |
+          Information about NRI, provided as "label" / "value" pairs.
+
+          <p><br /></p>
+
+          > **Note**: The information returned in this field, including the
+          > formatting of values and labels, should not be considered stable,
+          > and may change without notice.
+        type: "array"
+        items:
+          type: "array"
+          items:
+            type: "string"
+        example:
+          - ["plugin-path", "/opt/docker/nri/plugins"]
+
   ErrorDetail:
     type: "object"
     properties:
@@ -6980,6 +7005,8 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/DeviceInfo"
+      NRI:
+        $ref: "#/definitions/NRIInfo"
       Warnings:
         description: |
           List of warnings / informational messages about missing features, or

--- a/api/docs/v1.53.yaml
+++ b/api/docs/v1.53.yaml
@@ -467,10 +467,7 @@ definitions:
             type: "integer"
             format: "int64"
           Mode:
-            description: |
-              The permission mode for the tmpfs mount in an integer.
-              The value must not be in octal format (e.g. 755) but rather
-              the decimal representation of the octal value (e.g. 493).
+            description: "The permission mode for the tmpfs mount in an integer."
             type: "integer"
           Options:
             description: |

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2946,6 +2946,31 @@ definitions:
           The unique identifier for the device within its source driver.
           For CDI devices, this would be an FQDN like "vendor.com/gpu=0".
 
+  NRIInfo:
+    description: |
+      Information about the Node Resource Interface (NRI).
+
+      This field is only present if NRI is enabled.
+    type: "object"
+    x-nullable: true
+    properties:
+      Info:
+        description: |
+          Information about NRI, provided as "label" / "value" pairs.
+
+          <p><br /></p>
+
+          > **Note**: The information returned in this field, including the
+          > formatting of values and labels, should not be considered stable,
+          > and may change without notice.
+        type: "array"
+        items:
+          type: "array"
+          items:
+            type: "string"
+        example:
+          - ["plugin-path", "/opt/docker/nri/plugins"]
+
   ErrorDetail:
     type: "object"
     properties:
@@ -6983,6 +7008,8 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/DeviceInfo"
+      NRI:
+        $ref: "#/definitions/NRIInfo"
       Warnings:
         description: |
           List of warnings / informational messages about missing features, or

--- a/api/types/system/info.go
+++ b/api/types/system/info.go
@@ -74,6 +74,7 @@ type Info struct {
 	FirewallBackend     *FirewallInfo        `json:"FirewallBackend,omitempty"`
 	CDISpecDirs         []string
 	DiscoveredDevices   []DeviceInfo `json:",omitempty"`
+	NRI                 *NRIInfo     `json:",omitempty"`
 
 	Containerd *ContainerdInfo `json:",omitempty"`
 
@@ -162,4 +163,9 @@ type DeviceInfo struct {
 	// ID is the unique identifier for the device.
 	// Example: CDI FQDN like "vendor.com/gpu=0", or other driver-specific device ID
 	ID string `json:"ID"`
+}
+
+// NRIInfo describes the NRI configuration.
+type NRIInfo struct {
+	Info [][2]string `json:"Info,omitempty"`
 }

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -58,7 +58,7 @@ const (
 	// MaxAPIVersion is the highest REST API version supported by the daemon.
 	//
 	// This version may be lower than the version of the api library module used.
-	MaxAPIVersion = "1.52"
+	MaxAPIVersion = "1.53"
 	// defaultMinAPIVersion is the minimum API version supported by the API.
 	// This version can be overridden through the "DOCKER_MIN_API_VERSION"
 	// environment variable. The minimum allowed version is determined

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -72,6 +72,7 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*system.Info, error) {
 		LiveRestoreEnabled: cfg.LiveRestoreEnabled,
 		Isolation:          daemon.defaultIsolation,
 		CDISpecDirs:        promoteNil(cfg.CDISpecDirs),
+		NRI:                daemon.nri.GetInfo(),
 	}
 
 	daemon.fillContainerStates(v)

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -118,6 +118,10 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 				"BridgeNfIp6tables": json.RawMessage("false"),
 			}))
 		}
+		if versions.LessThan(version, "1.53") {
+			// Field introduced in API v1.53.
+			info.NRI = nil
+		}
 		return compat.Wrap(info, legacyOptions...), nil
 	})
 

--- a/vendor/github.com/moby/moby/api/types/system/info.go
+++ b/vendor/github.com/moby/moby/api/types/system/info.go
@@ -74,6 +74,7 @@ type Info struct {
 	FirewallBackend     *FirewallInfo        `json:"FirewallBackend,omitempty"`
 	CDISpecDirs         []string
 	DiscoveredDevices   []DeviceInfo `json:",omitempty"`
+	NRI                 *NRIInfo     `json:",omitempty"`
 
 	Containerd *ContainerdInfo `json:",omitempty"`
 
@@ -162,4 +163,9 @@ type DeviceInfo struct {
 	// ID is the unique identifier for the device.
 	// Example: CDI FQDN like "vendor.com/gpu=0", or other driver-specific device ID
 	ID string `json:"ID"`
+}
+
+// NRIInfo describes the NRI configuration.
+type NRIInfo struct {
+	Info [][2]string `json:"Info,omitempty"`
 }


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/issues/51511

Include NRI in the "info" response.

**- How I did it**

For now - just name/value pairs ... maybe we'll want to be more concrete about the info in there at some point - we could add a config section, add a way to ask the NRI adaptation layer what plugins are registered, maybe add some stats etc etc. But this is probably the right way to start, to avoid deprecating fields that no longer make sense if/when we support NRI properly?

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`GET /info` now includes an `NRI` field. If the Node Resource Interface (NRI) is enabled, this field contains information describing it.
```

**- A picture of a cute animal (not mandatory but encouraged)**

