### PR TITLE
image: add opt-in identity field to image list API for containerd backend

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -13,6 +13,12 @@ keywords: "API, Docker, rcli, REST, documentation"
      will be rejected.
 -->
 
+## v1.54 API changes
+
+* `GET /images/json` now supports an `identity` query parameter. When set,
+  the response includes manifest summaries and may include an `Identity` field
+  for each manifest with trusted identity and origin information.
+
 ## v1.53 API changes
 
 * `GET /info` now includes an `NRI` field. If the Node Resource Interface (NRI)

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -19,10 +19,10 @@ produces:
 consumes:
   - "application/json"
   - "text/plain"
-basePath: "/v1.53"
+basePath: "/v1.54"
 info:
   title: "Docker Engine API"
-  version: "1.53"
+  version: "1.54"
   x-logo:
     url: "https://docs.docker.com/assets/images/logo-docker-main.png"
   description: |
@@ -1835,6 +1835,13 @@ definitions:
           compatibility.
         x-nullable: true
         $ref: "#/definitions/OCIDescriptor"
+      Identity:
+        description: |-
+          Identity holds information about the identity and origin of the image.
+          This is trusted information verified by the daemon and cannot be modified
+          by tagging an image to a different name.
+        x-nullable: true
+        $ref: "#/definitions/Identity"
       Manifests:
         description: |
           Manifests is a list of image manifests available in this image. It
@@ -1850,13 +1857,6 @@ definitions:
         x-nullable: true
         items:
           $ref: "#/definitions/ImageManifestSummary"
-      Identity:
-        description: |-
-          Identity holds information about the identity and origin of the image.
-          This is trusted information verified by the daemon and cannot be modified
-          by tagging an image to a different name.
-        x-nullable: true
-        $ref: "#/definitions/Identity"
       RepoTags:
         description: |
           List of image names/tags in the local image cache that reference this
@@ -8212,6 +8212,13 @@ definitions:
               OCI platform of the image. This will be the platform specified in the
               manifest descriptor from the index/manifest list.
               If it's not available, it will be obtained from the image config.
+          Identity:
+            description: |
+              Identity holds information about the identity and origin of this image.
+              For image list responses, this can duplicate Build/Pull fields across
+              image manifests, because those parts are image-level metadata.
+            x-nullable: true
+            $ref: "#/definitions/Identity"
           Containers:
             description: |
               The IDs of the containers that are using this image.
@@ -9720,6 +9727,11 @@ paths:
         - name: "manifests"
           in: "query"
           description: "Include `Manifests` in the image summary."
+          type: "boolean"
+          default: false
+        - name: "identity"
+          in: "query"
+          description: "Include `Identity` in each manifest summary. Requires `manifests=1`."
           type: "boolean"
           default: false
       tags: ["Image"]

--- a/api/types/image/manifest.go
+++ b/api/types/image/manifest.go
@@ -73,6 +73,11 @@ type ImageProperties struct {
 	// Required: true
 	Platform ocispec.Platform `json:"Platform"`
 
+	// Identity holds information about the identity and origin of the image.
+	// For image list responses, this can duplicate Build/Pull fields across
+	// image manifests, because those parts of identity are image-level metadata.
+	Identity *Identity `json:"Identity,omitempty"`
+
 	Size struct {
 		// Unpacked is the size (in bytes) of the locally unpacked
 		// (uncompressed) image content that's directly usable by the containers

--- a/client/client.go
+++ b/client/client.go
@@ -107,7 +107,7 @@ const DummyHost = "api.moby.localhost"
 // overriding the version and disable API-version negotiation.
 //
 // This version may be lower than the version of the api library module used.
-const MaxAPIVersion = "1.53"
+const MaxAPIVersion = "1.54"
 
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.

--- a/client/image_list.go
+++ b/client/image_list.go
@@ -41,6 +41,14 @@ func (cli *Client) ImageList(ctx context.Context, options ImageListOptions) (Ima
 			query.Set("manifests", "1")
 		}
 	}
+	if options.Identity {
+		if err := cli.requiresVersion(ctx, "1.54", "identity"); err != nil {
+			return ImageListResult{}, err
+		}
+		// Identity data in image list is scoped to manifests.
+		query.Set("manifests", "1")
+		query.Set("identity", "1")
+	}
 
 	resp, err := cli.get(ctx, "/images/json", query, nil)
 	defer ensureReaderClosed(resp)

--- a/client/image_list_opts.go
+++ b/client/image_list_opts.go
@@ -16,6 +16,9 @@ type ImageListOptions struct {
 
 	// Manifests indicates whether the image manifests should be returned.
 	Manifests bool
+
+	// Identity indicates whether image identity information should be returned.
+	Identity bool
 }
 
 // ImageListResult holds the result from ImageList.

--- a/client/image_list_test.go
+++ b/client/image_list_test.go
@@ -82,6 +82,16 @@ func TestImageList(t *testing.T) {
 				"shared-size": "1",
 			},
 		},
