### PR TITLE
Add trusted identity to images

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ keywords: "API, Docker, rcli, REST, documentation"
   is enabled, this field contains information describing it.
 * `GET /events` now also supports [`application/jsonl`](https://jsonlines.org/)
   when negotiating content-type.
+* `GET /images/{name}/json` now includes an `Identity` field with trusted
+  identity and origin information for the image.
 * Deprecated: The `POST /grpc` and `POST /session` endpoints are deprecated and
   will be removed in a future version.
 

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1836,6 +1836,13 @@ definitions:
         x-nullable: true
         items:
           $ref: "#/definitions/ImageManifestSummary"
+      Identity:
+        description: |-
+          Identity holds information about the identity and origin of the image.
+          This is trusted information verified by the daemon and cannot be modified
+          by tagging an image to a different name.
+        x-nullable: true
+        $ref: "#/definitions/Identity"
       RepoTags:
         description: |
           List of image names/tags in the local image cache that reference this
@@ -1962,6 +1969,220 @@ definitions:
             format: "dateTime"
             example: "2022-02-28T14:40:02.623929178Z"
             x-nullable: true
+
+  Identity:
+    description: |-
+      Identity holds information about the identity and origin of the image.
+      This is trusted information verified by the daemon and cannot be modified
+      by tagging an image to a different name.
+    type: "object"
+    properties:
+      Signature:
+        description: |-
+          Signature contains the properties of verified signatures for the image.
+        type: "array"
+        items:
+          $ref: "#/definitions/SignatureIdentity"
+      Pull:
+        description: |-
+          Pull contains remote location information if image was created via pull.
+          If image was pulled via mirror, this contains the original repository location.
+          After successful push this images also contains the pushed repository location.
+        type: "array"
+        items:
+          $ref: "#/definitions/PullIdentity"
+      Build:
+        description: |-
+          Build contains build reference information if image was created via build.
+        type: "array"
+        items:
+          $ref: "#/definitions/BuildIdentity"
+
+  BuildIdentity:
+    description: |-
+      BuildIdentity contains build reference information if image was created via build.
+    type: "object"
+    properties:
+      Ref:
+        description: |-
+          Ref is the identifier for the build request. This reference can be used to
+          look up the build details in BuildKit history API.
+        type: "string"
+      CreatedAt:
+        description: |-
+          CreatedAt is the time when the build ran.
+        type: "string"
+        format: "date-time"
+
+  PullIdentity:
+    description: |-
+      PullIdentity contains remote location information if image was created via pull.
+      If image was pulled via mirror, this contains the original repository location.
+    type: "object"
+    properties:
+      Repository:
+        description: |-
+          Repository is the remote repository location the image was pulled from.
+        type: "string"
+
+  SignatureIdentity:
+    description: |-
+      SignatureIdentity contains the properties of verified signatures for the image.
+    type: "object"
+    properties:
+      Name:
+        description: |-
+          Name is a textual description summarizing the type of signature.
+        type: "string"
+      Timestamps:
+        description: |-
+          Timestamps contains a list of verified signed timestamps for the signature.
+        type: "array"
+        items:
+          $ref: "#/definitions/SignatureTimestamp"
+      KnownSigner:
+        description: |-
+          KnownSigner is an identifier for a special signer identity that is known to the implementation.
+        $ref: "#/definitions/KnownSignerIdentity"
+      DockerReference:
+        description: |-
+          DockerReference is the Docker image reference associated with the signature.
+          This is an optional field only present in older hashedrecord signatures.
+        type: "string"
+      Signer:
+        description: |-
+          Signer contains information about the signer certificate used to sign the image.
+        $ref: "#/definitions/SignerIdentity"
+      SignatureType:
+        description: |-
+          SignatureType is the type of signature format. E.g. "bundle-v0.3" or "hashedrecord".
+        $ref: "#/definitions/SignatureType"
+      Error:
+        description: |-
+          Error contains error information if signature verification failed.
+          Other fields will be empty in this case.
+        type: "string"
+      Warnings:
+        description: |-
+          Warnings contains any warnings that occurred during signature verification.
+          For example, if there was no internet connectivity and cached trust roots were used.
+          Warning does not indicate a failed verification but may point to configuration issues.
+        type: "array"
+        items:
+          type: "string"
+
+  SignatureTimestamp:
+    description: |-
+      SignatureTimestamp contains information about a verified signed timestamp for an image signature.
+    type: "object"
+    properties:
+      Type:
+        $ref: "#/definitions/SignatureTimestampType"
+      URI:
+        type: "string"
+      Timestamp:
+        type: "string"
+        format: "date-time"
+
+  SignatureTimestampType:
+    description: |-
+      SignatureTimestampType is the type of timestamp used in the signature.
+    type: "string"
+    enum:
+      - "Tlog"
+      - "TimestampAuthority"
+
+  SignatureType:
+    description: |-
+      SignatureType is the type of signature format.
+    type: "string"
+    enum:
+      - "bundle-v0.3"
+      - "simplesigning-v1"
+
+  KnownSignerIdentity:
+    description: |-
+      KnownSignerIdentity is an identifier for a special signer identity that is known to the implementation.
+    type: "string"
+    enum:
+      - "DHI"
+
+  SignerIdentity:
+    description: |-
+      SignerIdentity contains information about the signer certificate used to sign the image.
+    type: "object"
+    properties:
+      CertificateIssuer:
+        type: "string"
+        description: |-
+          CertificateIssuer is the certificate issuer.
+      SubjectAlternativeName:
+        type: "string"
+        description: |-
+          SubjectAlternativeName is the certificate subject alternative name.
+      Issuer:
+        type: "string"
+        description: |-
+          The OIDC issuer. Should match `iss` claim of ID token or, in the case of
+          a federated login like Dex it should match the issuer URL of the
+          upstream issuer. The issuer is not set the extensions are invalid and
+          will fail to render.
+      BuildSignerURI:
+        type: "string"
+        description: |-
+          Reference to specific build instructions that are responsible for signing.
+      BuildSignerDigest:
+        type: "string"
+        description: |-
+          Immutable reference to the specific version of the build instructions that is responsible for signing.
+      RunnerEnvironment:
+        type: "string"
+        description: |-
+          Specifies whether the build took place in platform-hosted cloud infrastructure or customer/self-hosted infrastructure.
+      SourceRepositoryURI:
+        type: "string"
+        description: |-
+          Source repository URL that the build was based on.
+      SourceRepositoryDigest:
+        type: "string"
+        description: |-
+          Immutable reference to a specific version of the source code that the build was based upon.
+      SourceRepositoryRef:
+        type: "string"
+        description: |-
+          Source Repository Ref that the build run was based upon.
+      SourceRepositoryIdentifier:
+        type: "string"
+        description: |-
+          Immutable identifier for the source repository the workflow was based upon.
+      SourceRepositoryOwnerURI:
+        type: "string"
+        description: |-
+          Source repository owner URL of the owner of the source repository that the build was based on.
+      SourceRepositoryOwnerIdentifier:
+        type: "string"
+        description: |-
+          Immutable identifier for the owner of the source repository that the workflow was based upon.
+      BuildConfigURI:
+        type: "string"
+        description: |-
+          Build Config URL to the top-level/initiating build instructions.
+      BuildConfigDigest:
+        type: "string"
+        description: |-
+          Immutable reference to the specific version of the top-level/initiating build instructions.
+      BuildTrigger:
+        type: "string"
+        description: |-
+          Event or action that initiated the build.
+      RunInvocationURI:
+        type: "string"
+        description: |-
+          Run Invocation URL to uniquely identify the build execution.
+      SourceRepositoryVisibilityAtSigning:
+        type: "string"
+        description: |-
+          Source repository visibility at the time of signing the certificate.
 
   ImageSummary:
     type: "object"

--- a/api/types/image/build_identity.go
+++ b/api/types/image/build_identity.go
@@ -1,0 +1,15 @@
+package image
+
+import (
+	"time"
+)
+
+// BuildIdentity contains build reference information if image was created via build.
+type BuildIdentity struct {
+	// Ref is the identifier for the build request. This reference can be used to
+	// look up the build details in BuildKit history API.
+	Ref string `json:"Ref,omitempty"`
+
+	// CreatedAt is the time when the build ran.
+	CreatedAt time.Time `json:"CreatedAt,omitempty"`
+}

--- a/api/types/image/identity.go
+++ b/api/types/image/identity.go
@@ -1,0 +1,15 @@
+package image
+
+// Identity holds information about the identity and origin of the image.
+// This is trusted information verified by the daemon and cannot be modified
+// by tagging an image to a different name.
+type Identity struct {
+	// Signature contains the properties of verified signatures for the image.
+	Signature []SignatureIdentity `json:"Signature,omitzero"`
+	// Pull contains remote location information if image was created via pull.
+	// If image was pulled via mirror, this contains the original repository location.
+	// After successful push this images also contains the pushed repository location.
+	Pull []PullIdentity `json:"Pull,omitzero"`
+	// Build contains build reference information if image was created via build.
+	Build []BuildIdentity `json:"Build,omitzero"`
+}

--- a/api/types/image/image_inspect.go
+++ b/api/types/image/image_inspect.go
@@ -105,4 +105,33 @@ type InspectResponse struct {
 	// WARNING: This is experimental and may change at any time without any backward
 	// compatibility.
 	Manifests []ManifestSummary `json:"Manifests,omitempty"`
+
+	// Identity holds information about the identity and origin of the image.
+	// This is trusted information verified by the daemon and cannot be modified
+	// by tagging an image to a different name.
+	Identity *Identity `json:"Identity,omitempty"`
 }
+
+// SignatureTimestampType is the type of timestamp used in the signature.
+type SignatureTimestampType string
+
+const (
+	SignatureTimestampTlog      SignatureTimestampType = "Tlog"
+	SignatureTimestampAuthority SignatureTimestampType = "TimestampAuthority"
+)
+
+// SignatureType is the type of signature format.
+type SignatureType string
+
+const (
+	SignatureTypeBundleV03       SignatureType = "bundle-v0.3"
+	SignatureTypeSimpleSigningV1 SignatureType = "simplesigning-v1"
+)
+
+// KnownSignerIdentity is an identifier for a special signer identity that is known to the implementation.
+type KnownSignerIdentity string
+
+const (
+	// KnownSignerDHI is the known identity for Docker Hardened Images.
+	KnownSignerDHI KnownSignerIdentity = "DHI"
+)

--- a/api/types/image/pull_identity.go
+++ b/api/types/image/pull_identity.go
@@ -1,0 +1,8 @@
+package image
+
+// PullIdentity contains remote location information if image was created via pull.
+// If image was pulled via mirror, this contains the original repository location.
+type PullIdentity struct {
+	// Repository is the remote repository location the image was pulled from.
+	Repository string `json:"Repository,omitempty"`
+}

--- a/api/types/image/signature_identity.go
+++ b/api/types/image/signature_identity.go
@@ -1,0 +1,26 @@
+package image
+
+// SignatureIdentity contains the properties of verified signatures for the image.
+type SignatureIdentity struct {
+	// Name is a textual description summarizing the type of signature.
+	Name string `json:"Name,omitempty"`
+	// Timestamps contains a list of verified signed timestamps for the signature.
+	Timestamps []SignatureTimestamp `json:"Timestamps,omitzero"`
+	// KnownSigner is an identifier for a special signer identity that is known to the implementation.
+	KnownSigner KnownSignerIdentity `json:"KnownSigner,omitempty"`
+	// DockerReference is the Docker image reference associated with the signature.
+	// This is an optional field only present in older hashedrecord signatures.
+	DockerReference string `json:"DockerReference,omitempty"`
+	// Signer contains information about the signer certificate used to sign the image.
+	Signer *SignerIdentity `json:"Signer,omitempty"`
+	// SignatureType is the type of signature format. E.g. "bundle-v0.3" or "hashedrecord".
+	SignatureType SignatureType `json:"SignatureType,omitempty"`
+
+	// Error contains error information if signature verification failed.
+	// Other fields will be empty in this case.
+	Error string `json:"Error,omitempty"`
+	// Warnings contains any warnings that occurred during signature verification.
+	// For example, if there was no internet connectivity and cached trust roots were used.
+	// Warning does not indicate a failed verification but may point to configuration issues.
+	Warnings []string `json:"Warnings,omitzero"`
+}

--- a/api/types/image/signature_timestamp.go
+++ b/api/types/image/signature_timestamp.go
@@ -1,0 +1,12 @@
+package image
+
+import (
+	"time"
+)
+
+// SignatureTimestamp contains information about a verified signed timestamp for an image signature.
+type SignatureTimestamp struct {
+	Type      SignatureTimestampType `json:"Type"`
+	URI       string                 `json:"URI"`
+	Timestamp time.Time              `json:"Timestamp"`
+}

--- a/api/types/image/signer_identity.go
+++ b/api/types/image/signer_identity.go
@@ -1,0 +1,57 @@
+package image
+
+// SignerIdentity contains information about the signer certificate used to sign the image.
+// This is [certificate.Summary] with deprecated fields removed and keys in Moby uppercase style.
+//
+// [certificate.Summary]: https://pkg.go.dev/github.com/sigstore/sigstore-go/pkg/fulcio/certificate#Summary
+type SignerIdentity struct {
+	CertificateIssuer      string `json:"CertificateIssuer"`
+	SubjectAlternativeName string `json:"SubjectAlternativeName"`
+	// The OIDC issuer. Should match `iss` claim of ID token or, in the case of
+	// a federated login like Dex it should match the issuer URL of the
+	// upstream issuer. The issuer is not set the extensions are invalid and
+	// will fail to render.
+	Issuer string `json:"Issuer,omitempty"` // OID 1.3.6.1.4.1.57264.1.8 and 1.3.6.1.4.1.57264.1.1 (Deprecated)
+
+	// Reference to specific build instructions that are responsible for signing.
+	BuildSignerURI string `json:"BuildSignerURI,omitempty"` // 1.3.6.1.4.1.57264.1.9
+
+	// Immutable reference to the specific version of the build instructions that is responsible for signing.
+	BuildSignerDigest string `json:"BuildSignerDigest,omitempty"` // 1.3.6.1.4.1.57264.1.10
+
+	// Specifies whether the build took place in platform-hosted cloud infrastructure or customer/self-hosted infrastructure.
+	RunnerEnvironment string `json:"RunnerEnvironment,omitempty"` // 1.3.6.1.4.1.57264.1.11
+
+	// Source repository URL that the build was based on.
+	SourceRepositoryURI string `json:"SourceRepositoryURI,omitempty"` // 1.3.6.1.4.1.57264.1.12
+
+	// Immutable reference to a specific version of the source code that the build was based upon.
+	SourceRepositoryDigest string `json:"SourceRepositoryDigest,omitempty"` // 1.3.6.1.4.1.57264.1.13
+
+	// Source Repository Ref that the build run was based upon.
+	SourceRepositoryRef string `json:"SourceRepositoryRef,omitempty"` // 1.3.6.1.4.1.57264.1.14
+
+	// Immutable identifier for the source repository the workflow was based upon.
+	SourceRepositoryIdentifier string `json:"SourceRepositoryIdentifier,omitempty"` // 1.3.6.1.4.1.57264.1.15
+
+	// Source repository owner URL of the owner of the source repository that the build was based on.
+	SourceRepositoryOwnerURI string `json:"SourceRepositoryOwnerURI,omitempty"` // 1.3.6.1.4.1.57264.1.16
+
+	// Immutable identifier for the owner of the source repository that the workflow was based upon.
+	SourceRepositoryOwnerIdentifier string `json:"SourceRepositoryOwnerIdentifier,omitempty"` // 1.3.6.1.4.1.57264.1.17
+
+	// Build Config URL to the top-level/initiating build instructions.
+	BuildConfigURI string `json:"BuildConfigURI,omitempty"` // 1.3.6.1.4.1.57264.1.18
+
+	// Immutable reference to the specific version of the top-level/initiating build instructions.
+	BuildConfigDigest string `json:"BuildConfigDigest,omitempty"` // 1.3.6.1.4.1.57264.1.19
+
+	// Event or action that initiated the build.
+	BuildTrigger string `json:"BuildTrigger,omitempty"` // 1.3.6.1.4.1.57264.1.20
+
+	// Run Invocation URL to uniquely identify the build execution.
+	RunInvocationURI string `json:"RunInvocationURI,omitempty"` // 1.3.6.1.4.1.57264.1.21
+
+	// Source repository visibility at the time of signing the certificate.
+	SourceRepositoryVisibilityAtSigning string `json:"SourceRepositoryVisibilityAtSigning,omitempty"` // 1.3.6.1.4.1.57264.1.22
+}

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -10,7 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/content"
 	c8dimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
@@ -22,8 +24,11 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/builder-next/exporter"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/sliceutil"
+	policyimage "github.com/moby/policy-helpers/image"
+	policytypes "github.com/moby/policy-helpers/types"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -87,7 +92,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 		target = multi.Best.Target()
 	}
 
