### PR TITLE
Update circl to 1.6.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,7 +152,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cilium/ebpf v0.17.3 // indirect
-	github.com/cloudflare/circl v1.6.1 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/container-storage-interface/spec v1.5.0 // indirect
 	github.com/containerd/accelerated-container-image v1.3.0 // indirect
 	github.com/containerd/console v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cfssl v1.6.5 h1:46zpNkm6dlNkMZH/wMW22ejih6gIaJbzL2du6vD7ZeI=
 github.com/cloudflare/cfssl v1.6.5/go.mod h1:Bk1si7sq8h2+yVEDrFJiz3d7Aw+pfjjJSZVaD+Taky4=
-github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
-github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y+bSQAYZnetRJ70VMVKm5CKI0=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=

--- a/vendor/github.com/cloudflare/circl/internal/sha3/xor_unaligned.go
+++ b/vendor/github.com/cloudflare/circl/internal/sha3/xor_unaligned.go
@@ -14,14 +14,14 @@ import "unsafe"
 type storageBuf [maxRate / 8]uint64
 
 func (b *storageBuf) asBytes() *[maxRate]byte {
-	return (*[maxRate]byte)(unsafe.Pointer(b))
+	return (*[maxRate]byte)(unsafe.Pointer(b)) //nolint:gosec
 }
 
 // xorInuses unaligned reads and writes to update d.a to contain d.a
 // XOR buf.
 func xorIn(d *State, buf []byte) {
 	n := len(buf)
-	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))[: n/8 : n/8]
+	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))[: n/8 : n/8] //nolint:gosec
 	if n >= 72 {
 		d.a[0] ^= bw[0]
 		d.a[1] ^= bw[1]
@@ -56,6 +56,6 @@ func xorIn(d *State, buf []byte) {
 }
 
 func copyOut(d *State, buf []byte) {
-	ab := (*[maxRate]uint8)(unsafe.Pointer(&d.a[0]))
+	ab := (*[maxRate]uint8)(unsafe.Pointer(&d.a[0])) //nolint:gosec
 	copy(buf, ab[:])
 }

--- a/vendor/github.com/cloudflare/circl/sign/sign.go
+++ b/vendor/github.com/cloudflare/circl/sign/sign.go
@@ -38,6 +38,12 @@ type PrivateKey interface {
 	encoding.BinaryMarshaler
 }
 
+// A private key that retains the seed with which it was generated.
+type Seeded interface {
+	// returns the seed if retained, otherwise nil
+	Seed() []byte
+}
+
 // A Scheme represents a specific instance of a signature scheme.
 type Scheme interface {
 	// Name of the scheme.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -347,7 +347,7 @@ github.com/cloudflare/cfssl/log
 github.com/cloudflare/cfssl/ocsp/config
 github.com/cloudflare/cfssl/signer
 github.com/cloudflare/cfssl/signer/local
-# github.com/cloudflare/circl v1.6.1
+# github.com/cloudflare/circl v1.6.3
 ## explicit; go 1.22.0
 github.com/cloudflare/circl/dh/x25519
 github.com/cloudflare/circl/dh/x448


### PR DESCRIPTION
circl library from v1.6.1 to v1.6.3 to fix a LOW severity security vulnerability.

## Summary
 
1. Why:
To remove CVEs:

     - [CVE-2026-1229](https://avd.aquasec.com/nvd/2026/cve-2026-1229/)

2. What:

     - Upgrade circl to v1.6.3 to remove [CVE-2026-1229](https://avd.aquasec.com/nvd/2026/cve-2026-1229/)
     
 ## Additional evidence
 
 Partial output from security scanner Trivy:
<img width="1660" height="120" alt="cve moby circl" src="https://github.com/user-attachments/assets/6b5e28db-f62c-41a8-9e83-b735bd82dc0e" />

 ## Categorization
 
- [x] security/CVE