### PR TITLE
WIP: container inspect: include OCI runtime spec

### DIFF
--- a/api/types/container/container.go
+++ b/api/types/container/container.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"encoding/json"
 	"os"
 	"time"
 
@@ -148,4 +149,6 @@ type InspectResponse struct {
 	NetworkSettings *NetworkSettings
 	// ImageManifestDescriptor is the descriptor of a platform-specific manifest of the image used to create the container.
 	ImageManifestDescriptor *ocispec.Descriptor `json:"ImageManifestDescriptor,omitempty"`
+
+	Spec map[string]json.RawMessage `json:",omitempty"`
 }

--- a/vendor/github.com/moby/moby/api/types/container/container.go
+++ b/vendor/github.com/moby/moby/api/types/container/container.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"encoding/json"
 	"os"
 	"time"
 
@@ -148,4 +149,6 @@ type InspectResponse struct {
 	NetworkSettings *NetworkSettings
 	// ImageManifestDescriptor is the descriptor of a platform-specific manifest of the image used to create the container.
 	ImageManifestDescriptor *ocispec.Descriptor `json:"ImageManifestDescriptor,omitempty"`
+
+	Spec map[string]json.RawMessage `json:",omitempty"`
 }


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/51705


Just a quick try if this would work; still needs design;

- Probably a slice instead of a map would be better
- Do we want the response to be part of the API, or keep it as a generic "json" blob?
- Do we want to show this info for stopped containers? (as in; what would be generated if the container would be started?)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

