### PR TITLE
daemon: remove deprecation warning for "windows-dns-proxy" feature flag

### DIFF
--- a/daemon/info_windows.go
+++ b/daemon/info_windows.go
@@ -10,10 +10,6 @@ import (
 
 // fillPlatformInfo fills the platform related info.
 func (daemon *Daemon) fillPlatformInfo(ctx context.Context, v *system.Info, sysInfo *sysinfo.SysInfo, cfg *configStore) error {
-	if _, ok := cfg.Features["windows-dns-proxy"]; ok {
-		v.Warnings = append(v.Warnings, `
-WARNING: Feature flag "windows-dns-proxy" has been removed, forwarding to external DNS resolvers is enabled.`)
-	}
 	return nil
 }
 


### PR DESCRIPTION
The feature flag "windows-dns-proxy" was;

- Added in 26.1.0 (6c68be24a2e6a4dea621b82ab4245e4ed363158e) https://github.com/moby/moby/pull/47584
- Enabled by default in 27.0.0 (33f9a5329a9259bc361f925a09633674878650be) https://github.com/moby/moby/pull/47826
- Removed in 28.0.0 (b79bba6b68a06870bf6d2138832effbcf6e85d63) https://github.com/moby/moby/pull/48738

Should be fine to remove the warning.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

