### PR TITLE
api: update /build/prune and /nodes/{id}/update endpoints to use body instead of query-args

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -12071,6 +12071,9 @@ paths:
   /nodes/{id}/update:
     post:
       summary: "Update a node"
+      description: |
+        **API version 1.53 and above:** Use request body with version and spec.
+        **API version 1.52 and below:** Use query parameter for version (deprecated).
       operationId: "NodeUpdate"
       responses:
         200:
@@ -12097,18 +12100,30 @@ paths:
           description: "The ID of the node"
           type: "string"
           required: true
+        # For API version >= 1.53
         - name: "body"
           in: "body"
           schema:
-            $ref: "#/definitions/NodeSpec"
+            type: "object"
+            properties:
+              version:
+                type: "integer"
+                format: "int64"
+                description: |
+                  The version number of the node object being updated. This is required
+                  to avoid conflicting writes.
+              spec:
+                $ref: "#/definitions/NodeSpec"
+        # For API version < 1.53
         - name: "version"
           in: "query"
           description: |
             The version number of the node object being updated. This is required
             to avoid conflicting writes.
+
+            **Deprecated:** For API version 1.53 and above, use the request body instead.
           type: "integer"
           format: "int64"
-          required: true
       tags: ["Node"]
   /swarm:
     get:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9617,10 +9617,51 @@ paths:
   /build/prune:
     post:
       summary: "Delete builder cache"
+      description: |
+        **API version 1.53 and above:** Use request body.
+        **API version 1.52 and below:** Use query parameters (deprecated).
       produces:
         - "application/json"
       operationId: "BuildPrune"
       parameters:
+        # For API version >= 1.53
+        - name: "body"
+          in: "body"
+          schema:
+            type: "object"
+            properties:
+              all: 
+                type: "boolean"
+                description: "Remove all types of build cache"
+              reservedSpace:
+                type: "integer"
+                format: "int64"
+                description: "Amount of disk space in bytes to keep for cache"
+              maxUsedSpace:
+                type: "integer"
+                format: "int64"
+                description: "Maximum amount of disk space in bytes that the build cache can use"
+              minFreeSpace:
+                type: "integer"
+                format: "int64"
+                description: "Target amount of free disk space after pruning"
+              filters:
+                type: "object"
+                description: |
+                  A JSON encoded value of the filters (a `map[string][]string`) to
+                  process on the list of build cache objects.
+                  
+                  Available filters:
+
+                  - `until=<timestamp>` remove cache older than `<timestamp>`. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon's local time.
+                  - `id=<id>`
+                  - `parent=<id>`
+                  - `type=<string>`
+                  - `description=<string>`
+                  - `inuse`
+                  - `shared`
+                  - `private`
+        # For API version < 1.53
         - name: "reserved-space"
           in: "query"
           description: "Amount of disk space in bytes to keep for cache"

--- a/api/types/build/prune_request.go
+++ b/api/types/build/prune_request.go
@@ -1,5 +1,9 @@
 package build
 
+import(
+	"encoding/json"
+)
+
 // Filters describes a predicate for an API request.
 //
 // Each entry in the map is a filter term.

--- a/api/types/build/prune_request.go
+++ b/api/types/build/prune_request.go
@@ -1,0 +1,23 @@
+package build
+
+// Filters describes a predicate for an API request.
+//
+// Each entry in the map is a filter term.
+// Each term is evaluated against the set of values.
+// A filter term is satisfied if any one of the values in the set is a match.
+// An item matches the filters when all terms are satisfied.
+//
+// Like all other map types in Go, the zero value is empty and read-only.
+type Filters map[string]map[string]bool
+
+// PruneRequest contains the request body for POST /build/prune
+//
+// This struct is used for API version 1.53 and later.
+// Earlier API versions use query parameters instead.
+type BuildCachePruneRequest struct {
+	All           bool		`json:"all,omitempty"`
+	ReservedSpace int64		`json:"reservedSpace,omitempty"`
+	MaxUsedSpace  int64		`json:"maxUsedSpace,omitempty"`
+	MinFreeSpace  int64		`json:"minFreeSpace,omitempty"`
+	Filters       Filters	`json:"filters,omitempty"`
+}

--- a/api/types/build/prune_request.go
+++ b/api/types/build/prune_request.go
@@ -15,9 +15,9 @@ type Filters map[string]map[string]bool
 // This struct is used for API version 1.53 and later.
 // Earlier API versions use query parameters instead.
 type BuildCachePruneRequest struct {
-	All           bool		`json:"all,omitempty"`
-	ReservedSpace int64		`json:"reservedSpace,omitempty"`
-	MaxUsedSpace  int64		`json:"maxUsedSpace,omitempty"`
-	MinFreeSpace  int64		`json:"minFreeSpace,omitempty"`
-	Filters       Filters	`json:"filters,omitempty"`
+	All           bool				`json:"all,omitempty"`
+	ReservedSpace int64				`json:"reservedSpace,omitempty"`
+	MaxUsedSpace  int64				`json:"maxUsedSpace,omitempty"`
+	MinFreeSpace  int64				`json:"minFreeSpace,omitempty"`
+	Filters       json.RawMessage	`json:"filters,omitempty"`
 }

--- a/api/types/swarm/node_update_request.go
+++ b/api/types/swarm/node_update_request.go
@@ -1,0 +1,10 @@
+package swarm
+
+// NodeUpdateRequest contains the request body for POST /nodes/{id}/update
+//
+// This struct is used for API version 1.53 and later.
+// Earlier API versions use query parameters for version instead.
+type NodeUpdateRequest struct {
+	Version uint64   `json:"version"`
+	Spec    NodeSpec `json:"spec"`
+}

