### PR TITLE
libn/d/overlay: calculate SPI like older engines

### DIFF
--- a/daemon/libnetwork/drivers/overlay/encryption_test.go
+++ b/daemon/libnetwork/drivers/overlay/encryption_test.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package overlay
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"net"
+	"net/netip"
+	"testing"
+)
+
+func legacyBuildSPI(src, dst net.IP, st uint32) int {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, st)
+	h := fnv.New32a()
+	h.Write(src)
+	h.Write(b)
+	h.Write(dst)
+	return int(binary.BigEndian.Uint32(h.Sum(nil)))
+}
+
+func TestBuildSPI(t *testing.T) {
+	cases := []struct {
+		src, dst string
+		st       uint32
+	}{
+		{"1.2.3.4", "5.6.7.8", 1234},
+		{"::ffff:1.2.3.4", "::ffff:5.6.7.8", 1234},
+		{"10.0.0.1", "2001:db8::1", 5678},
+		{"2002::abcd:1", "172.15.14.13", 54321},
+		{"2002:db8::42", "2002:db8::69", 9999},
+	}
+	for _, tc := range cases {
+		// The legacy buildSPI function is sensitive to whether src and
+		// dst are in 4-byte or 16-byte form. Versions of the driver
+		// using this function always pass the results of net.ParseIP(),
+		// which always parses the address into 16-byte form.
+		expected := legacyBuildSPI(net.ParseIP(tc.src), net.ParseIP(tc.dst), tc.st)
+
+		src, dst := netip.MustParseAddr(tc.src), netip.MustParseAddr(tc.dst)
+		actual := buildSPI(src, dst, tc.st)
+		if expected != actual {
+			t.Errorf("buildSPI(%v, %v, %v) = %v; want %v", src, dst, tc.st, actual, expected)
+		}
+		actual = buildSPI(src.Unmap(), dst.Unmap(), tc.st)
+		if expected != actual {
+			t.Errorf("buildSPI(%v, %v, %v) = %v; want %v", src.Unmap(), dst.Unmap(), tc.st, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Fixes #51798

The Security Parameter Index value signals to the recipient which key to decrypt the packet with. The overlay driver derives the SPI value for a flow from a hash digest of the source and destination IP addresses. The source and destination need to derive the same digest given the same information as the SPI values are not signaled over the overlay driver's control plane. Refactoring the overlay driver to use netip types accidentally changed the hash function to digest IPv4 addresses in 4-byte form, causing newer engines to calculate a different SPI value for a flow than older engines would. Restore the original calculation by hashing IPv4 addresses in their 16-byte form, and refactor the `buildSPI` function to take netip.Addr parameters to prevent 16-byte vs 4-byte mixups from being possible in the future.

**- How I did it**

While it would be straightforward to get the receiving side to decrypt packets tagged with both possible SPI values concurrently by programming two sets of states into the kernel, there is no easy solution for the sending side. The sender would need to know which algorithm each recipient is using to calculate its SPIs so that it can pick the same SPI to program the kernel to transmit with. ~Or it could transmit every packet twice.~ This may be possible to do so, e.g. by looking up the Engine version in Swarm's node inventory, but it would be a significant amount of work. Since we recommend against running Swarm clusters with mixed engine versions and only provide best-effort support, YAGNI. Mixed version clusters _should_ be a transient condition which only occurs during a rolling upgrade, so whatever heroics would be needed to get the latest engine to pass encrypted overlay traffic with engine versions that use the bugged SPI calculation would only be active for that one single maintenance window where degraded availability is already expected.

**- How to verify it**
1. Create a Swarm cluster with an engine running this code and a v28.5.2 engine.
2. Create an encrypted overlay network.
3. Start a container on each of the nodes, attached to the encrypted overlay network.
4. One container should be able to ping the other over the encrypted overlay network.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Fix encrypted overlay networks not passing traffic to containers on v28 and older Engines. Encrypted overlay networks will no longer pass traffic to containers on v29.2.0 thru v29.0.0, v28.2.2, v25.0.14 or v25.0.13.
```

**- A picture of a cute animal (not mandatory but encouraged)**

