### PR TITLE
integration: run more Buildkit tests on Windows

### DIFF
--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -93,9 +93,11 @@ jobs:
           New-Item -ItemType "directory" -Path "${{ env.BIN_OUT }}"
           docker cp "${{ env.TEST_CTN_NAME }}`:c`:\gopath\src\github.com\docker\docker\bundles\docker.exe" ${{ env.BIN_OUT }}\
           docker cp "${{ env.TEST_CTN_NAME }}`:c`:\gopath\src\github.com\docker\docker\bundles\dockerd.exe" ${{ env.BIN_OUT }}\
+          docker cp "${{ env.TEST_CTN_NAME }}`:c`:\gopath\src\github.com\docker\docker\bundles\docker-buildx.exe" ${{ env.BIN_OUT }}\
           docker cp "${{ env.TEST_CTN_NAME }}`:c`:\gopath\bin\gotestsum.exe" ${{ env.BIN_OUT }}\
           docker cp "${{ env.TEST_CTN_NAME }}`:c`:\containerd\bin\containerd.exe" ${{ env.BIN_OUT }}\
           docker cp "${{ env.TEST_CTN_NAME }}`:c`:\containerd\bin\containerd-shim-runhcs-v1.exe" ${{ env.BIN_OUT }}\
+          Get-ChildItem -Path ${{ env.BIN_OUT }}
       -
         name: Upload artifacts
         uses: actions/upload-artifact@v6
@@ -303,6 +305,9 @@ jobs:
         name: Init
         run: |
           New-Item -ItemType "directory" -Path "bundles" -ErrorAction SilentlyContinue
