### PR TITLE
client/pkg/streamformatter: cleanups, fixes and refactor

### DIFF
--- a/client/pkg/streamformatter/streamformatter.go
+++ b/client/pkg/streamformatter/streamformatter.go
@@ -137,9 +137,6 @@ func rawProgressString(p *jsonstream.Progress) string {
 }
 
 func (sf *rawProgressFormatter) formatProgress(id, action string, progress *jsonstream.Progress, aux any) []byte {
-	if progress == nil {
-		progress = &jsonstream.Progress{}
-	}
 	endl := "\r"
 	out := rawProgressString(progress)
 	if out == "" {

--- a/client/pkg/streamformatter/streamformatter.go
+++ b/client/pkg/streamformatter/streamformatter.go
@@ -19,7 +19,7 @@ const streamNewline = "\r\n"
 type jsonProgressFormatter struct{}
 
 func appendNewline(source []byte) []byte {
-	return append(source, []byte(streamNewline)...)
+	return append(source, '\r', '\n')
 }
 
 // formatStatus formats the specified objects according to the specified format (and id).

--- a/client/pkg/streamformatter/streamformatter.go
+++ b/client/pkg/streamformatter/streamformatter.go
@@ -149,8 +149,14 @@ type formatProgress interface {
 }
 
 type progressOutput struct {
-	sf       formatProgress
-	out      io.Writer
+	sf  formatProgress
+	out io.Writer
+
+	// TODO(thaJeztah): investigate if this can be removed or replaced.
+	//
+	// It was a workaround for responses adding an extra (final) (aux) message
+	// progress; see https://github.com/moby/moby/pull/1425. When updating, also
+	// check for the similar implementation in daemon/internal/streamformatter.
 	newLines bool
 	mu       sync.Mutex
 }

--- a/client/pkg/streamformatter/streamformatter_test.go
+++ b/client/pkg/streamformatter/streamformatter_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/moby/moby/api/types/jsonstream"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -72,17 +71,7 @@ func TestJsonProgressFormatterFormatProgress(t *testing.T) {
 		Aux:      &rawAux,
 		Progress: jsonProgress,
 	}
-	assert.DeepEqual(t, msg, expected, cmpJSONMessageOpt())
-}
-
-func cmpJSONMessageOpt() cmp.Option {
-	progressMessagePath := func(path cmp.Path) bool {
-		return path.String() == "ProgressMessage"
-	}
-	return cmp.Options{
-		// Ignore deprecated property that is a derivative of Progress
-		cmp.FilterPath(progressMessagePath, cmp.Ignore()),
-	}
+	assert.DeepEqual(t, msg, expected)
 }
 
 func TestJsonProgressFormatterFormatStatus(t *testing.T) {

--- a/client/pkg/streamformatter/streamformatter_test.go
+++ b/client/pkg/streamformatter/streamformatter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/jsonstream"
+	"github.com/moby/moby/client/pkg/progress"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -80,9 +81,50 @@ func TestJsonProgressFormatterFormatStatus(t *testing.T) {
 	assert.Check(t, is.Equal(`{"status":"a1","id":"ID"}`+streamNewline, string(res)))
 }
 
-func TestNewJSONProgressOutput(t *testing.T) {
-	b := bytes.Buffer{}
-	b.Write(formatStatus("id", "Downloading"))
-	_ = NewJSONProgressOutput(&b, false)
-	assert.Check(t, is.Equal(`{"status":"Downloading","id":"id"}`+streamNewline, b.String()))
+func TestJSONProgressOutputWriteProgress(t *testing.T) {
+	tests := []struct {
+		doc        string
+		newlines   bool
+		lastUpdate bool
+		expected   string
+	}{
+		{
+			doc:      "no newlines",
+			expected: `{"status":"Downloading","id":"id"}` + streamNewline,
+		},
+		{
+			doc:        "no newlines last update",
+			lastUpdate: true,
+			expected:   `{"status":"Downloading","id":"id"}` + streamNewline,
+		},
+		{
+			doc:        "newlines",
+			newlines:   true,
+			lastUpdate: false,
+			expected:   `{"status":"Downloading","id":"id"}` + streamNewline,
+		},
+		{
+			// Should print an extra (empty) message to add newlines after last message
+			// (LastUpdate=true); see https://github.com/moby/moby/pull/1425
+			doc:        "newlines last update",
+			newlines:   true,
+			lastUpdate: true,
+			expected:   `{"status":"Downloading","id":"id"}` + streamNewline + `{}` + streamNewline,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			var b bytes.Buffer
+			po := NewJSONProgressOutput(&b, tc.newlines)
+
+			err := po.WriteProgress(progress.Progress{
+				ID:         "id",
+				Message:    "Downloading",
+				LastUpdate: tc.lastUpdate,
+			})
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(b.String(), tc.expected))
+		})
+	}
 }

--- a/client/pkg/streamformatter/streamformatter_test.go
+++ b/client/pkg/streamformatter/streamformatter_test.go
@@ -3,7 +3,6 @@ package streamformatter
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 
@@ -14,53 +13,32 @@ import (
 )
 
 func TestRawProgressFormatterFormatStatus(t *testing.T) {
-	sf := rawProgressFormatter{}
-	res := sf.formatStatus("ID", "%s%d", "a", 1)
-	assert.Check(t, is.Equal("a1\r\n", string(res)))
+	res := new(rawProgressFormatter).formatStatus("ID", "status")
+	expected := "status" + streamNewline
+	assert.Check(t, is.Equal(string(res), expected))
 }
 
 func TestRawProgressFormatterFormatProgress(t *testing.T) {
-	sf := rawProgressFormatter{}
 	jsonProgress := &jsonstream.Progress{
 		Current: 15,
 		Total:   30,
 		Start:   1,
 	}
-	res := sf.formatProgress("id", "action", jsonProgress, nil)
+	res := new(rawProgressFormatter).formatProgress("id", "action", jsonProgress, nil)
 	out := string(res)
 	assert.Check(t, strings.HasPrefix(out, "action [===="))
 	assert.Check(t, is.Contains(out, "15B/30B"))
 	assert.Check(t, strings.HasSuffix(out, "\r"))
 }
 
