### PR TITLE
update to go1.25.8

### DIFF
--- a/.github/workflows/.test-unit.yml
+++ b/.github/workflows/.test-unit.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -21,7 +21,7 @@ on:
         default: "graphdriver"
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   ITG_CLI_MATRIX_SIZE: 6

--- a/.github/workflows/.vm.yml
+++ b/.github/workflows/.vm.yml
@@ -25,7 +25,7 @@ on:
         default: ""
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
   TESTSTAT_VERSION: v0.1.25
   TEMPLATE_NAME: ${{ inputs.template }}
 

--- a/.github/workflows/.windows.yml
+++ b/.github/workflows/.windows.yml
@@ -28,7 +28,7 @@ on:
         default: false
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
   GOTESTLIST_VERSION: v0.3.1
   TESTSTAT_VERSION: v0.1.25
   WINDOWS_BASE_IMAGE: mcr.microsoft.com/windows/servercore

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
   TESTSTAT_VERSION: v0.1.25
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge

--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
   DESTDIR: ./build
   SETUP_BUILDX_VERSION: edge
   SETUP_BUILDKIT_IMAGE: moby/buildkit:latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ on:
     - cron: '0 9 * * 4'
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
 
 jobs:
   codeql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: "1.25.7"
+  GO_VERSION: "1.25.8"
   GIT_PAGER: "cat"
   PAGER: "cat"
   SETUP_BUILDX_VERSION: edge

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ version: "2"
 run:
   # prevent golangci-lint from deducting the go version to lint for through go.mod,
   # which causes it to fallback to go1.17 semantics.
-  go: "1.25.7"
+  go: "1.25.8"
   # Only supported with go modules enabled (build flag -mod=vendor only valid when using modules)
   # modules-download-mode: vendor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 

--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -5,7 +5,7 @@
 
 # This represents the bare minimum required to build and test Docker.
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -161,7 +161,7 @@ FROM ${WINDOWS_BASE_IMAGE}:${WINDOWS_BASE_IMAGE_TAG}
 # Use PowerShell as the default shell
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 
 # GOTESTSUM_VERSION is the version of gotest.tools/gotestsum to install.
 ARG GOTESTSUM_VERSION=v1.13.0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 
 FROM golang:${GO_VERSION}-alpine AS base
 RUN apk add --no-cache bash make yamllint

--- a/hack/dockerfiles/generate-files.Dockerfile
+++ b/hack/dockerfiles/generate-files.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 ARG BASE_DEBIAN_DISTRO="bookworm"
 ARG PROTOC_VERSION=3.11.4
 

--- a/hack/dockerfiles/govulncheck.Dockerfile
+++ b/hack/dockerfiles/govulncheck.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 ARG GOVULNCHECK_VERSION=v1.1.4
 ARG FORMAT=text
 


### PR DESCRIPTION
go1.25.8 (released 2026-03-05) includes security fixes to the html/template, net/url, and os packages, as well as bug fixes to the go command, the compiler, and the os package. See the Go 1.25.8 milestone on our issue tracker for details.

- 1.25.8 https://github.com/golang/go/issues?q=milestone%3AGo1.25.8+label%3ACherryPickApproved
- diff: https://github.com/golang/go/compare/go1.25.7...go1.25.8
- 1.26.1 https://github.com/golang/go/issues?q=milestone%3AGo1.26.1+label%3ACherryPickApproved
- diff: https://github.com/golang/go/compare/go1.26.0...go1.26.1

---

We have just released Go versions 1.26.1 and 1.25.8, minor point releases.

These releases include 5 security fixes following the security policy:

crypto/x509: incorrect enforcement of email constraints

- When verifying a certificate chain which contains a certificate containing multiple email address constraints (composed of the full email address) which share common local portions (the portion of the address before the '@' character) but different domain portions (the portion of the address after the '@' character), these constraints will not be properly applied, and only the last constraint will be considered.

  This can allow certificates in the chain containing email addresses which are either not permitted or excluded by the relevant constraints to be returned by calls to Certificate.Verify. Since the name constraint checks happen after chain building is complete, this only applies to certificate chains which chain to trusted roots (root certificates either in VerifyOptions.Roots or in the system root certificate pool), requiring a trusted CA to issue certificates containing either not permitted or excluded email addresses.

  This issue only affects Go 1.26.

  Thanks to Jakub Ciolek for reporting this issue.

  This is CVE-2026-27137 and Go issue https://go.dev/issue/77952.

- crypto/x509: panic in name constraint checking for malformed certificates

  Certificate verification can panic when a certificate in the chain has an empty DNS name and another certificate in the chain has excluded name constraints. This can crash programs that are either directly verifying X.509 certificate chains, or those that use TLS.

  Since the name constraint checks happen after chain building is complete, this only applies to certificate chains which chain to trusted roots (root certificates either in VerifyOptions.Roots or in the system root certificate pool), requiring a trusted CA to issue certificates containing malformed DNS names.

  This issue only affects Go 1.26.

  Thanks to Jakub Ciolek for reporting this issue.

  This is CVE-2026-27138 and Go issue https://go.dev/issue/77953.

- html/template: URLs in meta content attribute actions are not escaped

  Actions which insert URLs into the content attribute of HTML meta tags are not escaped. This can allow XSS if the meta tag also has an http-equiv attribute with the value "refresh".

  A new GODEBUG setting has been added, htmlmetacontenturlescape, which can be used to disable escaping URLs in actions in the meta content attribute which follow "url=" by setting htmlmetacontenturlescape=0.

  This is CVE-2026-27142 and Go issue https://go.dev/issue/77954.

- net/url: reject IPv6 literal not at start of host

  The Go standard library function net/url.Parse insufficiently validated the host/authority component and accepted some invalid URLs by effectively treating garbage before an IP-literal as ignorable. The function should have rejected this as invalid.

  To prevent this behavior, net/url.Parse now rejects IPv6 literals that do not appear at the start of the host subcomponent of a URL.

  Thanks to Masaki Hara (https://github.com/qnighy) of Wantedly.

  This is CVE-2026-25679 and Go issue https://go.dev/issue/77578.

- os: FileInfo can escape from a Root

  On Unix platforms, when listing the contents of a directory using File.ReadDir or File.Readdir the returned FileInfo could reference a file outside of the Root in which the File was opened.

  The contents of the FileInfo were populated using the lstat system call, which takes the path to the file as a parameter. If a component of the full path of the file described by the FileInfo is replaced with a symbolic link, the target of the lstat can be directed to another location on the filesystem.

  The impact of this escape is limited to reading metadata provided by lstat from arbitrary locations on the filesystem. This could be used to probe for the presence or absence of files as well as gleaning metadata like file sizes, but does not permit reading or writing files outside the root.

  The FileInfo is now populated using fstatat.

  Thank you to Miloslav Trmač of Red Hat for reporting this issue.

  This is CVE-2026-27139 and Go issue https://go.dev/issue/77827.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update Go runtime to [1.25.8](https://go.dev/doc/devel/release#go1.25.8)
```

**- A picture of a cute animal (not mandatory but encouraged)**

