### PR TITLE
docs: document healthcheck timeout termination behavior

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -862,6 +862,10 @@ definitions:
         description: |
           The time to wait before considering the check to have hung. It should
           be 0 or at least 1000000 (1 ms). 0 means inherit.
+
+          If the health check command does not complete within this timeout,
+          the check is considered failed and the health check process is
+          forcibly terminated.
         type: "integer"
         format: "int64"
       Retries:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -838,7 +838,9 @@ definitions:
           Value: "UUID2"
 
   HealthConfig:
-    description: "A test to perform to check that the container is healthy."
+    description: |
+      A test to perform to check that the container is healthy.
+      Healthcheck commands should be side-effect free.
     type: "object"
     properties:
       Test:
@@ -849,6 +851,12 @@ definitions:
           - `["NONE"]` disable healthcheck
           - `["CMD", args...]` exec arguments directly
           - `["CMD-SHELL", command]` run command with system's default shell
+
+          A non-zero exit code indicates a failed healthcheck:
+          - `0` healthy
+          - `1` unhealthy
+          - `2` reserved (treated as unhealthy)
+          - other values: error running probe
         type: "array"
         items:
           type: "string"
@@ -865,7 +873,7 @@ definitions:
 
           If the health check command does not complete within this timeout,
           the check is considered failed and the health check process is
-          forcibly terminated.
+          forcibly terminated without a graceful shutdown.
         type: "integer"
         format: "int64"
       Retries:


### PR DESCRIPTION
## Summary

Document the behavior when a health check command exceeds its configured timeout.

## Changes

Added clarification to the `Timeout` field description in `HealthConfig` that when the health check command does not complete within the timeout, the check is considered failed and the process is forcibly terminated.

This provides users with a clear contract for understanding what happens when their health check commands hang or take too long.

Fixes #45927