-func TestFormatStatus(t *testing.T) {
-	res := formatStatus("ID", "%s%d", "a", 1)
-	expected := `{"status":"a1","id":"ID"}` + streamNewline
-	assert.Check(t, is.Equal(expected, string(res)))
-}
-
-func TestFormatError(t *testing.T) {
-	res := formatError(errors.New("Error for formatter"))
-	expected := `{"errorDetail":{"message":"Error for formatter"}}` + "\r\n"
-	assert.Check(t, is.Equal(expected, string(res)))
-}
-
-func TestFormatJSONError(t *testing.T) {
-	err := &jsonstream.Error{Code: 50, Message: "Json error"}
-	res := formatError(err)
-	expected := `{"errorDetail":{"code":50,"message":"Json error"}}` + streamNewline
-	assert.Check(t, is.Equal(expected, string(res)))
-}
-
-func TestJsonProgressFormatterFormatProgress(t *testing.T) {
-	sf := &jsonProgressFormatter{}
+func TestJSONProgressFormatterFormatProgress(t *testing.T) {
 	jsonProgress := &jsonstream.Progress{
 		Current: 15,
 		Total:   30,
 		Start:   1,
 	}
 	aux := "aux message"
-	res := sf.formatProgress("id", "action", jsonProgress, aux)
+	res := new(jsonProgressFormatter).formatProgress("id", "action", jsonProgress, aux)
 	msg := &jsonstream.Message{}
 
 	assert.NilError(t, json.Unmarshal(res, msg))
@@ -75,10 +53,10 @@ func TestJsonProgressFormatterFormatProgress(t *testing.T) {
 	assert.DeepEqual(t, msg, expected)
 }
 
-func TestJsonProgressFormatterFormatStatus(t *testing.T) {
-	sf := jsonProgressFormatter{}
-	res := sf.formatStatus("ID", "%s%d", "a", 1)
-	assert.Check(t, is.Equal(`{"status":"a1","id":"ID"}`+streamNewline, string(res)))
+func TestJSONProgressFormatterFormatStatus(t *testing.T) {
+	res := new(jsonProgressFormatter).formatStatus("ID", "status")
+	expected := `{"status":"status","id":"ID"}` + streamNewline
+	assert.Check(t, is.Equal(string(res), expected))
 }
 
 func TestJSONProgressOutputWriteProgress(t *testing.T) {


### PR DESCRIPTION
### client/pkg/streamformatter: remove redundant cmp-opts in test

This option was added to handle the deprecated `ProgressMessage` field,
which was removed in fdaccdb2331ebcff9a36e81a4bf1404c84d822ae.

### client/pkg/streamformatter: fix faulty TestNewJSONProgressOutput

This  test was added in 956c5b61cea9e476847b9d2231ac66d3ec85f018, but
wasn't really testing anything (other than testing stdlib).

Ironically there was a review comment on the PR, but about the naming
of the test, and not about the test itself;

> but it isn't really testing NewJSONProgressOutput. NewJSONProgressOutput
> just returns a struct. IMHO it's testing WriteProgress.

Let's make the test test something.


### client/pkg/streamformatter: remove redundant nil check

rawProgressString already checks for nil-values;
https://github.com/moby/moby/blob/f222c1ed0532b338c9761729bd6a6d1779fa4698/client/pkg/streamformatter/streamformatter.go#L83-L86

### client/pkg/streamformatter: optimize appendNewline

This function is called repeatedly; slightly optimize it.


###  client/pkg/streamformatter: add TODO for NewLines option

The "newLines" option was added in ba17f4a06a75a66e11b6cf2ca2cdb5bee4f7bfa8
to handle a display issue where an error during `docker build` would overwrite
a previous line due to a missing newline at the end. It was carried over in
refactorings (12b278d3540bc32699e8c2197b556188fd98b77b) and new implementations
(572ce802306a4e919802e5b77cbeca94acda7c0a).

It's used for `docker build` (see [1], [2]), and on `docker pull` ([3]); my
suspicion is that the common denominator is that these responses use `Aux`
message for the last response.

We should look if this option is still needed, or if it could be fixed
either by the Aux message itself, or by detecting that an Aux message
will be printed.

[1]: https://github.com/moby/moby/blob/f222c1ed0532b338c9761729bd6a6d1779fa4698/daemon/server/router/build/build_routes.go#L310
[2]: https://github.com/moby/moby/blob/f222c1ed0532b338c9761729bd6a6d1779fa4698/daemon/builder/dockerfile/copy.go#L413
[3]: https://github.com/moby/moby/blob/f222c1ed0532b338c9761729bd6a6d1779fa4698/daemon/server/router/image/image_routes.go#L145

### client/pkg/streamformatter: use blackbox testing

Don't test the internals, just the result.

### client/pkg/streamformatter: refactor

Internalize the `formatStatus` and `formatProgress` methods and consolidate
them into a single `format` method. The different implementations used
different arguments for these, so make those details internal to the
implementation.

Introduce an `emptyMessage` method, which is still used for the JSON formatter
but needs to be looked into.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

