### PR TITLE
Fix issue #48093: set SystemTemp environment variable

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -863,6 +863,10 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		}
 		_ = os.Setenv("TEMP", realTmp)
 		_ = os.Setenv("TMP", realTmp)
+		// Set the SystemTemp environment variable, because for system processes
+		// GetTempPath2() uses it rather than TEMP/TMP:
+		// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w
+		_ = os.Setenv("SystemTemp", realTmp)
 	} else {
 		_ = os.Setenv("TMPDIR", realTmp)
 	}


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/48093

On Windows also set the SystemTemp environment variable, because for system processes GetTempPath2() uses it rather than TEMP/TMP: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w


```markdown changelog
- Windows: Fix `DOCKER_TMPDIR` not being respected
```