### PR TITLE
loadDaemonCliConfig: explicitly set default host

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -639,6 +639,30 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 		}
 	}
 
+	// TODO(thaJeztah): consider making empty strings an error. Existing behavior allowed for empty strings to be used as default, even if explicitly set (`dockerd -H ""`).
+	conf.Hosts = slices.DeleteFunc(conf.Hosts, func(h string) bool {
+		return strings.TrimSpace(h) == ""
+	})
+	if len(conf.Hosts) == 0 {
+		// Set the default host if no hosts are configured.
+		// TODO(thaJeztah) can set defaults in config.New() instead?
+		if conf.TLS != nil && *conf.TLS {
+			// If no host is configured, but the "--tls" flag is set, we
+			// default to using a TCP connection instead of a unix-socket
+			// or named pipe.
+			//
+			// See https://github.com/moby/moby/commit/0906195fbbd6f379c163b80f23e4c5a60bcfc5f0
+			conf.Hosts = append(conf.Hosts, dopts.DefaultTLSHost)
+		} else {
+			// Otherwise use the default unix-socket (Linux) or named pipe (Windows).
+			h, err := defaultAPISocketPath(honorXDG)
+			if err != nil {
+				return nil, err
+			}
+			conf.Hosts = append(conf.Hosts, h)
+		}
+	}
+
 	if err := normalizeHosts(conf); err != nil {
 		return nil, err
 	}
@@ -718,27 +742,37 @@ func loadDaemonCliConfig(opts *daemonOptions) (*config.Config, error) {
 	return conf, nil
 }
 
