### PR TITLE
ci: renovate: group google.golang.org/genproto packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,10 +7,10 @@
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
-      "matchDatasources": ["go"],
+      "matchManagers": ["gomod"],
       "groupName": "golang.org/x packages",
       "groupSlug": "golang-x",
-      "matchPackageNames": ["/^golang\\.org\\/x\\//"]
+      "matchDepNames": ["/^golang\\.org\\/x\\//"]
     },
     {
       // Keep all the google.golang.org/genproto modules at the same version.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,14 @@
       "matchPackageNames": ["/^golang\\.org\\/x\\//"]
     },
     {
+      // Keep all the google.golang.org/genproto modules at the same version.
+      "matchManagers": ["gomod"],
+      "groupName": "google.golang.org/genproto packages",
+      "groupSlug": "google-genproto",
+      "matchDepNames": ["/^google\\.golang\\.org\\/genproto(\\/|$)/"],
+      "schedule": ["every month"],
+    },
+    {
       // Do not update "api" and "client" module dependencies. We keep dependency
       // versions low for these to stick with "MVS" (Minimum Version Selection);
       // https://research.swtch.com/vgo-mvs


### PR DESCRIPTION
Attempting to keep all the google.golang.org/genproto packages (which are from a mono-repo) at the same version.

- relates to https://github.com/moby/moby/pull/51893#discussion_r2720667380

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

