### PR TITLE
client: document that CopyToContainer requires TAR archive content

### DIFF
--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -47,10 +47,16 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID string, op
 // CopyToContainerOptions holds information
 // about files to copy into a container
 type CopyToContainerOptions struct {
-	DestinationPath           string
-	Content                   io.Reader
+	// DestinationPath is the path in the container where the content will be extracted.
+	DestinationPath string
+	// Content must be a TAR archive that will be extracted at DestinationPath.
+	// The archive can be compressed with gzip, bzip2, or xz.
+	Content io.Reader
+	// AllowOverwriteDirWithFile controls whether an existing directory can be
+	// replaced by a file and vice versa.
 	AllowOverwriteDirWithFile bool
-	CopyUIDGID                bool
+	// CopyUIDGID copies the UID/GID from the source files.
+	CopyUIDGID bool
 }
 
 type CopyToContainerResult struct{}


### PR DESCRIPTION
## Summary

Improve documentation for `CopyToContainerOptions` to clearly explain that the `Content` field must be a TAR archive.

## Changes

Added field-level documentation to `CopyToContainerOptions`:
- `DestinationPath`: clarified this is where content will be extracted
- `Content`: explicitly states it must be a TAR archive (can be compressed)
- `AllowOverwriteDirWithFile`: documented the overwrite behavior
- `CopyUIDGID`: documented UID/GID copy behavior

This addresses the confusion where the API documentation states tarball is required but the Go client documentation was unclear.

Fixes #31131