### PR TITLE
daemon: restore: register containers without rwlayer

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -293,10 +293,12 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 
 			rwlayer, err := daemon.imageService.GetLayerByID(c.ID)
 			if err != nil {
+				// A container without a rwlayer is in a bad state, but we must register that container to let users
+				// remove it. So, log the error but do not early-return.
 				logger.WithError(err).Error("failed to load container mount")
-				return
+			} else {
+				c.RWLayer = rwlayer
 			}
-			c.RWLayer = rwlayer
 			logger.WithFields(log.Fields{
 				"running": c.State.IsRunning(),
 				"paused":  c.State.IsPaused(),


### PR DESCRIPTION
- Related to https://github.com/moby/moby/pull/51692
- Fixes / addresses https://github.com/docker/desktop-linux/issues/309
- fixes / addresses https://github.com/docker/desktop-feedback/issues/253

**- What I did**

Under some undetermined circumstances, a container might end up with no rwlayer on daemon restart. The restore logic would add them to the containersReplica list but not to the 'containers' list. Thus, users would see them on `docker ps -a`, but would be unable to remove them.

To fix that, add these containers to the 'containers' list as well.

**- Human readable description for the release notes**

```markdown changelog
Fix a rare bug that could cause containers to become unremovable.
```