### PR TITLE
daemon/volume: don't print warnings for non-volume directories

### DIFF
--- a/daemon/volume/local/local.go
+++ b/daemon/volume/local/local.go
@@ -73,6 +73,7 @@ func New(scope string, rootIdentity idtools.Identity) (*Root, error) {
 	}
 
 	for _, d := range dirs {
+		// TODO(thaJeztah): this should probably skip non-volume directories (directories without a "_data" directory and no "opts.json" file).
 		if !d.IsDir() {
 			continue
 		}

--- a/daemon/volume/service/convert.go
+++ b/daemon/volume/service/convert.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -69,7 +71,12 @@ func (s *VolumesService) volumesToAPI(ctx context.Context, volumes []volume.Volu
 			}
 			sz, err := directory.Size(ctx, p)
 			if err != nil {
-				log.G(ctx).WithError(err).WithField("volume", v.Name()).Warnf("Failed to determine size of volume")
+				if !errors.Is(err, os.ErrNotExist) {
+					log.G(ctx).WithFields(log.Fields{
+						"error":  err,
+						"volume": v.Name(),
+					}).Warn("Failed to determine size of volume")
+				}
 				sz = -1
 			}
 			apiV.UsageData = &volumetypes.UsageData{Size: sz, RefCount: int64(s.vs.CountReferences(v))}


### PR DESCRIPTION
- relates to / fixes https://github.com/docker/compose/issues/13571


### daemon/volume: don't print warnings for non-volume directories

When restoring volumes at startup, the local volume driver's constructor ([daemon/volume/local.New]) iterates over all directories found inside the volume storage path (`/var/lib/docker/volumes`). It does not (currently) check for presence of other indicators that the directory is an actual volume, such as the `_data` directory being present, or a `opts.json`.

In situations where `/var/lib/docker/volumes` contains directories that were not created by docker, this can result in errors when calculating the size of volumes (`docker system df`);

Before (re)starting the daemon, create some directories;

    mkdir /var/lib/docker/volumes/notavolume
    echo "some file" > /var/lib/docker/volumes/notavolume/some-file
    mkdir /var/lib/docker/volumes/notavolume2

Then, start the daemon, and run `docker system df`. The daemon logs will now contain warnings about the path not being found:

    WARN[2026-02-09T11:27:31.940713593Z] Failed to determine size of volume            error="lstat /var/lib/docker/volumes/notavolume/_data: no such file or directory" volume=notavolume
    WARN[2026-02-09T11:27:31.940765468Z] Failed to determine size of volume            error="lstat /var/lib/docker/volumes/notavolume2/_data: no such file or directory" volume=notavolume2

The [calcSize] function used to calculate the size of a volume already ignores files _within_ the volume's storage that are not / no longer found, but does not ignore errors if the base directory (`_data`) itself doesn't exist.

This patch:

- makes the logs ignore "not found" errors
- adds a TODO to look into ignoring these directories during daemon startup (when instantiating the driver and restoring volumes).

[daemon/volume/local.New]: https://github.com/moby/moby/blob/6c5233e1098dc689b2e665087780695ac8864e95/daemon/volume/local/local.go#L51-L85
[calcSize]: https://github.com/moby/moby/blob/daeaac0d3cf147cc7450a3ab9a869327c71bad45/daemon/internal/directory/directory_unix.go#L13-L24

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Prevent logging "not found" warnings when calculating volume sizes.
```

**- A picture of a cute animal (not mandatory but encouraged)**

