### PR TITLE
client: set default user-agent based on module version

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,6 +59,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -67,6 +68,7 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/go-connections/sockets"
+	"github.com/moby/moby/client/internal/mod"
 	"github.com/moby/moby/client/pkg/versions"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
@@ -112,6 +114,10 @@ const MaxAPIVersion = "1.54"
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.
 const MinAPIVersion = "1.40"
+
+// defaultUserAgent returns the default User-Agent to use if none is set.
+// It defaults to "moby-client/<module version> os/arch"
+var defaultUserAgent = sync.OnceValue(userAgent)
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}
@@ -430,4 +436,15 @@ func (cli *Client) dialer() func(context.Context) (net.Conn, error) {
 			return net.Dial(cli.proto, cli.addr)
 		}
 	}
+}
+
+func userAgent() string {
+	const defaultVersion = "v0.0.0+unknown"
+	const moduleName = "github.com/moby/moby/client"
+
+	version := defaultVersion
+	if v := mod.Version(moduleName); v != "" {
+		version = v
+	}
+	return "moby-client/" + version + " " + runtime.GOOS + "/" + runtime.GOARCH
 }

--- a/client/client_options_test.go
+++ b/client/client_options_test.go
@@ -344,7 +344,7 @@ func TestWithUserAgent(t *testing.T) {
 		c, err := New(
 			WithHTTPHeaders(map[string]string{"Other-Header": "hello-world"}),
 			WithBaseMockClient(func(req *http.Request) (*http.Response, error) {
-				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), ""))
+				assert.Check(t, is.Equal(req.Header.Get("User-Agent"), defaultUserAgent()))
 				assert.Check(t, is.Equal(req.Header.Get("Other-Header"), "hello-world"))
 				return &http.Response{StatusCode: http.StatusOK}, nil
 			}),

