### PR TITLE
daemon/pkg/registry: Service.Auth: refactor, and reject non-http(s)

### DIFF
--- a/daemon/pkg/registry/service.go
+++ b/daemon/pkg/registry/service.go
@@ -57,7 +57,6 @@ func (s *Service) ReplaceConfig(options ServiceOptions) (commit func(), _ error)
 // and returns OK if authentication was successful.
 // It can be used to verify the validity of a client's credentials.
 func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, userAgent string) (token string, _ error) {
-	// TODO Use ctx when searching for repositories
 	registryHostName := IndexHostname
 
 	if authConfig.ServerAddress != "" {
@@ -104,14 +103,21 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 }
 
 func parseRegistryHostName(serverAddress string) (string, error) {
-	if !strings.HasPrefix(serverAddress, "https://") && !strings.HasPrefix(serverAddress, "http://") {
+	if !strings.Contains(serverAddress, "://") {
+		// url.Parse treats input without a scheme as path, not hostname.
 		serverAddress = "https://" + serverAddress
 	}
 	u, err := url.Parse(serverAddress)
 	if err != nil {
-		return "", invalidParamWrapf(err, "unable to parse server address")
+		return "", invalidParamWrapf(err, `invalid server address: unable to parse`)
 	}
-	return u.Host, nil
+	switch u.Scheme {
+	case "http", "https":
+		// all good
+		return u.Host, nil
+	default:
+		return "", invalidParamf(`invalid server address %q: unsupported URL scheme %q: must be "http" or "https"`, serverAddress, u.Scheme)
+	}
 }
 
 // ResolveAuthConfig looks up authentication for the given reference from the

--- a/daemon/pkg/registry/service.go
+++ b/daemon/pkg/registry/service.go
@@ -61,15 +61,11 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 	registryHostName := IndexHostname
 
 	if authConfig.ServerAddress != "" {
-		serverAddress := authConfig.ServerAddress
-		if !strings.HasPrefix(serverAddress, "https://") && !strings.HasPrefix(serverAddress, "http://") {
-			serverAddress = "https://" + serverAddress
-		}
-		u, err := url.Parse(serverAddress)
+		var err error
+		registryHostName, err = parseRegistryHostName(authConfig.ServerAddress)
 		if err != nil {
-			return "", invalidParamWrapf(err, "unable to parse server address")
+			return "", err
 		}
-		registryHostName = u.Host
 	}
 
 	// Lookup endpoints for authentication but exclude mirrors to prevent
@@ -105,6 +101,17 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 	}
 
 	return "", lastErr
+}
+
+func parseRegistryHostName(serverAddress string) (string, error) {
+	if !strings.HasPrefix(serverAddress, "https://") && !strings.HasPrefix(serverAddress, "http://") {
+		serverAddress = "https://" + serverAddress
+	}
+	u, err := url.Parse(serverAddress)
+	if err != nil {
+		return "", invalidParamWrapf(err, "unable to parse server address")
+	}
+	return u.Host, nil
 }
 
 // ResolveAuthConfig looks up authentication for the given reference from the

--- a/daemon/pkg/registry/service_test.go
+++ b/daemon/pkg/registry/service_test.go
@@ -1,0 +1,76 @@
+package registry
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestParseRegistryHostName(t *testing.T) {
+	tests := []struct {
+		doc           string
+		serverAddress string
+		want          string
+		wantErr       string
+	}{
+		{
+			doc:           "localhost without scheme",
+			serverAddress: "localhost",
+			want:          "localhost",
+		},
+		{
+			doc:           "localhost with port without scheme",
+			serverAddress: "localhost:5000",
+			want:          "localhost:5000",
+		},
+		{
+			doc:           "hostname and port without scheme",
+			serverAddress: "registry.example.com:5000",
+			want:          "registry.example.com:5000",
+		},
+		{
+			doc:           "ipv4 host and port without scheme",
+			serverAddress: "127.0.0.1:8080",
+			want:          "127.0.0.1:8080",
+		},
+		{
+			doc:           "ipv6 host and port without scheme",
+			serverAddress: "[::1]:5000",
+			want:          "[::1]:5000",
+		},
+		{
+			doc:           "https URL",
+			serverAddress: "https://127.0.0.1:8080",
+			want:          "127.0.0.1:8080",
+		},
+		{
+			doc:           "https URL with path",
+			serverAddress: "https://registry.example.com/foo",
+			want:          "registry.example.com",
+		},
+		{
+			doc:           "userinfo like input without scheme",
+			serverAddress: "user:pass@example.com",
+			want:          `example.com`,
+		},
+		{
+			doc:           "malformed http URL",
+			serverAddress: "http://[::1",
+			wantErr:       `unable to parse server address:`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			got, err := parseRegistryHostName(tc.serverAddress)
+			if tc.wantErr != "" {
+				assert.Check(t, is.ErrorContains(err, tc.wantErr))
+				assert.Check(t, is.Equal(got, tc.want))
+				return
+			}
+			assert.Check(t, err)
+			assert.Check(t, is.Equal(got, tc.want))
+		})
+	}
+}

--- a/daemon/pkg/registry/service_test.go
+++ b/daemon/pkg/registry/service_test.go
@@ -55,9 +55,14 @@ func TestParseRegistryHostName(t *testing.T) {
 			want:          `example.com`,
 		},
 		{
+			doc:           "unsupported scheme",
+			serverAddress: "ftp://registry.example.com",
+			wantErr:       `unsupported URL scheme "ftp"`,
+		},
+		{
 			doc:           "malformed http URL",
 			serverAddress: "http://[::1",
-			wantErr:       `unable to parse server address:`,
+			wantErr:       `invalid server address: unable to parse:`,
 		},
 	}
 


### PR DESCRIPTION
- Remove outdated TODO
- Use url.Parse's result to detect whether a scheme was needed to prevent prepending "http(s)://" to URLs that already have a scheme.
- Reject non-http(s) schemes
- Touch-up errors

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

