### PR TITLE
When a "directory not empty" error occurs while  EnsureRemoveAll operation should be retried once.

### DIFF
--- a/daemon/internal/containerfs/rm.go
+++ b/daemon/internal/containerfs/rm.go
@@ -25,7 +25,7 @@ import (
 // This should not return a [os.ErrNotExist] kind of error under any circumstances.
 func EnsureRemoveAll(dir string) error {
 	notExistErr := make(map[string]bool)
-
+	notEmptyDir := make(map[string]bool)
 	// track retries
 	exitOnErr := make(map[string]int)
 	maxRetry := 50
@@ -58,6 +58,11 @@ func EnsureRemoveAll(dir string) error {
 			if pe.Path == dir {
 				return nil
 			}
+			continue
+		}
+
+		if errors.Is(pe.Err, syscall.ENOTEMPTY) && !notEmptyDir[pe.Path] {
+			notEmptyDir[pe.Path] = true
 			continue
 		}
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
when
fix: #52161
**- What I did**
I observed that the EnsureRemoveAll function is returning a "directory not empty" error upon execution — this behavior is unexpected and should not occur.

**- How I did it**
We should retry the os.RemoveAll operation if an ENOTEMPTY error is encountered.
**- How to verify it**
check code
**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
