### PR TITLE
[docker-29.x backport] remove uses of deprecated go-archive consts

### DIFF
--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moby/go-archive"
 	"github.com/moby/go-archive/chrootarchive"
+	"github.com/moby/go-archive/compression"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
@@ -278,7 +279,7 @@ func (daemon *Daemon) containerCopy(container *container.Container, resource str
 		filter = []string{f}
 	}
 	archv, err := chrootarchive.Tar(basePath, &archive.TarOptions{
-		Compression:  archive.Uncompressed,
+		Compression:  compression.None,
 		IncludeFiles: filter,
 	}, container.BaseFS)
 	if err != nil {

--- a/daemon/builder/dockerfile/evaluator_test.go
+++ b/daemon/builder/dockerfile/evaluator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/v2/daemon/builder/remotecontext"
 	"github.com/moby/sys/reexec"
 	"gotest.tools/v3/assert"
@@ -105,7 +106,7 @@ func TestDispatch(t *testing.T) {
 				createTestTempFile(t, contextDir, filename, content, 0o777)
 			}
 
-			tarStream, err := archive.Tar(contextDir, archive.Uncompressed)
+			tarStream, err := archive.Tar(contextDir, compression.None)
 			if err != nil {
 				t.Fatalf("Error when creating tar stream: %s", err)
 			}

--- a/daemon/builder/dockerfile/internals_test.go
+++ b/daemon/builder/dockerfile/internals_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/v2/daemon/builder"
@@ -61,7 +62,7 @@ func readAndCheckDockerfile(t *testing.T, testName, contextDir, dockerfilePath, 
 	if runtime.GOOS != "windows" {
 		skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 	}
-	tarStream, err := archive.Tar(contextDir, archive.Uncompressed)
+	tarStream, err := archive.Tar(contextDir, compression.None)
 	assert.NilError(t, err)
 
 	defer func() {

--- a/daemon/builder/remotecontext/git.go
+++ b/daemon/builder/remotecontext/git.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/v2/daemon/builder"
 	"github.com/moby/moby/v2/daemon/builder/remotecontext/git"
 )
@@ -17,7 +18,7 @@ func MakeGitContext(gitURL string) (builder.Source, error) {
 		return nil, err
 	}
 
-	c, err := archive.Tar(root, archive.Uncompressed)
+	c, err := archive.Tar(root, compression.None)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/builder/remotecontext/tarsum_test.go
+++ b/daemon/builder/remotecontext/tarsum_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/v2/daemon/builder"
 	"github.com/moby/sys/reexec"
 	"github.com/pkg/errors"
@@ -128,7 +129,7 @@ func TestRemoveDirectory(t *testing.T) {
 
 func makeTestArchiveContext(t *testing.T, dir string) builder.Source {
 	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
-	tarStream, err := archive.Tar(dir, archive.Uncompressed)
+	tarStream, err := archive.Tar(dir, compression.None)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/daemon/containerd/image_load_test.go
+++ b/daemon/containerd/image_load_test.go
@@ -15,6 +15,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/testutil/labelstore"
 	"github.com/moby/moby/v2/internal/testutil/specialimage"
@@ -39,7 +40,7 @@ func TestImageLoad(t *testing.T) {
 	imgSvc.defaultPlatformOverride = platforms.Only(linuxAmd64)
 
 	tryLoad := func(ctx context.Context, t *testing.T, dir string, platformList []ocispec.Platform) error {
-		tarRc, err := archive.Tar(dir, archive.Uncompressed)
+		tarRc, err := archive.Tar(dir, compression.None)
 		assert.NilError(t, err)
 		defer tarRc.Close()
 

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/go-archive"
 	"github.com/moby/go-archive/chrootarchive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/errdefs"
@@ -65,7 +66,7 @@ func (daemon *Daemon) containerExport(ctx context.Context, ctr *container.Contai
 	}()
 
 	archv, err := chrootarchive.Tar(basefs, &archive.TarOptions{
-		Compression: archive.Uncompressed,
+		Compression: compression.None,
 		IDMap:       daemon.idMapping,
 	}, basefs)
 	if err != nil {

--- a/daemon/graphdriver/fsdiff.go
+++ b/daemon/graphdriver/fsdiff.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/moby/go-archive"
 	"github.com/moby/go-archive/chrootarchive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/v2/pkg/ioutils"
 	"github.com/moby/sys/user"
 )
@@ -64,7 +65,7 @@ func (gdw *NaiveDiffDriver) Diff(id, parent string) (arch io.ReadCloser, retErr 
 	}()
 
 	if parent == "" {
-		tarArchive, err := archive.Tar(layerFs, archive.Uncompressed)
+		tarArchive, err := archive.Tar(layerFs, compression.None)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/moby/go-archive"
 	"github.com/moby/go-archive/chrootarchive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/locker"
 	"github.com/moby/moby/v2/daemon/graphdriver"
 	"github.com/moby/moby/v2/daemon/graphdriver/overlayutils"
@@ -721,7 +722,7 @@ func (d *Driver) Diff(id, parent string) (io.ReadCloser, error) {
 	diffPath := d.getDiffPath(id)
 	logger.Debugf("Tar with options on %s", diffPath)
 	return archive.TarWithOptions(diffPath, &archive.TarOptions{
-		Compression:    archive.Uncompressed,
+		Compression:    compression.None,
 		IDMap:          d.idMap,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
 	})

--- a/daemon/internal/image/tarexport/save.go
+++ b/daemon/internal/image/tarexport/save.go
@@ -17,6 +17,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	v1 "github.com/moby/moby/v2/daemon/internal/image/v1"
@@ -395,7 +396,7 @@ func (s *saveSession) writeTar(ctx context.Context, tempDir string, outStream io
 	ctx, span := tracing.StartSpan(ctx, "writeTar")
 	defer span.End()
 
-	fs, err := archive.Tar(tempDir, archive.Uncompressed)
+	fs, err := archive.Tar(tempDir, compression.None)
 	if err != nil {
 		span.SetStatus(err)
 		return err

--- a/daemon/internal/layer/layer_test.go
+++ b/daemon/internal/layer/layer_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containerd/continuity/driver"
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/v2/daemon/graphdriver"
 	"github.com/moby/moby/v2/daemon/graphdriver/vfs"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
@@ -587,7 +588,7 @@ func tarFromFiles(files ...FileApplier) ([]byte, error) {
 		}
 	}
 
-	r, err := archive.Tar(td, archive.Uncompressed)
+	r, err := archive.Tar(td, compression.None)
 	if err != nil {
 		return nil, err
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2024,11 +2024,11 @@ CMD ["cat", "/foo"]`),
 }
 
 func (s *DockerCLIBuildSuite) TestBuildContextTarGzip(c *testing.T) {
-	testContextTar(c, archive.Gzip)
+	testContextTar(c, compression.Gzip)
 }
 
 func (s *DockerCLIBuildSuite) TestBuildContextTarNoCompression(c *testing.T) {
-	testContextTar(c, archive.Uncompressed)
+	testContextTar(c, compression.None)
 }
 
 func (s *DockerCLIBuildSuite) TestBuildNoContext(c *testing.T) {

--- a/internal/testutil/fixtures/plugin/plugin.go
+++ b/internal/testutil/fixtures/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/api/types/events"
 	plugintypes "github.com/moby/moby/api/types/plugin"
 	"github.com/moby/moby/api/types/registry"
@@ -209,7 +210,7 @@ func makePluginBundle(inPath string, opts ...CreateOpt) (io.ReadCloser, error) {
 	if err := archive.NewDefaultArchiver().CopyFileWithTar(cfg.binPath, filepath.Join(inPath, "rootfs", p.Entrypoint[0])); err != nil {
 		return nil, errors.Wrap(err, "error copying plugin binary to rootfs path")
 	}
-	tar, err := archive.Tar(inPath, archive.Uncompressed)
+	tar, err := archive.Tar(inPath, compression.None)
 	return tar, errors.Wrap(err, "error making plugin archive")
 }
 

--- a/internal/testutil/specialimage/multilayer.go
+++ b/internal/testutil/specialimage/multilayer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/google/uuid"
 	"github.com/moby/go-archive"
+	"github.com/moby/go-archive/compression"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -137,7 +138,7 @@ func fileArchive(dir string, name string, content []byte) (io.ReadCloser, error)
 		return nil, err
 	}
 
-	return archive.Tar(tmp, archive.Uncompressed)
+	return archive.Tar(tmp, compression.None)
 }
 
 func writeLayerWithOneFile(dir string, filename string, content []byte) (ocispec.Descriptor, error) {


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51777

(cherry picked from commit 7239c72eca82be58f07cd22ba03868ae17fddfd6)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

