### PR TITLE
validate/module-replace: Ignore client/go.{mod,sum}

### DIFF
--- a/hack/validate/module-replace
+++ b/hack/validate/module-replace
@@ -13,7 +13,13 @@ api_files=$(
 		|| true
 )
 
-client_files=$(validate_diff --diff-filter=ACMR --name-only -- 'client/' || true)
+client_files=$(
+	validate_diff --diff-filter=ACMR --name-only -- \
+		'client/' \
+		':(exclude)client/go.mod' \
+		':(exclude)client/go.sum' \
+		|| true
+)
 
 has_errors=0
 


### PR DESCRIPTION
We're changing them when dropping the replace rules.