### PR TITLE
fix: typos in comments

### DIFF
--- a/daemon/archive_windows.go
+++ b/daemon/archive_windows.go
@@ -205,7 +205,7 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 	// TODO(thaJeztah): add check for writable path once windows supports read-only rootFS and (read-only) volumes during copy
 	//
 	// - e5261d6e4a1e96d4c0fa4b4480042046b695eda1 added "FIXME Post-TP4 / TP5"; check whether this would be possible to implement on Windows.
-	// - e5261d6e4a1e96d4c0fa4b4480042046b695eda1 added "or extracting to a mount point inside a volume"; check whether this is is still true, and adjust this check accordingly
+	// - e5261d6e4a1e96d4c0fa4b4480042046b695eda1 added "or extracting to a mount point inside a volume"; check whether this is still true, and adjust this check accordingly
 	//
 	// This comment is left in-place as a reminder :)
 	//

--- a/integration/image/tag_test.go
+++ b/integration/image/tag_test.go
@@ -81,7 +81,7 @@ func TestTagOfficialNames(t *testing.T) {
 			// ensure we don't have multiple tag names.
 			insp, err := apiClient.ImageInspect(ctx, "busybox")
 			assert.NilError(t, err)
-			// TODO(vvoland): Not sure what's actually being tested here. Is is still doing anything useful?
+			// TODO(vvoland): Not sure what's actually being tested here. Is it still doing anything useful?
 			assert.Assert(t, !is.Contains(insp.RepoTags, name)().Success())
 
 			_, err = apiClient.ImageTag(ctx, client.ImageTagOptions{Source: name + ":latest", Target: "test-tag-official-names/foobar:latest"})


### PR DESCRIPTION
Fix typos: `Is is` → `Is it`, `is is` → `is`