### PR TITLE
hack/test/unit: avoid unbound pkg vars with set -u

### DIFF
--- a/hack/test/unit
+++ b/hack/test/unit
@@ -18,6 +18,8 @@ TESTDIRS="${TESTDIRS:-./...}"
 
 : "${api_pkg_list:=}"
 : "${client_pkg_list:=}"
+: "${pkg_list:=}"
+: "${libnetwork_pkg_list:=}"
 
 mkdir -p bundles
 


### PR DESCRIPTION
**- What I did**

Fixed a `set -u` unbound-variable bug in `hack/test/unit` by ensuring
`pkg_list` and `libnetwork_pkg_list` are always defined before they are read.

**- How I did it**

Initialized `pkg_list` and `libnetwork_pkg_list` to empty values near the top
of the script (before case branches that may skip assignment), so later checks:

- `if [ -n "${pkg_list}" ]; then`
- `if [ -n "${libnetwork_pkg_list}" ]; then`

are safe for all `TESTDIRS` values (including `./api...` and `./client...`).

**- How to verify it**

1. Run with API-only dirs:
   `TESTDIRS=./api/... hack/test/unit`
2. Run with client-only dirs:
   `TESTDIRS=./client/... hack/test/unit`
3. Confirm script no longer exits due to unbound `pkg_list` /
   `libnetwork_pkg_list` under `set -u`.