### PR TITLE
integration/capabilities: Switch to debian:trixie-slim

### DIFF
--- a/integration/capabilities/capabilities_linux_test.go
+++ b/integration/capabilities/capabilities_linux_test.go
@@ -20,7 +20,7 @@ func TestNoNewPrivileges(t *testing.T) {
 	ctx := setupTest(t)
 
 	withFileCapability := `
-		FROM debian:bullseye-slim
+		FROM debian:trixie-slim
 		RUN apt-get update && apt-get install -y libcap2-bin --no-install-recommends
 		RUN setcap CAP_DAC_OVERRIDE=+eip /bin/cat
 		RUN echo "hello" > /txt && chown 0:0 /txt && chmod 700 /txt


### PR DESCRIPTION
Switch to `debian:trixie-slim`. 

See discussion in https://github.com/moby/moby/pull/52107/changes#r2865768952

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