-	identity, err := i.imageIdentity(ctx, target.Digest)
+	identity, err := i.imageIdentity(ctx, c8dImg.Target, multi)
 	if err != nil {
 		log.G(ctx).WithError(err).Warn("failed to determine Identity property")
 	}
@@ -146,8 +151,8 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 	return resp, nil
 }
 
-func (i *ImageService) imageIdentity(ctx context.Context, dgst digest.Digest) (*imagetypes.Identity, error) {
-	info, err := i.content.Info(ctx, dgst)
+func (i *ImageService) imageIdentity(ctx context.Context, desc ocispec.Descriptor, multi *multiPlatformSummary) (*imagetypes.Identity, error) {
+	info, err := i.content.Info(ctx, desc.Digest)
 	if err != nil {
 		return nil, err
 	}
@@ -188,6 +193,16 @@ func (i *ImageService) imageIdentity(ctx context.Context, dgst digest.Digest) (*
 		}
 	}
 
+	if multi.Best != nil {
+		si, err := i.signatureIdentity(ctx, desc, multi.Best, multi.BestPlatform)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("failed to validate image signature")
+		}
+		if si != nil {
+			identity.Signature = append(identity.Signature, *si)
+		}
+	}
+
 	// return nil if there is no identity information
 	if len(identity.Build) == 0 && len(identity.Pull) == 0 && len(identity.Signature) == 0 {
 		return nil, nil
@@ -198,6 +213,126 @@ func (i *ImageService) imageIdentity(ctx context.Context, dgst digest.Digest) (*
 	})
 
 	return identity, nil
