### PR TITLE
daemon/volume: cleanup some logs

### DIFF
--- a/daemon/volume/drivers/adapter.go
+++ b/daemon/volume/drivers/adapter.go
@@ -94,7 +94,10 @@ func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 	if err != nil {
 		// `GetCapabilities` is a not a required endpoint.
 		// On error assume it's a local-only driver
-		log.G(context.TODO()).WithError(err).WithField("driver", a.name).Debug("Volume driver returned an error while trying to query its capabilities, using default capabilities")
+		log.G(context.TODO()).WithFields(log.Fields{
+			"error":  err,
+			"driver": a.name,
+		}).Debug("Volume driver returned an error while trying to query its capabilities, using default capabilities")
 		return volume.Capability{Scope: volume.LocalScope}
 	}
 
@@ -105,7 +108,10 @@ func (a *volumeDriverAdapter) getCapabilities() volume.Capability {
 
 	capabilities.Scope = strings.ToLower(capabilities.Scope)
 	if capabilities.Scope != volume.LocalScope && capabilities.Scope != volume.GlobalScope {
-		log.G(context.TODO()).WithField("driver", a.Name()).WithField("scope", a.Scope).Warn("Volume driver returned an invalid scope")
+		log.G(context.TODO()).WithFields(log.Fields{
+			"driver": a.name,
+			"scope":  capabilities.Scope,
+		}).Warn("Volume driver returned an invalid scope")
 		capabilities.Scope = volume.LocalScope
 	}
 

--- a/daemon/volume/drivers/extpoint.go
+++ b/daemon/volume/drivers/extpoint.go
@@ -105,8 +105,12 @@ func (s *Store) lookup(name string, mode int) (volume.Driver, error) {
 		if err := validateDriver(d); err != nil {
 			if mode > 0 {
 				// Undo any reference count changes from the initial `Get`
-				if _, err := s.pluginGetter.Get(name, extName, mode*-1); err != nil {
-					log.G(context.TODO()).WithError(err).WithField("action", "validate-driver").WithField("plugin", name).Error("error releasing reference to plugin")
+				if _, getErr := s.pluginGetter.Get(name, extName, mode*-1); getErr != nil {
+					log.G(context.TODO()).WithFields(log.Fields{
+						"error":  getErr,
+						"action": "validate-driver",
+						"plugin": name,
+					}).Errorf("error releasing reference to plugin after validation error: %v", err)
 				}
 			}
 			return nil, err

--- a/daemon/volume/service/db.go
+++ b/daemon/volume/service/db.go
@@ -86,7 +86,10 @@ func listMeta(tx *bolt.Tx) []volumeMetadata {
 		var m volumeMetadata
 		if err := json.Unmarshal(v, &m); err != nil {
 			// Just log the error
-			log.G(context.TODO()).Errorf("Error while reading volume metadata for volume %q: %v", string(k), err)
+			log.G(context.TODO()).WithFields(log.Fields{
+				"error":  err,
+				"volume": string(k),
+			}).Error("Error while reading volume metadata for volume")
 			return nil
 		}
 		ls = append(ls, m)

--- a/daemon/volume/service/restore.go
+++ b/daemon/volume/service/restore.go
@@ -37,7 +37,11 @@ func (s *VolumeStore) restore() {
 			if meta.Driver != "" {
 				v, err = lookupVolume(ctx, s.drivers, meta.Driver, meta.Name)
 				if err != nil && !errors.Is(err, errNoSuchVolume) {
-					log.G(ctx).WithError(err).WithField("driver", meta.Driver).WithField("volume", meta.Name).Warn("Error restoring volume")
+					log.G(ctx).WithFields(log.Fields{
+						"error":  err,
+						"driver": meta.Driver,
+						"volume": meta.Name,
+					}).Warn("Error restoring volume")
 					return
 				}
 				if v == nil {
@@ -56,7 +60,11 @@ func (s *VolumeStore) restore() {
 
 				meta.Driver = v.DriverName()
 				if err := s.setMeta(v.Name(), meta); err != nil {
-					log.G(ctx).WithError(err).WithField("driver", meta.Driver).WithField("volume", v.Name()).Warn("Error updating volume metadata on restore")
+					log.G(ctx).WithFields(log.Fields{
+						"error":  err,
+						"driver": meta.Driver,
+						"volume": v.Name(),
+					}).Warn("Error updating volume metadata on restore")
 				}
 			}
 
@@ -78,7 +86,10 @@ func (s *VolumeStore) restore() {
 	s.db.Update(func(tx *bolt.Tx) error {
 		for meta := range chRemove {
 			if err := removeMeta(tx, meta.Name); err != nil {
-				log.G(ctx).WithField("volume", meta.Name).Warnf("Error removing stale entry from volume db: %v", err)
+				log.G(ctx).WithFields(log.Fields{
+					"error":  err,
+					"volume": meta.Name,
+				}).Warn("Error removing stale entry from volume db")
 			}
 		}
 		return nil

--- a/daemon/volume/service/service.go
+++ b/daemon/volume/service/service.go
@@ -76,9 +76,9 @@ func (s *VolumesService) Create(ctx context.Context, name, driverName string, op
 			driverName = volume.DefaultDriverName
 		}
 		options = append(options, opts.WithCreateLabel(AnonymousLabel, ""))
-		log.G(ctx).WithFields(log.Fields{"volume-name": name, "driver": driverName}).Debug("Creating anonymous volume")
+		log.G(ctx).WithFields(log.Fields{"volume": name, "driver": driverName}).Debug("Creating anonymous volume")
 	} else {
-		log.G(ctx).WithField("volume-name", name).Debug("Creating named volume")
+		log.G(ctx).WithField("volume", name).Debug("Creating named volume")
 	}
 	v, err := s.vs.Create(ctx, name, driverName, options...)
 	if err != nil {
@@ -245,10 +245,16 @@ func (s *VolumesService) Prune(ctx context.Context, filter filters.Args) (*volum
 
 		vSize, err := directory.Size(ctx, v.Path())
 		if err != nil {
-			log.G(ctx).WithField("volume", v.Name()).WithError(err).Warn("could not determine size of volume")
+			log.G(ctx).WithFields(log.Fields{
+				"error":  err,
+				"volume": v.Name(),
+			}).Warn("could not determine size of volume")
 		}
 		if err := s.vs.Remove(ctx, v); err != nil {
-			log.G(ctx).WithError(err).WithField("volume", v.Name()).Warnf("Could not determine size of volume")
+			log.G(ctx).WithFields(log.Fields{
+				"error":  err,
+				"volume": v.Name(),
+			}).Warn("Could not remove volume")
 			continue
 		}
 		rep.SpaceReclaimed += uint64(vSize)


### PR DESCRIPTION
We use `"volume"` in most places, so let's use that consistently;

    git grep '"volume-name"' | wc -l
    9
    git grep '"volume"' | wc -l
    403

Also update some logs to use structured logs and to use `WithFields` instead of chaining multiple `WithField` / `WithError`.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

