### PR TITLE
api: add root doc.go to prevent fallback to github.com/moby/moby

### DIFF
--- a/api/doc.go
+++ b/api/doc.go
@@ -1,0 +1,1 @@
+package api


### PR DESCRIPTION
**- What I did**

Fixes #51754 

This change adds a doc.go file to the root level of the api module to prevent fallback to `github.com/moby/moby`

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

