### PR TITLE
hack/validate: golangci-lint: rm deprecated --print-resources-usage flag

### DIFF
--- a/hack/validate/golangci-lint
+++ b/hack/validate/golangci-lint
@@ -25,7 +25,6 @@ for mod in "${mods[@]}"; do
 	# shellcheck disable=SC2086
 	GOGC=75 golangci-lint run \
 		${GOLANGCI_LINT_OPTS} \
-		--print-resources-usage \
 		--build-tags="${DOCKER_BUILDTAGS}" \
 		--verbose \
 		--config "${REPODIR}/.golangci.yml"


### PR DESCRIPTION
This flag was deprecated in favor of the `--verbose` flag, which was already set;

    Flag --print-resources-usage has been deprecated, use --verbose instead


**- A picture of a cute animal (not mandatory but encouraged)**

