### PR TITLE
docs: improve description of image tag API endpoint

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10002,7 +10002,12 @@ paths:
   /images/{name}/tag:
     post:
       summary: "Tag an image"
-      description: "Tag an image so that it becomes part of a repository."
+      description: |
+        Create a tag that refers to a source image.
+
+        This creates an additional reference (tag) to the source image. The tag
+        can include a different repository name and/or tag. If the repository
+        or tag already exists, it will be overwritten.
       operationId: "ImageTag"
       responses:
         201:


### PR DESCRIPTION
## Summary

Improve the description of the `/images/{name}/tag` API endpoint to better explain what it does.

## Changes

Updated the description from:
> Tag an image so that it becomes part of a repository.

To a clearer explanation:
> Create a tag that refers to a source image.
>
> This creates an additional reference (tag) to the source image. The tag can include a different repository name and/or tag. If the repository or tag already exists, it will be overwritten.

Fixes #22402