### PR TITLE
daemon/pkg/registry: use lazyregexp again

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -343,10 +343,6 @@ linters:
         path: "libnetwork/cmd/networkdb-test/dbclient"
         linters:
           - forbidigo
-      - text: 'use of `regexp.MustCompile` forbidden'
-        path: "registry/"
-        linters:
-          - forbidigo
 
       # These interfaces in the client module are identical by design to allow future expansion.
       - text: "^identical: interface '(ContainerExportResult|ContainerLogsResult|ImagePullResponse|ImagePushResponse|ImageImportResult|ImageLoadResult|ImageSaveResult|ServiceLogsResult|TaskLogsResult)'"


### PR DESCRIPTION
- reverts https://github.com/moby/moby/pull/50465
- relates to https://github.com/moby/moby/pull/50446

This was removed in f651a5d5e9f31f52074e0c1f8b86f1d5dc6a4de1, because at the time docker/cli was importing this package. It's now moved internal to the daemon, and should no longer be used externally, so we can revert that change.

This reverts commit f651a5d5e9f31f52074e0c1f8b86f1d5dc6a4de1.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

