### PR TITLE
daemon: Fix panic in shutdown after daemon init fails

### DIFF
--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -154,6 +154,9 @@ func (e *Events) loadBufferedEvents(since, until time.Time, topic func(any) bool
 
 // Close all the channels returned to event subscribers.
 func (e *Events) Close() error {
+	if e == nil || e.pub == nil {
+		return nil
+	}
 	e.pub.Close()
 	return nil
 }


### PR DESCRIPTION
When error during daemon initialization fails before the events manager is created the daemon will panic instead of erroring out cleanly with an actual error message.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x194fcec]

goroutine 1 [running, locked to thread]:
github.com/moby/moby/v2/daemon/events.(*Events).Close(...)
	/go/src/github.com/docker/docker/daemon/events/events.go:157
github.com/moby/moby/v2/daemon.(*Daemon).Shutdown(0x40001bf908, {0x2d664f0, 0x44c87e0})
	/go/src/github.com/docker/docker/daemon/daemon.go:1505 +0x3bc
github.com/moby/moby/v2/daemon.NewDaemon.func1()
	/go/src/github.com/docker/docker/daemon/daemon.go:907 +0x44
github.com/moby/moby/v2/daemon.NewDaemon({0x2d66560, 0x4000051c20}, 0x40004a6108, 0x40006fe810, 0x4000318700)
	/go/src/github.com/docker/docker/daemon/daemon.go:1371 +0x2130
github.com/moby/moby/v2/daemon/command.(*daemonCLI).start(0x4000051bd0, {0x2d664f0, 0x44c87e0})
	/go/src/github.com/docker/docker/daemon/command/daemon.go:264 +0xb90
github.com/moby/moby/v2/daemon/command.runDaemon(...)
	/go/src/github.com/docker/docker/daemon/command/docker_unix.go:13
github.com/moby/moby/v2/daemon/command.newDaemonCommand.func1(0x4000381808, {0x40006ac780?, 0x7?, 0x287f0b1?})
	/go/src/github.com/docker/docker/daemon/command/docker.go:48 +0xb0
github.com/spf13/cobra.(*Command).execute(0x4000381808, {0x4000050060, 0x4, 0x4})
	/go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1015 +0x7d4
github.com/spf13/cobra.(*Command).ExecuteC(0x4000381808)
	/go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/go/src/github.com/docker/docker/vendor/github.com/spf13/cobra/command.go:1064
github.com/moby/moby/v2/daemon/command.daemonRunner.Run({0x2d35440?}, {0x2d664f0, 0x44c87e0})
	/go/src/github.com/docker/docker/daemon/command/docker.go:97 +0x6c
main.main()
	/go/src/github.com/docker/docker/cmd/dockerd/main.go:35 +0x108
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix panic after failed daemon initialization
```

**- A picture of a cute animal (not mandatory but encouraged)**

