### PR TITLE
container/prune: Don't fail early on layer size errors

### DIFF
--- a/daemon/prune.go
+++ b/daemon/prune.go
@@ -70,7 +70,11 @@ func (daemon *Daemon) ContainerPrune(ctx context.Context, pruneFilters filters.A
 			}
 			cSize, _, err := daemon.imageService.GetContainerLayerSize(ctx, c.ID)
 			if err != nil {
-				return nil, err
+				// Debug log only, the size is only for informational purposes anyway
+				log.G(ctx).WithFields(log.Fields{
+					"error":     err,
+					"container": c.ID,
+				}).Debug("failed to get layer size for container")
 			}
 			// TODO: sets RmLink to true?
 			err = daemon.containerRm(cfg, c.ID, &backend.ContainerRmConfig{})


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/52012

When ContainerPrune calls GetContainerLayerSize, the container's RW layer snapshot may have already been removed by a concurrent operation.

This causes GetContainerLayerSize to return a "rw layer snapshot not found" error, which previously aborted the entire prune operation.

The layer size is only calculated for informational purposes so it's not worth failing the whole prune operation anyway.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker system prune` failing with "rw layer snapshot not found" when a container is concurrently removed
```

**- A picture of a cute animal (not mandatory but encouraged)**

