### PR TITLE
golangci-lint: make exclusions more specific, and combine some

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -294,16 +294,20 @@ linters:
           - gosec
 
       - text: "^G402: " # Look for bad TLS connection settings
+        path: '^client/'
         source: "cmpopts\\.Ignore"
         linters:
           - gosec
 
         # FIXME: ignoring unused assigns to ctx for now; too many hits in libnetwork/xxx functions that setup traces
       - text: "assigned to ctx, but never used afterwards"
+        path: '^daemon/'
+        source: "ctx[, ].*=.*\\(ctx[,)]"
         linters:
           - wastedassign
 
       - text: "ineffectual assignment to ctx"
+        path: '^daemon/'
         source: "ctx[, ].*=.*\\(ctx[,)]"
         linters:
           - ineffassign
@@ -328,24 +332,13 @@ linters:
         linters:
           - govet
       - text: 'use of `regexp.MustCompile` forbidden'
-        path: _test\.go
-        linters:
-          - forbidigo
-      - text: 'use of `regexp.MustCompile` forbidden'
-        path: "daemon/internal/lazyregexp"
-        linters:
-          - forbidigo
-      - text: 'use of `regexp.MustCompile` forbidden'
-        path: "internal/testutils"
-        linters:
-          - forbidigo
-      - text: 'use of `regexp.MustCompile` forbidden'
-        path: "libnetwork/cmd/networkdb-test/dbclient"
+        path: '(_test\.go|^daemon/internal/lazyregexp|^integration/internal/testutils|^daemon/libnetwork/cmd/networkdb-test/dbclient)'
         linters:
           - forbidigo
 
       # These interfaces in the client module are identical by design to allow future expansion.
       - text: "^identical: interface '(ContainerExportResult|ContainerLogsResult|ImagePullResponse|ImagePushResponse|ImageImportResult|ImageLoadResult|ImageSaveResult|ServiceLogsResult|TaskLogsResult)'"
+        path: '^client/'
         linters:
           - iface
 


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/moby/moby/pull/51982

----

### golangci-lint: make exclusions more specific, and combine some

- use anchored regexes for exclusion paths; paths are by default
  evaluated relative to the config-file, which is at the root of
  the repository (alternatively it can be configured to be relative
  to the git-root, but we may not have that around everywhere)
- combine some exclusions to a single regex


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

