### PR TITLE
client: container, service logs: skip "tail" parameter if not needed

### DIFF
--- a/client/container_logs.go
+++ b/client/container_logs.go
@@ -97,7 +97,23 @@ func (cli *Client) ContainerLogs(ctx context.Context, containerID string, option
 	if options.Follow {
 		query.Set("follow", "1")
 	}
-	query.Set("tail", options.Tail)
+
+	switch options.Tail {
+	case "", "all":
+		// don't send option; default is to show all logs.
+		//
+		// The default on the daemon-side is to show all logs; account for
+		// some special values. The CLI may set a magic "all" value that's
+		// used as default.
+		//
+		// Given that the default is to show all logs, we can ignore these
+		// values, and don't send "tail".
+		//
+		// see https://github.com/moby/moby/blob/0df791cb72b568eeadba2267fe9a5040d12b0487/daemon/logs.go#L75-L78
+		// see https://github.com/moby/moby/blob/4d20b6fe56dfb2b06f4a5dd1f32913215a9c317b/daemon/cluster/services.go#L425-L449
+	default:
+		query.Set("tail", options.Tail)
+	}
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/logs", query, nil)
 	if err != nil {

--- a/client/container_logs_test.go
+++ b/client/container_logs_test.go
@@ -63,8 +63,24 @@ func TestContainerLogs(t *testing.T) {
 	}{
 		{
 			doc: "no options",
+		},
+		{
+			// magic "all" value that's used as default in docker/cli
+			// is equivalent to "don't send a tail option".
+			doc: "tail all",
+			options: ContainerLogsOptions{
+				Tail: "all",
+			},
+		},
+		{
+			// TODO(thaJeztah): tail=0 currently means: "return zero lines"; perhaps we should just make it "all"
+			//   or error, similar to "service logs"; https://github.com/moby/moby/blob/4d20b6fe56dfb2b06f4a5dd1f32913215a9c317b/daemon/cluster/services.go#L425-L449
+			doc: "tail 0",
+			options: ContainerLogsOptions{
+				Tail: "0",
+			},
 			expectedQueryParams: map[string]string{
-				"tail": "",
+				"tail": "0",
 			},
 		},
 		{
@@ -86,7 +102,6 @@ func TestContainerLogs(t *testing.T) {
 				Follow:     true,
 			},
 			expectedQueryParams: map[string]string{
-				"tail":       "",
 				"stdout":     "1",
 				"stderr":     "1",
 				"timestamps": "1",
@@ -101,7 +116,6 @@ func TestContainerLogs(t *testing.T) {
 				Since: "1136073600.000000001",
 			},
 			expectedQueryParams: map[string]string{
-				"tail":  "",
 				"since": "1136073600.000000001",
 			},
 		},
@@ -112,7 +126,6 @@ func TestContainerLogs(t *testing.T) {
 				Until: "1136073600.000000001",
 			},
 			expectedQueryParams: map[string]string{
-				"tail":  "",
 				"until": "1136073600.000000001",
 			},
 		},

--- a/client/service_logs_test.go
+++ b/client/service_logs_test.go
@@ -46,8 +46,24 @@ func TestServiceLogs(t *testing.T) {
 	}{
 		{
 			doc: "no options",
+		},
+		{
+			// magic "all" value that's used as default in docker/cli
+			// is equivalent to "don't send a tail option".
+			doc: "tail all",
+			options: ServiceLogsOptions{
+				Tail: "all",
+			},
+		},
+		{
+			// TODO(thaJeztah): tail=0 currently means: "return zero lines"; perhaps we should just make it "all"
+			//   or error, similar to "service logs"; https://github.com/moby/moby/blob/4d20b6fe56dfb2b06f4a5dd1f32913215a9c317b/daemon/cluster/services.go#L425-L449
+			doc: "tail 0",
+			options: ServiceLogsOptions{
+				Tail: "0",
+			},
 			expectedQueryParams: map[string]string{
-				"tail": "",
+				"tail": "0",
 			},
 		},
 		{
@@ -69,7 +85,6 @@ func TestServiceLogs(t *testing.T) {
 				Follow:     true,
 			},
 			expectedQueryParams: map[string]string{
-				"tail":       "",
 				"stdout":     "1",
 				"stderr":     "1",
 				"timestamps": "1",
@@ -84,7 +99,6 @@ func TestServiceLogs(t *testing.T) {
 				Since: "1136073600.000000001",
 			},
 			expectedQueryParams: map[string]string{
-				"tail":  "",
 				"since": "1136073600.000000001",
 			},
 		},

--- a/vendor/github.com/moby/moby/client/container_logs.go
+++ b/vendor/github.com/moby/moby/client/container_logs.go
@@ -97,7 +97,23 @@ func (cli *Client) ContainerLogs(ctx context.Context, containerID string, option
 	if options.Follow {
 		query.Set("follow", "1")
 	}
-	query.Set("tail", options.Tail)
+
+	switch options.Tail {
+	case "", "all":
+		// don't send option; default is to show all logs.
+		//
+		// The default on the daemon-side is to show all logs; account for
+		// some special values. The CLI may set a magic "all" value that's
+		// used as default.
+		//
+		// Given that the default is to show all logs, we can ignore these
+		// values, and don't send "tail".
+		//
+		// see https://github.com/moby/moby/blob/0df791cb72b568eeadba2267fe9a5040d12b0487/daemon/logs.go#L75-L78
+		// see https://github.com/moby/moby/blob/4d20b6fe56dfb2b06f4a5dd1f32913215a9c317b/daemon/cluster/services.go#L425-L449
+	default:
+		query.Set("tail", options.Tail)
+	}
 
 	resp, err := cli.get(ctx, "/containers/"+containerID+"/logs", query, nil)
 	if err != nil {


### PR DESCRIPTION
The default on the daemon-side is to show all logs; update the client code accordingly, and skip some "magic" values that are equivalent to showing all logs.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

