### PR TITLE
api/types: add MediaType pseudo-type, and touch-up docs

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -1,21 +1,33 @@
 package types
 
+// MediaType represents an HTTP media type (MIME type) used in API
+// Content-Type and Accept headers.
+//
+// In addition to standard media types (for example, "application/json"),
+// this package defines vendor-specific vendor media types for streaming
+// endpoints, such as raw TTY streams and multiplexed stdout/stderr streams.
+type MediaType = string
+
 const (
-	// MediaTypeRawStream is vendor specific MIME-Type set for raw TTY streams.
-	MediaTypeRawStream = "application/vnd.docker.raw-stream"
+	// MediaTypeRawStream is a vendor-specific media type for raw TTY streams.
+	MediaTypeRawStream MediaType = "application/vnd.docker.raw-stream"
 
-	// MediaTypeMultiplexedStream is vendor specific MIME-Type set for stdin/stdout/stderr multiplexed streams.
-	MediaTypeMultiplexedStream = "application/vnd.docker.multiplexed-stream"
+	// MediaTypeMultiplexedStream is a vendor-specific media type for streams
+	// where stdin, stdout, and stderr are multiplexed into a single byte stream.
+	//
+	// Use stdcopy.StdCopy (https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy)
+	// to demultiplex the stream.
+	MediaTypeMultiplexedStream MediaType = "application/vnd.docker.multiplexed-stream"
 
-	// MediaTypeJSON is the MIME-Type for JSON objects.
-	MediaTypeJSON = "application/json"
+	// MediaTypeJSON is the media type for JSON objects.
+	MediaTypeJSON MediaType = "application/json"
 
-	// MediaTypeNDJSON is the MIME-Type for Newline Delimited JSON objects streams (https://github.com/ndjson/ndjson-spec).
-	MediaTypeNDJSON = "application/x-ndjson"
+	// MediaTypeNDJSON is the media type for newline-delimited JSON streams (https://github.com/ndjson/ndjson-spec).
+	MediaTypeNDJSON MediaType = "application/x-ndjson"
 
-	// MediaTypeJSONLines is the MIME-Type for JSONLines objects streams (https://jsonlines.org/).
-	MediaTypeJSONLines = "application/jsonl"
+	// MediaTypeJSONLines is the media type for JSON Lines streams (https://jsonlines.org/).
+	MediaTypeJSONLines MediaType = "application/jsonl"
 
-	// MediaTypeJSONSequence is the MIME-Type for JSON Text Sequences (RFC7464).
-	MediaTypeJSONSequence = "application/json-seq"
+	// MediaTypeJSONSequence is the media type for JSON text sequences (RFC 7464).
+	MediaTypeJSONSequence MediaType = "application/json-seq"
 )

--- a/vendor/github.com/moby/moby/api/types/types.go
+++ b/vendor/github.com/moby/moby/api/types/types.go
@@ -1,21 +1,33 @@
 package types
 
+// MediaType represents an HTTP media type (MIME type) used in API
+// Content-Type and Accept headers.
+//
+// In addition to standard media types (for example, "application/json"),
+// this package defines vendor-specific vendor media types for streaming
+// endpoints, such as raw TTY streams and multiplexed stdout/stderr streams.
+type MediaType = string
+
 const (
-	// MediaTypeRawStream is vendor specific MIME-Type set for raw TTY streams.
-	MediaTypeRawStream = "application/vnd.docker.raw-stream"
+	// MediaTypeRawStream is a vendor-specific media type for raw TTY streams.
+	MediaTypeRawStream MediaType = "application/vnd.docker.raw-stream"
 
-	// MediaTypeMultiplexedStream is vendor specific MIME-Type set for stdin/stdout/stderr multiplexed streams.
-	MediaTypeMultiplexedStream = "application/vnd.docker.multiplexed-stream"
+	// MediaTypeMultiplexedStream is a vendor-specific media type for streams
+	// where stdin, stdout, and stderr are multiplexed into a single byte stream.
+	//
+	// Use stdcopy.StdCopy (https://pkg.go.dev/github.com/moby/moby/api/pkg/stdcopy)
+	// to demultiplex the stream.
+	MediaTypeMultiplexedStream MediaType = "application/vnd.docker.multiplexed-stream"
 
-	// MediaTypeJSON is the MIME-Type for JSON objects.
-	MediaTypeJSON = "application/json"
+	// MediaTypeJSON is the media type for JSON objects.
+	MediaTypeJSON MediaType = "application/json"
 
-	// MediaTypeNDJSON is the MIME-Type for Newline Delimited JSON objects streams (https://github.com/ndjson/ndjson-spec).
-	MediaTypeNDJSON = "application/x-ndjson"
+	// MediaTypeNDJSON is the media type for newline-delimited JSON streams (https://github.com/ndjson/ndjson-spec).
+	MediaTypeNDJSON MediaType = "application/x-ndjson"
 
-	// MediaTypeJSONLines is the MIME-Type for JSONLines objects streams (https://jsonlines.org/).
-	MediaTypeJSONLines = "application/jsonl"
+	// MediaTypeJSONLines is the media type for JSON Lines streams (https://jsonlines.org/).
+	MediaTypeJSONLines MediaType = "application/jsonl"
 
-	// MediaTypeJSONSequence is the MIME-Type for JSON Text Sequences (RFC7464).
-	MediaTypeJSONSequence = "application/json-seq"
+	// MediaTypeJSONSequence is the media type for JSON text sequences (RFC 7464).
+	MediaTypeJSONSequence MediaType = "application/json-seq"
 )


### PR DESCRIPTION
Add a `MediaType` pseudo-type to help discoverability of mediatypes we use, and slightly touch up the documentation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add a `MediaType` pseudo-type to help discoverability of available mediatypes.
```

**- A picture of a cute animal (not mandatory but encouraged)**

