### PR TITLE
OCI: make `/run` a tmpfs

### DIFF
--- a/daemon/initlayer/setup_unix.go
+++ b/daemon/initlayer/setup_unix.go
@@ -24,6 +24,7 @@ func Setup(initLayerFs string, uid int, gid int) error {
 		"/dev/pts":         "dir",
 		"/dev/shm":         "dir",
 		"/proc":            "dir",
+		"/run":             "dir",
 		"/sys":             "dir",
 		"/.dockerenv":      "file",
 		"/etc/resolv.conf": "file",

--- a/daemon/pkg/oci/defaults.go
+++ b/daemon/pkg/oci/defaults.go
@@ -104,6 +104,12 @@ func DefaultLinuxSpec() specs.Spec {
 				Source:      "shm",
 				Options:     []string{"nosuid", "noexec", "nodev", "mode=1777"},
 			},
+			{
+				Destination: "/run",
+				Type:        "tmpfs",
+				Source:      "tmpfs",
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			},
 		},
 		Linux: &specs.Linux{
 			MaskedPaths: defaultLinuxMaskedPaths(),


### PR DESCRIPTION
- relates to https://github.com/actions/actions-runner-controller/issues/4362#issuecomment-3796175581

Our defaults currently don't specify a mount for `/run`, which means that files inside that directory are persisted in the container's filesystem. This can be problematic in some cases, for example, after a forced shutdown of a container (`SIGKILL`), pid-files may be left behind (e.g. `/run/docker.pid` in a DIND container), preventing the docker daemon to be started.

From the [FHS spec]:

> This directory contains system information data describing the system
> since it was booted. Files under this directory must be cleared (removed
> or truncated as appropriate) at the beginning of the boot process.

From the [systemd file hierarchy requirements]:

> `/run` must exist as an empty mount point and will automatically be mounted
> by systemd with a tmpfs.

In moby, these defaults were added in 9c4570a958df42d1ad19364b1a8da55b891d850a, but copying the [existing defaults] before that.

Comparing the defaults with containerd; containerd uses a tmpfs for `/run`. This mount was added in the [initial client] implementation; unortunately, there's no additional context in that commit describing it diverging from docker's defaults.

This patch aligns the defaults with containerd and adds `/run` as a tmpfs, using the same options as [containerd's defaults].

With this patch:

    docker run --rm alpine sh -c 'mount | grep /run'
    tmpfs on /run type tmpfs (rw,nosuid,size=65536k,mode=755)

[existing defaults]: https://github.com/moby/moby/blob/9c4570a958df42d1ad19364b1a8da55b891d850a/daemon/execdriver/native/template/default_template_linux.go#L46-L85
[FHS spec]: https://specifications.freedesktop.org/fhs/latest/run.html
[systemd file hierarchy requirements]: https://github.com/systemd/systemd/blob/v259/docs/SYSTEMD_FILE_HIERARCHY_REQUIREMENTS.md#systemd-file-hierarchy-requirements
[initial client]: https://github.com/containerd/containerd/commit/d0e5732f0bae741a68c9daec01cc5f77da42ded2
[containerd's defaults]: https://github.com/containerd/containerd/blob/v2.2.1/pkg/oci/mounts.go#L63-L68

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

