### PR TITLE
c8d/pull: Emit Aux messages containing raw OCI registry errors

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   is enabled, this field contains information describing it.
 * Deprecated: The `POST /grpc` and `POST /session` endpoints are deprecated and
   will be removed in a future version.
+* `POST /images/pull` now propagates raw OCI registry errors through the aux
+  progress stream.
 
 ## v1.52 API changes
 

--- a/api/types/auxprogress/pull.go
+++ b/api/types/auxprogress/pull.go
@@ -1,0 +1,16 @@
+package auxprogress
+
+// OCIRegistryErrors contains raw errors as returned by the registry.
+//
+// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes
+type OCIRegistryErrors struct {
+	Errors []OCIRegistryError `json:"errors"`
+}
+
+// OCIRegistryError is only used in OCIRegistryErrors - it's not a valid AUX
+// message by itself.
+type OCIRegistryError struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message,omitempty"`
+	Detail  interface{} `json:"detail,omitempty"`
+}

--- a/daemon/containerd/registry_errors.go
+++ b/daemon/containerd/registry_errors.go
@@ -19,6 +19,15 @@ func translateRegistryError(ctx context.Context, err error) error {
 		return nil
 	}
 
+	derrs, legacyErr := extractOCIErrors(ctx, err)
+	if legacyErr != nil {
+		return legacyErr
+	}
+
+	return convertOCIErrors(derrs, err)
+}
+
+func extractOCIErrors(ctx context.Context, err error) (ociErrs docker.Errors, legacyErr error) {
 	// Check for registry specific error
 	var derrs docker.Errors
 	if !errors.As(err, &derrs) {
@@ -27,7 +36,7 @@ func translateRegistryError(ctx context.Context, err error) error {
 		if errors.As(err, &remoteErr) {
 			if jerr := json.Unmarshal(remoteErr.Body, &derrs); jerr != nil {
 				log.G(ctx).WithError(jerr).Debug("unable to unmarshal registry error")
-				return fmt.Errorf("%w: %w", cerrdefs.ErrUnknown, err)
+				return nil, fmt.Errorf("%w: %w", cerrdefs.ErrUnknown, err)
 			}
 			if len(derrs) == 0 && (remoteErr.StatusCode == http.StatusUnauthorized || remoteErr.StatusCode == http.StatusForbidden) {
 				// Some registries or token servers may use an old deprecated error format
@@ -37,17 +46,21 @@ func translateRegistryError(ctx context.Context, err error) error {
 				}
 				if jerr := json.Unmarshal(remoteErr.Body, &tokenErr); jerr == nil && tokenErr.Details != "" {
 					if remoteErr.StatusCode == http.StatusUnauthorized {
-						return cerrdefs.ErrUnauthenticated.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeUnauthorized.Message(), tokenErr.Details))
+						return nil, cerrdefs.ErrUnauthenticated.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeUnauthorized.Message(), tokenErr.Details))
 					}
-					return cerrdefs.ErrPermissionDenied.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeDenied.Message(), tokenErr.Details))
+					return nil, cerrdefs.ErrPermissionDenied.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeDenied.Message(), tokenErr.Details))
 				}
 			}
 		} else if errors.As(err, &derr) {
 			derrs = append(derrs, derr)
 		} else {
-			return err
+			return nil, err
 		}
 	}
