### PR TITLE
bugfix: handle duplicate exit events via task status

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	containerdcli "github.com/containerd/containerd/v2/client"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	containertypes "github.com/moby/moby/api/types/container"
@@ -378,20 +379,60 @@ func (daemon *Daemon) shouldIgnoreExitEventWithLock(c *container.Container, e *l
 		return true
 
 	case containertypes.StateRunning:
-		// If the container is running, but the exit event is from
-		// before it was started, ignore it. This can happen when a
-		// duplicate exit arrives while the restart path holds the
-		// container lock; by the time we process it, a new task is
-		// already running, so the exit belongs to the previous task.
-		return !e.ExitedAt.IsZero() && e.ExitedAt.Before(c.State.StartedAt)
+		task, ok := c.State.Task()
+		if !ok {
+			log.G(context.TODO()).WithFields(log.Fields{
+				"container": c.ID,
+			}).Warn("container in running state but no task found while checking for duplicate exit event")
+			return false
+		}
+
+		ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+		status, err := task.Status(ctx)
+		cancel()
+		if err != nil {
+			// If containerd-shim crashed, the task will be deleted
+			// automatically by containerd, so treat a NotFound
+			// error as meaning the task is not running.
+			log.G(ctx).WithFields(log.Fields{
+				"error":     err,
+				"container": c.ID,
+			}).Warn("failed to get task status while checking for duplicate exit event")
+			return false
+		}
+
+		// If the container is still running, then this exit event must
+		// be a duplicate from a previous run, so ignore it. If the
+		// container is not running, then we should process the exit
+		// event to transition the container to exited.
+		//
+		// Timestamp is not reliable for determining whether an exit
+		// event is a duplicate, because CLOCK_REALTIME can jump backwards
+		// (e.g., due to NTP adjustments).
+		//
+		// See moby/moby#52153 for more details.
+		if status.Status == containerdcli.Running {
+			return true
+		}
+
+		if status.Status == containerdcli.Stopped {
+			if status.ExitStatus != e.ExitCode {
+				log.G(ctx).WithFields(log.Fields{
+					"container": c.ID,
+					"exitCode":  status.ExitStatus,
+					"eventCode": e.ExitCode,
+				}).Warn("container stopped with different exit code than exit event while checking for duplicate exit event")
+				return true
+			}
+		}
+		return false
 
 	case containertypes.StateRestarting:
 		// The restart path acquires and holds the container lock before
-		// processing; on failure it transitions the container to exited,
-		// and on success it transitions to running. Therefore, any exit
-		// event observed while still restarting is a late duplicate from
-		// the previous task and should be ignored.
-		return !e.ExitedAt.IsZero() && e.ExitedAt.After(c.State.FinishedAt)
+		// processing. So, if we're currently restarting, then we know
+		// for certain that we are still processing the previous exit
+		// event, and any new exit events must be duplicates.
+		return true
 
 	default:
 		return false


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes: https://github.com/moby/moby/issues/52153

**- How I did it**

Replace timestamp-based duplicate exit detection for running containers with a live containerd task status check, and ignore exits only when the task is still `Running`.

Also simplify restarting-state handling by always treating exit events as duplicates while restart processing is in progress, and add warning logs for task status lookups.

This avoids relying on wall-clock timestamps that can move backward (e.g., NTP), which could misclassify duplicate exit events.

**- How to verify it**

Manually run container and force containerd-shim to publish duplicated events

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Improved duplicate container-exit handling by using live containerd task state (not timestamps)
```

**- A picture of a cute animal (not mandatory but encouraged)**

