### PR TITLE
Add compatibility with API v1.40 and up

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -111,7 +111,7 @@ const MaxAPIVersion = "1.53"
 
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.
-const MinAPIVersion = "1.41"
+const MinAPIVersion = "1.40"
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}

--- a/client/client.go
+++ b/client/client.go
@@ -111,7 +111,7 @@ const MaxAPIVersion = "1.53"
 
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.
-const MinAPIVersion = "1.44"
+const MinAPIVersion = "1.41"
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -64,7 +64,7 @@ const (
 	// This version can be overridden through the "DOCKER_MIN_API_VERSION"
 	// environment variable. The minimum allowed version is determined
 	// by [MinAPIVersion].
-	defaultMinAPIVersion = "1.44"
+	defaultMinAPIVersion = "1.41"
 	// MinAPIVersion is the minimum API version supported by the daemon.
 	MinAPIVersion = "1.24"
 	// SeccompProfileDefault is the built-in default seccomp profile.

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -64,7 +64,7 @@ const (
 	// This version can be overridden through the "DOCKER_MIN_API_VERSION"
 	// environment variable. The minimum allowed version is determined
 	// by [MinAPIVersion].
-	defaultMinAPIVersion = "1.41"
+	defaultMinAPIVersion = "1.40"
 	// MinAPIVersion is the minimum API version supported by the daemon.
 	MinAPIVersion = "1.24"
 	// SeccompProfileDefault is the built-in default seccomp profile.

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -34,6 +34,10 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+// errLegacyCapabilities is returned when a client sends the deprecated
+// HostConfig.Capabilities field, which this daemon can no longer fulfill.
+var errLegacyCapabilities = errdefs.InvalidParameter(errors.New("the HostConfig.Capabilities field is not supported by this daemon; use CapAdd and CapDrop to set capabilities"))
+
 // commitRequest may contain an optional [container.Config].
 type commitRequest struct {
 	*container.Config
@@ -672,8 +676,19 @@ func (c *containerRouter) postContainersCreate(ctx context.Context, w http.Respo
 			//
 			// MacAddress field is deprecated since API v1.44. Use EndpointSettings.MacAddress instead.
 			MacAddress network.HardwareAddr `json:",omitempty"`
+
+			HostConfig struct {
+				// Capabilities was removed in commit 24f173a003 for
+				// API version 1.41, favoring CapAdd and CapDrop instead.
+				Capabilities []string `json:",omitempty"`
+			} `json:",omitempty"`
 		}
 		_ = json.Unmarshal(requestBody.Bytes(), &legacyConfig)
+
+		if err := rejectLegacyCapabilities(legacyConfig.HostConfig.Capabilities, version); err != nil {
+			return err
+		}
+
 		if warn, err := handleMACAddressBC(hostConfig, networkingConfig, version, legacyConfig.MacAddress); err != nil {
 			return err
 		} else if warn != "" {
@@ -739,6 +754,26 @@ func handleVolumeDriverBC(version string, hostConfig *container.HostConfig) (war
 		return "WARNING: the container-wide volume-driver configuration is ignored for volumes specified via 'mount'. Use '--mount type=volume,volume-driver=...' instead"
 	}
 	return ""
+}
+
+// rejectLegacyCapabilities returns an error if the deprecated
+// HostConfig.Capabilities field is present in a request for API version 1.40.
+//
+// The Capabilities field was added in API 1.40 (Docker 19.03) as a way to
+// specify the exact set of kernel capabilities for a container, overriding
+// the CapAdd/CapDrop mechanism. It was removed before API 1.41 (Docker 20.10)
+// because putting the burden of providing the full capability list on the
+// client was considered a poor design (see 24f173a003).
+//
+// The field has since been deleted from the API type, so json.Unmarshal
+// silently drops it. This daemon cannot honor the field, so it is best to
+// return an explicit error rather than silently ignoring the field when it is
+// expected to be supported.
+func rejectLegacyCapabilities(capabilities []string, version string) error {
+	if len(capabilities) > 0 && versions.Equal(version, "1.40") {
+		return errLegacyCapabilities
+	}
+	return nil
 }
 
 // handleMACAddressBC takes care of backward-compatibility for the container-wide MAC address by mutating the

--- a/daemon/server/router/container/container_routes_test.go
+++ b/daemon/server/router/container/container_routes_test.go
@@ -236,6 +236,58 @@ func TestEpConfigForNetMode(t *testing.T) {
 	}
 }
 
+func TestRejectLegacyCapabilities(t *testing.T) {
+	testcases := []struct {
+		name         string
+		apiVersion   string
+		capabilities []string
+		expError     bool
+	}{
+		{
+			name:         "API 1.40 with capabilities is rejected",
+			apiVersion:   "1.40",
+			capabilities: []string{"CAP_NET_RAW", "CAP_SYS_CHROOT"},
+			expError:     true,
+		},
+		{
+			name:         "API 1.40 with empty capabilities is allowed",
+			apiVersion:   "1.40",
+			capabilities: []string{},
+		},
+		{
+			name:         "API 1.40 with nil capabilities is allowed",
+			apiVersion:   "1.40",
+			capabilities: nil,
+		},
+		{
+			name:         "API 1.41 with capabilities is ignored",
+			apiVersion:   "1.41",
+			capabilities: []string{"CAP_NET_RAW"},
+		},
+		{
+			name:         "API 1.43 with capabilities is ignored",
+			apiVersion:   "1.43",
+			capabilities: []string{"CAP_NET_RAW"},
+		},
+		{
+			name:         "API 1.44 with capabilities is ignored",
+			apiVersion:   "1.44",
+			capabilities: []string{"CAP_NET_RAW"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := rejectLegacyCapabilities(tc.capabilities, tc.apiVersion)
+			if !tc.expError {
+				assert.Check(t, err)
+			} else {
+				assert.Check(t, is.ErrorIs(err, errLegacyCapabilities))
+			}
+		})
+	}
+}
+
 func TestHandleSysctlBC(t *testing.T) {
 	testcases := []struct {
 		name               string

--- a/daemon/server/router/image/image_list_response_test.go
+++ b/daemon/server/router/image/image_list_response_test.go
@@ -1,0 +1,81 @@
+package image
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/v2/daemon/internal/compat"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestImageListVirtualSize verifies that wrapping image summaries with
+// compat.Wrap injects a VirtualSize field equal to Size for older API
+// versions (< 1.44), and that VirtualSize is absent when the wrapper
+// is not used.
+func TestImageListVirtualSize(t *testing.T) {
+	images := []image.Summary{
+		{
+			ID:          "sha256:abc123",
+			RepoTags:    []string{"myimage:latest"},
+			RepoDigests: []string{},
+			Size:        12345,
+			SharedSize:  -1,
+			Containers:  -1,
+		},
+		{
+			ID:          "sha256:def456",
+			RepoTags:    []string{},
+			RepoDigests: []string{"myimage@sha256:def456"},
+			Size:        67890,
+			SharedSize:  -1,
+			Containers:  -1,
+		},
+	}
+
+	t.Run("with VirtualSize (API < 1.44)", func(t *testing.T) {
+		wrapped := make([]*compat.Wrapper, len(images))
+		for i := range images {
+			wrapped[i] = compat.Wrap(&images[i], compat.WithExtraFields(map[string]any{
+				"VirtualSize": images[i].Size,
+			}))
+		}
+
+		out, err := json.Marshal(wrapped)
+		assert.NilError(t, err)
+
+		var result []map[string]any
+		err = json.Unmarshal(out, &result)
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(result, 2))
+
+		for i, img := range result {
+			vs, ok := img["VirtualSize"]
+			assert.Assert(t, ok, "VirtualSize should be present for image %d", i)
+			// json.Unmarshal decodes numbers as float64
+			assert.Check(t, is.Equal(vs, float64(images[i].Size)),
+				"VirtualSize should equal Size for image %d", i)
+
+			sz, ok := img["Size"]
+			assert.Assert(t, ok, "Size should be present for image %d", i)
+			assert.Check(t, is.Equal(sz, float64(images[i].Size)),
+				"Size should be preserved for image %d", i)
+		}
+	})
+
+	t.Run("without VirtualSize (API >= 1.44)", func(t *testing.T) {
+		out, err := json.Marshal(images)
+		assert.NilError(t, err)
+
+		var result []map[string]any
+		err = json.Unmarshal(out, &result)
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(result, 2))
+
+		for i, img := range result {
+			_, ok := img["VirtualSize"]
+			assert.Assert(t, !ok, "VirtualSize should NOT be present for image %d", i)
+		}
+	})
+}

--- a/daemon/server/router/image/image_routes.go
+++ b/daemon/server/router/image/image_routes.go
@@ -531,6 +531,16 @@ func (ir *imageRouter) getImagesJSON(ctx context.Context, w http.ResponseWriter,
 		}
 	}
 
+	if versions.LessThan(version, "1.44") {
+		wrapped := make([]*compat.Wrapper, len(images))
+		for i := range images {
+			wrapped[i] = compat.Wrap(&images[i], compat.WithExtraFields(map[string]any{
+				"VirtualSize": images[i].Size,
+			}))
+		}
+		return httputils.WriteJSON(w, http.StatusOK, wrapped)
+	}
+
 	return httputils.WriteJSON(w, http.StatusOK, images)
 }
 

