### PR TITLE
libnetwork: send neighbor advertisements on restore

### DIFF
--- a/daemon/libnetwork/sandbox_store.go
+++ b/daemon/libnetwork/sandbox_store.go
@@ -256,7 +256,7 @@ func (c *Controller) sandboxRestore(activeSandboxes map[string]any) error {
 
 		// reconstruct osl sandbox field
 		if !sb.config.useDefaultSandBox {
-			if err := sb.restoreOslSandbox(); err != nil {
+			if err := sb.restoreOslSandbox(ctx); err != nil {
 				log.G(ctx).WithError(err).Error("Failed to populate fields for osl sandbox")
 				continue
 			}

--- a/daemon/libnetwork/sandbox_windows.go
+++ b/daemon/libnetwork/sandbox_windows.go
@@ -24,7 +24,7 @@ func (sb *Sandbox) releaseOSSbox() error {
 	return nil
 }
 
-func (sb *Sandbox) restoreOslSandbox() error {
+func (sb *Sandbox) restoreOslSandbox(_ context.Context) error {
 	// not implemented on Windows (Sandbox.osSbox is always nil)
 	return nil
 }


### PR DESCRIPTION
When the Docker daemon restarts with live-restore enabled, containers retain their network namespaces but neighboring hosts may have stale ARP/neighbor cache entries. This causes IPv6 connectivity issues because unlike IPv4, where gratuitous ARP is sent on interface setup, IPv6 relies on Neighbor Discovery Protocol which requires explicit Neighbor Advertisement messages to update caches.

This change adds unsolicited ARP (for IPv4) and Neighbor Advertisement (for IPv6) messages when restoring interfaces after a daemon restart, mirroring the behavior that already exists in AddInterface for new containers.

The fix also handles network drivers (such as SR-IOV and macvlan) that don't store the MAC address in the endpoint configuration by fetching it from the actual link when needed.

fixes #47176 