### PR TITLE
daemon: prevent invalid swarm events from unknown action kinds

### DIFF
--- a/daemon/events_test.go
+++ b/daemon/events_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 	"time"
 
+	gogotypes "github.com/gogo/protobuf/types"
 	containertypes "github.com/moby/moby/api/types/container"
 	eventtypes "github.com/moby/moby/api/types/events"
 	"github.com/moby/moby/v2/daemon/container"
 	"github.com/moby/moby/v2/daemon/events"
+	swarmapi "github.com/moby/swarmkit/v2/api"
 )
 
 func TestLogContainerEventCopyLabels(t *testing.T) {
@@ -85,5 +87,76 @@ func validateTestAttributes(t *testing.T, l chan any, expectedAttributesToTest m
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("LogEvent test timed out")
+	}
+}
+
+func TestEventTimestamp(t *testing.T) {
+	now := time.Now()
+	createdAt := &gogotypes.Timestamp{Seconds: now.Unix(), Nanos: int32(now.Nanosecond())}
+	updatedAt := &gogotypes.Timestamp{Seconds: now.Add(time.Hour).Unix(), Nanos: int32(now.Add(time.Hour).Nanosecond())}
+
+	tests := []struct {
+		doc    string
+		meta   swarmapi.Meta
+		action swarmapi.WatchActionKind
+		check  func(t *testing.T, result time.Time)
+	}{
+		{
+			doc:    "Create action uses CreatedAt timestamp",
+			meta:   swarmapi.Meta{CreatedAt: createdAt},
+			action: swarmapi.WatchActionKindCreate,
+			check: func(t *testing.T, result time.Time) {
+				if result.Unix() != now.Unix() {
+					t.Errorf("expected CreatedAt timestamp, got %v", result)
+				}
+			},
+		},
+		{
+			doc:    "Update action uses UpdatedAt timestamp",
+			meta:   swarmapi.Meta{UpdatedAt: updatedAt},
+			action: swarmapi.WatchActionKindUpdate,
+			check: func(t *testing.T, result time.Time) {
+				if result.Unix() != now.Add(time.Hour).Unix() {
+					t.Errorf("expected UpdatedAt timestamp, got %v", result)
+				}
+			},
+		},
+		{
+			doc:    "Remove action uses current time",
+			meta:   swarmapi.Meta{},
+			action: swarmapi.WatchActionKindRemove,
+			check: func(t *testing.T, result time.Time) {
+				if result.IsZero() {
+					t.Error("expected non-zero timestamp for Remove action")
+				}
+			},
+		},
+		{
+			doc:    "Unknown action returns valid timestamp",
+			meta:   swarmapi.Meta{},
+			action: swarmapi.WatchActionKindUnknown,
+			check: func(t *testing.T, result time.Time) {
+				if result.IsZero() {
+					t.Error("expected non-zero timestamp for Unknown action")
+				}
+			},
+		},
+		{
+			doc:    "Invalid action falls back to current time",
+			meta:   swarmapi.Meta{},
+			action: swarmapi.WatchActionKind(123456789),
+			check: func(t *testing.T, result time.Time) {
+				if result.IsZero() {
+					t.Error("expected non-zero timestamp for invalid action")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			result := eventTimestamp(tc.meta, tc.action)
+			tc.check(t, result)
+		})
 	}
 }


### PR DESCRIPTION
Resolve TODO comment by making eventTimestamp() switch exhaustive:
- Explicitly handle WatchActionKindUnknown
- Use current time as fallback for any unexpected action kinds
- Prevent zero-value timestamps

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed invalid swarm event generation when `WatchActionKindUnknown` or unexpected action kinds are encountered.

Previously, the `eventTimestamp()` function had a TODO comment asking whether anything should be done for `WatchActionKindUnknown`. This PR resolves that TODO by:

1. Making the switch statement in `eventTimestamp()` exhaustive
2. Adding defensive checks in `logClusterEvent()` to prevent publishing invalid events
3. Adding test coverage for all `WatchActionKind` values

Without this fix, invalid events could be generated with:
- Zero-value timestamps (1970-01-01 00:00:00)
- Empty Action fields (`""`)

**- How I did it**
**In `daemon/events.go`:**

1. **`eventTimestamp()` function:**
   - Explicitly handle `WatchActionKindUnknown` case
   - Use `fallthrough` to default case for consistent behavior
   - Default case now returns `time.Now()` as fallback instead of zero-value

2. **`logClusterEvent()` function:**
   - Check if action exists in `clusterEventAction` map before publishing
   - Return early if unknown action to prevent publishing invalid events
   - This prevents empty Action fields from zero-value map lookups

**In `daemon/events_test.go`:**

3. **`TestEventTimestamp()` test:**
   - Test all four action kinds: Create, Update, Remove, Unknown
   - Verify timestamps are never zero-value
   - Verify correct timestamp source for each action type

**- How to verify it**
```bash
go test -v -run TestEventTimestamp ./daemon
```

All test cases should pass:
- ✅ Create action uses CreatedAt timestamp
- ✅ Update action uses UpdatedAt timestamp  
- ✅ Remove action uses current time
- ✅ Unknown action returns valid timestamp (not zero-value)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown
- Fix potential invalid swarm event generation for unknown action kinds
```

**- A picture of a cute animal (not mandatory but encouraged)**
🐋