--- a/client/internal/mod/mod.go
+++ b/client/internal/mod/mod.go
@@ -1,0 +1,213 @@
+// Package mod provides a small helper to extract a module's version
+// from [debug.BuildInfo] without depending on [golang.org/x/mod].
+//
+// [golang.org/x/mod]: https://pkg.go.dev/golang.org/x/mod
+package mod
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var readBuildInfo = sync.OnceValues(debug.ReadBuildInfo)
+
+// Version returns a best-effort version string for the given module path,
+// similar to [mod.Version] in the daemon.
+//
+// If the module is present in [debug.BuildInfo] dependencies, its version
+// is returned. Tagged versions are returned as-is (with "+incompatible"
+// stripped). [Pseudo-versions] are normalized to:
+//
+//	<base>+<revision>[+meta...][+dirty]
+//
+// Where "<base>" matches the behavior of [module.PseudoVersionBase] (i.e.,
+// downgrade to the previous tag for non-prerelease Pseudo-versions).
+//
+// If the module is replaced (for example via go.work or replace directives),
+// or no usable version information is available, Version returns an empty string.
+//
+// The returned value is intended for display purposes (e.g., in a default
+// User-Agent), not for version comparison.
+//
+// [mod.Version]: https://pkg.go.dev/github.com/moby/moby/v2@v2.0.0-beta.7/daemon/internal/builder-next/worker/mod#Version
+// [module.PseudoVersionBase]: https://pkg.go.dev/golang.org/x/mod@v0.34.0/module#PseudoVersionBase
+// [Pseudo-versions]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.34.0:module/pseudo.go;l=5-33
+func Version(name string) string {
+	bi, ok := readBuildInfo()
+	if !ok || bi == nil {
+		return ""
+	}
+	return moduleVersion(name, bi)
+}
+
+func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
+	if bi == nil {
+		return ""
+	}
+	for _, dep := range bi.Deps {
+		if dep.Path != name {
+			continue
+		}
+
+		v := dep.Version
+		if dep.Replace != nil && dep.Replace.Version != "" {
+			v = dep.Replace.Version
+		}
+		if v == "" || v == "(devel)" {
+			return ""
+		}
+
+		return normalize(v)
+	}
+
+	return ""
+}
+
+// normalize converts a Go module version into a display-friendly form:
+//
+//   - strips "+incompatible" unconditionally
+//   - if pseudo: vX.Y.Z[-pre][+rev][+meta...][+dirty]
+//   - if tagged: vX.Y.Z[-pre][+meta...][+dirty]
+func normalize(v string) string {
+	base, metas, dirty := splitMetadata(v)
+
+	out := base
+	if base2, rev, undoPatch, ok := splitPseudo(base); ok {
+		if undoPatch {
+			// Downgrade the patch version that was raised by pseudo-versions:
+			//
+			//	(2) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456
+			if major, minor, patch, ok := parseSemVer(base2); ok && patch > 0 {
+				patch--
+				base2 = fmt.Sprintf("v%d.%d.%d", major, minor, patch)
+			}
+		}
+		// Go pseudo rev is typically 12, but be defensive.
+		if len(rev) > 12 {
+			rev = rev[:12]
+		}
+		out = base2 + "+" + rev
+	}
+
+	// Preserve other metadata (except for "+incompatible").
+	for _, m := range metas {
+		out += m
+	}
+	if dirty {
+		// +dirty goes last
+		out += "+dirty"
+	}
+	return out
+}
+
+func splitMetadata(v string) (base string, metas []string, dirty bool) {
+	base, meta, ok := strings.Cut(v, "+")
+	if !ok || meta == "" {
+		return base, nil, false
+	}
+	for m := range strings.SplitSeq(meta, "+") {
+		// drop incompatible, extract dirty, preserve everything else.
+		switch m {
+		case "incompatible", "":
+			// drop "+incompatible" and empty strings
+		case "dirty":
+			dirty = true
+		default:
+			metas = append(metas, "+"+m)
+		}
+	}
+
+	return base, metas, dirty
+}
+
+// splitPseudo splits a pseudo-version into base + revision, and reports whether
+// it is a (Z+1) pseudo that needs patch undo.
+//
+// Supported (after stripping +incompatible/+dirty metadata):
+//
+// (1) vX.0.0-yyyymmddhhmmss-abcdef123456
+// (2) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456
+// (4) vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456
+func splitPseudo(v string) (base, rev string, undoPatch bool, ok bool) {
+	// Split off revision at the last '-'.
+	last := strings.LastIndexByte(v, '-')
+	if last < 0 || last+1 >= len(v) {
+		return "", "", false, false
+	}
+	rev = v[last+1:]
+	left := v[:last]
+
+	// First try the dot-joined timestamp forms:
+	//   ...-0.<ts>   (release pseudo; undoPatch)
+	//   ....0.<ts>   (prerelease pseudo; preserve prerelease)
+	if dot := strings.LastIndexByte(left, '.'); dot > 0 && dot+1 < len(left) {
+		ts := left[dot+1:]
+		if isTimestamp(ts) {
+			prefix := left[:dot] // ends with "-0" or ".0" for forms (2)/(4)
+			switch {
+			case strings.HasSuffix(prefix, "-0"):
+				// (2) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456
+				return prefix[:len(prefix)-2], rev, true, true
+			case strings.HasSuffix(prefix, ".0"):
+				// (4) vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456
+				return prefix[:len(prefix)-2], rev, false, true
+			}
+		}
+	}
+
+	// Fall back to form (1): ...-<ts>-<rev>
+	//
+	// (1) vX.0.0-yyyymmddhhmmss-abcdef123456
+	if dash := strings.LastIndexByte(left, '-'); dash > 0 && dash+1 < len(left) {
+		ts := left[dash+1:]
+		if isTimestamp(ts) {
+			return left[:dash], rev, false, true
+		}
+	}
+
+	return "", "", false, false
+}
+
+// isTimestamp checks whether s is a timestamp ("yyyymmddhhmmss")
+// component in a module version (vX.0.0-yyyymmddhhmmss-abcdef123456).
+func isTimestamp(s string) bool {
+	if len(s) != 14 {
+		return false
+	}
+	for i := range len(s) {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// parseSemVer parses "vX.Y.Z" into numeric components.
+// It intentionally handles only the strict three-segment core form.
+func parseSemVer(v string) (major, minor, patch int, ok bool) {
+	if len(v) < 2 || v[0] != 'v' {
+		return 0, 0, 0, false
+	}
+	parts := strings.Split(v[1:], ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var err error
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	patch, err = strconv.Atoi(parts[2])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	return major, minor, patch, true
+}

--- a/client/internal/mod/mod.go
+++ b/client/internal/mod/mod.go
@@ -47,23 +47,36 @@ func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
 	if bi == nil {
 		return ""
 	}
+
+	// Check if we're the main module.
+	if ok, v := getVersion(name, &bi.Main); ok {
+		return v
+	}
+
+	// iterate over all dependencies and find name
 	for _, dep := range bi.Deps {
-		if dep.Path != name {
-			continue
+		if ok, v := getVersion(name, dep); ok {
+			return v
 		}
-
-		v := dep.Version
-		if dep.Replace != nil && dep.Replace.Version != "" {
-			v = dep.Replace.Version
-		}
-		if v == "" || v == "(devel)" {
-			return ""
-		}
-
-		return normalize(v)
 	}
 
 	return ""
+}
+
+func getVersion(name string, dep *debug.Module) (bool, string) {
+	if dep == nil || dep.Path != name {
+		return false, ""
+	}
+
+	v := dep.Version
+	if dep.Replace != nil && dep.Replace.Version != "" {
+		v = dep.Replace.Version
+	}
+	if v == "" || v == "(devel)" {
+		return true, ""
+	}
+
+	return true, normalize(v)
 }
 
 // normalize converts a Go module version into a display-friendly form:

--- a/client/internal/mod/mod_test.go
+++ b/client/internal/mod/mod_test.go
@@ -1,0 +1,72 @@
+package mod
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestModuleVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		module      string
+		biContent   string
+		wantVersion string
+	}{
+		{
+			name: "returns empty string if build information not available",
+			biContent: `
+go	go1.20.3
+path	github.com/moby/moby/v2/daemon/internal/builder-next/worker
+mod	github.com/moby/moby/v2	(devel)
+			`,
+			module:      "github.com/moby/buildkit",
+			wantVersion: "",
+		},
+		{
+			name: "returns the version of buildkit dependency",
+			biContent: `
+go	go1.20.3
+path	github.com/moby/moby/v2/daemon/internal/builder-next/worker
+mod	github.com/moby/moby/v2	(devel)
+dep	github.com/moby/buildkit	v0.11.5	h1:JZvvWzulcnA2G4c/gJiSIqKDUoBjctYw2WMuS+XJexU=
+			`,
+			module:      "github.com/moby/buildkit",
+			wantVersion: "v0.11.5",
+		},
+		{
+			name: "returns the replaced version of buildkit dependency",
+			biContent: `
+go	go1.20.3
+path	github.com/moby/moby/v2/daemon/internal/builder-next/worker
+mod	github.com/moby/moby/v2	(devel)
+dep	github.com/moby/buildkit	v0.11.5	h1:JZvvWzulcnA2G4c/gJiSIqKDUoBjctYw2WMuS+XJexU=
+=>	github.com/moby/buildkit	v0.12.0	h1:3YO8J4RtmG7elEgaWMb4HgmpS2CfY1QlaOz9nwB+ZSs=
+			`,
+			module:      "github.com/moby/buildkit",
+			wantVersion: "v0.12.0",
+		},
+		{
+			name: "returns the base version of pseudo version",
+			biContent: `
+go	go1.20.3
+path	github.com/moby/moby/v2/daemon/internal/builder-next/worker
+mod	github.com/moby/moby/v2	(devel)
+dep	github.com/moby/buildkit	v0.10.7-0.20230306143919-70f2ad56d3e5	h1:JZvvWzulcnA2G4c/gJiSIqKDUoBjctYw2WMuS+XJexU=
+			`,
+			module:      "github.com/moby/buildkit",
+			wantVersion: "v0.10.6+70f2ad56d3e5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bi, err := debug.ParseBuildInfo(tc.biContent)
+			if err != nil {
+				t.Fatalf("failed to parse build info: %v", err)
+			}
+			if gotVersion := moduleVersion(tc.module, bi); gotVersion != tc.wantVersion {
+				t.Errorf("moduleVersion() = %v, want %v", gotVersion, tc.wantVersion)
+			}
+		})
+	}
+}

