### PR TITLE
daemon: fix getSourceMount to handle multiple mounts at same path

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -391,10 +391,11 @@ func getSourceMount(source string) (string, string, error) {
 		return "", "", fmt.Errorf("Can't find mount point of %s", source)
 	}
 
-	// find the longest mount point
+	// find the longest mount point, preferring later entries when there are
+	// multiple mounts at the same path (e.g., with different propagation settings)
 	var idx, maxlen int
 	for i := range mi {
-		if len(mi[i].Mountpoint) > maxlen {
+		if len(mi[i].Mountpoint) >= maxlen {
 			maxlen = len(mi[i].Mountpoint)
 			idx = i
 		}


### PR DESCRIPTION
## Summary

Fix `getSourceMount` to correctly handle cases where a mountpoint is mounted multiple times with different propagation settings.

## Problem

When a path is mounted multiple times (e.g., first as slave, then as shared):

```bash
mount --bind --make-slave /testvolume /testvolume
mount --bind --make-shared /testvolume /testvolume
```

The `/proc/self/mountinfo` shows multiple entries for the same path:
```
8217 25 8:1 /testvolume /testvolume rw,relatime master:1 - ext4 /dev/sda1 rw
8379 8217 8:1 /testvolume /testvolume rw,relatime shared:1187 master:1 - ext4 /dev/sda1 rw
```

The old code used `>` to find the longest mount path, which would always select the first entry. This caused Docker to incorrectly report "path is not a shared mount" even when the most recent mount has shared propagation.

## Solution

Change the comparison from `>` to `>=` so that when multiple mounts have the same path length, the later entry (which represents the current mount state) is preferred.

Fixes #43714

```markdown changelog
Fix shared mount detection for paths mounted multiple times, which caused "not a shared mount" errors when using bind propagation.
```