### PR TITLE
daemon/container: Container.Reset: remove "lock" argument and use structured logs

### DIFF
--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -746,7 +746,7 @@ func (container *Container) CloseStreams() error {
 // InitializeStdio is called by libcontainerd to connect the stdio.
 func (container *Container) InitializeStdio(iop *cio.DirectIO) (cio.IO, error) {
 	if err := container.startLogging(); err != nil {
-		container.Reset(false)
+		container.Reset()
 		return nil, err
 	}
 

--- a/daemon/container/monitor.go
+++ b/daemon/container/monitor.go
@@ -12,12 +12,9 @@ const (
 )
 
 // Reset puts a container into a state where it can be restarted again.
-func (container *Container) Reset(lock bool) {
-	if lock {
-		container.Lock()
-		defer container.Unlock()
-	}
-
+//
+// Callers are expected to obtain a lock on the container.
+func (container *Container) Reset() {
 	if err := container.CloseStreams(); err != nil {
 		log.G(context.TODO()).Errorf("%s: %s", container.ID, err)
 	}

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -83,7 +83,7 @@ func (daemon *Daemon) handleContainerExit(c *container.Container, e *libcontaine
 	c.StreamConfig.Wait(ctx)
 	cancel()
 
-	c.Reset(false)
+	c.Reset()
 
 	if e != nil {
 		ctrExitStatus.ExitCode = int(e.ExitCode)

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -113,7 +113,7 @@ func (daemon *Daemon) containerStart(ctx context.Context, daemonCfg *configStore
 			if err := container.CheckpointTo(context.WithoutCancel(ctx), daemon.containersReplica); err != nil {
 				log.G(ctx).Errorf("%s: failed saving state on start failure: %v", container.ID, err)
 			}
-			container.Reset(false)
+			container.Reset()
 
 			daemon.Cleanup(context.WithoutCancel(ctx), container)
 			// if containers AutoRemove flag is set, remove it after clean up


### PR DESCRIPTION
### daemon/container: Container.Reset: remove "lock" argument

This argument was added in 517ba44e3742c39c4c3fc249b8c40e9b7ddd845f,
at which time some code-paths used it to obtain a lock. Currently,
none of the code-paths use this argument, so we can remove it.

### daemon/container: Container.Reset: use structured logs


### daemon/container: Container.Reset: use early return


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

