### PR TITLE
Remove direct dependency on code.cloudfoundry.org/clock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.5
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	cloud.google.com/go/logging v1.13.1
-	code.cloudfoundry.org/clock v1.60.0
 	dario.cat/mergo v1.0.2
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c
@@ -126,6 +125,7 @@ require (
 	cloud.google.com/go/auth v0.18.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/longrunning v0.7.0 // indirect
+	code.cloudfoundry.org/clock v1.60.0 // indirect
 	cyphar.com/go-pathrs v0.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect


### PR DESCRIPTION
- obsoletes, closes https://github.com/moby/moby/pull/52026

Replace Clock field with a simpler func() time.Time that defaults to time.Now.

This still allows time injection in tests if needed, without pulling in a full Clock interface when only Now() is used.

The clock.Clock.Now() implementation just wraps time.Now(), so there is no difference in time resolution or behavior.

The package is an indirect dependency via swarmkit.
