### PR TITLE
integration: Support containerd pull error message

### DIFF
--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -188,8 +188,10 @@ func TestImagePullNonExisting(t *testing.T) {
 				rdr.Close()
 			}
 
-			expectedMsg := fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", "asdfasdf")
-			assert.Check(t, is.ErrorContains(err, expectedMsg))
+			legacyMsg := fmt.Sprintf("pull access denied for %s, repository does not exist or may require 'docker login'", "asdfasdf")
+			modernMsg := fmt.Sprintf("failed to resolve reference %q", "docker.io/library/asdfasdf:latest")
+			errMsg := err.Error()
+			assert.Check(t, strings.Contains(errMsg, legacyMsg) || strings.Contains(errMsg, modernMsg))
 			assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
 			if all {
 				// pull -a on a nonexistent registry should fall back as well


### PR DESCRIPTION
Docker v29+ uses containerd's error format for non-existent images.

**- What I did**

Support both legacy & containerd pull error messages.  Otherwise test fails with:

```
=== PAUSE TestImagePullNonExisting/asdfasdf
=== CONT  TestImagePullNonExisting/asdfasdf
    pull_test.go:192: assertion failed: expected error to contain "pull access denied for asdfasdf, repository does not exist or may require 'docker login'", got "Error response from daemon: failed to resolve reference \"docker.io/library/asdfasdf:latest\": docker.io/library/asdfasdf:latest: not found"
--- FAIL: TestImagePullNonExisting/asdfasdf (0.84s)
```

**- How I did it**

vim.

**- How to verify it**

https://openqa.opensuse.org/tests/5640264

**- Human readable description for the release notes**

**- A picture of a cute animal (not mandatory but encouraged)**

