### PR TITLE
api: expose image push digest in push result

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -9941,6 +9941,16 @@ paths:
         `registry.example.com/myimage:latest`.
 
         The push is cancelled if the HTTP connection is closed.
+
+        The response is a stream of JSON objects. The final object in the stream
+        contains the image digest in an `aux` field:
+
+        ```json
+        {"progressDetail":{},"aux":{"Tag":"latest","Digest":"sha256:...","Size":1234}}
+        ```
+
+        The `Digest` field contains the content-addressable digest of the pushed
+        image manifest, which can be used to reference the image.
       operationId: "ImagePush"
       consumes:
         - "application/octet-stream"


### PR DESCRIPTION
## Summary

Expose image push digest via a structured `push` field in the JSON stream, instead of relying on legacy `aux`. Keep legacy `aux` emission for deprecated content trust compatibility.

## Changes
- Add `push` field to JSON stream message schema and `PushResult` type.
- Emit `push` in the final status message of image push.
- Document `push` field in `/images/{name}/push` response stream.

## Notes
Legacy `aux` message is kept for backwards compatibility with deprecated content trust.