+// defaultAPISocketPath returns the default path for the Unix socket (Linux)
+// or named pipe (Windows).
+//
+// When running with rootlessKit, XDG dirs should be preferred, and the
+// default is to listen on an unprivileged socket in [XDG_RUNTIME_DIR].
+//
+// [XDG_RUNTIME_DIR]: https://specifications.freedesktop.org/basedir/0.8/#variables
+func defaultAPISocketPath(honorXDG bool) (string, error) {
+	if honorXDG {
+		runtimeDir, err := homedir.GetRuntimeDir()
+		if err != nil {
+			return "", err
+		}
+		return "unix://" + filepath.Join(runtimeDir, "docker.sock"), nil
+	}
+
+	// default unix-socket (Linux) or named pipe (Windows).
+	return dopts.DefaultHost, nil
+}
+
 // normalizeHosts normalizes the configured config.Hosts and removes duplicates.
 // It returns an error if it fails to parse a host.
 func normalizeHosts(cfg *config.Config) error {
+	if len(cfg.Hosts) == 0 {
+		return errors.New("no hosts specified")
+	}
+
 	hosts := slices.Clone(cfg.Hosts)
-	if len(hosts) == 0 {
-		// if no hosts are configured, create a single entry slice, so that the
-		// default is used.
-		//
-		// TODO(thaJeztah) implement a cleaner way for this; this depends on a
-		//                 side-effect of how we parse empty/partial hosts.
-		hosts = make([]string, 1)
-	}
-
-	useTLS := DefaultTLSValue
-	if cfg.TLS != nil {
-		useTLS = *cfg.TLS
-	}
-
 	for i, h := range hosts {
 		var err error
-		hosts[i], err = dopts.ParseHost(useTLS, honorXDG, h)
+		hosts[i], err = dopts.ParseDaemonHost(h)
 		if err != nil {
 			return err
 		}

--- a/daemon/pkg/opts/hosts.go
+++ b/daemon/pkg/opts/hosts.go
@@ -36,9 +36,9 @@ const (
 // ValidateHost validates that the specified string is a valid host and returns it.
 func ValidateHost(val string) (string, error) {
 	host := strings.TrimSpace(val)
-	// The empty string means default and is not handled by parseDaemonHost
+	// The empty string means default and is not handled by ParseDaemonHost
 	if host != "" {
-		_, err := parseDaemonHost(host)
+		_, err := ParseDaemonHost(host)
 		if err != nil {
 			return val, err
 		}
@@ -66,7 +66,7 @@ func ParseHost(defaultToTLS, defaultToUnixXDG bool, val string) (string, error) 
 		}
 	} else {
 		var err error
-		host, err = parseDaemonHost(host)
+		host, err = ParseDaemonHost(host)
 		if err != nil {
 			return val, err
 		}
@@ -74,9 +74,9 @@ func ParseHost(defaultToTLS, defaultToUnixXDG bool, val string) (string, error) 
 	return host, nil
 }
 
-// parseDaemonHost parses the specified address and returns an address that will be used as the host.
+// ParseDaemonHost parses the specified address and returns an address that will be used as the host.
 // Depending on the address specified, this may return one of the global Default* strings defined in hosts.go.
-func parseDaemonHost(address string) (string, error) {
+func ParseDaemonHost(address string) (string, error) {
 	proto, addr, ok := strings.Cut(address, "://")
 	if !ok && proto != "" {
 		addr = proto

--- a/daemon/pkg/opts/hosts.go
+++ b/daemon/pkg/opts/hosts.go
@@ -3,11 +3,9 @@ package opts
 import (
 	"net"
 	"net/url"
-	"path/filepath"
 	"strconv"
 	"strings"
 
-	"github.com/moby/moby/v2/pkg/homedir"
 	"github.com/pkg/errors"
 )
 
@@ -46,32 +44,6 @@ func ValidateHost(val string) (string, error) {
 	// Note: unlike most flag validators, we don't return the mutated value here
 	//       we need to know what the user entered later (using ParseHost) to adjust for TLS
 	return val, nil
-}
-
-// ParseHost and set defaults for a Daemon host string.
-// defaultToTLS is preferred over defaultToUnixXDG.
-func ParseHost(defaultToTLS, defaultToUnixXDG bool, val string) (string, error) {
-	host := strings.TrimSpace(val)
-	if host == "" {
-		if defaultToTLS {
-			host = DefaultTLSHost
-		} else if defaultToUnixXDG {
-			runtimeDir, err := homedir.GetRuntimeDir()
-			if err != nil {
-				return "", err
-			}
-			host = "unix://" + filepath.Join(runtimeDir, "docker.sock")
-		} else {
-			host = DefaultHost
-		}
-	} else {
-		var err error
-		host, err = ParseDaemonHost(host)
-		if err != nil {
-			return val, err
-		}
-	}
-	return host, nil
 }
 
 // ParseDaemonHost parses the specified address and returns an address that will be used as the host.

--- a/daemon/pkg/opts/hosts_test.go
+++ b/daemon/pkg/opts/hosts_test.go
@@ -116,7 +116,7 @@ func TestParseDockerDaemonHost(t *testing.T) {
 	}
 	for invalidAddr, expectedError := range invalids {
 		t.Run(invalidAddr, func(t *testing.T) {
-			addr, err := parseDaemonHost(invalidAddr)
+			addr, err := ParseDaemonHost(invalidAddr)
 			if err == nil || err.Error() != expectedError {
 				t.Errorf(`expected error "%s", got "%v"`, expectedError, err)
 			}
@@ -127,7 +127,7 @@ func TestParseDockerDaemonHost(t *testing.T) {
 	}
 	for validAddr, expectedAddr := range valids {
 		t.Run(validAddr, func(t *testing.T) {
-			addr, err := parseDaemonHost(validAddr)
+			addr, err := ParseDaemonHost(validAddr)
 			if err != nil {
 				t.Errorf(`unexpected error: "%v"`, err)
 			}

--- a/daemon/pkg/opts/hosts_test.go
+++ b/daemon/pkg/opts/hosts_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestParseHost(t *testing.T) {
-	invalid := map[string]string{
+func TestParseDockerDaemonHost(t *testing.T) {
+	invalids := map[string]string{
 		"something with spaces": `invalid bind address (something with spaces): parse "tcp://something with spaces": invalid character " " in host name`,
 		"://":                   `invalid bind address (://): unsupported proto ''`,
 		"unknown://":            `invalid bind address (unknown://): unsupported proto 'unknown'`,
@@ -20,15 +20,43 @@ func TestParseHost(t *testing.T) {
 		"tcp://[::1]:/":         `invalid bind address (tcp://[::1]:/): should not contain a path element`,
 		"tcp://[::1]:5555/":     `invalid bind address (tcp://[::1]:5555/): should not contain a path element`,
 		"tcp://[::1]:5555/p":    `invalid bind address (tcp://[::1]:5555/p): should not contain a path element`,
-		" tcp://:5555/path ":    `invalid bind address (tcp://:5555/path): should not contain a path element`,
-	}
 
-	valid := map[string]string{
-		"":                         DefaultHost,
-		" ":                        DefaultHost,
-		"  ":                       DefaultHost,
+		"tcp:a.b.c.d":                   `invalid bind address (tcp:a.b.c.d): parse "tcp://tcp:a.b.c.d": invalid port ":a.b.c.d" after host`,
+		"tcp:a.b.c.d/path":              `invalid bind address (tcp:a.b.c.d/path): parse "tcp://tcp:a.b.c.d/path": invalid port ":a.b.c.d" after host`,
+		"tcp://127.0.0.1/":              "invalid bind address (tcp://127.0.0.1/): should not contain a path element",
+		"udp://127.0.0.1":               "invalid bind address (udp://127.0.0.1): unsupported proto 'udp'",
+		"udp://127.0.0.1:5555":          "invalid bind address (udp://127.0.0.1:5555): unsupported proto 'udp'",
+		"tcp://unix:///run/docker.sock": "invalid bind address (tcp://unix:///run/docker.sock): should not contain a path element",
+		" tcp://:5555/path ":            "invalid bind address ( tcp://:5555/path ): unsupported proto ' tcp'", //nolint:gocritic // This is a valid test case.
+		"":                              "invalid bind address (): unsupported proto ''",
+		" ":                             `invalid bind address ( ): parse "tcp:// ": invalid character " " in host name`,
+		":5555/path":                    "invalid bind address (:5555/path): should not contain a path element",
+		"0.0.0.1:5555/path":             "invalid bind address (0.0.0.1:5555/path): should not contain a path element",
+		"[::1]:5555/path":               "invalid bind address ([::1]:5555/path): should not contain a path element",
+		"[0:0:0:0:0:0:0:1]:5555/path":   "invalid bind address ([0:0:0:0:0:0:0:1]:5555/path): should not contain a path element",
+		"tcp://:5555/path":              "invalid bind address (tcp://:5555/path): should not contain a path element",
+		"localhost:5555/path":           "invalid bind address (localhost:5555/path): should not contain a path element",
+		"unix://tcp://127.0.0.1":        "invalid bind address (unix://tcp://127.0.0.1): invalid unix address: tcp://127.0.0.1",
+		"unix://unix://tcp://127.0.0.1": "invalid bind address (unix://unix://tcp://127.0.0.1): invalid unix address: unix://tcp://127.0.0.1",
+	}
+	valids := map[string]string{
+		":":                        DefaultTCPHost,
+		":5555":                    fmt.Sprintf("tcp://%s:5555", DefaultHTTPHost), //nolint:nosprintfhostport // sprintf is more readable for this case.
+		"0.0.0.1:":                 fmt.Sprintf("tcp://0.0.0.1:%d", DefaultHTTPPort),
+		"0.0.0.1:5555":             "tcp://0.0.0.1:5555",
+		"[::1]":                    fmt.Sprintf("tcp://[::1]:%d", DefaultHTTPPort),
+		"[::1]:":                   fmt.Sprintf("tcp://[::1]:%d", DefaultHTTPPort),
+		"[::1]:5555":               "tcp://[::1]:5555",
+		"[0:0:0:0:0:0:0:1]":        fmt.Sprintf("tcp://[0:0:0:0:0:0:0:1]:%d", DefaultHTTPPort),
+		"[0:0:0:0:0:0:0:1]:":       fmt.Sprintf("tcp://[0:0:0:0:0:0:0:1]:%d", DefaultHTTPPort),
+		"[0:0:0:0:0:0:0:1]:5555":   "tcp://[0:0:0:0:0:0:0:1]:5555",
+		"localhost":                fmt.Sprintf("tcp://localhost:%d", DefaultHTTPPort),
+		"localhost:":               fmt.Sprintf("tcp://localhost:%d", DefaultHTTPPort),
+		"localhost:5555":           "tcp://localhost:5555",
 		"fd://":                    "fd://",
 		"fd://something":           "fd://something",
+		"npipe://":                 "npipe://" + DefaultNamedPipe,
+		"npipe:////./pipe/foo":     "npipe:////./pipe/foo",
 		"tcp://host:":              fmt.Sprintf("tcp://host:%d", DefaultHTTPPort),
 		"tcp://":                   DefaultTCPHost,
 		"tcp://:":                  DefaultTCPHost,
@@ -43,76 +71,7 @@ func TestParseHost(t *testing.T) {
 		"tcp://docker.com:5555":    "tcp://docker.com:5555",
 		"unix://":                  "unix://" + DefaultUnixSocket,
 		"unix://path/to/socket":    "unix://path/to/socket",
-		"npipe://":                 "npipe://" + DefaultNamedPipe,
-		"npipe:////./pipe/foo":     "npipe:////./pipe/foo",
-	}
-
-	for value, expectedError := range invalid {
-		t.Run(value, func(t *testing.T) {
-			_, err := ParseHost(false, false, value)
-			if err == nil || err.Error() != expectedError {
-				t.Errorf(`expected error "%s", got "%v"`, expectedError, err)
-			}
-		})
-	}
-
-	for value, expected := range valid {
-		t.Run(value, func(t *testing.T) {
-			actual, err := ParseHost(false, false, value)
-			if err != nil {
-				t.Errorf(`unexpected error: "%v"`, err)
-			}
-			if actual != expected {
-				t.Errorf(`expected "%s", got "%s""`, expected, actual)
-			}
-		})
-	}
-}
-
-func TestParseDockerDaemonHost(t *testing.T) {
-	invalids := map[string]string{
-		"tcp:a.b.c.d":                   `invalid bind address (tcp:a.b.c.d): parse "tcp://tcp:a.b.c.d": invalid port ":a.b.c.d" after host`,
-		"tcp:a.b.c.d/path":              `invalid bind address (tcp:a.b.c.d/path): parse "tcp://tcp:a.b.c.d/path": invalid port ":a.b.c.d" after host`,
-		"tcp://127.0.0.1/":              "invalid bind address (tcp://127.0.0.1/): should not contain a path element",
-		"udp://127.0.0.1":               "invalid bind address (udp://127.0.0.1): unsupported proto 'udp'",
-		"udp://127.0.0.1:5555":          "invalid bind address (udp://127.0.0.1:5555): unsupported proto 'udp'",
-		"tcp://unix:///run/docker.sock": "invalid bind address (tcp://unix:///run/docker.sock): should not contain a path element",
-		" tcp://:5555/path ":            "invalid bind address ( tcp://:5555/path ): unsupported proto ' tcp'", //nolint:gocritic // This is a valid test case.
-		"":                              "invalid bind address (): unsupported proto ''",
-		":5555/path":                    "invalid bind address (:5555/path): should not contain a path element",
-		"0.0.0.1:5555/path":             "invalid bind address (0.0.0.1:5555/path): should not contain a path element",
-		"[::1]:5555/path":               "invalid bind address ([::1]:5555/path): should not contain a path element",
-		"[0:0:0:0:0:0:0:1]:5555/path":   "invalid bind address ([0:0:0:0:0:0:0:1]:5555/path): should not contain a path element",
-		"tcp://:5555/path":              "invalid bind address (tcp://:5555/path): should not contain a path element",
-		"localhost:5555/path":           "invalid bind address (localhost:5555/path): should not contain a path element",
-		"unix://tcp://127.0.0.1":        "invalid bind address (unix://tcp://127.0.0.1): invalid unix address: tcp://127.0.0.1",
-		"unix://unix://tcp://127.0.0.1": "invalid bind address (unix://unix://tcp://127.0.0.1): invalid unix address: unix://tcp://127.0.0.1",
-	}
-	valids := map[string]string{
-		":":                       DefaultTCPHost,
-		":5555":                   fmt.Sprintf("tcp://%s:5555", DefaultHTTPHost), //nolint:nosprintfhostport // sprintf is more readable for this case.
-		"0.0.0.1:":                fmt.Sprintf("tcp://0.0.0.1:%d", DefaultHTTPPort),
-		"0.0.0.1:5555":            "tcp://0.0.0.1:5555",
-		"[::1]":                   fmt.Sprintf("tcp://[::1]:%d", DefaultHTTPPort),
-		"[::1]:":                  fmt.Sprintf("tcp://[::1]:%d", DefaultHTTPPort),
-		"[::1]:5555":              "tcp://[::1]:5555",
-		"[0:0:0:0:0:0:0:1]":       fmt.Sprintf("tcp://[0:0:0:0:0:0:0:1]:%d", DefaultHTTPPort),
-		"[0:0:0:0:0:0:0:1]:":      fmt.Sprintf("tcp://[0:0:0:0:0:0:0:1]:%d", DefaultHTTPPort),
-		"[0:0:0:0:0:0:0:1]:5555":  "tcp://[0:0:0:0:0:0:0:1]:5555",
-		"localhost":               fmt.Sprintf("tcp://localhost:%d", DefaultHTTPPort),
-		"localhost:":              fmt.Sprintf("tcp://localhost:%d", DefaultHTTPPort),
-		"localhost:5555":          "tcp://localhost:5555",
-		"fd://":                   "fd://",
-		"fd://something":          "fd://something",
-		"npipe://":                "npipe://" + DefaultNamedPipe,
-		"npipe:////./pipe/foo":    "npipe:////./pipe/foo",
-		"tcp://":                  DefaultTCPHost,
-		"tcp://:5555":             fmt.Sprintf("tcp://%s:5555", DefaultHTTPHost), //nolint:nosprintfhostport // sprintf is more readable for this case.
-		"tcp://[::1]":             fmt.Sprintf("tcp://[::1]:%d", DefaultHTTPPort),
-		"tcp://[::1]:":            fmt.Sprintf("tcp://[::1]:%d", DefaultHTTPPort),
-		"tcp://[::1]:5555":        "tcp://[::1]:5555",
-		"unix://":                 "unix://" + DefaultUnixSocket,
-		"unix:///run/docker.sock": "unix:///run/docker.sock",
+		"unix:///run/docker.sock":  "unix:///run/docker.sock",
 	}
 	for invalidAddr, expectedError := range invalids {
 		t.Run(invalidAddr, func(t *testing.T) {


### PR DESCRIPTION
### loadDaemonCliConfig: explicitly set default host

Setting the default host was implicitly handled in `normalizeHosts`; if
no hosts were provided, an empty entry was added to the list of hosts,
then passed through to `opts.ParseHost`, which handled an empty value
to set the default location (depending on TLS being enabled or XDG paths
to be used (when running with RootlessKit).

This patch makes the logic less magical:

- If no hosts are configured by the user (through CLI-flags or daemon.json),
  then we append the default location.
- The handling for TLS listeners is open-coded for now; we need to decide
  if we want to preserve this behavior (magically using TCP instead of a
  unix-socket or named pipe if TLS is enabled).



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

