### PR TITLE
c8d/system: Fix race between `df` and `prune`

### DIFF
--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -180,6 +180,10 @@ func (i *ImageService) layerDiskUsage(ctx context.Context) (allLayersSize int64,
 	err = snapshotter.Walk(ctx, func(ctx context.Context, info snapshots.Info) error {
 		usage, err := snapshotter.Usage(ctx, info.Name)
 		if err != nil {
+			// Snapshot may have been deleted already.
+			if cerrdefs.IsNotFound(err) {
+				return nil
+			}
 			return err
 		}
 		allLayersSize += usage.Size

--- a/integration/system/disk_usage_prune_test.go
+++ b/integration/system/disk_usage_prune_test.go
@@ -1,0 +1,92 @@
+package system
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/v2/integration/internal/image"
+	"github.com/moby/moby/v2/internal/testutil"
+	"github.com/moby/moby/v2/internal/testutil/daemon"
+	"github.com/moby/moby/v2/internal/testutil/specialimage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
+)
+
+// TestDiskUsageConcurrentPrune tests that running DiskUsage concurrently with
+// image removal does not cause an error.
+// Regression test for https://github.com/moby/moby/issues/51978
+func TestDiskUsageConcurrentPrune(t *testing.T) {
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "cannot start multiple daemons on windows")
+	skip.If(t, testEnv.IsRemoteDaemon, "cannot run daemon when remote daemon")
+	skip.If(t, !testEnv.UsingSnapshotter(), "only happens with containerd image store")
+
+	ctx := testutil.StartSpan(baseContext, t)
+
+	d := daemon.New(t)
+	d.Start(t, "--iptables=false", "--ip6tables=false")
+	defer d.Stop(t)
+
+	apiClient := d.NewClientT(t)
+
+	// Load unique images with multiple layers each.
+	// More snapshots = higher chance of hitting the race.
+	const numImages = 10
+	const layersPerImage = 10
+	imageNames := make([]string, 0, numImages)
+	for i := range numImages {
+		var layers []specialimage.SingleFileLayer
+		for j := range layersPerImage {
+			layers = append(layers, specialimage.SingleFileLayer{
+				Name:    fmt.Sprintf("file-%d-%d", i, j),
+				Content: fmt.Appendf(nil, "content-%d-%d", i, j),
+			})
+		}
+		imageName := fmt.Sprintf("test-image-%d:latest", i)
+		imageNames = append(imageNames, imageName)
+		image.Load(ctx, t, apiClient, func(dir string) (*ocispec.Index, error) {
+			return specialimage.MultiLayerCustom(dir, imageName, layers)
+		})
+	}
+
+	t.Cleanup(func() {
+		for _, name := range imageNames {
+			_, _ = apiClient.ImageRemove(ctx, name, client.ImageRemoveOptions{Force: true})
+		}
+	})
+
+	const diskUsageCount = 5
+	var wg sync.WaitGroup
+	errCh := make(chan error, diskUsageCount)
+	removeStarted := make(chan struct{})
+
+	for range diskUsageCount {
+		wg.Go(func() {
+			<-removeStarted
+			time.Sleep(time.Millisecond)
+			_, err := apiClient.DiskUsage(ctx, client.DiskUsageOptions{
+				Images: true,
+			})
+			if err != nil {
+				errCh <- err
+			}
+		})
+	}
+
+	wg.Go(func() {
+		close(removeStarted)
+		for _, name := range imageNames {
+			_, _ = apiClient.ImageRemove(ctx, name, client.ImageRemoveOptions{Force: true})
+		}
+	})
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		assert.NilError(t, err, "DiskUsage should not error when images are being removed concurrently")
+	}
+}


### PR DESCRIPTION
- fixes: https://github.com/moby/moby/issues/51978

When running `docker system df` concurrently with `docker system prune` or image removal, `DiskUsage` would fail with "snapshot does not exist" error.

This happened because layerDiskUsage walks all snapshots and gets their usage, but a concurrent prune could delete a snapshot between Walk and Usage calls.

Handle NotFound errors gracefully by skipping deleted snapshots instead of returning an error.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker system df` failing when run concurrently with `docker system prune`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

