### PR TITLE
daemon/libnetwork: Fix panic in findHNSEp when IP networks are nil

### DIFF
--- a/daemon/libnetwork/network_windows.go
+++ b/daemon/libnetwork/network_windows.go
@@ -251,9 +251,14 @@ func deleteEpFromResolverImpl(
 }
 
 func findHNSEp(ip4, ip6 *net.IPNet, hnsEndpoints []hcsshim.HNSEndpoint) *hcsshim.HNSEndpoint {
+	if ip4 == nil && ip6 == nil {
+		return nil
+	}
 	for _, hnsEp := range hnsEndpoints {
-		if (hnsEp.IPAddress != nil && hnsEp.IPAddress.Equal(ip4.IP)) ||
-			(hnsEp.IPv6Address != nil && hnsEp.IPv6Address.Equal(ip6.IP)) {
+		if ip4 != nil && hnsEp.IPAddress != nil && hnsEp.IPAddress.Equal(ip4.IP) {
+			return &hnsEp
+		}
+		if ip6 != nil && hnsEp.IPv6Address != nil && hnsEp.IPv6Address.Equal(ip6.IP) {
 			return &hnsEp
 		}
 	}


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/51822


**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker run --network none` panic on Windows
```

**- A picture of a cute animal (not mandatory but encouraged)**

