### PR TITLE
daemon/internal/builder-next: add executorOpts struct

### DIFF
--- a/daemon/internal/builder-next/controller.go
+++ b/daemon/internal/builder-next/controller.go
@@ -154,19 +154,19 @@ func newSnapshotterController(ctx context.Context, rt http.RoundTripper, opt Opt
 	wo.RegistryHosts = opt.RegistryHosts
 	wo.Labels = getLabels(opt, wo.Labels)
 
-	exec, err := newExecutor(
-		opt.Root,
-		opt.DefaultCgroupParent,
-		opt.NetworkController,
-		dnsConfig,
-		opt.Rootless,
-		opt.IdentityMapping,
-		opt.ApparmorProfile,
-		cdiManager,
-		opt.ContainerdAddress,
-		opt.ContainerdNamespace,
-		opt.HyperVIsolation,
-	)
+	exec, err := newExecutor(executorOpts{
+		root:                opt.Root,
+		networkController:   opt.NetworkController,
+		dnsConfig:           dnsConfig,
+		cdiManager:          cdiManager,
+		cgroupParent:        opt.DefaultCgroupParent,
+		apparmorProfile:     opt.ApparmorProfile,
+		rootless:            opt.Rootless,
+		identityMapping:     opt.IdentityMapping,
+		containerdAddr:      opt.ContainerdAddress,
+		containerdNamespace: opt.ContainerdNamespace,
+		hypervIsolation:     opt.HyperVIsolation,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -354,25 +354,26 @@ func newGraphDriverController(ctx context.Context, rt http.RoundTripper, opt Opt
 		return nil, err
 	}
 
-	dns := getDNSConfig(opt.DNSConfig)
-
 	cdiManager, err := getCDIManager(opt)
 	if err != nil {
 		return nil, err
 	}
 
-	exec, err := newExecutorGD(
-		root,
-		opt.DefaultCgroupParent,
-		opt.NetworkController,
-		dns,
-		opt.Rootless,
-		opt.IdentityMapping,
-		opt.ApparmorProfile,
-		cdiManager,
-		opt.ContainerdAddress,
-		opt.ContainerdNamespace,
-	)
+	exec, err := newExecutorGD(executorOpts{
+		root:              root,
+		networkController: opt.NetworkController,
+		dnsConfig:         getDNSConfig(opt.DNSConfig),
+		cdiManager:        cdiManager,
+		cgroupParent:      opt.DefaultCgroupParent,
+		apparmorProfile:   opt.ApparmorProfile,
+		rootless:          opt.Rootless,
+		identityMapping:   opt.IdentityMapping,
+
+		// Windows-only fields (currently not used, as newExecutorGD is not implemented on Windows)
+		containerdAddr:      opt.ContainerdAddress,
+		containerdNamespace: opt.ContainerdNamespace,
+		hypervIsolation:     opt.HyperVIsolation,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/internal/builder-next/executor_linux.go
+++ b/daemon/internal/builder-next/executor_linux.go
@@ -8,24 +8,20 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/moby/buildkit/executor"
-	"github.com/moby/buildkit/executor/oci"
 	"github.com/moby/buildkit/executor/resources"
 	"github.com/moby/buildkit/executor/runcexecutor"
-	"github.com/moby/buildkit/solver/llbsolver/cdidevices"
 	"github.com/moby/buildkit/solver/pb"
 	"github.com/moby/buildkit/util/network"
 	"github.com/moby/moby/v2/daemon/internal/stringid"
-	"github.com/moby/moby/v2/daemon/libnetwork"
-	"github.com/moby/sys/user"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const networkName = "bridge"
 
-func newExecutor(root, cgroupParent string, net *libnetwork.Controller, dnsConfig *oci.DNSConfig, rootless bool, idmap user.IdentityMapping, apparmorProfile string, cdiManager *cdidevices.Manager, _, _ string, _ bool) (executor.Executor, error) {
-	netRoot := filepath.Join(root, "net")
+func newExecutor(opts executorOpts) (executor.Executor, error) {
+	netRoot := filepath.Join(opts.root, "net")
 	networkProviders := map[pb.NetMode]network.Provider{
-		pb.NetMode_UNSET: &bridgeProvider{Controller: net, Root: netRoot},
+		pb.NetMode_UNSET: &bridgeProvider{Controller: opts.networkController, Root: netRoot},
 		pb.NetMode_HOST:  network.NewHostProvider(),
 		pb.NetMode_NONE:  network.NewNoneProvider(),
 	}
@@ -43,9 +39,9 @@ func newExecutor(root, cgroupParent string, net *libnetwork.Controller, dnsConfi
 
 	// Returning a non-nil but empty *IdentityMapping breaks BuildKit:
 	// https://github.com/moby/moby/pull/39444
-	pidmap := &idmap
-	if idmap.Empty() {
-		pidmap = nil
+	idmap := &opts.identityMapping
+	if opts.identityMapping.Empty() {
+		idmap = nil
 	}
 
 	rm, err := resources.NewMonitor()
@@ -53,43 +49,30 @@ func newExecutor(root, cgroupParent string, net *libnetwork.Controller, dnsConfi
 		return nil, err
 	}
 
-	runcCmds := []string{"runc"}
-
 	// TODO: FIXME: testing env var, replace with something better or remove in a major version or two
+	runcCmds := []string{"runc"}
 	if runcOverride := os.Getenv("DOCKER_BUILDKIT_RUNC_COMMAND"); runcOverride != "" {
 		runcCmds = []string{runcOverride}
 	}
 
 	return runcexecutor.New(runcexecutor.Opt{
-		Root:                filepath.Join(root, "executor"),
+		Root:                filepath.Join(opts.root, "executor"),
 		CommandCandidates:   runcCmds,
-		DefaultCgroupParent: cgroupParent,
-		Rootless:            rootless,
+		DefaultCgroupParent: opts.cgroupParent,
+		Rootless:            opts.rootless,
 		NoPivot:             os.Getenv("DOCKER_RAMDISK") != "",
-		IdentityMapping:     pidmap,
-		DNS:                 dnsConfig,
-		ApparmorProfile:     apparmorProfile,
+		IdentityMapping:     idmap,
+		DNS:                 opts.dnsConfig,
+		ApparmorProfile:     opts.apparmorProfile,
 		ResourceMonitor:     rm,
-		CDIManager:          cdiManager,
+		CDIManager:          opts.cdiManager,
 	}, networkProviders)
 }
 
-// newExecutorGD calls newExecutor() on Linux.
-// Created for symmetry with the non-linux platforms, esp. Windows.
-func newExecutorGD(root, cgroupParent string, net *libnetwork.Controller, dnsConfig *oci.DNSConfig, rootless bool, idmap user.IdentityMapping, apparmorProfile string, cdiManager *cdidevices.Manager, _, _ string) (executor.Executor, error) {
-	return newExecutor(
-		root,
-		cgroupParent,
-		net,
-		dnsConfig,
-		rootless,
-		idmap,
-		apparmorProfile,
-		cdiManager,
-		"",
-		"",
-		false,
-	)
+// newExecutorGD calls newExecutor() on Linux. It returns a stubExecutor on
+// other platforms.
+func newExecutorGD(opts executorOpts) (executor.Executor, error) {
+	return newExecutor(opts)
 }
 
 func (iface *lnInterface) Set(s *specs.Spec) error {

--- a/daemon/internal/builder-next/executor_nolinux.go
+++ b/daemon/internal/builder-next/executor_nolinux.go
@@ -8,11 +8,7 @@ import (
 	"runtime"
 
 	"github.com/moby/buildkit/executor"
-	"github.com/moby/buildkit/executor/oci"
 	resourcetypes "github.com/moby/buildkit/executor/resources/types"
-	"github.com/moby/buildkit/solver/llbsolver/cdidevices"
-	"github.com/moby/moby/v2/daemon/libnetwork"
-	"github.com/moby/sys/user"
 )
 
 type stubExecutor struct{}
@@ -26,6 +22,6 @@ func (w *stubExecutor) Exec(ctx context.Context, id string, process executor.Pro
 }
 
 // function stub created for GraphDriver
-func newExecutorGD(_, _ string, _ *libnetwork.Controller, _ *oci.DNSConfig, _ bool, _ user.IdentityMapping, _ string, _ *cdidevices.Manager, _, _ string) (executor.Executor, error) {
+func newExecutorGD(executorOpts) (executor.Executor, error) {
 	return &stubExecutor{}, nil
 }

--- a/daemon/internal/builder-next/executor_opts.go
+++ b/daemon/internal/builder-next/executor_opts.go
@@ -1,0 +1,29 @@
+package buildkit
+
+import (
+	"github.com/moby/buildkit/executor/oci"
+	"github.com/moby/buildkit/solver/llbsolver/cdidevices"
+	"github.com/moby/moby/v2/daemon/libnetwork"
+	"github.com/moby/sys/user"
+)
+
+// executorOpts holds options for constructing an executor. It contains fields
+// used on Linux, Windows, or both.
+type executorOpts struct {
+	// common fields
+	root              string
+	networkController *libnetwork.Controller
+	dnsConfig         *oci.DNSConfig
+	cdiManager        *cdidevices.Manager
+
+	// linux-only fields
+	cgroupParent    string
+	apparmorProfile string
+	rootless        bool
+	identityMapping user.IdentityMapping
+
+	// windows-only fields
+	containerdAddr      string
+	containerdNamespace string
+	hypervIsolation     bool
+}

--- a/daemon/internal/builder-next/executor_others.go
+++ b/daemon/internal/builder-next/executor_others.go
@@ -4,12 +4,8 @@ package buildkit
 
 import (
 	"github.com/moby/buildkit/executor"
-	"github.com/moby/buildkit/executor/oci"
-	"github.com/moby/buildkit/solver/llbsolver/cdidevices"
-	"github.com/moby/moby/v2/daemon/libnetwork"
-	"github.com/moby/sys/user"
 )
 
-func newExecutor(_, _ string, _ *libnetwork.Controller, _ *oci.DNSConfig, _ bool, _ user.IdentityMapping, _ string, _ *cdidevices.Manager, _, _ string, _ bool) (executor.Executor, error) {
+func newExecutor(executorOpts) (executor.Executor, error) {
 	return &stubExecutor{}, nil
 }


### PR DESCRIPTION
- [x] follow-up to / stacked on https://github.com/moby/moby/pull/51990

### daemon/internal/builder-next: add executorOpts struct

The newExecutor and newExecutorGD constructors started to gain
a long list of arguments, some of which were platform-specific
and not used on other platforms.

Add a basic struct to pass options, which also allows documenting
platform-specific fields through comments, and makes it easier to
maintain platform-specific stubs.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

