### PR TITLE
client: add support for overriding minimum API version

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -333,8 +333,15 @@ func (cli *Client) negotiateAPIVersion(pingVersion string) error {
 		return err
 	}
 
-	if versions.LessThan(pingVersion, MinAPIVersion) {
-		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, MinAPIVersion))
+	minVersion := MinAPIVersion
+	if cli.envMinAPIVersion != "" {
+		minVersion = cli.envMinAPIVersion
+	} else if cli.minAPIVersion != "" {
+		minVersion = cli.minAPIVersion
+	}
+
+	if versions.LessThan(pingVersion, minVersion) {
+		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, minVersion))
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version

--- a/client/envvars.go
+++ b/client/envvars.go
@@ -20,6 +20,15 @@ const (
 	// it can set the client to use an incompatible (or invalid) API version.
 	EnvOverrideAPIVersion = "DOCKER_API_VERSION"
 
+	// EnvOverrideMinAPIVersion is the name of the environment-variable to
+	// override the minimum API version provided by the client within constraints
+	// of the minimum and maximum (current) supported API versions.
+	//
+	// API versions older than [defaultMinimumAPIVersion] are deprecated and
+	// to be removed in a future release. This environment variable should
+	// only be used for exceptional cases.
+	EnvOverrideMinAPIVersion = "DOCKER_MIN_API_VERSION"
+
 	// EnvOverrideCertPath is the name of the environment variable that can be
 	// used to specify the directory from which to load the TLS certificates
 	// (ca.pem, cert.pem, key.pem) from. These certificates are used to configure

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -333,8 +333,15 @@ func (cli *Client) negotiateAPIVersion(pingVersion string) error {
 		return err
 	}
 
-	if versions.LessThan(pingVersion, MinAPIVersion) {
-		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, MinAPIVersion))
+	minVersion := MinAPIVersion
+	if cli.envMinAPIVersion != "" {
+		minVersion = cli.envMinAPIVersion
+	} else if cli.minAPIVersion != "" {
+		minVersion = cli.minAPIVersion
+	}
+
+	if versions.LessThan(pingVersion, minVersion) {
+		return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("API version %s is not supported by this client: the minimum supported API version is %s", pingVersion, minVersion))
 	}
 
 	// if the client is not initialized with a version, start with the latest supported version

--- a/vendor/github.com/moby/moby/client/envvars.go
+++ b/vendor/github.com/moby/moby/client/envvars.go
@@ -20,6 +20,15 @@ const (
 	// it can set the client to use an incompatible (or invalid) API version.
 	EnvOverrideAPIVersion = "DOCKER_API_VERSION"
 
+	// EnvOverrideMinAPIVersion is the name of the environment-variable to
+	// override the minimum API version provided by the client within constraints
+	// of the minimum and maximum (current) supported API versions.
+	//
+	// API versions older than [defaultMinimumAPIVersion] are deprecated and
+	// to be removed in a future release. This environment variable should
+	// only be used for exceptional cases.
+	EnvOverrideMinAPIVersion = "DOCKER_MIN_API_VERSION"
+
 	// EnvOverrideCertPath is the name of the environment variable that can be
 	// used to specify the directory from which to load the TLS certificates
 	// (ca.pem, cert.pem, key.pem) from. These certificates are used to configure


### PR DESCRIPTION
- relates to https://github.com/docker/buildx/issues/3654
- relates to https://github.com/moby/moby/pull/51119
- relates to https://github.com/moby/moby/pull/51186
- relates to https://github.com/moby/moby/pull/46887
- supersedes, closes https://github.com/moby/moby/pull/46962


This adds options to override the minimum API version considered when performing API-version negotiation. These options allow the client to either downgrade to versions lower than supported (lower than MinAPIVersion), which may result in degraded functionality, or to raise the minimum version to exclude older API versions.

The `WithMinAPIVersion` can be used to set the version programmatically. The `WithMinAPIVersionFromEnv` allows a user to set the minimum API version at runtime through the `DOCKER_MIN_API_VERSION` env-var.

The `WithMinAPIVersionFromEnv` is more permissive to account for slightly malformed valus in the environment variables; it accepts whitespace, and API versions with a "v" prefix. It also ignores empty values in the environment-variable (which are considered a no-op).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- client: add `WithMinAPIVersion` and `WithMinAPIVersionFromEnv ` options to allow overriding the minimum API versions considered for API version negotiation. These options allow the client to either downgrade to versions lower than supported (lower than MinAPIVersion), which may result in degraded functionality, or to raise the minimum version to exclude older API versions.
- client: the `FromEnv` option now includes `WithMinAPIVersionFromEnv`, adding support for overriding the minimum API version through a `DOCKER_MIN_API_VERSION` environment variable.
```

**- A picture of a cute animal (not mandatory but encouraged)**

