### PR TITLE
client: add missing doc comments to various client types

### DIFF
--- a/client/build_cancel.go
+++ b/client/build_cancel.go
@@ -5,8 +5,10 @@ import (
 	"net/url"
 )
 
+// BuildCancelOptions holds options for [Client.BuildCancel].
 type BuildCancelOptions struct{}
 
+// BuildCancelResult holds the result of [Client.BuildCancel].
 type BuildCancelResult struct{}
 
 // BuildCancel requests the daemon to cancel the ongoing build request

--- a/client/config_remove.go
+++ b/client/config_remove.go
@@ -2,10 +2,12 @@ package client
 
 import "context"
 
+// ConfigRemoveOptions holds options for [Client.ConfigRemove].
 type ConfigRemoveOptions struct {
 	// Add future optional parameters here
 }
 
+// ConfigRemoveResult holds the result of [Client.ConfigRemove].
 type ConfigRemoveResult struct {
 	// Add future fields here
 }

--- a/client/config_update.go
+++ b/client/config_update.go
@@ -13,6 +13,7 @@ type ConfigUpdateOptions struct {
 	Spec    swarm.ConfigSpec
 }
 
+// ConfigUpdateResult holds the result of [Client.ConfigUpdate].
 type ConfigUpdateResult struct{}
 
 // ConfigUpdate attempts to update a config

--- a/client/image_tag.go
+++ b/client/image_tag.go
@@ -9,11 +9,13 @@ import (
 	"github.com/distribution/reference"
 )
 
+// ImageTagOptions holds options for [Client.ImageTag].
 type ImageTagOptions struct {
 	Source string
 	Target string
 }
 
+// ImageTagResult holds the result of [Client.ImageTag].
 type ImageTagResult struct{}
 
 // ImageTag tags an image in the docker host

