### PR TITLE
daemon/libnetwork/drivers/bridge: Check if endpoint data exists in po…

### DIFF
--- a/daemon/libnetwork/datastore/datastore.go
+++ b/daemon/libnetwork/datastore/datastore.go
@@ -163,6 +163,10 @@ func (ds *Store) List(kvObject KVObject) ([]KVObject, error) {
 	return ds.cache.list(kvObject)
 }
 
+func (ds *Store) KVStore() store.Store {
+	return ds.store
+}
+
 func (ds *Store) iterateKVPairsFromStore(key string, ctor KVObject, callback func(string, KVObject)) error {
 	// Make sure the parent key exists
 	if err := ds.ensureParent(key); err != nil {

--- a/daemon/libnetwork/drivers/bridge/bridge_store.go
+++ b/daemon/libnetwork/drivers/bridge/bridge_store.go
@@ -28,6 +28,7 @@ const (
 	// prefix with different root
 	bridgePrefix         = "bridge"
 	bridgeEndpointPrefix = "bridge-endpoint"
+	endpointPrefix       = "endpoint"
 )
 
 func (d *driver) initStore() error {
@@ -84,12 +85,33 @@ func (d *driver) populateEndpoints() error {
 	if errors.Is(err, datastore.ErrKeyNotFound) {
 		return nil
 	}
+	// Add check if the endpoint exists
+	eps := make(map[string]any)
+	if kvList, err := d.store.KVStore().List(datastore.Key(endpointPrefix)); err == nil {
+		for _, kvPair := range kvList {
+			if len(kvPair.Value) == 0 {
+				continue
+			}
+			ep := make(map[string]any)
+			if err = json.Unmarshal(kvPair.Value, &ep); err != nil {
+				log.G(context.TODO()).Warnf("failed to unmarshal endpoint %v", err)
+				continue
+			}
+			id, ok := ep["id"].(string)
+			if ok {
+				eps[id] = true
+			}
+		}
+	} else {
+		log.G(context.TODO()).Debugf("failed to get endpoints from store: %v", err)
+	}
 
 	for _, kvo := range kvol {
 		ep := kvo.(*bridgeEndpoint)
 		n, ok := d.networks[ep.nid]
-		if !ok {
-			log.G(context.TODO()).Debugf("Network (%.7s) not found for restored bridge endpoint (%.7s)", ep.nid, ep.id)
+		_, ok_1 := eps[ep.id]
+		if !ok || !ok_1 {
+			log.G(context.TODO()).Debugf("Network (%.7s) or endpoint not found for restored bridge endpoint (%.7s)", ep.nid, ep.id)
 			log.G(context.TODO()).Debugf("Deleting stale bridge endpoint (%.7s) from store", ep.id)
 			if err := d.storeDelete(ep); err != nil {
 				log.G(context.TODO()).Debugf("Failed to delete stale bridge endpoint (%.7s) from store", ep.id)


### PR DESCRIPTION
In the populateEndpoints function, only the existence of the network corresponding to the bridge-endpoint is checked. We should also ensure that the endpoint data exists; otherwise, ports may be erroneously listened on due to residual bridge-endpoint data. This issue may occur in scenarios where container run or remove processes are abnormal.

otherwise like this：
[root@anolis~]# docker ps -a
CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES
[root@anolis~]# netstat -tunlp |grep 5000
tcp 0 0 0.0.0.0:5000 0.0.0.0:* LISTEN 3650/docker-proxy
tcp6 0 0 :::5000 :::* LISTEN 3657/docker-proxy

fixes #52092 


**- What I did**
Prevent mislistening of container ports due to residual data in local-kv.db
**- How I did it**
Check for the existence of endpoint data associated with the bridge-endpoint before exposing the container port.
**- How to verify it**

