### PR TITLE
vendor: github.com/moby/policy-helpers eeebf1a0ab2b

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/moby/moby/api v1.53.0
 	github.com/moby/moby/client v0.2.2
 	github.com/moby/patternmatcher v0.6.0
-	github.com/moby/policy-helpers v0.0.0-20251206004813-9fcc1a9ec5c9
+	github.com/moby/policy-helpers v0.0.0-20260127165209-eeebf1a0ab2b
 	github.com/moby/profiles/apparmor v0.1.0
 	github.com/moby/profiles/seccomp v0.1.0
 	github.com/moby/pubsub v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -572,8 +572,8 @@ github.com/moby/moby/client v0.2.2 h1:Pt4hRMCAIlyjL3cr8M5TrXCwKzguebPAc2do2ur7dE
 github.com/moby/moby/client v0.2.2/go.mod h1:2EkIPVNCqR05CMIzL1mfA07t0HvVUUOl85pasRz/GmQ=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
-github.com/moby/policy-helpers v0.0.0-20251206004813-9fcc1a9ec5c9 h1:SISQT6l9QO+JGSTJ8QN0yWCueiSgfTStSU9KT+p537M=
-github.com/moby/policy-helpers v0.0.0-20251206004813-9fcc1a9ec5c9/go.mod h1:nJ1clNCIXZqUu3jxCkaUBpeR5bKyzzb7wmEG4xhecTI=
+github.com/moby/policy-helpers v0.0.0-20260127165209-eeebf1a0ab2b h1:WcW9/84hduRbc//v0Q6qG1ZHGNv0uWPjA/7e4B/nTLI=
+github.com/moby/policy-helpers v0.0.0-20260127165209-eeebf1a0ab2b/go.mod h1:nJ1clNCIXZqUu3jxCkaUBpeR5bKyzzb7wmEG4xhecTI=
 github.com/moby/profiles/apparmor v0.1.0 h1:dMUt6fqdOeU9tfKjntPN9hBY1C5tJtsUWZNiIuHK8QM=
 github.com/moby/profiles/apparmor v0.1.0/go.mod h1:2iRxPw+MrPuDvmb5lAEAeLB1kcOt7AzZeW3paBs2TQY=
 github.com/moby/profiles/seccomp v0.1.0 h1:kVf1lc5ytNB1XPxEdZUVF+oPpbBYJHR50eEvPt/9k8A=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1197,7 +1197,7 @@ github.com/moby/moby/client/pkg/versions
 ## explicit; go 1.19
 github.com/moby/patternmatcher
 github.com/moby/patternmatcher/ignorefile
-# github.com/moby/policy-helpers v0.0.0-20251206004813-9fcc1a9ec5c9
+# github.com/moby/policy-helpers v0.0.0-20260127165209-eeebf1a0ab2b
 ## explicit; go 1.25.0
 github.com/moby/policy-helpers
 github.com/moby/policy-helpers/image


### PR DESCRIPTION
relates to:

- https://github.com/moby/buildkit/pull/6495
- https://github.com/moby/policy-helpers/pull/21


verifier: fix race when loadTrustRoot called in parallel

full diff: https://github.com/moby/policy-helpers/compare/9fcc1a9ec5c9...eeebf1a0ab2b

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

