### PR TITLE
Reapply: daemon/command: add support for sd_notify "reload" notifications

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -550,6 +550,13 @@ func (cli *daemonCLI) reloadConfig() {
 		}
 	}
 
+	// On Linux, we use sd_notify to indicate we're reloading config. We send
+	// this signal as early as possible to let systemd know we're reloading,
+	// but must signal "ready" after this completes (even on failure), which
+	// is done by the reload function defined above.
+	done := notifyReloading()
+	defer done()
+
 	if err := config.Reload(*cli.configFile, cli.flags, reload); err != nil {
 		log.G(ctx).WithError(err).Error("Error reloading configuration")
 		return

--- a/daemon/command/daemon_freebsd.go
+++ b/daemon/command/daemon_freebsd.go
@@ -11,6 +11,10 @@ func preNotifyReady() error {
 func notifyReady() {
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration. It is a no-op on FreeBSD.
+func notifyReloading() func() { return func() {} }
+
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
 }

--- a/daemon/command/daemon_linux.go
+++ b/daemon/command/daemon_linux.go
@@ -58,6 +58,25 @@ func notifyStopping() {
 	go systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyStopping)
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration, see [sd_notify(3)]. The server should be running
+// as a systemd unit with "Type=notify" or "Type=notify-reload" (see
+// [systemd.service(5)]).
+//
+// notifyReloading returns a callback that must be called after reloading completes
+// (either successfully or unsuccessfully) to send [notifyReady].
+//
+// [sd_notify(3)]: https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#RELOADING=1
+// [systemd.service(5)]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=
+func notifyReloading() (done func()) {
+	sent, _ := systemdDaemon.SdNotify(false, systemdDaemon.SdNotifyReloading+"\n"+systemdDaemon.SdNotifyMonotonicUsec())
+	if !sent {
+		// Nothing to do if no reloading event was sent.
+		return func() {}
+	}
+	return notifyReady
+}
+
 func validateCPURealtimeOptions(cfg *config.Config) error {
 	if cfg.CPURealtimePeriod == 0 && cfg.CPURealtimeRuntime == 0 {
 		return nil

--- a/daemon/command/daemon_windows.go
+++ b/daemon/command/daemon_windows.go
@@ -56,6 +56,10 @@ func preNotifyReady() error {
 func notifyReady() {
 }
 
+// notifyReloading sends a message to the host when the server got signaled to
+// reloading its configuration. It is a no-op on Windows.
+func notifyReloading() func() { return func() {} }
+
 // notifyStopping sends a message to the host when the server is shutting down
 func notifyStopping() {
 }


### PR DESCRIPTION
- reapply: https://github.com/moby/moby/pull/51965

Restoring for 29.3.0

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Send sd_notify ["READY"](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#READY=1) and ["STOPPING"](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#STOPPING=1) synchronously to make sure they are sent before we proceed.
- Add sd_notify ["RELOADING"](https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#RELOADING=1) notifications when signalling the daemon to reload its configuration.
- Add support for the systemd 253 `Type=notify-reload` service reload protocol.
```

**- A picture of a cute animal (not mandatory but encouraged)**