+		{
+			doc: "with identity",
+			options: ImageListOptions{
+				Identity: true,
+			},
+			expectedQueryParams: map[string]string{
+				"identity":  "1",
+				"manifests": "1",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -59,7 +59,7 @@ const (
 	// MaxAPIVersion is the highest REST API version supported by the daemon.
 	//
 	// This version may be lower than the version of the api library module used.
-	MaxAPIVersion = "1.53"
+	MaxAPIVersion = "1.54"
 	// defaultMinAPIVersion is the minimum API version supported by the API.
 	// This version can be overridden through the "DOCKER_MIN_API_VERSION"
 	// environment variable. The minimum allowed version is determined

--- a/daemon/containerd/identitycache/backend.go
+++ b/daemon/containerd/identitycache/backend.go
@@ -1,0 +1,41 @@
+package identitycache
+
+import (
+	"context"
+	"time"
+
+	imagetypes "github.com/moby/moby/api/types/image"
+)
+
+// Entry contains a persisted image signature cache record.
+type Entry struct {
+	CachedAt  time.Time
+	ExpiresAt time.Time
+	Signature *imagetypes.SignatureIdentity
+}
+
+// Backend is a persistent storage backend for image signature cache entries.
+type Backend interface {
+	Load(ctx context.Context, cacheKey string, now time.Time) (Entry, bool, error)
+	Store(ctx context.Context, cacheKey string, entry Entry, now time.Time) error
+	Close() error
+}
+
+type nopBackend struct{}
+
+// NewNopBackend returns a backend that never persists or returns entries.
+func NewNopBackend() Backend {
+	return nopBackend{}
+}
+
+func (nopBackend) Load(context.Context, string, time.Time) (Entry, bool, error) {
+	return Entry{}, false, nil
+}
+
+func (nopBackend) Store(context.Context, string, Entry, time.Time) error {
+	return nil
+}
+
+func (nopBackend) Close() error {
+	return nil
+}

--- a/daemon/containerd/identitycache/backend.go
+++ b/daemon/containerd/identitycache/backend.go
@@ -18,6 +18,8 @@ type Entry struct {
 type Backend interface {
 	Load(ctx context.Context, cacheKey string, now time.Time) (Entry, bool, error)
 	Store(ctx context.Context, cacheKey string, entry Entry, now time.Time) error
+	Walk(ctx context.Context, now time.Time, fn func(cacheKey string, entry Entry) error) error
+	PruneExpired(ctx context.Context, now time.Time) error
 	Close() error
 }
 
@@ -33,6 +35,14 @@ func (nopBackend) Load(context.Context, string, time.Time) (Entry, bool, error) 
 }
 
 func (nopBackend) Store(context.Context, string, Entry, time.Time) error {
+	return nil
+}
+
+func (nopBackend) Walk(context.Context, time.Time, func(string, Entry) error) error {
+	return nil
+}
+
+func (nopBackend) PruneExpired(context.Context, time.Time) error {
 	return nil
 }
 

--- a/daemon/containerd/identitycache/bbolt.go
+++ b/daemon/containerd/identitycache/bbolt.go
@@ -1,0 +1,180 @@
+package identitycache
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	boltdb "github.com/moby/buildkit/util/db"
+	"github.com/moby/buildkit/util/db/boltutil"
+	bolt "go.etcd.io/bbolt"
+)
+
+var bboltCacheBucket = []byte("image-identity-cache-v1")
+
+const (
+	// 15m matches the shortest cache TTL (imageIdentityErrorCacheTTL), so
+	// prune won't lag far behind shortest-lived entries.
+	pruneIntervalMin    = 15 * time.Minute
+	pruneIntervalSpread = 15 * time.Minute
+)
+
+type boltBackend struct {
+	db        boltdb.DB
+	closeOnce sync.Once
+	closeErr  error
+	stopPrune chan struct{}
+	pruneDone chan struct{}
+}
+
+// NewBoltDBBackend creates a bbolt-backed persistent cache backend.
+func NewBoltDBBackend(root string) (Backend, error) {
+	if root == "" {
+		return NewNopBackend(), nil
+	}
+	cacheDir := filepath.Join(root, "image")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return nil, err
+	}
+	db, err := boltutil.SafeOpen(filepath.Join(cacheDir, "identity-cache.db"), 0o600, nil)
+	if err != nil {
+		return nil, err
+	}
+	b := &boltBackend{db: db}
+	if err := b.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(bboltCacheBucket)
+		return err
+	}); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	b.startPrune()
+	return b, nil
+}
+
+func (b *boltBackend) Load(_ context.Context, cacheKey string, now time.Time) (Entry, bool, error) {
+	var (
+		entry   Entry
+		payload []byte
+	)
+	err := b.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(bboltCacheBucket)
+		if bucket == nil {
+			return nil
+		}
+		value := bucket.Get([]byte(cacheKey))
+		if value == nil {
+			return nil
+		}
+		payload = append([]byte(nil), value...)
+		return nil
+	})
+	if err != nil {
+		return Entry{}, false, err
+	}
+	if len(payload) == 0 {
+		return Entry{}, false, nil
+	}
+	if err := json.Unmarshal(payload, &entry); err != nil {
+		_ = b.delete(cacheKey)
+		return Entry{}, false, nil
+	}
+	if now.After(entry.ExpiresAt) {
+		if err := b.delete(cacheKey); err != nil {
+			return Entry{}, false, err
+		}
+		return Entry{}, false, nil
+	}
+	return entry, true, nil
+}
+
+func (b *boltBackend) Store(_ context.Context, cacheKey string, entry Entry, _ time.Time) error {
+	payload, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(bboltCacheBucket)
+		if err != nil {
+			return err
+		}
+		return bucket.Put([]byte(cacheKey), payload)
+	})
+}
+
+func (b *boltBackend) Close() error {
+	if b == nil || b.db == nil {
+		return nil
+	}
+	b.closeOnce.Do(func() {
+		if b.stopPrune != nil {
+			close(b.stopPrune)
+		}
+		if b.pruneDone != nil {
+			<-b.pruneDone
+		}
+		b.closeErr = b.db.Close()
+	})
+	return b.closeErr
+}
+
+func (b *boltBackend) delete(cacheKey string) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(bboltCacheBucket)
+		if bucket == nil {
+			return nil
+		}
+		return bucket.Delete([]byte(cacheKey))
+	})
+}
+
+func (b *boltBackend) startPrune() {
+	b.stopPrune = make(chan struct{})
+	b.pruneDone = make(chan struct{})
+	go func() {
+		defer close(b.pruneDone)
+		timer := time.NewTimer(nextPruneDelay())
+		defer timer.Stop()
+		for {
+			select {
+			case <-b.stopPrune:
+				return
+			case <-timer.C:
+				_ = b.pruneExpiredEntries(time.Now().UTC())
+				timer.Reset(nextPruneDelay())
+			}
+		}
+	}()
+}
+
+func nextPruneDelay() time.Duration {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(pruneIntervalSpread)))
+	if err != nil {
+		return pruneIntervalMin
+	}
+	return pruneIntervalMin + time.Duration(n.Int64())
+}
+
+func (b *boltBackend) pruneExpiredEntries(now time.Time) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(bboltCacheBucket)
+		if bucket == nil {
+			return nil
+		}
+		cursor := bucket.Cursor()
+		for key, value := cursor.First(); key != nil; key, value = cursor.Next() {
+			var entry Entry
+			if err := json.Unmarshal(value, &entry); err != nil || now.After(entry.ExpiresAt) {
+				if err := cursor.Delete(); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/daemon/containerd/identitycache/bbolt_test.go
+++ b/daemon/containerd/identitycache/bbolt_test.go
@@ -1,0 +1,76 @@
+package identitycache
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestBoltBackendWalkIncludesExpiredEntriesUntilPrune(t *testing.T) {
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	backend, err := NewBoltDBBackend(t.TempDir())
+	assert.NilError(t, err)
+	defer backend.Close()
+
+	boltbk := backend.(*boltBackend)
+
+	assert.NilError(t, boltbk.Store(ctx, "fresh", Entry{
+		CachedAt:  now.Add(-time.Minute),
+		ExpiresAt: now.Add(time.Hour),
+	}, now))
+	assert.NilError(t, boltbk.Store(ctx, "expired", Entry{
+		CachedAt:  now.Add(-2 * time.Hour),
+		ExpiresAt: now.Add(-time.Minute),
+	}, now))
+
+	var keys []string
+	assert.NilError(t, boltbk.Walk(ctx, now, func(cacheKey string, _ Entry) error {
+		keys = append(keys, cacheKey)
+		return nil
+	}))
+	sort.Strings(keys)
+	assert.Check(t, is.DeepEqual(keys, []string{"expired", "fresh"}))
+
+	assert.NilError(t, boltbk.PruneExpired(ctx, now))
+
+	keys = nil
+	assert.NilError(t, boltbk.Walk(ctx, now, func(cacheKey string, _ Entry) error {
+		keys = append(keys, cacheKey)
+		return nil
+	}))
+	assert.Check(t, is.DeepEqual(keys, []string{"fresh"}))
+}
+
+func TestBoltBackendLoadExpiredReturnsMissWithoutDelete(t *testing.T) {
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	backend, err := NewBoltDBBackend(t.TempDir())
+	assert.NilError(t, err)
+	defer backend.Close()
+
+	boltbk := backend.(*boltBackend)
+
+	assert.NilError(t, boltbk.Store(ctx, "expired", Entry{
+		CachedAt:  now.Add(-2 * time.Hour),
+		ExpiresAt: now.Add(-time.Minute),
+	}, now))
+
+	_, ok, err := boltbk.Load(ctx, "expired", now)
+	assert.NilError(t, err)
+	assert.Check(t, !ok)
+
+	seen := false
+	assert.NilError(t, boltbk.Walk(ctx, now, func(cacheKey string, _ Entry) error {
+		if cacheKey == "expired" {
+			seen = true
+		}
+		return nil
+	}))
+	assert.Check(t, seen)
+}

--- a/daemon/containerd/image_exporter.go
+++ b/daemon/containerd/image_exporter.go
@@ -346,6 +346,10 @@ func (i *ImageService) LoadImage(ctx context.Context, inTar io.ReadCloser, platf
 			name = reference.FamiliarString(reference.TagNameOnly(named))
 		}
 
+		if !isDanglingImage(img) {
+			i.warmImageIdentityCache(ctx, img)
+		}
+
 		err = i.walkImageManifests(ctx, img, func(platformImg *ImageManifest) error {
 			logger := log.G(ctx).WithFields(log.Fields{
 				"image":    name,

--- a/daemon/containerd/image_identity.go
+++ b/daemon/containerd/image_identity.go
@@ -1,0 +1,207 @@
+package containerd
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/pkg/labels"
+	"github.com/containerd/log"
+	"github.com/distribution/reference"
+	imagetypes "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/v2/daemon/internal/builder-next/exporter"
+	policyimage "github.com/moby/policy-helpers/image"
+	policytypes "github.com/moby/policy-helpers/types"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+func (i *ImageService) imageIdentity(ctx context.Context, desc ocispec.Descriptor, multi *multiPlatformSummary) (*imagetypes.Identity, error) {
+	info, err := i.content.Info(ctx, desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+	identity := &imagetypes.Identity{}
+
+	seenRepos := make(map[string]struct{})
+
+	for k, v := range info.Labels {
+		if ref, ok := strings.CutPrefix(k, exporter.BuildRefLabel); ok {
+			var val exporter.BuildRefLabelValue
+			if err := json.Unmarshal([]byte(v), &val); err == nil {
+				var createdAt time.Time
+				if val.CreatedAt != nil {
+					createdAt = *val.CreatedAt
+				}
+				identity.Build = append(identity.Build, imagetypes.BuildIdentity{
+					Ref:       ref,
+					CreatedAt: createdAt,
+				})
+			}
+		}
+		if registry, ok := strings.CutPrefix(k, labels.LabelDistributionSource+"."); ok {
+			for repo := range strings.SplitSeq(v, ",") {
+				ref, err := reference.ParseNormalizedNamed(registry + "/" + repo)
+				if err != nil {
+					log.G(ctx).WithError(err).Error("failed to parse image name as reference")
+					continue
+				}
+				name := ref.Name()
+				if _, ok := seenRepos[name]; ok {
+					continue
+				}
+				seenRepos[name] = struct{}{}
+				identity.Pull = append(identity.Pull, imagetypes.PullIdentity{
+					Repository: name,
+				})
+			}
+		}
+	}
+
+	if multi.Best != nil {
+		si, err := i.signatureIdentity(ctx, desc, multi.Best, multi.BestPlatform)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("failed to validate image signature")
+		}
+		if si != nil {
+			identity.Signature = append(identity.Signature, *si)
+		}
+	}
+
+	// return nil if there is no identity information
+	if len(identity.Build) == 0 && len(identity.Pull) == 0 && len(identity.Signature) == 0 {
+		return nil, nil
+	}
+
+	slices.SortFunc(identity.Build, func(a, b imagetypes.BuildIdentity) int {
+		return cmp.Compare(a.Ref, b.Ref)
+	})
+
+	return identity, nil
+}
+
+func (i *ImageService) signatureIdentity(ctx context.Context, desc ocispec.Descriptor, img *ImageManifest, platform ocispec.Platform) (*imagetypes.SignatureIdentity, error) {
+	rp := &referrersProvider{Store: i.content}
+	sc, err := policyimage.ResolveSignatureChain(ctx, rp, desc, &platform)
+	if err != nil {
+		return nil, errors.Wrapf(err, "resolving signature chain for image %s", desc.Digest)
+	}
+	if sc.SignatureManifest == nil || sc.ImageManifest == nil {
+		return nil, nil
+	}
+
+	if sc.ImageManifest.Digest != img.Target().Digest {
+		log.L.Infof("signature chain image manifest digest mismatch: %s != %s", sc.ImageManifest.Digest, img.Target().Digest)
+		return nil, nil
+	}
+
+	v, err := i.policyVerifier()
+	if err != nil {
+		return nil, err
+	}
+
+	out := &imagetypes.SignatureIdentity{}
+
+	si, err := v.VerifyImage(ctx, rp, desc, &platform)
+	if err != nil {
+		out.Error = err.Error()
+		return out, nil
+	}
+
+	out.Name = si.Name()
+	out.DockerReference = si.DockerReference
+
+	if si.IsDHI { // update upstream to also use known signer type instead of bool
+		out.KnownSigner = imagetypes.KnownSignerDHI
+	}
+
+	switch si.SignatureType {
+	case policytypes.SignatureBundleV03:
+		out.SignatureType = imagetypes.SignatureTypeBundleV03
+	case policytypes.SignatureSimpleSigningV1:
+		out.SignatureType = imagetypes.SignatureTypeSimpleSigningV1
+	}
+
+	for _, ts := range si.Timestamps {
+		out.Timestamps = append(out.Timestamps, imagetypes.SignatureTimestamp{
+			Type:      imagetypes.SignatureTimestampType(ts.Type),
+			URI:       ts.URI,
+			Timestamp: ts.Timestamp,
+		})
+	}
+
+	if signer := si.Signer; signer != nil {
+		out.Signer = &imagetypes.SignerIdentity{
+			CertificateIssuer:                   signer.CertificateIssuer,
+			SubjectAlternativeName:              signer.SubjectAlternativeName,
+			Issuer:                              signer.Issuer,
+			BuildSignerURI:                      signer.BuildSignerURI,
+			BuildSignerDigest:                   signer.BuildSignerDigest,
+			RunnerEnvironment:                   signer.RunnerEnvironment,
+			SourceRepositoryURI:                 signer.SourceRepositoryURI,
+			SourceRepositoryDigest:              signer.SourceRepositoryDigest,
+			SourceRepositoryRef:                 signer.SourceRepositoryRef,
+			SourceRepositoryIdentifier:          signer.SourceRepositoryIdentifier,
+			SourceRepositoryOwnerURI:            signer.SourceRepositoryOwnerURI,
+			SourceRepositoryOwnerIdentifier:     signer.SourceRepositoryOwnerIdentifier,
+			BuildConfigURI:                      signer.BuildConfigURI,
+			BuildConfigDigest:                   signer.BuildConfigDigest,
+			BuildTrigger:                        signer.BuildTrigger,
+			RunInvocationURI:                    signer.RunInvocationURI,
+			SourceRepositoryVisibilityAtSigning: signer.SourceRepositoryVisibilityAtSigning,
+		}
+	}
+
+	if si.TrustRootStatus.Error != "" {
+		out.Warnings = append(out.Warnings, si.TrustRootStatus.Error)
+	}
+
+	return out, nil
+}
+
+type referrersProvider struct {
+	content.Store
+}
+
+var _ policyimage.ReferrersProvider = &referrersProvider{}
+
+func (p *referrersProvider) FetchReferrers(ctx context.Context, dgst digest.Digest, opts ...remotes.FetchReferrersOpt) ([]ocispec.Descriptor, error) {
+	rfe := &referrersForExport{store: p.Store}
+	descs, err := rfe.Referrers(ctx, ocispec.Descriptor{Digest: dgst})
+	if err != nil {
+		return nil, errors.Wrapf(err, "fetching referrers for %s", dgst)
+	}
+
+	if len(descs) == 0 {
+		return nil, nil
+	}
+
+	cfg := &remotes.FetchReferrersConfig{}
+	for _, opt := range opts {
+		if err := opt(ctx, cfg); err != nil {
+			return nil, err
+		}
+	}
+	filter := make(map[string]struct{})
+	for _, t := range cfg.ArtifactTypes {
+		filter[t] = struct{}{}
+	}
+
+	if len(filter) == 0 {
+		return descs, nil
+	}
+
+	out := make([]ocispec.Descriptor, 0, len(descs))
+	for _, d := range descs {
+		if _, ok := filter[d.MediaType]; ok {
+			out = append(out, d)
+		}
+	}
+	return out, nil
+}

--- a/daemon/containerd/image_identity.go
+++ b/daemon/containerd/image_identity.go
@@ -4,34 +4,121 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"net"
+	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/containerd/v2/core/content"
+	c8dimages "github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	imagetypes "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/v2/daemon/containerd/identitycache"
 	"github.com/moby/moby/v2/daemon/internal/builder-next/exporter"
 	policyimage "github.com/moby/policy-helpers/image"
 	policytypes "github.com/moby/policy-helpers/types"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 )
 
+const (
+	imageIdentityCacheTTL      = 48 * time.Hour
+	imageIdentityErrorCacheTTL = 15 * time.Minute
+	imageIdentityWarmupTimeout = 2 * time.Minute
+)
+
+type imageIdentityCacheEntry = identitycache.Entry
+
+type imageIdentityState struct {
+	flight     singleflight.Group
+	cacheMu    sync.Mutex
+	cache      map[string]imageIdentityCacheEntry
+	cacheStore identitycache.Backend
+}
+
 func (i *ImageService) imageIdentity(ctx context.Context, desc ocispec.Descriptor, multi *multiPlatformSummary) (*imagetypes.Identity, error) {
+	return i.imageIdentityWithCachePolicy(ctx, desc, multi, true)
+}
+
+func (i *ImageService) imageIdentityFromCache(ctx context.Context, desc ocispec.Descriptor, multi *multiPlatformSummary) (*imagetypes.Identity, error) {
+	return i.imageIdentityWithCachePolicy(ctx, desc, multi, false)
+}
+
+func (i *ImageService) imageIdentityWithCachePolicy(ctx context.Context, desc ocispec.Descriptor, multi *multiPlatformSummary, computeOnCacheMiss bool) (*imagetypes.Identity, error) {
 	info, err := i.content.Info(ctx, desc.Digest)
 	if err != nil {
 		return nil, err
 	}
-	identity := &imagetypes.Identity{}
 
+	identity := imageIdentityFromLabels(ctx, info.Labels)
+	bestDigest, bestPlatform := imageIdentityBestMatch(multi)
+	cacheKey := imageIdentityCacheKey(desc.Digest.String(), bestDigest, bestPlatform)
+	signature, ok, err := i.imageSignatureIdentityFromCache(ctx, cacheKey)
+	if err != nil {
+		log.G(ctx).WithError(err).WithField("image", desc.Digest).Debug("failed to load image identity cache entry")
+	}
+	if !ok && computeOnCacheMiss {
+		v, err, _ := i.identity.flight.Do(cacheKey, func() (any, error) {
+			if cached, ok, err := i.imageSignatureIdentityFromCache(ctx, cacheKey); err == nil && ok {
+				return cached, nil
+			} else if err != nil {
+				log.G(ctx).WithError(err).WithField("image", desc.Digest).Debug("failed to refresh image identity cache entry")
+			}
+
+			computedSignature, hasTransientVerificationError := i.computeSignatureIdentity(ctx, desc, multi)
+			ttl := imageIdentityCacheTTL
+			if hasTransientVerificationError {
+				// signature verification errors can be temporary (e.g. no network),
+				// so cache these for a shorter period
+				ttl = imageIdentityErrorCacheTTL
+			}
+			if err := i.updateImageIdentityCache(ctx, cacheKey, computedSignature, ttl); err != nil {
+				log.G(ctx).WithError(err).WithField("image", desc.Digest).Debug("failed to update image identity cache entry")
+			}
+
+			return computedSignature, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		cachedSignature, ok := v.(*imagetypes.SignatureIdentity)
+		if !ok {
+			return nil, errors.Errorf("unexpected cached signature identity type %T", v)
+		}
+		signature = cachedSignature
+	}
+
+	if signature != nil {
+		identity.Signature = append(identity.Signature, *signature)
+	}
+
+	if len(identity.Build) == 0 && len(identity.Pull) == 0 && len(identity.Signature) == 0 {
+		return nil, nil
+	}
+
+	return identity, nil
+}
+
+func imageIdentityBestMatch(multi *multiPlatformSummary) (bestDigest string, bestPlatform string) {
+	if multi == nil || multi.Best == nil {
+		return "", ""
+	}
+	return multi.Best.Target().Digest.String(), platforms.FormatAll(multi.BestPlatform)
+}
+
+func imageIdentityFromLabels(ctx context.Context, labelsByDigest map[string]string) *imagetypes.Identity {
+	identity := &imagetypes.Identity{}
 	seenRepos := make(map[string]struct{})
 
-	for k, v := range info.Labels {
+	for k, v := range labelsByDigest {
 		if ref, ok := strings.CutPrefix(k, exporter.BuildRefLabel); ok {
 			var val exporter.BuildRefLabelValue
 			if err := json.Unmarshal([]byte(v), &val); err == nil {
@@ -64,26 +151,185 @@ func (i *ImageService) imageIdentity(ctx context.Context, desc ocispec.Descripto
 		}
 	}
 
-	if multi.Best != nil {
-		si, err := i.signatureIdentity(ctx, desc, multi.Best, multi.BestPlatform)
-		if err != nil {
-			log.G(ctx).WithError(err).Error("failed to validate image signature")
-		}
-		if si != nil {
-			identity.Signature = append(identity.Signature, *si)
-		}
-	}
-
-	// return nil if there is no identity information
-	if len(identity.Build) == 0 && len(identity.Pull) == 0 && len(identity.Signature) == 0 {
-		return nil, nil
-	}
-
 	slices.SortFunc(identity.Build, func(a, b imagetypes.BuildIdentity) int {
 		return cmp.Compare(a.Ref, b.Ref)
 	})
 
-	return identity, nil
+	return identity
+}
+
+func (i *ImageService) computeSignatureIdentity(ctx context.Context, desc ocispec.Descriptor, multi *multiPlatformSummary) (*imagetypes.SignatureIdentity, bool) {
+	if multi == nil || multi.Best == nil {
+		return nil, false
+	}
+
+	signatureIdentity, err := i.signatureIdentity(ctx, desc, multi.Best, multi.BestPlatform)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("failed to validate image signature")
+		return nil, signatureVerificationErrorIsTransient(err)
+	}
+
+	// verification errors are represented as a payload field. Treat only
+	// network-like errors as transient so deterministic verification failures
+	// remain cached with the normal TTL
+	hasTransientVerificationError := signatureIdentity != nil && signatureVerificationMessageIsTransient(signatureIdentity.Error)
+	return signatureIdentity, hasTransientVerificationError
+}
+
+func signatureVerificationErrorIsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return true
+		}
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return signatureVerificationErrorIsTransient(urlErr.Err)
+	}
+
+	return signatureVerificationMessageIsTransient(err.Error())
+}
+
+func signatureVerificationMessageIsTransient(msg string) bool {
+	msg = strings.ToLower(msg)
+	// TODO: replace message-based transient detection with structured error
+	//  classification from policy-helpers / signature verification (e.g. typed
+	//  retryable errors), so cache TTL decisions do not depend on string
+	//  matching.
+	for _, transient := range []string{
+		"context deadline exceeded",
+		"i/o timeout",
+		"tls handshake timeout",
+		"no such host",
+		"temporary failure in name resolution",
+		"connection refused",
+		"connection reset by peer",
+		"network is unreachable",
+		"dial tcp",
+	} {
+		if strings.Contains(msg, transient) {
+			return true
+		}
+	}
+	return false
+}
+
+func imageIdentityCacheKey(imageDigest, bestDigest, bestPlatform string) string {
+	return strings.Join([]string{imageDigest, bestDigest, bestPlatform}, "|")
+}
+
+func (i *ImageService) imageSignatureIdentityFromCache(ctx context.Context, cacheKey string) (*imagetypes.SignatureIdentity, bool, error) {
+	now := time.Now()
+
+	i.identity.cacheMu.Lock()
+	if cached, ok := i.identity.cache[cacheKey]; ok {
+		if now.After(cached.ExpiresAt) {
+			delete(i.identity.cache, cacheKey)
+		} else {
+			i.identity.cacheMu.Unlock()
+			return cloneSignatureIdentity(cached.Signature), true, nil
+		}
+	}
+	i.identity.cacheMu.Unlock()
+
+	if i.identity.cacheStore == nil {
+		return nil, false, nil
+	}
+	cached, ok, err := i.identity.cacheStore.Load(ctx, cacheKey, now)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+
+	i.identity.cacheMu.Lock()
+	if i.identity.cache == nil {
+		i.identity.cache = map[string]imageIdentityCacheEntry{}
+	}
+	i.identity.cache[cacheKey] = cached
+	i.identity.cacheMu.Unlock()
+	return cloneSignatureIdentity(cached.Signature), true, nil
+}
+
+func (i *ImageService) updateImageIdentityCache(ctx context.Context, cacheKey string, signature *imagetypes.SignatureIdentity, ttl time.Duration) error {
+	if ttl <= 0 {
+		return nil
+	}
+
+	now := time.Now()
+	entry := imageIdentityCacheEntry{
+		CachedAt:  now,
+		ExpiresAt: now.Add(ttl),
+		Signature: cloneSignatureIdentity(signature),
+	}
+
+	i.identity.cacheMu.Lock()
+	if i.identity.cache == nil {
+		i.identity.cache = map[string]imageIdentityCacheEntry{}
+	}
+	i.identity.cache[cacheKey] = entry
+	pruneImageIdentityCacheEntries(i.identity.cache, now)
+	i.identity.cacheMu.Unlock()
+
+	if i.identity.cacheStore == nil {
+		return nil
+	}
+	return i.identity.cacheStore.Store(ctx, cacheKey, entry, now)
+}
+
+func cloneSignatureIdentity(s *imagetypes.SignatureIdentity) *imagetypes.SignatureIdentity {
+	if s == nil {
+		return nil
+	}
+	out := *s
+	out.Timestamps = slices.Clone(s.Timestamps)
+	out.Warnings = slices.Clone(s.Warnings)
+	if s.Signer != nil {
+		signer := *s.Signer
+		out.Signer = &signer
+	}
+	return &out
+}
+
+func pruneImageIdentityCacheEntries(entries map[string]imageIdentityCacheEntry, now time.Time) {
+	for key, entry := range entries {
+		if now.After(entry.ExpiresAt) {
+			delete(entries, key)
+		}
+	}
+}
+
+func (i *ImageService) warmImageIdentityCache(ctx context.Context, img c8dimages.Image) {
+	if i.policyVerifier == nil {
+		return
+	}
+	go func() {
+		warmCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), imageIdentityWarmupTimeout)
+		defer cancel()
+		multi, err := i.multiPlatformSummary(warmCtx, img, matchAnyWithPreference(platforms.Default(), nil))
+		if err != nil {
+			log.G(warmCtx).WithError(err).WithField("image", img.Name).Debug("failed to build image identity cache in background")
+			return
+		}
+		if _, err := i.imageIdentity(warmCtx, img.Target, multi); err != nil {
+			log.G(warmCtx).WithError(err).WithField("image", img.Name).Debug("failed to build image identity cache in background")
+		}
+	}()
 }
 
 func (i *ImageService) signatureIdentity(ctx context.Context, desc ocispec.Descriptor, img *ImageManifest, platform ocispec.Platform) (*imagetypes.SignatureIdentity, error) {
@@ -98,6 +344,10 @@ func (i *ImageService) signatureIdentity(ctx context.Context, desc ocispec.Descr
 
 	if sc.ImageManifest.Digest != img.Target().Digest {
 		log.L.Infof("signature chain image manifest digest mismatch: %s != %s", sc.ImageManifest.Digest, img.Target().Digest)
+		return nil, nil
+	}
+
+	if i.policyVerifier == nil {
 		return nil, nil
 	}
 

--- a/daemon/containerd/image_identity.go
+++ b/daemon/containerd/image_identity.go
@@ -326,8 +326,14 @@ func (i *ImageService) warmImageIdentityCache(ctx context.Context, img c8dimages
 			log.G(warmCtx).WithError(err).WithField("image", img.Name).Debug("failed to build image identity cache in background")
 			return
 		}
-		if _, err := i.imageIdentity(warmCtx, img.Target, multi); err != nil {
-			log.G(warmCtx).WithError(err).WithField("image", img.Name).Debug("failed to build image identity cache in background")
+		// Warm signature identities for all locally available image manifests.
+		for _, ref := range multi.manifestIdentityRefs {
+			if _, err := i.imageIdentity(warmCtx, img.Target, &multiPlatformSummary{
+				Best:         ref.manifest,
+				BestPlatform: ref.platform,
+			}); err != nil {
+				log.G(warmCtx).WithError(err).WithField("image", img.Name).Debug("failed to build image identity cache in background")
+			}
 		}
 	}()
 }

--- a/daemon/containerd/image_identity_test.go
+++ b/daemon/containerd/image_identity_test.go
@@ -1,0 +1,360 @@
+package containerd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/url"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/metadata"
+	"github.com/containerd/containerd/v2/pkg/labels"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/plugins/content/local"
+	imagetypes "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/v2/daemon/containerd/identitycache"
+	"github.com/moby/moby/v2/daemon/internal/builder-next/exporter"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	bolt "go.etcd.io/bbolt"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestImageIdentityCacheRoundTripDeepCopy(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	service := &ImageService{content: newWritableContentStore(ctx, t)}
+
+	key := imageIdentityCacheKey("img", "best", "linux/amd64")
+	now := time.Now().UTC()
+	signature := &imagetypes.SignatureIdentity{
+		Name: "signature",
+		Timestamps: []imagetypes.SignatureTimestamp{
+			{
+				Type:      imagetypes.SignatureTimestampTlog,
+				URI:       "https://example.test/tlog",
+				Timestamp: now,
+			},
+		},
+		Warnings: []string{"warning"},
+		Signer: &imagetypes.SignerIdentity{
+			CertificateIssuer: "issuer",
+		},
+	}
+
+	assert.NilError(t, service.updateImageIdentityCache(ctx, key, signature, time.Minute))
+
+	// mutate source after storing to verify cache stores an isolated copy
+	signature.Timestamps[0].URI = "mutated-source"
+	signature.Warnings[0] = "mutated-source"
+	signature.Signer.CertificateIssuer = "mutated-source"
+
+	first, ok, err := service.imageSignatureIdentityFromCache(ctx, key)
+	assert.NilError(t, err)
+	assert.Check(t, ok)
+	if first == nil {
+		t.Fatal("expected cached signature identity")
+	}
+	if first.Signer == nil {
+		t.Fatal("expected cached signature signer")
+	}
+	assert.Check(t, is.Equal(first.Timestamps[0].URI, "https://example.test/tlog"))
+	assert.Check(t, is.Equal(first.Warnings[0], "warning"))
+	assert.Check(t, is.Equal(first.Signer.CertificateIssuer, "issuer"))
+
+	// mutate fetched value to verify reads also return isolated copies
+	first.Timestamps[0].URI = "mutated-read"
+	first.Warnings[0] = "mutated-read"
+	first.Signer.CertificateIssuer = "mutated-read"
+
+	second, ok, err := service.imageSignatureIdentityFromCache(ctx, key)
+	assert.NilError(t, err)
+	assert.Check(t, ok)
+	if second == nil {
+		t.Fatal("expected cached signature identity on second read")
+	}
+	if second.Signer == nil {
+		t.Fatal("expected cached signature signer on second read")
+	}
+	assert.Check(t, is.Equal(second.Timestamps[0].URI, "https://example.test/tlog"))
+	assert.Check(t, is.Equal(second.Warnings[0], "warning"))
+	assert.Check(t, is.Equal(second.Signer.CertificateIssuer, "issuer"))
+}
+
+func TestImageIdentityCacheExpiredEntryIsDropped(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	service := &ImageService{content: newWritableContentStore(ctx, t)}
+
+	key := imageIdentityCacheKey("img", "best", "linux/amd64")
+	service.identity.cache = map[string]imageIdentityCacheEntry{
+		key: {
+			CachedAt:  time.Now().UTC().Add(-2 * time.Minute),
+			ExpiresAt: time.Now().UTC().Add(-1 * time.Minute),
+			Signature: &imagetypes.SignatureIdentity{Name: "expired"},
+		},
+	}
+
+	res, ok, err := service.imageSignatureIdentityFromCache(ctx, key)
+	assert.NilError(t, err)
+	assert.Check(t, !ok)
+	assert.Check(t, res == nil)
+	assert.Check(t, is.Len(service.identity.cache, 0))
+}
+
+func TestImageIdentityCacheZeroTTLNoop(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	service := &ImageService{content: newWritableContentStore(ctx, t)}
+
+	key := imageIdentityCacheKey("img", "best", "linux/amd64")
+	assert.NilError(t, service.updateImageIdentityCache(ctx, key, &imagetypes.SignatureIdentity{Name: "sig"}, 0))
+	assert.Check(t, is.Len(service.identity.cache, 0))
+}
+
+func TestImageIdentityCachePruneRemovesExpiredEntries(t *testing.T) {
+	now := time.Now().UTC()
+	entries := map[string]imageIdentityCacheEntry{
+		"expired": {
+			CachedAt:  now.Add(-2 * time.Hour),
+			ExpiresAt: now.Add(-time.Second),
+			Signature: &imagetypes.SignatureIdentity{Name: "expired"},
+		},
+		"fresh": {
+			CachedAt:  now.Add(-time.Minute),
+			ExpiresAt: now.Add(time.Hour),
+			Signature: &imagetypes.SignatureIdentity{Name: "fresh"},
+		},
+	}
+
+	pruneImageIdentityCacheEntries(entries, now)
+
+	assert.Check(t, is.Len(entries, 1))
+	_, expiredExists := entries["expired"]
+	assert.Check(t, !expiredExists)
+	_, freshExists := entries["fresh"]
+	assert.Check(t, freshExists)
+}
+
+func TestImageIdentityBestMatchNil(t *testing.T) {
+	d, p := imageIdentityBestMatch(nil)
+	assert.Check(t, is.Equal(d, ""))
+	assert.Check(t, is.Equal(p, ""))
+
+	d, p = imageIdentityBestMatch(&multiPlatformSummary{})
+	assert.Check(t, is.Equal(d, ""))
+	assert.Check(t, is.Equal(p, ""))
+}
+
+func TestImageIdentityCacheKey(t *testing.T) {
+	got := imageIdentityCacheKey("sha256:image", "sha256:best", "linux/amd64")
+	assert.Check(t, is.Equal(got, "sha256:image|sha256:best|linux/amd64"))
+}
+
+func TestCloneSignatureIdentityNil(t *testing.T) {
+	var sig *imagetypes.SignatureIdentity
+	assert.Check(t, cloneSignatureIdentity(sig) == nil)
+}
+
+func TestImageIdentityCacheRoundTripNilSignature(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	service := &ImageService{content: newWritableContentStore(ctx, t)}
+
+	key := imageIdentityCacheKey("img", "best", "linux/amd64")
+	assert.NilError(t, service.updateImageIdentityCache(ctx, key, nil, time.Minute))
+	res, ok, err := service.imageSignatureIdentityFromCache(ctx, key)
+	assert.NilError(t, err)
+	assert.Check(t, ok)
+	assert.Check(t, res == nil)
+}
+
+func TestImageIdentityCachePersistsAcrossRestart(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	root := t.TempDir()
+	backendA, err := identitycache.NewBoltDBBackend(root)
+	assert.NilError(t, err)
+	defer backendA.Close()
+	serviceA := &ImageService{
+		identity: imageIdentityState{
+			cache:      map[string]imageIdentityCacheEntry{},
+			cacheStore: backendA,
+		},
+	}
+
+	key := imageIdentityCacheKey("img", "best", "linux/amd64")
+	assert.NilError(t, serviceA.updateImageIdentityCache(ctx, key, &imagetypes.SignatureIdentity{Name: "persisted"}, time.Minute))
+	assert.NilError(t, backendA.Close())
+
+	backendB, err := identitycache.NewBoltDBBackend(root)
+	assert.NilError(t, err)
+	defer backendB.Close()
+	serviceB := &ImageService{
+		identity: imageIdentityState{
+			cache:      map[string]imageIdentityCacheEntry{},
+			cacheStore: backendB,
+		},
+	}
+
+	res, ok, err := serviceB.imageSignatureIdentityFromCache(ctx, key)
+	assert.NilError(t, err)
+	assert.Check(t, ok)
+	if res == nil {
+		t.Fatal("expected cached signature identity after restart")
+	}
+	assert.Check(t, is.Equal(res.Name, "persisted"))
+}
+
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "timeout network error" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return false }
+
+func TestSignatureVerificationErrorIsTransient(t *testing.T) {
+	t.Run("deadline exceeded", func(t *testing.T) {
+		assert.Check(t, signatureVerificationErrorIsTransient(context.DeadlineExceeded))
+	})
+	t.Run("canceled", func(t *testing.T) {
+		assert.Check(t, signatureVerificationErrorIsTransient(context.Canceled))
+	})
+	t.Run("timeout net error", func(t *testing.T) {
+		var err error = timeoutNetError{}
+		assert.Check(t, signatureVerificationErrorIsTransient(err))
+	})
+	t.Run("dns error", func(t *testing.T) {
+		assert.Check(t, signatureVerificationErrorIsTransient(&net.DNSError{Err: "no such host", Name: "example.invalid"}))
+	})
+	t.Run("url wrapped timeout", func(t *testing.T) {
+		err := &url.Error{
+			Op:  "Get",
+			URL: "https://example.invalid",
+			Err: timeoutNetError{},
+		}
+		assert.Check(t, signatureVerificationErrorIsTransient(err))
+	})
+	t.Run("non transient", func(t *testing.T) {
+		assert.Check(t, !signatureVerificationErrorIsTransient(errors.New("permanent failure")))
+	})
+}
+
+func TestSignatureVerificationMessageIsTransient(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{name: "deadline", msg: "context deadline exceeded", want: true},
+		{name: "io timeout", msg: "i/o timeout", want: true},
+		{name: "tls timeout", msg: "tls handshake timeout", want: true},
+		{name: "dns", msg: "no such host", want: true},
+		{name: "dial tcp", msg: "dial tcp 127.0.0.1:443", want: true},
+		{name: "uppercase still matches", msg: "NETWORK IS UNREACHABLE", want: true},
+		{name: "non transient", msg: "invalid signature", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Check(t, is.Equal(signatureVerificationMessageIsTransient(tc.msg), tc.want))
+		})
+	}
+}
+
+func TestImageIdentityFromLabels(t *testing.T) {
+	createdB := time.Date(2024, 7, 20, 0, 0, 0, 0, time.UTC)
+	createdA := time.Date(2024, 7, 21, 0, 0, 0, 0, time.UTC)
+
+	buildAdt, err := json.Marshal(exporter.BuildRefLabelValue{CreatedAt: &createdB})
+	assert.NilError(t, err)
+	buildBdt, err := json.Marshal(exporter.BuildRefLabelValue{CreatedAt: &createdA})
+	assert.NilError(t, err)
+
+	identity := imageIdentityFromLabels(t.Context(), map[string]string{
+		exporter.BuildRefLabel + "z-ref":              string(buildBdt),
+		exporter.BuildRefLabel + "a-ref":              string(buildAdt),
+		exporter.BuildRefLabel + "bad":                "{not-json}",
+		labels.LabelDistributionSource + ".docker.io": "library/alpine,library/alpine,invalid//repo",
+		labels.LabelDistributionSource + ".ghcr.io":   "myorg/myimage",
+	})
+
+	assert.Check(t, is.Len(identity.Build, 2))
+	assert.Check(t, is.Equal(identity.Build[0].Ref, "a-ref"))
+	assert.Check(t, is.Equal(identity.Build[1].Ref, "z-ref"))
+	assert.Check(t, is.Equal(identity.Build[0].CreatedAt, createdB))
+	assert.Check(t, is.Equal(identity.Build[1].CreatedAt, createdA))
+
+	repos := make([]string, 0, len(identity.Pull))
+	for _, pull := range identity.Pull {
+		repos = append(repos, pull.Repository)
+	}
+	sort.Strings(repos)
+	assert.Check(t, is.DeepEqual(repos, []string{
+		"docker.io/library/alpine",
+		"ghcr.io/myorg/myimage",
+	}))
+}
+
+func TestImageIdentityReturnsNilWhenNoData(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	service := &ImageService{content: newWritableContentStore(ctx, t)}
+
+	dgst := writeTestBlob(ctx, t, service.content, []byte("root"), nil)
+	got, err := service.imageIdentity(ctx, ocispec.Descriptor{Digest: dgst}, nil)
+	assert.NilError(t, err)
+	assert.Check(t, got == nil)
+}
+
+func TestImageIdentityFromCacheOnlyDoesNotPopulateCache(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing-"+t.Name())
+	service := &ImageService{content: newWritableContentStore(ctx, t)}
+
+	dgst := writeTestBlob(ctx, t, service.content, []byte("root"), nil)
+	desc := ocispec.Descriptor{Digest: dgst}
+
+	got, err := service.imageIdentityFromCache(ctx, desc, nil)
+	assert.NilError(t, err)
+	assert.Check(t, got == nil)
+	assert.Check(t, is.Len(service.identity.cache, 0))
+
+	got, err = service.imageIdentity(ctx, desc, nil)
+	assert.NilError(t, err)
+	assert.Check(t, got == nil)
+	assert.Check(t, is.Len(service.identity.cache, 1))
+}
+
+func newWritableContentStore(ctx context.Context, t testing.TB) content.Store {
+	t.Helper()
+
+	dir := t.TempDir()
+	bdb, err := bolt.Open(filepath.Join(dir, "metadata.db"), 0o600, &bolt.Options{})
+	assert.NilError(t, err)
+	t.Cleanup(func() { bdb.Close() })
+
+	cs, err := local.NewStore(filepath.Join(dir, "blobs"))
+	assert.NilError(t, err)
+
+	mdb := metadata.NewDB(bdb, cs, nil)
+	assert.NilError(t, mdb.Init(ctx))
+
+	return mdb.ContentStore()
+}
+
+func writeTestBlob(ctx context.Context, t testing.TB, cs content.Store, payload []byte, lbls map[string]string) digest.Digest {
+	t.Helper()
+
+	dgst := digest.FromBytes(payload)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageConfig,
+		Digest:    dgst,
+		Size:      int64(len(payload)),
+	}
+	var opts []content.Opt
+	if lbls != nil {
+		opts = append(opts, content.WithLabels(lbls))
+	}
+	err := content.WriteBlob(ctx, cs, dgst.String(), bytes.NewReader(payload), desc, opts...)
+	assert.NilError(t, err)
+	return dgst
+}

--- a/daemon/containerd/image_inspect.go
+++ b/daemon/containerd/image_inspect.go
@@ -1,19 +1,12 @@
 package containerd
 
 import (
-	"cmp"
 	"context"
-	"encoding/json"
 	"fmt"
-	"slices"
-	"strings"
 	"sync/atomic"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/content"
 	c8dimages "github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes"
-	"github.com/containerd/containerd/v2/pkg/labels"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/platforms"
@@ -21,14 +14,9 @@ import (
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	imagetypes "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/api/types/storage"
-	"github.com/moby/moby/v2/daemon/internal/builder-next/exporter"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/sliceutil"
-	policyimage "github.com/moby/policy-helpers/image"
-	policytypes "github.com/moby/policy-helpers/types"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -153,190 +141,6 @@ func (i *ImageService) ImageInspect(ctx context.Context, refOrID string, opts im
 	}
 
 	return resp, nil
-}
-
-func (i *ImageService) imageIdentity(ctx context.Context, desc ocispec.Descriptor, multi *multiPlatformSummary) (*imagetypes.Identity, error) {
-	info, err := i.content.Info(ctx, desc.Digest)
-	if err != nil {
-		return nil, err
-	}
-	identity := &imagetypes.Identity{}
-
-	seenRepos := make(map[string]struct{})
-
-	for k, v := range info.Labels {
-		if ref, ok := strings.CutPrefix(k, exporter.BuildRefLabel); ok {
-			var val exporter.BuildRefLabelValue
-			if err := json.Unmarshal([]byte(v), &val); err == nil {
-				var createdAt time.Time
-				if val.CreatedAt != nil {
-					createdAt = *val.CreatedAt
-				}
-				identity.Build = append(identity.Build, imagetypes.BuildIdentity{
-					Ref:       ref,
-					CreatedAt: createdAt,
-				})
-			}
-		}
-		if registry, ok := strings.CutPrefix(k, labels.LabelDistributionSource+"."); ok {
-			for repo := range strings.SplitSeq(v, ",") {
-				ref, err := reference.ParseNormalizedNamed(registry + "/" + repo)
-				if err != nil {
-					log.G(ctx).WithError(err).Error("failed to parse image name as reference")
-					continue
-				}
-				name := ref.Name()
-				if _, ok := seenRepos[name]; ok {
-					continue
-				}
-				seenRepos[name] = struct{}{}
-				identity.Pull = append(identity.Pull, imagetypes.PullIdentity{
-					Repository: name,
-				})
-			}
-		}
-	}
-
-	if multi.Best != nil {
-		si, err := i.signatureIdentity(ctx, desc, multi.Best, multi.BestPlatform)
-		if err != nil {
-			log.G(ctx).WithError(err).Error("failed to validate image signature")
-		}
-		if si != nil {
-			identity.Signature = append(identity.Signature, *si)
-		}
-	}
-
-	// return nil if there is no identity information
-	if len(identity.Build) == 0 && len(identity.Pull) == 0 && len(identity.Signature) == 0 {
-		return nil, nil
-	}
-
-	slices.SortFunc(identity.Build, func(a, b imagetypes.BuildIdentity) int {
-		return cmp.Compare(a.Ref, b.Ref)
-	})
-
-	return identity, nil
-}
-
-func (i *ImageService) signatureIdentity(ctx context.Context, desc ocispec.Descriptor, img *ImageManifest, platform ocispec.Platform) (*imagetypes.SignatureIdentity, error) {
-	rp := &referrersProvider{Store: i.content}
-	sc, err := policyimage.ResolveSignatureChain(ctx, rp, desc, &platform)
-	if err != nil {
-		return nil, errors.Wrapf(err, "resolving signature chain for image %s", desc.Digest)
-	}
-	if sc.SignatureManifest == nil || sc.ImageManifest == nil {
-		return nil, nil
-	}
-
-	if sc.ImageManifest.Digest != img.Target().Digest {
-		log.L.Infof("signature chain image manifest digest mismatch: %s != %s", sc.ImageManifest.Digest, img.Target().Digest)
-		return nil, nil
-	}
-
-	v, err := i.policyVerifier()
-	if err != nil {
-		return nil, err
-	}
-
-	out := &imagetypes.SignatureIdentity{}
-
-	si, err := v.VerifyImage(ctx, rp, desc, &platform)
-	if err != nil {
-		out.Error = err.Error()
-		return out, nil
-	}
-
-	out.Name = si.Name()
-	out.DockerReference = si.DockerReference
-
-	if si.IsDHI { // update upstream to also use known signer type instead of bool
-		out.KnownSigner = imagetypes.KnownSignerDHI
-	}
-
-	switch si.SignatureType {
-	case policytypes.SignatureBundleV03:
-		out.SignatureType = imagetypes.SignatureTypeBundleV03
-	case policytypes.SignatureSimpleSigningV1:
-		out.SignatureType = imagetypes.SignatureTypeSimpleSigningV1
-	}
-
-	for _, ts := range si.Timestamps {
-		out.Timestamps = append(out.Timestamps, imagetypes.SignatureTimestamp{
-			Type:      imagetypes.SignatureTimestampType(ts.Type),
-			URI:       ts.URI,
-			Timestamp: ts.Timestamp,
-		})
-	}
-
-	if signer := si.Signer; signer != nil {
-		out.Signer = &imagetypes.SignerIdentity{
-			CertificateIssuer:                   signer.CertificateIssuer,
-			SubjectAlternativeName:              signer.SubjectAlternativeName,
-			Issuer:                              signer.Issuer,
-			BuildSignerURI:                      signer.BuildSignerURI,
-			BuildSignerDigest:                   signer.BuildSignerDigest,
-			RunnerEnvironment:                   signer.RunnerEnvironment,
-			SourceRepositoryURI:                 signer.SourceRepositoryURI,
-			SourceRepositoryDigest:              signer.SourceRepositoryDigest,
-			SourceRepositoryRef:                 signer.SourceRepositoryRef,
-			SourceRepositoryIdentifier:          signer.SourceRepositoryIdentifier,
-			SourceRepositoryOwnerURI:            signer.SourceRepositoryOwnerURI,
-			SourceRepositoryOwnerIdentifier:     signer.SourceRepositoryOwnerIdentifier,
-			BuildConfigURI:                      signer.BuildConfigURI,
-			BuildConfigDigest:                   signer.BuildConfigDigest,
-			BuildTrigger:                        signer.BuildTrigger,
-			RunInvocationURI:                    signer.RunInvocationURI,
-			SourceRepositoryVisibilityAtSigning: signer.SourceRepositoryVisibilityAtSigning,
-		}
-	}
-
-	if si.TrustRootStatus.Error != "" {
-		out.Warnings = append(out.Warnings, si.TrustRootStatus.Error)
-	}
-
-	return out, nil
-}
-
-type referrersProvider struct {
-	content.Store
-}
-
-var _ policyimage.ReferrersProvider = &referrersProvider{}
-
-func (p *referrersProvider) FetchReferrers(ctx context.Context, dgst digest.Digest, opts ...remotes.FetchReferrersOpt) ([]ocispec.Descriptor, error) {
-	rfe := &referrersForExport{store: p.Store}
-	descs, err := rfe.Referrers(ctx, ocispec.Descriptor{Digest: dgst})
-	if err != nil {
-		return nil, errors.Wrapf(err, "fetching referrers for %s", dgst)
-	}
-
-	if len(descs) == 0 {
-		return nil, nil
-	}
-
-	cfg := &remotes.FetchReferrersConfig{}
-	for _, opt := range opts {
-		if err := opt(ctx, cfg); err != nil {
-			return nil, err
-		}
-	}
-	filter := make(map[string]struct{})
-	for _, t := range cfg.ArtifactTypes {
-		filter[t] = struct{}{}
-	}
-
-	if len(filter) == 0 {
-		return descs, nil
-	}
-
-	out := make([]ocispec.Descriptor, 0, len(descs))
-	for _, d := range descs {
-		if _, ok := filter[d.MediaType]; ok {
-			out = append(out, d)
-		}
-	}
-	return out, nil
 }
 
 func collectRepoTagsAndDigests(ctx context.Context, tagged []c8dimages.Image) (repoTags []string, repoDigests []string) {

--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -270,6 +270,7 @@ func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platfor
 	}
 
 	i.LogImageEvent(ctx, reference.FamiliarString(ref), reference.FamiliarName(ref), events.ActionPull)
+	i.warmImageIdentityCache(ctx, img.Metadata())
 	outNewImg = img
 
 	return nil

--- a/daemon/containerd/image_tag.go
+++ b/daemon/containerd/image_tag.go
@@ -82,12 +82,12 @@ func (i *ImageService) createOrReplaceImage(ctx context.Context, newImg c8dimage
 
 	if !creatingDangling {
 		defer i.LogImageEvent(ctx, string(newImg.Target.Digest), imageFamiliarName(newImg), events.ActionTag)
-
 		if err := i.images.Delete(ctx, danglingName); err != nil {
 			if !cerrdefs.IsNotFound(err) {
 				logger.WithError(err).Warn("unexpected error when deleting dangling image")
 			}
 		}
+		i.warmImageIdentityCache(ctx, newImg)
 	}
 
 	return nil

--- a/daemon/containerd/service.go
+++ b/daemon/containerd/service.go
@@ -64,7 +64,7 @@ type ImageServiceConfig struct {
 
 // NewService creates a new ImageService.
 func NewService(config ImageServiceConfig) *ImageService {
-	return &ImageService{
+	service := &ImageService{
 		client:  config.Client,
 		images:  config.Client.ImageService(),
 		content: config.Client.ContentStore(),
@@ -89,6 +89,8 @@ func NewService(config ImageServiceConfig) *ImageService {
 			}(),
 		},
 	}
+	service.startImageIdentityCacheRefresh()
+	return service
 }
 
 func (i *ImageService) snapshotterService(snapshotter string) snapshots.Snapshotter {
@@ -144,6 +146,7 @@ func (i *ImageService) GetLayerMountID(cid string) (string, error) {
 // Cleanup resources before the process is shutdown.
 // called from daemon.go Daemon.Shutdown()
 func (i *ImageService) Cleanup() error {
+	i.stopImageIdentityCacheRefresh()
 	if i.identity.cacheStore != nil {
 		return i.identity.cacheStore.Close()
 	}

--- a/daemon/server/imagebackend/image.go
+++ b/daemon/server/imagebackend/image.go
@@ -45,6 +45,9 @@ type ListOptions struct {
 
 	// Manifests indicates whether the image manifests should be returned.
 	Manifests bool
+
+	// Identity indicates whether image identity information should be returned.
+	Identity bool
 }
 
 // GetImageOpts holds parameters to retrieve image information

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -496,11 +496,20 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		manifests = httputils.BoolValue(r, "manifests")
 	}
 
+	var identity bool
+	if versions.GreaterThanOrEqualTo(version, "1.54") {
+		identity = httputils.BoolValue(r, "identity")
+		if identity && !manifests {
+			return errdefs.InvalidParameter(errors.New("conflicting options: identity requires manifests=1"))
+		}
+	}
+
 	images, err := ir.backend.Images(ctx, imagebackend.ListOptions{
 		All:        httputils.BoolValue(r, "all"),
 		Filters:    imageFilters,
 		SharedSize: sharedSize,
 		Manifests:  manifests,
+		Identity:   identity,
 	})
 	if err != nil {
 		return err

--- a/integration/image/identity_test.go
+++ b/integration/image/identity_test.go
@@ -1,0 +1,215 @@
+package image
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/client/pkg/versions"
+	"github.com/moby/moby/v2/internal/testutil/request"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/skip"
+)
+
+func TestImageListIdentity(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.54"), "requires API version 1.54 or newer")
+
+	ctx := setupTest(t)
+
+	withoutIdentity := imageListRaw(t, ctx, "/v1.54/images/json")
+	for _, img := range withoutIdentity {
+		_, has := img["Identity"]
+		assert.Check(t, !has, "Identity should not be present unless identity=1 is requested")
+	}
+
+	withIdentity := imageListRaw(t, ctx, "/v1.54/images/json?identity=1&manifests=1")
+	foundManifestIdentity := false
+	for _, img := range withIdentity {
+		manifests, has := img["Manifests"]
+		if !has {
+			continue
+		}
+		manifestsList, ok := manifests.([]any)
+		if !ok {
+			continue
+		}
+		for _, manifest := range manifestsList {
+			manifestObj, ok := manifest.(map[string]any)
+			if !ok {
+				continue
+			}
+			imageData, has := manifestObj["ImageData"]
+			if !has || imageData == nil {
+				continue
+			}
+			imageDataObj, ok := imageData.(map[string]any)
+			if !ok {
+				continue
+			}
+			identity, has := imageDataObj["Identity"]
+			if !has {
+				continue
+			}
+			foundManifestIdentity = true
+			assert.Check(t, identity != nil)
+			_, isObject := identity.(map[string]any)
+			assert.Check(t, isObject, "Identity should be a JSON object when present on image manifest data")
+		}
+	}
+	if !foundManifestIdentity {
+		t.Skip("no images with identity metadata were available in this environment")
+	}
+}
+
+func TestImageListIdentityRequiresManifests(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.54"), "requires API version 1.54 or newer")
+
+	ctx := setupTest(t)
+	resp, body, err := request.Get(ctx, "/v1.54/images/json?identity=1", request.JSON)
+	assert.NilError(t, err)
+	assert.Equal(t, resp.StatusCode, http.StatusBadRequest)
+
+	buf, err := request.ReadBody(body)
+	assert.NilError(t, err)
+	assert.Check(t, strings.Contains(string(buf), "identity requires manifests=1"), string(buf))
+}
+
+func TestImageInspectIdentity(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.53"), "requires API version 1.53 or newer")
+
+	ctx := setupTest(t)
+
+	images := imageListRaw(t, ctx, "/v1.53/images/json")
+	if len(images) == 0 {
+		t.Skip("no images available to validate inspect identity response")
+	}
+
+	foundIdentity := false
+	for _, img := range images {
+		id, _ := img["Id"].(string)
+		if id == "" {
+			continue
+		}
+
+		imagePath := url.PathEscape(id)
+		current := imageInspectRaw(t, ctx, fmt.Sprintf("/v1.53/images/%s/json", imagePath))
+		identity, hasCurrent := current["Identity"]
+		if !hasCurrent {
+			continue
+		}
+
+		foundIdentity = true
+		assert.Check(t, identity != nil)
+		_, isObject := identity.(map[string]any)
+		assert.Check(t, isObject, "Identity should be a JSON object when present in API 1.53 image inspect response")
+		break
+	}
+	if !foundIdentity {
+		t.Skip("no image with identity metadata found to validate inspect response")
+	}
+}
+
+func TestImageListIdentityAfterInspectWarmup(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.54"), "requires API version 1.54 or newer")
+
+	ctx := setupTest(t)
+
+	images := imageListRaw(t, ctx, "/v1.54/images/json")
+	if len(images) == 0 {
+		t.Skip("no images available to validate list identity response")
+	}
+
+	imageID := ""
+	for _, img := range images {
+		id, _ := img["Id"].(string)
+		if id == "" {
+			continue
+		}
+		inspect := imageInspectRaw(t, ctx, fmt.Sprintf("/v1.53/images/%s/json", url.PathEscape(id)))
+		identity, has := inspect["Identity"]
+		if !has || identity == nil {
+			continue
+		}
+		_, isObject := identity.(map[string]any)
+		assert.Check(t, isObject, "Identity should be a JSON object when present in API 1.53 image inspect response")
+		imageID = id
+		break
+	}
+	if imageID == "" {
+		t.Skip("no image with identity metadata found to validate cache warmup and list behavior")
+	}
+
+	withIdentity := imageListRaw(t, ctx, "/v1.54/images/json?identity=1&manifests=1")
+	foundImage := false
+	for _, img := range withIdentity {
+		id, _ := img["Id"].(string)
+		if id != imageID {
+			continue
+		}
+		foundImage = true
+		manifests, has := img["Manifests"]
+		assert.Check(t, has, "Manifests should be present in API 1.54 image list response when identity=1 is requested")
+		manifestList, ok := manifests.([]any)
+		assert.Check(t, ok)
+		foundManifestIdentity := false
+		for _, manifest := range manifestList {
+			manifestObj, ok := manifest.(map[string]any)
+			if !ok {
+				continue
+			}
+			imageData, has := manifestObj["ImageData"]
+			if !has || imageData == nil {
+				continue
+			}
+			imageDataObj, ok := imageData.(map[string]any)
+			if !ok {
+				continue
+			}
+			identity, has := imageDataObj["Identity"]
+			if !has || identity == nil {
+				continue
+			}
+			foundManifestIdentity = true
+			_, isObject := identity.(map[string]any)
+			assert.Check(t, isObject, "Identity should be a JSON object when present on image manifest data in API 1.54 image list response")
+			break
+		}
+		assert.Check(t, foundManifestIdentity, "at least one image manifest should have ImageData.Identity in API 1.54 image list response after inspect warmup")
+		break
+	}
+	assert.Check(t, foundImage, "inspected image should be present in image list response")
+}
+
+func imageListRaw(t *testing.T, ctx context.Context, endpoint string) []map[string]any {
+	t.Helper()
+
+	resp, body, err := request.Get(ctx, endpoint, request.JSON)
+	assert.NilError(t, err)
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	buf, err := request.ReadBody(body)
+	assert.NilError(t, err)
+
+	var images []map[string]any
+	assert.NilError(t, json.Unmarshal(buf, &images), string(buf))
+	return images
+}
+
+func imageInspectRaw(t *testing.T, ctx context.Context, endpoint string) map[string]any {
+	t.Helper()
+
+	resp, body, err := request.Get(ctx, endpoint, request.JSON)
+	assert.NilError(t, err)
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	buf, err := request.ReadBody(body)
+	assert.NilError(t, err)
+
+	var image map[string]any
+	assert.NilError(t, json.Unmarshal(buf, &image), string(buf))
+	return image
+}

--- a/vendor/github.com/moby/moby/api/types/image/manifest.go
+++ b/vendor/github.com/moby/moby/api/types/image/manifest.go
@@ -73,6 +73,11 @@ type ImageProperties struct {
 	// Required: true
 	Platform ocispec.Platform `json:"Platform"`
 
+	// Identity holds information about the identity and origin of the image.
+	// For image list responses, this can duplicate Build/Pull fields across
+	// image manifests, because those parts of identity are image-level metadata.
+	Identity *Identity `json:"Identity,omitempty"`
+
 	Size struct {
 		// Unpacked is the size (in bytes) of the locally unpacked
 		// (uncompressed) image content that's directly usable by the containers

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -107,7 +107,7 @@ const DummyHost = "api.moby.localhost"
 // overriding the version and disable API-version negotiation.
 //
 // This version may be lower than the version of the api library module used.
-const MaxAPIVersion = "1.53"
+const MaxAPIVersion = "1.54"
 
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.

--- a/vendor/github.com/moby/moby/client/image_list.go
+++ b/vendor/github.com/moby/moby/client/image_list.go
@@ -41,6 +41,14 @@ func (cli *Client) ImageList(ctx context.Context, options ImageListOptions) (Ima
 			query.Set("manifests", "1")
 		}
 	}
+	if options.Identity {
+		if err := cli.requiresVersion(ctx, "1.54", "identity"); err != nil {
+			return ImageListResult{}, err
+		}
+		// Identity data in image list is scoped to manifests.
+		query.Set("manifests", "1")
+		query.Set("identity", "1")
+	}
 
 	resp, err := cli.get(ctx, "/images/json", query, nil)
 	defer ensureReaderClosed(resp)

--- a/vendor/github.com/moby/moby/client/image_list_opts.go
+++ b/vendor/github.com/moby/moby/client/image_list_opts.go
@@ -16,6 +16,9 @@ type ImageListOptions struct {
 
 	// Manifests indicates whether the image manifests should be returned.
 	Manifests bool
+
+	// Identity indicates whether image identity information should be returned.
+	Identity bool
 }
 
 // ImageListResult holds the result from ImageList.


### PR DESCRIPTION
This PR extends image identity support to `GET /images/json` (`docker image ls` API path), building on the prior inspect work in #51737. For image list, identity is opt-in and manifest-scoped: when requested, identity is returned on `Manifests[].ImageData.Identity` (for locally available image manifests), not as a single image-level verdict. Identity is requested with `identity=1` and requires `manifests=1`. The implementation reuses the shared inspect/list identity computation and cache path.

Listing images is the next natural API surface, but list operations are much more frequent and can include many images. Running full verification for every list by default would be too expensive.

The goals here are to expose identity on image list when explicitly requested and avoid repeated re-verification by reusing cache. But also mutualize inspect/list identity logic in one place and keep default list behavior unchanged unless opt-in is requested.

Testing:

```
$ docker image pull busybox
$ docker image pull moby/buildkit:latest
```

Default behavior (no identity):

```
$ curl -sk "https://localhost:12375/v1.54/images/json?all=1" | jq
```
<details>
<summary>JSON output</summary>

```json
[
  {
    "Containers": 0,
    "Created": 1769684624,
    "Id": "sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368",
    "Labels": {},
    "ParentId": "",
    "Descriptor": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368",
      "size": 4654
    },
    "RepoDigests": [
      "moby/buildkit@sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368"
    ],
    "RepoTags": [
      "moby/buildkit:latest"
    ],
    "SharedSize": -1,
    "Size": 344651113
  },
  {
    "Containers": 0,
    "Created": 1727386302,
    "Id": "sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f",
    "Labels": {},
    "ParentId": "",
    "Descriptor": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f",
      "size": 9535
    },
    "RepoDigests": [
      "busybox@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f"
    ],
    "RepoTags": [
      "busybox:latest"
    ],
    "SharedSize": -1,
    "Size": 6774325
  }
]
```
</details>

Opt-in identity:

```
$ curl -sk "https://localhost:12375/v1.54/images/json?all=1&manifests=1&identity=1" | jq
```
<details>
<summary>JSON output</summary>

```json
[
  {
    "Containers": 0,
    "Created": 1769684624,
    "Id": "sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368",
    "Labels": {},
    "ParentId": "",
    "Descriptor": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368",
      "size": 4654
    },
    "Manifests": [
      {
        "ID": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428",
          "size": 1885,
          "platform": {
            "architecture": "amd64",
            "os": "linux"
          }
        },
        "Available": true,
        "Size": {
          "Content": 106662530,
          "Total": 343173762
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "amd64",
            "os": "linux"
          },
          "Identity": {
            "Signature": [
              {
                "Name": "Docker GitHub Builder Experimental (moby/buildkit@v0.27.1)",
                "Timestamps": [
                  {
                    "Type": "Tlog",
                    "URI": "https://rekor.sigstore.dev",
                    "Timestamp": "2026-01-29T11:04:09Z"
                  },
                  {
                    "Type": "TimestampAuthority",
                    "URI": "https://timestamp.sigstore.dev/api/v1/timestamp",
                    "Timestamp": "2026-01-29T11:04:08Z"
                  }
                ],
                "Signer": {
                  "CertificateIssuer": "CN=sigstore-intermediate,O=sigstore.dev",
                  "SubjectAlternativeName": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@7643588149117bf0ca3a906caa3968c70484027a",
                  "Issuer": "https://token.actions.githubusercontent.com",
                  "BuildSignerURI": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@7643588149117bf0ca3a906caa3968c70484027a",
                  "BuildSignerDigest": "7643588149117bf0ca3a906caa3968c70484027a",
                  "RunnerEnvironment": "github-hosted",
                  "SourceRepositoryURI": "https://github.com/moby/buildkit",
                  "SourceRepositoryDigest": "5fbebf9d177edcc7af06c36c78728fdd357bf964",
                  "SourceRepositoryRef": "refs/tags/v0.27.1",
                  "SourceRepositoryIdentifier": "92969352",
                  "SourceRepositoryOwnerURI": "https://github.com/moby",
                  "SourceRepositoryOwnerIdentifier": "27259197",
                  "BuildConfigURI": "https://github.com/moby/buildkit/.github/workflows/buildkit.yml@refs/tags/v0.27.1",
                  "BuildConfigDigest": "5fbebf9d177edcc7af06c36c78728fdd357bf964",
                  "BuildTrigger": "push",
                  "RunInvocationURI": "https://github.com/moby/buildkit/actions/runs/21475065050/attempts/1",
                  "SourceRepositoryVisibilityAtSigning": "public"
                },
                "SignatureType": "bundle-v0.3"
              }
            ],
            "Pull": [
              {
                "Repository": "docker.io/moby/buildkit"
              }
            ]
          },
          "Size": {
            "Unpacked": 236511232
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:60cdc2c47022ab8ac6df002cbfc427a55b4c4b2ad2e17e59b1f57dbd6e33996e",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:60cdc2c47022ab8ac6df002cbfc427a55b4c4b2ad2e17e59b1f57dbd6e33996e",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": true,
        "Size": {
          "Content": 1477351,
          "Total": 1477351
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428"
        }
      },
      {
        "ID": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04",
          "size": 1885,
          "platform": {
            "architecture": "arm64",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm64",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:00c6cb41371baf0a8da83c3af1866c8f1711c98a2119c46e8762caf60856d14a",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:00c6cb41371baf0a8da83c3af1866c8f1711c98a2119c46e8762caf60856d14a",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04"
        }
      },
      {
        "ID": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103",
          "size": 1885,
          "platform": {
            "architecture": "ppc64le",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "ppc64le",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:47aa137c0989b59d052cb302eb6cc3d31834e358cd51b02817f87f69dd0bae29",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:47aa137c0989b59d052cb302eb6cc3d31834e358cd51b02817f87f69dd0bae29",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103"
        }
      },
      {
        "ID": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b",
          "size": 1885,
          "platform": {
            "architecture": "riscv64",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "riscv64",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:75530b99ff63f171ba46c1b17cb741d1e9ddbb3b7fcf6eb5dcb3dd9b9aef4908",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:75530b99ff63f171ba46c1b17cb741d1e9ddbb3b7fcf6eb5dcb3dd9b9aef4908",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b"
        }
      },
      {
        "ID": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece",
          "size": 1885,
          "platform": {
            "architecture": "s390x",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "s390x",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:86834bac34c93b0c31974404cf5614566cd4fc6a98ea622bd44300400e752eee",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:86834bac34c93b0c31974404cf5614566cd4fc6a98ea622bd44300400e752eee",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece"
        }
      },
      {
        "ID": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553",
          "size": 1884,
          "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:1662e1ad2943ef140b2e12a819a74a1e296e3d42961618343adae88c89b40d4a",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:1662e1ad2943ef140b2e12a819a74a1e296e3d42961618343adae88c89b40d4a",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553"
        }
      }
    ],
    "RepoDigests": [
      "moby/buildkit@sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368"
    ],
    "RepoTags": [
      "moby/buildkit:latest"
    ],
    "SharedSize": -1,
    "Size": 344651113
  },
  {
    "Containers": 0,
    "Created": 1727386302,
    "Id": "sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f",
    "Labels": {},
    "ParentId": "",
    "Descriptor": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f",
      "size": 9535
    },
    "Manifests": [
      {
        "ID": "sha256:70ce0a747f09cd7c09c2d6eaeab69d60adb0398f569296e8c0e844599388ebd6",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:70ce0a747f09cd7c09c2d6eaeab69d60adb0398f569296e8c0e844599388ebd6",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "amd64",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "cf5073498e5dd419f77f0a6af431fcec847de048",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "amd64",
            "os": "linux"
          }
        },
        "Available": true,
        "Size": {
          "Content": 2212725,
          "Total": 6771573
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "amd64",
            "os": "linux"
          },
          "Identity": {
            "Pull": [
              {
                "Repository": "docker.io/library/busybox"
              }
            ]
          },
          "Size": {
            "Unpacked": 4558848
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:afa90197716ae01be9facc62cdd0d029caaacd89d7aceea84b828817f7251b94",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:afa90197716ae01be9facc62cdd0d029caaacd89d7aceea84b828817f7251b94",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "amd64",
            "vnd.docker.reference.digest": "sha256:70ce0a747f09cd7c09c2d6eaeab69d60adb0398f569296e8c0e844599388ebd6",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": true,
        "Size": {
          "Content": 2752,
          "Total": 2752
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:70ce0a747f09cd7c09c2d6eaeab69d60adb0398f569296e8c0e844599388ebd6"
        }
      },
      {
        "ID": "sha256:a8f87a9308d2019066be00520f7704dda3f6255e75902fa70e29ff5801cceadc",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:a8f87a9308d2019066be00520f7704dda3f6255e75902fa70e29ff5801cceadc",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "arm32v5",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "36426ad7ac2f3d5c807cef900d8dbee0e29ba477",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v5"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v5"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:df563415b6109aa0da73993952cdd8e2b1d7cd821f553f844f9c690fdca20329",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:df563415b6109aa0da73993952cdd8e2b1d7cd821f553f844f9c690fdca20329",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "arm32v5",
            "vnd.docker.reference.digest": "sha256:a8f87a9308d2019066be00520f7704dda3f6255e75902fa70e29ff5801cceadc",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:a8f87a9308d2019066be00520f7704dda3f6255e75902fa70e29ff5801cceadc"
        }
      },
      {
        "ID": "sha256:d1ba3375824b1e605503225e2f42280aea16d388fb2e400b9fe7c4d93b9e8d42",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:d1ba3375824b1e605503225e2f42280aea16d388fb2e400b9fe7c4d93b9e8d42",
          "size": 608,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "arm32v6",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-22T18:01:52Z",
            "org.opencontainers.image.revision": "e4def65e99453b20d5cb5a90b2029fe38825c3e3",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-musl"
          },
          "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v6"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v6"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:9068648d425cdab0144ced6b2f6671d56856dd48c5dfd65349545f7e3b972743",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:9068648d425cdab0144ced6b2f6671d56856dd48c5dfd65349545f7e3b972743",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "arm32v7",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "e36bb53e58b98ea14b6974c374f7a25c45215c72",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:1247378d9e4c733a8bda3b5c22b9626446d3449342c67684ad2b5e8af75dfc09",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:1247378d9e4c733a8bda3b5c22b9626446d3449342c67684ad2b5e8af75dfc09",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "arm32v7",
            "vnd.docker.reference.digest": "sha256:9068648d425cdab0144ced6b2f6671d56856dd48c5dfd65349545f7e3b972743",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:9068648d425cdab0144ced6b2f6671d56856dd48c5dfd65349545f7e3b972743"
        }
      },
      {
        "ID": "sha256:bf9536d50cebf4337eb4a802e4786f25a9068665385d82a780d210316b818cf8",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:bf9536d50cebf4337eb4a802e4786f25a9068665385d82a780d210316b818cf8",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "arm64v8",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "f9967ecdd4c9957e38cac7a1327949b262c593b7",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "arm64",
            "os": "linux",
            "variant": "v8"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm64",
            "os": "linux",
            "variant": "v8"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:6496ba7cedf7ded74d50a58ef76c601b2bedbe7426b5eea9307946b2c85704fd",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:6496ba7cedf7ded74d50a58ef76c601b2bedbe7426b5eea9307946b2c85704fd",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "arm64v8",
            "vnd.docker.reference.digest": "sha256:bf9536d50cebf4337eb4a802e4786f25a9068665385d82a780d210316b818cf8",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:bf9536d50cebf4337eb4a802e4786f25a9068665385d82a780d210316b818cf8"
        }
      },
      {
        "ID": "sha256:4630ec42856ce4bb9e3c3c28974b2e5352e5ddb83f30f6dff593af6bd61a04fc",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:4630ec42856ce4bb9e3c3c28974b2e5352e5ddb83f30f6dff593af6bd61a04fc",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "i386",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "81727bf17c1db6d3bf38dd853028cad04380c1d7",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "386",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "386",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:39f40e786c548e737ca4dcbd54bc7aa5523b4c3cfba55f992fc48173cb1bf604",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:39f40e786c548e737ca4dcbd54bc7aa5523b4c3cfba55f992fc48173cb1bf604",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "i386",
            "vnd.docker.reference.digest": "sha256:4630ec42856ce4bb9e3c3c28974b2e5352e5ddb83f30f6dff593af6bd61a04fc",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:4630ec42856ce4bb9e3c3c28974b2e5352e5ddb83f30f6dff593af6bd61a04fc"
        }
      },
      {
        "ID": "sha256:41f9ea4595f1e281d876d5552fddeebe7aae73227d87ff36cce6cf2d8a4dfd76",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:41f9ea4595f1e281d876d5552fddeebe7aae73227d87ff36cce6cf2d8a4dfd76",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "ppc64le",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "782c2e1ec06596179dcfaeb54c5b98dae706b398",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "ppc64le",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "ppc64le",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:a130874970495456eab6247439ce281394112d623b706cf2c2a435c54b515041",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:a130874970495456eab6247439ce281394112d623b706cf2c2a435c54b515041",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "ppc64le",
            "vnd.docker.reference.digest": "sha256:41f9ea4595f1e281d876d5552fddeebe7aae73227d87ff36cce6cf2d8a4dfd76",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:41f9ea4595f1e281d876d5552fddeebe7aae73227d87ff36cce6cf2d8a4dfd76"
        }
      },
      {
        "ID": "sha256:1d91cf227b86953df96c0407e45cb6bae3b54c8483f1a9d4e8da66b3150afe2a",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:1d91cf227b86953df96c0407e45cb6bae3b54c8483f1a9d4e8da66b3150afe2a",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "riscv64",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "7075be67a8b05f6d4fd03c0662f7653ebcdd8dd6",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "riscv64",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "riscv64",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:46786dc99f64b9c92dbe24bc4de3d6c081c2bd5c04e3a4a47876376a02527324",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:46786dc99f64b9c92dbe24bc4de3d6c081c2bd5c04e3a4a47876376a02527324",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "riscv64",
            "vnd.docker.reference.digest": "sha256:1d91cf227b86953df96c0407e45cb6bae3b54c8483f1a9d4e8da66b3150afe2a",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:1d91cf227b86953df96c0407e45cb6bae3b54c8483f1a9d4e8da66b3150afe2a"
        }
      },
      {
        "ID": "sha256:ec7f86785d9baa161eb74285aabd5d98a388d7ea9c7ab9d31bb1d653ab55f974",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:ec7f86785d9baa161eb74285aabd5d98a388d7ea9c7ab9d31bb1d653ab55f974",
          "size": 610,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "s390x",
            "org.opencontainers.image.base.name": "scratch",
            "org.opencontainers.image.created": "2026-01-05T17:31:19Z",
            "org.opencontainers.image.revision": "12a7475c2080084ba5091bddfe227a896859ef41",
            "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
            "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
            "org.opencontainers.image.version": "1.37.0-glibc"
          },
          "platform": {
            "architecture": "s390x",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "s390x",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:feeeebd21329b236e67d2d717b9087ddaf4b19a970352dd297694463cf619653",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:feeeebd21329b236e67d2d717b9087ddaf4b19a970352dd297694463cf619653",
          "size": 559,
          "annotations": {
            "com.docker.official-images.bashbrew.arch": "s390x",
            "vnd.docker.reference.digest": "sha256:ec7f86785d9baa161eb74285aabd5d98a388d7ea9c7ab9d31bb1d653ab55f974",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:ec7f86785d9baa161eb74285aabd5d98a388d7ea9c7ab9d31bb1d653ab55f974"
        }
      }
    ],
    "RepoDigests": [
      "busybox@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f"
    ],
    "RepoTags": [
      "busybox:latest"
    ],
    "SharedSize": -1,
    "Size": 6774325
  }
]
```
</details>

When pulling multiple platforms, identity is retrieved for them:

```
$ docker image pull --platform=linux/amd64 moby/buildkit:latest
$ docker image pull --platform=linux/arm64 moby/buildkit:latest
$ curl -sk "https://localhost:12375/v1.54/images/json?all=1&manifests=1&identity=1" | jq
```
<details>
<summary>JSON output</summary>

```json
[
  {
    "Containers": 0,
    "Created": 1769684624,
    "Id": "sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368",
    "Labels": {},
    "ParentId": "",
    "Descriptor": {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368",
      "size": 4654
    },
    "Manifests": [
      {
        "ID": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428",
          "size": 1885,
          "platform": {
            "architecture": "amd64",
            "os": "linux"
          }
        },
        "Available": true,
        "Size": {
          "Content": 106662530,
          "Total": 343173762
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "amd64",
            "os": "linux"
          },
          "Identity": {
            "Signature": [
              {
                "Name": "Docker GitHub Builder Experimental (moby/buildkit@v0.27.1)",
                "Timestamps": [
                  {
                    "Type": "Tlog",
                    "URI": "https://rekor.sigstore.dev",
                    "Timestamp": "2026-01-29T11:04:09Z"
                  },
                  {
                    "Type": "TimestampAuthority",
                    "URI": "https://timestamp.sigstore.dev/api/v1/timestamp",
                    "Timestamp": "2026-01-29T11:04:08Z"
                  }
                ],
                "Signer": {
                  "CertificateIssuer": "CN=sigstore-intermediate,O=sigstore.dev",
                  "SubjectAlternativeName": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@7643588149117bf0ca3a906caa3968c70484027a",
                  "Issuer": "https://token.actions.githubusercontent.com",
                  "BuildSignerURI": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@7643588149117bf0ca3a906caa3968c70484027a",
                  "BuildSignerDigest": "7643588149117bf0ca3a906caa3968c70484027a",
                  "RunnerEnvironment": "github-hosted",
                  "SourceRepositoryURI": "https://github.com/moby/buildkit",
                  "SourceRepositoryDigest": "5fbebf9d177edcc7af06c36c78728fdd357bf964",
                  "SourceRepositoryRef": "refs/tags/v0.27.1",
                  "SourceRepositoryIdentifier": "92969352",
                  "SourceRepositoryOwnerURI": "https://github.com/moby",
                  "SourceRepositoryOwnerIdentifier": "27259197",
                  "BuildConfigURI": "https://github.com/moby/buildkit/.github/workflows/buildkit.yml@refs/tags/v0.27.1",
                  "BuildConfigDigest": "5fbebf9d177edcc7af06c36c78728fdd357bf964",
                  "BuildTrigger": "push",
                  "RunInvocationURI": "https://github.com/moby/buildkit/actions/runs/21475065050/attempts/1",
                  "SourceRepositoryVisibilityAtSigning": "public"
                },
                "SignatureType": "bundle-v0.3"
              }
            ],
            "Pull": [
              {
                "Repository": "docker.io/moby/buildkit"
              }
            ]
          },
          "Size": {
            "Unpacked": 236511232
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:60cdc2c47022ab8ac6df002cbfc427a55b4c4b2ad2e17e59b1f57dbd6e33996e",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:60cdc2c47022ab8ac6df002cbfc427a55b4c4b2ad2e17e59b1f57dbd6e33996e",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": true,
        "Size": {
          "Content": 1477351,
          "Total": 1477351
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:f5bf1331bda8069997e7d7d4f8977d6c0e5e6f12f770ec06015a34f8bc0f5428"
        }
      },
      {
        "ID": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04",
          "size": 1885,
          "platform": {
            "architecture": "arm64",
            "os": "linux"
          }
        },
        "Available": true,
        "Size": {
          "Content": 100729803,
          "Total": 333648843
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm64",
            "os": "linux"
          },
          "Identity": {
            "Signature": [
              {
                "Name": "Docker GitHub Builder Experimental (moby/buildkit@v0.27.1)",
                "Timestamps": [
                  {
                    "Type": "Tlog",
                    "URI": "https://rekor.sigstore.dev",
                    "Timestamp": "2026-01-29T11:04:10Z"
                  },
                  {
                    "Type": "TimestampAuthority",
                    "URI": "https://timestamp.sigstore.dev/api/v1/timestamp",
                    "Timestamp": "2026-01-29T11:04:10Z"
                  }
                ],
                "Signer": {
                  "CertificateIssuer": "CN=sigstore-intermediate,O=sigstore.dev",
                  "SubjectAlternativeName": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@7643588149117bf0ca3a906caa3968c70484027a",
                  "Issuer": "https://token.actions.githubusercontent.com",
                  "BuildSignerURI": "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml@7643588149117bf0ca3a906caa3968c70484027a",
                  "BuildSignerDigest": "7643588149117bf0ca3a906caa3968c70484027a",
                  "RunnerEnvironment": "github-hosted",
                  "SourceRepositoryURI": "https://github.com/moby/buildkit",
                  "SourceRepositoryDigest": "5fbebf9d177edcc7af06c36c78728fdd357bf964",
                  "SourceRepositoryRef": "refs/tags/v0.27.1",
                  "SourceRepositoryIdentifier": "92969352",
                  "SourceRepositoryOwnerURI": "https://github.com/moby",
                  "SourceRepositoryOwnerIdentifier": "27259197",
                  "BuildConfigURI": "https://github.com/moby/buildkit/.github/workflows/buildkit.yml@refs/tags/v0.27.1",
                  "BuildConfigDigest": "5fbebf9d177edcc7af06c36c78728fdd357bf964",
                  "BuildTrigger": "push",
                  "RunInvocationURI": "https://github.com/moby/buildkit/actions/runs/21475065050/attempts/1",
                  "SourceRepositoryVisibilityAtSigning": "public"
                },
                "SignatureType": "bundle-v0.3"
              }
            ],
            "Pull": [
              {
                "Repository": "docker.io/moby/buildkit"
              }
            ]
          },
          "Size": {
            "Unpacked": 232919040
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:00c6cb41371baf0a8da83c3af1866c8f1711c98a2119c46e8762caf60856d14a",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:00c6cb41371baf0a8da83c3af1866c8f1711c98a2119c46e8762caf60856d14a",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": true,
        "Size": {
          "Content": 1474250,
          "Total": 1474250
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:7a9e2a8abc3428a555ade8db975f899241d4f5d242fb5599dedd4a0f97e8fc04"
        }
      },
      {
        "ID": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103",
          "size": 1885,
          "platform": {
            "architecture": "ppc64le",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "ppc64le",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:47aa137c0989b59d052cb302eb6cc3d31834e358cd51b02817f87f69dd0bae29",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:47aa137c0989b59d052cb302eb6cc3d31834e358cd51b02817f87f69dd0bae29",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:100572864af4134d51d0c7837aa1d8f7079ea9b3e27d02ccbef7935b48a09103"
        }
      },
      {
        "ID": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b",
          "size": 1885,
          "platform": {
            "architecture": "riscv64",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "riscv64",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:75530b99ff63f171ba46c1b17cb741d1e9ddbb3b7fcf6eb5dcb3dd9b9aef4908",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:75530b99ff63f171ba46c1b17cb741d1e9ddbb3b7fcf6eb5dcb3dd9b9aef4908",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:598953ef120bfa7d0719e030e17bc5ba024a70c14c94049329b4e96f68a44a3b"
        }
      },
      {
        "ID": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece",
          "size": 1885,
          "platform": {
            "architecture": "s390x",
            "os": "linux"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "s390x",
            "os": "linux"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:86834bac34c93b0c31974404cf5614566cd4fc6a98ea622bd44300400e752eee",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:86834bac34c93b0c31974404cf5614566cd4fc6a98ea622bd44300400e752eee",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:7985ce1de8899f5727d3d483e19b1794446f6dc51be106d24bcf1caba6a3bece"
        }
      },
      {
        "ID": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553",
          "size": 1884,
          "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "image",
        "ImageData": {
          "Platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
          },
          "Size": {
            "Unpacked": 0
          },
          "Containers": null
        }
      },
      {
        "ID": "sha256:1662e1ad2943ef140b2e12a819a74a1e296e3d42961618343adae88c89b40d4a",
        "Descriptor": {
          "mediaType": "application/vnd.oci.image.manifest.v1+json",
          "digest": "sha256:1662e1ad2943ef140b2e12a819a74a1e296e3d42961618343adae88c89b40d4a",
          "size": 1384,
          "annotations": {
            "vnd.docker.reference.digest": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553",
            "vnd.docker.reference.type": "attestation-manifest"
          },
          "platform": {
            "architecture": "unknown",
            "os": "unknown"
          }
        },
        "Available": false,
        "Size": {
          "Content": 0,
          "Total": 0
        },
        "Kind": "attestation",
        "AttestationData": {
          "For": "sha256:d5ff0f224469a641a2b467f32b4400aca2c4d06e4edf311eac35e4112e4b7553"
        }
      }
    ],
    "RepoDigests": [
      "moby/buildkit@sha256:1e110c71d389d6d24f67b9438e2f7b8da749a6ff407b22a1631e025c95599368"
    ],
    "RepoTags": [
      "moby/buildkit:latest"
    ],
    "SharedSize": -1,
    "Size": 679774206
  }
]
```
</details>

changelog:
```markdown changelog
`GET /images/json` now supports an `identity` query parameter. When set, the response includes manifest summaries and may include an `Identity` field for each manifest with trusted identity and origin information.
client: `ImageListOptions` now supports `Identity` field. When set, the response includes manifest summaries and may include an `Identity` field for each manifest with trusted identity and origin information.
```