### PR TITLE
Dockerfile: update containerd binary to v2.2.1 (static binaries and CI only)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN git init . && git remote add origin "https://github.com/containerd/container
 # integration tests. The distributed docker .deb and .rpm packages depend on a
 # separate (containerd.io) package, which may be a different version as is
 # specified here.
-ARG CONTAINERD_VERSION=v2.2.0
+ARG CONTAINERD_VERSION=v2.2.1
 RUN git fetch -q --depth 1 origin "${CONTAINERD_VERSION}" +refs/tags/*:refs/tags/* && git checkout -q FETCH_HEAD
 
 FROM base AS containerd-build

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -171,7 +171,7 @@ ARG GOWINRES_VERSION=v0.3.3
 
 # TODO: Update containerd version to match Linux version once 
 # https://github.com/microsoft/hcsshim/issues/2488 is resolved.
-ARG CONTAINERD_VERSION=v2.0.7
+ARG CONTAINERD_VERSION=v2.2.1
 
 # Environment variable notes:
 #  - GO_VERSION must be consistent with 'Dockerfile' used by Linux.


### PR DESCRIPTION
### Dockerfile: update containerd binary to v2.2.1 (static binaries and CI only)

  Update the containerd binary that's used in CI and static binaries

  - full diff: https://github.com/containerd/containerd/compare/v2.2.0...v2.2.1
  - release notes: https://github.com/containerd/containerd/releases/tag/v2.2.1

```markdown changelog
Update containerd (static binaries only) to [v2.2.1](https://github.com/containerd/containerd/releases/tag/v2.2.1)
```
