### PR TITLE
validate/module-replace: Also allow changing ref of the api module

### DIFF
--- a/hack/validate/module-replace
+++ b/hack/validate/module-replace
@@ -28,7 +28,8 @@ echo "go.mod:"
 cat go.mod
 echo "================================================"
 
-# reads stdin and returns 1 or 0 if the replace rule for the module is present
+# reads stdin and returns 1 or 0 if it only contains changes related to the
+# provided module
 # example input:
 # -	github.com/moby/moby/api v1.52.0
 # +	github.com/moby/moby/api v1.52.1-0.20251217102041-b8093b76fb43
@@ -36,13 +37,9 @@ echo "================================================"
 # -replace github.com/moby/moby/api => ../api
 # +github.com/moby/moby/api v1.52.1-0.20251217102041-b8093b76fb43 h1:CTVB9ByfoOULdpH0GiDWwHK3B1jxwjoWtHiEGia1nRc=
 # +github.com/moby/moby/api v1.52.1-0.20251217102041-b8093b76fb43/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
-only_removes_replace_rule_for_module() {
+only_changes_module() {
 	local module="$1"
 	input=$(cat | sed '/^[-+]$/d') # strip empty lines
-
-	if ! grep -qE "^-replace ${module} => " <<< "${input}"; then
-		return 1
-	fi
 
 	# Check if ALL lines contain the module string
 	# The grep command checks if there's NO match for the module string, and
@@ -77,8 +74,8 @@ echo >&2 "================================================"
 # Check if changes to ./client require a replace rule in go.mod
 if [ -n "${TEST_FORCE_VALIDATE:-}" ] || [ -n "${client_diff}" ]; then
 	echo "Detected changes in ./client directory, checking for replace rule..."
-	if only_removes_replace_rule_for_module "github.com/moby/moby/api" <<< "${client_diff}"; then
-		echo >&2 "✓ This seems to only remove the replace rule for github.com/moby/moby/api"
+	if only_changes_module "github.com/moby/moby/api" <<< "${client_diff}"; then
+		echo >&2 "✓ This seems to only change the module github.com/moby/moby/api revision"
 	elif ! go list -mod=readonly -m -json github.com/moby/moby/client | jq -e '.Replace'; then
 		echo >&2 "ERROR: Changes detected in ./client but go.mod is missing a replace rule for github.com/moby/moby/client"
 		echo >&2 "Please run ./hack/vendor.sh replace"


### PR DESCRIPTION
Remove the `replace` rule check as it's not needed because it will also pass the second check.