### PR TITLE
layer: Clean up init layer if initialization fails

### DIFF
--- a/daemon/internal/layer/layer_store.go
+++ b/daemon/internal/layer/layer_store.go
@@ -645,7 +645,7 @@ func (ls *layerStore) saveMount(mount *mountedLayer) error {
 	return nil
 }
 
-func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc MountInit, storageOpt map[string]string) (string, error) {
+func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc MountInit, storageOpt map[string]string) (_ string, retErr error) {
 	// Use "<graph-id>-init" to maintain compatibility with graph drivers
 	// which are expecting this layer with this special name. If all
 	// graph drivers can be updated to not rely on knowing about this layer
@@ -662,9 +662,8 @@ func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc Mou
 	}
 
 	// Clean up init layer if any subsequent operation fails
-	successful := false
 	defer func() {
-		if !successful {
+		if retErr != nil {
 			if err := ls.driver.Remove(initID); err != nil {
 				log.G(context.TODO()).WithFields(log.Fields{"init-id": initID, "error": err}).Error("Failed to clean up init layer after error")
 			}
@@ -685,7 +684,6 @@ func (ls *layerStore) initMount(graphID, parent, mountLabel string, initFunc Mou
 		return "", err
 	}
 
-	successful = true
 	return initID, nil
 }
 


### PR DESCRIPTION
**- What I did**

Add cleanup for the init layer directory if any operation fails after `driver.CreateReadWrite()` succeeds in `initMount()`. Previously, failures in `driver.Get()`, `initFunc()`, or `driver.Put()` would leave an orphaned overlay2 directory.

Related to #45939

**- How I did it**

Added a defer-based cleanup with a success flag (same pattern as `registerWithDescriptor()`). If any operation after `CreateReadWrite()` fails, the init layer is removed.

**- How to verify it**

- All existing layer tests pass: `go test ./daemon/internal/layer/...`
- golangci-lint passes with 0 issues
- Code review confirms the fix prevents the orphan scenario


```markdown changelog
Fix potential creation of orphaned overlay2 layers
```