### PR TITLE
api: improve, fix content-negotiation for /events endpoint

### DIFF
--- a/daemon/server/httputils/contenttype/contenttype.go
+++ b/daemon/server/httputils/contenttype/contenttype.go
@@ -1,0 +1,53 @@
+package contenttype
+
+import (
+	"net/http"
+
+	"github.com/golang/gddo/httputil"
+	"github.com/golang/gddo/httputil/header"
+)
+
+// MatchAcceptStrict returns the best matching offer explicitly listed in the
+// request's Accept header, ignoring wildcard media ranges ("*/*" and "type/*").
+//
+// Only exact media-type matches are considered. Entries with q=0 are ignored.
+// If multiple offers match, the one with the highest q-value is selected.
+// If q-values tie, the offer that appears earlier in the offers slice wins.
+//
+// MatchAcceptStrict returns "" if the Accept header is not present or no
+// explicit match is found.
+func MatchAcceptStrict(requestHeaders http.Header, offers []string) string {
+	accept := requestHeaders.Get("Accept")
+	if accept == "" {
+		return ""
+	}
+
+	specs := header.ParseAccept(requestHeaders, "Accept")
+
+	best := ""
+	bestQ := -1.0
+
+	for _, offer := range offers {
+		for _, spec := range specs {
+			if spec.Q == 0 || spec.Value != offer {
+				continue
+			}
+			if spec.Q > bestQ {
+				bestQ = spec.Q
+				best = offer
+			}
+		}
+	}
+
+	return best
+}
+
+// Negotiate returns the best offered content type for the request's
+// Accept header. If two offers match with equal weight, then the more specific
+// offer is preferred.  For example, text/* trumps */*. If two offers match
+// with equal weight and specificity, then the offer earlier in the list is
+// preferred. If no offers match, then defaultOffer is returned.
+func Negotiate(requestHeaders http.Header, offers []string, defaultOffer string) string {
+	req := &http.Request{Header: requestHeaders}
+	return httputil.NegotiateContentType(req, offers, defaultOffer)
+}

