### PR TITLE
container/logs: add support for JSON streams (experimental)

### DIFF
--- a/daemon/server/httputils/logstream/json_logstream.go
+++ b/daemon/server/httputils/logstream/json_logstream.go
@@ -1,0 +1,119 @@
+package logstream
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/moby/moby/v2/daemon/server/backend"
+	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/pkg/ioutils"
+)
+
+// WriteJSON writes a JSON stream of log messages from the messages channel.
+func WriteJSON(ctx context.Context, w http.ResponseWriter, msgs <-chan *backend.LogMessage, config *backend.ContainerLogsOptions) {
+	// See https://github.com/moby/moby/issues/47448
+	// Trigger headers to be written immediately.
+	w.WriteHeader(http.StatusOK)
+
+	wf := ioutils.NewWriteFlusher(w)
+	defer wf.Close()
+
+	wf.Flush()
+
+	jsonWriter := newJSONLogWriter(wf, w.Header().Get("Content-Type"), config)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-msgs:
+			if !ok {
+				return
+			}
+			if msg.Err != nil {
+				// message contains an error; write the error and continue
+				jsonWriter.write(msg)
+				continue
+			}
+			switch msg.Source {
+			case "stdout":
+				if config.ShowStdout {
+					jsonWriter.write(msg)
+				}
+			case "stderr":
+				if config.ShowStderr {
+					jsonWriter.write(msg)
+				}
+			default:
+				// unknown source
+			}
+		}
+	}
+}
+
+type jsonLogWriter struct {
+	encode  httputils.EncoderFn
+	details bool
+}
+
+func newJSONLogWriter(w io.Writer, contentType string, opts *backend.ContainerLogsOptions) *jsonLogWriter {
+	encode := httputils.NewJSONStreamEncoder(w, contentType)
+	return &jsonLogWriter{
+		encode:  encode,
+		details: opts != nil && opts.Details,
+	}
+}
+
+// jsonLogMessage represents a single log entry in JSON log streaming format.
+//
+// Each message is serialized as a standalone JSON object and emitted as
+// part of a stream (one object per line) in container log responses when
+// a JSON-formatted output is requested.
+//
+// TODO(thaJeztah): move to the api module and generate from swagger.
+type jsonLogMessage struct {
+	// Line contains the log payload as UTF-8 text when text encoding is used.
+	// When an alternate encoding is requested, this field is omitted.
+	Line string `json:"Line,omitempty"`
+
+	// Source identifies the originating stream ("stdout" or "stderr").
+	Source string `json:"Source,omitempty"`
+
+	// Timestamp is the time at which the log record was produced,
+	// encoded in RFC3339Nano format.
+	Timestamp time.Time `json:"Timestamp,omitempty"`
+
+	// Attrs contains optional structured attributes when "details" is
+	// enabled, and if supported by the logging driver in use.
+	Attrs []backend.LogAttr `json:"Attrs,omitempty"`
+
+	// MetaData contains metadata for partial log records that must be
+	// reassembled by the client.
+	MetaData *backend.PartialLogMetaData `json:"MetaData,omitempty"`
+
+	// Error contains an associated error encountered while processing the
+	// log message, if any.
+	Error string `json:"Error,omitempty"`
+}
+
+func (w *jsonLogWriter) write(msg *backend.LogMessage) {
+	var errMsg string
+	if msg.Err != nil {
+		errMsg = msg.Err.Error()
+	}
+
+	var attrs []backend.LogAttr
+	if w.details {
+		attrs = msg.Attrs
+	}
+
+	_ = w.encode(jsonLogMessage{
+		Line:      string(msg.Line),
+		Source:    msg.Source,
+		Timestamp: msg.Timestamp,
+		Attrs:     attrs,
+		MetaData:  msg.PLogMetaData,
+		Error:     errMsg,
+	})
+}

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -28,6 +28,7 @@ import (
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httpstatus"
 	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/daemon/server/httputils/contenttype"
 	"github.com/moby/moby/v2/daemon/server/httputils/logstream"
 	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/ioutils"
@@ -182,6 +183,12 @@ func (c *containerRouter) getContainersStats(ctx context.Context, w http.Respons
 	})
 }
 
+var jsonTypes = []string{
+	types.MediaTypeJSONLines,
+	types.MediaTypeNDJSON,
+	types.MediaTypeJSONSequence,
+}
+
 func (c *containerRouter) getContainersLogs(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
@@ -215,6 +222,23 @@ func (c *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 		}
 	}
 