+	return derrs, nil
+}
+
+func convertOCIErrors(derrs docker.Errors, fallbackErr error) error {
 	var errs []error
 	for _, err := range derrs {
 		var derr docker.Error
@@ -83,9 +96,11 @@ func translateRegistryError(ctx context.Context, err error) error {
 		}
 		errs = append(errs, err)
 	}
+
+	var err error
 	switch len(errs) {
 	case 0:
-		err = cerrdefs.ErrUnknown.WithMessage(err.Error())
+		return cerrdefs.ErrUnknown.WithMessage(fallbackErr.Error())
 	case 1:
 		err = errs[0]
 	default:

--- a/daemon/containerd/registry_errors.go
+++ b/daemon/containerd/registry_errors.go
@@ -30,32 +30,33 @@ func translateRegistryError(ctx context.Context, err error) error {
 func extractOCIErrors(ctx context.Context, err error) (ociErrs docker.Errors, legacyErr error) {
 	// Check for registry specific error
 	var derrs docker.Errors
-	if !errors.As(err, &derrs) {
-		var remoteErr remoteerrors.ErrUnexpectedStatus
-		var derr docker.Error
-		if errors.As(err, &remoteErr) {
-			if jerr := json.Unmarshal(remoteErr.Body, &derrs); jerr != nil {
-				log.G(ctx).WithError(jerr).Debug("unable to unmarshal registry error")
-				return nil, fmt.Errorf("%w: %w", cerrdefs.ErrUnknown, err)
-			}
-			if len(derrs) == 0 && (remoteErr.StatusCode == http.StatusUnauthorized || remoteErr.StatusCode == http.StatusForbidden) {
-				// Some registries or token servers may use an old deprecated error format
-				// which only has a "details" field and not the OCI defined "errors" array.
-				var tokenErr struct {
-					Details string `json:"details"`
-				}
-				if jerr := json.Unmarshal(remoteErr.Body, &tokenErr); jerr == nil && tokenErr.Details != "" {
-					if remoteErr.StatusCode == http.StatusUnauthorized {
-						return nil, cerrdefs.ErrUnauthenticated.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeUnauthorized.Message(), tokenErr.Details))
-					}
-					return nil, cerrdefs.ErrPermissionDenied.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeDenied.Message(), tokenErr.Details))
-				}
-			}
-		} else if errors.As(err, &derr) {
-			derrs = append(derrs, derr)
-		} else {
-			return nil, err
+	if errors.As(err, &derrs) {
+		return derrs, nil
+	}
+	var remoteErr remoteerrors.ErrUnexpectedStatus
+	var derr docker.Error
+	if errors.As(err, &remoteErr) {
+		if jerr := json.Unmarshal(remoteErr.Body, &derrs); jerr != nil {
+			log.G(ctx).WithError(jerr).Debug("unable to unmarshal registry error")
+			return nil, fmt.Errorf("%w: %w", cerrdefs.ErrUnknown, err)
 		}
+		if len(derrs) == 0 && (remoteErr.StatusCode == http.StatusUnauthorized || remoteErr.StatusCode == http.StatusForbidden) {
+			// Some registries or token servers may use an old deprecated error format
+			// which only has a "details" field and not the OCI defined "errors" array.
+			var tokenErr struct {
+				Details string `json:"details"`
+			}
+			if jerr := json.Unmarshal(remoteErr.Body, &tokenErr); jerr == nil && tokenErr.Details != "" {
+				if remoteErr.StatusCode == http.StatusUnauthorized {
+					return nil, cerrdefs.ErrUnauthenticated.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeUnauthorized.Message(), tokenErr.Details))
+				}
+				return nil, cerrdefs.ErrPermissionDenied.WithMessage(fmt.Sprintf("%s - %s", docker.ErrorCodeDenied.Message(), tokenErr.Details))
+			}
+		}
+	} else if errors.As(err, &derr) {
+		derrs = append(derrs, derr)
+	} else {
+		return derrs, err
 	}
 	return derrs, nil
 }