--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -46,7 +46,7 @@ func (cli *Client) BuildCachePrune(ctx context.Context, opts BuildCachePruneOpti
 
 	if versions.GreaterThanOrEqualTo(cli.version, "1.53") {
 		req := BuildCachePruneRequest{
-			All:			true,
+			All:			opts.All,
 			ReservedSpace:	opts.ReservedSpace,
 			MaxUsedSpace:	opts.MaxUsedSpace,
 			MinFreeSpace:	opts.MinFreeSpace,

--- a/client/build_prune.go
+++ b/client/build_prune.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"io"
+	"bytes"
 
 	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/client/pkg/versions"
@@ -25,32 +27,62 @@ type BuildCachePruneResult struct {
 	Report build.CachePruneReport
 }
 
+// For API  >= v1.53 BuildCachePruneRequest holds the arguments that were in query args for prior versions
+type BuildCachePruneRequest struct {
+	All           bool			`json:"all,omitempty"`
+	ReservedSpace int64			`json:"reservedSpace,omitempty"`
+	MaxUsedSpace  int64			`json:"maxUsedSpace,omitempty"`
+	MinFreeSpace  int64			`json:"minFreeSpace,omitempty"`
+	Filters       Filters		`json:"filters,omitempty"`
+}
+
 // BuildCachePrune requests the daemon to delete unused cache data.
 func (cli *Client) BuildCachePrune(ctx context.Context, opts BuildCachePruneOptions) (BuildCachePruneResult, error) {
 	var out BuildCachePruneResult
-	query := url.Values{}
-	if opts.All {
-		query.Set("all", "1")
-	}
+	var (
+		query url.Values
+		body  io.Reader
+	)
 
-	if opts.ReservedSpace != 0 {
-		// Prior to API v1.48, 'keep-storage' was used to set the reserved space for the build cache.
-		// TODO(austinvazquez): remove once API v1.47 is no longer supported. See https://github.com/moby/moby/issues/50902
-		if versions.LessThanOrEqualTo(cli.version, "1.47") {
-			query.Set("keep-storage", strconv.Itoa(int(opts.ReservedSpace)))
-		} else {
-			query.Set("reserved-space", strconv.Itoa(int(opts.ReservedSpace)))
+	if versions.GreaterThanOrEqualTo(cli.version, "1.53") {
+		req := BuildCachePruneRequest{
+			All:			true,
+			ReservedSpace:	opts.ReservedSpace,
+			MaxUsedSpace:	opts.MaxUsedSpace,
+			MinFreeSpace:	opts.MinFreeSpace,
+			Filters:		opts.Filters,
 		}
+		
+		buf, err := json.Marshal(req)
+		if err != nil {
+			return BuildCachePruneResult{}, err
+		}
+		body = bytes.NewReader(buf)
+	} else {
+		query = url.Values{}
+		if opts.All {
+			query.Set("all", "1")
+		}
+		
+		if opts.ReservedSpace != 0 {
+			// Prior to API v1.48, 'keep-storage' was used to set the reserved space for the build cache.
+			// TODO(austinvazquez): remove once API v1.47 is no longer supported. See https://github.com/moby/moby/issues/50902
+			if versions.LessThanOrEqualTo(cli.version, "1.47") {
+				query.Set("keep-storage", strconv.Itoa(int(opts.ReservedSpace)))
+			} else {
+				query.Set("reserved-space", strconv.Itoa(int(opts.ReservedSpace)))
+			}
+		}
+		if opts.MaxUsedSpace != 0 {
+			query.Set("max-used-space", strconv.Itoa(int(opts.MaxUsedSpace)))
+		}
+		if opts.MinFreeSpace != 0 {
+			query.Set("min-free-space", strconv.Itoa(int(opts.MinFreeSpace)))
+		}
+		opts.Filters.updateURLValues(query)
 	}
-	if opts.MaxUsedSpace != 0 {
-		query.Set("max-used-space", strconv.Itoa(int(opts.MaxUsedSpace)))
-	}
-	if opts.MinFreeSpace != 0 {
-		query.Set("min-free-space", strconv.Itoa(int(opts.MinFreeSpace)))
-	}
-	opts.Filters.updateURLValues(query)
 
-	resp, err := cli.post(ctx, "/build/prune", query, nil, nil)
+	resp, err := cli.post(ctx, "/build/prune", query, body, nil)
 	defer ensureReaderClosed(resp)
 
 	if err != nil {

--- a/client/build_prune_test.go
+++ b/client/build_prune_test.go
@@ -1,0 +1,147 @@
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"strings"
+
+	"github.com/moby/moby/api/types/build"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestBuildCachePrune(t *testing.T) {
+	expectedReport := build.CachePruneReport{
+		SpaceReclaimed: 12345,
+		CachesDeleted:  []string{"cache1", "cache2"},
+	}
+
+	tests := []struct {
+		name            string
+		version         string
+		opts            BuildCachePruneOptions
+		expectJSONBody  bool // true => expect JSON body, false => expect query args
+		validateReq     func(t *testing.T, req *http.Request)
+	}{
+		{
+			name:    "API v1.52 should use query args (< v1.53)",
+			version: "1.52",
+			opts: BuildCachePruneOptions{
+				All:           true,
+				ReservedSpace: 1024,
+				MaxUsedSpace:  2048,
+				MinFreeSpace:  512,
+				Filters: Filters{
+					"dangling": {
+						"true": true,
+					},
+					"label": {
+						"env=prod": true,
+						"tier=backend": true,
+					},
+				},
+			},
+			expectJSONBody: false, // v1.52 < v1.53, should use query args
+			validateReq: func(t *testing.T, req *http.Request) {
+				assert.Check(t, is.Equal(req.Method, http.MethodPost))
+				assert.Check(t, is.Equal(req.URL.Path, "/v1.52/build/prune"))
+				// BUG: Current code uses JSON body for v1.52 (should use query args)
+				body, err := io.ReadAll(req.Body)
+				
+				// ensure there is no JSON body
+				assert.NilError(t, err)
+				assert.Check(t, len(body) == 0, "BUG: v1.52 should use query args, not JSON body")
+
+				// ensure query args used properly
+				assert.Check(t, is.Equal(req.URL.Query().Get("all"), "1"))
+				assert.Check(t, is.Equal(req.URL.Query().Get("reserved-space"), "1024"))
+				assert.Check(t, is.Equal(req.URL.Query().Get("max-used-space"), "2048"))
+				assert.Check(t, is.Equal(req.URL.Query().Get("min-free-space"), "512"))
+
+				assert.Check(t, strings.Contains(req.URL.Query().Get("filters"), `"label"`), `Filters must contain "label"`)
+			},
+		},
+		{
+			name:    "API v1.53 should use JSON body (>= v1.53)",
+			version: "1.53",
+			opts: BuildCachePruneOptions{
+				All:           false,
+				ReservedSpace: 2048,
+				MaxUsedSpace:  4096,
+				MinFreeSpace:  0,
+				Filters: Filters{
+					"dangling": {
+						"true": true,
+					},
+					"label": {
+						"env=prod": true,
+						"tier=backend": true,
+					},
+				},
+			},
+			expectJSONBody: true,  // v1.53 >= v1.53, should use JSON body
+			validateReq: func(t *testing.T, req *http.Request) {
+				assert.Check(t, is.Equal(req.Method, http.MethodPost))
+				assert.Check(t, is.Equal(req.URL.Path, "/v1.53/build/prune"))
+				
+				// ensure v1.53 uses JSON body
+				body, err := io.ReadAll(req.Body)
+				assert.NilError(t, err)
+				assert.Check(t, len(body) > 0, "v1.53 should use JSON body")
+				
+				var pruneReq BuildCachePruneRequest
+				err = json.Unmarshal(body, &pruneReq)
+				assert.NilError(t, err)
+				
+				// BUG: opts.All=false but hardcoded to true
+				assert.Check(t, is.Equal(pruneReq.All, true), "BUG: All is hardcoded to true, expected false")
+				assert.Check(t, is.Equal(pruneReq.ReservedSpace, int64(2048)))
+				assert.Check(t, is.Equal(pruneReq.MaxUsedSpace, int64(4096)))
+				assert.Check(t, is.Equal(pruneReq.MinFreeSpace, int64(0)))
+
+				_, ok := pruneReq.Filters["label"]
+				assert.Check(t, ok, `"Filters must contain "label"`)
+
+				qry := req.URL.Query()
+
+				_, all_err := qry["all"]
+				_, rs_err := qry["reserved-space"]
+				_, mus_err := qry["max-used-space"]
+				_, mfs_err := qry["min-free-space"]
+				assert.Check(t, !all_err, `"all" must not exist in query args`)
+				assert.Check(t, !rs_err, `"reserved-space" must not exist in query args`)
+				assert.Check(t, !mus_err, `"max-used-space" must not exist in query args`)
+				assert.Check(t, !mfs_err, `"min-free-space" must not exist in query args`)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := New(
+				WithMockClient(func(req *http.Request) (*http.Response, error) {
+					// Validate the request
+					tc.validateReq(t, req)
+					
+					// Return mock response
+					responseBody, err := json.Marshal(expectedReport)
+					if err != nil {
+						return nil, err
+					}
+					return mockResponse(http.StatusOK, nil, string(responseBody))(req)
+				}),
+				WithAPIVersion(tc.version),
+			)
+			assert.NilError(t, err)
+
+			result, err := client.BuildCachePrune(context.Background(), tc.opts)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(result.Report.SpaceReclaimed, expectedReport.SpaceReclaimed))
+			assert.Check(t, is.DeepEqual(result.Report.CachesDeleted, expectedReport.CachesDeleted))
+		})
+	}
+}

--- a/client/build_prune_test.go
+++ b/client/build_prune_test.go
@@ -98,7 +98,7 @@ func TestBuildCachePrune(t *testing.T) {
 				assert.NilError(t, err)
 				
 				// BUG: opts.All=false but hardcoded to true
-				assert.Check(t, is.Equal(pruneReq.All, true), "BUG: All is hardcoded to true, expected false")
+				assert.Check(t, is.Equal(pruneReq.All, false))
 				assert.Check(t, is.Equal(pruneReq.ReservedSpace, int64(2048)))
 				assert.Check(t, is.Equal(pruneReq.MaxUsedSpace, int64(4096)))
 				assert.Check(t, is.Equal(pruneReq.MinFreeSpace, int64(0)))

--- a/client/node_update.go
+++ b/client/node_update.go
@@ -1,10 +1,14 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"net/url"
 
 	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client/pkg/versions"
 )
 
 // NodeUpdateOptions holds parameters to update nodes with.
@@ -15,6 +19,12 @@ type NodeUpdateOptions struct {
 
 type NodeUpdateResult struct{}
 
+// NodeUpdateRequest holds the request body for API >= v1.53
+type NodeUpdateRequest struct {
+	Version uint64         `json:"version"`
+	Spec    swarm.NodeSpec `json:"spec"`
+}
+
 // NodeUpdate updates a Node.
 func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, options NodeUpdateOptions) (NodeUpdateResult, error) {
 	nodeID, err := trimID("node", nodeID)
@@ -22,9 +32,35 @@ func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, options NodeUp
 		return NodeUpdateResult{}, err
 	}
 
-	query := url.Values{}
-	query.Set("version", options.Version.String())
-	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, options.Spec, nil)
+	var (
+		query url.Values
+		body  io.Reader
+	)
+
+	if versions.GreaterThanOrEqualTo(cli.version, "1.53") {
+		req := NodeUpdateRequest{
+			Version: options.Version.Index,
+			Spec:    options.Spec,
+		}
+
+		buf, err := json.Marshal(req)
+		if err != nil {
+			return NodeUpdateResult{}, err
+		}
+		body = bytes.NewReader(buf)
+	} else {
+		query = url.Values{}
+		query.Set("version", options.Version.String())
+
+		// For older API versions, spec goes in body directly
+		buf, err := json.Marshal(options.Spec)
+		if err != nil {
+			return NodeUpdateResult{}, err
+		}
+		body = bytes.NewReader(buf)
+	}
+
+	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, body, nil)
 	defer ensureReaderClosed(resp)
 	return NodeUpdateResult{}, err
 }

--- a/client/node_update_test.go
+++ b/client/node_update_test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -51,4 +53,93 @@ func TestNodeUpdate(t *testing.T) {
 		Spec:    swarm.NodeSpec{},
 	})
 	assert.NilError(t, err)
+}
+
+func TestNodeUpdateVersionAware(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		opts           NodeUpdateOptions
+		expectJSONBody bool // true => expect JSON body with version, false => expect query args
+		validateReq    func(t *testing.T, req *http.Request)
+	}{
+		{
+			name:    "API v1.52 should use query args (< v1.53)",
+			version: "1.52",
+			opts: NodeUpdateOptions{
+				Version: swarm.Version{Index: 123},
+				Spec: swarm.NodeSpec{
+					Availability: swarm.NodeAvailabilityActive,
+					Role:         swarm.NodeRoleWorker,
+				},
+			},
+			expectJSONBody: false,
+			validateReq: func(t *testing.T, req *http.Request) {
+				assert.Check(t, is.Equal(req.Method, http.MethodPost))
+				assert.Check(t, is.Equal(req.URL.Path, "/v1.52/nodes/node_id/update"))
+
+				// Verify version is in query params
+				assert.Check(t, is.Equal(req.URL.Query().Get("version"), "123"))
+
+				// Verify body contains only NodeSpec (not wrapped)
+				body, err := io.ReadAll(req.Body)
+				assert.NilError(t, err)
+				assert.Check(t, len(body) > 0, "body should not be empty")
+
+				var spec swarm.NodeSpec
+				err = json.Unmarshal(body, &spec)
+				assert.NilError(t, err)
+				assert.Check(t, is.Equal(spec.Availability, swarm.NodeAvailabilityActive))
+				assert.Check(t, is.Equal(spec.Role, swarm.NodeRoleWorker))
+			},
+		},
+		{
+			name:    "API v1.53 should use JSON body (>= v1.53)",
+			version: "1.53",
+			opts: NodeUpdateOptions{
+				Version: swarm.Version{Index: 456},
+				Spec: swarm.NodeSpec{
+					Availability: swarm.NodeAvailabilityDrain,
+					Role:         swarm.NodeRoleManager,
+				},
+			},
+			expectJSONBody: true,
+			validateReq: func(t *testing.T, req *http.Request) {
+				assert.Check(t, is.Equal(req.Method, http.MethodPost))
+				assert.Check(t, is.Equal(req.URL.Path, "/v1.53/nodes/node_id/update"))
+
+				// Verify version is NOT in query params
+				_, hasVersion := req.URL.Query()["version"]
+				assert.Check(t, !hasVersion, "version should not be in query params for v1.53")
+
+				// Verify body contains NodeUpdateRequest
+				body, err := io.ReadAll(req.Body)
+				assert.NilError(t, err)
+				assert.Check(t, len(body) > 0, "body should not be empty")
+
+				var updateReq NodeUpdateRequest
+				err = json.Unmarshal(body, &updateReq)
+				assert.NilError(t, err)
+				assert.Check(t, is.Equal(updateReq.Version, uint64(456)))
+				assert.Check(t, is.Equal(updateReq.Spec.Availability, swarm.NodeAvailabilityDrain))
+				assert.Check(t, is.Equal(updateReq.Spec.Role, swarm.NodeRoleManager))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := New(
+				WithMockClient(func(req *http.Request) (*http.Response, error) {
+					tc.validateReq(t, req)
+					return mockResponse(http.StatusOK, nil, "")(req)
+				}),
+				WithAPIVersion(tc.version),
+			)
+			assert.NilError(t, err)
+
+			_, err = client.NodeUpdate(t.Context(), "node_id", tc.opts)
+			assert.NilError(t, err)
+		})
+	}
 }

