### PR TITLE
gha/labeler: Remove *_test.go from area/testing label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -136,7 +136,6 @@ area/testing:
       - any-glob-to-any-file:
         - 'integration/**'
         - 'integration-cli/**'
-        - '**/*_test.go'
         - 'internal/test*'
         - 'internal/testutil/**'
       - all-globs-to-all-files: '!vendor/**'


### PR DESCRIPTION
The *_test.go pattern was causing excessive noise by labeling all PRs that include test files with area/testing, even when the primary focus of the PR was not testing infrastructure itself.
