### PR TITLE
update to go1.25.6

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -21,7 +21,7 @@ on:
         default: "graphdriver"
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   ITG_CLI_MATRIX_SIZE: 6

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   TESTSTAT_VERSION: v0.1.25
   TEMPLATE_NAME: ${{ inputs.template }}
 

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -28,7 +28,7 @@ on:
         default: false
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   TESTSTAT_VERSION: v0.1.25
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ on:
     - cron: '0 9 * * 4'
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
 
 jobs:
   codeql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.25.5"
+  GO_VERSION: "1.25.6"
   GIT_PAGER: "cat"
   PAGER: "cat"
   SETUP_BUILDX_VERSION: edge

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ version: "2"
 run:
   # prevent golangci-lint from deducting the go version to lint for through go.mod,
   # which causes it to fallback to go1.17 semantics.
-  go: "1.25.5"
+  go: "1.25.6"
   # Only supported with go modules enabled (build flag -mod=vendor only valid when using modules)
   # modules-download-mode: vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.25.6
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.25.6
 
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.25.6
 
 # GOTESTSUM_VERSION is the version of gotest.tools/gotestsum to install.
 ARG GOTESTSUM_VERSION=v1.13.0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.25.6
 
 FROM golang:${GO_VERSION}-alpine AS base
 RUN apk add --no-cache bash make yamllint

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.25.6
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG PROTOC_VERSION=3.11.4
 

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.25.6
 ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 


### PR DESCRIPTION
- https://github.com/golang/go/issues?q=milestone%3AGo1.25.6+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.25.5...go1.25.6

This releases includes 6 security fixes following the security policy:

  - archive/zip: denial of service when parsing arbitrary ZIP archives

      archive/zip used a super-linear file name indexing algorithm that is invoked the first time a file in an archive is opened. This can lead to a denial of service when consuming a maliciously constructed ZIP archive.

      Thanks to Thanks to Jakub Ciolek for reporting this issue.

      This is CVE-2025-61728 and Go issue https://go.dev/issue/77102.

  - net/http: memory exhaustion in Request.ParseForm

      When parsing a URL-encoded form net/http may allocate an unexpected amount of
     memory when provided a large number of key-value pairs. This can result in a
     denial of service due to memory exhaustion.

      Thanks to jub0bs for reporting this issue.

      This is CVE-2025-61726 and Go issue https://go.dev/issue/77101.

  - crypto/tls: Config.Clone copies automatically generated session ticket keys, session resumption does not account for the expiration of full certificate chain

      The Config.Clone methods allows cloning a Config which has already been passed
     to a TLS function, allowing it to be mutated and reused.

      If Config.SessionTicketKey has not been set, and Config.SetSessionTicketKeys has
     not been called, crypto/tls will generate random session ticket keys and
     automatically rotate them. Config.Clone would copy these automatically generated
     keys into the returned Config, meaning that the two Configs would share session
     ticket keys, allowing sessions created using one Config could be used to resume
     sessions with the other Config. This can allow clients to resume sessions even
     though the Config may be configured such that they should not be able to do so.

      Config.Clone no longer copies the automatically generated session ticket keys.
     Config.Clone still copies keys which are explicitly provided, either by setting
     Config.SessionTicketKey or by calling Config.SetSessionTicketKeys.

      This issue was discoverd by the Go Security team while investigating another
     issue reported by Coia Prant (github.com/rbqvq).

      Additionally, on the server side only the expiration of the leaf certificate, if
     one was provided during the initial handshake, was checked when considering if a
     session could be resumed. This allowed sessions to be resumed if an intermediate
     or root certificate in the chain had expired.

      Session resumption now takes into account of the full chain when determining if
     the session can be resumed.

      Thanks to Coia Prant (github.com/rbqvq) for reporting this issue.

      This is CVE-2025-68121 and Go issue https://go.dev/issue/77113.

  - cmd/go: bypass of flag sanitization can lead to arbitrary code execution

      Usage of 'CgoPkgConfig' allowed execution of the pkg-config
     binary with flags that are not explicitly safe-listed.

      To prevent this behavior, compiler flags resulting from usage
     of 'CgoPkgConfig' are sanitized prior to invoking pkg-config.

      Thank you to RyotaK (https://ryotak.net) of GMO Flatt Security Inc.
     for reporting this issue.

      This is CVE-2025-61731 and go.dev/issue/77100.

  - cmd/go: unexpected code execution when invoking toolchain

      The Go toolchain supports multiple VCS which are used retrieving modules and
     embedding build information into binaries.

      On systems with Mercurial installed (hg) downloading modules (e.g. via go get or
     go mod download) from non-standard sources (e.g. custom domains) can cause
     unexpected code execution due to how external VCS commands are constructed.

      On systems with Git installed, downloading and building modules with malicious
     version strings could allow an attacker to write to arbitrary files on the
     system the user has access to. This can only be triggered by explicitly
     providing the malicious version strings to the toolchain, and does not affect
     usage of @latest or bare module paths.

      The toolchain now uses safer VCS options to prevent misinterpretation of
     untrusted inputs. In addition, the toolchain now disallows module version
     strings prefixed with a "-" or "/" character.

      Thanks to splitline (@splitline) from DEVCORE Research Team for reporting this
     issue.

      This is CVE-2025-68119 and Go issue https://go.dev/issue/77099.

  - crypto/tls: handshake messages may be processed at the incorrect encryption level

      During the TLS 1.3 handshake if multiple messages are sent in records that span
     encryption level boundaries (for instance the Client Hello and Encrypted
     Extensions messages), the subsequent messages may be processed before the
     encryption level changes. This can cause some minor information disclosure if a
     network-local attacker can inject messages during the handshake.

      Thanks to Coia Prant (github.com/rbqvq) for reporting this issue.

      This is CVE-2025-61730 and Go issue https://go.dev/issue/76443

  View the release notes for more information: https://go.dev/doc/devel/release#go1.25.6


**- Description for the changelog**

```markdown changelog
Update Go runtime to [1.25.6](https://go.dev/doc/devel/release#go1.25.6)
```