### PR TITLE
builder-next: close boltdb instances on error and some minor fixes

### DIFF
--- a/daemon/internal/builder-next/adapters/snapshot/snapshot.go
+++ b/daemon/internal/builder-next/adapters/snapshot/snapshot.go
@@ -60,12 +60,17 @@ type snapshotter struct {
 }
 
 // NewSnapshotter creates a new snapshotter
-func NewSnapshotter(opt Opt, prevLM leases.Manager, ns string) (snapshot.Snapshotter, *leaseutil.Manager, error) {
+func NewSnapshotter(opt Opt, prevLM leases.Manager, ns string) (_ snapshot.Snapshotter, _ *leaseutil.Manager, retErr error) {
 	dbPath := filepath.Join(opt.Root, "snapshots.db")
 	db, err := bolt.Open(dbPath, 0o600, nil)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to open database file %s", dbPath)
 	}
+	defer func() {
+		if retErr != nil {
+			_ = db.Close()
+		}
+	}()
 
 	reg, ok := opt.LayerStore.(graphIDRegistrar)
 	if !ok {

--- a/daemon/internal/builder-next/executor.go
+++ b/daemon/internal/builder-next/executor.go
@@ -113,7 +113,9 @@ func getDNSConfig(cfg config.DNSConfig) *oci.DNSConfig {
 func ipAddresses(ips []netip.Addr) []string {
 	var addrs []string
 	for _, ip := range ips {
-		addrs = append(addrs, ip.String())
+		if ip.IsValid() {
+			addrs = append(addrs, ip.String())
+		}
 	}
 	return addrs
 }


### PR DESCRIPTION

### builder-next: close boltdb instances on error

These parts were flagged by my IDE, complaining about resources not being closed properly. These code-paths open a bolt DB (which includes opening the DB file, and acquiring a advisory lock on some file-descriptors).

This _probably_ is mostly cleanliness, as (AFAICS) all code paths leading to an error would be in the daemon startup, and make the daemon exit, and BoltDB should handle those OK, but probably won't do harm either to explicitly close.


### builder-next: remove some intermediate vars

### builder-next: prevent "invalid IP" used for DNS

netip.Addr returns "invalid IP" for zero-values; while we should
not have those in the slice of IP-addresses, let's make sure we
don't accidentally set this as value.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

