### PR TITLE
integration/container: use page-aligned shm size to fix test on ppc64le

### DIFF
--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -502,7 +502,7 @@ func TestCgroupRW(t *testing.T) {
 func TestContainerShmSize(t *testing.T) {
 	ctx := setupTest(t)
 
-	const defaultSize = "1000k"
+	const defaultSize = "1024k"
 	defaultSizeBytes, err := units.RAMInBytes(defaultSize)
 	assert.NilError(t, err)
 
@@ -531,7 +531,7 @@ func TestContainerShmSize(t *testing.T) {
 		{
 			doc:     "custom shmSize",
 			opt:     container.WithHostConfig(&containertypes.HostConfig{ShmSize: defaultSizeBytes * 2}),
-			expSize: "2000k",
+			expSize: "2048k",
 		},
 		{
 			doc:    "negative shmSize",
@@ -568,7 +568,7 @@ func TestContainerShmSize(t *testing.T) {
 			out, err := container.Output(ctx, apiClient, cID)
 			assert.NilError(t, err)
 
-			// e.g., "218 213 0:87 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=1000k"
+			// e.g., "218 213 0:87 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=1024k"
 			assert.Assert(t, is.Contains(out.Stdout, "/dev/shm "), "shm mount not found in output: \n%v", out.Stdout)
 			assert.Check(t, is.Contains(out.Stdout, "size="+tc.expSize))
 		})


### PR DESCRIPTION
On architectures with 64k page size (e.g. ppc64le), the kernel rounds shm sizes up to the nearest page boundary. Using 1000k as the default shm size resulted in the custom size test requesting 2000k, which was rounded up to 2048k in /proc/self/mountinfo, causing the test to fail.

Switch the default to 1024k so that the doubled value (2048k) is already aligned on both 4k and 64k page boundaries.

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

