### PR TITLE
daemon: fix spurious "ShouldRestart failed" warning on shutdown

### DIFF
--- a/daemon/container/container.go
+++ b/daemon/container/container.go
@@ -405,7 +405,7 @@ func cleanScopedPath(path string) string {
 // path. See symlink.FollowSymlinkInScope for more details.
 func (container *Container) GetRootResourcePath(path string) (string, error) {
 	// IMPORTANT - These are paths on the OS where the daemon is running, hence
-	// any filepath operations must be done in an OS agnostic way.
+	// any filepath operations must be done in an OS-agnostic way.
 	cleanPath := filepath.Join(string(os.PathSeparator), path)
 	return symlink.FollowSymlinkInScope(filepath.Join(container.Root, cleanPath), container.Root)
 }
@@ -413,6 +413,11 @@ func (container *Container) GetRootResourcePath(path string) (string, error) {
 // ExitOnNext signals to the monitor that it should not restart the container
 // after we send the kill signal.
 func (container *Container) ExitOnNext() {
+	if !container.HostConfig.RestartPolicy.IsNone() {
+		log.G(context.TODO()).WithField("container", container.ID).Info("stopping restart-manager")
+	}
+	// If the container does not have a restartmanager, one is created (through
+	// [container.RestartManager]), which is needed to handle daemon shutdown.
 	container.RestartManager().Cancel()
 }
 

--- a/daemon/internal/libcontainerd/remote/client.go
+++ b/daemon/internal/libcontainerd/remote/client.go
@@ -687,7 +687,7 @@ func (c *client) processEventStream(ctx context.Context, ns string) {
 					"topic":     ev.Topic,
 					"type":      reflect.TypeOf(t),
 					"container": t.ContainerID,
-				}).Info("ignoring event")
+				}).Info("received task-delete event from containerd")
 			default:
 				c.logger.WithFields(log.Fields{
 					"topic": ev.Topic,


### PR DESCRIPTION
When shutting down the daemon, containers are stopped/killed, which calls `container.ExitOnNext()` to stop the restart manager to prevent containers with a restart policy from being restarted. However, when the daemon handles the container exit (Daemon.handleContainerExit), it checks whether the container should be restarted (`container.RestartManager().ShouldRestart`), which returns an `ErrRestartCanceled` if the restart manager is stopped.

This patch:

- Prevents the `ErrRestartCanceled` from being logged as a warning; for other errors, a log is still produced; also splitting the `exitStatus` field to `exitCode` and `exitedAt` as the string presentation of it was not human-readable.
- Adds an "info" log to log when the restart-manager is disabled for a container with a restart-policy.
- Changes the confusing "ignoring event" log for a more informative message ("received task-delete event from containerd"). We don't act on this event, but do want to log it to verify containerd handled the shutdown.
- Changes the "restarting container" log from "Debug" to "Info"; this allows verifying that the restart-monitor handled a container-exit

Before this patch:

    ^CINFO[2026-02-21T20:04:42.937057877Z] Processing signal 'interrupt'
    INFO[2026-02-21T20:04:43.074175085Z] ignoring event                                container=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
    INFO[2026-02-21T20:04:43.073736502Z] shim disconnected                             id=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 namespace=moby
    INFO[2026-02-21T20:04:43.074380960Z] cleaning up after shim disconnected           id=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 namespace=moby
    INFO[2026-02-21T20:04:43.074393169Z] cleaning up dead shim                         id=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 namespace=moby
    WARN[2026-02-21T20:04:43.084973627Z] ShouldRestart failed, container will not be restarted  container=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 daemonShuttingDown=true error="restart canceled" execDuration=4.868244252s exitStatus="{0 2026-02-21 20:04:43.061117752 +0000 UTC}" hasBeenManuallyStopped=false restartCount=0
    INFO[2026-02-21T20:04:43.231618294Z] stopping event stream following graceful shutdown  error="<nil>" module=libcontainerd namespace=moby
    INFO[2026-02-21T20:04:43.232019419Z] stopping healthcheck following graceful shutdown  module=libcontainerd
    INFO[2026-02-21T20:04:43.232244877Z] stopping event stream following graceful shutdown  error="context canceled" module=libcontainerd namespace=plugins.moby
    INFO[2026-02-21T20:04:44.238598878Z] Daemon shutdown complete

With this patch:

    ^CINFO[2026-02-21T20:07:39.524114750Z] Processing signal 'interrupt'
    INFO[2026-02-21T20:07:39.525043125Z] stopping restart-manager                      container=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8
    INFO[2026-02-21T20:07:39.592829959Z] received task-delete event from containerd    container=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
    INFO[2026-02-21T20:07:39.592859084Z] shim disconnected                             id=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 namespace=moby
    INFO[2026-02-21T20:07:39.593019334Z] cleaning up after shim disconnected           id=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 namespace=moby
    INFO[2026-02-21T20:07:39.593038667Z] cleaning up dead shim                         id=1ed1fcfd71c27b5ff4f04c1b33104c17725a841fba7661acea205879fdd687c8 namespace=moby
    INFO[2026-02-21T20:07:39.710357042Z] stopping event stream following graceful shutdown  error="<nil>" module=libcontainerd namespace=moby
    INFO[2026-02-21T20:07:39.710912875Z] stopping healthcheck following graceful shutdown  module=libcontainerd
    INFO[2026-02-21T20:07:39.710989959Z] stopping event stream following graceful shutdown  error="context canceled" module=libcontainerd namespace=plugins.moby
    INFO[2026-02-21T20:07:40.724286834Z] Daemon shutdown complete

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix spurious "ShouldRestart failed" warning on shutdown.
```

**- A picture of a cute animal (not mandatory but encouraged)**

