### PR TITLE
api: swagger: document "platform" param for `GET /image/{name}/json`

### DIFF
--- a/api/docs/v1.49.yaml
+++ b/api/docs/v1.49.yaml
@@ -9737,10 +9737,31 @@ paths:
           required: true
         - name: "manifests"
           in: "query"
-          description: "Include Manifests in the image summary."
+          description: |-
+            Include Manifests in the image summary.
+
+            The `manifests` and `platform` options are mutually exclusive, and
+            an error is produced if both are set.
           type: "boolean"
           default: false
           required: false
+        - name: "platform"
+          type: "string"
+          in: "query"
+          description: |-
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show inspect. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            The `platform` and `manifests` options are mutually exclusive, and
+            an error is produced if both are set.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
       tags: ["Image"]
   /images/{name}/history:
     get:

--- a/api/docs/v1.50.yaml
+++ b/api/docs/v1.50.yaml
@@ -9567,10 +9567,31 @@ paths:
           required: true
         - name: "manifests"
           in: "query"
-          description: "Include Manifests in the image summary."
+          description: |-
+            Include Manifests in the image summary.
+
+            The `manifests` and `platform` options are mutually exclusive, and
+            an error is produced if both are set.
           type: "boolean"
           default: false
           required: false
+        - name: "platform"
+          type: "string"
+          in: "query"
+          description: |-
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show inspect. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            The `platform` and `manifests` options are mutually exclusive, and
+            an error is produced if both are set.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
       tags: ["Image"]
   /images/{name}/history:
     get:

--- a/api/docs/v1.51.yaml
+++ b/api/docs/v1.51.yaml
@@ -9588,10 +9588,31 @@ paths:
           required: true
         - name: "manifests"
           in: "query"
-          description: "Include Manifests in the image summary."
+          description: |-
+            Include Manifests in the image summary.
+
+            The `manifests` and `platform` options are mutually exclusive, and
+            an error is produced if both are set.
           type: "boolean"
           default: false
           required: false
+        - name: "platform"
+          type: "string"
+          in: "query"
+          description: |-
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show inspect. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            The `platform` and `manifests` options are mutually exclusive, and
+            an error is produced if both are set.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
       tags: ["Image"]
   /images/{name}/history:
     get:

--- a/api/docs/v1.52.yaml
+++ b/api/docs/v1.52.yaml
@@ -9868,10 +9868,31 @@ paths:
           required: true
         - name: "manifests"
           in: "query"
-          description: "Include Manifests in the image summary."
+          description: |-
+            Include Manifests in the image summary.
+
+            The `manifests` and `platform` options are mutually exclusive, and
+            an error is produced if both are set.
           type: "boolean"
           default: false
           required: false
+        - name: "platform"
+          type: "string"
+          in: "query"
+          description: |-
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show inspect. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            The `platform` and `manifests` options are mutually exclusive, and
+            an error is produced if both are set.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
       tags: ["Image"]
   /images/{name}/history:
     get:

--- a/api/docs/v1.53.yaml
+++ b/api/docs/v1.53.yaml
@@ -10116,10 +10116,31 @@ paths:
           required: true
         - name: "manifests"
           in: "query"
-          description: "Include Manifests in the image summary."
+          description: |-
+            Include Manifests in the image summary.
+
+            The `manifests` and `platform` options are mutually exclusive, and
+            an error is produced if both are set.
           type: "boolean"
           default: false
           required: false
+        - name: "platform"
+          type: "string"
+          in: "query"
+          description: |-
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show inspect. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            The `platform` and `manifests` options are mutually exclusive, and
+            an error is produced if both are set.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
       tags: ["Image"]
   /images/{name}/history:
     get:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10116,10 +10116,31 @@ paths:
           required: true
         - name: "manifests"
           in: "query"
-          description: "Include Manifests in the image summary."
+          description: |-
+            Include Manifests in the image summary.
+
+            The `manifests` and `platform` options are mutually exclusive, and
+            an error is produced if both are set.
           type: "boolean"
           default: false
           required: false
+        - name: "platform"
+          type: "string"
+          in: "query"
+          description: |-
+            JSON-encoded OCI platform to select the platform-variant.
+            If omitted, it defaults to any locally available platform,
+            prioritizing the daemon's host platform.
+
+            If the daemon provides a multi-platform image store, this selects
+            the platform-variant to show inspect. If the image is
+            a single-platform image, or if the multi-platform image does not
+            provide a variant matching the given platform, an error is returned.
+
+            The `platform` and `manifests` options are mutually exclusive, and
+            an error is produced if both are set.
+
+            Example: `{"os": "linux", "architecture": "arm", "variant": "v5"}`
       tags: ["Image"]
   /images/{name}/history:
     get:


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/52081
- relates to https://github.com/moby/moby/pull/49586


### api: swagger: document "platform" param for `GET /image/{name}/json`

This parameter was added in 59169d0f9746cca5a6fc302eac33e65ca00dd14e
(API v1.49, docker 28.5.1), but forgot to update the swagger definition.


### api/docs: add "platform" param for `GET /image/{name}/json` (API v1.49-v1.53)

This parameter was added in 59169d0f9746cca5a6fc302eac33e65ca00dd14e
(API v1.49, docker 28.5.1), but forgot to update the swagger definition.



**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

