### PR TITLE
[docker-29.x backport] ci: Remove concurrency setting from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
   # prevent golangci-lint from deducting the go version to lint for through go.mod,
   # which causes it to fallback to go1.17 semantics.
   go: "1.25.5"
-  concurrency: 2
   # Only supported with go modules enabled (build flag -mod=vendor only valid when using modules)
   # modules-download-mode: vendor
 


### PR DESCRIPTION
- backport: https://github.com/moby/moby/pull/51723

Remove the hardcoded concurrency limit of 2 from the golangci-lint configuration to allow the linter to match the machine CPU's core count.

This makes a cleaner cherrypick of the Go update.