### PR TITLE
client: add missing doc comments to container copy types

### DIFF
--- a/client/container_copy.go
+++ b/client/container_copy.go
@@ -14,10 +14,12 @@ import (
 	"github.com/moby/moby/api/types/container"
 )
 
+// ContainerStatPathOptions holds options for [Client.ContainerStatPath].
 type ContainerStatPathOptions struct {
 	Path string
 }
 
+// ContainerStatPathResult holds the result of [Client.ContainerStatPath].
 type ContainerStatPathResult struct {
 	Stat container.PathStat
 }
@@ -53,6 +55,7 @@ type CopyToContainerOptions struct {
 	CopyUIDGID                bool
 }
 
+// CopyToContainerResult holds the result of [Client.CopyToContainer].
 type CopyToContainerResult struct{}
 
 // CopyToContainer copies content into the container filesystem.
@@ -83,10 +86,12 @@ func (cli *Client) CopyToContainer(ctx context.Context, containerID string, opti
 	return CopyToContainerResult{}, nil
 }
 
+// CopyFromContainerOptions holds options for [Client.CopyFromContainer].
 type CopyFromContainerOptions struct {
 	SourcePath string
 }
 
+// CopyFromContainerResult holds the result of [Client.CopyFromContainer].
 type CopyFromContainerResult struct {
 	Content io.ReadCloser
 	Stat    container.PathStat

--- a/vendor/github.com/moby/moby/client/container_copy.go
+++ b/vendor/github.com/moby/moby/client/container_copy.go
@@ -14,10 +14,12 @@ import (
 	"github.com/moby/moby/api/types/container"
 )
 
+// ContainerStatPathOptions holds options for [Client.ContainerStatPath].
 type ContainerStatPathOptions struct {
 	Path string
 }
 
+// ContainerStatPathResult holds the result of [Client.ContainerStatPath].
 type ContainerStatPathResult struct {
 	Stat container.PathStat
 }
@@ -53,6 +55,7 @@ type CopyToContainerOptions struct {
 	CopyUIDGID                bool
 }
 
+// CopyToContainerResult holds the result of [Client.CopyToContainer].
 type CopyToContainerResult struct{}
 
 // CopyToContainer copies content into the container filesystem.
@@ -83,10 +86,12 @@ func (cli *Client) CopyToContainer(ctx context.Context, containerID string, opti
 	return CopyToContainerResult{}, nil
 }
 
+// CopyFromContainerOptions holds options for [Client.CopyFromContainer].
 type CopyFromContainerOptions struct {
 	SourcePath string
 }
 
+// CopyFromContainerResult holds the result of [Client.CopyFromContainer].
 type CopyFromContainerResult struct {
 	Content io.ReadCloser
 	Stat    container.PathStat


### PR DESCRIPTION
Add missing Go doc comments to the exported option and result types
in `client/container_copy.go`. These were the only exported types in
this file without documentation, which is required for exported
declarations per the project's coding style guidelines.

**- What I did**

Added one-line Go doc comments to five exported types:
- `ContainerStatPathOptions`
- `ContainerStatPathResult`
- `CopyToContainerResult`
- `CopyFromContainerOptions`
- `CopyFromContainerResult`

**- How I did it**

Added standard Go doc comments following the same pattern used by
other types in the same package (e.g., `ExecCreateOptions`,
`ExecCreateResult` in `container_exec.go`).

**- How to verify it**

```bash
go build ./...
```

No functional change; documentation only.

**- Human readable description for the release notes**

```markdown changelog

```