### PR TITLE
client: ContainerListOptions: deprecate `Since`, `Before`, and `Latest` fields

### DIFF
--- a/client/container_list.go
+++ b/client/container_list.go
@@ -13,9 +13,13 @@ import (
 type ContainerListOptions struct {
 	Size    bool
 	All     bool
-	Latest  bool
 	Limit   int
 	Filters Filters
+
+	// Latest is non-functional and should not be used. Use Limit: 1 instead.
+	//
+	// Deprecated: the Latest option is non-functional and should not be used. Use Limit: 1 instead.
+	Latest bool
 
 	// Since is no longer supported. Use the "since" filter instead.
 	//

--- a/client/container_list.go
+++ b/client/container_list.go
@@ -14,10 +14,18 @@ type ContainerListOptions struct {
 	Size    bool
 	All     bool
 	Latest  bool
-	Since   string
-	Before  string
 	Limit   int
 	Filters Filters
+
+	// Since is no longer supported. Use the "since" filter instead.
+	//
+	// Deprecated: the Since option is no longer supported since docker 1.12 (API 1.24). Use the "since" filter instead.
+	Since string
+
+	// Before is no longer supported. Use the "since" filter instead.
+	//
+	// Deprecated: the Before option is no longer supported since docker 1.12 (API 1.24). Use the "before" filter instead.
+	Before string
 }
 
 type ContainerListResult struct {
@@ -34,14 +42,6 @@ func (cli *Client) ContainerList(ctx context.Context, options ContainerListOptio
 
 	if options.Limit > 0 {
 		query.Set("limit", strconv.Itoa(options.Limit))
-	}
-
-	if options.Since != "" {
-		query.Set("since", options.Since)
-	}
-
-	if options.Before != "" {
-		query.Set("before", options.Before)
 	}
 
 	if options.Size {

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -44,8 +44,8 @@ func TestContainerList(t *testing.T) {
 			expected: url.Values{"all": []string{"1"}},
 		},
 		{
-			doc:      "latest", // FIXME(thaJeztah): the "latest" option is a cli-side shortcut for "limit: 1". It has never been used https://github.com/moby/moby/commit/d05aa418b0466553a24d42896f99176cfa29765f
-			options:  ContainerListOptions{Latest: true},
+			doc:      "latest",
+			options:  ContainerListOptions{Latest: true}, //nolint:staticcheck // ignore SA1019: field is deprecated.
 			expected: url.Values{},
 		},
 		{

--- a/client/container_list_test.go
+++ b/client/container_list_test.go
@@ -49,14 +49,14 @@ func TestContainerList(t *testing.T) {
 			expected: url.Values{},
 		},
 		{
-			doc:      "since", // FIXME(thaJeztah): the "since" option was deprecated, and is no longer handled by the API server; https://github.com/moby/moby/pull/22138
-			options:  ContainerListOptions{Since: "container"},
-			expected: url.Values{"since": []string{"container"}},
+			doc:      "since",
+			options:  ContainerListOptions{Since: "container"}, //nolint:staticcheck // ignore SA1019: field is deprecated.
+			expected: url.Values{},
 		},
 		{
-			doc:      "before", // FIXME(thaJeztah): the "before" option was deprecated, and is no longer handled by the API server; https://github.com/moby/moby/pull/22138
-			options:  ContainerListOptions{Before: "container"},
-			expected: url.Values{"before": []string{"container"}},
+			doc:      "before",
+			options:  ContainerListOptions{Before: "container"}, //nolint:staticcheck // ignore SA1019: field is deprecated.
+			expected: url.Values{},
 		},
 		{
 			doc:      "limit",

--- a/vendor/github.com/moby/moby/client/container_list.go
+++ b/vendor/github.com/moby/moby/client/container_list.go
@@ -13,9 +13,13 @@ import (
 type ContainerListOptions struct {
 	Size    bool
 	All     bool
-	Latest  bool
 	Limit   int
 	Filters Filters
+
+	// Latest is non-functional and should not be used. Use Limit: 1 instead.
+	//
+	// Deprecated: the Latest option is non-functional and should not be used. Use Limit: 1 instead.
+	Latest bool
 
 	// Since is no longer supported. Use the "since" filter instead.
 	//

--- a/vendor/github.com/moby/moby/client/container_list.go
+++ b/vendor/github.com/moby/moby/client/container_list.go
@@ -14,10 +14,18 @@ type ContainerListOptions struct {
 	Size    bool
 	All     bool
 	Latest  bool
-	Since   string
-	Before  string
 	Limit   int
 	Filters Filters
+
+	// Since is no longer supported. Use the "since" filter instead.
+	//
+	// Deprecated: the Since option is no longer supported since docker 1.12 (API 1.24). Use the "since" filter instead.
+	Since string
+
+	// Before is no longer supported. Use the "since" filter instead.
+	//
+	// Deprecated: the Before option is no longer supported since docker 1.12 (API 1.24). Use the "before" filter instead.
+	Before string
 }
 
 type ContainerListResult struct {
@@ -34,14 +42,6 @@ func (cli *Client) ContainerList(ctx context.Context, options ContainerListOptio
 
 	if options.Limit > 0 {
 		query.Set("limit", strconv.Itoa(options.Limit))
-	}
-
-	if options.Since != "" {
-		query.Set("since", options.Since)
-	}
-
-	if options.Before != "" {
-		query.Set("before", options.Before)
 	}
 
 	if options.Size {


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/51878
- https://github.com/moby/moby/pull/17718
- https://github.com/moby/moby/pull/20135
- https://github.com/moby/moby/pull/22138
- https://github.com/moby/moby/pull/51877#discussion_r2707849218
- https://github.com/moby/moby/pull/432
- https://github.com/moby/moby/pull/18472


### client: deprecate ContainerListOptions.Since, ContainerListOptions.Before

The `Before` and `Since` options were used for the `before` and `since`
query parameters. These parameters were replaced with the `before` and
`since` filters in docker 1.10.0 (API 1.22)through [moby@1921c62], and
[moby@b41dba5].

The query parameters were removed from the CLI and daemon in docker 1.12.0
(API 1.24) through [moby@91b7157], however the fields themselves were never
removed.

This patch deprecates the fields as they are non-functional.

[moby@1921c62]: https://github.com/moby/moby/commit/1921c629381d25ebff7b8b8c8348a0a81525f264
[moby@b41dba5]: https://github.com/moby/moby/commit/b41dba58a01855e0d222bd6c14af9874c298c154
[moby@91b7157]: https://github.com/moby/moby/commit/91b715706493059d39c9f8b1d01c9d80ce1799d9




### client: deprecate ContainerListOptions.Latest

The `--latest` option was implemented in [moby@b295239] as a CLI shortcut
for `--last=1`.

However, as part of a large refactor of the client in [moby@d05aa41], a
`ContainerListOptions` type was introduced, which contained a `Latest`
field.

This field was never used, as the `Latest` option was handled in the CLI,
and had no corresponding option for the API (other than `limit`).

This patch deprecates the field as it is non-functional.

[moby@b295239]: https://github.com/moby/moby/commit/b295239de20f15620ee4149fcc7c13ce461cdaac
[moby@d05aa41]: https://github.com/moby/moby/commit/d05aa418b0466553a24d42896f99176cfa29765f


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: ContainerListOptions: deprecate `Since`, `Before`, and `Latest` fields.
```

**- A picture of a cute animal (not mandatory but encouraged)**

