### PR TITLE
daemon: assorted cleanups and fixes

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1325,10 +1325,11 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 				continue
 			}
 			for id := range all {
-				log.G(ctx).WithField("container", id).
-					WithField("driver", driver).
-					WithField("current_driver", driverName).
-					Debugf("not restoring container because it was created with another storage driver (%s)", driver)
+				log.G(ctx).WithFields(log.Fields{
+					"container":      id,
+					"driver":         driver,
+					"current_driver": driverName,
+				}).Debugf("not restoring container because it was created with another storage driver (%s)", driver)
 			}
 		}
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -304,14 +304,14 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 			}).Debug("loaded container")
 
 			if err := daemon.registerName(c); err != nil {
-				log.G(ctx).WithError(err).Errorf("failed to register container name: %s", c.Name)
+				logger.WithError(err).Errorf("failed to register container name: %s", c.Name)
 				mapLock.Lock()
 				delete(containers, c.ID)
 				mapLock.Unlock()
 				return
 			}
 			if err := daemon.register(context.TODO(), c); err != nil {
-				log.G(ctx).WithError(err).Error("failed to register container")
+				logger.WithError(err).Error("failed to register container")
 				mapLock.Lock()
 				delete(containers, c.ID)
 				mapLock.Unlock()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -310,7 +310,7 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 				mapLock.Unlock()
 				return
 			}
-			if err := daemon.register(context.TODO(), c); err != nil {
+			if err := daemon.register(ctx, c); err != nil {
 				logger.WithError(err).Error("failed to register container")
 				mapLock.Lock()
 				delete(containers, c.ID)


### PR DESCRIPTION
Had this in a branch I was working on for other changes; let's get these out of the way already.

### daemon: Daemon.restartSwarmContainers(): reduce nested if

### daemon: Daemon.restore: use correct logger

Use the logger that was created in this loop.

### daemon: Daemon.restore: pass through context to daemon.register

Pass through the context, which is used in Container.CheckpointTo
for a trace. The `Daemon.restore` function is called by NewDaemon,
so we likely won't need a `context.WithoutCancel()` and can pass
it as-is.

### daemon: NewDaemon: update log that chained "WithField"

### daemon/internal/metrics: CleanupPlugin: minor cleanup

- Use "WithFields"
- Remove redundant capturing of loop var

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

