### PR TITLE
client: Client.Events: prefer json-lines, ndjson over json-seq

### DIFF
--- a/client/system_events.go
+++ b/client/system_events.go
@@ -45,9 +45,9 @@ func (cli *Client) Events(ctx context.Context, options EventsListOptions) Events
 		}
 
 		headers := http.Header{}
-		headers.Add("Accept", types.MediaTypeJSONSequence)
-		headers.Add("Accept", types.MediaTypeJSONLines)
-		headers.Add("Accept", types.MediaTypeNDJSON)
+		headers.Add("Accept", types.MediaTypeJSONLines) // Implicit q=1.0; in case server doesn't parse correctly.
+		headers.Add("Accept", types.MediaTypeNDJSON+";q=0.9")
+		headers.Add("Accept", types.MediaTypeJSONSequence+";q=0.5")
 		resp, err := cli.get(ctx, "/events", query, headers)
 		if err != nil {
 			close(started)

--- a/vendor/github.com/moby/moby/client/system_events.go
+++ b/vendor/github.com/moby/moby/client/system_events.go
@@ -45,9 +45,9 @@ func (cli *Client) Events(ctx context.Context, options EventsListOptions) Events
 		}
 
 		headers := http.Header{}
-		headers.Add("Accept", types.MediaTypeJSONSequence)
-		headers.Add("Accept", types.MediaTypeJSONLines)
-		headers.Add("Accept", types.MediaTypeNDJSON)
+		headers.Add("Accept", types.MediaTypeJSONLines) // Implicit q=1.0; in case server doesn't parse correctly.
+		headers.Add("Accept", types.MediaTypeNDJSON+";q=0.9")
+		headers.Add("Accept", types.MediaTypeJSONSequence+";q=0.5")
 		resp, err := cli.get(ctx, "/events", query, headers)
 		if err != nil {
 			close(started)


### PR DESCRIPTION
Processing json sequences (RFC7464) requires some additional handling (see [client/internal.NewJSONStreamDecoder]).

Change the order in which we set the accept headers, and set q-factors to explicitly indicate our preference (default is "q=1.0").

[client/internal.NewJSONStreamDecoder]: https://github.com/moby/moby/blob/65d8d0b8cc9b02362be2f0b7e06ffca879c44b2f/client/internal/json-stream.go#L15-L25

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

