### PR TITLE
layer: Clean up RW layer if mount metadata save fails

### DIFF
--- a/daemon/internal/layer/layer_store.go
+++ b/daemon/internal/layer/layer_store.go
@@ -535,6 +535,9 @@ func (ls *layerStore) CreateRWLayer(name string, parent ChainID, opts *CreateRWL
 		return nil, err
 	}
 	if err := ls.saveMount(m); err != nil {
+		if removeErr := ls.driver.Remove(m.mountID); removeErr != nil {
+			log.G(context.TODO()).WithFields(log.Fields{"mount-id": m.mountID, "error": removeErr}).Error("Failed to clean up RW layer after mount save failure")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
**- What I did**

Add cleanup for the RW layer directory if `saveMount()` fails after `driver.CreateReadWrite()` succeeds in `CreateRWLayer()`. Previously, this failure path would leave an orphaned overlay2 directory with no corresponding metadata.

Related to #45939

**- How I did it**

If `saveMount()` fails, call `driver.Remove()` to clean up the RW layer directory that was just created. This mirrors the cleanup pattern used in `registerWithDescriptor()` after #51700.

**- How to verify it**

- All existing layer tests pass: `go test ./daemon/internal/layer/...`
- golangci-lint passes with 0 issues
- Code review confirms the fix prevents the orphan scenario

```markdown changelog
Fix potential creation of orphaned overlay2 layers
```