### PR TITLE
Check system requirements before initialization

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -114,6 +114,11 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 		debug.Enable()
 	}
 
+	// Verify platform-specific requirements before proceeding with daemon initialization
+	if err := daemon.CheckSystem(); err != nil {
+		return fmt.Errorf("system requirements not met: %w", err)
+	}
+
 	if rootless.RunningWithRootlessKit() && !cli.Config.IsRootless() {
 		return errors.New("rootless mode needs to be enabled for running with RootlessKit")
 	}

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -93,6 +93,12 @@ func newDaemonCLI(opts *daemonOptions) (*daemonCLI, error) {
 		return nil, err
 	}
 
+	// Verify platform-specific requirements.
+	// This is checked early so that `dockerd --validate` also validates system requirements.
+	if err := daemon.CheckSystem(); err != nil {
+		return nil, fmt.Errorf("system requirements not met: %w", err)
+	}
+
 	return &daemonCLI{
 		Config:       cfg,
 		configFile:   &opts.configFile,
@@ -112,11 +118,6 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 
 	if cli.Config.Debug {
 		debug.Enable()
-	}
-
-	// Verify platform-specific requirements before proceeding with daemon initialization
-	if err := daemon.CheckSystem(); err != nil {
-		return fmt.Errorf("system requirements not met: %w", err)
 	}
 
 	if rootless.RunningWithRootlessKit() && !cli.Config.IsRootless() {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -807,15 +807,15 @@ func (daemon *Daemon) IsSwarmCompatible() error {
 	return daemon.config().IsSwarmCompatible()
 }
 
+// CheckSystem verifies that the system meets the platform-specific requirements
+// for running the Docker daemon.
+func CheckSystem() error {
+	return checkSystem()
+}
+
 // NewDaemon sets up everything for the daemon to be able to service
 // requests from the webserver.
 func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.Store, authzMiddleware *authorization.Middleware) (_ *Daemon, retErr error) {
-	// Verify platform-specific requirements.
-	// TODO(thaJeztah): this should be called before we try to create the daemon; perhaps together with the config validation.
-	if err := checkSystem(); err != nil {
-		return nil, err
-	}
-
 	registryService, err := registry.NewService(config.ServiceOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Resolved the TODO in `daemon/daemon.go:814` by moving the `checkSystem()` call from inside `NewDaemon()` to an earlier point in the startup process (`cli.start()` in `daemon/command/daemon.go`).

This ensures platform-specific system requirements are validated before any daemon initialization begins.

Related to TODO added in 17fb29c9e8.

**- How I did it**
1. Exported `checkSystem()` as a public function `CheckSystem()` in the daemon package
2. Added a call to `daemon.CheckSystem()` in `daemon/command/daemon.go`'s `cli.start()` function, right after debug mode is enabled and before any resource allocation
3. Removed the `checkSystem()` call from inside `NewDaemon()`
4. Removed the TODO comment

The changes ensure:
- System requirements are checked immediately after startup logging is configured
- On Windows, OS version, vmcompute.dll, and required services are validated before creating directories, registry services, or other resources
- Cleaner error flow without needing complex defer cleanup on unsupported systems

**- How to verify it**
**Build and run:**
```bash
# Build should succeed without errors
go build ./daemon/command

# On supported systems, daemon should start normally
sudo dockerd
# or
dockerd --validate
```
On unsupported systems (e.g., Windows < build 17763), daemon fails immediately with system requirements error before any resource allocation.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
The `--validate` flag on dockerd now also verifies system requirements, allowing for system requirements to be checked before starting the daemon.
```

System requirement errors on Windows are now reported immediately on startup, before resource allocation.

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="416" height="325" alt="image" src="https://github.com/user-attachments/assets/34a25164-c3a7-41bd-8843-a3d0f437be67" />
