### PR TITLE
client: implement WithResponseHook option

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,6 +59,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -240,6 +241,13 @@ func New(ops ...Opt) (*Client, error) {
 	}
 
 	c.client.Transport = otelhttp.NewTransport(c.client.Transport, c.traceOpts...)
+
+	if len(cfg.responseHooks) > 0 {
+		c.client.Transport = &responseHookTransport{
+			base:  c.client.Transport,
+			hooks: slices.Clone(cfg.responseHooks),
+		}
+	}
 
 	return c, nil
 }

--- a/client/client_options.go
+++ b/client/client_options.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -55,9 +56,18 @@ type clientConfig struct {
 	// takes precedence. Either field disables API-version negotiation.
 	envAPIVersion string
 
+	// responseHooks is a list of custom response hooks to call on responses.
+	responseHooks []ResponseHook
+
 	// traceOpts is a list of options to configure the tracing span.
 	traceOpts []otelhttp.Option
 }
+
+// ResponseHook is called for each HTTP response returned by the daemon.
+// Hooks are invoked in the order they were added.
+//
+// Hooks must not read or close resp.Body.
+type ResponseHook func(*http.Response) error
 
 // Opt is a configuration option to initialize a [Client].
 type Opt func(*clientConfig) error
@@ -345,6 +355,21 @@ func WithTraceProvider(provider trace.TracerProvider) Opt {
 func WithTraceOptions(opts ...otelhttp.Option) Opt {
 	return func(c *clientConfig) error {
 		c.traceOpts = append(c.traceOpts, opts...)
+		return nil
+	}
+}
+
+// WithResponseHook adds a ResponseHook to the client. ResponseHooks are called
+// for each HTTP response returned by the daemon. Hooks are invoked in the order
+// they were added.
+//
+// Hooks must not read or close resp.Body.
+func WithResponseHook(h ResponseHook) Opt {
+	return func(c *clientConfig) error {
+		if h == nil {
+			return errors.New("invalid response hook: hook is nil")
+		}
+		c.responseHooks = append(c.responseHooks, h)
 		return nil
 	}
 }

--- a/client/client_options.go
+++ b/client/client_options.go
@@ -67,7 +67,7 @@ type clientConfig struct {
 // Hooks are invoked in the order they were added.
 //
 // Hooks must not read or close resp.Body.
-type ResponseHook func(*http.Response) error
+type ResponseHook func(*http.Response)
 
 // Opt is a configuration option to initialize a [Client].
 type Opt func(*clientConfig) error

--- a/client/client_responsehook.go
+++ b/client/client_responsehook.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"net/http"
+)
+
+type responseHookTransport struct {
+	base  http.RoundTripper
+	hooks []ResponseHook
+}
+
+func (t *responseHookTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	for _, h := range t.hooks {
+		if err := h(resp); err != nil {
+			_ = resp.Body.Close()
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}

--- a/client/client_responsehook.go
+++ b/client/client_responsehook.go
@@ -16,10 +16,7 @@ func (t *responseHookTransport) RoundTrip(req *http.Request) (*http.Response, er
 	}
 
 	for _, h := range t.hooks {
-		if err := h(resp); err != nil {
-			_ = resp.Body.Close()
-			return nil, err
-		}
+		h(resp)
 	}
 
 	return resp, nil

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -59,6 +59,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -240,6 +241,13 @@ func New(ops ...Opt) (*Client, error) {
 	}
 
 	c.client.Transport = otelhttp.NewTransport(c.client.Transport, c.traceOpts...)
+
+	if len(cfg.responseHooks) > 0 {
+		c.client.Transport = &responseHookTransport{
+			base:  c.client.Transport,
+			hooks: slices.Clone(cfg.responseHooks),
+		}
+	}
 
 	return c, nil
 }

--- a/vendor/github.com/moby/moby/client/client_options.go
+++ b/vendor/github.com/moby/moby/client/client_options.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -55,9 +56,18 @@ type clientConfig struct {
 	// takes precedence. Either field disables API-version negotiation.
 	envAPIVersion string
 
+	// responseHooks is a list of custom response hooks to call on responses.
+	responseHooks []ResponseHook
+
 	// traceOpts is a list of options to configure the tracing span.
 	traceOpts []otelhttp.Option
 }
+
+// ResponseHook is called for each HTTP response returned by the daemon.
+// Hooks are invoked in the order they were added.
+//
+// Hooks must not read or close resp.Body.
+type ResponseHook func(*http.Response) error
 
 // Opt is a configuration option to initialize a [Client].
 type Opt func(*clientConfig) error
@@ -345,6 +355,21 @@ func WithTraceProvider(provider trace.TracerProvider) Opt {
 func WithTraceOptions(opts ...otelhttp.Option) Opt {
 	return func(c *clientConfig) error {
 		c.traceOpts = append(c.traceOpts, opts...)
+		return nil
+	}
+}
+
+// WithResponseHook adds a ResponseHook to the client. ResponseHooks are called
+// for each HTTP response returned by the daemon. Hooks are invoked in the order
+// they were added.
+//
+// Hooks must not read or close resp.Body.
+func WithResponseHook(h ResponseHook) Opt {
+	return func(c *clientConfig) error {
+		if h == nil {
+			return errors.New("invalid response hook: hook is nil")
+		}
+		c.responseHooks = append(c.responseHooks, h)
 		return nil
 	}
 }

--- a/vendor/github.com/moby/moby/client/client_options.go
+++ b/vendor/github.com/moby/moby/client/client_options.go
@@ -67,7 +67,7 @@ type clientConfig struct {
 // Hooks are invoked in the order they were added.
 //
 // Hooks must not read or close resp.Body.
-type ResponseHook func(*http.Response) error
+type ResponseHook func(*http.Response)
 
 // Opt is a configuration option to initialize a [Client].
 type Opt func(*clientConfig) error

--- a/vendor/github.com/moby/moby/client/client_responsehook.go
+++ b/vendor/github.com/moby/moby/client/client_responsehook.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"net/http"
+)
+
+type responseHookTransport struct {
+	base  http.RoundTripper
+	hooks []ResponseHook
+}
+
+func (t *responseHookTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	for _, h := range t.hooks {
+		if err := h(resp); err != nil {
+			_ = resp.Body.Close()
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}

--- a/vendor/github.com/moby/moby/client/client_responsehook.go
+++ b/vendor/github.com/moby/moby/client/client_responsehook.go
@@ -16,10 +16,7 @@ func (t *responseHookTransport) RoundTrip(req *http.Request) (*http.Response, er
 	}
 
 	for _, h := range t.hooks {
-		if err := h(resp); err != nil {
-			_ = resp.Body.Close()
-			return nil, err
-		}
+		h(resp)
 	}
 
 	return resp, nil


### PR DESCRIPTION
This options allows a client to call hooks on API responses, for example, to get response header, or other information from the response.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

