### PR TITLE
daemon/volume/mounts: extract validation for extra fields

### DIFF
--- a/daemon/volume/mounts/linux_parser.go
+++ b/daemon/volume/mounts/linux_parser.go
@@ -46,6 +46,10 @@ func (p *linuxParser) ValidateMountConfig(mnt *mount.Mount) error {
 }
 
 func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSourceExists bool) error {
+	if err := validateExclusiveOptions(mnt); err != nil {
+		return &errMountConfig{mount: mnt, err: err}
+	}
+
 	if mnt.Target == "" {
 		return &errMountConfig{mnt, errMissingField("Target")}
 	}
@@ -71,12 +75,6 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 				}
 			}
 		}
-		if mnt.VolumeOptions != nil {
-			return &errMountConfig{mnt, errExtraField("VolumeOptions")}
-		}
-		if mnt.ImageOptions != nil {
-			return &errMountConfig{mnt, errExtraField("ImageOptions")}
-		}
 
 		if err := linuxValidateAbsolute(mnt.Source); err != nil {
 			return &errMountConfig{mnt, err}
@@ -95,12 +93,6 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 		}
 
 	case mount.TypeVolume:
-		if mnt.BindOptions != nil {
-			return &errMountConfig{mnt, errExtraField("BindOptions")}
-		}
-		if mnt.ImageOptions != nil {
-			return &errMountConfig{mnt, errExtraField("ImageOptions")}
-		}
 		anonymousVolume := mnt.Source == ""
 
 		if mnt.VolumeOptions != nil && mnt.VolumeOptions.Subpath != "" {
@@ -113,12 +105,6 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 			}
 		}
 	case mount.TypeTmpfs:
-		if mnt.BindOptions != nil {
-			return &errMountConfig{mnt, errExtraField("BindOptions")}
-		}
-		if mnt.ImageOptions != nil {
-			return &errMountConfig{mnt, errExtraField("ImageOptions")}
-		}
 		if mnt.Source != "" {
 			return &errMountConfig{mnt, errExtraField("Source")}
 		}
@@ -126,12 +112,6 @@ func (p *linuxParser) validateMountConfigImpl(mnt *mount.Mount, validateBindSour
 			return &errMountConfig{mnt, err}
 		}
 	case mount.TypeImage:
-		if mnt.BindOptions != nil {
-			return &errMountConfig{mnt, errExtraField("BindOptions")}
-		}
-		if mnt.VolumeOptions != nil {
-			return &errMountConfig{mnt, errExtraField("VolumeOptions")}
-		}
 		if mnt.Source == "" {
 			return &errMountConfig{mnt, errMissingField("Source")}
 		}

--- a/daemon/volume/mounts/validate.go
+++ b/daemon/volume/mounts/validate.go
@@ -27,3 +27,24 @@ func errExtraField(name string) error {
 func errMissingField(name string) error {
 	return errors.Errorf("field %s must not be empty", name)
 }
+
+// validateExclusiveOptions checks if the given mount config only contains
+// options for the given mount-type.
+func validateExclusiveOptions(mnt *mount.Mount) error {
+	if mnt.Type != mount.TypeBind && mnt.BindOptions != nil {
+		return errExtraField("BindOptions")
+	}
+	if mnt.Type != mount.TypeVolume && mnt.VolumeOptions != nil {
+		return errExtraField("VolumeOptions")
+	}
+	if mnt.Type != mount.TypeImage && mnt.ImageOptions != nil {
+		return errExtraField("ImageOptions")
+	}
+	if mnt.Type != mount.TypeTmpfs && mnt.TmpfsOptions != nil {
+		return errExtraField("TmpfsOptions")
+	}
+	if mnt.Type != mount.TypeCluster && mnt.ClusterOptions != nil {
+		return errExtraField("ClusterOptions")
+	}
+	return nil
+}

--- a/daemon/volume/mounts/windows_parser.go
+++ b/daemon/volume/mounts/windows_parser.go
@@ -214,6 +214,10 @@ func (defaultFileInfoProvider) fileInfo(path string) (exist, isDir bool, _ error
 }
 
 func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValidators ...mountValidator) error {
+	if err := validateExclusiveOptions(mnt); err != nil {
+		return &errMountConfig{mount: mnt, err: err}
+	}
+
 	if mnt.Target == "" {
 		return &errMountConfig{mnt, errMissingField("Target")}
 	}
@@ -234,9 +238,6 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 				return &errMountConfig{mnt, fmt.Errorf("invalid propagation mode: %s", opts.Propagation)}
 			}
 		}
-		if mnt.VolumeOptions != nil {
-			return &errMountConfig{mnt, errExtraField("VolumeOptions")}
-		}
 
 		if err := windowsValidateAbsolute(mnt.Source); err != nil {
 			return &errMountConfig{mnt, err}
@@ -254,10 +255,6 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 		}
 
 	case mount.TypeVolume:
-		if mnt.BindOptions != nil {
-			return &errMountConfig{mnt, errExtraField("BindOptions")}
-		}
-
 		anonymousVolume := mnt.Source == ""
 		if mnt.VolumeOptions != nil && mnt.VolumeOptions.Subpath != "" {
 			if anonymousVolume {
@@ -278,10 +275,6 @@ func (p *windowsParser) validateMountConfigReg(mnt *mount.Mount, additionalValid
 	case mount.TypeNamedPipe:
 		if mnt.Source == "" {
 			return &errMountConfig{mnt, errMissingField("Source")}
-		}
-
-		if mnt.BindOptions != nil {
-			return &errMountConfig{mnt, errExtraField("BindOptions")}
 		}
 
 		if mnt.ReadOnly {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/51596

These options can only be specified for the matching Mount.Type, but some of the branches were missing checks. Extract the validation to a separate function so that we can keep this validation central and make the code less repetitive.

**- A picture of a cute animal (not mandatory but encouraged)**

