### PR TITLE
network/connect: Support MacAddress

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -18,6 +18,8 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /images/json` now supports an `identity` query parameter. When set,
   the response includes manifest summaries and may include an `Identity` field
   for each manifest with trusted identity and origin information.
+* `POST /networks/{id}/connect` now correctly applies the `MacAddress` field in
+  `EndpointSettings`. This field was added in API v1.44, but was previously ignored.
 
 ## v1.53 API changes
 

--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -191,7 +191,8 @@ func (daemon *Daemon) updateNetworkSettings(ctr *container.Container, n *libnetw
 	}
 
 	ctr.NetworkSettings.Networks[n.Name()] = &network.EndpointSettings{
-		EndpointSettings: endpointConfig,
+		EndpointSettings:  endpointConfig,
+		DesiredMacAddress: endpointConfig.MacAddress,
 	}
 
 	return nil
@@ -1046,12 +1047,14 @@ func (daemon *Daemon) ConnectToNetwork(ctx context.Context, ctr *container.Conta
 			}
 		} else {
 			ctr.NetworkSettings.Networks[idOrName] = &network.EndpointSettings{
-				EndpointSettings: endpointConfig,
+				EndpointSettings:  endpointConfig,
+				DesiredMacAddress: endpointConfig.MacAddress,
 			}
 		}
 	} else {
 		epc := &network.EndpointSettings{
-			EndpointSettings: endpointConfig,
+			EndpointSettings:  endpointConfig,
+			DesiredMacAddress: endpointConfig.MacAddress,
 		}
 		if err := daemon.connectToNetwork(ctx, &daemon.config().Config, ctr, idOrName, epc); err != nil {
 			return err

--- a/daemon/server/router/network/network_routes.go
+++ b/daemon/server/router/network/network_routes.go
@@ -292,6 +292,11 @@ func (n *networkRouter) postNetworkConnect(ctx context.Context, w http.ResponseW
 		return err
 	}
 
+	// TODO: Do we want to apply it to the older APIs too?
+	if versions.LessThan(httputils.VersionFromContext(ctx), "1.54") && connect.EndpointConfig != nil {
+		connect.EndpointConfig.MacAddress = nil
+	}
+
 	// Unlike other operations, we does not check ambiguity of the name/ID here.
 	// The reason is that, In case of attachable network in swarm scope, the actual local network
 	// may not be available at the time. At the same time, inside daemon `ConnectContainerToNetwork`


### PR DESCRIPTION
- addresses: https://github.com/moby/moby/issues/51796

**- What I did**

respect the `MacAddress` field in network connect.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`POST /networks/{id}/connect` now correctly applies the `MacAddress` field in `EndpointSettings`. This field was added in API v1.44, but was previously ignored.

```

**- A picture of a cute animal (not mandatory but encouraged)**

