### PR TITLE
Bump go-tuf from v2.3.1 to v2.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -255,7 +255,7 @@ require (
 	github.com/spdx/tools-golang v0.5.7 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tetratelabs/wazero v1.11.0 // indirect
-	github.com/theupdateframework/go-tuf/v2 v2.3.1 // indirect
+	github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect
 	github.com/tinylib/msgp v1.3.0 // indirect
 	github.com/tonistiigi/dchapes-mode v0.0.0-20250318174251-73d941a28323 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f // indirect

--- a/go.sum
+++ b/go.sum
@@ -775,8 +775,8 @@ github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbw
 github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
-github.com/theupdateframework/go-tuf/v2 v2.3.1 h1:fReZUTLvPdqIL8Rd9xEKPmaxig8GIXe0kS4RSEaRfaM=
-github.com/theupdateframework/go-tuf/v2 v2.3.1/go.mod h1:9S0Srkf3c13FelsOyt5OyG3ZZDq9OJDA4IILavrt72Y=
+github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4+coG1iNURAGCw=
+github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/vendor/github.com/theupdateframework/go-tuf/v2/metadata/config/config.go
+++ b/vendor/github.com/theupdateframework/go-tuf/v2/metadata/config/config.go
@@ -84,7 +84,12 @@ func (cfg *UpdaterConfig) EnsurePathsExist() error {
 	}
 
 	for _, path := range []string{cfg.LocalMetadataDir, cfg.LocalTargetsDir} {
-		if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		// Use 0700 for cache directories: only the owner can read, write, and
+		// access the directory. This prevents other users on shared systems from
+		// reading or writing to the TUF cache, which could be a security risk.
+		// If different permissions are needed, pre-create the directories with
+		// the desired permissions before calling this function.
+		if err := os.MkdirAll(path, 0700); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/theupdateframework/go-tuf/v2/metadata/keys.go
+++ b/vendor/github.com/theupdateframework/go-tuf/v2/metadata/keys.go
@@ -118,16 +118,17 @@ func KeyFromPublicKey(k crypto.PublicKey) (*Key, error) {
 	return key, nil
 }
 
-// ID returns the keyID value for the given Key
-func (k *Key) ID() string {
+// ID returns the keyID value for the given Key, or an error if the key
+// cannot be canonically encoded.
+func (k *Key) ID() (string, error) {
 	// the identifier is a hexdigest of the SHA-256 hash of the canonical form of the key
 	if k.id == "" {
 		data, err := cjson.EncodeCanonical(k)
 		if err != nil {
-			panic(fmt.Errorf("error creating key ID: %w", err))
+			return "", fmt.Errorf("error creating key ID: %w", err)
 		}
 		digest := sha256.Sum256(data)
 		k.id = hex.EncodeToString(digest[:])
 	}
-	return k.id
+	return k.id, nil
 }

--- a/vendor/github.com/theupdateframework/go-tuf/v2/metadata/trustedmetadata/trustedmetadata.go
+++ b/vendor/github.com/theupdateframework/go-tuf/v2/metadata/trustedmetadata/trustedmetadata.go
@@ -24,7 +24,11 @@ import (
 	"github.com/theupdateframework/go-tuf/v2/metadata"
 )
 
-// TrustedMetadata struct for storing trusted metadata
+// TrustedMetadata struct for storing trusted metadata.
+//
+// Thread Safety: TrustedMetadata is NOT safe for concurrent use. If multiple
+// goroutines need to access a TrustedMetadata instance concurrently, external
+// synchronization is required (e.g., a sync.Mutex).
 type TrustedMetadata struct {
 	Root      *metadata.Metadata[metadata.RootType]
 	Snapshot  *metadata.Metadata[metadata.SnapshotType]

--- a/vendor/github.com/theupdateframework/go-tuf/v2/metadata/updater/updater.go
+++ b/vendor/github.com/theupdateframework/go-tuf/v2/metadata/updater/updater.go
@@ -58,6 +58,11 @@ import (
 //     target file is already locally cached.
 //   - DownloadTarget() downloads a target file and ensures it is
 //     verified correct by the metadata.
+//
+// Thread Safety: Updater is NOT safe for concurrent use. If multiple goroutines
+// need to use an Updater concurrently, external synchronization is required
+// (e.g., a sync.Mutex). Alternatively, create separate Updater instances for
+// each goroutine.
 type Updater struct {
 	trusted *trustedmetadata.TrustedMetadata
 	cfg     *config.UpdaterConfig

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1545,7 +1545,7 @@ github.com/tetratelabs/wazero/internal/wasm/binary
 github.com/tetratelabs/wazero/internal/wasmdebug
 github.com/tetratelabs/wazero/internal/wasmruntime
 github.com/tetratelabs/wazero/sys
-# github.com/theupdateframework/go-tuf/v2 v2.3.1
+# github.com/theupdateframework/go-tuf/v2 v2.4.1
 ## explicit; go 1.25.5
 github.com/theupdateframework/go-tuf/v2/metadata
 github.com/theupdateframework/go-tuf/v2/metadata/config


### PR DESCRIPTION
 ## Summary
 
1. Why:
To remove CVEs:

     - [CVE-2026-24686](https://avd.aquasec.com/nvd/2026/cve-2026-24686/)

2. What:

     - Upgrade go-tuf to v2.4.1 to remove [CVE-2026-24686](https://avd.aquasec.com/nvd/2026/cve-2026-24686/)
 
 ## Additional evidence
 
 Partial output from security scanner Trivy:
<img width="1791" height="143" alt="cve moby go-tuf" src="https://github.com/user-attachments/assets/abbf4b81-1835-4d16-8d15-099e50c577aa" />

 ## Categorization
 
- [x] security/CVE