### PR TITLE
docs: fix base64 encoding description for secrets and configs

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5700,8 +5700,8 @@ definitions:
           com.example.some-other-label: "some-other-value"
       Data:
         description: |
-          Data is the data to store as a secret, formatted as a Base64-url-safe-encoded
-          ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) string.
+          Data is the data to store as a secret, formatted as a standard base64-encoded
+          ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-4)) string.
           It must be empty if the Driver field is set, in which case the data is
           loaded from an external secret store. The maximum allowed size is 500KB,
           as defined in [MaxSecretSize](https://pkg.go.dev/github.com/moby/swarmkit/v2@v2.0.0/api/validation#MaxSecretSize).
@@ -5755,8 +5755,8 @@ definitions:
           type: "string"
       Data:
         description: |
-          Data is the data to store as a config, formatted as a Base64-url-safe-encoded
-          ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-5)) string.
+          Data is the data to store as a config, formatted as a standard base64-encoded
+          ([RFC 4648](https://tools.ietf.org/html/rfc4648#section-4)) string.
           The maximum allowed size is 1000KB, as defined in [MaxConfigSize](https://pkg.go.dev/github.com/moby/swarmkit/v2@v2.0.0-20250103191802-8c1959736554/manager/controlapi#MaxConfigSize).
         type: "string"
       Templating:


### PR DESCRIPTION
## Summary

Fix the API documentation for secrets and configs Data field to correctly describe the base64 encoding format.

## Problem

The documentation incorrectly stated that the `Data` field should use "Base64-url-safe-encoded (RFC 4648 section 5)" format. However, Docker actually expects standard base64 encoding (RFC 4648 section 4).

This caused users to receive "illegal base64 data" errors when they followed the documentation and used URL-safe base64 encoding.

## Changes

Updated both `SecretSpec.Data` and `ConfigSpec.Data` descriptions:
- Changed from "Base64-url-safe-encoded" to "standard base64-encoded"
- Changed RFC reference from section 5 to section 4

Fixes #37671