### PR TITLE
docs: fix typo in IPv6 constant comment

### DIFF
--- a/cmd/docker-proxy/proxy_linux.go
+++ b/cmd/docker-proxy/proxy_linux.go
@@ -8,7 +8,7 @@ type ipVersion string
 const (
 	// IPv4 is version 4
 	ip4 ipVersion = "4"
-	// IPv4 is version 6
+	// IPv6 is version 6
 	ip6 ipVersion = "6"
 )
 


### PR DESCRIPTION
**- What I did**
Fixed a typo in the comment for the IPv6 constant declaration in the IP version definitions.

**- How I did it**
Changed the duplicate comment "// IPv4 is version 6" to the correct "// IPv6 is version 6" on line 11.

**- How to verify it**
Review the comment change in the code - it's a documentation-only fix with no functional changes.

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 (Penguins are pretty cute, right?)