### PR TITLE
Fix missing error check in ContainerTop on Windows

### DIFF
--- a/daemon/top_windows.go
+++ b/daemon/top_windows.go
@@ -51,6 +51,10 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.TopRe
 		return task, nil
 	}()
 
+	if err != nil {
+		return nil, err
+	}
+
 	s, err := task.Summary(context.Background())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**- What I did**

Fixed a missing error check in `ContainerTop` on Windows that could cause a nil pointer panic.

**- How I did it**

Added an `if err != nil` check after the IIFE that acquires the running task under lock in `daemon/top_windows.go`. Previously, if `GetRunningTask()` failed (e.g., container not running) or the container was in a restarting state, the error was silently dropped and `task.Summary()` was called on a nil task, resulting in a panic.

**- How to verify it**

1. Run `docker top` against a stopped or restarting Windows container.
2. Before this fix: nil pointer panic.
3. After this fix: a proper error message is returned.

This matches the existing error handling pattern in `daemon/top_unix.go`.

**- Human readable description for the release notes**

```markdown changelog
Fix a panic when running `docker top` on a non-running Windows container.
```