### PR TITLE
integration/container: migrate StatsNoStreamGetCPU test

### DIFF
--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -17,49 +16,7 @@ import (
 	"github.com/moby/moby/v2/internal/testutil/request"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
-	"gotest.tools/v3/skip"
 )
-
-func (s *DockerAPISuite) TestAPIStatsNoStreamGetCpu(c *testing.T) {
-	skip.If(c, RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
-	skip.If(c, onlyCgroupsv2(), "FIXME: cgroupsV2 not supported yet")
-	out := cli.DockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;usleep 100; do echo 'Hello'; done").Stdout()
-	id := strings.TrimSpace(out)
-	cli.WaitRun(c, id)
-	resp, body, err := request.Get(testutil.GetContext(c), fmt.Sprintf("/containers/%s/stats?stream=false", id))
-	assert.NilError(c, err)
-	assert.Equal(c, resp.StatusCode, http.StatusOK)
-	assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
-	assert.Equal(c, resp.Header.Get("Content-Type"), "application/json")
-
-	var v container.StatsResponse
-	err = json.NewDecoder(body).Decode(&v)
-	assert.NilError(c, err)
-	_ = body.Close()
-
-	cpuPercent := 0.0
-
-	if testEnv.DaemonInfo.OSType != "windows" {
-		cpuDelta := float64(v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage)
-		systemDelta := float64(v.CPUStats.SystemUsage - v.PreCPUStats.SystemUsage)
-		cpuPercent = (cpuDelta / systemDelta) * float64(len(v.CPUStats.CPUUsage.PercpuUsage)) * 100.0
-	} else {
-		// Max number of 100ns intervals between the previous time read and now
-		possIntervals := uint64(v.Read.Sub(v.PreRead).Nanoseconds()) // Start with number of ns intervals
-		possIntervals /= 100                                         // Convert to number of 100ns intervals
-		possIntervals *= uint64(v.NumProcs)                          // Multiple by the number of processors
-
-		// Intervals used
-		intervalsUsed := v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage
-
-		// Percentage avoiding divide-by-zero
-		if possIntervals > 0 {
-			cpuPercent = float64(intervalsUsed) / float64(possIntervals) * 100.0
-		}
-	}
-
-	assert.Assert(c, cpuPercent != 0.0, "docker stats with no-stream get cpu usage failed: was %v", cpuPercent)
-}
 
 func (s *DockerAPISuite) TestAPIStatsStoppedContainerInGoroutines(c *testing.T) {
 	out := cli.DockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo 1").Stdout()

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -171,6 +171,48 @@ func TestStatsNetworkStats(t *testing.T) {
 	}, poll.WithDelay(100*time.Millisecond), poll.WithTimeout(2*time.Second))
 }
 
+func TestStatsNoStreamGetCPU(t *testing.T) {
+	skip.If(t, testEnv.RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
+	skip.If(t, testEnv.IsRootless() && testEnv.DaemonInfo.CgroupVersion == "1", "Rootless Mode does not support cgroups v1 stats")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, apiClient)
+
+	var res client.ContainerStatsResult
+
+	res, err := apiClient.ContainerStats(ctx, cID, client.ContainerStatsOptions{Stream: false})
+	assert.NilError(t, err)
+	defer res.Body.Close()
+
+	var v containertypes.StatsResponse
+	dec := json.NewDecoder(res.Body)
+	assert.NilError(t, dec.Decode(&v))
+
+	cpuPercent := 0.0
+
+	if testEnv.DaemonInfo.OSType != "windows" {
+		cpuDelta := float64(v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage)
+		systemDelta := float64(v.CPUStats.SystemUsage - v.PreCPUStats.SystemUsage)
+		cpuPercent = (cpuDelta / systemDelta) * float64(v.CPUStats.OnlineCPUs) * 100
+	} else {
+		// Windows measures CPU time in 100-nanosecond intervals
+		// Max number of 100ns intervals between previous time read and now
+		possIntervals := uint64(v.Read.Sub(v.PreRead).Nanoseconds()) // Start with number of ns intervals
+		possIntervals /= 100                                         // Convert to number of 100ns intervals
+		possIntervals *= uint64(v.NumProcs)                          // Multiply by number of processors
+
+		// Intervals used
+		intervalsUsed := v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage
+		if possIntervals > 0 {
+			cpuPercent = float64(intervalsUsed) / float64(possIntervals) * 100.0
+		}
+	}
+
+	assert.Assert(t, cpuPercent != 0.0, "Docker stats with no-stream get cpu usage failed: was %v", cpuPercent)
+}
+
 func getNetworkStats(ctx context.Context, t *testing.T, apiClient client.APIClient, id string) map[string]containertypes.NetworkStats {
 	res, err := apiClient.ContainerStats(ctx, id, client.ContainerStatsOptions{Stream: false})
 	assert.NilError(t, err)

--- a/integration/container/stats_test.go
+++ b/integration/container/stats_test.go
@@ -169,6 +169,48 @@ func TestStatsNetworkStats(t *testing.T) {
 	}, poll.WithDelay(100*time.Millisecond), poll.WithTimeout(2*time.Second))
 }
 
