### PR TITLE
[docker-29.x backport] daemon/volumes: More fs friendly image mount layer names

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -259,10 +260,11 @@ func (daemon *Daemon) registerMountPoints(ctr *container.Container, defaultReadO
 				StorageOpt: ctr.HostConfig.StorageOpt,
 			}
 
-			// Include the destination in the layer name to make it unique for each mount point and container.
+			// Hash the source and destination to create a safe, unique identifier for each mount point and container.
 			// This makes sure that the same image can be mounted multiple times with different destinations.
-			// Hex encode the destination to create a safe, unique identifier
-			layerName := hex.EncodeToString([]byte(ctr.ID + ",src=" + mp.Source + ",dst=" + mp.Destination))
+			// We hash it so that the snapshot name is friendly to the underlying filesystem and doesn't exceed path length limits.
+			destHash := sha256.Sum256([]byte(ctr.ID + "-src=" + mp.Source + "-dst=" + mp.Destination))
+			layerName := hex.EncodeToString(destHash[:])
 			layer, err := daemon.imageService.CreateLayerFromImage(img, layerName, rwLayerOpts)
 			if err != nil {
 				return err


### PR DESCRIPTION
- backport https://github.com/moby/moby/pull/51827
- fixes: https://github.com/moby/moby/issues/51687
- reverts suggestion: https://github.com/moby/moby/pull/50268#discussion_r2169096442

### daemon/volumes: More fs friendly image mount layer names

  Hash the container ID, mount source and destination together to form a layer name.

  This ensures the generated names are filesystem-friendly and don't exceed path length limits while maintaining uniqueness across different mount points and containers.

```markdown changelog
Fix image mounts failing with "file name too long" for long mount paths
```