### PR TITLE
[25.0 backport] libn/d/overlay: calculate SPI like older engines

### DIFF
--- a/libnetwork/drivers/overlay/encryption.go
+++ b/libnetwork/drivers/overlay/encryption.go
@@ -133,7 +133,7 @@ func (d *driver) setupEncryption(remoteIP netip.Addr) error {
 	indices := make([]spi, 0, len(d.keys))
 
 	for i, k := range d.keys {
-		spis := spi{buildSPI(advIP.AsSlice(), remoteIP.AsSlice(), k.tag), buildSPI(remoteIP.AsSlice(), advIP.AsSlice(), k.tag)}
+		spis := spi{buildSPI(advIP, remoteIP, k.tag), buildSPI(remoteIP, advIP, k.tag)}
 		dir := reverse
 		if i == 0 {
 			dir = bidir
@@ -428,14 +428,14 @@ func spExists(sp *netlink.XfrmPolicy) (bool, error) {
 	}
 }
 
-func buildSPI(src, dst net.IP, st uint32) int {
-	b := make([]byte, 4)
-	binary.BigEndian.PutUint32(b, st)
+func buildSPI(src, dst netip.Addr, st uint32) int {
 	h := fnv.New32a()
-	h.Write(src)
-	h.Write(b)
-	h.Write(dst)
-	return int(binary.BigEndian.Uint32(h.Sum(nil)))
+	v := src.As16()
+	h.Write(v[:])
+	binary.Write(h, binary.BigEndian, st)
+	v = dst.As16()
+	h.Write(v[:])
+	return int(h.Sum32())
 }
 
 func buildAeadAlgo(k *key, s int) *netlink.XfrmStateAlgo {
@@ -505,7 +505,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
 	}
 
 	for rIP, node := range d.secMap {
-		idxs := updateNodeKey(lIP.AsSlice(), aIP.AsSlice(), rIP.AsSlice(), node.spi, d.keys, newIdx, priIdx, delIdx)
+		idxs := updateNodeKey(lIP, aIP, rIP, node.spi, d.keys, newIdx, priIdx, delIdx)
 		if idxs != nil {
 			d.secMap[rIP] = encrNode{idxs, node.count}
 		}
@@ -535,7 +535,7 @@ func (d *driver) updateKeys(newKey, primary, pruneKey *key) error {
  *********************************************************/
 
 // Spis and keys are sorted in such away the one in position 0 is the primary
-func updateNodeKey(lIP, aIP, rIP net.IP, idxs []spi, curKeys []*key, newIdx, priIdx, delIdx int) []spi {
+func updateNodeKey(lIP, aIP, rIP netip.Addr, idxs []spi, curKeys []*key, newIdx, priIdx, delIdx int) []spi {
 	log.G(context.TODO()).Debugf("Updating keys for node: %s (%d,%d,%d)", rIP, newIdx, priIdx, delIdx)
 
 	spis := idxs
@@ -551,17 +551,17 @@ func updateNodeKey(lIP, aIP, rIP net.IP, idxs []spi, curKeys []*key, newIdx, pri
 
 	if delIdx != -1 {
 		// -rSA0
-		programSA(lIP, rIP, spis[delIdx], nil, reverse, false)
+		programSA(lIP.AsSlice(), rIP.AsSlice(), spis[delIdx], nil, reverse, false)
 	}
 
 	if newIdx > -1 {
 		// +rSA2
-		programSA(lIP, rIP, spis[newIdx], curKeys[newIdx], reverse, true)
+		programSA(lIP.AsSlice(), rIP.AsSlice(), spis[newIdx], curKeys[newIdx], reverse, true)
 	}
 
 	if priIdx > 0 {
 		// +fSA2
-		fSA2, _, _ := programSA(lIP, rIP, spis[priIdx], curKeys[priIdx], forward, true)
+		fSA2, _, _ := programSA(lIP.AsSlice(), rIP.AsSlice(), spis[priIdx], curKeys[priIdx], forward, true)
 
 		// +fSP2, -fSP1
 		s := getMinimalIP(fSA2.Src)
@@ -592,7 +592,7 @@ func updateNodeKey(lIP, aIP, rIP net.IP, idxs []spi, curKeys []*key, newIdx, pri
 		}
 
 		// -fSA1
-		programSA(lIP, rIP, spis[0], nil, forward, false)
+		programSA(lIP.AsSlice(), rIP.AsSlice(), spis[0], nil, forward, false)
 	}
 
 	// swap

--- a/libnetwork/drivers/overlay/encryption_test.go
+++ b/libnetwork/drivers/overlay/encryption_test.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package overlay
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"net"
+	"net/netip"
+	"testing"
+)
+
+func legacyBuildSPI(src, dst net.IP, st uint32) int {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, st)
+	h := fnv.New32a()
+	h.Write(src)
+	h.Write(b)
+	h.Write(dst)
+	return int(binary.BigEndian.Uint32(h.Sum(nil)))
+}
+
+func TestBuildSPI(t *testing.T) {
+	cases := []struct {
+		src, dst string
+		st       uint32
+	}{
+		{"1.2.3.4", "5.6.7.8", 1234},
+		{"::ffff:1.2.3.4", "::ffff:5.6.7.8", 1234},
+		{"10.0.0.1", "2001:db8::1", 5678},
+		{"2002::abcd:1", "172.15.14.13", 54321},
+		{"2002:db8::42", "2002:db8::69", 9999},
+	}
+	for _, tc := range cases {
+		// The legacy buildSPI function is sensitive to whether src and
+		// dst are in 4-byte or 16-byte form. Versions of the driver
+		// using this function always pass the results of net.ParseIP(),
+		// which always parses the address into 16-byte form.
+		expected := legacyBuildSPI(net.ParseIP(tc.src), net.ParseIP(tc.dst), tc.st)
+
+		src, dst := netip.MustParseAddr(tc.src), netip.MustParseAddr(tc.dst)
+		actual := buildSPI(src, dst, tc.st)
+		if expected != actual {
+			t.Errorf("buildSPI(%v, %v, %v) = %v; want %v", src, dst, tc.st, actual, expected)
+		}
+		actual = buildSPI(src.Unmap(), dst.Unmap(), tc.st)
+		if expected != actual {
+			t.Errorf("buildSPI(%v, %v, %v) = %v; want %v", src.Unmap(), dst.Unmap(), tc.st, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Backported #51951 to 25.0
- For #51798

The Security Parameter Index value signals to the recipient which key to decrypt the packet with. The overlay driver derives the SPI value for a flow from a hash digest of the source and destination IP addresses. The source and destination need to derive the same digest given the same information as the SPI values are not signaled over the overlay driver's control plane. Refactoring the overlay driver to use netip types accidentally changed the hash function to digest IPv4 addresses in 4-byte form, causing newer engines to calculate a different SPI value for a flow than older engines would. Restore the original calculation by hashing IPv4 addresses in their 16-byte form, and refactor the `buildSPI` function to take netip.Addr parameters to prevent 16-byte vs 4-byte mixups from being possible in the future.

**- How I did it**

While it would be straightforward to get the receiving side to decrypt packets tagged with both possible SPI values concurrently by programming two sets of states into the kernel, there is no easy solution for the sending side. The sender would need to know which algorithm each recipient is using to calculate its SPIs so that it can pick the same SPI to program the kernel to transmit with. ~Or it could transmit every packet twice.~ This may be possible to do so, e.g. by looking up the Engine version in Swarm's node inventory, but it would be a significant amount of work. Since we recommend against running Swarm clusters with mixed engine versions and only provide best-effort support, YAGNI. Mixed version clusters _should_ be a transient condition which only occurs during a rolling upgrade, so whatever heroics would be needed to get the latest engine to pass encrypted overlay traffic with engine versions that use the bugged SPI calculation would only be active for that one single maintenance window where degraded availability is already expected.

**- How to verify it**
1. Create a Swarm cluster with an engine running this code and a v28.5.2 engine.
2. Create an encrypted overlay network.
3. Start a container on each of the nodes, attached to the encrypted overlay network.
4. One container should be able to ping the other over the encrypted overlay network.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Fix encrypted overlay networks not passing traffic to containers on v28 and older Engines. Encrypted overlay networks will no longer pass traffic to containers on v29.2.0 thru v29.0.0, v28.2.2, v25.0.14 or v25.0.13.
```

**- A picture of a cute animal (not mandatory but encouraged)**

