### PR TITLE
api/types/swarm: PortConfig: add Compare method

### DIFF
--- a/api/types/swarm/network.go
+++ b/api/types/swarm/network.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"cmp"
 	"net/netip"
 
 	"github.com/moby/moby/api/types/network"
@@ -39,6 +40,27 @@ type PortConfig struct {
 	PublishedPort uint32 `json:",omitempty"`
 	// PublishMode is the mode in which port is published
 	PublishMode PortConfigPublishMode `json:",omitempty"`
+}
+
+// Compare returns the lexical ordering of p and other, and can be used
+// with [slices.SortFunc].
+//
+// The comparison is performed in the following priority order:
+//  1. PublishedPort (host port)
+//  2. TargetPort (container port)
+//  3. Protocol
+//  4. PublishMode
+func (p PortConfig) Compare(other PortConfig) int {
+	if n := cmp.Compare(p.PublishedPort, other.PublishedPort); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(p.TargetPort, other.TargetPort); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(p.Protocol, other.Protocol); n != 0 {
+		return n
+	}
+	return cmp.Compare(p.PublishMode, other.PublishMode)
 }
 
 // PortConfigPublishMode represents the mode in which the port is to

--- a/api/types/swarm/network_test.go
+++ b/api/types/swarm/network_test.go
@@ -1,0 +1,94 @@
+package swarm_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/api/types/swarm"
+	"gotest.tools/v3/assert"
+)
+
+func TestPortConfigCompareSort(t *testing.T) {
+	tests := []struct {
+		doc      string
+		ports    []swarm.PortConfig
+		expected []swarm.PortConfig
+	}{
+		{
+			doc: "sort ports lexicographically",
+			ports: []swarm.PortConfig{
+				{
+					PublishedPort: 443,
+					TargetPort:    443,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+				{
+					PublishedPort: 80,
+					TargetPort:    8080,
+					Protocol:      network.UDP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+				{
+					PublishedPort: 80,
+					TargetPort:    9090,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+				{
+					PublishedPort: 80,
+					TargetPort:    8080,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+				{
+					PublishedPort: 80,
+					TargetPort:    8080,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeHost,
+				},
+			},
+			expected: []swarm.PortConfig{
+				{
+					PublishedPort: 80,
+					TargetPort:    8080,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeHost,
+				},
+				{
+					PublishedPort: 80,
+					TargetPort:    8080,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+				{
+					PublishedPort: 80,
+					TargetPort:    8080,
+					Protocol:      network.UDP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+				{
+					PublishedPort: 80,
+					TargetPort:    9090,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+				{
+					PublishedPort: 443,
+					TargetPort:    443,
+					Protocol:      network.TCP,
+					PublishMode:   swarm.PortConfigPublishModeIngress,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			got := slices.Clone(tc.ports)
+			slices.SortFunc(got, swarm.PortConfig.Compare)
+			assert.DeepEqual(t, tc.expected, got)
+		})
+	}
+}

--- a/vendor/github.com/moby/moby/api/types/swarm/network.go
+++ b/vendor/github.com/moby/moby/api/types/swarm/network.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"cmp"
 	"net/netip"
 
 	"github.com/moby/moby/api/types/network"
@@ -39,6 +40,27 @@ type PortConfig struct {
 	PublishedPort uint32 `json:",omitempty"`
 	// PublishMode is the mode in which port is published
 	PublishMode PortConfigPublishMode `json:",omitempty"`
+}
+
+// Compare returns the lexical ordering of p and other, and can be used
+// with [slices.SortFunc].
+//
+// The comparison is performed in the following priority order:
+//  1. PublishedPort (host port)
+//  2. TargetPort (container port)
+//  3. Protocol
+//  4. PublishMode
+func (p PortConfig) Compare(other PortConfig) int {
+	if n := cmp.Compare(p.PublishedPort, other.PublishedPort); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(p.TargetPort, other.TargetPort); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(p.Protocol, other.Protocol); n != 0 {
+		return n
+	}
+	return cmp.Compare(p.PublishMode, other.PublishMode)
 }
 
 // PortConfigPublishMode represents the mode in which the port is to


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6803

Add a compare function that can be used for slices.SortFunc to have a canonical definition of sorting.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api/types/swarm: PortConfig: add Compare method.
```

**- A picture of a cute animal (not mandatory but encouraged)**

