### PR TITLE
hack/validate: only search repo-dir for modules

### DIFF
--- a/hack/validate/golangci-lint
+++ b/hack/validate/golangci-lint
@@ -16,7 +16,7 @@ if pkg-config 'libsystemd' 2> /dev/null; then
 fi
 
 # Note: exclude github.com/docker/docker/man as it contains no Go code.
-mods=($(find . -name "go.mod" -type f -exec dirname {} \; | grep -v "man" | sort -u))
+mods=($(find "${REPODIR}" -name "go.mod" -type f -exec dirname {} \; | grep -v "/man" | sort -u))
 for mod in "${mods[@]}"; do
 	pushd "${mod}" > /dev/null
 	echo -e "\n\033[0;36mINFO\033[0m Start validation for module '${mod}' with golang-ci-lint"


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/51783

Minor enhancement / follow-up to c8aaeea285c63f9add09e01bd8260d1bce61a97d; make sure we never attempt to find `go.mod` files in other locations.

**- A picture of a cute animal (not mandatory but encouraged)**

