### PR TITLE
gha/vm: Limit to cgroup-related integration packages

### DIFF
--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -18,6 +18,11 @@ on:
       template:
         required: true
         type: string
+      integration_dir:
+        description: If set, only run integration tests from these directories (space-separated)
+        required: false
+        type: string
+        default: ""
 
 env:
   GO_VERSION: "1.25.7"
@@ -137,6 +142,7 @@ jobs:
           # TODO: enable GHA cache?
           LIMA_WORKDIR=/tmp/docker lima \
             TEST_SKIP_INTEGRATION_CLI=1 \
+            TEST_INTEGRATION_DIR="${{ inputs.integration_dir }}" \
             TEST_INTEGRATION_USE_GRAPHDRIVER=1 \
             DOCKER_ROOTLESS=${DOCKER_ROOTLESS} \
             DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER} \

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -33,14 +33,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        template:
+        include:
           # EL 8 is used for running the tests with cgroup v1.
           # Do not upgrade this to EL 9 until formally deprecating the cgroup v1 support.
+          #
+          # To minimize CI time the whole test suite takes, only run
+          # integration packages that currently contain cgroup-v1/v2 specific
+          # coverage (cgroup namespaces, cgroup driver/systemd, and resource
+          # update verification via /sys/fs/cgroup paths).
           #
           # FIXME: use almalinux-8, then probably no need to keep oraclelinux-8 here.
           # On almalinux-8, port forwarding tests are failing:
           # https://github.com/moby/moby/pull/49819#issuecomment-2815676000
-          - template:oraclelinux-8  # Oracle's kernel 5.15
-          # - template:almalinux-8  # kernel 4.18
+          - template: template:oraclelinux-8  # Oracle's kernel 5.15
+            integration_dir: ./integration/container ./integration/build ./integration/system
     with:
       template: ${{ matrix.template }}
+      integration_dir: ${{ matrix.integration_dir }}


### PR DESCRIPTION
Running the entire integration test suite in a VM is very long and takes almost an hour. Combined with flaky tests this puts heavy burden on the CI resources.

Since the primary purpose of the VM tests is to validate cgroup v1 functionality (using Oracle Linux 8), make it only run integration packages that contain cgroup-specific test coverage.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

