### PR TITLE
hack: Restore rootlesskit and tini installers

### DIFF
--- a/hack/dockerfile/install/install.sh
+++ b/hack/dockerfile/install/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+set -x
+
+RM_GOPATH=0
+
+TMP_GOPATH=${TMP_GOPATH:-""}
+
+: ${PREFIX:="/usr/local/bin"}
+
+if [ -z "$TMP_GOPATH" ]; then
+	export GOPATH="$(mktemp -d)"
+	RM_GOPATH=1
+else
+	export GOPATH="$TMP_GOPATH"
+fi
+case "$(go env GOARCH)" in
+	mips* | ppc64)
+		# pie build mode is not supported on mips architectures
+		export GO_BUILDMODE=""
+		;;
+	*)
+		export GO_BUILDMODE="-buildmode=pie"
+		;;
+esac
+
+dir="$(dirname $0)"
+
+bin=$1
+shift
+
+if [ ! -f "${dir}/${bin}.installer" ]; then
+	echo "Could not find installer for \"$bin\""
+	exit 1
+fi
+
+. ${dir}/${bin}.installer
+install_${bin} "$@"

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# When updating, also update go.mod and Dockerfile accordingly.
+: "${ROOTLESSKIT_VERSION:=v2.3.5}"
+
+install_rootlesskit() {
+	case "$1" in
+		"dynamic")
+			install_rootlesskit_dynamic
+			return
+			;;
+		"")
+			export CGO_ENABLED=0
+			_install_rootlesskit
+			;;
+		*)
+			echo 'Usage: $0 [dynamic]'
+			;;
+	esac
+}
+
+install_rootlesskit_dynamic() {
+	export ROOTLESSKIT_LDFLAGS="-linkmode=external" install_rootlesskit
+	export BUILD_MODE=${GO_BUILDMODE}
+	_install_rootlesskit
+}
+
+_install_rootlesskit() (
+	echo "Install rootlesskit version ${ROOTLESSKIT_VERSION}"
+	GOBIN="${PREFIX}" go install ${BUILD_MODE} -ldflags="$ROOTLESSKIT_LDFLAGS" "github.com/rootless-containers/rootlesskit/v2/cmd/rootlesskit@${ROOTLESSKIT_VERSION}"
+)

--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# TINI_VERSION specifies the version of tini (docker-init) to build, and install
+# from the https://github.com/krallin/tini repository. This binary is used
+# when starting containers with the `--init` option.
+: "${TINI_VERSION:=v0.19.0}"
+
+install_tini() {
+	echo "Install tini version $TINI_VERSION"
+	git clone https://github.com/krallin/tini.git "$GOPATH/tini"
+	cd "$GOPATH/tini"
+	git checkout -q "$TINI_VERSION"
+	cmake .
+	make tini-static
+	mkdir -p "${PREFIX}"
+	cp tini-static "${PREFIX}/docker-init"
+}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/51640

Revert a part of 9e72c44daea2cbc485dd0c3d43c161c3fe156711

These are still used by packaging scripts.