--- a/daemon/server/httputils/contenttype/contenttype_test.go
+++ b/daemon/server/httputils/contenttype/contenttype_test.go
@@ -1,0 +1,139 @@
+package contenttype_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/moby/moby/v2/daemon/server/httputils/contenttype"
+)
+
+func TestMatchAcceptStrict(t *testing.T) {
+	tests := []struct {
+		doc      string
+		accept   string
+		offers   []string
+		expected string
+	}{
+		{
+			doc:      "no Accept header",
+			offers:   []string{"application/json"},
+			expected: "",
+		},
+		{
+			doc:      "no explicit match",
+			accept:   "application/xml",
+			offers:   []string{"application/json"},
+			expected: "",
+		},
+		{
+			doc:      "wildcard ignored",
+			accept:   "*/*",
+			offers:   []string{"application/json"},
+			expected: "",
+		},
+		{
+			doc:      "type wildcard ignored",
+			accept:   "application/*",
+			offers:   []string{"application/json"},
+			expected: "",
+		},
+		{
+			doc:      "exact match selected",
+			accept:   "application/json",
+			offers:   []string{"application/json"},
+			expected: "application/json",
+		},
+		{
+			doc:      "q=0 ignored",
+			accept:   "application/json;q=0",
+			offers:   []string{"application/json"},
+			expected: "",
+		},
+		{
+			doc:      "highest q wins",
+			accept:   "application/json;q=0.5, application/xml;q=0.9",
+			offers:   []string{"application/json", "application/xml"},
+			expected: "application/xml",
+		},
+		{
+			doc:      "tie q earlier offer wins",
+			accept:   "application/json;q=0.8, application/xml;q=0.8",
+			offers:   []string{"application/xml", "application/json"},
+			expected: "application/xml",
+		},
+		{
+			doc:      "duplicate media types highest q applies",
+			accept:   "application/json;q=0.3, application/json;q=0.9",
+			offers:   []string{"application/json"},
+			expected: "application/json",
+		},
+		{
+			doc:      "multiple accept entries first matching offer wins by q",
+			accept:   "application/xml;q=0.7, application/json;q=0.6",
+			offers:   []string{"application/json", "application/xml"},
+			expected: "application/xml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			t.Parallel()
+
+			h := make(http.Header)
+			if tc.accept != "" {
+				h.Set("Accept", tc.accept)
+			}
+
+			got := contenttype.MatchAcceptStrict(h, tc.offers)
+			if got != tc.expected {
+				t.Fatalf("got %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// Code below is:
+//
+// Copyright 2013 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+var negotiateContentTypeTests = []struct {
+	s            string
+	offers       []string
+	defaultOffer string
+	expect       string
+}{
+	{"text/html, */*;q=0", []string{"x/y"}, "", ""},
+	{"text/html, */*", []string{"x/y"}, "", "x/y"},
+	{"text/html, image/png", []string{"text/html", "image/png"}, "", "text/html"},
+	{"text/html, image/png", []string{"image/png", "text/html"}, "", "image/png"},
+	{"text/html, image/png; q=0.5", []string{"image/png"}, "", "image/png"},
+	{"text/html, image/png; q=0.5", []string{"text/html"}, "", "text/html"},
+	{"text/html, image/png; q=0.5", []string{"foo/bar"}, "", ""},
+	{"text/html, image/png; q=0.5", []string{"image/png", "text/html"}, "", "text/html"},
+	{"text/html, image/png; q=0.5", []string{"text/html", "image/png"}, "", "text/html"},
+	{"text/html;q=0.5, image/png", []string{"image/png"}, "", "image/png"},
+	{"text/html;q=0.5, image/png", []string{"text/html"}, "", "text/html"},
+	{"text/html;q=0.5, image/png", []string{"image/png", "text/html"}, "", "image/png"},
+	{"text/html;q=0.5, image/png", []string{"text/html", "image/png"}, "", "image/png"},
+	{"image/png, image/*;q=0.5", []string{"image/jpg", "image/png"}, "", "image/png"},
+	{"image/png, image/*;q=0.5", []string{"image/jpg"}, "", "image/jpg"},
+	{"image/png, image/*;q=0.5", []string{"image/jpg", "image/gif"}, "", "image/jpg"},
+	{"image/png, image/*", []string{"image/jpg", "image/gif"}, "", "image/jpg"},
+	{"image/png, image/*", []string{"image/gif", "image/jpg"}, "", "image/gif"},
+	{"image/png, image/*", []string{"image/gif", "image/png"}, "", "image/png"},
+	{"image/png, image/*", []string{"image/png", "image/gif"}, "", "image/png"},
+}
+
+func TestNegotiateContentType(t *testing.T) {
+	for _, tt := range negotiateContentTypeTests {
+		h := http.Header{"Accept": {tt.s}}
+		actual := contenttype.Negotiate(h, tt.offers, tt.defaultOffer)
+		if actual != tt.expect {
+			t.Errorf("NegotiateContentType(%q, %#v, %q)=%q, want %q", tt.s, tt.offers, tt.defaultOffer, actual, tt.expect)
+		}
+	}
+}

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/containerd/log"
-	"github.com/golang/gddo/httputil"
 	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/types"
 	"github.com/moby/moby/api/types/events"
@@ -22,6 +21,7 @@ import (
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/buildbackend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/daemon/server/httputils/contenttype"
 	"github.com/moby/moby/v2/daemon/server/router/build"
 	"github.com/moby/moby/v2/pkg/ioutils"
 	"github.com/pkg/errors"
@@ -310,7 +310,7 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 		return err
 	}
 
-	contentType := httputil.NegotiateContentType(r, []string{
+	contentType := contenttype.Negotiate(r.Header, []string{
 		types.MediaTypeJSONLines,
 		types.MediaTypeNDJSON,
 		types.MediaTypeJSONSequence,

--- a/daemon/server/router/system/system_routes.go
+++ b/daemon/server/router/system/system_routes.go
@@ -270,6 +270,12 @@ func (e invalidRequestError) Error() string {
 
 func (e invalidRequestError) InvalidParameter() {}
 
+var jsonTypes = []string{
+	types.MediaTypeJSONLines,
+	types.MediaTypeNDJSON,
+	types.MediaTypeJSONSequence,
+}
+
 func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := httputils.ParseForm(r); err != nil {
 		return err
@@ -310,11 +316,14 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 		return err
 	}
 
-	contentType := contenttype.Negotiate(r.Header, []string{
-		types.MediaTypeJSONLines,
-		types.MediaTypeNDJSON,
-		types.MediaTypeJSONSequence,
-	}, types.MediaTypeJSON) // output isn't actually JSON but API used to  this content-type
+	contentType := types.MediaTypeJSONLines
+	if versions.LessThan(httputils.VersionFromContext(ctx), "1.52") {
+		// output isn't actually JSON but API used to use this content-type.
+		contentType = types.MediaTypeJSON
+	}
+	if ct := contenttype.MatchAcceptStrict(r.Header, jsonTypes); ct != "" {
+		contentType = ct
+	}
 	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(http.StatusOK)
 	output := ioutils.NewWriteFlusher(w)


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/50953
- https://github.com/moby/moby/pull/51668


### daemon/server/httputils: contenttype package and MatchAcceptStrict utility

This allows negotiating the content-type without wildcard-matching.
In most of our uses, we want to provide the best match that the
client accepts, but have to avoid picking the first match if a
client would send "*/*" (or, e.g., "application/*").

For example, the events endpoint added support for JSON-stream
content types, but older API versions unconditionally returned
"application/json". Clients sending "*/*" (such as docker/docker-py)
would now get a different content type as before.

For convenience, also adding a wrapper for the gddo NegotiateContentType
utility with a slightly different signature (accepting just the headers
instead of the whole request).


### api: improve, fix content-negotiation for /events endpoint

Commits df506c107e7c5b8134d755a596f794009a61b5d4 and aef5d996cef66640d20f52d7b6b97d781d62a31e
fixed the content-type advertised by the `/events` endpoint, and added content
negotiation as an "opt-in" by clients.

A fallback / default value was added to keep the old (`application/json`)
content type, however, some clients may send `*/*` as a default, which
would considered as "opt-in" in the negotiation, and pick the first "offer"
(`application/jsonl`) instead of the fallback.

On docker 28.x and lower, omitting an `Accept` header, or sending `*/*`
would produce the `application/json` content-type:

```bash
curl -sS -D - --unix-socket /var/run/docker.sock 'http://localhost/v1.50/events?until=1' | grep 'Content-Type'
# Content-Type: application/json

curl -sS -D - -H 'Accept: */*' --unix-socket /var/run/docker.sock 'http://localhost/v1.50/events?until=1' | grep 'Content-Type'
# Content-Type: application/json
```

On docker 29.x, a missing accept header, or a `*/*` would use the new content-type,
not the previous default;

```bash
curl -sS -D - --unix-socket /var/run/docker.sock 'http://localhost/v1.50/events?until=1' | grep 'Content-Type'
# Content-Type: application/jsonl

curl -sS -D - -H 'Accept: */*' --unix-socket /var/run/docker.sock 'http://localhost/v1.50/events?until=1' | grep 'Content-Type'
# Content-Type: application/jsonl
```

With this patch, the default depends on the API version, and we only
override the content-type if there's a match with any of the types
set in the `Accept` header, ignoring wildcards (`*/*`) that are sent
as default by some clients, such as cURL or `docker-py`;

```bash
curl -sS -D - --unix-socket /var/run/docker.sock 'http://localhost/v1.51/events?until=1' | grep 'Content-Type'
# Content-Type: application/json

curl -sS -D - -H 'Accept: */*' --unix-socket /var/run/docker.sock 'http://localhost/v1.51/events?until=1' | grep 'Content-Type'
# Content-Type: application/json

curl -sS -D - --unix-socket /var/run/docker.sock 'http://localhost/v1.52/events?until=1' | grep 'Content-Type'
Content-Type: application/jsonl

curl -sS -D - -H 'Accept: */*' --unix-socket /var/run/docker.sock 'http://localhost/v1.52/events?until=1' | grep 'Content-Type'
# Content-Type: application/jsonl

curl -sS -D - -H 'Accept: application/json-seq' --unix-socket /var/run/docker.sock 'http://localhost/v1.50/events?until=1' | grep 'Content-Type'
# Content-Type: application/json-seq
```




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

