### PR TITLE
client: do not modify user-provided HTTP client

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -293,6 +293,11 @@ linters:
         linters:
           - gosec
 
+      - text: "^G402: " # Look for bad TLS connection settings
+        source: "cmpopts\\.Ignore"
+        linters:
+          - gosec
+
         # FIXME: ignoring unused assigns to ctx for now; too many hits in libnetwork/xxx functions that setup traces
       - text: "assigned to ctx, but never used afterwards"
         linters:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed constructing two Engine API clients from the same http.Client so that the second behaves the same as the first.

**- How I did it**
The `http.Client` passed into `client.WithHTTPClient()` is modified by the constructor in-place: the value of its `Transport` field is mutated and wrapped in an OpenTelemetry decorator. This can lead to very surprising behaviour when a second client is constructed reusing the same `http.Client` value. If the `http.Client` is configured for TLS, the second client will fail to detect that and will incorrectly dial the Engine API socket as cleartext HTTP. Copy the provided `http.Client` so our modifications don't leak out to unexpected places.

**- How to verify it**
New unit test.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- The http.Client value passed to client.WithHTTPClient() is now copied rather than mutated in-place.
```

**- A picture of a cute animal (not mandatory but encouraged)**