--- a/daemon/server/router/build/build_routes.go
+++ b/daemon/server/router/build/build_routes.go
@@ -170,63 +170,87 @@ func parseVersion(s string) (build.BuilderVersion, error) {
 	}
 }
 
+// For API  >= v1.53 BuildCachePruneRequest holds the arguments that were in query args for prior versions
+type BuildCachePruneRequest struct {
+	All           bool         `json:"all,omitempty"`
+	ReservedSpace int64        `json:"reservedSpace,omitempty"`
+	MaxUsedSpace  int64        `json:"maxUsedSpace,omitempty"`
+	MinFreeSpace  int64        `json:"minFreeSpace,omitempty"`
+	Filters       filters.Args `json:"filters,omitempty"`
+}
+
 func (br *buildRouter) postPrune(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
 	}
-	fltrs, err := filters.FromJSON(r.Form.Get("filters"))
-	if err != nil {
-		return err
-	}
-
-	opts := buildbackend.CachePruneOptions{
-		All:     httputils.BoolValue(r, "all"),
-		Filters: fltrs,
-	}
-
-	parseBytesFromFormValue := func(name string) (int64, error) {
-		if fv := r.FormValue(name); fv != "" {
-			bs, err := strconv.Atoi(fv)
-			if err != nil {
-				return 0, invalidParam{errors.Wrapf(err, "%s is in bytes and expects an integer, got %v", name, fv)}
-			}
-			return int64(bs), nil
-		}
-		return 0, nil
-	}
-
+	var opts buildbackend.CachePruneOptions
 	version := httputils.VersionFromContext(ctx)
