### PR TITLE
gha/bin-image: Fix build not running for tags

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/.dco.yml
 
   build:
-    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only') }}
+    if: ${{ !failure() && !cancelled() && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only')) }}
     uses: docker/github-builder/.github/workflows/bake.yml@v1
     needs:
       - validate-dco


### PR DESCRIPTION
The build job has validate-dco as a dependency, but validate-dco is skipped for tags.