### PR TITLE
fix: prevent potential panic in Shutdown when EventsService is nil

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1498,7 +1498,9 @@ func (daemon *Daemon) Shutdown(ctx context.Context) error {
 	// running anymore. If there are still some open connections to the
 	// '/events' endpoint, closing the EventsService should tear them down
 	// immediately.
-	daemon.EventsService.Close()
+	if daemon.EventsService != nil {
+		daemon.EventsService.Close()
+	}
 
 	return daemon.cleanupMounts(cfg)
 }


### PR DESCRIPTION
Add nil check before calling EventsService.Close() to prevent panic when daemon.EventsService is not initialized during shutdown.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x3eaea6d]

goroutine 1 [running, locked to thread]:
github.com/moby/moby/v2/daemon/events.(*Events).Close(...)
        /go/src/github.com/docker/docker/daemon/events/events.go:157
github.com/moby/moby/v2/daemon.(*Daemon).Shutdown(0xc000249408, {0xf4cf80, 0x4a854a0})
        /go/src/github.com/docker/docker/daemon/daemon.go:1513 +0x50d
github.com/moby/moby/v2/daemon.NewDaemon.func1()
        /go/src/github.com/docker/docker/daemon/daemon.go:914 +0x49
github.com/moby/moby/v2/daemon.NewDaemon({0xf4cff0, 0xc00037c5a0}, 0xc000536c08, 0xc00041ba40, 0xc000069220)
        /go/src/github.com/docker/docker/daemon/daemon.go:1379 +0x2be5
github.com/moby/moby/v2/daemon/command.(*daemonCLI).start(0xc00037c0f0, {0xf4cf80, 0x4a854a0})
        /go/src/github.com/docker/docker/daemon/command/daemon.go:270 +0x1075
github.com/moby/moby/v2/daemon/command.runDaemon(...)
        /go/src/github.com/docker/docker/daemon/command/docker_unix.go:13
github.com/moby/moby/v2/daemon/command.newDaemonCommand.func1(0xc0007c0008, {0xc000708180?, 0x7?, 0xa38a40?})
        /go/src/github.com/docker/docker/daemon/command/docker.go:48 +0xb3
github.com/spf13/cobra.(*Command).execute(0xc0007c0008, {0xc000052060, 0x4, 0x4})
        /go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0xc0007c0008)
        /go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
        /go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1064
github.com/moby/moby/v2/daemon/command.daemonRunner.Run({0xf19640?}, {0xf4cf80, 0x4a854a0})
        /go/src/github.com/docker/docker/daemon/command/docker.go:97 +0x6e
main.main()
        /go/src/github.com/docker/docker/cmd/dockerd/main.go:35 +0x119
```

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Prevent a potential panic on daemon shutdown after an incomplete initialization
```

**- A picture of a cute animal (not mandatory but encouraged)**

