### PR TITLE
daemon/libnetwork/options: GenerateFromModel: remove redundant check

### DIFF
--- a/daemon/libnetwork/options/options.go
+++ b/daemon/libnetwork/options/options.go
@@ -3,7 +3,6 @@
 package options
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 )
@@ -55,9 +54,6 @@ func GenerateFromModel[T any](options Generic) (T, error) {
 	var zero T
 
 	modType := reflect.TypeFor[T]()
-	if modType == nil {
-		return zero, errors.New("invalid model: model is nil")
-	}
 
 	isPtr := modType.Kind() == reflect.Ptr
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/51744
- relates to https://github.com/moby/moby/pull/51625


This check was added in 14c5cd377d884e71e98e565d651ffd945dc44695 to prevent passing `nil` as type (`GenerateFromModel[nil](....)`), however, `nil` is not a type, so trying to do so won't compile. Even if it would, it would be theoretical at best, so let's just remove it.

fix linting:

    daemon/libnetwork/options/options.go:57:13: SA4023(related information): the lhs of the comparison is the 1st return value of this function call (staticcheck)
        modType := reflect.TypeFor[T]()
                   ^
    daemon/libnetwork/options/options.go:58:5: SA4023: this comparison is never true (staticcheck)
        if modType == nil {
           ^

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

