### PR TITLE
daemon/container: close logger asynchronously in Reset()

### DIFF
--- a/daemon/container/monitor.go
+++ b/daemon/container/monitor.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/containerd/log"
+	"github.com/moby/moby/v2/daemon/logger"
 )
 
 const (
@@ -31,10 +32,30 @@ func (container *Container) Reset() {
 		return
 	}
 
-	if container.LogCopier != nil {
+	// Detach the log driver from the container under the lock, then
+	// close it asynchronously. Closing can block for a long time if
+	// the underlying driver is unresponsive (e.g. a stuck fluentd or
+	// syslog backend). Holding the container lock during that time
+	// would prevent any other operation on this container, and also
+	// stall startup of other containers that share the same log
+	// driver configuration.
+	logDriver := container.LogDriver
+	logCopier := container.LogCopier
+	container.LogDriver = nil
+	container.LogCopier = nil
+
+	go closeLogger(container.ID, logDriver, logCopier)
+}
+
+// closeLogger waits for the log copier to finish (with a timeout) and
+// then closes the log driver. It runs in its own goroutine because the
+// driver's Close method may block indefinitely when the underlying
+// logging backend is unresponsive.
+func closeLogger(containerID string, logDriver logger.Logger, logCopier *logger.Copier) {
+	if logCopier != nil {
 		exit := make(chan struct{})
 		go func() {
-			container.LogCopier.Wait()
+			logCopier.Wait()
 			close(exit)
 		}()
 
@@ -43,17 +64,15 @@ func (container *Container) Reset() {
 		select {
 		case <-timer.C:
 			log.G(context.TODO()).WithFields(log.Fields{
-				"container": container.ID,
+				"container": containerID,
 			}).Warn("logger didn't exit in time: logs may be truncated")
 		case <-exit:
 		}
 	}
-	if err := container.LogDriver.Close(); err != nil {
+	if err := logDriver.Close(); err != nil {
 		log.G(context.TODO()).WithFields(log.Fields{
-			"container": container.ID,
+			"container": containerID,
 			"error":     err,
 		}).Warn("error closing log driver")
 	}
-	container.LogCopier = nil
-	container.LogDriver = nil
 }

--- a/daemon/container/monitor_test.go
+++ b/daemon/container/monitor_test.go
@@ -1,0 +1,71 @@
+package container
+
+import (
+	"testing"
+	"time"
+
+	containertypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/v2/daemon/logger"
+)
+
+// blockingCloseLogger is a logger whose Close method blocks on a channel.
+// It simulates a log driver with an unresponsive backend.
+type blockingCloseLogger struct {
+	unblock chan struct{}
+	closed  chan struct{}
+}
+
+func (l *blockingCloseLogger) Log(*logger.Message) error { return nil }
+func (l *blockingCloseLogger) Name() string              { return "blocking" }
+
+func (l *blockingCloseLogger) Close() error {
+	<-l.unblock
+	close(l.closed)
+	return nil
+}
+
+// TestResetDoesNotBlockOnStuckLogger verifies that Reset() returns
+// promptly even when the log driver's Close method blocks indefinitely.
+// Before the fix, Reset() would hold the container lock for the entire
+// duration of LogDriver.Close(), blocking unrelated operations.
+func TestResetDoesNotBlockOnStuckLogger(t *testing.T) {
+	bl := &blockingCloseLogger{
+		unblock: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+	defer close(bl.unblock)
+
+	c := NewBaseContainer("test", t.TempDir())
+	c.Config = &containertypes.Config{}
+	c.LogDriver = bl
+
+	done := make(chan struct{})
+	go func() {
+		c.Reset()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reset() blocked on stuck LogDriver.Close()")
+	}
+
+	if c.LogDriver != nil {
+		t.Fatal("LogDriver should be nil after Reset()")
+	}
+	if c.LogCopier != nil {
+		t.Fatal("LogCopier should be nil after Reset()")
+	}
+
+	// Verify Close is still running in the background (not finished yet).
+	select {
+	case <-bl.closed:
+		t.Fatal("background Close finished prematurely; unblock was sent")
+	default:
+	}
+
+	// Reset() must be idempotent — a second call with LogDriver already nil
+	// should return quickly without spawning another close goroutine.
+	c.Reset()
+}


### PR DESCRIPTION
When an underlying log driver (e.g. fluentd, syslog) becomes unresponsive, `LogDriver.Close()` can block for a long time. `container.Reset()` calls `Close()` while holding the container state mutex, which stalls every other operation on the container - and because the same driver is likely used by other containers, their startup can block too, cascading the outage.

This PR moves the `Close()` call into a goroutine. The container lock is released as soon as `Reset()` returns; the slow close happens in the background.

Per @cpuguy83's review of the previous approach, fixing this at the caller level is the correct place - ring logger timeouts were a band-aid that still held the lock for up to 5 s.

### Changes

- `daemon/container/monitor.go`: `Reset()` now detaches `LogDriver` / `LogCopier` under the caller's lock (sets them to `nil`), then launches a single goroutine to wait for the copier and close the driver. The existing 10 s copier-wait timeout is preserved.
- `daemon/container/monitor_test.go` (new): `TestResetDoesNotBlockOnStuckLogger` verifies `Reset()` returns promptly with a `LogDriver.Close()` that blocks indefinitely.

### Test plan

- [x] \`go build ./daemon/container/\` succeeds
- [x] \`go vet ./daemon/container/\` passes
- [x] \`go test -race ./daemon/container/\` — all tests pass including the new one

### Notes

- If the driver's `Close()` never returns, the background goroutine leaks until daemon shutdown. That's the driver's bug, not something ring logger / monitor can fix without API-level cancellation on `Logger.Log`/`Logger.Close`.
- `container.LogDriver` is nil'd under the lock before spawning the goroutine, so a subsequent `Reset()` is a no-op and no double-close can happen.