### PR TITLE
api/types: use "omitzero" instead of "omitempty" for "netip" fields

### DIFF
--- a/api/types/network/endpoint.go
+++ b/api/types/network/endpoint.go
@@ -58,9 +58,9 @@ func (es *EndpointSettings) Copy() *EndpointSettings {
 
 // EndpointIPAMConfig represents IPAM configurations for the endpoint
 type EndpointIPAMConfig struct {
-	IPv4Address  netip.Addr   `json:",omitempty"`
-	IPv6Address  netip.Addr   `json:",omitempty"`
-	LinkLocalIPs []netip.Addr `json:",omitempty"`
+	IPv4Address  netip.Addr   `json:"IPv4Address,omitzero"`
+	IPv6Address  netip.Addr   `json:"IPv6Address,omitzero"`
+	LinkLocalIPs []netip.Addr `json:"LinkLocalIPs,omitempty"`
 }
 
 // Copy makes a copy of the endpoint ipam config

--- a/api/types/network/ipam.go
+++ b/api/types/network/ipam.go
@@ -13,9 +13,9 @@ type IPAM struct {
 
 // IPAMConfig represents IPAM configurations
 type IPAMConfig struct {
-	Subnet     netip.Prefix          `json:",omitempty"`
-	IPRange    netip.Prefix          `json:",omitempty"`
-	Gateway    netip.Addr            `json:",omitempty"`
+	Subnet     netip.Prefix          `json:"Subnet,omitzero"`
+	IPRange    netip.Prefix          `json:"IPRange,omitzero"`
+	Gateway    netip.Addr            `json:"Gateway,omitzero"`
 	AuxAddress map[string]netip.Addr `json:"AuxiliaryAddresses,omitempty"`
 }
 

--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -61,7 +61,7 @@ type EndpointVirtualIP struct {
 	// Addr is the virtual ip address.
 	// This field accepts CIDR notation, for example `10.0.0.1/24`, to maintain backwards
 	// compatibility, but only the IP address is used.
-	Addr netip.Prefix `json:",omitempty"`
+	Addr netip.Prefix `json:"Addr,omitzero"`
 }
 
 // Network represents a network.
@@ -111,7 +111,7 @@ type IPAMOptions struct {
 
 // IPAMConfig represents ipam configuration.
 type IPAMConfig struct {
-	Subnet  netip.Prefix `json:",omitempty"`
-	Range   netip.Prefix `json:",omitempty"`
-	Gateway netip.Addr   `json:",omitempty"`
+	Subnet  netip.Prefix `json:"Subnet,omitzero"`
+	Range   netip.Prefix `json:"Range,omitzero"`
+	Gateway netip.Addr   `json:"Gateway,omitzero"`
 }

--- a/vendor/github.com/moby/moby/api/types/network/endpoint.go
+++ b/vendor/github.com/moby/moby/api/types/network/endpoint.go
@@ -58,9 +58,9 @@ func (es *EndpointSettings) Copy() *EndpointSettings {
 
 // EndpointIPAMConfig represents IPAM configurations for the endpoint
 type EndpointIPAMConfig struct {
-	IPv4Address  netip.Addr   `json:",omitempty"`
-	IPv6Address  netip.Addr   `json:",omitempty"`
-	LinkLocalIPs []netip.Addr `json:",omitempty"`
+	IPv4Address  netip.Addr   `json:"IPv4Address,omitzero"`
+	IPv6Address  netip.Addr   `json:"IPv6Address,omitzero"`
+	LinkLocalIPs []netip.Addr `json:"LinkLocalIPs,omitempty"`
 }
 
 // Copy makes a copy of the endpoint ipam config

--- a/vendor/github.com/moby/moby/api/types/network/ipam.go
+++ b/vendor/github.com/moby/moby/api/types/network/ipam.go
@@ -13,9 +13,9 @@ type IPAM struct {
 
 // IPAMConfig represents IPAM configurations
 type IPAMConfig struct {
-	Subnet     netip.Prefix          `json:",omitempty"`
-	IPRange    netip.Prefix          `json:",omitempty"`
-	Gateway    netip.Addr            `json:",omitempty"`
+	Subnet     netip.Prefix          `json:"Subnet,omitzero"`
+	IPRange    netip.Prefix          `json:"IPRange,omitzero"`
+	Gateway    netip.Addr            `json:"Gateway,omitzero"`
 	AuxAddress map[string]netip.Addr `json:"AuxiliaryAddresses,omitempty"`
 }
 

--- a/vendor/github.com/moby/moby/api/types/swarm/network.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/network.go
@@ -61,7 +61,7 @@ type EndpointVirtualIP struct {
 	// Addr is the virtual ip address.
 	// This field accepts CIDR notation, for example `10.0.0.1/24`, to maintain backwards
 	// compatibility, but only the IP address is used.
-	Addr netip.Prefix `json:",omitempty"`
+	Addr netip.Prefix `json:"Addr,omitzero"`
 }
 
 // Network represents a network.
@@ -111,7 +111,7 @@ type IPAMOptions struct {
 
 // IPAMConfig represents ipam configuration.
 type IPAMConfig struct {
-	Subnet  netip.Prefix `json:",omitempty"`
-	Range   netip.Prefix `json:",omitempty"`
-	Gateway netip.Addr   `json:",omitempty"`
+	Subnet  netip.Prefix `json:"Subnet,omitzero"`
+	Range   netip.Prefix `json:"Range,omitzero"`
+	Gateway netip.Addr   `json:"Gateway,omitzero"`
 }


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/51890
- relates to https://github.com/moby/moby/pull/50956


Pull request 50956 (88adc28731cec903e5846aea1b3197bf19aadf60) updated various types in the API module from a string to a `netip.Prefix` or `netip.Addr`. A side-effect of this was that zero values would no longer be omitted, and instead marshaled as an empty string;

    package main

    import (
        "encoding/json"
        "fmt"
        "net/netip"
    )

    type Foo struct {
        OmitEmpty netip.Prefix `json:",omitempty"`
        OmitZero  netip.Prefix `json:",omitzero"`
    }

    func main() {
        out, _ := json.Marshal(Foo{})
        fmt.Println(string(out))
    }

The above produces `{"OmitEmpty":""}`, not omitting the empty address.

This patch;

- updates most types to use `omitzero` instead of `omitempty`.
- adds explicit `json` names to fields.

There's one type remaining that uses `omitzero`, but it's generated by go-swagger, which currently doesn't support `omitzero`; the `PortSummary.IP`; https://github.com/moby/moby/blob/335f60509fde10cf8a148ef96f67faeba6517a4b/api/types/container/port_summary.go#L12-L20

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**


```bash
docker network create foo
docker run -d --name foo --network name=foo,ip=172.19.0.10 nginx:alpine
```

Before this patch:

```bash
docker container inspect foo | jq .[].NetworkSettings.Networks.foo.IPAMConfig
{
  "IPv4Address": "172.19.0.10",
  "IPv6Address": ""
}
```

With this patch:

```bash
docker container inspect foo | jq .[].NetworkSettings.Networks.foo.IPAMConfig
{
  "IPv4Address": "172.19.0.10"
}
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix some empty fields not being omitted in API responses.
```

**- A picture of a cute animal (not mandatory but encouraged)**