--- a/integration/image/pull_registry_error_test.go
+++ b/integration/image/pull_registry_error_test.go
@@ -1,0 +1,180 @@
+package image
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/moby/moby/api/types/auxprogress"
+	"github.com/moby/moby/client"
+	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
+)
+
+// TestImagePullRegistryErrorAux tests that OCI registry errors are propagated
+// through the aux progress stream when pulling fails.
+func TestImagePullRegistryErrorAux(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "We don't run a test registry on Windows")
+	skip.If(t, testEnv.IsRootless, "Rootless has a different view of localhost")
+	skip.If(t, !testEnv.UsingSnapshotter(), "Not supported for graphdrivers yet")
+
+	ctx := setupTest(t)
+
+	testCases := []struct {
+		name         string
+		responseBody string
+		statusCode   int
+		expectErrors auxprogress.OCIRegistryErrors
+	}{
+		{
+			name:       "UNAUTHORIZED error",
+			statusCode: http.StatusUnauthorized,
+			responseBody: `{
+				"errors": [
+					{"code": "UNAUTHORIZED", "message": "authentication required"}
+				]
+			}`,
+			expectErrors: auxprogress.OCIRegistryErrors{
+				Errors: []auxprogress.OCIRegistryError{
+					{Code: "UNAUTHORIZED", Message: "authentication required"},
+				},
+			},
+		},
+		{
+			name:       "DENIED error",
+			statusCode: http.StatusForbidden,
+			responseBody: `{
+				"errors": [
+					{"code": "DENIED", "message": "access forbidden"}
+				]
+			}`,
+			expectErrors: auxprogress.OCIRegistryErrors{
+				Errors: []auxprogress.OCIRegistryError{
+					{Code: "DENIED", Message: "access forbidden"},
+				},
+			},
+		},
+		{
+			name:       "multiple errors",
+			statusCode: http.StatusForbidden,
+			responseBody: `{
+				"errors": [
+					{"code": "DENIED", "message": "access denied"},
+					{"code": "UNAUTHORIZED", "message": "not authenticated"}
+				]
+			}`,
+			expectErrors: auxprogress.OCIRegistryErrors{
+				Errors: []auxprogress.OCIRegistryError{
+					{Code: "DENIED", Message: "access denied"},
+					{Code: "UNAUTHORIZED", Message: "not authenticated"},
+				},
+			},
+		},
+		{
+			name:       "DENIED error with detail",
+			statusCode: http.StatusForbidden,
+			responseBody: `{
+				"errors": [
+					{"code": "DENIED", "message": "manifest pull has failed policy validation", "detail": "policy validation failed"}
+				]
+			}`,
+			expectErrors: auxprogress.OCIRegistryErrors{
+				Errors: []auxprogress.OCIRegistryError{
+					{
+						Code:    "DENIED",
+						Message: "manifest pull has failed policy validation",
+						Detail:  "policy validation failed",
+					},
+				},
+			},
+		},
+	}
+
+	manifestDigest := digest.SHA256.FromString("{}")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a mock registry server that returns the OCI error
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Logf("Mock registry received: %s %s", r.Method, r.URL.Path)
+
+				// Handle /v2/ ping
+				if r.URL.Path == "/v2/" || r.URL.Path == "/v2" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+
+				handleManifestRequest := func() {
+					w.Header().Set("Content-Type", "application/json")
+					if r.Method == http.MethodHead {
+						w.Header().Set("Docker-Content-Digest", manifestDigest.String())
+						w.Header().Set("Content-Length", "2")
+						w.WriteHeader(http.StatusOK)
+						return
+					}
+					w.WriteHeader(tc.statusCode)
+					_, _ = w.Write([]byte(tc.responseBody))
+					t.Logf("manifests: Returning %d for %s %s", tc.statusCode, r.Method, r.URL.Path)
+				}
+
+				// Return error for manifest requests
+				if strings.Contains(r.URL.Path, "/manifests/") {
+					handleManifestRequest()
+					return
+				}
+
+				// If manifests returns error, the client will try to fetch it from the blobs endpoint.
+				if strings.Contains(r.URL.Path, "/blobs/"+manifestDigest.String()) {
+					handleManifestRequest()
+					return
+				}
+
+				t.Logf("Returning 404 for %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer ts.Close()
+
+			// Extract host:port from the test server URL
+			registryHost := strings.TrimPrefix(ts.URL, "http://")
+			imageRef := path.Join(registryHost, "test/image:latest")
+
+			apiClient := testEnv.APIClient()
+			res, err := apiClient.ImagePull(ctx, imageRef, client.ImagePullOptions{})
+			t.Logf("ImagePull error: %v", err)
+			if err != nil {
+				var derrs docker.Errors
+				if !errors.As(err, &derrs) {
+					assert.NilError(t, err, "Initiating pull request failed, %T: %v", err, err)
+				}
+				return
+			}
+			defer res.Close()
+
+			// Collect aux messages from the JSON stream
+			var auxMessages []auxprogress.OCIRegistryErrors
+			for msg, err := range res.JSONMessages(ctx) {
+				if err != nil {
+					t.Logf("JSONMessages error: %v", err)
+					break
+				}
+				if msg.Aux != nil {
+					var ociErrs auxprogress.OCIRegistryErrors
+					if err := json.Unmarshal(*msg.Aux, &ociErrs); err == nil && len(ociErrs.Errors) > 0 {
+						auxMessages = append(auxMessages, ociErrs)
+					}
+				}
+			}
+
+			// Verify we received the expected aux messages
+			assert.Assert(t, is.Len(auxMessages, 1), "expected 1 aux message with OCI errors")
+			assert.Check(t, is.DeepEqual(auxMessages[0], tc.expectErrors))
+		})
+	}
+}

--- a/vendor/github.com/moby/moby/api/types/auxprogress/pull.go
+++ b/vendor/github.com/moby/moby/api/types/auxprogress/pull.go
@@ -1,0 +1,16 @@
+package auxprogress
+
+// OCIRegistryErrors contains raw errors as returned by the registry.
+//
+// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes
+type OCIRegistryErrors struct {
+	Errors []OCIRegistryError `json:"errors"`
+}
+
+// OCIRegistryError is only used in OCIRegistryErrors - it's not a valid AUX
+// message by itself.
+type OCIRegistryError struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message,omitempty"`
+	Detail  interface{} `json:"detail,omitempty"`
+}


### PR DESCRIPTION
Previously, registry errors were only handled through generic error translation.

Enhance the image pull operation to extract and emit OCI registry errors as auxiliary progress messages when pull operations fail.

This allows clients to receive the original, unprocessed registry error enabling better error reporting and handling in the Docker CLI and other API consumers.



```markdown changelog
containerd image store: `POST /images/pull` now propagates raw OCI registry errors through the aux progress stream.
```

**- A picture of a cute animal (not mandatory but encouraged)**

