### PR TITLE
migrate TestContainerAPIPostContainerStop to integration

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -953,19 +953,6 @@ func (s *DockerAPISuite) TestContainerAPIChunkedEncoding(c *testing.T) {
 	assert.Equal(c, resp.StatusCode, http.StatusCreated)
 }
 
-func (s *DockerAPISuite) TestContainerAPIPostContainerStop(c *testing.T) {
-	containerID := runSleepingContainer(c)
-	cli.WaitRun(c, containerID)
-
-	apiClient, err := client.New(client.FromEnv)
-	assert.NilError(c, err)
-	defer apiClient.Close()
-
-	_, err = apiClient.ContainerStop(testutil.GetContext(c), containerID, client.ContainerStopOptions{})
-	assert.NilError(c, err)
-	assert.NilError(c, waitInspect(containerID, "{{ .State.Running  }}", "false", 60*time.Second))
-}
-
 // Ensure an error occurs when you have a container read-only rootfs but you
 // extract an archive to a symlink in a writable volume which points to a
 // directory outside of the volume.

--- a/integration/container/stop_test.go
+++ b/integration/container/stop_test.go
@@ -1,12 +1,15 @@
 package container
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/moby/moby/api/types/common"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
+	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/poll"
@@ -108,6 +111,63 @@ func TestStopContainerWithTimeout(t *testing.T) {
 			inspect, err := apiClient.ContainerInspect(ctx, id, client.ContainerInspectOptions{})
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(inspect.Container.State.ExitCode, tc.expectedExitCode))
+		})
+	}
+}
+
+func TestContainerAPIPostContainerStop(t *testing.T) {
+	apiClient := testEnv.APIClient()
+	ctx := setupTest(t)
+
+	tests := []struct {
+		testName            string
+		id                  string
+		expStatusCode       int
+		expError            string
+		checkContainerState bool
+		expStateRunning     bool
+	}{
+		{
+			testName:            "no error",
+			id:                  container.Run(ctx, t, apiClient),
+			expStatusCode:       http.StatusNoContent,
+			checkContainerState: true,
+			expStateRunning:     false,
+		},
+		{
+			testName:            "container already stopped",
+			id:                  container.Create(ctx, t, apiClient),
+			expStatusCode:       http.StatusNotModified,
+			checkContainerState: true,
+			expStateRunning:     false,
+		},
+		{
+			testName:            "no such container",
+			id:                  "test1234",
+			expStatusCode:       http.StatusNotFound,
+			expError:            `No such container: test1234`,
+			checkContainerState: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+
+			res, _, err := request.Post(ctx, "/containers/"+tc.id+"/stop")
+
+			assert.Equal(t, res.StatusCode, tc.expStatusCode)
+			assert.NilError(t, err)
+
+			if tc.expError != "" {
+				var respErr common.ErrorResponse
+				assert.NilError(t, request.ReadJSONResponse(res, &respErr))
+				assert.ErrorContains(t, respErr, tc.expError)
+			}
+
+			if tc.checkContainerState {
+				inspectRes := container.Inspect(ctx, t, apiClient, tc.id)
+				assert.Equal(t, inspectRes.State.Running, tc.expStateRunning)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I migrated TestContainerAPIPostContainerStop to integration tests. 
Relates to #50159 

**- How I did it**

- Migrated TestContainerAPIPostContainerStop to integration/container/stop_test.go from integration-cli/docker_api_containers_test.go.
- Changed from apiClient calls to direct HTTP requests because,
  - apiClient usage is already covered in other test. (e.g. TestContainerAPIStop)
  - the test targets the route handler behavior, as indicated by its name.
- Added subtests for scenarios where the container is already stopped and where the container does not exist.

**- How to verify it**

Verified running the integration test with following command.
`TEST_FILTER='TestContainerAPIPostContainerStop' TEST_SKIP_INTEGRATION_CLI=1 make test-integration`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