--- a/client/node_inspect.go
+++ b/client/node_inspect.go
@@ -12,6 +12,7 @@ import (
 // NodeInspectOptions holds parameters to inspect nodes with.
 type NodeInspectOptions struct{}
 
+// NodeInspectResult holds the result of [Client.NodeInspect].
 type NodeInspectResult struct {
 	Node swarm.Node
 	Raw  json.RawMessage

--- a/client/node_list.go
+++ b/client/node_list.go
@@ -13,6 +13,7 @@ type NodeListOptions struct {
 	Filters Filters
 }
 
+// NodeListResult holds the result of [Client.NodeList].
 type NodeListResult struct {
 	Items []swarm.Node
 }

--- a/client/node_remove.go
+++ b/client/node_remove.go
@@ -9,6 +9,8 @@ import (
 type NodeRemoveOptions struct {
 	Force bool
 }
+
+// NodeRemoveResult holds the result of [Client.NodeRemove].
 type NodeRemoveResult struct{}
 
 // NodeRemove removes a Node.

--- a/client/node_update.go
+++ b/client/node_update.go
@@ -13,6 +13,7 @@ type NodeUpdateOptions struct {
 	Spec    swarm.NodeSpec
 }
 
+// NodeUpdateResult holds the result of [Client.NodeUpdate].
 type NodeUpdateResult struct{}
 
 // NodeUpdate updates a Node.

--- a/client/secret_remove.go
+++ b/client/secret_remove.go
@@ -2,10 +2,12 @@ package client
 
 import "context"
 
+// SecretRemoveOptions holds options for [Client.SecretRemove].
 type SecretRemoveOptions struct {
 	// Add future optional parameters here
 }
 
+// SecretRemoveResult holds the result of [Client.SecretRemove].
 type SecretRemoveResult struct {
 	// Add future fields here
 }

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -13,6 +13,7 @@ type SecretUpdateOptions struct {
 	Spec    swarm.SecretSpec
 }
 
+// SecretUpdateResult holds the result of [Client.SecretUpdate].
 type SecretUpdateResult struct{}
 
 // SecretUpdate attempts to update a secret.

--- a/client/system_info.go
+++ b/client/system_info.go
@@ -9,10 +9,12 @@ import (
 	"github.com/moby/moby/api/types/system"
 )
 
+// InfoOptions holds options for [Client.Info].
 type InfoOptions struct {
 	// No options currently; placeholder for future use
 }
 
+// SystemInfoResult holds the result of [Client.Info].
 type SystemInfoResult struct {
 	Info system.Info
 }

--- a/vendor/github.com/moby/moby/client/build_cancel.go
+++ b/vendor/github.com/moby/moby/client/build_cancel.go
@@ -5,8 +5,10 @@ import (
 	"net/url"
 )
 
+// BuildCancelOptions holds options for [Client.BuildCancel].
 type BuildCancelOptions struct{}
 
+// BuildCancelResult holds the result of [Client.BuildCancel].
 type BuildCancelResult struct{}
 
 // BuildCancel requests the daemon to cancel the ongoing build request

--- a/vendor/github.com/moby/moby/client/config_remove.go
+++ b/vendor/github.com/moby/moby/client/config_remove.go
@@ -2,10 +2,12 @@ package client
 
 import "context"
 
+// ConfigRemoveOptions holds options for [Client.ConfigRemove].
 type ConfigRemoveOptions struct {
 	// Add future optional parameters here
 }
 
+// ConfigRemoveResult holds the result of [Client.ConfigRemove].
 type ConfigRemoveResult struct {
 	// Add future fields here
 }

--- a/vendor/github.com/moby/moby/client/config_update.go
+++ b/vendor/github.com/moby/moby/client/config_update.go
@@ -13,6 +13,7 @@ type ConfigUpdateOptions struct {
 	Spec    swarm.ConfigSpec
 }
 
+// ConfigUpdateResult holds the result of [Client.ConfigUpdate].
 type ConfigUpdateResult struct{}
 
 // ConfigUpdate attempts to update a config

--- a/vendor/github.com/moby/moby/client/image_tag.go
+++ b/vendor/github.com/moby/moby/client/image_tag.go
@@ -9,11 +9,13 @@ import (
 	"github.com/distribution/reference"
 )
 
+// ImageTagOptions holds options for [Client.ImageTag].
 type ImageTagOptions struct {
 	Source string
 	Target string
 }
 
+// ImageTagResult holds the result of [Client.ImageTag].
 type ImageTagResult struct{}
 
 // ImageTag tags an image in the docker host

--- a/vendor/github.com/moby/moby/client/node_inspect.go
+++ b/vendor/github.com/moby/moby/client/node_inspect.go
@@ -12,6 +12,7 @@ import (
 // NodeInspectOptions holds parameters to inspect nodes with.
 type NodeInspectOptions struct{}
 
+// NodeInspectResult holds the result of [Client.NodeInspect].
 type NodeInspectResult struct {
 	Node swarm.Node
 	Raw  json.RawMessage

--- a/vendor/github.com/moby/moby/client/node_list.go
+++ b/vendor/github.com/moby/moby/client/node_list.go
@@ -13,6 +13,7 @@ type NodeListOptions struct {
 	Filters Filters
 }
 
+// NodeListResult holds the result of [Client.NodeList].
 type NodeListResult struct {
 	Items []swarm.Node
 }

--- a/vendor/github.com/moby/moby/client/node_remove.go
+++ b/vendor/github.com/moby/moby/client/node_remove.go
@@ -9,6 +9,8 @@ import (
 type NodeRemoveOptions struct {
 	Force bool
 }
+
+// NodeRemoveResult holds the result of [Client.NodeRemove].
 type NodeRemoveResult struct{}
 
 // NodeRemove removes a Node.

--- a/vendor/github.com/moby/moby/client/node_update.go
+++ b/vendor/github.com/moby/moby/client/node_update.go
@@ -13,6 +13,7 @@ type NodeUpdateOptions struct {
 	Spec    swarm.NodeSpec
 }
 
+// NodeUpdateResult holds the result of [Client.NodeUpdate].
 type NodeUpdateResult struct{}
 
 // NodeUpdate updates a Node.

--- a/vendor/github.com/moby/moby/client/secret_remove.go
+++ b/vendor/github.com/moby/moby/client/secret_remove.go
@@ -2,10 +2,12 @@ package client
 
 import "context"
 
+// SecretRemoveOptions holds options for [Client.SecretRemove].
 type SecretRemoveOptions struct {
 	// Add future optional parameters here
 }
 
+// SecretRemoveResult holds the result of [Client.SecretRemove].
 type SecretRemoveResult struct {
 	// Add future fields here
 }

--- a/vendor/github.com/moby/moby/client/secret_update.go
+++ b/vendor/github.com/moby/moby/client/secret_update.go
@@ -13,6 +13,7 @@ type SecretUpdateOptions struct {
 	Spec    swarm.SecretSpec
 }
 
+// SecretUpdateResult holds the result of [Client.SecretUpdate].
 type SecretUpdateResult struct{}
 
 // SecretUpdate attempts to update a secret.

--- a/vendor/github.com/moby/moby/client/system_info.go
+++ b/vendor/github.com/moby/moby/client/system_info.go
@@ -9,10 +9,12 @@ import (
 	"github.com/moby/moby/api/types/system"
 )
 
+// InfoOptions holds options for [Client.Info].
 type InfoOptions struct {
 	// No options currently; placeholder for future use
 }
 
+// SystemInfoResult holds the result of [Client.Info].
 type SystemInfoResult struct {
 	Info system.Info
 }


### PR DESCRIPTION
Add missing Go doc comments to exported option and result types
across several files in the `client/` package. These types had no
documentation, which is required for exported declarations per the
project's coding style guidelines.

**- What I did**

Added one-line Go doc comments to exported types in:
- `image_tag.go`: `ImageTagOptions`, `ImageTagResult`
- `build_cancel.go`: `BuildCancelOptions`, `BuildCancelResult`
- `system_info.go`: `InfoOptions`, `SystemInfoResult`
- `config_remove.go`: `ConfigRemoveOptions`, `ConfigRemoveResult`
- `config_update.go`: `ConfigUpdateResult`
- `secret_remove.go`: `SecretRemoveOptions`, `SecretRemoveResult`
- `secret_update.go`: `SecretUpdateResult`
- `node_inspect.go`: `NodeInspectResult`
- `node_list.go`: `NodeListResult`
- `node_remove.go`: `NodeRemoveResult`
- `node_update.go`: `NodeUpdateResult`

**- How I did it**

Added standard Go doc comments following the same pattern used by
other types in the package.

**- How to verify it**

```bash
go build ./...
```

No functional change; documentation only.

**- Human readable description for the release notes**

```markdown changelog

```