### PR TITLE
[docker-29.x backport] layer: Clean up RW layer if mount metadata save fails

### DIFF
--- a/daemon/internal/layer/layer_store.go
+++ b/daemon/internal/layer/layer_store.go
@@ -535,6 +535,9 @@ func (ls *layerStore) CreateRWLayer(name string, parent ChainID, opts *CreateRWL
 		return nil, err
 	}
 	if err := ls.saveMount(m); err != nil {
+		if removeErr := ls.driver.Remove(m.mountID); removeErr != nil {
+			log.G(context.TODO()).WithFields(log.Fields{"mount-id": m.mountID, "error": removeErr}).Error("Failed to clean up RW layer after mount save failure")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51714


Add cleanup for the RW layer directory if saveMount() fails after driver.CreateReadWrite() succeeds. Previously, this failure path would leave an orphaned overlay2 directory with no corresponding metadata.

Related to moby/moby#45939


(cherry picked from commit d7a6250b91a7e3ded0f6d659b7e55aa2d41a3644)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix potential creation of orphaned overlay2 layers
```

**- A picture of a cute animal (not mandatory but encouraged)**

