### PR TITLE
cmd/docker-proxy: fix lock ordering in UDP proxy replyLoop

### DIFF
--- a/cmd/docker-proxy/udp_proxy_linux.go
+++ b/cmd/docker-proxy/udp_proxy_linux.go
@@ -102,8 +102,9 @@ func (proxy *UDPProxy) replyLoop(cte *connTrackEntry, serverAddr net.IP, clientA
 		proxy.connTrackLock.Lock()
 		delete(proxy.connTrackTable, *clientKey)
 		cte.mu.Lock()
-		proxy.connTrackLock.Unlock()
 		cte.conn.Close()
+		cte.mu.Unlock()
+		proxy.connTrackLock.Unlock()
 	}()
 
 	var oob []byte


### PR DESCRIPTION
The replyLoop method in udp_proxy_linux.go had inconsistent lock ordering that could lead to potential deadlocks. The locks were acquired in the order connTrackLock -> cte.mu, but released in the same order instead of LIFO (Last In First Out).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed a potential deadlock issue in the UDP proxy's `replyLoop` method caused by inconsistent lock ordering.

**- How I did it**
Modified the defer function in `replyLoop` (cmd/docker-proxy/udp_proxy_linux.go:100-108) to unlock mutexes in LIFO order:

- **Lock acquisition order**: `connTrackLock` → `cte.mu`
- **Lock release order**: `cte.mu` → `connTrackLock` (reversed)

**Before**:
```go
defer func() {
    proxy.connTrackLock.Lock()
    delete(proxy.connTrackTable, *clientKey)
    cte.mu.Lock()
    proxy.connTrackLock.Unlock()  // Released first (wrong)
    cte.conn.Close()
}()  // cte.mu implicitly unlocked
```
**After**:
```go
defer func() {
    proxy.connTrackLock.Lock()
    delete(proxy.connTrackTable, *clientKey)
    cte.mu.Lock()
    cte.conn.Close()
    cte.mu.Unlock()              // Explicitly released first (correct)
    proxy.connTrackLock.Unlock()
}()
```

This ensures consistency with the locking convention documented in the code comments at line 58:
`Never lock mu without locking UDPProxy.connTrackLock first.`

**- How to verify it**
All existing tests pass without race conditions:
```sh
# Run all tests
go test ./cmd/docker-proxy

# Run with race detector
go test -race ./cmd/docker-proxy
```
Test results: 15 tests passed

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="456" height="412" alt="image" src="https://github.com/user-attachments/assets/a37b4c93-98a2-4c52-b107-7428dbab1200" />
