### PR TITLE
api, client: add //go:fix inline directives to deprecated functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -352,6 +352,11 @@ linters:
         linters:
           - iface
 
+      # TODO(thaJeztah): remove once https://github.com/leighmcculloch/gocheckcompilerdirectives/issues/7 is fixed.
+      - text: "compiler directive unrecognized: //go:fix"
+        linters:
+          - gocheckcompilerdirectives
+
     # Log a warning if an exclusion rule is unused.
     # Default: false
     warn-unused: true

--- a/api/types/strslice/strslice.go
+++ b/api/types/strslice/strslice.go
@@ -3,4 +3,6 @@ package strslice
 // StrSlice represents a string or an array of strings.
 //
 // Deprecated: this type was used for compatibility with deprecated API versions. Use []string instead.
+//
+//go:fix inline
 type StrSlice = []string

--- a/client/client.go
+++ b/client/client.go
@@ -165,7 +165,9 @@ func CheckRedirect(_ *http.Request, via []*http.Request) error {
 
 // NewClientWithOpts initializes a new API client.
 //
-// Deprecated: use New. This function will be removed in the next release.
+// Deprecated: use [New]. This function will be removed in the next release.
+//
+//go:fix inline
 func NewClientWithOpts(ops ...Opt) (*Client, error) {
 	return New(ops...)
 }

--- a/client/client_options.go
+++ b/client/client_options.go
@@ -295,6 +295,8 @@ func WithAPIVersion(version string) Opt {
 // WithVersion overrides the client version with the specified one.
 //
 // Deprecated: use [WithAPIVersion] instead.
+//
+//go:fix inline
 func WithVersion(version string) Opt {
 	return WithAPIVersion(version)
 }
@@ -328,6 +330,8 @@ func WithAPIVersionFromEnv() Opt {
 // the DOCKER_API_VERSION ([EnvOverrideAPIVersion]) environment variable.
 //
 // Deprecated: use [WithAPIVersionFromEnv] instead.
+//
+//go:fix inline
 func WithVersionFromEnv() Opt {
 	return WithAPIVersionFromEnv()
 }
@@ -337,8 +341,11 @@ func WithVersionFromEnv() Opt {
 // to use when making requests. API version negotiation is performed on the first
 // request; subsequent requests do not re-negotiate.
 //
-// Deprecated: API-version negotiation is now enabled by default. Use [WithAPIVersion]
-// or [WithAPIVersionFromEnv] to disable API version negotiation.
+// Deprecated: API-version negotiation is now enabled by default and this options
+// is now a no-op.
+//
+// Use [WithAPIVersion] or [WithAPIVersionFromEnv] to set a fixed API version
+// instead of using automatic negotiation.
 func WithAPIVersionNegotiation() Opt {
 	return func(c *clientConfig) error {
 		return nil

--- a/client/internal/gofix/a/example_test.go
+++ b/client/internal/gofix/a/example_test.go
@@ -1,0 +1,31 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import (
+	"context"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/strslice"
+	"github.com/moby/moby/client"
+)
+
+func OK() {
+	opts := []client.Opt{
+		client.FromEnv,
+		client.WithVersion("1.38"),
+		client.WithVersionFromEnv(),
+	}
+
+	c, err := client.NewClientWithOpts(opts...)
+	if err != nil {
+		return
+	}
+
+	_, _ = c.ContainerCreate(context.Background(), client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image: "busybox",
+			Cmd:   strslice.StrSlice{"top"},
+		},
+	})
+	_ = c.Close()
+}

--- a/client/internal/gofix/b/example_test.go
+++ b/client/internal/gofix/b/example_test.go
@@ -1,0 +1,8 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+func OK() {
+	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"))
+}

--- a/client/internal/gofix/c/example_test.go
+++ b/client/internal/gofix/c/example_test.go
@@ -1,0 +1,8 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+func OK() {
+	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"), client.WithVersionFromEnv())
+}

--- a/client/internal/gofix/d/example_test.go
+++ b/client/internal/gofix/d/example_test.go
@@ -1,0 +1,8 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+func OK() {
+	_, _ = client.NewClientWithOpts(client.FromEnv)
+}

--- a/client/internal/gofix/doc_test.go
+++ b/client/internal/gofix/doc_test.go
@@ -1,0 +1,170 @@
+/*
+package example illustrates results of "//go:fix replace"
+
+It currently tests for combinations of:
+
+	// Deprecated: use []string instead.
+	//
+	//go:fix inline
+	type StrSlice = []string
+
+	// Deprecated: use [New] instead.
+	//
+	//go:fix inline
+	func NewClientWithOpts(ops ...Opt) (*Client, error) {
+		return New(ops...)
+	}
+
+	// Deprecated: use [WithAPIVersion] instead.
+	//
+	//go:fix inline
+	func WithVersion(version string) Opt {
+		return WithAPIVersion(version)
+	}
+
+	// Deprecated: use [WithAPIVersionFromEnv] instead.
+	//
+	//go:fix inline
+	func WithVersionFromEnv() Opt {
+		return WithAPIVersionFromEnv()
+	}
+
+### Usage
+
+Try running "go fix" on this package:
+
+	go fix -mod=readonly ./...
+	# github.com/moby/moby/client/internal/gofix/f
+	# [github.com/moby/moby/client/internal/gofix/f]
+	fix: applied 2 of 3 fixes; 1 file updated. (Re-run the command to apply more.)
+	# github.com/moby/moby/client/internal/gofix/g
+	# [github.com/moby/moby/client/internal/gofix/g]
+	fix: applied 2 of 3 fixes; 2 files updated. (Re-run the command to apply more.)
+	# github.com/moby/moby/client/internal/gofix/h
+	# [github.com/moby/moby/client/internal/gofix/h]
+	fix: applied 1 of 2 fixes; 1 file updated. (Re-run the command to apply more.)
+	# github.com/moby/moby/client/internal/gofix/i
+	# [github.com/moby/moby/client/internal/gofix/i]
+	fix: applied 1 of 3 fixes; 1 file updated. (Re-run the command to apply more.)
+	# github.com/moby/moby/client/internal/gofix/j
+	# [github.com/moby/moby/client/internal/gofix/j]
+	fix: applied 1 of 3 fixes; 1 file updated. (Re-run the command to apply more.)
+	# github.com/moby/moby/client/internal/gofix/k_test
+	# [github.com/moby/moby/client/internal/gofix/k_test]
+	fix: applied 1 of 2 fixes; 1 file updated. (Re-run the command to apply more.)
+
+Or (showing the diff);
+
+	go fix -mod=readonly -diff ./... 2> /dev/null
+	--- /go/src/example/a/example_test.go (old)
+	+++ /go/src/example/a/example_test.go (new)
+	@@ -4,19 +4,18 @@
+	 import (
+		"context"
+
+	-	"github.com/moby/moby/api/types/container"
+	-	"github.com/moby/moby/api/types/strslice"
+	+	"github.com/moby/moby/api/types/container"
+		"github.com/moby/moby/client"
+	 )
+
+	 func OK() {
+		opts := []client.Opt{
+			client.FromEnv,
+	-		client.WithVersion("1.38"),
+	+		client.WithAPIVersion("1.38"),
+	-		client.WithVersionFromEnv(),
+	+		client.WithAPIVersionFromEnv(),
+		}
+
+	-	c, err := client.NewClientWithOpts(opts...)
+	+	c, err := client.New(opts...)
+		if err != nil {
+			return
+		}
+	@@ -24,7 +15,7 @@
+		_, _ = c.ContainerCreate(context.Background(), client.ContainerCreateOptions{
+			Config: &container.Config{
+				Image: "busybox",
+	-			Cmd:   strslice.StrSlice{"top"},
+	+			Cmd:   []string{"top"},
+			},
+		})
+		_ = c.Close()
+	--- /go/src/example/b/example_test.go (old)
+	+++ /go/src/example/b/example_test.go (new)
+	@@ -4,5 +4,5 @@
+	 import "github.com/moby/moby/client"
+
+	 func OK() {
+	-	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"))
+	+	_, _ = client.New(client.FromEnv, client.WithAPIVersion("1.38"))
+	 }
+	--- /go/src/example/c/example_test.go (old)
+	+++ /go/src/example/c/example_test.go (new)
+	@@ -4,5 +4,5 @@
+	 import "github.com/moby/moby/client"
+
+	 func OK() {
+	-	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"), client.WithVersionFromEnv())
+	+	_, _ = client.New(client.FromEnv, client.WithAPIVersion("1.38"), client.WithAPIVersionFromEnv())
+	 }
+	--- /go/src/example/d/example_test.go (old)
+	+++ /go/src/example/d/example_test.go (new)
+	@@ -4,5 +4,5 @@
+	 import "github.com/moby/moby/client"
+
+	 func OK() {
+	-	_, _ = client.NewClientWithOpts(client.FromEnv)
+	+	_, _ = client.New(client.FromEnv)
+	 }
+	--- /go/src/example/e/example_test.go (old)
+	+++ /go/src/example/e/example_test.go (new)
+	@@ -4,8 +4,7 @@
+	 import (
+		"context"
+
+	-	"github.com/moby/moby/api/types/container"
+	-	"github.com/moby/moby/api/types/strslice"
+	+	"github.com/moby/moby/api/types/container"
+		"github.com/moby/moby/client"
+	 )
+
+	@@ -18,7 +17,7 @@
+		_, _ = c.ContainerCreate(context.Background(), client.ContainerCreateOptions{
+			Config: &container.Config{
+				Image: "busybox",
+	-			Cmd:   strslice.StrSlice{"top"},
+	+			Cmd:   []string{"top"},
+			},
+		})
+		_ = c.Close()
+	--- /go/src/example/k/example1_test.go (old)
+	+++ /go/src/example/k/example1_test.go (new)
+	@@ -5,5 +5,5 @@
+
+	 // OK works and is in a different package than [KO] (which is in "main_test")
+	 func OK() {
+	-	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"))
+	+	_, _ = client.New(client.FromEnv, client.WithAPIVersion("1.38"))
+	 }
+
+### Results
+
+- a: works: multiple inlines, but none are "nested".
+- b: works: inlines a single option.
+- c: works: inlines multiple options.
+- d: works: inlines "outer" method, no deprecated options used.
+- f: fails: combines "b" ("OK") and "d" ("KO") in same package.
+- g: fails: same as f, but in separate files.
+- h: fails; likely due to nested inline.
+- i: fails; same as h, but with multiple inlines.
+- j: fails; same as i, but formatted over multiple lines.
+- k: partially fails; same as g, but using two packages ("main", and "main_test").
+
+Failing cases don't resolve themselves when running "go fix" multiple times,
+likely because they're not related to "conflicts".
+
+*/
+
+package gofix

--- a/client/internal/gofix/e/example_test.go
+++ b/client/internal/gofix/e/example_test.go
@@ -1,0 +1,25 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import (
+	"context"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/strslice"
+	"github.com/moby/moby/client"
+)
+
+func OK() {
+	c, err := client.New(client.FromEnv)
+	if err != nil {
+		return
+	}
+
+	_, _ = c.ContainerCreate(context.Background(), client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image: "busybox",
+			Cmd:   strslice.StrSlice{"top"},
+		},
+	})
+	_ = c.Close()
+}

--- a/client/internal/gofix/f/example_test.go
+++ b/client/internal/gofix/f/example_test.go
@@ -1,0 +1,14 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+// OK works when in a separate package (see package "b"), but fails when in same package as [KO]
+func OK() {
+	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"))
+}
+
+// KO fails (due to nested inlines?), and causes whole package to be skipped.
+func KO() {
+	_, _ = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+}

--- a/client/internal/gofix/g/example1_test.go
+++ b/client/internal/gofix/g/example1_test.go
@@ -1,0 +1,9 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+// OK works when in a separate package (see package "b"), but fails when in same package as [KO]
+func OK() {
+	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"))
+}

--- a/client/internal/gofix/g/example2_test.go
+++ b/client/internal/gofix/g/example2_test.go
@@ -1,0 +1,9 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+// KO fails (due to nested inlines?), and causes whole package to be skipped.
+func KO() {
+	_, _ = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+}

--- a/client/internal/gofix/h/example_test.go
+++ b/client/internal/gofix/h/example_test.go
@@ -1,0 +1,9 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+// KO fails (due to nested inline?)
+func KO() {
+	_, _ = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+}

--- a/client/internal/gofix/i/example_test.go
+++ b/client/internal/gofix/i/example_test.go
@@ -1,0 +1,9 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+// KO fails (due to nested inlines?)
+func KO() {
+	_, _ = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"), client.WithVersionFromEnv())
+}

--- a/client/internal/gofix/j/example_test.go
+++ b/client/internal/gofix/j/example_test.go
@@ -1,0 +1,13 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+// KO fails (due to nested inlines?) but works if options are in a slice.
+func KO() {
+	_, _ = client.NewClientWithOpts(
+		client.FromEnv,
+		client.WithVersion("1.38"),
+		client.WithVersionFromEnv(),
+	)
+}

--- a/client/internal/gofix/k/example1_test.go
+++ b/client/internal/gofix/k/example1_test.go
@@ -1,0 +1,9 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main
+
+import "github.com/moby/moby/client"
+
+// OK works and is in a different package than [KO] (which is in "main_test")
+func OK() {
+	_, _ = client.New(client.FromEnv, client.WithVersion("1.38"))
+}

--- a/client/internal/gofix/k/example2_test.go
+++ b/client/internal/gofix/k/example2_test.go
@@ -1,0 +1,9 @@
+//nolint:staticcheck // Uses deprecated functions on purpose
+package main_test
+
+import "github.com/moby/moby/client"
+
+// KO fails (due to nested inlines?), and causes whole package to be skipped.
+func KO() {
+	_, _ = client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.38"))
+}

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -165,7 +165,9 @@ func CheckRedirect(_ *http.Request, via []*http.Request) error {
 
 // NewClientWithOpts initializes a new API client.
 //
-// Deprecated: use New. This function will be removed in the next release.
+// Deprecated: use [New]. This function will be removed in the next release.
+//
+//go:fix inline
 func NewClientWithOpts(ops ...Opt) (*Client, error) {
 	return New(ops...)
 }

--- a/vendor/github.com/moby/moby/client/client_options.go
+++ b/vendor/github.com/moby/moby/client/client_options.go
@@ -295,6 +295,8 @@ func WithAPIVersion(version string) Opt {
 // WithVersion overrides the client version with the specified one.
 //
 // Deprecated: use [WithAPIVersion] instead.
+//
+//go:fix inline
 func WithVersion(version string) Opt {
 	return WithAPIVersion(version)
 }
@@ -328,6 +330,8 @@ func WithAPIVersionFromEnv() Opt {
 // the DOCKER_API_VERSION ([EnvOverrideAPIVersion]) environment variable.
 //
 // Deprecated: use [WithAPIVersionFromEnv] instead.
+//
+//go:fix inline
 func WithVersionFromEnv() Opt {
 	return WithAPIVersionFromEnv()
 }
@@ -337,8 +341,11 @@ func WithVersionFromEnv() Opt {
 // to use when making requests. API version negotiation is performed on the first
 // request; subsequent requests do not re-negotiate.
 //
-// Deprecated: API-version negotiation is now enabled by default. Use [WithAPIVersion]
-// or [WithAPIVersionFromEnv] to disable API version negotiation.
+// Deprecated: API-version negotiation is now enabled by default and this options
+// is now a no-op.
+//
+// Use [WithAPIVersion] or [WithAPIVersionFromEnv] to set a fixed API version
+// instead of using automatic negotiation.
 func WithAPIVersionNegotiation() Opt {
 	return func(c *clientConfig) error {
 		return nil


### PR DESCRIPTION
- depends on https://github.com/moby/moby/pull/52177
- related: https://github.com/golang/go/issues/78164

## api, client: add //go:fix inline directives to deprecated functions

This allows (with limitations) users to automatically upgrade to the replacements (see https://go.dev/blog/inliner);

```bash
go fix -mod=readonly ./...
```

### golanci-lint: gocheckcompilerdirectives: ignore "//go:fix"

The linter has not been updated yet to recognize this directive.


### api/types/strslice: add //go:fix inline directives for deprecated type

This allows `go fix ./..` to automatically migrate legacy code.


### client: add //go:fix inline directives to deprecated functions

This allows `go fix ./..` to automatically migrate legacy code.


### add example for go fix

Add an example package to verify the `//go:fix inline` comments
work; some cases do not work (for which I opened tickets in the
go issue tracker).



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
api, client: add `//go:fix inline` directives to deprecated functions to help automatically migrating using `go fix`
```

**- A picture of a cute animal (not mandatory but encouraged)**

