### PR TITLE
api: deprecate /grpc and /session endpoints

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 
 * `GET /info` now includes an `NRI` field. If the Node Resource Interface (NRI)
   is enabled, this field contains information describing it.
+* Deprecated: The `POST /grpc` and `POST /session` endpoints are deprecated and
+  will be removed in a future version.
 
 ## v1.52 API changes
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -13548,6 +13548,9 @@ paths:
         Start a new interactive session with a server. Session allows server to
         call back to the client for advanced capabilities.
 
+        > **Deprecated**: This endpoint is deprecated and will be removed in a future version.
+        > Server should support gRPC directly on the listening socket.
+
         ### Hijacking
 
         This endpoint hijacks the HTTP connection to HTTP2 transport that allows

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -44,7 +44,7 @@ import (
 	"github.com/moby/moby/v2/daemon/server/router/container"
 	debugrouter "github.com/moby/moby/v2/daemon/server/router/debug"
 	distributionrouter "github.com/moby/moby/v2/daemon/server/router/distribution"
-	grpcrouter "github.com/moby/moby/v2/daemon/server/router/grpc"
+	grpcrouter "github.com/moby/moby/v2/daemon/server/router/grpc" //nolint:staticcheck // Deprecated endpoint kept for backward compatibility
 	"github.com/moby/moby/v2/daemon/server/router/image"
 	"github.com/moby/moby/v2/daemon/server/router/network"
 	pluginrouter "github.com/moby/moby/v2/daemon/server/router/plugin"
@@ -730,7 +730,7 @@ func buildRouters(opts routerOptions) []router.Router {
 		systemrouter.NewRouter(opts.daemon, opts.cluster, opts.builder.buildkit, opts.daemon.Features),
 		volume.NewRouter(opts.daemon.VolumesService(), opts.cluster),
 		build.NewRouter(opts.builder.backend, opts.daemon),
-		sessionrouter.NewRouter(opts.builder.sessionManager),
+		sessionrouter.NewRouter(opts.builder.sessionManager), //nolint:staticcheck // Deprecated endpoint kept for backward compatibility
 		swarmrouter.NewRouter(opts.cluster),
 		pluginrouter.NewRouter(opts.daemon.PluginManager()),
 		distributionrouter.NewRouter(opts.daemon.ImageBackend()),
@@ -739,7 +739,7 @@ func buildRouters(opts routerOptions) []router.Router {
 	}
 
 	if opts.builder.backend != nil {
-		routers = append(routers, grpcrouter.NewRouter(opts.builder.backend))
+		routers = append(routers, grpcrouter.NewRouter(opts.builder.backend)) //nolint:staticcheck // Deprecated endpoint kept for backward compatibility
 	}
 
 	if opts.daemon.HasExperimental() {

--- a/daemon/server/router/grpc/grpc.go
+++ b/daemon/server/router/grpc/grpc.go
@@ -1,3 +1,9 @@
+// Package grpc provides the router for the /grpc endpoint.
+//
+// Deprecated: The /grpc endpoint is deprecated and will be removed in the next
+// major version. The Engine now properly supports HTTP/2 and h2c requests and can
+// serve gRPC without this endpoint. Clients should establish gRPC connections
+// directly over HTTP/2.
 package grpc
 
 import (
@@ -25,6 +31,9 @@ type grpcRouter struct {
 }
 
 // NewRouter initializes a new grpc http router
+//
+// Deprecated: The /grpc endpoint is deprecated and will be removed in the next
+// major version. The Engine now properly supports HTTP/2 and h2c requests.
 func NewRouter(backends ...Backend) router.Router {
 	tp, _ := otelutil.NewTracerProvider(context.Background(), false)
 	opts := []grpc.ServerOption{

--- a/daemon/server/router/session/session.go
+++ b/daemon/server/router/session/session.go
@@ -9,6 +9,9 @@ type sessionRouter struct {
 }
 
 // NewRouter initializes a new session router
+//
+// Deprecated: The /session endpoint is deprecated and will be removed in the next
+// major version. The Engine now properly supports HTTP/2 and h2c requests.
 func NewRouter(b Backend) router.Router {
 	r := &sessionRouter{
 		backend: b,


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/51696

### api: deprecate /grpc and /session endpoints

  The /grpc and /session endpoints are now deprecated as the Engine has been upgraded to properly support HTTP/2 and h2c requests, making these specialized endpoints unnecessary.

  These endpoints will be removed in the next major API version to complete the cleanup.


```markdown changelog
`POST /grpc` and `POST /sessions` are deprecated and will be removed in future.
```