### PR TITLE
integration: Support iputils ping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -477,7 +477,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-dev-aptlib,target=/var/lib/apt \
             bash-completion \
             bzip2 \
             fuse-overlayfs \
-            inetutils-ping \
+            iputils-ping \
             iproute2 \
             iptables \
             nftables \

--- a/integration/networking/port_mapping_linux_test.go
+++ b/integration/networking/port_mapping_linux_test.go
@@ -759,7 +759,7 @@ func TestDirectRoutingOpenPorts(t *testing.T) {
 		t.Parallel()
 		l3.Hosts["remote"].Do(t, func() {
 			t.Helper()
-			pingRes := icmd.RunCommand(cmd, "--numeric", "--count=1", "--timeout=3", addr)
+			pingRes := icmd.RunCommand(cmd, "-n", "-c1", "-W3", addr)
 			assert.Check(t, pingRes.ExitCode == expExit, "%s %s -> out:%s err:%s",
 				cmd, addr, pingRes.Stdout(), pingRes.Stderr())
 		})
@@ -880,7 +880,7 @@ func TestAcceptFwMark(t *testing.T) {
 		t.Parallel()
 		l3.Hosts["remote"].Do(t, func() {
 			t.Helper()
-			pingRes := icmd.RunCommand(cmd, "--numeric", "--count=1", "--timeout=3", addr)
+			pingRes := icmd.RunCommand(cmd, "-n", "-c1", "-W3", addr)
 			assert.Check(t, pingRes.ExitCode == expExit, "%s %s -> out:%s err:%s",
 				cmd, addr, pingRes.Stdout(), pingRes.Stderr())
 		})


### PR DESCRIPTION
Support iputils ping.  This patch makes it easier to run the tests on distros that don't package GNU inetutils like openSUSE & Fedora.  For this we just need to use the short options like in other parts of the test code.