### PR TITLE
daemon/command: add support for sd_notify "reload" notifications

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -521,6 +521,13 @@ func (cli *daemonCLI) reloadConfig() {
 		}
 	}
 
+	// On Linux, we use sd_notify to indicate we're reloading config. We send
+	// this signal as early as possible to let systemd know we're reloading,
+	// but must signal "ready" after this completes (even on failure), which
+	// is done by the reload function defined above.
+	done := notifyReloading()
+	defer done()
+
 	if err := config.Reload(*cli.configFile, cli.flags, reload); err != nil {
 		log.G(ctx).WithError(err).Error("Error reloading configuration")
 		return

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -336,7 +336,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 	cli.setupConfigReloadTrap()
 
 	// after the daemon is done setting up we can notify systemd api
-	go notifyReady()
+	notifyReady()
 	log.G(ctx).Info("Daemon has completed initialization")
 
 	// Daemon is fully initialized. Start handling API traffic
@@ -369,7 +369,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 	c.Cleanup()
 
 	// notify systemd that we're shutting down
-	go notifyStopping()
+	notifyStopping()
 	shutdownDaemon(ctx, d)
 
 	// shutdown / close BuildKit backend

--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -336,7 +336,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 	cli.setupConfigReloadTrap()
 
 	// after the daemon is done setting up we can notify systemd api
-	notifyReady()
+	go notifyReady()
 	log.G(ctx).Info("Daemon has completed initialization")
 
 	// Daemon is fully initialized. Start handling API traffic
@@ -369,7 +369,7 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 	c.Cleanup()
 
 	// notify systemd that we're shutting down
-	notifyStopping()
+	go notifyStopping()
 	shutdownDaemon(ctx, d)
 
 	// shutdown / close BuildKit backend

--- a/daemon/command/daemon_freebsd.go
+++ b/daemon/command/daemon_freebsd.go
@@ -11,6 +11,10 @@ func preNotifyReady() error {
 func notifyReady() {
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration. It is a no-op on FreeBSD.
+func notifyReloading() func() { return func() {} }
+
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
 }

--- a/daemon/command/daemon_linux.go
+++ b/daemon/command/daemon_linux.go
@@ -50,12 +50,12 @@ func preNotifyReady() error {
 // notifyReady sends a message to the host when the server is ready to be used
 func notifyReady() {
 	// Tell the init daemon we are accepting requests
-	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReady)
+	_, _ = systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReady)
 }
 
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
-	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)
+	_, _ = systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)
 }
 
 func validateCPURealtimeOptions(cfg *config.Config) error {

--- a/daemon/command/daemon_windows.go
+++ b/daemon/command/daemon_windows.go
@@ -56,6 +56,10 @@ func preNotifyReady() error {
 func notifyReady() {
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration. It is a no-op on Windows.
+func notifyReloading() func() { return func() {} }
+
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/22446
- fixes https://github.com/moby/moby/issues/47353
- closes #47358 


commit f74b856e1ac2805fe48ceb52bc83cd7a3cec870c added an [ExecReload] to the systemd unit, which allows users to signal the daemon to reload its config through systemd (`systemctl reload docker.service`).

While reloading works, systemd expects the `ExecReload` command to be synchronous, so that it knows when the reload completes, and can account for this when managing dependent services.

> Note however that reloading a daemon by enqueuing a signal (...) is usually
> not a good choice, because this is an asynchronous operation and hence not
> suitable when ordering reloads of multiple services against each other.

Systemd 253 introduced a new Type (Type=notify-reload, see [systemd#25916]), which allows setting a "ReloadSignal" instead, if the service supports it by including a [MONOTONIC_USEC] value in its "RELOADING=1" notifications.

This patch:

- adds reload notifications to the daemon to notify when the daemon got signaled to reload its configuration see [sd_notify(3)].
- appends a [MONOTONIC_USEC] value to the reload notification to support systemd 253's notify-reload protocol. This is backwards-compatible with older systemd releases as the systemd service manager ignores unknown assignments in notifications.
- adds a `notifyReady` callback to notify when the reload finished, which we currently send regardless if the reload was successful or failed (which could be due to an invalid config).


[sd_notify(3)]: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#RELOADING=1
[systemd.service(5)]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=
[ExecReload]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecReload=
[MONOTONIC_USEC]: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#MONOTONIC_USEC=…
[systemd#25916]: https://github.com/systemd/systemd/pull/25916

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**
