### PR TITLE
migrate TestAPISwarmCAHash to Integration Test

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -184,22 +184,6 @@ func (s *DockerSwarmSuite) TestUpdateSwarmAddExternalCA(c *testing.T) {
 	assert.Equal(c, info.Cluster.Spec.CAConfig.ExternalCAs[1].CACert, "cacert")
 }
 
-func (s *DockerSwarmSuite) TestAPISwarmCAHash(c *testing.T) {
-	ctx := testutil.GetContext(c)
-	d1 := s.AddDaemon(ctx, c, true, true)
-	d2 := s.AddDaemon(ctx, c, false, false)
-	splitToken := strings.Split(d1.JoinTokens(c).Worker, "-")
-	splitToken[2] = "1kxftv4ofnc6mt30lmgipg6ngf9luhwqopfk1tz6bdmnkubg0e"
-	replacementToken := strings.Join(splitToken, "-")
-	c2 := d2.NewClientT(c)
-	_, err := c2.SwarmJoin(testutil.GetContext(c), client.SwarmJoinOptions{
-		ListenAddr:  d2.SwarmListenAddr(),
-		JoinToken:   replacementToken,
-		RemoteAddrs: []string{d1.SwarmListenAddr()},
-	})
-	assert.ErrorContains(c, err, "remote CA does not match fingerprint")
-}
-
 func (s *DockerSwarmSuite) TestAPISwarmPromoteDemote(c *testing.T) {
 	ctx := testutil.GetContext(c)
 	d1 := s.AddDaemon(ctx, c, false, false)

--- a/integration/service/swarm_test.go
+++ b/integration/service/swarm_test.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/v2/integration/internal/swarm"
+	"github.com/moby/moby/v2/internal/testutil/daemon"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
+)
+
+func TestSwarmCAHash(t *testing.T) {
+	skip.If(t, strings.HasPrefix(testEnv.FirewallBackendDriver(), "nftables"), "swarm cannot be used with nftables")
+	ctx := setupTest(t)
+
+	d1 := swarm.NewSwarm(ctx, t, testEnv)
+	defer d1.Stop(t)
+	d2 := daemon.New(t)
+	d2.Start(t)
+	defer d2.Stop(t)
+
+	splitToken := strings.Split(d1.JoinTokens(t).Worker, "-")
+	splitToken[2] = "1kxftv4ofnc6mt30lmgipg6ngf9luhwqopfk1tz6bdmnkubg0e"
+	replacementToken := strings.Join(splitToken, "-")
+	c2 := d2.NewClientT(t)
+	defer c2.Close()
+
+	_, err := c2.SwarmJoin(ctx, client.SwarmJoinOptions{
+		ListenAddr:  d2.SwarmListenAddr(),
+		JoinToken:   replacementToken,
+		RemoteAddrs: []string{d1.SwarmListenAddr()},
+	})
+	assert.ErrorContains(t, err, "remote CA does not match fingerprint")
+}


### PR DESCRIPTION

**- What I did**

Migrated the TestSwarmCAHash test from integration-cli/docker_api_swarm_test.go to the new integration test framework under integration/service/swarm_test.go.
