### PR TITLE
daemon: add disable-init-layer configuration option

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -208,6 +208,14 @@ type CommonConfig struct {
 	// alive upon daemon shutdown/start
 	LiveRestoreEnabled bool `json:"live-restore,omitempty"`
 
+	// InsecureDisableInitLayer disables the setup of the init layer for containers.
+	// WARNING: This is a security-sensitive option. The init layer protects against
+	// malicious images controlling paths that will be bind-mounted by the runtime,
+	// which could lead to overwriting files on the host. Only disable this in
+	// specialized, trusted environments where you can ensure the runtime will not
+	// follow symlinks on bind mount sources.
+	InsecureDisableInitLayer bool `json:"insecure-disable-init-layer,omitempty"`
+
 	// MaxConcurrentDownloads is the maximum number of downloads that
 	// may take place at a time for each pull.
 	MaxConcurrentDownloads int `json:"max-concurrent-downloads,omitempty"`

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/images"
 	"github.com/moby/moby/v2/daemon/internal/image"
+	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/moby/moby/v2/daemon/internal/metrics"
 	"github.com/moby/moby/v2/daemon/internal/multierror"
 	"github.com/moby/moby/v2/daemon/internal/otelutil"
@@ -227,8 +228,12 @@ func (daemon *Daemon) create(ctx context.Context, daemonCfg *config.Config, opts
 
 	ctr.ImageManifest = imgManifest
 
+	var initLayerFunc layer.MountInit
+	if !daemonCfg.InsecureDisableInitLayer {
+		initLayerFunc = setupInitLayer(daemon.idMapping.RootPair())
+	}
 	// Set RWLayer for container after mount labels have been set
-	rwLayer, err := daemon.imageService.CreateLayer(ctr, setupInitLayer(daemon.idMapping.RootPair()))
+	rwLayer, err := daemon.imageService.CreateLayer(ctr, initLayerFunc)
 	if err != nil {
 		return nil, errdefs.System(err)
 	}

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -25,6 +25,7 @@ dockerd - Enable daemon mode
 [**--default-ipc-mode**=*MODE*]
 [**--default-shm-size**[=*64MiB*]]
 [**--default-ulimit**[=*[]*]]
+[**--insecure-disable-init-layer**[=**false**]]
 [**--dns**[=*[]*]]
 [**--dns-opt**[=*[]*]]
 [**--dns-search**[=*[]*]]
@@ -195,6 +196,18 @@ Bridge networks will accept packets with this firewall mark/mask.
 
 **--default-ulimit**=[]
   Default ulimits for containers.
+
+**--insecure-disable-init-layer**=**true**|**false**
+  Disable the setup of the init layer for containers. Default is **false**.
+
+  **WARNING: This is a security-sensitive option.**
+
+  The init layer is not just for initializing special files (such as
+  /etc/resolv.conf, /etc/hosts, /.dockerenv). More importantly, it protects
+  against malicious images that control paths which will be bind-mounted by
+  the runtime. Without the init layer, such malicious images could use
+  symlinks or other mechanisms to cause the runtime to overwrite files on
+  the host system.
 
 **--dns**=""
   Force Docker to use specific DNS servers.


### PR DESCRIPTION
Add a new configuration option 'disable-init-layer' to control whether the init layer setup should be performed when creating containers.

Changes:
- Add DisableInitLayer field to CommonConfig structure
- Add documentation in dockerd.8.md manual page

The option can be configured via:
- Command line: dockerd --disable-init-layer
- Configuration file: {"disable-init-layer": true}

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

