### PR TITLE
Add linux/riscv64 to cross-build platform targets

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -86,6 +86,7 @@ target "_platforms" {
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
+    "linux/riscv64",
     "linux/s390x",
     "windows/amd64"
   ]
@@ -123,6 +124,7 @@ target "binary-smoketest" {
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
+    "linux/riscv64",
     "linux/s390x"
   ]
 }
@@ -159,6 +161,7 @@ target "bin-image-cross" {
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
+    "linux/riscv64",
     "linux/s390x",
     "windows/amd64"
   ]


### PR DESCRIPTION
**- What I did**

Added `linux/riscv64` to the three platform lists in `docker-bake.hcl`:
- `_platforms` (used by `binary-cross` and `all-cross`)
- `binary-smoketest`
- `bin-image-cross`

This enables Moby release artifacts to include riscv64 binaries.

Closes #44319

**- How I did it**

Added `"linux/riscv64"` in alphabetical order to each platform list, matching the pattern of all other architectures.

**- How to verify it**

```bash
docker buildx bake binary-cross --print 2>/dev/null | jq '.target["binary-cross"].platforms'
```

Should now include `linux/riscv64` in the output.

**- Human readable description for the release notes**

```markdown changelog
Add linux/riscv64 to cross-build platform targets so that Moby release artifacts include riscv64 binaries.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Here's a [capybara lounging on RISC-V hardware](https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Capybara_%28Hydrochoerus_hydrochaeris%29.JPG/1280px-Capybara_%28Hydrochoerus_hydrochaeris%29.JPG) 🦫

---

**Context**: All Moby dependencies already ship riscv64 release binaries (runc, containerd, BuildKit, BuildX, Compose). Go has supported GOARCH=riscv64 since Go 1.14. Debian Trixie provides full riscv64 support. The [docker-for-riscv64](https://github.com/gounthar/docker-for-riscv64) project has been producing riscv64 Docker builds (including Moby) for 117+ releases, demonstrating the build works reliably. Moby is the last piece of the Docker stack missing official riscv64 in its release artifacts.