### PR TITLE
daemon: ignore duplicate task exit events in daemon state

### DIFF
--- a/daemon/container/state.go
+++ b/daemon/container/state.go
@@ -299,7 +299,11 @@ func (s *State) SetRestarting(exitStatus *ExitStatus) {
 	s.Restarting = true
 	s.Paused = false
 	s.Pid = 0
-	s.FinishedAt = time.Now().UTC()
+	finishedAt := exitStatus.ExitedAt
+	if finishedAt.IsZero() {
+		finishedAt = time.Now().UTC()
+	}
+	s.FinishedAt = finishedAt
 	s.ExitCode = exitStatus.ExitCode
 
 	s.notifyAndClear(&s.stopWaiters)


### PR DESCRIPTION
- supersedes / closes https://github.com/moby/moby/pull/46391
- ref: https://github.com/moby/moby/issues/46212

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added daemon-side duplicate TaskExit filtering based on container state and timestamps
to avoid reprocessing late exits.

**- How I did it**

- Introduced `shouldIgnoreExitEventWithLock` in `daemon/monitor.go` and invoked
   it from `handleContainerExit` while holding the container lock.
- Ignored duplicates when the container is removing/exited/dead, or when a
   restart is in progress and the exit timestamp is newer than FinishedAt, or
   when a new task is already running and the exit predates StartedAt.


**- How to verify it**

-  Manually run a workload that triggers duplicate TaskExit events (e.g., shim
    panic during restart) and confirm no state regressions.
    - Manually build containerd and force it to send duplicate TaskExit on task.Delete API call
    - Using [failpoint-based shim](https://github.com/containerd/containerd/blob/816a845410af4671c5e56aec9d0b34dcb568b59c/integration/failpoint/cmd/containerd-shim-runc-fp-v1/main_linux.go#L27) to run 
       - `docker run -d --runtime runc-fp --annotation "io.containerd.runtime.v2.shim.failpoint.Delete=1*panic(oops)" ubuntu:latest sleep 5`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix daemon handling of duplicate container exit events to avoid repeated cleanup and state transitions.
```

**- A picture of a cute animal (not mandatory but encouraged)**


REF: https://github.com/moby/moby/issues/46212

