### PR TITLE
client/pkg/jsonmessage: make DisplayJSONMessages accept a iter.Seq2

### DIFF
--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -144,14 +144,14 @@ func Display(jm jsonstream.Message, out io.Writer, isTerminal bool, width uint16
 	return nil
 }
 
-type JSONMessagesStream iter.Seq2[jsonstream.Message, error]
+type JSONMessagesStream = iter.Seq2[jsonstream.Message, error]
 
 // DisplayJSONMessagesStream reads a JSON message stream from in, and writes
 // each [JSONMessage] to out.
 // see DisplayJSONMessages for details
 func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	dec := json.NewDecoder(in)
-	var f JSONMessagesStream = func(yield func(jsonstream.Message, error) bool) {
+	f := func(yield func(jsonstream.Message, error) bool) {
 		for {
 			var jm jsonstream.Message
 			err := dec.Decode(&jm)
@@ -183,7 +183,7 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 //   - auxCallback allows handling the [JSONMessage.Aux] field. It is
 //     called if a JSONMessage contains an Aux field, in which case
 //     DisplayJSONMessagesStream does not present the JSONMessage.
-func DisplayJSONMessages(messages JSONMessagesStream, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
+func DisplayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	ids := make(map[string]uint)
 	var width uint16 = 200
 	if isTerminal {

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -144,14 +144,14 @@ func Display(jm jsonstream.Message, out io.Writer, isTerminal bool, width uint16
 	return nil
 }
 
-type JSONMessagesStream iter.Seq2[jsonstream.Message, error]
+type JSONMessagesStream = iter.Seq2[jsonstream.Message, error]
 
 // DisplayJSONMessagesStream reads a JSON message stream from in, and writes
 // each [JSONMessage] to out.
 // see DisplayJSONMessages for details
 func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	dec := json.NewDecoder(in)
-	var f JSONMessagesStream = func(yield func(jsonstream.Message, error) bool) {
+	f := func(yield func(jsonstream.Message, error) bool) {
 		for {
 			var jm jsonstream.Message
 			err := dec.Decode(&jm)
@@ -183,7 +183,7 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 //   - auxCallback allows handling the [JSONMessage.Aux] field. It is
 //     called if a JSONMessage contains an Aux field, in which case
 //     DisplayJSONMessagesStream does not present the JSONMessage.
-func DisplayJSONMessages(messages JSONMessagesStream, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
+func DisplayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	ids := make(map[string]uint)
 	var width uint16 = 200
 	if isTerminal {


### PR DESCRIPTION
The `DisplayJSONMessages` only accepted a `JSONMessagesStream`. This meant that it would not accept the output from (for example) [client.ImagePushResponse].

This patch:

- Makes `DisplayJSONMessages` accept any `iter.Seq2[jsonstream.Message, error]`
- Makes `JSONMessagesStream` an alias instead of a concrete type (TBD if we actually need the type).
- Some minor cleanups in the implementation.

[client.ImagePushResponse]: https://github.com/moby/moby/blob/fa87120ae64a170fd42096de3b873b439b95016b/client/image_push.go#L20-L24

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client/pkg/jsonmessage.DisplayJSONMessages now accepts an `iter.Seq2[jsonstream.Message, error]` instead of only a `JSONMessagesStream`,
```

**- A picture of a cute animal (not mandatory but encouraged)**

