### PR TITLE
fix: goroutine leak in TestRingLogger

### DIFF
--- a/daemon/logger/ring_test.go
+++ b/daemon/logger/ring_test.go
@@ -26,7 +26,7 @@ func (l *mockLogger) Close() error {
 func TestRingLogger(t *testing.T) {
 	mockLog := &mockLogger{make(chan *Message)} // no buffer on this channel
 	ring := newRingLogger(mockLog, Info{}, 1)
-	defer ring.setClosed()
+	defer ring.Close()
 
 	// this should never block
 	ring.Log(&Message{Line: []byte("1")})


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/49717

## Summary

Fixes a goroutine leak in TestRingLogger by using 
ing.Close() instead of 
ing.setClosed().

## Details


ing.setClosed() only sets the close flag but doesn't:
- Call 
.buffer.Close() which would broadcast to waiting goroutines
- Wait for goroutines to finish

This leaves the goroutine started by 
ewRingLogger waiting forever on cond.Wait().


ing.Close() properly broadcasts to wake up waiting goroutines and waits for them to complete.

## Test plan

- [x] Simple one-line fix
- [ ] CI tests pass

Fixes #49717