### PR TITLE
integration/container: migrate stream connected containers test

### DIFF
--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -1,10 +1,13 @@
 package container
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
+	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
 	containertypes "github.com/moby/moby/api/types/container"
@@ -92,4 +95,32 @@ func TestStatsContainerNotFound(t *testing.T) {
 			assert.ErrorContains(t, err, "no-such-container")
 		})
 	}
+}
+
+func TestStatsNoStreamConnectedContainers(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, testEnv.IsRootless() && testEnv.DaemonInfo.CgroupVersion == "1", "Rootless Mode does not support cgroups v1 stats")
+	ctx := setupTest(t)
+
+	apiClient := testEnv.APIClient()
+
+	cID1 := container.Run(ctx, t, apiClient)
+	cID2 := container.Run(ctx, t, apiClient, func(tcc *container.TestContainerConfig) {
+		tcc.HostConfig.NetworkMode = containertypes.NetworkMode(fmt.Sprintf("container:%s", cID1))
+	})
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	statsResult, err := apiClient.ContainerStats(ctx, cID2, client.ContainerStatsOptions{Stream: false})
+	assert.NilError(t, err)
+
+	defer statsResult.Body.Close()
+
+	var v containertypes.StatsResponse
+	dec := json.NewDecoder(statsResult.Body)
+	assert.NilError(t, dec.Decode(&v))
+	assert.Check(t, is.Equal(v.ID, cID2))
+	err = dec.Decode(&v)
+	assert.Check(t, is.ErrorIs(err, io.EOF), "Expected only a single result")
 }


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/50159

relates to:

- https://github.com/moby/moby/issues/21848
- https://github.com/moby/moby/pull/21904

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Migrated the test `TestAPIStatsNoStreamConnectedContainer` from the `integration-cli/` directory to the `integration/` directory in reference to epic #50159.
**- How I did it**
Rewriting the test using the Go-client and moving it to the `integration/` diectory
**- How to verify it**
```basg
TESTDIRS='./integration/container/' TESTFLAGS='-test.run TestStatsNoStreamConnectedContainers' make test-integration
```