### PR TITLE
forwardExtDNS: Don't cancel context then use it

### DIFF
--- a/daemon/libnetwork/resolver.go
+++ b/daemon/libnetwork/resolver.go
@@ -542,9 +542,9 @@ func (r *Resolver) forwardExtDNS(ctx context.Context, proto string, remoteAddr n
 		}
 
 		// limits the number of outstanding concurrent queries.
-		ctx, cancel := context.WithTimeout(ctx, extIOTimeout)
-		err := r.fwdSem.Acquire(ctx, 1)
-		cancel()
+		semAcqCtx, cancelSemAcqCtx := context.WithTimeout(ctx, extIOTimeout)
+		err := r.fwdSem.Acquire(semAcqCtx, 1)
+		cancelSemAcqCtx()
 
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {


### PR DESCRIPTION
**- What I did**

- fix an oddity introduced by https://github.com/moby/moby/pull/46551

forwardExtDNS used to create a context in order to run a timeout on acquisition of a semaphore, it cancels the context as soon as it's got the semaphore.

Since commit 4de8459, the context it creates shadows the context passed in to the function, that new context is still cancelled, then it's used for logging, including in a call to `r.exchange`.

So, harmless, but a booby-trap.

(Spotted by Claude, while looking for something else!)

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

