### PR TITLE
daemon/volume: Drop BindOptions for image mounts

### DIFF
--- a/daemon/volume/mounts/linux_parser.go
+++ b/daemon/volume/mounts/linux_parser.go
@@ -356,13 +356,9 @@ func (p *linuxParser) parseMountSpec(cfg mount.Mount, validateBindSourceExists b
 		// NOP
 	case mount.TypeImage:
 		mp.Source = cfg.Source
-		if cfg.BindOptions != nil && len(cfg.BindOptions.Propagation) > 0 {
-			mp.Propagation = cfg.BindOptions.Propagation
-		} else {
-			// If user did not specify a propagation mode, get
-			// default propagation mode.
-			mp.Propagation = linuxDefaultPropagationMode
-		}
+		// Propagation is currently not configurable for image mounts.
+		// See https://github.com/moby/moby/issues/51980#issuecomment-3848407167
+		mp.Propagation = linuxDefaultPropagationMode
 	default:
 		// TODO(thaJeztah): make switch exhaustive: anything to do for mount.TypeNamedPipe, mount.TypeCluster ?
 	}


### PR DESCRIPTION
- relates to / introduced in https://github.com/moby/moby/commit/8c58934106e91a9330daf6a97bf0db1def0aa307 / https://github.com/moby/moby/pull/48798

Image mounts are validated to not accept BindOptions (validateExclusiveOptions), so BindOptions.Propagation handling in the Linux mount parser is unreachable.

Set default propagation unconditionally and left  comment for future reference.

Fixes moby/moby#51980.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/6d1020e4-9a72-41ef-a904-6c19f9adf3ab)