--- a/daemon/server/router/system/disk_usage_test.go
+++ b/daemon/server/router/system/disk_usage_test.go
@@ -1,0 +1,142 @@
+package system
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/v2/daemon/internal/compat"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestDiskUsageVirtualSize verifies that wrapping the legacyDiskUsage
+// struct with compat.Wrap injects VirtualSize into each image summary
+// for older API versions (< 1.44), and that VirtualSize is absent when
+// the wrapper is not used.
+func TestDiskUsageVirtualSize(t *testing.T) {
+	legacy := legacyDiskUsage{
+		LayersSize: 100000,
+		Images: []image.Summary{
+			{
+				ID:          "sha256:abc123",
+				RepoTags:    []string{"myimage:latest"},
+				RepoDigests: []string{},
+				Size:        12345,
+				SharedSize:  -1,
+				Containers:  -1,
+			},
+			{
+				ID:          "sha256:def456",
+				RepoTags:    []string{},
+				RepoDigests: []string{"myimage@sha256:def456"},
+				Size:        67890,
+				SharedSize:  -1,
+				Containers:  -1,
+			},
+		},
+	}
+
+	t.Run("with VirtualSize (API < 1.44)", func(t *testing.T) {
+		wrappedImages := make([]*compat.Wrapper, len(legacy.Images))
+		for i := range legacy.Images {
+			wrappedImages[i] = compat.Wrap(&legacy.Images[i], compat.WithExtraFields(map[string]any{
+				"VirtualSize": legacy.Images[i].Size,
+			}))
+		}
+
+		wrapped := compat.Wrap(&legacy,
+			compat.WithOmittedFields("Images"),
+			compat.WithExtraFields(map[string]any{
+				"Images": wrappedImages,
+			}),
+		)
+
+		out, err := json.Marshal(wrapped)
+		assert.NilError(t, err)
+
+		var result map[string]any
+		err = json.Unmarshal(out, &result)
+		assert.NilError(t, err)
+
+		imagesRaw, ok := result["Images"]
+		assert.Assert(t, ok, "Images field should be present")
+
+		imagesList, ok := imagesRaw.([]any)
+		assert.Assert(t, ok, "Images should be an array")
+		assert.Assert(t, is.Len(imagesList, 2))
+
+		for i, imgRaw := range imagesList {
+			img, ok := imgRaw.(map[string]any)
+			assert.Assert(t, ok, "each image should be an object")
+
+			vs, ok := img["VirtualSize"]
+			assert.Assert(t, ok, "VirtualSize should be present for image %d", i)
+			assert.Check(t, is.Equal(vs, float64(legacy.Images[i].Size)),
+				"VirtualSize should equal Size for image %d", i)
+
+			sz, ok := img["Size"]
+			assert.Assert(t, ok, "Size should be present for image %d", i)
+			assert.Check(t, is.Equal(sz, float64(legacy.Images[i].Size)),
+				"Size should be preserved for image %d", i)
+		}
+
+		// LayersSize should still be present
+		ls, ok := result["LayersSize"]
+		assert.Assert(t, ok, "LayersSize should be present")
+		assert.Check(t, is.Equal(ls, float64(100000)))
+	})
+
+	t.Run("without VirtualSize (API >= 1.44)", func(t *testing.T) {
+		out, err := json.Marshal(&legacy)
+		assert.NilError(t, err)
+
+		var result map[string]any
+		err = json.Unmarshal(out, &result)
+		assert.NilError(t, err)
+
+		imagesRaw, ok := result["Images"]
+		assert.Assert(t, ok, "Images field should be present")
+
+		imagesList, ok := imagesRaw.([]any)
+		assert.Assert(t, ok, "Images should be an array")
+		assert.Assert(t, is.Len(imagesList, 2))
+
+		for i, imgRaw := range imagesList {
+			img, ok := imgRaw.(map[string]any)
+			assert.Assert(t, ok, "each image should be an object")
+
+			_, ok = img["VirtualSize"]
+			assert.Assert(t, !ok, "VirtualSize should NOT be present for image %d", i)
+		}
+	})
+
+	t.Run("empty images list", func(t *testing.T) {
+		emptyLegacy := legacyDiskUsage{
+			LayersSize: 0,
+			Images:     []image.Summary{},
+		}
+
+		// Even with the wrapping logic, empty images should produce an empty array
+		wrappedImages := make([]*compat.Wrapper, 0)
+		wrapped := compat.Wrap(&emptyLegacy,
+			compat.WithOmittedFields("Images"),
+			compat.WithExtraFields(map[string]any{
+				"Images": wrappedImages,
+			}),
+		)
+
+		out, err := json.Marshal(wrapped)
+		assert.NilError(t, err)
+
+		var result map[string]any
+		err = json.Unmarshal(out, &result)
+		assert.NilError(t, err)
+
+		imagesRaw, ok := result["Images"]
+		assert.Assert(t, ok, "Images field should be present")
+		imagesList, ok := imagesRaw.([]any)
+		assert.Assert(t, ok, "Images should be an array")
+		assert.Assert(t, is.Len(imagesList, 0))
+	})
+}

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -237,6 +237,20 @@ func (s *systemRouter) getDiskUsage(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 	if versions.LessThan(version, "1.52") {
+		if versions.LessThan(version, "1.44") && len(legacy.Images) > 0 {
+			wrappedImages := make([]*compat.Wrapper, len(legacy.Images))
+			for i := range legacy.Images {
+				wrappedImages[i] = compat.Wrap(&legacy.Images[i], compat.WithExtraFields(map[string]any{
+					"VirtualSize": legacy.Images[i].Size,
+				}))
+			}
+			return httputils.WriteJSON(w, http.StatusOK, compat.Wrap(&legacy,
+				compat.WithOmittedFields("Images"),
+				compat.WithExtraFields(map[string]any{
+					"Images": wrappedImages,
+				}),
+			))
+		}
 		return httputils.WriteJSON(w, http.StatusOK, &legacy)
 	}
 

--- a/integration/container/create_test.go
+++ b/integration/container/create_test.go
@@ -762,6 +762,7 @@ func TestCreateWithMultipleEndpointSettings(t *testing.T) {
 
 func TestCreateWithCustomMACs(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType == "windows")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "requires API v1.44")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/container/exec_linux_test.go
+++ b/integration/container/exec_linux_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/skip"
@@ -12,6 +13,7 @@ import (
 
 func TestExecConsoleSize(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.42"), "requires API v1.42")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/container/ipcmode_linux_test.go
+++ b/integration/container/ipcmode_linux_test.go
@@ -9,6 +9,7 @@ import (
 
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
 	"github.com/moby/moby/v2/internal/testutil/daemon"
@@ -315,6 +316,7 @@ func TestDaemonIpcModeShareableFromConfig(t *testing.T) {
 // by default, even when the daemon default is private.
 func TestIpcModeOlderClient(t *testing.T) {
 	apiClient := testEnv.APIClient()
+	skip.If(t, versions.LessThan(apiClient.ClientVersion(), "1.40"), "requires client API >= 1.40")
 
 	t.Parallel()
 

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -18,6 +18,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/integration/internal/container"
 	net "github.com/moby/moby/v2/integration/internal/network"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -178,6 +179,7 @@ func TestPrivilegedHostDevices(t *testing.T) {
 
 func TestRunConsoleSize(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.42"), "requires API v1.42")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/integration/internal/container"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -261,6 +262,8 @@ func TestAPIImagesListManifests(t *testing.T) {
 		assert.Assert(t, is.Len(imageList.Items, 1))
 		assert.Check(t, is.Nil(imageList.Items[0].Manifests))
 	})
+
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.47"), "requires API v1.47")
 
 	api147 := d.NewClientT(t, client.WithAPIVersion("1.47"))
 

--- a/integration/image/save_test.go
+++ b/integration/image/save_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cpuguy83/tar2go"
 	"github.com/moby/go-archive/compression"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/integration/internal/build"
 	"github.com/moby/moby/v2/integration/internal/container"
 	iimage "github.com/moby/moby/v2/integration/internal/image"
@@ -90,6 +91,8 @@ func TestSaveCheckTimes(t *testing.T) {
 
 // Regression test for https://github.com/moby/moby/issues/47065
 func TestSaveOCI(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "OCI layout support was introduced in v25")
+
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 

--- a/integration/network/bridge/bridge_linux_test.go
+++ b/integration/network/bridge/bridge_linux_test.go
@@ -14,6 +14,7 @@ import (
 	containertypes "github.com/moby/moby/api/types/container"
 	networktypes "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge"
 	"github.com/moby/moby/v2/daemon/libnetwork/netlabel"
@@ -31,6 +32,8 @@ import (
 )
 
 func TestCreateWithMultiNetworks(t *testing.T) {
+	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "requires API v1.44")
+
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
 

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -111,7 +111,7 @@ const MaxAPIVersion = "1.53"
 
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.
-const MinAPIVersion = "1.41"
+const MinAPIVersion = "1.40"
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -111,7 +111,7 @@ const MaxAPIVersion = "1.53"
 
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.
-const MinAPIVersion = "1.44"
+const MinAPIVersion = "1.41"
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}


### PR DESCRIPTION
Restores API versions all the way back to v1.40.
All the API gates were still in place.
Some minor fixups:

1. Add VirtualSize to the response object older API versions for image list and disk usage endpoints.
2. Error if client sets HostConfig.Capabilities on version 1.40 which we can't easily fulfill.
3. Add test skips where necessary


```markdown changelog
Lower minimum API version from v1.44 to v1.40 (Docker 19.03).
```
