### PR TITLE
gha/labeler: Filter out vendor changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,7 @@ area/daemon:
 area/builder/buildkit:
   - changed-files:
     - any-glob-to-any-file:
-      - '**/*buildkit*'
+      - 'vendor/github.com/moby/buildkit/**'
       - 'daemon/internal/builder-next/**'
 
 area/builder/classic-builder:
@@ -23,12 +23,13 @@ area/builder/classic-builder:
       - 'daemon/builder/**'
 
 area/builder:
-  - labels:
+  - changed-files:
     - any-glob-to-any-file:
-      - '**/*buildkit*'
+      - 'vendor/github.com/moby/buildkit/**'
       - 'daemon/internal/builder-next/**'
       - 'daemon/images/*_build*'
       - 'daemon/builder/**'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/networking:
   - changed-files:
@@ -64,6 +65,7 @@ area/logging:
     - any-glob-to-any-file:
       - 'daemon/logger/**'
       - '**/*log*'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/security:
   - changed-files:
@@ -71,28 +73,33 @@ area/security:
       - '**/*seccomp*'
       - '**/*apparmor*'
       - '**/*selinux*'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/security/apparmor:
   - changed-files:
     - any-glob-to-any-file:
       - '**/*apparmor*'
       - 'contrib/apparmor/**'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/security/selinux:
   - changed-files:
     - any-glob-to-any-file:
       - '**/*selinux*'
       - 'contrib/selinux/**'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/security/seccomp:
   - changed-files:
     - any-glob-to-any-file: '**/*seccomp*'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/systemd:
   - changed-files:
     - any-glob-to-any-file:
       - '**/*systemd*'
       - 'contrib/init/systemd/**'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/contrib:
   - changed-files:
@@ -115,6 +122,7 @@ area/rootless:
     - any-glob-to-any-file:
       - '**/*rootless*'
       - 'contrib/dockerd-rootless*'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/testing:
   - changed-files:
@@ -124,6 +132,7 @@ area/testing:
       - '**/*_test.go'
       - 'internal/test*'
       - 'internal/testutil/**'
+      - '!vendor/**'
 
 area/docs:
   - changed-files:
@@ -132,6 +141,7 @@ area/docs:
       - 'docs/**'
       - '**/*.md'
       - 'man/**'
+    - all-globs-to-all-files: '!vendor/**'
 
 area/dependencies:
 - all:
@@ -153,6 +163,7 @@ platform/windows:
     - any-glob-to-any-file:
       - '**/*_windows.go'
       - 'Dockerfile.windows'
+    - all-globs-to-all-files: '!vendor/**'
 
 impact/changelog:
   - changed-files:


### PR DESCRIPTION
### gha/labeler: Filter out vendor changes

  Labeler was too eagerly applying labels because of files changed in vendor.