--- a/client/internal/mod/mod_test.go
+++ b/client/internal/mod/mod_test.go
@@ -13,6 +13,90 @@ func TestModuleVersion(t *testing.T) {
 		wantVersion string
 	}{
 		{
+			name: "main module in devel mode returns empty string",
+			biContent: `
+go	go1.20.3
+path	github.com/moby/moby/v2/daemon/internal/builder-next/worker
+mod	github.com/moby/moby/v2	(devel)
+dep	github.com/moby/buildkit	v0.11.5	h1:JZvvWzulcnA2G4c/gJiSIqKDUoBjctYw2WMuS+XJexU=
+=>	github.com/moby/buildkit	v0.12.0	h1:3YO8J4RtmG7elEgaWMb4HgmpS2CfY1QlaOz9nwB+ZSs=
+			`,
+			module:      "github.com/moby/moby/v2",
+			wantVersion: "",
+		},
+		{
+			name: "main module returns tagged version",
+			biContent: `
+go	go1.25.8
+path	github.com/moby/moby/v2/daemon/internal/mod/gen
+mod	github.com/moby/moby/v2	v2.0.0-beta.7
+build	-buildmode=exe
+build	-compiler=gc
+build	CGO_ENABLED=1
+build	CGO_CFLAGS=
+build	CGO_CPPFLAGS=
+build	CGO_CXXFLAGS=
+build	CGO_LDFLAGS=
+build	GOARCH=arm64
+build	GOOS=linux
+build	GOARM64=v8.0
+build	vcs=git
+build	vcs.revision=83bca512aa7ffc1bb4f37ce1107e0d3e3489ad43
+build	vcs.time=2026-03-05T14:05:47Z
+build	vcs.modified=false
+			`,
+			module:      "github.com/moby/moby/v2",
+			wantVersion: "v2.0.0-beta.7",
+		},
+		{
+			name: "main module returns the base version of pseudo version",
+			biContent: `
+go	go1.25.8
+path	github.com/moby/moby/v2/daemon/internal/mod/gen
+mod	github.com/moby/moby/v2	v2.0.0-beta.7.0.20260312170906-aac47873cb5c
+build	-buildmode=exe
+build	-compiler=gc
+build	CGO_ENABLED=1
+build	CGO_CFLAGS=
+build	CGO_CPPFLAGS=
+build	CGO_CXXFLAGS=
+build	CGO_LDFLAGS=
+build	GOARCH=arm64
+build	GOOS=linux
+build	GOARM64=v8.0
+build	vcs=git
+build	vcs.revision=aac47873cb5c31561169c069dba48193ddcbd45c
+build	vcs.time=2026-03-12T17:09:06Z
+build	vcs.modified=false
+`,
+			module:      "github.com/moby/moby/v2",
+			wantVersion: "v2.0.0-beta.7+aac47873cb5c",
+		},
+		{
+			name: "main module git dirty",
+			biContent: `
+go	go1.25.8
+path	github.com/moby/moby/v2/daemon/internal/mod/gen
+mod	github.com/moby/moby/v2	v2.0.0-beta.7.0.20260312170906-aac47873cb5c+dirty
+build	-buildmode=exe
+build	-compiler=gc
+build	CGO_ENABLED=1
+build	CGO_CFLAGS=
+build	CGO_CPPFLAGS=
+build	CGO_CXXFLAGS=
+build	CGO_LDFLAGS=
+build	GOARCH=arm64
+build	GOOS=linux
+build	GOARM64=v8.0
+build	vcs=git
+build	vcs.revision=aac47873cb5c31561169c069dba48193ddcbd45c
+build	vcs.time=2026-03-12T17:09:06Z
+build	vcs.modified=true
+`,
+			module:      "github.com/moby/moby/v2",
+			wantVersion: "v2.0.0-beta.7+aac47873cb5c+dirty",
+		},
+		{
 			name: "returns empty string if build information not available",
 			biContent: `
 go	go1.20.3

--- a/client/request.go
+++ b/client/request.go
@@ -317,12 +317,17 @@ func (cli *Client) addHeaders(req *http.Request, headers http.Header) *http.Requ
 		req.Header[http.CanonicalHeaderKey(k)] = v
 	}
 
-	if cli.userAgent != nil {
-		if *cli.userAgent == "" {
-			req.Header.Del("User-Agent")
-		} else {
-			req.Header.Set("User-Agent", *cli.userAgent)
+	if cli.userAgent == nil {
+		// No custom User-Agent set: use the default.
+		if req.Header.Get("User-Agent") == "" {
+			req.Header.Set("User-Agent", defaultUserAgent())
 		}
+	} else if *cli.userAgent == "" {
+		// User-Agent set to empty value; remove User-Agent.
+		req.Header.Del("User-Agent")
+	} else {
+		// Custom User-Agent set.
+		req.Header.Set("User-Agent", *cli.userAgent)
 	}
 	return req
 }

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -59,6 +59,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -67,6 +68,7 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/go-connections/sockets"
+	"github.com/moby/moby/client/internal/mod"
 	"github.com/moby/moby/client/pkg/versions"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
@@ -112,6 +114,10 @@ const MaxAPIVersion = "1.54"
 // MinAPIVersion is the minimum API version supported by the client. API versions
 // below this version are not considered when performing API-version negotiation.
 const MinAPIVersion = "1.40"
+
+// defaultUserAgent returns the default User-Agent to use if none is set.
+// It defaults to "moby-client/<module version> os/arch"
+var defaultUserAgent = sync.OnceValue(userAgent)
 
 // Ensure that Client always implements APIClient.
 var _ APIClient = &Client{}
@@ -430,4 +436,15 @@ func (cli *Client) dialer() func(context.Context) (net.Conn, error) {
 			return net.Dial(cli.proto, cli.addr)
 		}
 	}
+}
+
+func userAgent() string {
+	const defaultVersion = "v0.0.0+unknown"
+	const moduleName = "github.com/moby/moby/client"
+
+	version := defaultVersion
+	if v := mod.Version(moduleName); v != "" {
+		version = v
+	}
+	return "moby-client/" + version + " " + runtime.GOOS + "/" + runtime.GOARCH
 }

--- a/vendor/github.com/moby/moby/client/internal/mod/mod.go
+++ b/vendor/github.com/moby/moby/client/internal/mod/mod.go
@@ -1,0 +1,213 @@
+// Package mod provides a small helper to extract a module's version
+// from [debug.BuildInfo] without depending on [golang.org/x/mod].
+//
+// [golang.org/x/mod]: https://pkg.go.dev/golang.org/x/mod
+package mod
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var readBuildInfo = sync.OnceValues(debug.ReadBuildInfo)
+
+// Version returns a best-effort version string for the given module path,
+// similar to [mod.Version] in the daemon.
+//
+// If the module is present in [debug.BuildInfo] dependencies, its version
+// is returned. Tagged versions are returned as-is (with "+incompatible"
+// stripped). [Pseudo-versions] are normalized to:
+//
+//	<base>+<revision>[+meta...][+dirty]
+//
+// Where "<base>" matches the behavior of [module.PseudoVersionBase] (i.e.,
+// downgrade to the previous tag for non-prerelease Pseudo-versions).
+//
+// If the module is replaced (for example via go.work or replace directives),
+// or no usable version information is available, Version returns an empty string.
+//
+// The returned value is intended for display purposes (e.g., in a default
+// User-Agent), not for version comparison.
+//
+// [mod.Version]: https://pkg.go.dev/github.com/moby/moby/v2@v2.0.0-beta.7/daemon/internal/builder-next/worker/mod#Version
+// [module.PseudoVersionBase]: https://pkg.go.dev/golang.org/x/mod@v0.34.0/module#PseudoVersionBase
+// [Pseudo-versions]: https://cs.opensource.google/go/x/mod/+/refs/tags/v0.34.0:module/pseudo.go;l=5-33
+func Version(name string) string {
+	bi, ok := readBuildInfo()
+	if !ok || bi == nil {
+		return ""
+	}
+	return moduleVersion(name, bi)
+}
+
+func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
+	if bi == nil {
+		return ""
+	}
+	for _, dep := range bi.Deps {
+		if dep.Path != name {
+			continue
+		}
+
+		v := dep.Version
+		if dep.Replace != nil && dep.Replace.Version != "" {
+			v = dep.Replace.Version
+		}
+		if v == "" || v == "(devel)" {
+			return ""
+		}
+
+		return normalize(v)
+	}
+
+	return ""
+}
+
+// normalize converts a Go module version into a display-friendly form:
+//
+//   - strips "+incompatible" unconditionally
+//   - if pseudo: vX.Y.Z[-pre][+rev][+meta...][+dirty]
+//   - if tagged: vX.Y.Z[-pre][+meta...][+dirty]
+func normalize(v string) string {
+	base, metas, dirty := splitMetadata(v)
+
+	out := base
+	if base2, rev, undoPatch, ok := splitPseudo(base); ok {
+		if undoPatch {
+			// Downgrade the patch version that was raised by pseudo-versions:
+			//
+			//	(2) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456
+			if major, minor, patch, ok := parseSemVer(base2); ok && patch > 0 {
+				patch--
+				base2 = fmt.Sprintf("v%d.%d.%d", major, minor, patch)
+			}
+		}
+		// Go pseudo rev is typically 12, but be defensive.
+		if len(rev) > 12 {
+			rev = rev[:12]
+		}
+		out = base2 + "+" + rev
+	}
+
+	// Preserve other metadata (except for "+incompatible").
+	for _, m := range metas {
+		out += m
+	}
+	if dirty {
+		// +dirty goes last
+		out += "+dirty"
+	}
+	return out
+}
+
+func splitMetadata(v string) (base string, metas []string, dirty bool) {
+	base, meta, ok := strings.Cut(v, "+")
+	if !ok || meta == "" {
+		return base, nil, false
+	}
+	for m := range strings.SplitSeq(meta, "+") {
+		// drop incompatible, extract dirty, preserve everything else.
+		switch m {
+		case "incompatible", "":
+			// drop "+incompatible" and empty strings
+		case "dirty":
+			dirty = true
+		default:
+			metas = append(metas, "+"+m)
+		}
+	}
+
+	return base, metas, dirty
+}
+
+// splitPseudo splits a pseudo-version into base + revision, and reports whether
+// it is a (Z+1) pseudo that needs patch undo.
+//
+// Supported (after stripping +incompatible/+dirty metadata):
+//
+// (1) vX.0.0-yyyymmddhhmmss-abcdef123456
+// (2) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456
+// (4) vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456
+func splitPseudo(v string) (base, rev string, undoPatch bool, ok bool) {
+	// Split off revision at the last '-'.
+	last := strings.LastIndexByte(v, '-')
+	if last < 0 || last+1 >= len(v) {
+		return "", "", false, false
+	}
+	rev = v[last+1:]
+	left := v[:last]
+
+	// First try the dot-joined timestamp forms:
+	//   ...-0.<ts>   (release pseudo; undoPatch)
+	//   ....0.<ts>   (prerelease pseudo; preserve prerelease)
+	if dot := strings.LastIndexByte(left, '.'); dot > 0 && dot+1 < len(left) {
+		ts := left[dot+1:]
+		if isTimestamp(ts) {
+			prefix := left[:dot] // ends with "-0" or ".0" for forms (2)/(4)
+			switch {
+			case strings.HasSuffix(prefix, "-0"):
+				// (2) vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdef123456
+				return prefix[:len(prefix)-2], rev, true, true
+			case strings.HasSuffix(prefix, ".0"):
+				// (4) vX.Y.Z-pre.0.yyyymmddhhmmss-abcdef123456
+				return prefix[:len(prefix)-2], rev, false, true
+			}
+		}
+	}
+
+	// Fall back to form (1): ...-<ts>-<rev>
+	//
+	// (1) vX.0.0-yyyymmddhhmmss-abcdef123456
+	if dash := strings.LastIndexByte(left, '-'); dash > 0 && dash+1 < len(left) {
+		ts := left[dash+1:]
+		if isTimestamp(ts) {
+			return left[:dash], rev, false, true
+		}
+	}
+
+	return "", "", false, false
+}
+
+// isTimestamp checks whether s is a timestamp ("yyyymmddhhmmss")
+// component in a module version (vX.0.0-yyyymmddhhmmss-abcdef123456).
+func isTimestamp(s string) bool {
+	if len(s) != 14 {
+		return false
+	}
+	for i := range len(s) {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// parseSemVer parses "vX.Y.Z" into numeric components.
+// It intentionally handles only the strict three-segment core form.
+func parseSemVer(v string) (major, minor, patch int, ok bool) {
+	if len(v) < 2 || v[0] != 'v' {
+		return 0, 0, 0, false
+	}
+	parts := strings.Split(v[1:], ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var err error
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	patch, err = strconv.Atoi(parts[2])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	return major, minor, patch, true
+}

--- a/vendor/github.com/moby/moby/client/internal/mod/mod.go
+++ b/vendor/github.com/moby/moby/client/internal/mod/mod.go
@@ -47,23 +47,36 @@ func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
 	if bi == nil {
 		return ""
 	}
+
+	// Check if we're the main module.
+	if ok, v := getVersion(name, &bi.Main); ok {
+		return v
+	}
+
+	// iterate over all dependencies and find name
 	for _, dep := range bi.Deps {
-		if dep.Path != name {
-			continue
+		if ok, v := getVersion(name, dep); ok {
+			return v
 		}
-
-		v := dep.Version
-		if dep.Replace != nil && dep.Replace.Version != "" {
-			v = dep.Replace.Version
-		}
-		if v == "" || v == "(devel)" {
-			return ""
-		}
-
-		return normalize(v)
 	}
 
 	return ""
+}
+
+func getVersion(name string, dep *debug.Module) (bool, string) {
+	if dep == nil || dep.Path != name {
+		return false, ""
+	}
+
+	v := dep.Version
+	if dep.Replace != nil && dep.Replace.Version != "" {
+		v = dep.Replace.Version
+	}
+	if v == "" || v == "(devel)" {
+		return true, ""
+	}
+
+	return true, normalize(v)
 }
 
 // normalize converts a Go module version into a display-friendly form:

--- a/vendor/github.com/moby/moby/client/request.go
+++ b/vendor/github.com/moby/moby/client/request.go
@@ -317,12 +317,17 @@ func (cli *Client) addHeaders(req *http.Request, headers http.Header) *http.Requ
 		req.Header[http.CanonicalHeaderKey(k)] = v
 	}
 
-	if cli.userAgent != nil {
-		if *cli.userAgent == "" {
-			req.Header.Del("User-Agent")
-		} else {
-			req.Header.Set("User-Agent", *cli.userAgent)
+	if cli.userAgent == nil {
+		// No custom User-Agent set: use the default.
+		if req.Header.Get("User-Agent") == "" {
+			req.Header.Set("User-Agent", defaultUserAgent())
 		}
+	} else if *cli.userAgent == "" {
+		// User-Agent set to empty value; remove User-Agent.
+		req.Header.Del("User-Agent")
+	} else {
+		// Custom User-Agent set.
+		req.Header.Set("User-Agent", *cli.userAgent)
 	}
 	return req
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1192,6 +1192,7 @@ github.com/moby/moby/api/types/volume
 ## explicit; go 1.24.0
 github.com/moby/moby/client
 github.com/moby/moby/client/internal
+github.com/moby/moby/client/internal/mod
 github.com/moby/moby/client/internal/timestamp
 github.com/moby/moby/client/pkg/jsonmessage
 github.com/moby/moby/client/pkg/stringid


### PR DESCRIPTION
### client: set default user-agent based on module version

Before this change, the client would use Go's default (`Go-http-client/1.1`)
user-agent if nothing was configured; this default User-Agent is known to
be blocked by various services, so users should always opt for setting an
explicit User-Agent, but for situations where it's not set, we now set a
default based on the module version, falling back to `v0.0.0+unknown` when
failing;

    moby-client/v0.0.0+unknown linux/arm64


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: the client now sets a default User-Agent if none was set, to prevent Go's default (`Go-http-client/1.1`) from being used.
```

**- A picture of a cute animal (not mandatory but encouraged)**

