### PR TITLE
Update NVIDIA --gpu requests using CDI to match AMD logic

### DIFF
--- a/daemon/devices.go
+++ b/daemon/devices.go
@@ -39,9 +39,18 @@ func registerDeviceDriver(name string, d *deviceDriver) {
 	deviceDrivers[name] = d
 }
 
+type vendors []string
+
+var defaultVendors = vendors{"nvidia.com", "amd.com"}
+
 func getFirstAvailableVendor(vendorList []string) (string, error) {
-	knownVendors := []string{"nvidia.com", "amd.com"}
-	for _, vendor := range knownVendors {
+	return defaultVendors.getFirstAvailableIn(vendorList)
+}
+
+// getFirstAvailableIn returns the first of the defined vendors in the specified
+// vendor list.
+func (v vendors) getFirstAvailableIn(vendorList []string) (string, error) {
+	for _, vendor := range v {
 		for _, available := range vendorList {
 			if vendor == available {
 				return vendor, nil

--- a/daemon/devices_amd_linux.go
+++ b/daemon/devices_amd_linux.go
@@ -35,7 +35,7 @@ func setAMDGPUs(s *specs.Spec, dev *deviceInstance) error {
 
 func createAMDCDIUpdater(cdiCache *cdi.Cache) func(*specs.Spec, *deviceInstance) error {
 	return func(s *specs.Spec, dev *deviceInstance) error {
-		injector := createCDIInjector(cdiCache, "amd.com")
+		injector := createCDIDeviceInjector(cdiCache, "amd.com")
 		return injector.injectDevices(s, dev)
 	}
 }

--- a/daemon/devices_amd_linux.go
+++ b/daemon/devices_amd_linux.go
@@ -1,8 +1,6 @@
 package daemon
 
 import (
-	"errors"
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -37,18 +35,7 @@ func setAMDGPUs(s *specs.Spec, dev *deviceInstance) error {
 
 func createAMDCDIUpdater(cdiCache *cdi.Cache) func(*specs.Spec, *deviceInstance) error {
 	return func(s *specs.Spec, dev *deviceInstance) error {
-		vendor, err := getFirstAvailableVendor(cdiCache.ListVendors())
-		if err != nil {
-			return fmt.Errorf("failed to discover GPU vendor from CDI: %w", err)
-		}
-
-		if vendor != "amd.com" {
-			return errors.New("AMD CDI spec not found")
-		}
-
-		injector := &cdiDeviceInjector{
-			defaultCDIDeviceKind: "amd.com/gpu",
-		}
+		injector := createCDIInjector(cdiCache, "amd.com")
 		return injector.injectDevices(s, dev)
 	}
 }

--- a/daemon/devices_linux.go
+++ b/daemon/devices_linux.go
@@ -8,11 +8,11 @@ import (
 )
 
 // RegisterGPUDeviceDrivers registers GPU device drivers.
-// If the cdiCache is provided, it is used to detect presence of CDI specs for AMD GPUs.
-// For NVIDIA GPUs, presence of CDI specs is detected by checking for the nvidia-cdi-hook binary.
+// If the cdiCache is provided, it is used to discover the vendor via available CDI specs
+// and translate the GPU requests to CDI device requests.
 func RegisterGPUDeviceDrivers(cdiCache *cdi.Cache) {
 	// Register NVIDIA device drivers.
-	if nvidiaDrivers := getNVIDIADeviceDrivers(); len(nvidiaDrivers) > 0 {
+	if nvidiaDrivers := getNVIDIADeviceDrivers(cdiCache); len(nvidiaDrivers) > 0 {
 		for name, driver := range nvidiaDrivers {
 			registerDeviceDriver(name, driver)
 		}

--- a/daemon/devices_linux.go
+++ b/daemon/devices_linux.go
@@ -1,9 +1,6 @@
 package daemon
 
 import (
-	"fmt"
-
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
@@ -24,34 +21,4 @@ func RegisterGPUDeviceDrivers(cdiCache *cdi.Cache) {
 		registerDeviceDriver("amd", amdDriver)
 		return
 	}
-}
-
-// a cdiCacheInjector uses the specified CDI cache to inject device requests
-// into a CDI spec.
-type cdiCacheInjector struct {
-	cdiCache *cdi.Cache
-	// optionalVendor allows a specific vendor to be specified.
-	// If this is not specified, the first supported vendor will be chosen.
-	optionalVendor string
-}
-
-func createCDIInjector(cdiCache *cdi.Cache, optionalVendor string) *cdiCacheInjector {
-	return &cdiCacheInjector{
-		cdiCache:       cdiCache,
-		optionalVendor: optionalVendor,
-	}
-}
-
-func (c *cdiCacheInjector) injectDevices(s *specs.Spec, dev *deviceInstance) error {
-	vendor, err := getFirstAvailableVendor(c.cdiCache.ListVendors())
-	if err != nil {
-		return fmt.Errorf("failed to discover GPU vendor from CDI: %w", err)
-	}
-	if c.optionalVendor != "" && vendor != c.optionalVendor {
-		return fmt.Errorf("CDI specs for required vendor %v not found", c.optionalVendor)
-	}
-	injector := &cdiDeviceInjector{
-		defaultCDIDeviceKind: c.optionalVendor + "/gpu",
-	}
-	return injector.injectDevices(s, dev)
 }

--- a/daemon/devices_linux.go
+++ b/daemon/devices_linux.go
@@ -1,6 +1,11 @@
 package daemon
 
-import "tags.cncf.io/container-device-interface/pkg/cdi"
+import (
+	"fmt"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
+)
 
 // RegisterGPUDeviceDrivers registers GPU device drivers.
 // If the cdiCache is provided, it is used to detect presence of CDI specs for AMD GPUs.
@@ -19,4 +24,34 @@ func RegisterGPUDeviceDrivers(cdiCache *cdi.Cache) {
 		registerDeviceDriver("amd", amdDriver)
 		return
 	}
+}
+
+// a cdiCacheInjector uses the specified CDI cache to inject device requests
+// into a CDI spec.
+type cdiCacheInjector struct {
+	cdiCache *cdi.Cache
+	// optionalVendor allows a specific vendor to be specified.
+	// If this is not specified, the first supported vendor will be chosen.
+	optionalVendor string
+}
+
+func createCDIInjector(cdiCache *cdi.Cache, optionalVendor string) *cdiCacheInjector {
+	return &cdiCacheInjector{
+		cdiCache:       cdiCache,
+		optionalVendor: optionalVendor,
+	}
+}
+
+func (c *cdiCacheInjector) injectDevices(s *specs.Spec, dev *deviceInstance) error {
+	vendor, err := getFirstAvailableVendor(c.cdiCache.ListVendors())
+	if err != nil {
+		return fmt.Errorf("failed to discover GPU vendor from CDI: %w", err)
+	}
+	if c.optionalVendor != "" && vendor != c.optionalVendor {
+		return fmt.Errorf("CDI specs for required vendor %v not found", c.optionalVendor)
+	}
+	injector := &cdiDeviceInjector{
+		defaultCDIDeviceKind: c.optionalVendor + "/gpu",
+	}
+	return injector.injectDevices(s, dev)
 }

--- a/daemon/devices_linux_test.go
+++ b/daemon/devices_linux_test.go
@@ -1,0 +1,62 @@
+package daemon
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCDIDeviceInjectorResolveVendor(t *testing.T) {
+	testCases := []struct {
+		description      string
+		availableVendors mockVendorLister
+		allowedVendors   []string
+
+		expectedError  string
+		expectedVendor string
+	}{
+		{
+			description:      "predefined vendors not found",
+			availableVendors: []string{"not.amd.com", "not.nvidia.com"},
+			expectedError:    "no known GPU vendor found",
+		},
+		{
+			description:      "required vendor is used",
+			availableVendors: []string{"another.com", "example.com"},
+			allowedVendors:   []string{"example.com"},
+			expectedVendor:   "example.com",
+		},
+		{
+			description:      "required vendor not found",
+			availableVendors: []string{"another.com", "example.com"},
+			allowedVendors:   []string{"not.example.com"},
+			expectedError:    "no known GPU vendor found",
+		},
+		{
+			description:      "multiple required / allowed vendors",
+			availableVendors: []string{"another.com", "example.com"},
+			allowedVendors:   []string{"not.example.com", "another.com"},
+			expectedVendor:   "another.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			i := createCDIDeviceInjector(tc.availableVendors, tc.allowedVendors...)
+
+			vendor, err := i.resolveVendor()
+			if tc.expectedError == "" {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedError)
+			}
+			assert.Equal(t, tc.expectedVendor, vendor)
+		})
+	}
+}
+
+type mockVendorLister []string
+
+func (m mockVendorLister) ListVendors() []string {
+	return m
+}

--- a/daemon/devices_nvidia_linux.go
+++ b/daemon/devices_nvidia_linux.go
@@ -42,7 +42,7 @@ func getNVIDIADeviceDrivers(cdiCache *cdi.Cache) map[string]*deviceDriver {
 	if cdiCache != nil {
 		// Create a device injector that handles --gpus device requests using
 		// nvidia.com CDI requests.
-		injector := createCDIInjector(cdiCache, "nvidia.com")
+		injector := createCDIDeviceInjector(cdiCache, "nvidia.com")
 		// Register a named device driver for this injector so that a user can
 		// explicitly request it.
 		// This has no capabilities associated to not inadvertently match requests.
@@ -191,7 +191,29 @@ func countToDevices(count int) []string {
 // A cdiDeviceInjector is used to map regular device requests to CDI device
 // requests.
 type cdiDeviceInjector struct {
-	defaultCDIDeviceKind string
+	availableVendors vendorLister
+	validVendors     vendors
+}
+
+type vendorLister interface {
+	ListVendors() []string
+}
+
+// createCDIInjector creates a injector for CDI devices from the specified a set
+// of available vendors.
+// The available vendors are resolved at the point of injection and compared
+// against the set of allowed vendors. If no allowed vendors are specified, the
+// default list is used.
+func createCDIDeviceInjector(availableVendors vendorLister, allowedVendors ...string) *cdiDeviceInjector {
+	validVendors := defaultVendors
+	if len(allowedVendors) > 0 {
+		validVendors = vendors(allowedVendors)
+	}
+
+	return &cdiDeviceInjector{
+		availableVendors: availableVendors,
+		validVendors:     validVendors,
+	}
 }
 
 // injectDevices converts an incoming device request to a request for devices
@@ -215,7 +237,11 @@ func (i *cdiDeviceInjector) injectDevices(s *specs.Spec, dev *deviceInstance) er
 
 	var cdiDeviceIDs []string
 	for _, deviceID := range deviceIDs {
-		cdiDeviceIDs = append(cdiDeviceIDs, i.normalizeDeviceID(deviceID))
+		cdiDeviceID, err := i.normalizeDeviceID(deviceID)
+		if err != nil {
+			return err
+		}
+		cdiDeviceIDs = append(cdiDeviceIDs, cdiDeviceID)
 	}
 
 	// We construct a device instance using the CDI device IDs and forward this
@@ -235,12 +261,25 @@ func (i *cdiDeviceInjector) injectDevices(s *specs.Spec, dev *deviceInstance) er
 // If the deviceID is already a fully-qualified CDI device name it is returned
 // as-is, otherwise, the default CDI device kind (vendor/class) is used to
 // construct a fully qualified CDI device name.
-func (i *cdiDeviceInjector) normalizeDeviceID(deviceID string) string {
+func (i *cdiDeviceInjector) normalizeDeviceID(deviceID string) (string, error) {
 	// if deviceID is of the form vendor.com/class=name, we return it as-is.
 	// TODO: We should ideally use the parser from the tags.cncf.io/cdi packages.
 	if _, _, ok := strings.Cut(deviceID, "="); ok {
-		return deviceID
+		return deviceID, nil
 	}
 
-	return i.defaultCDIDeviceKind + "=" + deviceID
+	cdiVendor, err := i.resolveVendor()
+	if err != nil {
+		return "", fmt.Errorf("failed to discover GPU vendor from CDI: %w", err)
+	}
+
+	return cdiVendor + "/gpu=" + deviceID, nil
+}
+
+func (i *cdiDeviceInjector) resolveVendor() (string, error) {
+	vendor, err := i.validVendors.getFirstAvailableIn(i.availableVendors.ListVendors())
+	if err != nil {
+		return "", err
+	}
+	return vendor, nil
 }

--- a/daemon/devices_nvidia_linux.go
+++ b/daemon/devices_nvidia_linux.go
@@ -78,8 +78,10 @@ func getNVIDIADeviceDrivers() map[string]*deviceDriver {
 	return nvidiaDrivers
 }
 
-// specUpdaters refer to a list of functions used updated an OCI spec for a
-// given device instance.
+// firstSuccessfulUpdater refer to a list of functions used updated an OCI spec
+// for a given device instance.
+// The functions are called in sequence, and if an error is returned, the next
+// function is called.
 type firstSuccessfulUpdater []func(*specs.Spec, *deviceInstance) error
 
 // updateSpec returns on the first successful spec update.

--- a/daemon/devices_nvidia_linux.go
+++ b/daemon/devices_nvidia_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/v2/daemon/internal/capabilities"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 // TODO: nvidia should not be hard-coded, and should be a device plugin instead on the daemon object.
@@ -22,7 +23,6 @@ var errConflictCountDeviceIDs = errors.New("cannot set both Count and DeviceIDs 
 
 const (
 	nvidiaContainerRuntimeHookExecutableName = "nvidia-container-runtime-hook"
-	nvidiaCDIHookExecutableName              = "nvidia-cdi-hook"
 )
 
 // These are NVIDIA-specific capabilities stolen from github.com/containerd/containerd/contrib/nvidia.allCaps
@@ -35,20 +35,21 @@ var allNvidiaCaps = map[string]struct{}{
 	"display":  {},
 }
 
-func getNVIDIADeviceDrivers() map[string]*deviceDriver {
+func getNVIDIADeviceDrivers(cdiCache *cdi.Cache) map[string]*deviceDriver {
 	var composite firstSuccessfulUpdater
 	nvidiaDrivers := make(map[string]*deviceDriver)
 
-	if _, err := exec.LookPath(nvidiaCDIHookExecutableName); err == nil {
-		// Register a driver specific to CDI if present.
+	if cdiCache != nil {
+		// Create a device injector that handles --gpus device requests using
+		// nvidia.com CDI requests.
+		injector := createCDIInjector(cdiCache, "nvidia.com")
+		// Register a named device driver for this injector so that a user can
+		// explicitly request it.
 		// This has no capabilities associated to not inadvertently match requests.
-		cdiDeviceDriver := &deviceDriver{
-			updateSpec: (&cdiDeviceInjector{
-				defaultCDIDeviceKind: "nvidia.com/gpu",
-			}).injectDevices,
+		nvidiaDrivers["nvidia.cdi"] = &deviceDriver{
+			updateSpec: injector.injectDevices,
 		}
-		nvidiaDrivers["nvidia.cdi"] = cdiDeviceDriver
-		composite = append(composite, cdiDeviceDriver.updateSpec)
+		composite = append(composite, injector.injectDevices)
 	}
 
 	if _, err := exec.LookPath(nvidiaContainerRuntimeHookExecutableName); err == nil {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Refactored the handling of `--gpus` requests for NVIDIA devices to align with AMD device requests. See #52048.

**- How I did it**

Introduced a `cdiCacheInjector` and update the AMD-specific code to make use of this type. I then migrated the NVIDIA implementation to this.

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

