### PR TITLE
hack/dockerfile: fix tini build with newer CMake versions

### DIFF
--- a/hack/dockerfile/install/tini.installer
+++ b/hack/dockerfile/install/tini.installer
@@ -10,7 +10,13 @@ install_tini() {
 	git clone https://github.com/krallin/tini.git "$GOPATH/tini"
 	cd "$GOPATH/tini"
 	git checkout -q "$TINI_VERSION"
-	cmake .
+
+	# CMake 4.x removed compatibility with CMake < 3.5, which breaks building
+	# tini, as it declares support for old policy versions.
+	#
+	# can be removed once https://github.com/krallin/tini/pull/233 is in a release.
+	cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 .
+
 	make tini-static
 	mkdir -p "${PREFIX}"
 	cp tini-static "${PREFIX}/docker-init"


### PR DESCRIPTION
relates to:

- https://github.com/docker/packaging/pull/362
- https://github.com/docker/packaging/pull/369#issuecomment-3916015345
- https://github.com/krallin/tini/pull/233


The script is failing on Fedora 44, which ships with a newer version of CMake that dropped removed compatibility with CMake < 3.5

    + install_tini
    + echo 'Install tini version v0.19.0' Install tini version v0.19.0
    + git clone https://github.com/krallin/tini.git /go/tini Cloning into '/go/tini'...
    + cd /go/tini
    + git checkout -q v0.19.0
    + cmake . CMake Error at CMakeLists.txt:1 (cmake_minimum_required): Compatibility with CMake < 3.5 has been removed from CMake.

      Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax to tell CMake that the project requires at least <min> but has been updated to work with policies introduced by <max> or earlier.

      Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

