### PR TITLE
Use fuse-overlayfs for rootless tests when SELinux is enforced

### DIFF
--- a/integration/daemon/default_storage_test.go
+++ b/integration/daemon/default_storage_test.go
@@ -38,6 +38,13 @@ func TestGraphDriverPersistence(t *testing.T) {
 	t.Setenv("DOCKER_DRIVER", "")
 	t.Setenv("DOCKER_GRAPHDRIVER", "")
 	t.Setenv("TEST_INTEGRATION_USE_GRAPHDRIVER", "")
+
+	graphdriver := "overlay2"
+	// overlay2 doesn't work rootless with SELinux enforcing; use fuse-overlayfs instead.
+	if testEnv.IsRootless() && testEnv.IsSELinuxEnforcing() {
+		graphdriver = "fuse-overlayfs"
+	}
+
 	ctx := testutil.StartSpan(baseContext, t)
 
 	// Phase 1: Start daemon with explicit graphdriver (overlay2)
@@ -47,12 +54,14 @@ func TestGraphDriverPersistence(t *testing.T) {
 	})
 
 	const testImage = "busybox:latest"
-	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false", "--storage-driver=overlay2")
+	d.StartWithBusybox(ctx, t, "--iptables=false", "--ip6tables=false", "--storage-driver="+graphdriver)
 	c := d.NewClientT(t)
 
 	// Verify we're using graphdriver
 	info := d.Info(t)
-	assert.Check(t, info.DriverStatus[0][1] != "io.containerd.snapshotter.v1")
+	if len(info.DriverStatus) > 0 {
+		assert.Check(t, info.DriverStatus[0][1] != "io.containerd.snapshotter.v1")
+	}
 	prevDriver := info.Driver
 
 	containerResp, err := c.ContainerCreate(ctx, client.ContainerCreateOptions{
@@ -74,7 +83,9 @@ func TestGraphDriverPersistence(t *testing.T) {
 	// Verify daemon still uses graphdriver (not containerd snapshotter)
 	// Verify we're using graphdriver
 	info = d.Info(t)
-	assert.Check(t, info.DriverStatus[0][1] != "io.containerd.snapshotter.v1")
+	if len(info.DriverStatus) > 0 {
+		assert.Check(t, info.DriverStatus[0][1] != "io.containerd.snapshotter.v1")
+	}
 	assert.Check(t, is.Equal(info.Driver, prevDriver))
 
 	// Verify our image is still there

--- a/integration/daemon/migration_test.go
+++ b/integration/daemon/migration_test.go
@@ -16,7 +16,14 @@ import (
 )
 
 func TestMigrateOverlaySnapshotter(t *testing.T) {
-	testMigrateSnapshotter(t, "overlay2", "overlayfs")
+	graphdriver := "overlay2"
+	snapshotter := "overlayfs"
+	// overlay2 doesn't work rootless with SELinux enforcing; use fuse-overlayfs instead.
+	if testEnv.IsRootless() && testEnv.IsSELinuxEnforcing() {
+		graphdriver = "fuse-overlayfs"
+		snapshotter = "fuse-overlayfs"
+	}
+	testMigrateSnapshotter(t, graphdriver, snapshotter)
 }
 
 func TestMigrateNativeSnapshotter(t *testing.T) {
@@ -100,6 +107,12 @@ func TestMigrateSaveLoad(t *testing.T) {
 		snapshotter = "overlayfs"
 	)
 	defer d.Stop(t)
+
+	// overlay2 doesn't work rootless with SELinux enforcing; use fuse-overlayfs instead.
+	if testEnv.IsRootless() && testEnv.IsSELinuxEnforcing() {
+		graphdriver = "fuse-overlayfs"
+		snapshotter = "fuse-overlayfs"
+	}
 
 	d.Start(t, "--iptables=false", "--ip6tables=false", "-s", graphdriver)
 	info := d.Info(t)

--- a/internal/testutil/environment/environment.go
+++ b/internal/testutil/environment/environment.go
@@ -208,6 +208,21 @@ func (e *Execution) HasExistingImage(t testing.TB, reference string) bool {
 	return len(imageList.Items) > 0
 }
 
+// IsSELinuxEnforcing returns true if SELinux is enabled and running in enforcing mode.
+// Returns false on non-Linux systems or if SELinux is not available or not enabled.
+func (e *Execution) IsSELinuxEnforcing() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+
+	data, err := os.ReadFile("/sys/fs/selinux/enforce")
+	if err != nil {
+		return false
+	}
+
+	return strings.TrimSpace(string(data)) == "1"
+}
+
 // EnsureFrozenImagesLinux loads frozen test images into the daemon
 // if they aren't already loaded
 func EnsureFrozenImagesLinux(ctx context.Context, testEnv *Execution) error {

--- a/internal/testutil/environment/environment.go
+++ b/internal/testutil/environment/environment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 


### PR DESCRIPTION
**- What I did**

- Add a `testEnv.IsSELinuxEnforcing` helper.
- Use fuse-overlayfs for rootless tests when SELinux is enforced.

Otherwise these tests will fail with:

`daemon.go:333: [db4ea7214b947] time="2026-01-30T23:19:52.659705723Z" level=error msg="overlay is not supported for Rootless with SELinux" storage-driver=overlay2`

https://openqa-assets.opensuse.org/tests/5639049/file/docker_engine-report.txt

**- How I did it**

**- How to verify it**

https://openqa.opensuse.org/tests/5639119