### PR TITLE
builder-next: remove MigrateV2 cache migration

### DIFF
--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -287,10 +287,6 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 		return nil, err
 	}
 
-	if err := cache.MigrateV2(context.Background(), filepath.Join(root, "metadata.db"), filepath.Join(root, "metadata_v2.db"), store, snapshotter, lm); err != nil {
-		return nil, err
-	}
-
 	md, err := metadata.NewStore(filepath.Join(root, "metadata_v2.db"))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
relates to:

- https://github.com/moby/buildkit/pull/6509
- https://github.com/moby/moby/pull/41106
- https://github.com/moby/buildkit/pull/1176




This migration code was added in BuildKit v0.7.0 (Docker v20.10.0) in 9b28939345c9e870e40de7423a0a0e57c731d802. That was in 2020, which is now 6 Years ago, so it's very unlikely for the old files to be still present.

Removing this code would impact users migrating from Docker 19.03 or older, which are versions that reached EOL many years ago, so very unlikely.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