+	var logFormat string
+	// TODO(thaJeztah): this is currently experimental; there is no implementation
+	// for this feature yet in the client, and the response struct is not yet part
+	// of the API type definitions. Change this to API 1.55 once the remaining parts
+	// are completed.
+	if versions.GreaterThanOrEqualTo(httputils.VersionFromContext(ctx), "1.54") {
+		// Opt-in through "format" query-arg or JSON stream "Accept" header if
+		// set; wildcards ("*/*", "application/*") are not considered.
+		logFormat = r.Form.Get("format")
+		if logFormat != "" && logFormat != "json" {
+			return errdefs.InvalidParameter(errors.New("unsupported log format"))
+		}
+		if logFormat == "" && contenttype.MatchAcceptStrict(r.Header, jsonTypes) != "" {
+			logFormat = "json"
+		}
+	}
+
 	containerName := vars["name"]
 	logsConfig := &backend.ContainerLogsOptions{
 		Follow:     httputils.BoolValue(r, "follow"),
@@ -230,6 +254,12 @@ func (c *containerRouter) getContainersLogs(ctx context.Context, w http.Response
 	msgs, tty, err := c.backend.ContainerLogs(ctx, containerName, logsConfig)
 	if err != nil {
 		return err
+	}
+
+	if logFormat == "json" {
+		w.Header().Set("Content-Type", contenttype.Negotiate(r.Header, jsonTypes, types.MediaTypeNDJSON))
+		logstream.WriteJSON(ctx, w, msgs, logsConfig)
+		return nil
 	}
 
 	contentType := types.MediaTypeRawStream


### PR DESCRIPTION
This adds support for streaming logs as JSON stream either through an "Accept" header ("application/jsonl", "application/x-ndjson", or "application/json-seq"), or through a `format=json` query variable.

By default log messages are included as UTF-8 encoded strings, which should work for regular logs, but can be lossy.

```bash
docker rm -fv my-container3
docker run \
    -qit \
    --name my-container3 \
    --label=labelA=foo \
    --label=labelB=bar \
    --log-opt labels=labelA,labelB \
    ubuntu bash
```

Inside the container:

```bash
root@b36bfcd439e9:/# echo {1..9} && exit
1 2 3 4 5 6 7 8 9
exit
```

With the message encoded as utf-8;

```bash
curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.54/containers/my-container3/logs?stdout=1&stderr=1&format=json' | jq .
{
  "Line": "\u001b[?2004h\u001b]0;root@1065b85dd167: /\u0007root@1065b85dd167:/# \u001b[7mecho {1..9} && exit\u001b[27m\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\becho {1..9} && exit\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.083531419Z"
}
{
  "Line": "\u001b[?2004l\r1 2 3 4 5 6 7 8 9\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.088152377Z"
}
{
  "Line": "exit\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.088183336Z"
}
```

With `details` enabled;

```bash
curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.54/containers/my-container3/logs?stdout=1&stderr=1&format=json&details=1' | jq .
{
  "Line": "\u001b[?2004h\u001b]0;root@1065b85dd167: /\u0007root@1065b85dd167:/# \u001b[7mecho {1..9} && exit\u001b[27m\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\becho {1..9} && exit\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.083531419Z",
  "Attrs": [{"Key": "labelA","Value": "foo"},{"Key": "labelB","Value": "bar"}]
}
{
  "Line": "\u001b[?2004l\r1 2 3 4 5 6 7 8 9\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.088152377Z",
  "Attrs": [{"Key": "labelA","Value": "foo"},{"Key": "labelB","Value": "bar"}]
}
{
  "Line": "exit\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.088183336Z",
  "Attrs": [{"Key": "labelA","Value": "foo"},{"Key": "labelB","Value": "bar"}]
}
```

Using `Accept` header instead of the `format=json` query parameter;

```bash
curl -s -H 'Accept: application/json-seq' --unix-socket /var/run/docker.sock 'http://localhost/v1.54/containers/my-container3/logs?stdout=1&stderr=1' | jq .
{
  "Line": "\u001b[?2004h\u001b]0;root@1065b85dd167: /\u0007root@1065b85dd167:/# \u001b[7mecho {1..9} && exit\u001b[27m\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\becho {1..9} && exit\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.083531419Z"
}
{
  "Line": "\u001b[?2004l\r1 2 3 4 5 6 7 8 9\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.088152377Z"
}
{
  "Line": "exit\r\n",
  "Source": "stdout",
  "Timestamp": "2026-02-20T15:39:01.088183336Z"
}
```

Metadata about partial messages is included (except for the json-file logging driver, which doesn't use it currently);

The partial messages also don't get a trailing newline, except for the last entry;

```bash
docker run --name bar alpine sh -c 'head -c 20000 /dev/zero | tr "\0" A; echo'
curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.54/containers/bar/logs?stdout=1&stderr=1&format=json'
{"Line":"AAAAAAAAAA....AAAA","Source":"stdout","Timestamp":"2026-02-21T21:45:47.075093919Z"}
{"Line":"AAAAAAAAAAAAAAAA\n","Source":"stdout","Timestamp":"2026-02-21T21:45:47.075093919Z"}
```

And for logging drivers other than the `json-file`, we have information about partials in a slightly more structured format:

```bash
docker run --name baz --log-driver=local alpine sh -c 'head -c 20000 /dev/zero | tr "\0" A; echo'
curl -s --unix-socket /var/run/docker.sock 'http://localhost/v1.54/containers/baz/logs?stdout=1&stderr=1&format=json'
{"Line":"AAAAAAAAAA....ASAA","Source":"stdout","Timestamp":"2026-02-21T21:49:42.453363584Z","LogMetaData":{"Last":false,"ID":"46a9188a552a068c1d63a5096b7335788aea7e430817f3d2d83c5fd90c6365ef","Ordinal":1}}
{"Line":"AAAAAAAAAAAAAAAA\n","Source":"stdout","Timestamp":"2026-02-21T21:49:42.453363584Z","LogMetaData":{"Last":true,"ID":"46a9188a552a068c1d63a5096b7335788aea7e430817f3d2d83c5fd90c6365ef","Ordinal":2}}
```


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

