### PR TITLE
daemon: allow service registration on Windows with missing system dependencies

### DIFF
--- a/daemon/command/docker_windows.go
+++ b/daemon/command/docker_windows.go
@@ -11,7 +11,7 @@ import (
 func runDaemon(ctx context.Context, cli *daemonCLI) error {
 	// On Windows, this may be launching as a service or with an option to
 	// register the service.
-	stop, runAsService, err := initService(cli)
+	stop, runAsService, err := initService(ctx, cli)
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -809,6 +809,9 @@ func (daemon *Daemon) IsSwarmCompatible() error {
 // CheckSystem verifies that the system meets the platform-specific requirements
 // for running the Docker daemon.
 func CheckSystem() error {
+	if os.Getenv("TEST_SYSTEM_REQUIREMENTS_FAILURE") != "" {
+		return errors.New("fake system requirements not met error")
+	}
 	return checkSystem()
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -806,13 +806,15 @@ func (daemon *Daemon) IsSwarmCompatible() error {
 	return daemon.config().IsSwarmCompatible()
 }
 
+var checkSystemOnce = sync.OnceValue(checkSystem)
+
 // CheckSystem verifies that the system meets the platform-specific requirements
 // for running the Docker daemon.
 func CheckSystem() error {
 	if os.Getenv("TEST_SYSTEM_REQUIREMENTS_FAILURE") != "" {
 		return errors.New("fake system requirements not met error")
 	}
-	return checkSystem()
+	return checkSystemOnce()
 }
 
 // NewDaemon sets up everything for the daemon to be able to service

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -94,6 +94,7 @@ func TestDaemonConfigValidation(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        []string
+		envs        []string
 		expectedOut string
 	}{
 		{
@@ -121,12 +122,20 @@ func TestDaemonConfigValidation(t *testing.T) {
 			args:        append(params, filepath.Join(testdata, "valid-config-1.json")),
 			expectedOut: validOut,
 		},
+		{
+			name:        "unmet system requirements",
+			envs:        []string{"TEST_SYSTEM_REQUIREMENTS_FAILURE=1"},
+			expectedOut: failedOut,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_ = testutil.StartSpan(ctx, t)
 			cmd := exec.Command(dockerBinary, tc.args...)
+			if tc.envs != nil {
+				cmd.Env = append(cmd.Env, tc.envs...)
+			}
 			out, err := cmd.CombinedOutput()
 			assert.Check(t, is.Contains(string(out), tc.expectedOut))
 			if tc.expectedOut == failedOut {


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/51997
- relates to / introduced in https://github.com/moby/moby/pull/51868


Before b0c8ff7d0c990d28e67d0df3432abcdf6804d847, system validation would not take place until the daemon was actually started. This allowed (on Windows) (un)registering the system service (`dockerd --register-service`, `dockerd --unregister-service`) before installing other system requirements (most notably, the Windows Containers feature).

This patch changes the behavior to allow this scenario; we perform validation when explicitly requested (through the `--validate` flag), and perform the same validation when starting the daemon.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix a regression in v29.2.0 that prevented registering the dockerd service on Windows if system requirements were not yet installed.
```

**- A picture of a cute animal (not mandatory but encouraged)**

