### PR TITLE
Add `nri_no_wasm` build tag to reduce binary size

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -53,9 +53,15 @@ target "docker-metadata-action" {
 variable "DESTDIR" {
   default = ""
 }
+
 function "bindir" {
   params = [defaultdir]
   result = DESTDIR != "" ? DESTDIR : "./bundles/${defaultdir}"
+}
+
+function "buildtags" {
+  params = [defaulttags]
+  result = "${defaulttags} nri_no_wasm"
 }
 
 target "_common" {
@@ -64,7 +70,7 @@ target "_common" {
     DOCKER_DEBUG = DOCKER_DEBUG
     DOCKER_STATIC = DOCKER_STATIC
     DOCKER_LDFLAGS = DOCKER_LDFLAGS
-    DOCKER_BUILDTAGS = DOCKER_BUILDTAGS
+    DOCKER_BUILDTAGS = buildtags(DOCKER_BUILDTAGS)
     DOCKER_GITCOMMIT = DOCKER_GITCOMMIT
     VERSION = VERSION
     PLATFORM = PLATFORM


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This change adds the `nri_no_wasm` build tag to disable WASM support. Reference: https://github.com/containerd/nri/blob/1078130fa016884b4c03880d9d587e6691a67d98/README.md#webassembly-support

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