+}
+
+func (i *ImageService) signatureIdentity(ctx context.Context, desc ocispec.Descriptor, img *ImageManifest, platform ocispec.Platform) (*imagetypes.SignatureIdentity, error) {
+	rp := &referrersProvider{Store: i.content}
+	sc, err := policyimage.ResolveSignatureChain(ctx, rp, desc, &platform)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolving signature chain for image %s", desc.Digest)
+	}
+	if sc.SignatureManifest == nil || sc.ImageManifest == nil {
+		return nil, nil
+	}
+
+	if sc.ImageManifest.Digest != img.Target().Digest {
+		log.L.Infof("signature chain image manifest digest mismatch: %s != %s", sc.ImageManifest.Digest, img.Target().Digest)
+		return nil, nil
+	}
+
+	v, err := i.policyVerifier()
+	if err != nil {
+		return nil, err
+	}
+
+	out := &imagetypes.SignatureIdentity{}
+
+	si, err := v.VerifyImage(ctx, rp, desc, &platform)
+	if err != nil {
+		out.Error = err.Error()
+		return out, nil
+	}
+
+	out.Name = si.Name()
+	out.DockerReference = si.DockerReference
+
+	if si.IsDHI { // update upstream to also use known signer type instead of bool
+		out.KnownSigner = imagetypes.KnownSignerDHI
+	}
+
+	switch si.SignatureType {
+	case policytypes.SignatureBundleV03:
+		out.SignatureType = imagetypes.SignatureTypeBundleV03
+	case policytypes.SignatureSimpleSigningV1:
+		out.SignatureType = imagetypes.SignatureTypeSimpleSigningV1
+	}
+
+	for _, ts := range si.Timestamps {
+		out.Timestamps = append(out.Timestamps, imagetypes.SignatureTimestamp{
+			Type:      imagetypes.SignatureTimestampType(ts.Type),
+			URI:       ts.URI,
+			Timestamp: ts.Timestamp,
+		})
+	}
+
+	if signer := si.Signer; signer != nil {
+		out.Signer = &imagetypes.SignerIdentity{
+			CertificateIssuer:                   signer.CertificateIssuer,
+			SubjectAlternativeName:              signer.SubjectAlternativeName,
+			Issuer:                              signer.Issuer,
+			BuildSignerURI:                      signer.BuildSignerURI,
+			BuildSignerDigest:                   signer.BuildSignerDigest,
+			RunnerEnvironment:                   signer.RunnerEnvironment,
+			SourceRepositoryURI:                 signer.SourceRepositoryURI,
+			SourceRepositoryDigest:              signer.SourceRepositoryDigest,
+			SourceRepositoryRef:                 signer.SourceRepositoryRef,
+			SourceRepositoryIdentifier:          signer.SourceRepositoryIdentifier,
+			SourceRepositoryOwnerURI:            signer.SourceRepositoryOwnerURI,
+			SourceRepositoryOwnerIdentifier:     signer.SourceRepositoryOwnerIdentifier,
+			BuildConfigURI:                      signer.BuildConfigURI,
+			BuildConfigDigest:                   signer.BuildConfigDigest,
+			BuildTrigger:                        signer.BuildTrigger,
+			RunInvocationURI:                    signer.RunInvocationURI,
+			SourceRepositoryVisibilityAtSigning: signer.SourceRepositoryVisibilityAtSigning,
+		}
+	}
+
+	if si.TrustRootStatus.Error != "" {
+		out.Warnings = append(out.Warnings, si.TrustRootStatus.Error)
+	}
+
+	return out, nil
+}
+
+type referrersProvider struct {
+	content.Store
+}
+
+var _ policyimage.ReferrersProvider = &referrersProvider{}
+
+func (p *referrersProvider) FetchReferrers(ctx context.Context, dgst digest.Digest, opts ...remotes.FetchReferrersOpt) ([]ocispec.Descriptor, error) {
+	rfe := &referrersForExport{store: p.Store}
+	descs, err := rfe.Referrers(ctx, ocispec.Descriptor{Digest: dgst})
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetching referrers for %s", dgst)
+	}
+
+	if len(descs) == 0 {
+		return nil, nil
+	}
+
+	cfg := &remotes.FetchReferrersConfig{}
+	for _, opt := range opts {
+		if err := opt(ctx, cfg); err != nil {
+			return nil, err
+		}
+	}
+	filter := make(map[string]struct{})
+	for _, t := range cfg.ArtifactTypes {
+		filter[t] = struct{}{}
+	}
+
+	if len(filter) == 0 {
+		return descs, nil
+	}
+
+	out := make([]ocispec.Descriptor, 0, len(descs))
+	for _, d := range descs {
+		if _, ok := filter[d.MediaType]; ok {
+			out = append(out, d)
+		}
+	}
+	return out, nil
 }
 
 func collectRepoTagsAndDigests(ctx context.Context, tagged []c8dimages.Image) (repoTags []string, repoDigests []string) {

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -1,8 +1,12 @@
 package containerd
 
 import (
+	"cmp"
 	"context"
+	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -14,8 +18,10 @@ import (
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	imagetypes "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/storage"
+	"github.com/moby/moby/v2/daemon/internal/builder-next/exporter"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/sliceutil"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
 )
@@ -80,6 +86,11 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 		target = multi.Best.Target()
 	}
 
+	identity, err := i.imageIdentity(ctx, target.Digest)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to determine Identity property")
+	}
+
 	resp := &imagebackend.InspectData{
 		InspectResponse: imagetypes.InspectResponse{
 			ID:          target.Digest.String(),
@@ -91,6 +102,7 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 			Metadata: imagetypes.Metadata{
 				LastTagTime: lastUpdated,
 			},
+			Identity: identity,
 		},
 		Parent: parent, // field is deprecated with the legacy builder, but returned by the API if present.
 
@@ -131,6 +143,41 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 	}
 
 	return resp, nil
