### PR TITLE
daemon/server/httputils: remove badParameterError

### DIFF
--- a/daemon/server/httputils/form.go
+++ b/daemon/server/httputils/form.go
@@ -114,16 +114,6 @@ type ArchiveOptions struct {
 	Path string
 }
 
-type badParameterError struct {
-	param string
-}
-
-func (e badParameterError) Error() string {
-	return "bad parameter: " + e.param + "cannot be empty"
-}
-
-func (e badParameterError) InvalidParameter() {}
-
 // ArchiveFormValues parses form values and turns them into ArchiveOptions.
 // It fails if the archive name and path are not in the request.
 func ArchiveFormValues(r *http.Request, vars map[string]string) (ArchiveOptions, error) {
@@ -133,11 +123,11 @@ func ArchiveFormValues(r *http.Request, vars map[string]string) (ArchiveOptions,
 
 	name := vars["name"]
 	if name == "" {
-		return ArchiveOptions{}, badParameterError{"name"}
+		return ArchiveOptions{}, errdefs.InvalidParameter(errors.New("bad parameter: name cannot be empty"))
 	}
 	path := r.Form.Get("path")
 	if path == "" {
-		return ArchiveOptions{}, badParameterError{"path"}
+		return ArchiveOptions{}, errdefs.InvalidParameter(errors.New("bad parameter: path cannot be empty"))
 	}
 	return ArchiveOptions{name, path}, nil
 }


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/51795

The "param" field was only used to generate the error-message, and the produced error-message was missing a space so we may as well just inline it.

**- A picture of a cute animal (not mandatory but encouraged)**

