### PR TITLE
[25.0 backport] libnetwork: fix (*Controller).getLBIndex panics

### DIFF
--- a/libnetwork/service_common.go
+++ b/libnetwork/service_common.go
@@ -160,9 +160,14 @@ func (c *Controller) getLBIndex(sid, nid string, ingressPorts []*PortConfig) int
 	}
 
 	s.Lock()
+	defer s.Unlock()
+	if s.deleted {
+		return 0
+	}
 	lb := s.loadBalancers[nid]
-	s.Unlock()
-
+	if lb == nil {
+		return 0
+	}
 	return int(lb.fwMark)
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Backported #51966 to 25.0

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Fix potential panic on `docker network prune`
```

**- A picture of a cute animal (not mandatory but encouraged)**

