### PR TITLE
daemon/server: don't log context cancelation as error

### DIFF
--- a/daemon/server/server.go
+++ b/daemon/server/server.go
@@ -22,6 +22,19 @@ import (
 // when a request is about to be served.
 const versionMatcher = "/v{version:[0-9.]+}"
 
+// statusClientClosedRequest (HTTP 499 Client Closed Request) is a non-standard
+// HTTP status code used by NGINX to indicate that the client closed the connection
+// before the server was able to send a response.
+//
+// It is not part of the IANA HTTP status code registry and is primarily used
+// for logging and telemetry. The client will typically not observe this status,
+// as the connection is already closed.
+//
+// See:
+//   - https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/error-499/
+//   - https://nginx.org/en/docs/http/ngx_http_log_module.html
+const statusClientClosedRequest = 499
+
 // Server contains instance details for the server
 type Server struct {
 	middlewares []middleware.Middleware
@@ -33,9 +46,9 @@ func (s *Server) UseMiddleware(m middleware.Middleware) {
 	s.middlewares = append(s.middlewares, m)
 }
 
-func (s *Server) makeHTTPHandler(r router.Route) http.HandlerFunc {
-	handler := r.Handler()
-	operation := r.Method() + " " + r.Path()
+func (s *Server) makeHTTPHandler(route router.Route) http.HandlerFunc {
+	handler := route.Handler()
+	operation := route.Method() + " " + route.Path()
 	return otelhttp.NewHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Define the context that we'll pass around to share info
 		// like the docker-request-id.
@@ -61,10 +74,24 @@ func (s *Server) makeHTTPHandler(r router.Route) http.HandlerFunc {
 		}
 
 		if err := handlerFunc(ctx, w, r, vars); err != nil {
-			statusCode := httpstatus.FromError(err)
-			if statusCode >= http.StatusInternalServerError {
-				log.G(ctx).Errorf("Handler for %s %s returned error: %v", r.Method, r.URL.Path, err)
+			if r.Context().Err() != nil {
+				// Request is canceled, and client likely went away. Don't attempt
+				// to write JSON body, but log for debugging. Log the status as
+				// "499 Client Closed Request", which is non-standard, but aligns
+				// with NGINX and CloudFlare.
+				w.WriteHeader(statusClientClosedRequest) // for OTEL/metrics
+				log.G(ctx).WithFields(log.Fields{
+					"module":      "api",
+					"method":      route.Method(),
+					"request-url": r.RequestURI,
+					"vars":        vars,
+					"error":       err,
+					"status":      statusClientClosedRequest,
+				}).Info("request cancelled by client")
+				return
 			}
+
+			statusCode := httpstatus.FromError(err)
 			// While we no longer support API versions older than 1.24 [config.DefaultMinAPIVersion],
 			// a client may try to connect using an older version and expect a plain-text error
 			// instead of a JSON error. This would result in an "API version too old" error
@@ -78,6 +105,16 @@ func (s *Server) makeHTTPHandler(r router.Route) http.HandlerFunc {
 				_ = httputils.WriteJSON(w, statusCode, &common.ErrorResponse{
 					Message: err.Error(),
 				})
+			}
+			if statusCode >= http.StatusInternalServerError {
+				log.G(ctx).WithFields(log.Fields{
+					"module":         "api",
+					"method":         route.Method(),
+					"request-url":    r.RequestURI,
+					"vars":           vars,
+					"error-response": err,
+					"status":         statusCode,
+				}).Errorf("Handler for %s %s returned error", route.Method(), route.Path())
 			}
 		}
 	}), operation).ServeHTTP


### PR DESCRIPTION
The [httpstatus.FromError] utility currently maps context cancellation and deadline errors to a 500 ("internal server error"). As a result, a client disconnecting would produce an error log:

    ERRO[2026-03-11T11:54:39.872784425Z] Handler for POST /v1.54/images/create returned error: failed to resolve reference "docker.io/library/alpine:latest": failed to do request: Head "https://registry-1.docker.io/v2/library/alpine/manifests/latest": context canceled

This patch:

- Checks for context-cancelation on the context, and instead logs an "INFO" message. For tracing/OTEL, it produces a "499" status code, which is non- standard, but commonly accepted (and used by NGINX, CloudFront). Given that no client should be listening anymore, it omits an actual response.
- Adds more structured logs, to align with the logs we produce in our Debug middleware.

With this patch:

    INFO[2026-03-11T16:43:55.567731845Z] API listen on /var/run/docker.sock
    INFO[2026-03-11T16:43:58.152254638Z] fetch failed                                  error="failed to do request: Head \"https://registry-1.docker.io/v2/library/alpine/manifests/latest\": context canceled" host=registry-1.docker.io
    INFO[2026-03-11T16:43:58.152608805Z] Cancel with lease, leased resources will remain until expiration  expires_at="2026-03-12 00:43:57.965872638 +0000 UTC m=+28803.424778128" lease=965878679-Q_SJ
    INFO[2026-03-11T16:43:58.152917138Z] request cancelled by client                   error="failed to resolve reference \"docker.io/library/alpine:latest\": failed to do request: Head \"https://registry-1.docker.io/v2/library/alpine/manifests/latest\": context canceled" method=POST module=api request-url="/v1.54/images/create?fromImage=docker.io%2Flibrary%2Falpine&tag=latest" status=499 vars="map[version:1.54]"

Note some duplication in logs, as some logs are produced by containerd code.

[httpstatus.FromError]: https://github.com/moby/moby/blob/v2.0.0-beta.7/daemon/server/httpstatus/status.go#L44-L45


**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

