### PR TITLE
feat: support force check image layer exist

### DIFF
--- a/client/image_push.go
+++ b/client/image_push.go
@@ -63,6 +63,10 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options ImagePus
 		query.Set("platform", string(pJson))
 	}
 
+	if options.ForceCheckLayerExist {
+		query.Set("force-check", "true")
+	}
+
 	resp, err := cli.tryImagePush(ctx, ref.Name(), query, staticAuth(options.RegistryAuth))
 	if cerrdefs.IsUnauthorized(err) && options.PrivilegeFunc != nil {
 		resp, err = cli.tryImagePush(ctx, ref.Name(), query, options.PrivilegeFunc)

--- a/client/image_push_opts.go
+++ b/client/image_push_opts.go
@@ -8,8 +8,9 @@ import (
 
 // ImagePushOptions holds information to push images.
 type ImagePushOptions struct {
-	All          bool
-	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
+	All                  bool
+	RegistryAuth         string // RegistryAuth is the base64 encoded credentials for the registry
+	ForceCheckLayerExist bool
 
 	// PrivilegeFunc is a function that clients can supply to retry operations
 	// after getting an authorization error. This function returns the registry

--- a/daemon/images/image_push.go
+++ b/daemon/images/image_push.go
@@ -59,9 +59,10 @@ func (i *ImageService) PushImage(ctx context.Context, ref reference.Named, optio
 			ImageStore:       distribution.NewImageConfigStoreFromStore(i.imageStore),
 			ReferenceStore:   i.referenceStore,
 		},
-		ConfigMediaType: schema2.MediaTypeImageConfig,
-		LayerStores:     distribution.NewLayerProvidersFromStore(i.layerStore),
-		UploadManager:   i.uploadManager,
+		ForceCheckLayerExist: options.ForceCheckLayerExist,
+		ConfigMediaType:      schema2.MediaTypeImageConfig,
+		LayerStores:          distribution.NewLayerProvidersFromStore(i.layerStore),
+		UploadManager:        i.uploadManager,
 	}
 
 	err := distribution.Push(ctx, ref, imagePushConfig)

--- a/daemon/internal/distribution/config.go
+++ b/daemon/internal/distribution/config.go
@@ -72,6 +72,8 @@ type ImagePushConfig struct {
 	ConfigMediaType string
 	// LayerStores manages layers.
 	LayerStores PushLayerProvider
+	// ForceCheckLayerExist indicates force checking if layers exist in remote registry when pushing image layers
+	ForceCheckLayerExist bool
 	// UploadManager dispatches uploads.
 	UploadManager *xfer.LayerUploadManager
 }

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -20,10 +20,11 @@ type PullOptions struct {
 }
 
 type PushOptions struct {
-	Platforms   []ocispec.Platform
-	MetaHeaders http.Header
-	AuthConfig  *registry.AuthConfig
-	OutStream   io.Writer
+	Platforms            []ocispec.Platform
+	ForceCheckLayerExist bool
+	MetaHeaders          http.Header
+	AuthConfig           *registry.AuthConfig
+	OutStream            io.Writer
 }
 
 type RemoveOptions struct {

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -222,10 +222,17 @@ func (ir *imageRouter) postImagesPush(ctx context.Context, w http.ResponseWriter
 			platform = p
 		}
 	}
+	var forceCheck bool
+	if formForceCheck := r.Form.Get("force-check"); formForceCheck != "" {
+		if val, err := strconv.ParseBool(formForceCheck); err == nil {
+			forceCheck = val
+		}
+	}
 	pushOptions := imagebackend.PushOptions{
-		AuthConfig:  authConfig,
-		MetaHeaders: metaHeaders,
-		OutStream:   output,
+		AuthConfig:           authConfig,
+		MetaHeaders:          metaHeaders,
+		ForceCheckLayerExist: forceCheck,
+		OutStream:            output,
 	}
 	if platform != nil {
 		pushOptions.Platforms = append(pushOptions.Platforms, *platform)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
```console
Dec 18 13:45:44 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:45:44.231315878+08:00" level=error msg="Can't add file /var/snap/docker/common/var-lib-docker/overlay2/e65dde42e206d2b99f42fd14d932102991d4faff2be738bad9552ef6dceb5df8/diff/tmp/dotnet-diagnostic-958-36333-socket to tar: archive/tar: sockets not supported"
Dec 18 13:45:44 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:45:44.231326398+08:00" level=error msg="Can't add file /var/snap/docker/common/var-lib-docker/overlay2/e65dde42e206d2b99f42fd14d932102991d4faff2be738bad9552ef6dceb5df8/diff/tmp/dotnet-diagnostic-959-36333-socket to tar: archive/tar: sockets not supported"
Dec 18 13:45:44 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:45:44.231870934+08:00" level=error msg="Can't add file /var/snap/docker/common/var-lib-docker/overlay2/e65dde42e206d2b99f42fd14d932102991d4faff2be738bad9552ef6dceb5df8/diff/tmp/o2MYfGP7OtHfGQUwDZD+gS0BsXD0_iA2jTEw8WLe0nM to tar: archive/tar: sockets not supported"
Dec 18 13:45:53 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:45:53.863331533+08:00" level=debug msg="Applied tar sha256:3507412798cda6bb82435b2cd035d4baee255597c9df8666e55eb6a101bfd7eb to a093b720283a77e6353f1a0668d05a677251baf57f65c7c6d0ff3bc746454c29, size: 2268472094"
Dec 18 13:45:53 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:45:53.979920497+08:00" level=debug msg=event module=libcontainerd namespace=moby topic=/tasks/resumed
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.076893416+08:00" level=debug msg="handling HEAD request" method=HEAD module=api request-url=/_ping vars="map[]"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.077259366+08:00" level=debug msg="handling POST request" method=POST module=api request-url="/v1.51/images/eventstore__eventstore-4730/tag?repo=%2Feflops%2Fswe-universe&tag=eventstore__eventstore-4730" vars="map[name:eventstore__eventstore-4730 version:1.51]"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.088308239+08:00" level=debug msg="handling HEAD request" method=HEAD module=api request-url=/_ping vars="map[]"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.088629779+08:00" level=debug msg="handling POST request" method=POST module=api request-url=/v1.51/containers/c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d/stop vars="map[name:c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d version:1.51]"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.088685120+08:00" level=debug msg="sending signal 15 (terminated) to container" container=c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d signal=15
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.144333375+08:00" level=debug msg="handling HEAD request" method=HEAD module=api request-url=/_ping vars="map[]"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.146052075+08:00" level=debug msg="hostDir: /etc/docker/certs.d/
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.153369299+08:00" level=debug msg="Pushing layer: sha256:3507412798cda6bb82435b2cd035d4baee255597c9df8666e55eb6a101bfd7eb"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.153680938+08:00" level=debug msg="Checking for presence of layer sha256:9e2bd532623d9b0e951b04be41fb301c176ec2a0f9ece9cef071a1343323a68c (sha256:23d55a674b2e3641a37b7f2053f00af6fe4f2a89576ffb917d4b7b4deaf24591) in
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.153681768+08:00" level=debug msg="Checking for presence of layer sha256:81754f5dc87d69b94c676f0252b4d2de8771ff46ec56aefc7abf6e8c4028c905 (sha256:13cc39f8244ac66bf1dd9149e1da421ab1bbc80d612dc14fe368753e7be17b33) in 
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.153741999+08:00" level=debug msg="Checking for presence of layer sha256:01c58a646ede18ca0a2adb5ac5bd2e4ec534a2f3aa6f19842e10a5e13cb405ae (sha256:e3143549f2b8b3ad8d79efdc47824641c6771796b3770f3c637a38aabd2b3462) in
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.154221344+08:00" level=debug msg="Checking for presence of layer sha256:06589319ba9282f1604132458c6b4b532930c44fdb8a0246f3a280c6bc339581 (sha256:72e8e93b0d018b135d833207c6feaba205653ac52e0a80d214477ec0de239dee) in
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.174089373+08:00" level=debug msg="Pushing layer: sha256:81754f5dc87d69b94c676f0252b4d2de8771ff46ec56aefc7abf6e8c4028c905"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.202329998+08:00" level=debug msg="Assembling tar data for a093b720283a77e6353f1a0668d05a677251baf57f65c7c6d0ff3bc746454c29"
Dec 18 13:46:04 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:04.222899229+08:00" level=debug msg="Assembling tar data for b949090f5f63cd7067c3d64f9277c74d8e2073f6b23f0d4ccfed90498a3cc725"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.096927268+08:00" level=info msg="Container failed to exit within 10s of signal 15 - using the force" container=c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.096963599+08:00" level=debug msg="sending signal 9 (killed) to container" container=c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d signal=9
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.359412794+08:00" level=debug msg=event module=libcontainerd namespace=moby topic=/tasks/exit
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2778]: time="2025-12-18T13:46:14.366623633+08:00" level=info msg="shim disconnected" id=c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d namespace=moby
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2778]: time="2025-12-18T13:46:14.366656524+08:00" level=warning msg="cleaning up after shim disconnected" id=c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d namespace=moby
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2778]: time="2025-12-18T13:46:14.366665304+08:00" level=info msg="cleaning up dead shim" namespace=moby
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.366684405+08:00" level=debug msg=event module=libcontainerd namespace=moby topic=/tasks/delete
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.366701965+08:00" level=info msg="ignoring event" container=c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2778]: time="2025-12-18T13:46:14.394673337+08:00" level=warning msg="cleanup warnings time=\"2025-12-18T13:46:14+08:00\" level=debug msg=\"starting signal loop\" namespace=moby pid=15894 runtime=io.containerd.runc.v2\n" namespace=moby
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.397178279+08:00" level=debug msg="Revoking external connectivity on endpoint" eid=78aa1b0c94bd45cc9a25f41b69d011c22e683f682f41d42705472fa65b22fbcb ep=minisweagent-91df4dc2 net=bridge nid=2dffeea44b4e4ad9e22b2fddb99139ca345160b54663e199ae2689dbee159877
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.476754818+08:00" level=debug msg="/usr/sbin/iptables, [--wait -t raw -C PREROUTING -d 172.17.0.2 ! -i docker0 -j DROP]"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.486665096+08:00" level=debug msg="/usr/sbin/iptables, [--wait -t raw -D PREROUTING -d 172.17.0.2 ! -i docker0 -j DROP]"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.576076149+08:00" level=debug msg="Releasing addresses for endpoint minisweagent-91df4dc2's interface on network bridge"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.576099810+08:00" level=debug msg="ReleaseAddress(LocalDefault/172.17.0.0/16, 172.17.0.2)"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.576119451+08:00" level=debug msg="Released address Address:172.17.0.2 Sequence:Bits: 65536, Unselected: 65533, Sequence: (0xc0000000, 1)->(0x0, 2046)->(0x1, 1)->end Curr:3"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.700585122+08:00" level=debug msg="handling HEAD request" method=HEAD module=api request-url=/_ping vars="map[]"
Dec 18 13:46:14 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:14.700994944+08:00" level=debug msg="handling DELETE request" method=DELETE module=api request-url="/v1.51/containers/c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d?force=1" vars="map[name:c5ce910c0d3d9a68feeea1a057e6f986823efedef5f3faf458fe5bc6c241940d version:1.51]"
Dec 18 13:46:20 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:46:20.653272836+08:00" level=debug msg="uploaded layer sha256:81754f5dc87d69b94c676f0252b4d2de8771ff46ec56aefc7abf6e8c4028c905 (sha256:e7230fc042bea57fedb2885bea0431363c4149f9c87115876d5d6c96e6fde3db), 50476024 bytes"
Dec 18 13:49:57 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:49:57.060296404+08:00" level=debug msg="clean 57 unused exec commands"
Dec 18 13:54:57 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T13:54:57.059902808+08:00" level=debug msg="clean 12 unused exec commands"
Dec 18 14:06:39 iZt4n9a6nhseyww1drtpxwZ docker.dockerd[2704]: time="2025-12-18T14:06:39.486489762+08:00" level=debug msg="uploaded layer sha256:3507412798cda6bb82435b2cd035d4baee255597c9df8666e55eb6a101bfd7eb (sha256:bd9b1b5950b74edad861a92f94c326b6cafafb47fb8f3eb9256a191020af1441), 1027077222 bytes"

================
client log:

The push refers to repository 
3507412798cd: Preparing
9e2bd532623d: Preparing
06589319ba92: Preparing
01c58a646ede: Preparing
81754f5dc87d: Preparing
06589319ba92: Layer already exists
9e2bd532623d: Layer already exists
01c58a646ede: Layer already exists
81754f5dc87d: Pushed
3507412798cd: Pushed
eventstore__eventstore-4730: digest: sha256:456f1578ba72d9fd21f16c323f11a0e05e4bba28092ea59eed354c3435ef23b3 size: 1380
```

layer `sha256:81754f5dc87d69b94c676f0252b4d2de8771ff46ec56aefc7abf6e8c4028c905`  is already exists in my remote repository, but still re-pushed


**- How I did it**
add a docker option to force check whether the layer already exist in the remote repository or not
**- How to verify it**
when `force-check` is setted, then check whether the layer already exist in the remote repository or not force

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

