### PR TITLE
integration/capabilities: Skip test on non amd64/arm64 arches

### DIFF
--- a/integration/capabilities/capabilities_linux_test.go
+++ b/integration/capabilities/capabilities_linux_test.go
@@ -3,6 +3,7 @@ package capabilities
 import (
 	"bytes"
 	"io"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -17,6 +18,11 @@ import (
 )
 
 func TestNoNewPrivileges(t *testing.T) {
+	switch runtime.GOARCH {
+	case "amd64", "arm64":
+	default:
+		t.Skipf("skipping on unsupported architecture: %s", runtime.GOARCH)
+	}
 	ctx := setupTest(t)
 
 	withFileCapability := `


### PR DESCRIPTION
The base image is not available for ppc64le & s390x

Otherwise the test fails with:
`capabilities_linux_test.go:81: assertion failed: error is not nil: Error response from daemon: No such image: captest:latest`

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

