### PR TITLE
daemon: remove obsolete warning for legacy "overlay"

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -150,16 +150,6 @@ func (daemon *Daemon) SystemVersion(ctx context.Context) (system.VersionResponse
 func (daemon *Daemon) fillDriverInfo(v *system.Info) {
 	v.Driver = daemon.imageService.StorageDriver()
 	v.DriverStatus = daemon.imageService.LayerStoreStatus()
-
-	const warnMsg = `
-WARNING: The %s storage-driver is deprecated, and will be removed in a future release.
-         Refer to the documentation for more information: https://docs.docker.com/go/storage-driver/`
-
-	switch v.Driver {
-	case "overlay":
-		v.Warnings = append(v.Warnings, fmt.Sprintf(warnMsg, v.Driver))
-	}
-
 	fillDriverWarnings(v)
 }
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45359

The driver was removed in f72548956faa500b30c2086f5609bee1d2a4cd56, so users won't be able to have it configured.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

