### PR TITLE
renovate: ignore docker/github-builder-experimental

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,5 +28,9 @@
   "ignoreDeps": [
     // We're using the "v2" branch, not the default ("v1") branch.
     "github.com/Graylog2/go-gelf",
+    // This action has no tagged releases, so Renovate would open a PR for
+    // every new commit.
+    // TODO: Remove once there's a tagged release.
+    "docker/github-builder-experimental",
   ]
 }


### PR DESCRIPTION
### renovate: ignore docker/github-builder-experimental

  This action has no tagged releases, so Renovate would open a PR for every new commit. The action is still experimental and frequently receives commits that would trigger unnecessary update PRs.