### PR TITLE
WIP: client/pull: Use ImagePullJSONMessage type

### DIFF
--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -14,8 +14,15 @@ import (
 	"github.com/moby/moby/client/internal"
 )
 
+type OCIRegistryError struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message,omitempty"`
+	Detail  interface{} `json:"detail,omitempty"`
+}
+
 type ImagePullJSONMessage struct {
 	jsonstream.Message
+	RegistryErrors []OCIRegistryError
 }
 
 type ImagePullResponse interface {

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -60,7 +60,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		return nil, err
 	}
 
-	return internal.NewJSONMessageStream(resp.Body), nil
+	return internal.NewJSONMessageStream[jsonstream.Message](resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/client/image_pull.go
+++ b/client/image_pull.go
@@ -14,9 +14,13 @@ import (
 	"github.com/moby/moby/client/internal"
 )
 
+type ImagePullJSONMessage struct {
+	jsonstream.Message
+}
+
 type ImagePullResponse interface {
 	io.ReadCloser
-	JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error]
+	JSONMessages(ctx context.Context) iter.Seq2[ImagePullJSONMessage, error]
 	Wait(ctx context.Context) error
 }
 
@@ -60,7 +64,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		return nil, err
 	}
 
-	return internal.NewJSONMessageStream[jsonstream.Message](resp.Body), nil
+	return internal.NewJSONMessageStream[ImagePullJSONMessage](resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/client/image_pull_test.go
+++ b/client/image_pull_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
-	"github.com/moby/moby/api/types/jsonstream"
 	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client/internal"
 	"gotest.tools/v3/assert"
@@ -190,10 +189,10 @@ func TestImagePullWithoutErrors(t *testing.T) {
 
 func TestImagePullResponse(t *testing.T) {
 	r, w := io.Pipe()
-	response := internal.NewJSONMessageStream(r)
+	response := internal.NewJSONMessageStream[ImagePullJSONMessage](r)
 	ctx, cancel := context.WithCancel(t.Context())
 	messages := response.JSONMessages(ctx)
-	c := make(chan jsonstream.Message)
+	c := make(chan ImagePullJSONMessage)
 	go func() {
 		for message, err := range messages {
 			if err != nil {

--- a/client/image_push.go
+++ b/client/image_push.go
@@ -70,7 +70,7 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options ImagePus
 	if err != nil {
 		return nil, err
 	}
-	return internal.NewJSONMessageStream(resp.Body), nil
+	return internal.NewJSONMessageStream[jsonstream.Message](resp.Body), nil
 }
 
 func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, resolveAuth registry.RequestAuthConfig) (*http.Response, error) {

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -7,27 +7,25 @@ import (
 	"io"
 	"iter"
 	"sync"
-
-	"github.com/moby/moby/api/types/jsonstream"
 )
 
-func NewJSONMessageStream(rc io.ReadCloser) stream {
+func NewJSONMessageStream[T any](rc io.ReadCloser) stream[T] {
 	if rc == nil {
 		panic("nil io.ReadCloser")
 	}
-	return stream{
+	return stream[T]{
 		rc:    rc,
 		close: sync.OnceValue(rc.Close),
 	}
 }
 
-type stream struct {
+type stream[T any] struct {
 	rc    io.ReadCloser
 	close func() error
 }
 
 // Read implements io.ReadCloser
-func (r stream) Read(p []byte) (n int, err error) {
+func (r stream[T]) Read(p []byte) (n int, err error) {
 	if r.rc == nil {
 		return 0, io.EOF
 	}
@@ -35,7 +33,7 @@ func (r stream) Read(p []byte) (n int, err error) {
 }
 
 // Close implements io.ReadCloser
-func (r stream) Close() error {
+func (r stream[T]) Close() error {
 	if r.close == nil {
 		return nil
 	}
@@ -44,15 +42,15 @@ func (r stream) Close() error {
 
 // JSONMessages decodes the response stream as a sequence of JSONMessages.
 // if stream ends or context is cancelled, the underlying [io.Reader] is closed.
-func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error] {
+func (r stream[T]) JSONMessages(ctx context.Context) iter.Seq2[T, error] {
 	context.AfterFunc(ctx, func() {
 		_ = r.Close()
 	})
 	dec := json.NewDecoder(r)
-	return func(yield func(jsonstream.Message, error) bool) {
+	return func(yield func(T, error) bool) {
 		defer r.Close()
 		for {
-			var jm jsonstream.Message
+			var jm T
 			err := dec.Decode(&jm)
 			if errors.Is(err, io.EOF) {
 				break
@@ -69,7 +67,7 @@ func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 }
 
 // Wait waits for operation to complete and detects errors reported as JSONMessage
-func (r stream) Wait(ctx context.Context) error {
+func (r stream[T]) Wait(ctx context.Context) error {
 	for _, err := range r.JSONMessages(ctx) {
 		if err != nil {
 			return err

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -14,8 +14,15 @@ import (
 	"github.com/moby/moby/client/internal"
 )
 
+type OCIRegistryError struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message,omitempty"`
+	Detail  interface{} `json:"detail,omitempty"`
+}
+
 type ImagePullJSONMessage struct {
 	jsonstream.Message
+	RegistryErrors []OCIRegistryError
 }
 
 type ImagePullResponse interface {

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -60,7 +60,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		return nil, err
 	}
 
-	return internal.NewJSONMessageStream(resp.Body), nil
+	return internal.NewJSONMessageStream[jsonstream.Message](resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/vendor/github.com/moby/moby/client/image_pull.go
+++ b/vendor/github.com/moby/moby/client/image_pull.go
@@ -14,9 +14,13 @@ import (
 	"github.com/moby/moby/client/internal"
 )
 
+type ImagePullJSONMessage struct {
+	jsonstream.Message
+}
+
 type ImagePullResponse interface {
 	io.ReadCloser
-	JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error]
+	JSONMessages(ctx context.Context) iter.Seq2[ImagePullJSONMessage, error]
 	Wait(ctx context.Context) error
 }
 
@@ -60,7 +64,7 @@ func (cli *Client) ImagePull(ctx context.Context, refStr string, options ImagePu
 		return nil, err
 	}
 
-	return internal.NewJSONMessageStream[jsonstream.Message](resp.Body), nil
+	return internal.NewJSONMessageStream[ImagePullJSONMessage](resp.Body), nil
 }
 
 // getAPITagFromNamedRef returns a tag from the specified reference.

--- a/vendor/github.com/moby/moby/client/image_push.go
+++ b/vendor/github.com/moby/moby/client/image_push.go
@@ -70,7 +70,7 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options ImagePus
 	if err != nil {
 		return nil, err
 	}
-	return internal.NewJSONMessageStream(resp.Body), nil
+	return internal.NewJSONMessageStream[jsonstream.Message](resp.Body), nil
 }
 
 func (cli *Client) tryImagePush(ctx context.Context, imageID string, query url.Values, resolveAuth registry.RequestAuthConfig) (*http.Response, error) {

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -7,27 +7,25 @@ import (
 	"io"
 	"iter"
 	"sync"
-
-	"github.com/moby/moby/api/types/jsonstream"
 )
 
-func NewJSONMessageStream(rc io.ReadCloser) stream {
+func NewJSONMessageStream[T any](rc io.ReadCloser) stream[T] {
 	if rc == nil {
 		panic("nil io.ReadCloser")
 	}
-	return stream{
+	return stream[T]{
 		rc:    rc,
 		close: sync.OnceValue(rc.Close),
 	}
 }
 
-type stream struct {
+type stream[T any] struct {
 	rc    io.ReadCloser
 	close func() error
 }
 
 // Read implements io.ReadCloser
-func (r stream) Read(p []byte) (n int, err error) {
+func (r stream[T]) Read(p []byte) (n int, err error) {
 	if r.rc == nil {
 		return 0, io.EOF
 	}
@@ -35,7 +33,7 @@ func (r stream) Read(p []byte) (n int, err error) {
 }
 
 // Close implements io.ReadCloser
-func (r stream) Close() error {
+func (r stream[T]) Close() error {
 	if r.close == nil {
 		return nil
 	}
@@ -44,15 +42,15 @@ func (r stream) Close() error {
 
 // JSONMessages decodes the response stream as a sequence of JSONMessages.
 // if stream ends or context is cancelled, the underlying [io.Reader] is closed.
-func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error] {
+func (r stream[T]) JSONMessages(ctx context.Context) iter.Seq2[T, error] {
 	context.AfterFunc(ctx, func() {
 		_ = r.Close()
 	})
 	dec := json.NewDecoder(r)
-	return func(yield func(jsonstream.Message, error) bool) {
+	return func(yield func(T, error) bool) {
 		defer r.Close()
 		for {
-			var jm jsonstream.Message
+			var jm T
 			err := dec.Decode(&jm)
 			if errors.Is(err, io.EOF) {
 				break
@@ -69,7 +67,7 @@ func (r stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 }
 
 // Wait waits for operation to complete and detects errors reported as JSONMessage
-func (r stream) Wait(ctx context.Context) error {
+func (r stream[T]) Wait(ctx context.Context) error {
 	for _, err := range r.JSONMessages(ctx) {
 		if err != nil {
 			return err


### PR DESCRIPTION
### client/jsonstream: Make generic

  To support types that extend the base jsonstream.Message



### client/pull: Use ImagePullJSONMessage type

  Adds a specific type for image pull JSON messages that embeds the base jsonstream.Message.

  This allows us to extend the pull-specific message.



### client/pull: Add raw OCI registry error to stream message