### PR TITLE
hack: add nri_no_wasm build when building dockerd

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -88,7 +88,7 @@ if [ -z "$DOCKER_DEBUG" ]; then
 	LDFLAGS='-w'
 fi
 
-BUILDFLAGS=(${BUILDFLAGS} -tags "netgo osusergo static_build $DOCKER_BUILDTAGS")
+BUILDFLAGS=(${BUILDFLAGS} -tags "netgo osusergo static_build nri_no_wasm $DOCKER_BUILDTAGS")
 LDFLAGS_STATIC="-extldflags -static"
 
 if [ "$(uname -s)" = 'FreeBSD' ]; then


### PR DESCRIPTION
- alternative to: https://github.com/moby/moby/pull/51767

Add the nri_no_wasm build tag to the BUILDFLAGS to disable WASM plugins support in the NRI (Node Resource Interface) component.

See: https://github.com/containerd/nri/blob/1078130fa016884b4c03880d9d587e6691a67d98/README.md#webassembly-support

The NRI support is still minimal and disabling WASM plugins shaves off a couple of MiB of the binary size.