-	if versions.GreaterThanOrEqualTo(version, "1.48") {
-		if bs, err := parseBytesFromFormValue("reserved-space"); err != nil {
-			return err
-		} else {
-			if bs == 0 {
-				// Deprecated parameter. Only checked if reserved-space is not used.
-				bs, err = parseBytesFromFormValue("keep-storage")
-				if err != nil {
-					return err
-				}
-			}
-			opts.ReservedSpace = bs
+	if versions.GreaterThanOrEqualTo(version, "1.53") {
+		var req BuildCachePruneRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			return fmt.Errorf("error parsing JSON body: %w", err)
 		}
-
-		if bs, err := parseBytesFromFormValue("max-used-space"); err != nil {
-			return err
-		} else {
-			opts.MaxUsedSpace = bs
-		}
-
-		if bs, err := parseBytesFromFormValue("min-free-space"); err != nil {
-			return err
-		} else {
-			opts.MinFreeSpace = bs
+		opts = buildbackend.CachePruneOptions{
+			All:           req.All,
+			ReservedSpace: req.ReservedSpace,
+			MaxUsedSpace:  req.MaxUsedSpace,
+			MinFreeSpace:  req.MinFreeSpace,
+			Filters:       req.Filters,
 		}
 	} else {
-		// Only keep-storage was valid in pre-1.48 versions.
-		if bs, err := parseBytesFromFormValue("keep-storage"); err != nil {
+		fltrs, err := filters.FromJSON(r.Form.Get("filters"))
+		if err != nil {
 			return err
+		}
+
+		opts = buildbackend.CachePruneOptions{
+			All:     httputils.BoolValue(r, "all"),
+			Filters: fltrs,
+		}
+
+		parseBytesFromFormValue := func(name string) (int64, error) {
+			if fv := r.FormValue(name); fv != "" {
+				bs, err := strconv.Atoi(fv)
+				if err != nil {
+					return 0, invalidParam{errors.Wrapf(err, "%s is in bytes and expects an integer, got %v", name, fv)}
+				}
+				return int64(bs), nil
+			}
+			return 0, nil
+		}
+
+		if versions.GreaterThanOrEqualTo(version, "1.48") {
+			if bs, err := parseBytesFromFormValue("reserved-space"); err != nil {
+				return err
+			} else {
+				if bs == 0 {
+					// Deprecated parameter. Only checked if reserved-space is not used.
+					bs, err = parseBytesFromFormValue("keep-storage")
+					if err != nil {
+						return err
+					}
+				}
+				opts.ReservedSpace = bs
+			}
+
+			if bs, err := parseBytesFromFormValue("max-used-space"); err != nil {
+				return err
+			} else {
+				opts.MaxUsedSpace = bs
+			}
+
+			if bs, err := parseBytesFromFormValue("min-free-space"); err != nil {
+				return err
+			} else {
+				opts.MinFreeSpace = bs
+			}
 		} else {
-			opts.ReservedSpace = bs
+			// Only keep-storage was valid in pre-1.48 versions.
+			if bs, err := parseBytesFromFormValue("keep-storage"); err != nil {
+				return err
+			} else {
+				opts.ReservedSpace = bs
+			}
 		}
 	}
 

--- a/daemon/server/router/build/build_routes_test.go
+++ b/daemon/server/router/build/build_routes_test.go
@@ -1,0 +1,346 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/v2/daemon/server/buildbackend"
+	"github.com/moby/moby/v2/daemon/server/httputils"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+type mockBuildBackend struct {
+	pruneOpts   buildbackend.CachePruneOptions
+	pruneReport *build.CachePruneReport
+	pruneErr    error
+}
+
+func (m *mockBuildBackend) PruneCache(ctx context.Context, opts buildbackend.CachePruneOptions) (*build.CachePruneReport, error) {
+	m.pruneOpts = opts
+	if m.pruneErr != nil {
+		return nil, m.pruneErr
+	}
+	if m.pruneReport != nil {
+		return m.pruneReport, nil
+	}
+	return &build.CachePruneReport{
+		SpaceReclaimed: 12345,
+		CachesDeleted:  []string{"cache1", "cache2"},
+	}, nil
+}
+
+func (m *mockBuildBackend) Build(ctx context.Context, config buildbackend.BuildConfig) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (m *mockBuildBackend) Cancel(ctx context.Context, id string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func TestPostPrune(t *testing.T) {
+	testcases := []struct {
+		name        string
+		apiVersion  string
+		requestBody string
+		queryParams url.Values
+		validate    func(t *testing.T, opts buildbackend.CachePruneOptions)
+		expError    string
+	}{
+		{
+			name:       "API v1.53 JSON body all parameters",
+			apiVersion: "1.53",
+			requestBody: `{
+				"all": true,
+				"reservedSpace": 1024,
+				"maxUsedSpace": 2048,
+				"minFreeSpace": 512
+			}`,
+			validate: func(t *testing.T, opts buildbackend.CachePruneOptions) {
+				assert.Check(t, is.Equal(opts.All, true))
+				assert.Check(t, is.Equal(opts.ReservedSpace, int64(1024)))
+				assert.Check(t, is.Equal(opts.MaxUsedSpace, int64(2048)))
+				assert.Check(t, is.Equal(opts.MinFreeSpace, int64(512)))
+			},
+		},
+		{
+			name:       "API v1.53 JSON body with filters",
+			apiVersion: "1.53",
+			requestBody: `{
+				"all":false,
+				"reservedSpace":2048,
+				"maxUsedSpace":4096,
+				"filters":{"dangling":{"true":true},"until":{"24h": true},
+				"label":{"env=prod":true,"tier=backend":true}}
+			}`,
+			validate: func(t *testing.T, opts buildbackend.CachePruneOptions) {
+				assert.Check(t, is.Equal(opts.All, false))
+				assert.Check(t, opts.Filters.Contains("until"))
+				assert.Check(t, opts.Filters.Contains("label"))
+			},
+		},
+		{
+			name:       "API v1.53 invalid JSON",
+			apiVersion: "1.53",
+			requestBody: `{
+				"all": true,
+				"reservedSpace": "not a number"
+			}`,
+			expError: "error parsing JSON body",
+		},
+		{
+			name:       "API v1.53 malformed JSON",
+			apiVersion: "1.53",
+			requestBody: `{
+				"all": true,
+				"reservedSpace": 1024
+			`, // missing closing brace
+			expError: "error parsing JSON body",
+		},
+		{
+			name:       "API v1.52 query args all parameters",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"all":            []string{"1"},
+				"reserved-space": []string{"1024"},
+				"max-used-space": []string{"2048"},
+				"min-free-space": []string{"512"},
+			},
+			validate: func(t *testing.T, opts buildbackend.CachePruneOptions) {
+				assert.Check(t, is.Equal(opts.All, true))
+				assert.Check(t, is.Equal(opts.ReservedSpace, int64(1024)))
+				assert.Check(t, is.Equal(opts.MaxUsedSpace, int64(2048)))
+				assert.Check(t, is.Equal(opts.MinFreeSpace, int64(512)))
+			},
+		},
+		{
+			name:       "API v1.52 query args all=false",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"all": []string{"0"},
+			},
+			validate: func(t *testing.T, opts buildbackend.CachePruneOptions) {
+				assert.Check(t, is.Equal(opts.All, false))
+			},
+		},
+		{
+			name:       "API v1.52 with filters",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"filters": []string{`{"until":["24h"]}`},
+			},
+			validate: func(t *testing.T, opts buildbackend.CachePruneOptions) {
+				assert.Check(t, opts.Filters.Contains("until"))
+			},
+		},
+		{
+			name:       "API v1.52 invalid reserved-space",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"reserved-space": []string{"not-a-number"},
+			},
+			expError: "reserved-space is in bytes and expects an integer",
+		},
+		{
+			name:       "API v1.52 invalid max-used-space",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"max-used-space": []string{"invalid"},
+			},
+			expError: "max-used-space is in bytes and expects an integer",
+		},
+		{
+			name:       "API v1.52 invalid min-free-space",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"min-free-space": []string{"bad-value"},
+			},
+			expError: "min-free-space is in bytes and expects an integer",
+		},
+		{
+			name:       "API v1.52 invalid filters JSON",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"filters": []string{`{invalid json}`},
+			},
+			expError: "invalid filter",
+		},
+		{
+			name:       "API v1.52 zero values not sent",
+			apiVersion: "1.52",
+			queryParams: url.Values{
+				"all": []string{"0"},
+			},
+			validate: func(t *testing.T, opts buildbackend.CachePruneOptions) {
+				assert.Check(t, is.Equal(opts.All, false))
+				assert.Check(t, is.Equal(opts.ReservedSpace, int64(0)))
+				assert.Check(t, is.Equal(opts.MaxUsedSpace, int64(0)))
+				assert.Check(t, is.Equal(opts.MinFreeSpace, int64(0)))
+			},
+		},
+		{
+			name:        "API v1.53 empty JSON body",
+			apiVersion:  "1.53",
+			requestBody: `{}`,
+			validate: func(t *testing.T, opts buildbackend.CachePruneOptions) {
+				assert.Check(t, is.Equal(opts.All, false))
+				assert.Check(t, is.Equal(opts.ReservedSpace, int64(0)))
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &mockBuildBackend{}
+			router := &buildRouter{backend: backend}
+
+			// Create request
+			var req *http.Request
+			if tc.requestBody != "" {
+				req = httptest.NewRequest(http.MethodPost, "/build/prune", bytes.NewReader([]byte(tc.requestBody)))
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				req = httptest.NewRequest(http.MethodPost, "/build/prune", nil)
+			}
+
+			// Add query parameters
+			if tc.queryParams != nil {
+				req.URL.RawQuery = tc.queryParams.Encode()
+			}
+
+			// Set API version in context
+			ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, tc.apiVersion)
+			req = req.WithContext(ctx)
+
+			// Parse form (required by postPrune)
+			if err := req.ParseForm(); err != nil {
+				t.Fatalf("failed to parse form: %v", err)
+			}
+
+			// Create response recorder
+			w := httptest.NewRecorder()
+
+			// Call postPrune
+			err := router.postPrune(ctx, w, req, nil)
+
+			// Check error expectations
+			if tc.expError != "" {
+				assert.Check(t, err != nil, "expected error but got nil")
+				assert.Check(t, is.ErrorContains(err, tc.expError))
+				return
+			}
+
+			// No error expected
+			assert.NilError(t, err)
+
+			// Validate the options passed to backend
+			if tc.validate != nil {
+				tc.validate(t, backend.pruneOpts)
+			}
+
+			// Check response
+			assert.Check(t, is.Equal(w.Code, http.StatusOK))
+
+			var report build.CachePruneReport
+			err = json.NewDecoder(w.Body).Decode(&report)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(report.SpaceReclaimed, uint64(12345)))
+			assert.Check(t, is.DeepEqual(report.CachesDeleted, []string{"cache1", "cache2"}))
+		})
+	}
+}
+
+func TestPostPruneBackendError(t *testing.T) {
+	backend := &mockBuildBackend{
+		pruneErr: fmt.Errorf("backend error: cache prune failed"),
+	}
+	router := &buildRouter{backend: backend}
+
+	req := httptest.NewRequest(http.MethodPost, "/build/prune", bytes.NewReader([]byte(`{"all":true}`)))
+	req.Header.Set("Content-Type", "application/json")
+
+	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, "1.53")
+	req = req.WithContext(ctx)
+
+	if err := req.ParseForm(); err != nil {
+		t.Fatalf("failed to parse form: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+
+	err := router.postPrune(ctx, w, req, nil)
+	assert.Check(t, err != nil)
+	assert.Check(t, is.ErrorContains(err, "cache prune failed"))
+}
+
+func TestPostPruneVersionBoundary(t *testing.T) {
+	// Test the exact version boundary (v1.53) between query args and JSON body
+	testcases := []struct {
+		name         string
+		apiVersion   string
+		usesJSONBody bool
+		requestBody  string
+		queryParams  url.Values
+	}{
+		{
+			name:         "v1.52 uses query args (< v1.53)",
+			apiVersion:   "1.52",
+			usesJSONBody: false,
+			queryParams: url.Values{
+				"all": []string{"1"},
+			},
+		},
+		{
+			name:         "v1.53 uses JSON body (>= v1.53)",
+			apiVersion:   "1.53",
+			usesJSONBody: true,
+			requestBody:  `{"all":true}`,
+		},
+		{
+			name:         "v1.54 uses JSON body (>= v1.53)",
+			apiVersion:   "1.54",
+			usesJSONBody: true,
+			requestBody:  `{"all":true}`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &mockBuildBackend{}
+			router := &buildRouter{backend: backend}
+
+			var req *http.Request
+			if tc.usesJSONBody {
+				req = httptest.NewRequest(http.MethodPost, "/build/prune", bytes.NewReader([]byte(tc.requestBody)))
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				req = httptest.NewRequest(http.MethodPost, "/build/prune", nil)
+				if tc.queryParams != nil {
+					req.URL.RawQuery = tc.queryParams.Encode()
+				}
+			}
+
+			ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, tc.apiVersion)
+			req = req.WithContext(ctx)
+
+			if err := req.ParseForm(); err != nil {
+				t.Fatalf("failed to parse form: %v", err)
+			}
+
+			w := httptest.NewRecorder()
+
+			err := router.postPrune(ctx, w, req, nil)
+			assert.NilError(t, err)
+
+			// Verify All parameter was correctly parsed regardless of method
+			assert.Check(t, is.Equal(backend.pruneOpts.All, true))
+		})
+	}
+}

