### PR TITLE
ci: update docker/github-builder to v1

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,10 +35,6 @@
   ],
   "ignoreDeps": [
     // We're using the "v2" branch, not the default ("v1") branch.
-    "github.com/Graylog2/go-gelf",
-    // This action has no tagged releases, so Renovate would open a PR for
-    // every new commit.
-    // TODO: Remove once there's a tagged release.
-    "docker/github-builder-experimental",
+    "github.com/Graylog2/go-gelf"
   ]
 }

--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -32,7 +32,7 @@ jobs:
 
   build:
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
-    uses: docker/github-builder-experimental/.github/workflows/bake.yml@7643588149117bf0ca3a906caa3968c70484027a
+    uses: docker/github-builder/.github/workflows/bake.yml@v1
     needs:
       - validate-dco
     permissions:
@@ -45,12 +45,12 @@ jobs:
       cache-scope: bin-image
       output: image
       push: ${{ github.event_name != 'pull_request' }}
-      set: |
-        *.args.DOCKER_GITCOMMIT=${{ github.sha }}
-        *.args.VERSION=${{ github.ref }}
-        *.args.PLATFORM=Moby Engine - Nightly
-        *.args.PRODUCT=moby-bin
-        *.args.PACKAGER_NAME=The Moby Project
+      vars: |
+        DOCKER_GITCOMMIT=${{ github.sha }}
+        VERSION=${{ github.ref }}
+        PLATFORM=Moby Engine - Nightly
+        PRODUCT=moby-bin
+        PACKAGER_NAME=The Moby Project
       meta-images: |
         moby/moby-bin
       ### versioning strategy


### PR DESCRIPTION
GitHub Builder is now tagged.

We would need backport to branches using old `github-builder-experimental` repo because redirects don't look supported for reusable workflows :disappointed: