### PR TITLE
ci: module-replace: ignore Dockerfile for api changes

### DIFF
--- a/hack/validate/module-replace
+++ b/hack/validate/module-replace
@@ -12,6 +12,7 @@ filter_diff() {
 api_diff=$(
 	validate_diff --diff-filter=ACMR -U0 -- \
 		'api/' \
+		':(exclude)api/Dockerfile' \
 		':(exclude)api/README.md' \
 		':(exclude)api/swagger.yaml' \
 		':(exclude)api/docs/' \


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52150#issuecomment-4011886659

The API Dockerfile should be ok to ignore for this check, as it's not part of the module;

```
================================================
================================================
api diff:
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
================================================
Detected changes in ./api directory, checking for replace rule...
null
ERROR: Changes detected in ./api but go.mod is missing a replace rule for github.com/moby/moby/api
Please run ./hack/vendor.sh replace
================================================
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

