### PR TITLE
migrate TestAPISwarmErrorHandling to Integration Test

### DIFF
--- a/integration-cli/docker_api_swarm_test.go
+++ b/integration-cli/docker_api_swarm_test.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -904,20 +903,6 @@ func (s *DockerSwarmSuite) TestAPISwarmUnlockNotLocked(c *testing.T) {
 	d := s.AddDaemon(ctx, c, true, true)
 	err := d.SwarmUnlock(c, swarm.UnlockRequest{UnlockKey: "wrong-key"})
 	assert.ErrorContains(c, err, "swarm is not locked")
-}
-
-// #29885
-func (s *DockerSwarmSuite) TestAPISwarmErrorHandling(c *testing.T) {
-	ctx := testutil.GetContext(c)
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", defaultSwarmPort))
-	assert.NilError(c, err)
-	defer ln.Close()
-	d := s.AddDaemon(ctx, c, false, false)
-	cli := d.NewClientT(c)
-	_, err = cli.SwarmInit(testutil.GetContext(c), client.SwarmInitOptions{
-		ListenAddr: d.SwarmListenAddr(),
-	})
-	assert.ErrorContains(c, err, "address already in use")
 }
 
 // Test case for 30178

--- a/integration/service/swarm_test.go
+++ b/integration/service/swarm_test.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/v2/internal/testutil/daemon"
+	"gotest.tools/v3/assert"
+)
+
+const (
+	defaultSwarmPort = 2477
+)
+
+// #29885
+func TestSwarmErrorHandling(t *testing.T) {
+	ctx := setupTest(t)
+
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", defaultSwarmPort))
+	assert.NilError(t, err)
+	defer ln.Close()
+
+	d := daemon.New(t)
+	d.Start(t)
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+	defer apiClient.Close()
+
+	_, err = apiClient.SwarmInit(ctx, client.SwarmInitOptions{
+		ListenAddr: d.SwarmListenAddr(),
+	})
+	assert.ErrorContains(t, err, "address already in use")
+
+}


### PR DESCRIPTION

**- What I did**
Migrated the `TestAPISwarmErrorHandling` test from `integration-cli/docker_api_swarm_test.go` to the new integration test framework under `integration/service/swarm_test.go`.