+func TestStatsNoStreamGetCPU(t *testing.T) {
+	skip.If(t, testEnv.RuntimeIsWindowsContainerd(), "FIXME: Broken on Windows + containerd combination")
+	skip.If(t, testEnv.IsRootless() && testEnv.DaemonInfo.CgroupVersion == "1", "Rootless Mode does not support cgroups v1 stats")
+
+	ctx := setupTest(t)
+	apiClient := testEnv.APIClient()
+
+	cID := container.Run(ctx, t, apiClient)
+
+	var res client.ContainerStatsResult
+
+	res, err := apiClient.ContainerStats(ctx, cID, client.ContainerStatsOptions{Stream: false})
+	assert.NilError(t, err)
+	defer res.Body.Close()
+
+	var v containertypes.StatsResponse
+	dec := json.NewDecoder(res.Body)
+	assert.NilError(t, dec.Decode(&v))
+
+	cpuPercent := 0.0
+
+	if testEnv.DaemonInfo.OSType != "windows" {
+		cpuDelta := float64(v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage)
+		systemDelta := float64(v.CPUStats.SystemUsage - v.PreCPUStats.SystemUsage)
+		cpuPercent = (cpuDelta / systemDelta) * float64(v.CPUStats.OnlineCPUs) * 100
+	} else {
+		// Windows measures CPU time in 100-nanosecond intervals
+		// Max number of 100ns intervals between previous time read and now
+		possIntervals := uint64(v.Read.Sub(v.PreRead).Nanoseconds()) // Start with number of ns intervals
+		possIntervals /= 100                                         // Convert to number of 100ns intervals
+		possIntervals *= uint64(v.NumProcs)                          // Multiply by number of processors
+
+		// Intervals used
+		intervalsUsed := v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage
+		if possIntervals > 0 {
+			cpuPercent = float64(intervalsUsed) / float64(possIntervals) * 100.0
+		}
+	}
+
+	assert.Assert(t, cpuPercent != 0.0, "Docker stats with no-stream get cpu usage failed: was %v", cpuPercent)
+}
+
 func getNetworkStats(ctx context.Context, t *testing.T, apiClient client.APIClient, id string) map[string]containertypes.NetworkStats {
 	res, err := apiClient.ContainerStats(ctx, id, client.ContainerStatsOptions{Stream: false})
 	assert.NilError(t, err)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Migrated the test `TestAPIStatsNoStreamGetCPU` from the `integration-cli` to `integration` test suite. Additionally removed the Cgroups v2 skip since we can calculate CPU usage without relying on missing fields from Cgroupvs2, namely `CPUStats.CPUUsage.PercpuUsage`
**- How I did it**
Rewriting the test using the Go-client and moving it to the `integration/` module
**- How to verify it**
Running the following command:
`TESTDIRS='./integration/container/' TESTFLAGS='-test.run TestStatsNoStreamGetCPU' make test-integration`
**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="1249" height="837" alt="image" src="https://github.com/user-attachments/assets/beadb96c-0569-43bc-8e09-034a3356cfac" />
