### PR TITLE
fix: reassemble message chunks in `json-file` log driver

### DIFF
--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -26,13 +26,7 @@ func decodeLogLine(dec *json.Decoder, l *jsonlog.JSONLog) (*logger.Message, erro
 		return nil, err
 	}
 
-	var attrs []backend.LogAttr
-	if len(l.Attrs) != 0 {
-		attrs = make([]backend.LogAttr, 0, len(l.Attrs))
-		for k, v := range l.Attrs {
-			attrs = append(attrs, backend.LogAttr{Key: k, Value: v})
-		}
-	}
+	attrs := decodeAttrs(l.Attrs)
 	msg := &logger.Message{
 		Source:    l.Stream,
 		Timestamp: l.Created,
@@ -40,6 +34,17 @@ func decodeLogLine(dec *json.Decoder, l *jsonlog.JSONLog) (*logger.Message, erro
 		Attrs:     attrs,
 	}
 	return msg, nil
+}
+
+func decodeAttrs(m map[string]string) []backend.LogAttr {
+	if len(m) == 0 {
+		return nil
+	}
+	attrs := make([]backend.LogAttr, 0, len(m))
+	for k, v := range m {
+		attrs = append(attrs, backend.LogAttr{Key: k, Value: v})
+	}
+	return attrs
 }
 
 type decoder struct {


### PR DESCRIPTION
Addresses https://github.com/docker/cli/issues/4941 for `json-file`. Metadata for message reassembling is already here (`PLogMetaData`), drivers just need to support it.

- [x] **Test**
- [x] **Make sure all your commits include a signature generated with `git commit -s`**
- [ ] **Human readable description for the release notes**
- [x] **A picture of a cute animal (not mandatory but encouraged)**

```markdown changelog
TODO
```

<img width="1000" height="561" alt="image" src="https://github.com/user-attachments/assets/571492a9-7532-49cf-a43b-bc9cbbada70b" />

````sh
vladimir@lisa ~ % export DOCKER_HOST=tcp://127.0.0.1:2375

vladimir@lisa ~ % docker version

Client:
 Version:           29.1.3
 API version:       1.52
 Go version:        go1.25.5
 Git commit:        f52814d
 Built:             Fri Dec 12 14:48:46 2025
 OS/Arch:           darwin/arm64
 Context:           default

Server:
 Engine:
  Version:          dev
  API version:      1.53 (minimum version 1.44)
  Go version:       go1.25.7
  Git commit:       4d6426c7e26a8b4b98ca649118931a10992192c9
  Built:            Thu Feb 26 06:14:48 2026
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          v2.2.1
  GitCommit:        dea7da592f5d1d2b7755e3a161be07f43fad8f75
 runc:
  Version:          1.3.4
  GitCommit:        v1.3.4-0-gd6d73eb
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
vladimir@lisa ~ % docker run -d --name chunk-test busybox sh -c 'dd if=/dev/zero bs=1 count=70000 2>/dev/null | tr "\0" a; echo'

Unable to find image 'busybox:latest' locally
latest: Pulling from library/busybox
b85757a5ca1a: Pull complete
f9ec47fa49a3: Download complete
Digest: sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f
Status: Downloaded newer image for busybox:latest
db6ddb2c634954241153101311e00a52a80f38426b2d84d8a64f5d95073edd1b
vladimir@lisa ~ % docker wait chunk-test >/dev/null

vladimir@lisa ~ % docker logs chunk-test | wc -l

1
vladimir@lisa ~ % docker logs chunk-test | wc
      1       1   70001
vladimir@lisa ~ % docker rm -f chunk-test

chunk-test
```