### PR TITLE
renovate: Always run go mod tidy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     ":gitSignOff"
   ],
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       "matchDatasources": ["go"],


### PR DESCRIPTION
Fixes failing `validate vendor` check on https://github.com/moby/moby/pull/51893