### PR TITLE
api, client: go.mod: remove patch version

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/moby/api
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/docker/go-units v0.5.0

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/moby/moby/client
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1189,7 +1189,7 @@ github.com/moby/moby/api/types/swarm
 github.com/moby/moby/api/types/system
 github.com/moby/moby/api/types/volume
 # github.com/moby/moby/client v0.3.0 => ./client
-## explicit; go 1.24.0
+## explicit; go 1.24
 github.com/moby/moby/client
 github.com/moby/moby/client/internal
 github.com/moby/moby/client/internal/timestamp

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1167,7 +1167,7 @@ github.com/moby/ipvs
 ## explicit; go 1.13
 github.com/moby/locker
 # github.com/moby/moby/api v1.54.0 => ./api
-## explicit; go 1.24.0
+## explicit; go 1.24
 github.com/moby/moby/api/pkg/authconfig
 github.com/moby/moby/api/pkg/stdcopy
 github.com/moby/moby/api/types


### PR DESCRIPTION
drop the patch version, which is generally recommended, and prevents enforcing a specific toolchain patch version for users of the module.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

