### PR TITLE
config: update userland-proxy path handling to avoid unnecessary lookups

### DIFF
--- a/daemon/command/config_unix.go
+++ b/daemon/command/config_unix.go
@@ -37,7 +37,7 @@ func installConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.BoolVar(&conf.BridgeConfig.InterContainerCommunication, "icc", true, "Enable inter-container communication for the default bridge network")
 	flags.IPVar(&conf.BridgeConfig.DefaultIP, "ip", net.IPv4zero, "Host IP for port publishing from the default bridge network")
 	flags.BoolVar(&conf.BridgeConfig.EnableUserlandProxy, "userland-proxy", true, "Use userland proxy for loopback traffic")
-	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", conf.BridgeConfig.UserlandProxyPath, "Path to the userland proxy binary")
+	flags.StringVar(&conf.BridgeConfig.UserlandProxyPath, "userland-proxy-path", "", "Path to the userland proxy binary")
 	flags.BoolVar(&conf.BridgeConfig.AllowDirectRouting, "allow-direct-routing", false, "Allow remote access to published ports on container IP addresses")
 	flags.StringVar(&conf.BridgeConfig.BridgeAcceptFwMark, "bridge-accept-fwmark", "", "In bridge networks, accept packets with this firewall mark/mask")
 	flags.StringVar(&conf.CgroupParent, "cgroup-parent", "", "Set parent cgroup for all containers")

--- a/daemon/command/docker.go
+++ b/daemon/command/docker.go
@@ -16,7 +16,6 @@ import (
 var honorXDG bool
 
 func newDaemonCommand() (*cobra.Command, error) {
-	// FIXME(thaJeztah): config.New also looks up default binary-path, but this code is also executed when running "--version".
 	cfg, err := config.New()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Resolved the FIXME comment in `daemon/command/docker.go` by deferring the userland-proxy binary path lookup to avoid unnecessary filesystem searches during `config.New()`.


**- How I did it**
- Removed the binary path lookup from `setPlatformDefaults()` in `daemon/config/config_linux.go`
- Added new methods `GetUserlandProxyPath()` and `LookupUserlandProxyPath()` to enable lazy evaluation
- Modified `networkPlatformOptions()` in `daemon/daemon_unix.go` to look up the binary path only when userland-proxy is actually enabled
- Changed the default value of the `--userland-proxy-path` flag to empty string to avoid premature lookups
- Removed the FIXME comment from `daemon/command/docker.go` as the issue is now resolved

**- How to verify it**
1. Run `dockerd --version` and verify it executes without unnecessary filesystem lookups
2. Start the daemon with userland-proxy enabled (default) and verify it still finds the binary correctly
3. Start the daemon with `--userland-proxy=false` and verify it doesn't attempt to look up the binary
4. Verify that specifying a custom path with `--userland-proxy-path` still works as expected


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Improve startup performance by deferring userland-proxy binary lookup until needed
```

**- A picture of a cute animal (not mandatory but encouraged)**