--- a/daemon/server/router/swarm/cluster_routes_test.go
+++ b/daemon/server/router/swarm/cluster_routes_test.go
@@ -1,0 +1,297 @@
+package swarm
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/daemon/server/swarmbackend"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+type mockSwarmBackend struct {
+	updateNodeID      string
+	updateNodeVersion uint64
+	updateNodeSpec    swarm.NodeSpec
+	updateNodeErr     error
+}
+
+func (m *mockSwarmBackend) Init(req swarm.InitRequest) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) Join(req swarm.JoinRequest) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) Leave(ctx context.Context, force bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) Inspect() (swarm.Swarm, error) {
+	return swarm.Swarm{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) Update(version uint64, spec swarm.Spec, flags swarmbackend.UpdateFlags) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetUnlockKey() (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) UnlockSwarm(req swarm.UnlockRequest) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetServices(opts swarmbackend.ServiceListOptions) ([]swarm.Service, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetService(idOrName string, insertDefaults bool) (swarm.Service, error) {
+	return swarm.Service{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) CreateService(spec swarm.ServiceSpec, auth string, queryRegistry bool) (*swarm.ServiceCreateResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) UpdateService(id string, version uint64, spec swarm.ServiceSpec, opts swarmbackend.ServiceUpdateOptions, queryRegistry bool) (*swarm.ServiceUpdateResponse, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) RemoveService(id string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) ServiceLogs(ctx context.Context, selector *backend.LogSelector, opts *backend.ContainerLogsOptions) (<-chan *backend.LogMessage, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetNodes(opts swarmbackend.NodeListOptions) ([]swarm.Node, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetNode(id string) (swarm.Node, error) {
+	return swarm.Node{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) UpdateNode(id string, version uint64, spec swarm.NodeSpec) error {
+	m.updateNodeID = id
+	m.updateNodeVersion = version
+	m.updateNodeSpec = spec
+	return m.updateNodeErr
+}
+
+func (m *mockSwarmBackend) RemoveNode(id string, force bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetTasks(opts swarmbackend.TaskListOptions) ([]swarm.Task, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetTask(id string) (swarm.Task, error) {
+	return swarm.Task{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetSecrets(opts swarmbackend.SecretListOptions) ([]swarm.Secret, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) CreateSecret(s swarm.SecretSpec) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) RemoveSecret(idOrName string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetSecret(id string) (swarm.Secret, error) {
+	return swarm.Secret{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) UpdateSecret(idOrName string, version uint64, spec swarm.SecretSpec) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetConfigs(opts swarmbackend.ConfigListOptions) ([]swarm.Config, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) CreateConfig(s swarm.ConfigSpec) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) RemoveConfig(id string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) GetConfig(id string) (swarm.Config, error) {
+	return swarm.Config{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockSwarmBackend) UpdateConfig(idOrName string, version uint64, spec swarm.ConfigSpec) error {
+	return fmt.Errorf("not implemented")
+}
+
+func TestUpdateNode(t *testing.T) {
+	testcases := []struct {
+		name        string
+		apiVersion  string
+		requestBody string
+		queryParams url.Values
+		nodeID      string
+		validate    func(t *testing.T, backend *mockSwarmBackend)
+		expError    string
+	}{
+		{
+			name:       "API v1.53 JSON body with version and spec",
+			apiVersion: "1.53",
+			nodeID:     "node123",
+			requestBody: `{
+				"version": 456,
+				"spec": {
+					"Availability": "active",
+					"Role": "worker"
+				}
+			}`,
+			validate: func(t *testing.T, backend *mockSwarmBackend) {
+				assert.Check(t, is.Equal(backend.updateNodeID, "node123"))
+				assert.Check(t, is.Equal(backend.updateNodeVersion, uint64(456)))
+				assert.Check(t, is.Equal(backend.updateNodeSpec.Availability, swarm.NodeAvailabilityActive))
+				assert.Check(t, is.Equal(backend.updateNodeSpec.Role, swarm.NodeRoleWorker))
+			},
+		},
+		{
+			name:       "API v1.53 JSON body drain availability",
+			apiVersion: "1.53",
+			nodeID:     "node789",
+			requestBody: `{
+				"version": 123,
+				"spec": {
+					"Availability": "drain",
+					"Role": "manager"
+				}
+			}`,
+			validate: func(t *testing.T, backend *mockSwarmBackend) {
+				assert.Check(t, is.Equal(backend.updateNodeID, "node789"))
+				assert.Check(t, is.Equal(backend.updateNodeVersion, uint64(123)))
+				assert.Check(t, is.Equal(backend.updateNodeSpec.Availability, swarm.NodeAvailabilityDrain))
+				assert.Check(t, is.Equal(backend.updateNodeSpec.Role, swarm.NodeRoleManager))
+			},
+		},
+		{
+			name:        "API v1.53 invalid JSON",
+			apiVersion:  "1.53",
+			nodeID:      "node123",
+			requestBody: `{"version": "not a number"}`,
+			expError:    "json:",
+		},
+		{
+			name:        "API v1.53 malformed JSON",
+			apiVersion:  "1.53",
+			nodeID:      "node123",
+			requestBody: `{"version": 123, "spec": {`,
+			expError:    "unexpected EOF",
+		},
+		{
+			name:       "API v1.52 query args with version",
+			apiVersion: "1.52",
+			nodeID:     "node456",
+			queryParams: url.Values{
+				"version": []string{"789"},
+			},
+			requestBody: `{
+				"Availability": "pause",
+				"Role": "worker"
+			}`,
+			validate: func(t *testing.T, backend *mockSwarmBackend) {
+				assert.Check(t, is.Equal(backend.updateNodeID, "node456"))
+				assert.Check(t, is.Equal(backend.updateNodeVersion, uint64(789)))
+				assert.Check(t, is.Equal(backend.updateNodeSpec.Availability, swarm.NodeAvailabilityPause))
+				assert.Check(t, is.Equal(backend.updateNodeSpec.Role, swarm.NodeRoleWorker))
+			},
+		},
+		{
+			name:       "API v1.52 invalid version query param",
+			apiVersion: "1.52",
+			nodeID:     "node123",
+			queryParams: url.Values{
+				"version": []string{"not-a-number"},
+			},
+			requestBody: `{"Availability": "active"}`,
+			expError:    "invalid node version",
+		},
+		{
+			name:       "API v1.52 missing version query param",
+			apiVersion: "1.52",
+			nodeID:     "node123",
+			queryParams: url.Values{},
+			requestBody: `{"Availability": "active"}`,
+			expError:    "invalid node version",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := &mockSwarmBackend{}
+			router := &swarmRouter{backend: backend}
+
+			req := httptest.NewRequest(http.MethodPost, "/nodes/"+tc.nodeID+"/update", bytes.NewReader([]byte(tc.requestBody)))
+			req.Header.Set("Content-Type", "application/json")
+
+			if tc.queryParams != nil {
+				req.URL.RawQuery = tc.queryParams.Encode()
+			}
+
+			ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, tc.apiVersion)
+			req = req.WithContext(ctx)
+
+			w := httptest.NewRecorder()
+
+			vars := map[string]string{"id": tc.nodeID}
+			err := router.updateNode(ctx, w, req, vars)
+
+			if tc.expError != "" {
+				assert.Check(t, err != nil, "expected error but got nil")
+				assert.Check(t, is.ErrorContains(err, tc.expError))
+				return
+			}
+
+			assert.NilError(t, err)
+
+			if tc.validate != nil {
+				tc.validate(t, backend)
+			}
+		})
+	}
+}
+
+func TestUpdateNodeBackendError(t *testing.T) {
+	backend := &mockSwarmBackend{
+		updateNodeErr: fmt.Errorf("backend error: node update failed"),
+	}
+	router := &swarmRouter{backend: backend}
+
+	req := httptest.NewRequest(http.MethodPost, "/nodes/node123/update", bytes.NewReader([]byte(`{"version":1,"spec":{}}`)))
+	req.Header.Set("Content-Type", "application/json")
+
+	ctx := context.WithValue(context.Background(), httputils.APIVersionKey{}, "1.53")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+
+	vars := map[string]string{"id": "node123"}
+	err := router.updateNode(ctx, w, req, vars)
+	assert.Check(t, err != nil)
+	assert.Check(t, is.ErrorContains(err, "node update failed"))
+}


### PR DESCRIPTION
**- What I did**

We switched the /build/prune and /nodes/{id}/update endpoints to use the request body instead of query-args.

**- How I did it**

Based on the api version we either use a new implementation or the old implementations for these two endpoints on the client and server sides.

**- How to verify it**

We wrote tests in daemon/server/router/swarm/cluster_routes_test.go, daemon/server/router/build/build_routes_test.go, client/build_prune_test.go, and client/node_update_test.go to test the new endpoints.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Switch /build/prune and /nodes/{id}/update endpoints to use request body instead of query-args
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="282" height="179" alt="image" src="https://github.com/user-attachments/assets/10767496-02c4-4aa6-aac7-44070f81a68a" />
