### PR TITLE
fix: FROM --platform ends up with wrong platform in manifest

### DIFF
--- a/daemon/internal/builder-next/exporter/mobyexporter/export.go
+++ b/daemon/internal/builder-next/exporter/mobyexporter/export.go
@@ -133,6 +133,9 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp *exporter.Source
 			return nil, nil, errors.Errorf("number of platforms does not match references %d %d", len(ps.Platforms), len(inp.Refs))
 		}
 		config = inp.Metadata[fmt.Sprintf("%s/%s", exptypes.ExporterImageConfigKey, ps.Platforms[0].ID)]
+		if len(config) == 0 {
+			config = inp.Metadata[exptypes.ExporterImageConfigKey]
+		}
 	}
 
 	var diffs []digest.Digest

--- a/vendor/github.com/moby/buildkit/exporter/containerimage/exptypes/parse.go
+++ b/vendor/github.com/moby/buildkit/exporter/containerimage/exptypes/parse.go
@@ -3,6 +3,7 @@ package exptypes
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/containerd/platforms"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -33,7 +34,19 @@ func ParsePlatforms(meta map[string][]byte) (Platforms, error) {
 	}
 
 	var p ocispecs.Platform
-	if imgConfig, ok := meta[ExporterImageConfigKey]; ok {
+	var imgConfig []byte
+	if c, ok := meta[ExporterImageConfigKey]; ok {
+		imgConfig = c
+	} else {
+		for k, v := range meta {
+			if len(v) > 0 && strings.HasPrefix(k, ExporterImageConfigKey+"/") {
+				imgConfig = v
+				break
+			}
+		}
+	}
+
+	if len(imgConfig) > 0 {
 		var img ocispecs.Image
 		err := json.Unmarshal(imgConfig, &img)
 		if err != nil {

--- a/vendor/github.com/moby/buildkit/frontend/dockerui/build.go
+++ b/vendor/github.com/moby/buildkit/frontend/dockerui/build.go
@@ -57,7 +57,7 @@ func (bc *Client) Build(ctx context.Context, fn BuildFunc) (*ResultBuilder, erro
 			if tp != nil {
 				p = *tp
 			} else {
-				p = platforms.DefaultSpec()
+				p = img.Platform
 			}
 			expPlat := makeExportPlatform(p, img.Platform)
 			if bc.MultiPlatformRequested {


### PR DESCRIPTION
## Description
This PR fixes a bug where building a Dockerfile with \FROM --platform\ (but without an explicit \--platform\ build flag) would result in an image manifest list entry incorrectly labeled with the host's architecture instead of the image's actual architecture.

## Changes
- **dockerui**: In the \Build\ method, if no target platform is specified, we now default to the platform of the built image (\img.Platform\) instead of the host platform (\platforms.DefaultSpec()\). This ensures the export metadata correctly reflects the image's architecture.
- **exporter/containerimage**: Updated \ParsePlatforms\ to look for platform-suffixed configuration keys (e.g., \containerimage.config/linux/arm64\) if the base key is missing.
- **mobyexporter**: Added a fallback to the non-suffixed image config key if the platform-suffixed key is not found.

## Verification
- Verified that the image configuration architecture correctly propagates to the manifest list when using \FROM --platform\.
- Ran existing unit tests for \mobyexporter\ (\go test -v ./daemon/internal/builder-next/exporter/mobyexporter/...\), which passed.

Fixes #52050