### PR TITLE
vendor: google.golang.org/protobuf v1.36.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	golang.org/x/time v0.14.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5
 	google.golang.org/grpc v1.76.0
-	google.golang.org/protobuf v1.36.10
+	google.golang.org/protobuf v1.36.11
 	gotest.tools/v3 v3.5.2
 	pgregory.net/rapid v1.2.0
 	resenje.org/singleflight v0.4.3

--- a/go.sum
+++ b/go.sum
@@ -841,8 +841,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
-google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vendor/google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo/main.go
+++ b/vendor/google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo/main.go
@@ -817,6 +817,7 @@ func genExtensions(g *protogen.GeneratedFile, f *fileInfo) {
 			leadingComments = appendDeprecationSuffix(leadingComments,
 				x.Desc.ParentFile(),
 				x.Desc.Options().(*descriptorpb.FieldOptions).GetDeprecated())
+			g.AnnotateSymbol("E_"+x.GoIdent.GoName, protogen.Annotation{Location: x.Location})
 			g.P(leadingComments,
 				"E_", x.GoIdent, " = &", extensionTypesVarName(f), "[", allExtensionsByPtr[x], "]",
 				trailingComment(x.Comments.Trailing))

--- a/vendor/google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo/opaque.go
+++ b/vendor/google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo/opaque.go
@@ -796,10 +796,12 @@ func opaqueGenWhichOneof(g *protogen.GeneratedFile, f *fileInfo, message *messag
 			caseType := opaqueOneofCaseTypeName(oneof)
 			g.P("const ", message.GoIdent.GoName, "_", oneof.GoName, "_not_set_case ", caseType, " = ", 0)
 			for _, f := range oneof.Fields {
+				g.AnnotateSymbol(message.GoIdent.GoName+"_"+f.GoName+"_case", protogen.Annotation{Location: f.Location})
 				g.P("const ", message.GoIdent.GoName, "_", f.GoName, "_case ", caseType, " = ", f.Desc.Number())
 			}
 			fieldtrackNoInterface(g, message.noInterface)
 			whicherName := oneof.MethodName("Which")
+			g.AnnotateSymbol(message.GoIdent.GoName+"."+whicherName, protogen.Annotation{Location: oneof.Location})
 			g.P("func (x *", message.GoIdent, ") ", whicherName, "() ", caseType, " {")
 			g.P("if x == nil {")
 			g.P("return ", message.GoIdent.GoName, "_", oneof.GoName, "_not_set_case ")

--- a/vendor/google.golang.org/protobuf/internal/encoding/tag/tag.go
+++ b/vendor/google.golang.org/protobuf/internal/encoding/tag/tag.go
@@ -32,7 +32,7 @@ var byteType = reflect.TypeOf(byte(0))
 func Unmarshal(tag string, goType reflect.Type, evs protoreflect.EnumValueDescriptors) protoreflect.FieldDescriptor {
 	f := new(filedesc.Field)
 	f.L0.ParentFile = filedesc.SurrogateProto2
-	f.L1.EditionFeatures = f.L0.ParentFile.L1.EditionFeatures
+	packed := false
 	for len(tag) > 0 {
 		i := strings.IndexByte(tag, ',')
 		if i < 0 {
@@ -108,7 +108,7 @@ func Unmarshal(tag string, goType reflect.Type, evs protoreflect.EnumValueDescri
 				f.L1.StringName.InitJSON(jsonName)
 			}
 		case s == "packed":
-			f.L1.EditionFeatures.IsPacked = true
+			packed = true
 		case strings.HasPrefix(s, "def="):
 			// The default tag is special in that everything afterwards is the
 			// default regardless of the presence of commas.
@@ -119,6 +119,13 @@ func Unmarshal(tag string, goType reflect.Type, evs protoreflect.EnumValueDescri
 			f.L0.ParentFile = filedesc.SurrogateProto3
 		}
 		tag = strings.TrimPrefix(tag[i:], ",")
+	}
+
+	// Update EditionFeatures after the loop and after we know whether this is
+	// a proto2 or proto3 field.
+	f.L1.EditionFeatures = f.L0.ParentFile.L1.EditionFeatures
+	if packed {
+		f.L1.EditionFeatures.IsPacked = true
 	}
 
 	// The generator uses the group message name instead of the field name.

--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc.go
@@ -32,6 +32,7 @@ const (
 	EditionProto3      Edition = 999
 	Edition2023        Edition = 1000
 	Edition2024        Edition = 1001
+	EditionUnstable    Edition = 9999
 	EditionUnsupported Edition = 100000
 )
 

--- a/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
+++ b/vendor/google.golang.org/protobuf/internal/filedesc/desc_lazy.go
@@ -330,7 +330,6 @@ func (md *Message) unmarshalFull(b []byte, sb *strs.Builder) {
 				md.L1.Extensions.List[extensionIdx].unmarshalFull(v, sb)
 				extensionIdx++
 			case genid.DescriptorProto_Options_field_number:
-				md.unmarshalOptions(v)
 				rawOptions = appendOptions(rawOptions, v)
 			}
 		default:
@@ -354,27 +353,6 @@ func (md *Message) unmarshalFull(b []byte, sb *strs.Builder) {
 		}
 	}
 	md.L2.Options = md.L0.ParentFile.builder.optionsUnmarshaler(&descopts.Message, rawOptions)
-}
-
-func (md *Message) unmarshalOptions(b []byte) {
-	for len(b) > 0 {
-		num, typ, n := protowire.ConsumeTag(b)
-		b = b[n:]
-		switch typ {
-		case protowire.VarintType:
-			v, m := protowire.ConsumeVarint(b)
-			b = b[m:]
-			switch num {
-			case genid.MessageOptions_MapEntry_field_number:
-				md.L1.IsMapEntry = protowire.DecodeBool(v)
-			case genid.MessageOptions_MessageSetWireFormat_field_number:
-				md.L1.IsMessageSet = protowire.DecodeBool(v)
-			}
-		default:
-			m := protowire.ConsumeFieldValue(num, typ, b)
-			b = b[m:]
-		}
-	}
 }
 
 func unmarshalMessageReservedRange(b []byte) (r [2]protoreflect.FieldNumber) {

--- a/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
+++ b/vendor/google.golang.org/protobuf/internal/genid/descriptor_gen.go
@@ -26,6 +26,7 @@ const (
 	Edition_EDITION_PROTO3_enum_value          = 999
 	Edition_EDITION_2023_enum_value            = 1000
 	Edition_EDITION_2024_enum_value            = 1001
+	Edition_EDITION_UNSTABLE_enum_value        = 9999
 	Edition_EDITION_1_TEST_ONLY_enum_value     = 1
 	Edition_EDITION_2_TEST_ONLY_enum_value     = 2
 	Edition_EDITION_99997_TEST_ONLY_enum_value = 99997

--- a/vendor/google.golang.org/protobuf/internal/impl/codec_map.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/codec_map.go
@@ -113,6 +113,9 @@ func sizeMap(mapv reflect.Value, mapi *mapInfo, f *coderFieldInfo, opts marshalO
 }
 
 func consumeMap(b []byte, mapv reflect.Value, wtyp protowire.Type, mapi *mapInfo, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+	if opts.depth--; opts.depth < 0 {
+		return out, errRecursionDepth
+	}
 	if wtyp != protowire.BytesType {
 		return out, errUnknown
 	}
@@ -170,6 +173,9 @@ func consumeMap(b []byte, mapv reflect.Value, wtyp protowire.Type, mapi *mapInfo
 }
 
 func consumeMapOfMessage(b []byte, mapv reflect.Value, wtyp protowire.Type, mapi *mapInfo, f *coderFieldInfo, opts unmarshalOptions) (out unmarshalOutput, err error) {
+	if opts.depth--; opts.depth < 0 {
+		return out, errRecursionDepth
+	}
 	if wtyp != protowire.BytesType {
 		return out, errUnknown
 	}

--- a/vendor/google.golang.org/protobuf/internal/impl/decode.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/decode.go
@@ -102,8 +102,7 @@ var errUnknown = errors.New("unknown")
 
 func (mi *MessageInfo) unmarshalPointer(b []byte, p pointer, groupTag protowire.Number, opts unmarshalOptions) (out unmarshalOutput, err error) {
 	mi.init()
-	opts.depth--
-	if opts.depth < 0 {
+	if opts.depth--; opts.depth < 0 {
 		return out, errRecursionDepth
 	}
 	if flags.ProtoLegacy && mi.isMessageSet {

--- a/vendor/google.golang.org/protobuf/internal/impl/validate.go
+++ b/vendor/google.golang.org/protobuf/internal/impl/validate.go
@@ -68,9 +68,13 @@ func Validate(mt protoreflect.MessageType, in protoiface.UnmarshalInput) (out pr
 	if in.Resolver == nil {
 		in.Resolver = protoregistry.GlobalTypes
 	}
+	if in.Depth == 0 {
+		in.Depth = protowire.DefaultRecursionLimit
+	}
 	o, st := mi.validate(in.Buf, 0, unmarshalOptions{
 		flags:    in.Flags,
 		resolver: in.Resolver,
+		depth:    in.Depth,
 	})
 	if o.initialized {
 		out.Flags |= protoiface.UnmarshalInitialized
@@ -256,6 +260,9 @@ func (mi *MessageInfo) validate(b []byte, groupTag protowire.Number, opts unmars
 	if groupTag > 0 {
 		states[0].typ = validationTypeGroup
 		states[0].endGroup = groupTag
+	}
+	if opts.depth--; opts.depth < 0 {
+		return out, ValidationInvalid
 	}
 	initialized := true
 	start := len(b)
@@ -451,6 +458,13 @@ State:
 						mi:      vi.mi,
 						tail:    b,
 					})
+					if vi.typ == validationTypeMessage ||
+						vi.typ == validationTypeGroup ||
+						vi.typ == validationTypeMap {
+						if opts.depth--; opts.depth < 0 {
+							return out, ValidationInvalid
+						}
+					}
 					b = v
 					continue State
 				case validationTypeRepeatedVarint:
@@ -499,6 +513,9 @@ State:
 						mi:       vi.mi,
 						endGroup: num,
 					})
+					if opts.depth--; opts.depth < 0 {
+						return out, ValidationInvalid
+					}
 					continue State
 				case flags.ProtoLegacy && vi.typ == validationTypeMessageSetItem:
 					typeid, v, n, err := messageset.ConsumeFieldValue(b, false)
@@ -521,6 +538,13 @@ State:
 							mi:   xvi.mi,
 							tail: b[n:],
 						})
+						if xvi.typ == validationTypeMessage ||
+							xvi.typ == validationTypeGroup ||
+							xvi.typ == validationTypeMap {
+							if opts.depth--; opts.depth < 0 {
+								return out, ValidationInvalid
+							}
+						}
 						b = v
 						continue State
 					}
@@ -547,12 +571,14 @@ State:
 		switch st.typ {
 		case validationTypeMessage, validationTypeGroup:
 			numRequiredFields = int(st.mi.numRequiredFields)
+			opts.depth++
 		case validationTypeMap:
 			// If this is a map field with a message value that contains
 			// required fields, require that the value be present.
 			if st.mi != nil && st.mi.numRequiredFields > 0 {
 				numRequiredFields = 1
 			}
+			opts.depth++
 		}
 		// If there are more than 64 required fields, this check will
 		// always fail and we will report that the message is potentially

--- a/vendor/google.golang.org/protobuf/internal/version/version.go
+++ b/vendor/google.golang.org/protobuf/internal/version/version.go
@@ -52,7 +52,7 @@ import (
 const (
 	Major      = 1
 	Minor      = 36
-	Patch      = 10
+	Patch      = 11
 	PreRelease = ""
 )
 

--- a/vendor/google.golang.org/protobuf/proto/decode.go
+++ b/vendor/google.golang.org/protobuf/proto/decode.go
@@ -121,9 +121,8 @@ func (o UnmarshalOptions) unmarshal(b []byte, m protoreflect.Message) (out proto
 
 		out, err = methods.Unmarshal(in)
 	} else {
-		o.RecursionLimit--
-		if o.RecursionLimit < 0 {
-			return out, errors.New("exceeded max recursion depth")
+		if o.RecursionLimit--; o.RecursionLimit < 0 {
+			return out, errRecursionDepth
 		}
 		err = o.unmarshalMessageSlow(b, m)
 	}
@@ -220,6 +219,9 @@ func (o UnmarshalOptions) unmarshalSingular(b []byte, wtyp protowire.Type, m pro
 }
 
 func (o UnmarshalOptions) unmarshalMap(b []byte, wtyp protowire.Type, mapv protoreflect.Map, fd protoreflect.FieldDescriptor) (n int, err error) {
+	if o.RecursionLimit--; o.RecursionLimit < 0 {
+		return 0, errRecursionDepth
+	}
 	if wtyp != protowire.BytesType {
 		return 0, errUnknown
 	}
@@ -305,3 +307,5 @@ func (o UnmarshalOptions) unmarshalMap(b []byte, wtyp protowire.Type, mapv proto
 var errUnknown = errors.New("BUG: internal error (unknown)")
 
 var errDecode = errors.New("cannot parse invalid wire-format data")
+
+var errRecursionDepth = errors.New("exceeded maximum recursion depth")

--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
@@ -108,7 +108,9 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
 	if f.L1.Path == "" {
 		return nil, errors.New("file path must be populated")
 	}
-	if f.L1.Syntax == protoreflect.Editions && (fd.GetEdition() < editionssupport.Minimum || fd.GetEdition() > editionssupport.Maximum) {
+	if f.L1.Syntax == protoreflect.Editions &&
+		(fd.GetEdition() < editionssupport.Minimum || fd.GetEdition() > editionssupport.Maximum) &&
+		fd.GetEdition() != descriptorpb.Edition_EDITION_UNSTABLE {
 		// Allow cmd/protoc-gen-go/testdata to use any edition for easier
 		// testing of upcoming edition features.
 		if !strings.HasPrefix(fd.GetName(), "cmd/protoc-gen-go/testdata/") {
@@ -152,6 +154,7 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
 		imp := &f.L2.Imports[i]
 		imps.importPublic(imp.Imports())
 	}
+	optionImps := importSet{f.Path(): true}
 	if len(fd.GetOptionDependency()) > 0 {
 		optionImports := make(filedesc.FileImports, len(fd.GetOptionDependency()))
 		for i, path := range fd.GetOptionDependency() {
@@ -165,10 +168,12 @@ func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (prot
 			}
 			imp.FileDescriptor = f
 
-			if imps[imp.Path()] {
+			if imps[imp.Path()] || optionImps[imp.Path()] {
 				return nil, errors.New("already imported %q", path)
 			}
-			imps[imp.Path()] = true
+			// This needs to be a separate map so that we don't recognize non-options
+			// symbols coming from option imports.
+			optionImps[imp.Path()] = true
 		}
 		f.L2.OptionImports = func() protoreflect.FileImports {
 			return &optionImports

--- a/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
+++ b/vendor/google.golang.org/protobuf/reflect/protodesc/editions.go
@@ -46,6 +46,8 @@ func toEditionProto(ed filedesc.Edition) descriptorpb.Edition {
 		return descriptorpb.Edition_EDITION_2023
 	case filedesc.Edition2024:
 		return descriptorpb.Edition_EDITION_2024
+	case filedesc.EditionUnstable:
+		return descriptorpb.Edition_EDITION_UNSTABLE
 	default:
 		panic(fmt.Sprintf("unknown value for edition: %v", ed))
 	}
@@ -58,7 +60,7 @@ func getFeatureSetFor(ed filedesc.Edition) *descriptorpb.FeatureSet {
 		return def
 	}
 	edpb := toEditionProto(ed)
-	if defaults.GetMinimumEdition() > edpb || defaults.GetMaximumEdition() < edpb {
+	if (defaults.GetMinimumEdition() > edpb || defaults.GetMaximumEdition() < edpb) && edpb != descriptorpb.Edition_EDITION_UNSTABLE {
 		// This should never happen protodesc.(FileOptions).New would fail when
 		// initializing the file descriptor.
 		// This most likely means the embedded defaults were not updated.

--- a/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
+++ b/vendor/google.golang.org/protobuf/types/descriptorpb/descriptor.pb.go
@@ -69,6 +69,8 @@ const (
 	// comparison.
 	Edition_EDITION_2023 Edition = 1000
 	Edition_EDITION_2024 Edition = 1001
+	// A placeholder edition for developing and testing unscheduled features.
+	Edition_EDITION_UNSTABLE Edition = 9999
 	// Placeholder editions for testing feature resolution.  These should not be
 	// used or relied on outside of tests.
 	Edition_EDITION_1_TEST_ONLY     Edition = 1
@@ -91,6 +93,7 @@ var (
 		999:        "EDITION_PROTO3",
 		1000:       "EDITION_2023",
 		1001:       "EDITION_2024",
+		9999:       "EDITION_UNSTABLE",
 		1:          "EDITION_1_TEST_ONLY",
 		2:          "EDITION_2_TEST_ONLY",
 		99997:      "EDITION_99997_TEST_ONLY",
@@ -105,6 +108,7 @@ var (
 		"EDITION_PROTO3":          999,
 		"EDITION_2023":            1000,
 		"EDITION_2024":            1001,
+		"EDITION_UNSTABLE":        9999,
 		"EDITION_1_TEST_ONLY":     1,
 		"EDITION_2_TEST_ONLY":     2,
 		"EDITION_99997_TEST_ONLY": 99997,
@@ -4793,11 +4797,11 @@ const file_google_protobuf_descriptor_proto_rawDesc = "" +
 	"\x18EnumValueDescriptorProto\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06number\x18\x02 \x01(\x05R\x06number\x12;\n" +
-	"\aoptions\x18\x03 \x01(\v2!.google.protobuf.EnumValueOptionsR\aoptions\"\xa7\x01\n" +
+	"\aoptions\x18\x03 \x01(\v2!.google.protobuf.EnumValueOptionsR\aoptions\"\xb5\x01\n" +
 	"\x16ServiceDescriptorProto\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12>\n" +
 	"\x06method\x18\x02 \x03(\v2&.google.protobuf.MethodDescriptorProtoR\x06method\x129\n" +
-	"\aoptions\x18\x03 \x01(\v2\x1f.google.protobuf.ServiceOptionsR\aoptions\"\x89\x02\n" +
+	"\aoptions\x18\x03 \x01(\v2\x1f.google.protobuf.ServiceOptionsR\aoptionsJ\x04\b\x04\x10\x05R\x06stream\"\x89\x02\n" +
 	"\x15MethodDescriptorProto\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1d\n" +
 	"\n" +
@@ -5033,14 +5037,15 @@ const file_google_protobuf_descriptor_proto_rawDesc = "" +
 	"\bSemantic\x12\b\n" +
 	"\x04NONE\x10\x00\x12\a\n" +
 	"\x03SET\x10\x01\x12\t\n" +
-	"\x05ALIAS\x10\x02*\xa7\x02\n" +
+	"\x05ALIAS\x10\x02*\xbe\x02\n" +
 	"\aEdition\x12\x13\n" +
 	"\x0fEDITION_UNKNOWN\x10\x00\x12\x13\n" +
 	"\x0eEDITION_LEGACY\x10\x84\a\x12\x13\n" +
 	"\x0eEDITION_PROTO2\x10\xe6\a\x12\x13\n" +
 	"\x0eEDITION_PROTO3\x10\xe7\a\x12\x11\n" +
 	"\fEDITION_2023\x10\xe8\a\x12\x11\n" +
-	"\fEDITION_2024\x10\xe9\a\x12\x17\n" +
+	"\fEDITION_2024\x10\xe9\a\x12\x15\n" +
+	"\x10EDITION_UNSTABLE\x10\x8fN\x12\x17\n" +
 	"\x13EDITION_1_TEST_ONLY\x10\x01\x12\x17\n" +
 	"\x13EDITION_2_TEST_ONLY\x10\x02\x12\x1d\n" +
 	"\x17EDITION_99997_TEST_ONLY\x10\x9d\x8d\x06\x12\x1d\n" +

--- a/vendor/google.golang.org/protobuf/types/known/timestamppb/timestamp.pb.go
+++ b/vendor/google.golang.org/protobuf/types/known/timestamppb/timestamp.pb.go
@@ -172,13 +172,14 @@ import (
 // ) to obtain a formatter capable of generating timestamps in this format.
 type Timestamp struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Represents seconds of UTC time since Unix epoch
-	// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-	// 9999-12-31T23:59:59Z inclusive.
+	// Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must
+	// be between -315576000000 and 315576000000 inclusive (which corresponds to
+	// 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z).
 	Seconds int64 `protobuf:"varint,1,opt,name=seconds,proto3" json:"seconds,omitempty"`
-	// Non-negative fractions of a second at nanosecond resolution. Negative
-	// second values with fractions must still have non-negative nanos values
-	// that count forward in time. Must be from 0 to 999,999,999
+	// Non-negative fractions of a second at nanosecond resolution. This field is
+	// the nanosecond portion of the duration, not an alternative to seconds.
+	// Negative second values with fractions must still have non-negative nanos
+	// values that count forward in time. Must be between 0 and 999,999,999
 	// inclusive.
 	Nanos         int32 `protobuf:"varint,2,opt,name=nanos,proto3" json:"nanos,omitempty"`
 	unknownFields protoimpl.UnknownFields

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1823,7 +1823,7 @@ google.golang.org/grpc/serviceconfig
 google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
-# google.golang.org/protobuf v1.36.10
+# google.golang.org/protobuf v1.36.11
 ## explicit; go 1.23
 google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo
 google.golang.org/protobuf/compiler/protogen


### PR DESCRIPTION
full diff: https://github.com/protocolbuffers/protobuf-go/compare/v1.36.10...v1.36.11

User-visible changes:
CL/726780: encoding/prototext: Support URL chars in type URLs in text-format.

Bug fixes:
CL/728680: internal/impl: check recursion limit in lazy decoding validation CL/711015: reflect/protodesc: fix handling of import options in dynamic builds

Maintenance:
CL/728681: reflect/protodesc: add support for edition unstable CL/727960: all: add EDITION_UNSTABLE support
CL/727940: types: regenerate using latest protobuf v33.2 release CL/727140: internal/testprotos/lazy: convert .proto files to editions CL/723440: cmd/protoc-gen-go: add missing annotations for few generated protobuf symbols. CL/720980: internal/filedesc: remove duplicative Message.unmarshalOptions CL/716360: internal/encoding/tag: use proto3 defaults if proto3 CL/716520: proto: un-flake TestHasExtensionNoAlloc CL/713342: compiler/protogen: properly filter option dependencies in go-protobuf plugin. CL/711200: proto: add test for oneofs containing messages with required fields CL/710855: proto: add explicit test for a non-nil but empty byte slice

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

