### PR TITLE
docs: update stats API description for cgroups v2 compatibility

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -6247,7 +6247,11 @@ definitions:
         example: 0
       stats:
         description: |
-          All the stats exported via memory.stat. when using cgroups v2.
+          All the stats exported via memory.stat.
+
+          The fields in this object differ between cgroups v1 and v2.
+          On cgroups v1, fields such as `cache`, `rss`, `mapped_file` are available.
+          On cgroups v2, fields such as `file`, `anon`, `inactive_file` are available.
 
           This field is Linux-specific and omitted for Windows containers.
         type: "object"
@@ -8515,7 +8519,8 @@ paths:
 
         To calculate the values shown by the `stats` command of the docker cli tool
         the following formulas can be used:
-        * used_memory = `memory_stats.usage - memory_stats.stats.cache`
+        * used_memory = `memory_stats.usage - memory_stats.stats.cache` (cgroups v1)
+        * used_memory = `memory_stats.usage - memory_stats.stats.inactive_file` (cgroups v2)
         * available_memory = `memory_stats.limit`
         * Memory usage % = `(used_memory / available_memory) * 100.0`
         * cpu_delta = `cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage`


### PR DESCRIPTION
## Summary

Update the `/containers/{id}/stats` API documentation to clarify the differences between cgroups v1 and v2:

- Add cgroups v2 formula for calculating `used_memory` using `inactive_file` instead of `cache` field
- Update `memory_stats.stats` description to explain that field names differ between v1 and v2

## Changes

1. In the stats endpoint description, added cgroups version annotations to the memory calculation formula:
   - cgroups v1: `used_memory = memory_stats.usage - memory_stats.stats.cache`
   - cgroups v2: `used_memory = memory_stats.usage - memory_stats.stats.inactive_file`

2. Updated `memory_stats.stats` field description to clarify:
   - cgroups v1 provides fields like `cache`, `rss`, `mapped_file`
   - cgroups v2 provides fields like `file`, `anon`, `inactive_file`

Fixes #43810