+          New-Item -ItemType "directory" -Path "${env:ProgramData}\Docker" -ErrorAction SilentlyContinue
+          New-Item -ItemType "directory" -Path "${env:ProgramData}\Docker\cli-plugins" -ErrorAction SilentlyContinue
+          Move-Item -Path "${{ env.BIN_OUT }}\docker-buildx.exe" -Destination "${env:ProgramData}\Docker\cli-plugins\docker-buildx.exe" -Force -ErrorAction Continue
           If ("${{ inputs.os }}" -eq "windows-2025") {
             echo "WINDOWS_BASE_IMAGE_TAG=${{ env.WINDOWS_BASE_TAG_2025 }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           } ElseIf ("${{ inputs.os }}" -eq "windows-2022") {

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -340,19 +340,24 @@ jobs:
         name: Starting test daemon
         run: |
           Write-Host "Creating service"
+          $args = @(
+            "--debug",
+            "--host=npipe:////./pipe/docker_engine", `
+            "--data-root=$env:TEMP\moby-root", `
+            "--exec-root=$env:TEMP\moby-exec", `
+            "--pidfile=$env:TEMP\docker.pid", `
+            "--register-service"
+          )
           If ("${{ matrix.runtime }}" -eq "containerd") {
-            $runtimeArg="--default-runtime=io.containerd.runhcs.v1"
+            $args += "--default-runtime=io.containerd.runhcs.v1"
             echo "DOCKER_WINDOWS_CONTAINERD_RUNTIME=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          }
+          if ("${{ inputs.storage }}" -eq "snapshotter") {
+            $args += "--feature=containerd-snapshotter"
           }
           New-Item -ItemType Directory "$env:TEMP\moby-root" -ErrorAction SilentlyContinue | Out-Null
           New-Item -ItemType Directory "$env:TEMP\moby-exec" -ErrorAction SilentlyContinue | Out-Null
-          Start-Process -Wait -NoNewWindow "${{ env.BIN_OUT }}\dockerd" `
-            -ArgumentList $runtimeArg, "--debug", `
-              "--host=npipe:////./pipe/docker_engine", `
-              "--data-root=$env:TEMP\moby-root", `
-              "--exec-root=$env:TEMP\moby-exec", `
-              "--pidfile=$env:TEMP\docker.pid", `
-              "--register-service"
+          Start-Process -Wait -NoNewWindow "${{ env.BIN_OUT }}\dockerd" -ArgumentList $args
           # Make the env-var visible to the service-managed dockerd, as there's no CLI flag for this option.
           $dockerEnviron = @("DOCKER_MIN_API_VERSION=1.24")
           $dockerEnviron += @(Get-Item Env:\OTEL_* | ForEach-Object { "$($_.Name)=$($_.Value)" })

--- a/hack/make.ps1
+++ b/hack/make.ps1
@@ -540,6 +540,11 @@ Try {
             Finally {
                 Remove-Item -Force "docker.zip"
             }
+
+            if (-not ($buildx = $env:BUILDX_VERSION)) { $buildx = "0.31.1" }
+            Write-Host "INFO: Downloading docker/buildx version $buildx..."
+            $url = "https://github.com/docker/buildx/releases/download/v${buildx}/buildx-v${buildx}.windows-amd64.exe"
+            Invoke-WebRequest $url -OutFile "$PWD\bundles\docker-buildx.exe"
         }
     }
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6213,9 +6213,8 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsEvents(t *testing.T) {
 			},
 		} {
 			t.Run(fmt.Sprintf("buildkit=%v/%s", builder.buildkit, tc.name), func(t *testing.T) {
-				if builder.buildkit {
-					skip.If(t, DaemonIsWindows, "Buildkit is not supported on Windows")
-				}
+				skip.If(t, builder.buildkit && DaemonIsWindows() && !containerdSnapshotterEnabled(),
+					"Buildkit is not supported on Windows with graphdrivers")
 
 				time.Sleep(time.Second)
 				before := time.Now()

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -720,9 +720,8 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 
 	for _, builderVersion := range []build.BuilderVersion{build.BuilderV1, build.BuilderBuildKit} {
 		t.Run("v"+string(builderVersion), func(t *testing.T) {
-			if builderVersion == build.BuilderBuildKit {
-				skip.If(t, testEnv.DaemonInfo.OSType == "windows", "Buildkit is not supported on Windows")
-			}
+			skip.If(t, builderVersion == build.BuilderBuildKit && testEnv.DaemonInfo.OSType == "windows" && !testEnv.UsingSnapshotter(),
+				"Buildkit is not supported on Windows with graphdrivers")
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -774,7 +773,6 @@ func TestBuildEmitsImageCreateEvent(t *testing.T) {
 }
 
 func TestBuildHistoryDoesNotPreventRemoval(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "buildkit is not supported on Windows")
 	skip.If(t, !testEnv.UsingSnapshotter(), "only relevant to c8d integration")
 
 	ctx := setupTest(t)

--- a/integration/build/build_traces_test.go
+++ b/integration/build/build_traces_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 	"time"
 
+	// Register the npipe: protocol connection helper so the Buildkit client
+	// can dial Windows daemons.
+	_ "github.com/moby/buildkit/client/connhelper/npipe"
+
 	moby_buildkit_v1 "github.com/moby/buildkit/api/services/control"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
@@ -28,7 +32,8 @@ func (t *testWriter) Write(p []byte) (int, error) {
 }
 
 func TestBuildkitHistoryTracePropagation(t *testing.T) {
-	skip.If(t, testEnv.DaemonInfo.OSType == "windows", "buildkit is not supported on Windows")
+	skip.If(t, testEnv.DaemonInfo.OSType == "windows" && !testEnv.UsingSnapshotter(),
+		"buildkit is not supported on Windows with graphdrivers")
 
 	ctx := testutil.StartSpan(baseContext, t)
 

--- a/internal/testutil/environment/environment.go
+++ b/internal/testutil/environment/environment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -191,7 +190,7 @@ func (e *Execution) IsUserNamespaceInKernel() bool {
 // UsingSnapshotter returns whether containerd snapshotters are used for the
 // tests by checking if the "TEST_INTEGRATION_USE_GRAPHDRIVER" is empty
 func (e *Execution) UsingSnapshotter() bool {
-	return os.Getenv("TEST_INTEGRATION_USE_GRAPHDRIVER") == "" && runtime.GOOS != "windows"
+	return os.Getenv("TEST_INTEGRATION_USE_GRAPHDRIVER") == ""
 }
 
 // HasExistingImage checks whether there is an image with the given reference.

--- a/vendor/github.com/moby/buildkit/client/connhelper/npipe/npipe.go
+++ b/vendor/github.com/moby/buildkit/client/connhelper/npipe/npipe.go
@@ -1,0 +1,8 @@
+// Package npipe provides connhelper for npipe://<address>
+package npipe
+
+import "github.com/moby/buildkit/client/connhelper"
+
+func init() {
+	connhelper.Register("npipe", Helper)
+}

--- a/vendor/github.com/moby/buildkit/client/connhelper/npipe/npipe_other.go
+++ b/vendor/github.com/moby/buildkit/client/connhelper/npipe/npipe_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package npipe
+
+import (
+	"errors"
+	"net/url"
+
+	"github.com/moby/buildkit/client/connhelper"
+)
+
+func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
+	return nil, errors.New("npipe connections are only supported on windows")
+}

--- a/vendor/github.com/moby/buildkit/client/connhelper/npipe/npipe_windows.go
+++ b/vendor/github.com/moby/buildkit/client/connhelper/npipe/npipe_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package npipe
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/moby/buildkit/client/connhelper"
+	"github.com/pkg/errors"
+)
+
+// Helper returns helper for connecting to a url via npipes.
+func Helper(u *url.URL) (*connhelper.ConnectionHelper, error) {
+	addrParts := strings.SplitN(u.String(), "://", 2)
+	if len(addrParts) != 2 {
+		return nil, errors.Errorf("invalid address %s", u)
+	}
+	address := strings.ReplaceAll(addrParts[1], "/", "\\")
+	return &connhelper.ConnectionHelper{
+		ContextDialer: func(ctx context.Context, addr string) (net.Conn, error) {
+			return winio.DialPipeContext(ctx, address)
+		},
+	}, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -992,6 +992,7 @@ github.com/moby/buildkit/cache/util
 github.com/moby/buildkit/client
 github.com/moby/buildkit/client/buildid
 github.com/moby/buildkit/client/connhelper
+github.com/moby/buildkit/client/connhelper/npipe
 github.com/moby/buildkit/client/llb
 github.com/moby/buildkit/client/llb/imagemetaresolver
 github.com/moby/buildkit/client/llb/sourceresolver


### PR DESCRIPTION
- Updates #49740 

Buildkit was enabled for Windows engines when using containerd snapshotters in commit a9ec07a005eebda6c63339fab354e6358319a7ac. Buildkit's integration tests are run on Windows in CI, but a handful of daemon integration tests are still skipped. Change those tests to only skip on Windows when the daemon under test is not using containerd snapshotters.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