+}
+
+func (i *ImageService) imageIdentity(ctx context.Context, dgst digest.Digest) (*imagetypes.Identity, error) {
+	info, err := i.content.Info(ctx, dgst)
+	if err != nil {
+		return nil, err
+	}
+	identity := &imagetypes.Identity{}
+
+	for k, v := range info.Labels {
+		if ref, ok := strings.CutPrefix(k, exporter.BuildRefLabel); ok {
+			var val exporter.BuildRefLabelValue
+			if err := json.Unmarshal([]byte(v), &val); err == nil {
+				var createdAt time.Time
+				if val.CreatedAt != nil {
+					createdAt = *val.CreatedAt
+				}
+				identity.Build = append(identity.Build, imagetypes.BuildIdentity{
+					Ref:       ref,
+					CreatedAt: createdAt,
+				})
+			}
+		}
+	}
+
+	// return nil if there is no identity information
+	if len(identity.Build) == 0 && len(identity.Pull) == 0 && len(identity.Signature) == 0 {
+		return nil, nil
+	}
+
+	slices.SortFunc(identity.Build, func(a, b imagetypes.BuildIdentity) int {
+		return cmp.Compare(a.Ref, b.Ref)
+	})
+
+	return identity, nil
 }
 
 func collectRepoTagsAndDigests(ctx context.Context, tagged []c8dimages.Image) (repoTags []string, repoDigests []string) {

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	c8dimages "github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/labels"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -152,6 +153,8 @@ func (i *ImageService) imageIdentity(ctx context.Context, dgst digest.Digest) (*
 	}
 	identity := &imagetypes.Identity{}
 
+	seenRepos := make(map[string]struct{})
+
 	for k, v := range info.Labels {
 		if ref, ok := strings.CutPrefix(k, exporter.BuildRefLabel); ok {
 			var val exporter.BuildRefLabelValue
@@ -163,6 +166,23 @@ func (i *ImageService) imageIdentity(ctx context.Context, dgst digest.Digest) (*
 				identity.Build = append(identity.Build, imagetypes.BuildIdentity{
 					Ref:       ref,
 					CreatedAt: createdAt,
+				})
+			}
+		}
+		if registry, ok := strings.CutPrefix(k, labels.LabelDistributionSource+"."); ok {
+			for repo := range strings.SplitSeq(v, ",") {
+				ref, err := reference.ParseNormalizedNamed(registry + "/" + repo)
+				if err != nil {
+					log.G(ctx).WithError(err).Error("failed to parse image name as reference")
+					continue
+				}
+				name := ref.Name()
+				if _, ok := seenRepos[name]; ok {
+					continue
+				}
+				seenRepos[name] = struct{}{}
+				identity.Pull = append(identity.Pull, imagetypes.PullIdentity{
+					Repository: name,
 				})
 			}
 		}

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/distribution"
 	"github.com/moby/moby/v2/daemon/snapshotter"
 	"github.com/moby/moby/v2/errdefs"
+	policyverifier "github.com/moby/policy-helpers"
 	"github.com/moby/sys/user"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -40,20 +41,22 @@ type ImageService struct {
 	pruneRunning        atomic.Bool
 	refCountMounter     snapshotter.Mounter
 	idMapping           user.IdentityMapping
+	policyVerifier      func() (*policyverifier.Verifier, error)
 
 	// defaultPlatformOverride is used in tests to override the host platform.
 	defaultPlatformOverride platforms.MatchComparer
 }
 
 type ImageServiceConfig struct {
-	Client          *containerd.Client
-	Containers      container.Store
-	Snapshotter     string
-	RegistryHosts   docker.RegistryHosts
-	Registry        distribution.RegistryResolver
-	EventsService   *daemonevents.Events
-	RefCountMounter snapshotter.Mounter
-	IDMapping       user.IdentityMapping
+	Client                 *containerd.Client
+	Containers             container.Store
+	Snapshotter            string
+	RegistryHosts          docker.RegistryHosts
+	Registry               distribution.RegistryResolver
+	EventsService          *daemonevents.Events
+	RefCountMounter        snapshotter.Mounter
+	IDMapping              user.IdentityMapping
+	PolicyVerifierProvider func() (*policyverifier.Verifier, error)
 }
 
 // NewService creates a new ImageService.
@@ -72,6 +75,7 @@ func NewService(config ImageServiceConfig) *ImageService {
 		eventsService:   config.EventsService,
 		refCountMounter: config.RefCountMounter,
 		idMapping:       config.IDMapping,
+		policyVerifier:  config.PolicyVerifierProvider,
 	}
 }
 

--- a/daemon/internal/builder-next/exporter/exporter.go
+++ b/daemon/internal/builder-next/exporter/exporter.go
@@ -1,3 +1,10 @@
 package exporter
 
+import "time"
+
 const Moby = "moby"
+const BuildRefLabel = "moby/build.ref."
+
+type BuildRefLabelValue struct {
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+}

--- a/daemon/internal/builder-next/exporter/wrapper.go
+++ b/daemon/internal/builder-next/exporter/wrapper.go
@@ -2,8 +2,11 @@ package exporter
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
+	"time"
 
+	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/log"
 	"github.com/distribution/reference"
 	"github.com/moby/buildkit/exporter"
@@ -26,14 +29,16 @@ type BuildkitCallbacks struct {
 // overrides to the exporter attributes.
 type imageExporterMobyWrapper struct {
 	exp       exporter.Exporter
+	content   content.Store
 	callbacks BuildkitCallbacks
 }
 
 // NewWrapper returns an exporter wrapper that applies moby specific attributes
 // and hooks the export process.
-func NewWrapper(exp exporter.Exporter, callbacks BuildkitCallbacks) (exporter.Exporter, error) {
+func NewWrapper(exp exporter.Exporter, content content.Store, callbacks BuildkitCallbacks) (exporter.Exporter, error) {
 	return &imageExporterMobyWrapper{
 		exp:       exp,
+		content:   content,
 		callbacks: callbacks,
 	}, nil
 }
@@ -65,22 +70,43 @@ func (e *imageExporterMobyWrapper) Resolve(ctx context.Context, id int, exporter
 	return &imageExporterInstanceWrapper{
 		ExporterInstance: inst,
 		callbacks:        e.callbacks,
+		content:          e.content,
 	}, nil
 }
 
 type imageExporterInstanceWrapper struct {
 	exporter.ExporterInstance
 	callbacks BuildkitCallbacks
+	content   content.Store
 }
 
 func (i *imageExporterInstanceWrapper) Export(ctx context.Context, src *exporter.Source, buildInfo exporter.ExportBuildInfo) (map[string]string, exporter.DescriptorReference, error) {
 	out, ref, err := i.ExporterInstance.Export(ctx, src, buildInfo)
 	if err != nil {
-		return out, ref, err
+		return nil, nil, err
 	}
 
 	desc := ref.Descriptor()
 	imageID := out[exptypes.ExporterImageDigestKey]
+
+	now := time.Now()
+	refLabelBytes, err := json.Marshal(BuildRefLabelValue{
+		CreatedAt: &now,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	refLabelKey := BuildRefLabel + buildInfo.Ref
+	_, err = i.content.Update(ctx, content.Info{
+		Digest: desc.Digest,
+		Labels: map[string]string{
+			refLabelKey: string(refLabelBytes),
+		},
+	}, "labels."+refLabelKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if i.callbacks.Exported != nil {
 		i.callbacks.Exported(ctx, imageID, desc)
 	}

--- a/daemon/internal/builder-next/worker/containerdworker.go
+++ b/daemon/internal/builder-next/worker/containerdworker.go
@@ -46,7 +46,7 @@ func (w *ContainerdWorker) Exporter(name string, sm *session.Manager) (bkexporte
 		if err != nil {
 			return nil, err
 		}
-		return exporter.NewWrapper(exp, w.callbacks)
+		return exporter.NewWrapper(exp, w.ContentStore(), w.callbacks)
 	default:
 		return w.Worker.Exporter(name, sm)
 	}

--- a/vendor/github.com/moby/moby/api/types/image/build_identity.go
+++ b/vendor/github.com/moby/moby/api/types/image/build_identity.go
@@ -1,0 +1,15 @@
+package image
+
+import (
+	"time"
+)
+
+// BuildIdentity contains build reference information if image was created via build.
+type BuildIdentity struct {
+	// Ref is the identifier for the build request. This reference can be used to
+	// look up the build details in BuildKit history API.
+	Ref string `json:"Ref,omitempty"`
+
+	// CreatedAt is the time when the build ran.
+	CreatedAt time.Time `json:"CreatedAt,omitempty"`
+}

--- a/vendor/github.com/moby/moby/api/types/image/identity.go
+++ b/vendor/github.com/moby/moby/api/types/image/identity.go
@@ -1,0 +1,15 @@
+package image
+
+// Identity holds information about the identity and origin of the image.
+// This is trusted information verified by the daemon and cannot be modified
+// by tagging an image to a different name.
+type Identity struct {
+	// Signature contains the properties of verified signatures for the image.
+	Signature []SignatureIdentity `json:"Signature,omitzero"`
+	// Pull contains remote location information if image was created via pull.
+	// If image was pulled via mirror, this contains the original repository location.
+	// After successful push this images also contains the pushed repository location.
+	Pull []PullIdentity `json:"Pull,omitzero"`
+	// Build contains build reference information if image was created via build.
+	Build []BuildIdentity `json:"Build,omitzero"`
+}

--- a/vendor/github.com/moby/moby/api/types/image/image_inspect.go
+++ b/vendor/github.com/moby/moby/api/types/image/image_inspect.go
@@ -105,4 +105,33 @@ type InspectResponse struct {
 	// WARNING: This is experimental and may change at any time without any backward
 	// compatibility.
 	Manifests []ManifestSummary `json:"Manifests,omitempty"`
+
+	// Identity holds information about the identity and origin of the image.
+	// This is trusted information verified by the daemon and cannot be modified
+	// by tagging an image to a different name.
+	Identity *Identity `json:"Identity,omitempty"`
 }
+
+// SignatureTimestampType is the type of timestamp used in the signature.
+type SignatureTimestampType string
+
+const (
+	SignatureTimestampTlog      SignatureTimestampType = "Tlog"
+	SignatureTimestampAuthority SignatureTimestampType = "TimestampAuthority"
+)
+
+// SignatureType is the type of signature format.
+type SignatureType string
+
+const (
+	SignatureTypeBundleV03       SignatureType = "bundle-v0.3"
+	SignatureTypeSimpleSigningV1 SignatureType = "simplesigning-v1"
+)
+
+// KnownSignerIdentity is an identifier for a special signer identity that is known to the implementation.
+type KnownSignerIdentity string
+
+const (
+	// KnownSignerDHI is the known identity for Docker Hardened Images.
+	KnownSignerDHI KnownSignerIdentity = "DHI"
+)

--- a/vendor/github.com/moby/moby/api/types/image/pull_identity.go
+++ b/vendor/github.com/moby/moby/api/types/image/pull_identity.go
@@ -1,0 +1,8 @@
+package image
+
+// PullIdentity contains remote location information if image was created via pull.
+// If image was pulled via mirror, this contains the original repository location.
+type PullIdentity struct {
+	// Repository is the remote repository location the image was pulled from.
+	Repository string `json:"Repository,omitempty"`
+}

--- a/vendor/github.com/moby/moby/api/types/image/signature_identity.go
+++ b/vendor/github.com/moby/moby/api/types/image/signature_identity.go
@@ -1,0 +1,26 @@
+package image
+
+// SignatureIdentity contains the properties of verified signatures for the image.
+type SignatureIdentity struct {
+	// Name is a textual description summarizing the type of signature.
+	Name string `json:"Name,omitempty"`
+	// Timestamps contains a list of verified signed timestamps for the signature.
+	Timestamps []SignatureTimestamp `json:"Timestamps,omitzero"`
+	// KnownSigner is an identifier for a special signer identity that is known to the implementation.
+	KnownSigner KnownSignerIdentity `json:"KnownSigner,omitempty"`
+	// DockerReference is the Docker image reference associated with the signature.
+	// This is an optional field only present in older hashedrecord signatures.
+	DockerReference string `json:"DockerReference,omitempty"`
+	// Signer contains information about the signer certificate used to sign the image.
+	Signer *SignerIdentity `json:"Signer,omitempty"`
+	// SignatureType is the type of signature format. E.g. "bundle-v0.3" or "hashedrecord".
+	SignatureType SignatureType `json:"SignatureType,omitempty"`
+
+	// Error contains error information if signature verification failed.
+	// Other fields will be empty in this case.
+	Error string `json:"Error,omitempty"`
+	// Warnings contains any warnings that occurred during signature verification.
+	// For example, if there was no internet connectivity and cached trust roots were used.
+	// Warning does not indicate a failed verification but may point to configuration issues.
+	Warnings []string `json:"Warnings,omitzero"`
+}

--- a/vendor/github.com/moby/moby/api/types/image/signature_timestamp.go
+++ b/vendor/github.com/moby/moby/api/types/image/signature_timestamp.go
@@ -1,0 +1,12 @@
+package image
+
+import (
+	"time"
+)
+
+// SignatureTimestamp contains information about a verified signed timestamp for an image signature.
+type SignatureTimestamp struct {
+	Type      SignatureTimestampType `json:"Type"`
+	URI       string                 `json:"URI"`
+	Timestamp time.Time              `json:"Timestamp"`
+}

--- a/vendor/github.com/moby/moby/api/types/image/signer_identity.go
+++ b/vendor/github.com/moby/moby/api/types/image/signer_identity.go
@@ -1,0 +1,57 @@
+package image
+
+// SignerIdentity contains information about the signer certificate used to sign the image.
+// This is [certificate.Summary] with deprecated fields removed and keys in Moby uppercase style.
+//
+// [certificate.Summary]: https://pkg.go.dev/github.com/sigstore/sigstore-go/pkg/fulcio/certificate#Summary
+type SignerIdentity struct {
+	CertificateIssuer      string `json:"CertificateIssuer"`
+	SubjectAlternativeName string `json:"SubjectAlternativeName"`
+	// The OIDC issuer. Should match `iss` claim of ID token or, in the case of
+	// a federated login like Dex it should match the issuer URL of the
+	// upstream issuer. The issuer is not set the extensions are invalid and
+	// will fail to render.
+	Issuer string `json:"Issuer,omitempty"` // OID 1.3.6.1.4.1.57264.1.8 and 1.3.6.1.4.1.57264.1.1 (Deprecated)
+
+	// Reference to specific build instructions that are responsible for signing.
+	BuildSignerURI string `json:"BuildSignerURI,omitempty"` // 1.3.6.1.4.1.57264.1.9
+
+	// Immutable reference to the specific version of the build instructions that is responsible for signing.
+	BuildSignerDigest string `json:"BuildSignerDigest,omitempty"` // 1.3.6.1.4.1.57264.1.10
+
+	// Specifies whether the build took place in platform-hosted cloud infrastructure or customer/self-hosted infrastructure.
+	RunnerEnvironment string `json:"RunnerEnvironment,omitempty"` // 1.3.6.1.4.1.57264.1.11
+
+	// Source repository URL that the build was based on.
+	SourceRepositoryURI string `json:"SourceRepositoryURI,omitempty"` // 1.3.6.1.4.1.57264.1.12
+
+	// Immutable reference to a specific version of the source code that the build was based upon.
+	SourceRepositoryDigest string `json:"SourceRepositoryDigest,omitempty"` // 1.3.6.1.4.1.57264.1.13
+
+	// Source Repository Ref that the build run was based upon.
+	SourceRepositoryRef string `json:"SourceRepositoryRef,omitempty"` // 1.3.6.1.4.1.57264.1.14
+
+	// Immutable identifier for the source repository the workflow was based upon.
+	SourceRepositoryIdentifier string `json:"SourceRepositoryIdentifier,omitempty"` // 1.3.6.1.4.1.57264.1.15
+
+	// Source repository owner URL of the owner of the source repository that the build was based on.
+	SourceRepositoryOwnerURI string `json:"SourceRepositoryOwnerURI,omitempty"` // 1.3.6.1.4.1.57264.1.16
+
+	// Immutable identifier for the owner of the source repository that the workflow was based upon.
+	SourceRepositoryOwnerIdentifier string `json:"SourceRepositoryOwnerIdentifier,omitempty"` // 1.3.6.1.4.1.57264.1.17
+
+	// Build Config URL to the top-level/initiating build instructions.
+	BuildConfigURI string `json:"BuildConfigURI,omitempty"` // 1.3.6.1.4.1.57264.1.18
+
+	// Immutable reference to the specific version of the top-level/initiating build instructions.
+	BuildConfigDigest string `json:"BuildConfigDigest,omitempty"` // 1.3.6.1.4.1.57264.1.19
+
+	// Event or action that initiated the build.
+	BuildTrigger string `json:"BuildTrigger,omitempty"` // 1.3.6.1.4.1.57264.1.20
+
+	// Run Invocation URL to uniquely identify the build execution.
+	RunInvocationURI string `json:"RunInvocationURI,omitempty"` // 1.3.6.1.4.1.57264.1.21
+
+	// Source repository visibility at the time of signing the certificate.
+	SourceRepositoryVisibilityAtSigning string `json:"SourceRepositoryVisibilityAtSigning,omitempty"` // 1.3.6.1.4.1.57264.1.22
+}


### PR DESCRIPTION
This PR adds a new Identity property to images visible with inspect command. This information describes the origin of the image contents, is verified by the daemon, and is immutable for the user. If the user retags the image to a different name, its identity remains immutable to the initial information.

This allows users to understand if the image content really is what it claims to be and can be used to make policy decisions.

Currently the image origin can be provided in three different ways:

* Locally built images show their build ref that can be associated with BuildKit history API commands. Collecting this data is new and it will only be shown for images built with this PR. Depends on https://github.com/moby/buildkit/pull/6424
* Pulled images show the registry location from where the image was pulled. This data was already saved for existing pulls.
* Images that have a valid signed provenance attestation (cosign simplesigning or bundle format) are verified against trust roots and then can be inspected by the signature properties. This data is available for valid images since v29.1 . https://github.com/moby/moby/pull/51012 . These signatures persist when image is saved to tarball via docker save and loaded back later(to a different machine for example), and is the only way images created with docker load  can currently be identified in a secure way.

#### Examples

Locally built image:
```
# docker inspect a24955b787
        "Identity": {
            "Build": [
                {
                    "Ref": "rm66qy4pboh3shq168ztcbu3j",
                    "CreatedAt": "2025-12-16T01:06:06.449507136Z"
                }
            ]
        }
```

Pulled image:
```
# docker inspect alpine
        "Identity": {
            "Pull": [
                {
                    "Repository": "docker.io/library/alpine"
                }
            ]
        }
```

Image signed with [Docker Github Builder](https://github.com/docker/github-builder-experimental) (currently experimental), proving artifact integrity against the source reference:

```
# docker image inspect tonistiigi/xx:master
        "Identity": {
            "Signature": [
                {
                    "Name": "Docker GitHub Builder Experimental (tonistiigi/xx@master)",
                    "Timestamps": [
                        {
                            "Type": "Tlog",
                            "URI": "https://rekor.sigstore.dev",
                            "Timestamp": "2025-12-04T07:42:20Z"
                        },
                        {
                            "Type": "TimestampAuthority",
                            "URI": "https://timestamp.sigstore.dev/api/v1/timestamp",
                            "Timestamp": "2025-12-04T07:42:20Z"
                        }
                    ],
                    "Signer": {
                        "CertificateIssuer": "CN=sigstore-intermediate,O=sigstore.dev",
                        "SubjectAlternativeName": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@8fc70909404a502fd0eca6601b99b32fa7192b03",
                        "Issuer": "https://token.actions.githubusercontent.com",
                        "BuildSignerURI": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@8fc70909404a502fd0eca6601b99b32fa7192b03",
                        "BuildSignerDigest": "8fc70909404a502fd0eca6601b99b32fa7192b03",
                        "RunnerEnvironment": "github-hosted",
                        "SourceRepositoryURI": "https://github.com/tonistiigi/xx",
                        "SourceRepositoryDigest": "a5592eab7a57895e8d385394ff12241bc65ecd50",
                        "SourceRepositoryRef": "refs/heads/master",
                        "SourceRepositoryIdentifier": "150307921",
                        "SourceRepositoryOwnerURI": "https://github.com/tonistiigi",
                        "SourceRepositoryOwnerIdentifier": "585223",
                        "BuildConfigURI": "https://github.com/tonistiigi/xx/.github/workflows/build.yml@refs/heads/master",
                        "BuildConfigDigest": "a5592eab7a57895e8d385394ff12241bc65ecd50",
                        "BuildTrigger": "push",
                        "RunInvocationURI": "https://github.com/tonistiigi/xx/actions/runs/19921023628/attempts/1",
                        "SourceRepositoryVisibilityAtSigning": "public"
                    },
                    "SignatureType": "bundle-v0.3"
                }
            ]
```

Manual cosign signature I created in laptop:
```
# docker pull tonistiigi/test:sig1
        "Identity": {
            "Signature": [
                {
                    "Name": "Self-Signed Local (GitHub: tonistiigi@gmail.com)",
                    "Timestamps": [
                        {
                            "Type": "Tlog",
                            "URI": "https://rekor.sigstore.dev",
                            "Timestamp": "2025-11-13T04:22:19Z"
                        },
                        {
                            "Type": "TimestampAuthority",
                            "URI": "https://timestamp.sigstore.dev/api/v1/timestamp",
                            "Timestamp": "2025-11-13T04:22:18Z"
                        }
                    ],
                    "Signer": {
                        "CertificateIssuer": "CN=sigstore-intermediate,O=sigstore.dev",
                        "SubjectAlternativeName": "tonistiigi@gmail.com",
                        "Issuer": "https://github.com/login/oauth"
                    },
                    "SignatureType": "bundle-v0.3"
                }
            ],
            "Pull": [
                {
                    "Repository": "docker.io/tonistiigi/test"
                }
            ]
        }
```


changelog:
```markdown changelog
New `Identity` field has been added to the inspect endpoint to show trusted origin information about the image. This includes build ref for locally built images, remote registry repository for pulled images, and verified signature information for images that contain a valid signed provenance attestation.
```

--

I think we should also add a caching layer to avoid the cost of rerunning the signature verification. Initially I thought we should add temporary opt-in for this until we have caching. But when testing I don't see any extra slowness for the user experience. I think caching is a requirement if we want to have a summary of identity information to the image list endpoint. If we want to give us more time to make potential changes in the struct I'm still ok with a temporary opt-in, but I'm not really sure if it should be in client or daemon side.

@dmcgowan  @crazy-max @thaJeztah @ColinHemmings
