### PR TITLE
Use CDI  for GPU injection for AMD devices for --gpus

### DIFF
--- a/daemon/command/daemon.go
+++ b/daemon/command/daemon.go
@@ -268,6 +268,8 @@ func (cli *daemonCLI) start(ctx context.Context) (err error) {
 		cdiCache = daemon.RegisterCDIDriver(cli.Config.CDISpecDirs...)
 	}
 
+	daemon.RegisterGPUDeviceDrivers(cdiCache)
+
 	var apiServer apiserver.Server
 	cli.authzMiddleware, err = initMiddlewares(ctx, &apiServer, cli.Config, pluginStore)
 	if err != nil {

--- a/daemon/devices.go
+++ b/daemon/devices.go
@@ -10,12 +10,9 @@ import (
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/internal/capabilities"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 var deviceDrivers = map[string]*deviceDriver{}
-
-var RegisterGPUDeviceDrivers = func(_ *cdi.Cache) {}
 
 type deviceListing struct {
 	Devices  []system.DeviceInfo

--- a/daemon/devices.go
+++ b/daemon/devices.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/api/types/container"
@@ -9,9 +10,12 @@ import (
 	"github.com/moby/moby/v2/daemon/config"
 	"github.com/moby/moby/v2/daemon/internal/capabilities"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 var deviceDrivers = map[string]*deviceDriver{}
+
+var RegisterGPUDeviceDrivers = func(_ *cdi.Cache) {}
 
 type deviceListing struct {
 	Devices  []system.DeviceInfo
@@ -36,6 +40,18 @@ type deviceInstance struct {
 
 func registerDeviceDriver(name string, d *deviceDriver) {
 	deviceDrivers[name] = d
+}
+
+func getFirstAvailableVendor(vendorList []string) (string, error) {
+	knownVendors := []string{"nvidia.com", "amd.com"}
+	for _, vendor := range knownVendors {
+		for _, available := range vendorList {
+			if vendor == available {
+				return vendor, nil
+			}
+		}
+	}
+	return "", errors.New("no known GPU vendor found")
 }
 
 func (daemon *Daemon) handleDevice(req container.DeviceRequest, spec *specs.Spec) error {

--- a/daemon/devices_amd_linux.go
+++ b/daemon/devices_amd_linux.go
@@ -1,9 +1,18 @@
 package daemon
 
 import (
+	"errors"
+	"fmt"
+	"os/exec"
 	"strings"
 
+	"github.com/moby/moby/v2/daemon/internal/capabilities"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
+)
+
+const (
+	amdContainerRuntimeExecutableName = "amd-container-runtime"
 )
 
 func setAMDGPUs(s *specs.Spec, dev *deviceInstance) error {
@@ -24,4 +33,47 @@ func setAMDGPUs(s *specs.Spec, dev *deviceInstance) error {
 	}
 
 	return nil
+}
+
+func createAMDCDIUpdater(cdiCache *cdi.Cache) func(*specs.Spec, *deviceInstance) error {
+	return func(s *specs.Spec, dev *deviceInstance) error {
+		vendor, err := getFirstAvailableVendor(cdiCache.ListVendors())
+		if err != nil {
+			return fmt.Errorf("failed to discover GPU vendor from CDI: %w", err)
+		}
+
+		if vendor != "amd.com" {
+			return errors.New("AMD CDI spec not found")
+		}
+
+		injector := &cdiDeviceInjector{
+			defaultCDIDeviceKind: "amd.com/gpu",
+		}
+		return injector.injectDevices(s, dev)
+	}
+}
+
+func getAMDDeviceDrivers(cdiCache *cdi.Cache) *deviceDriver {
+	var composite firstSuccessfulUpdater
+
+	if cdiCache != nil {
+		composite = append(composite, createAMDCDIUpdater(cdiCache))
+	}
+
+	if _, err := exec.LookPath(amdContainerRuntimeExecutableName); err == nil {
+		composite = append(composite, setAMDGPUs)
+	}
+
+	if len(composite) == 0 {
+		return nil
+	}
+
+	// We do not support specifying driver with device requests for AMD GPUs.
+	// Hence only use the composite updater and try cdi and runtime driver in sequence
+	// based on availability.
+	capset := capabilities.Set{"gpu": struct{}{}, "amd": struct{}{}}
+	return &deviceDriver{
+		capset:     capset,
+		updateSpec: composite.updateSpec,
+	}
 }

--- a/daemon/devices_linux.go
+++ b/daemon/devices_linux.go
@@ -2,14 +2,10 @@ package daemon
 
 import "tags.cncf.io/container-device-interface/pkg/cdi"
 
-func init() {
-	RegisterGPUDeviceDrivers = registerGPUDeviceDrivers
-}
-
-// registerGPUDeviceDrivers registers GPU device drivers.
+// RegisterGPUDeviceDrivers registers GPU device drivers.
 // If the cdiCache is provided, it is used to detect presence of CDI specs for AMD GPUs.
 // For NVIDIA GPUs, presence of CDI specs is detected by checking for the nvidia-cdi-hook binary.
-func registerGPUDeviceDrivers(cdiCache *cdi.Cache) {
+func RegisterGPUDeviceDrivers(cdiCache *cdi.Cache) {
 	// Register NVIDIA device drivers.
 	if nvidiaDrivers := getNVIDIADeviceDrivers(); len(nvidiaDrivers) > 0 {
 		for name, driver := range nvidiaDrivers {

--- a/daemon/devices_linux.go
+++ b/daemon/devices_linux.go
@@ -1,0 +1,26 @@
+package daemon
+
+import "tags.cncf.io/container-device-interface/pkg/cdi"
+
+func init() {
+	RegisterGPUDeviceDrivers = registerGPUDeviceDrivers
+}
+
+// registerGPUDeviceDrivers registers GPU device drivers.
+// If the cdiCache is provided, it is used to detect presence of CDI specs for AMD GPUs.
+// For NVIDIA GPUs, presence of CDI specs is detected by checking for the nvidia-cdi-hook binary.
+func registerGPUDeviceDrivers(cdiCache *cdi.Cache) {
+	// Register NVIDIA device drivers.
+	if nvidiaDrivers := getNVIDIADeviceDrivers(); len(nvidiaDrivers) > 0 {
+		for name, driver := range nvidiaDrivers {
+			registerDeviceDriver(name, driver)
+		}
+		return
+	}
+
+	// Register AMD driver if AMD CDI spec or helper binary is present.
+	if amdDriver := getAMDDeviceDrivers(cdiCache); amdDriver != nil {
+		registerDeviceDriver("amd", amdDriver)
+		return
+	}
+}

--- a/daemon/devices_nonlinux.go
+++ b/daemon/devices_nonlinux.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package daemon
+
+import "tags.cncf.io/container-device-interface/pkg/cdi"
+
+// RegisterGPUDeviceDrivers is a no-op on non-Linux platforms.
+func RegisterGPUDeviceDrivers(_ *cdi.Cache) {}

--- a/daemon/devices_nvidia_linux.go
+++ b/daemon/devices_nvidia_linux.go
@@ -23,7 +23,6 @@ var errConflictCountDeviceIDs = errors.New("cannot set both Count and DeviceIDs 
 const (
 	nvidiaContainerRuntimeHookExecutableName = "nvidia-container-runtime-hook"
 	nvidiaCDIHookExecutableName              = "nvidia-cdi-hook"
-	amdContainerRuntimeExecutableName        = "amd-container-runtime"
 )
 
 // These are NVIDIA-specific capabilities stolen from github.com/containerd/containerd/contrib/nvidia.allCaps
@@ -34,27 +33,6 @@ var allNvidiaCaps = map[string]struct{}{
 	"utility":  {},
 	"video":    {},
 	"display":  {},
-}
-
-func init() {
-	// Register NVIDIA device drivers.
-	if nvidiaDrivers := getNVIDIADeviceDrivers(); len(nvidiaDrivers) > 0 {
-		for name, driver := range nvidiaDrivers {
-			registerDeviceDriver(name, driver)
-		}
-		return
-	}
-
-	// Register AMD driver if AMD helper binary is present.
-	if _, err := exec.LookPath(amdContainerRuntimeExecutableName); err == nil {
-		registerDeviceDriver("amd", &deviceDriver{
-			capset:     capabilities.Set{"gpu": struct{}{}, "amd": struct{}{}},
-			updateSpec: setAMDGPUs,
-		})
-		return
-	}
-
-	// No "gpu" capability
 }
 
 func getNVIDIADeviceDrivers() map[string]*deviceDriver {

--- a/daemon/devices_test.go
+++ b/daemon/devices_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetFirstAvailableVendor(t *testing.T) {
+	tests := []struct {
+		name         string
+		vendors      []string
+		expectVendor string
+		expectError  string
+	}{
+		{
+			name:         "NVIDIA vendor",
+			vendors:      []string{"nvidia.com"},
+			expectVendor: "nvidia.com",
+		},
+		{
+			name:         "AMD vendor",
+			vendors:      []string{"amd.com"},
+			expectVendor: "amd.com",
+		},
+		{
+			name:        "No vendors",
+			vendors:     nil,
+			expectError: "no known GPU vendor found",
+		},
+		{
+			name:        "Unknown vendor",
+			vendors:     []string{"unknown.com"},
+			expectError: "no known GPU vendor found",
+		},
+		{
+			name:         "Mixed vendor",
+			vendors:      []string{"amd.com", "nvidia.com"},
+			expectVendor: "nvidia.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vendor, err := getFirstAvailableVendor(tt.vendors)
+
+			if tt.expectError != "" {
+				assert.Error(t, err, tt.expectError)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tt.expectVendor, vendor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes #49824

This PR enhances the functionality of the `--gpus` option for AMD GPUs by utilizing CDI (Container Device Interface) specs for device injection when available. It falls back to the existing vendor runtime-based injection if AMD CDI specs are not detected on the machine.

**Related PR:** containerd/containerd#12839 (Similar implementation for `containerd/ctr`)

**- What I did**
Added support for CDI-based GPU device injection through `--gpus` option for AMD devices.

**- How I did it**
Created a similar composite device driver like NVIDIA's which discovers if AMD's CDI specs are there on the system during registration and registers itself with appropriate updaters to handle the device request.

**- How to verify it**
1.  Built the binaries using `make binary`.
2.  Started the newly built `dockerd` instance via `./bundles/binary/dockerd`.
3.  Used `amd-ctk cdi generate` to install the CDI specs on the host.
4.  **Test Injection:** Ran `docker run --rm --gpus all rocm/rocm-terminal rocm-smi`.
     * Verified that CDI-based GPU injection works as expected.
5.  **Test (Fallback Path):**
    * Deleted the CDI specs and restarted the `dockerd` process.
    * Retried using the runtime flag: `docker run --rm --runtime="amd" --gpus all rocm/rocm-terminal rocm-smi`.
    * Verified that the vendor runtime still works as a fallback when CDI specs are absent.
    * Checked the environment variable inside the container has `AMD_VISIBLE_DEVICES` set when CDI specs are not there to verify that the fallback is working correctly.

I have also added unit tests for vendor discovery function.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
The `--gpus` option now uses CDI-based injection for AMD GPUs.
```

**- A picture of a cute animal (not mandatory but encouraged)**

