### PR TITLE
api/build: remove deprecated keep-storage parameter

### DIFF
--- a/daemon/config/builder.go
+++ b/daemon/config/builder.go
@@ -25,9 +25,6 @@ func (x *BuilderGCRule) UnmarshalJSON(data []byte) error {
 		ReservedSpace string          `json:",omitempty"`
 		MaxUsedSpace  string          `json:",omitempty"`
 		MinFreeSpace  string          `json:",omitempty"`
-
-		// Deprecated option is now equivalent to ReservedSpace.
-		KeepStorage string `json:",omitempty"`
 	}
 	if err := json.Unmarshal(data, &xx); err != nil {
 		return err
@@ -38,9 +35,6 @@ func (x *BuilderGCRule) UnmarshalJSON(data []byte) error {
 	x.ReservedSpace = xx.ReservedSpace
 	x.MaxUsedSpace = xx.MaxUsedSpace
 	x.MinFreeSpace = xx.MinFreeSpace
-	if x.ReservedSpace == "" {
-		x.ReservedSpace = xx.KeepStorage
-	}
 	return nil
 }
 
@@ -102,9 +96,6 @@ func (x *BuilderGCConfig) UnmarshalJSON(data []byte) error {
 		DefaultReservedSpace string          `json:",omitempty"`
 		DefaultMaxUsedSpace  string          `json:",omitempty"`
 		DefaultMinFreeSpace  string          `json:",omitempty"`
-
-		// Deprecated option is now equivalent to DefaultReservedSpace.
-		DefaultKeepStorage string `json:",omitempty"`
 	}
 
 	// Set defaults.
@@ -119,9 +110,6 @@ func (x *BuilderGCConfig) UnmarshalJSON(data []byte) error {
 	x.DefaultReservedSpace = xx.DefaultReservedSpace
 	x.DefaultMaxUsedSpace = xx.DefaultMaxUsedSpace
 	x.DefaultMinFreeSpace = xx.DefaultMinFreeSpace
-	if x.DefaultReservedSpace == "" {
-		x.DefaultReservedSpace = xx.DefaultKeepStorage
-	}
 	return nil
 }
 

--- a/daemon/config/builder_test.go
+++ b/daemon/config/builder_test.go
@@ -44,14 +44,13 @@ func TestBuilderGC(t *testing.T) {
 	assert.Assert(t, filters.Args(cfg.Builder.GC.Policy[1].Filter).UniqueExactMatch("unused-for", "3300h"))
 }
 
-func TestBuilderGC_DeprecatedKeepStorage(t *testing.T) {
+func TestBuilderGC_DeprecatedKeepStorageIgnored(t *testing.T) {
 	tempFile := fs.NewFile(t, "config", fs.WithContent(`{
   "builder": {
     "gc": {
       "enabled": true,
       "policy": [
         {"keepStorage": "10GB", "filter": ["unused-for=2200h"]},
-        {"keepStorage": "50GB", "filter": {"unused-for": {"3300h": true}}},
         {"keepStorage": "100GB", "all": true}
       ]
     }
@@ -64,17 +63,12 @@ func TestBuilderGC_DeprecatedKeepStorage(t *testing.T) {
 	assert.Assert(t, cfg.Builder.GC.IsEnabled())
 	f1 := filters.NewArgs()
 	f1.Add("unused-for", "2200h")
-	f2 := filters.NewArgs()
-	f2.Add("unused-for", "3300h")
 	expectedPolicy := []BuilderGCRule{
-		{ReservedSpace: "10GB", Filter: BuilderGCFilter(f1)},
-		{ReservedSpace: "50GB", Filter: BuilderGCFilter(f2)}, /* parsed from deprecated form */
-		{ReservedSpace: "100GB", All: true},
+		{Filter: BuilderGCFilter(f1)},
+		{All: true},
 	}
+	// keepStorage is no longer mapped to ReservedSpace
 	assert.DeepEqual(t, cfg.Builder.GC.Policy, expectedPolicy, cmp.AllowUnexported(BuilderGCFilter{}))
-	// double check to please the skeptics
-	assert.Assert(t, filters.Args(cfg.Builder.GC.Policy[0].Filter).UniqueExactMatch("unused-for", "2200h"))
-	assert.Assert(t, filters.Args(cfg.Builder.GC.Policy[1].Filter).UniqueExactMatch("unused-for", "3300h"))
 }
 
 // TestBuilderGCFilterUnmarshal is a regression test for https://github.com/moby/moby/issues/44361,

--- a/daemon/server/router/build/build_routes.go
+++ b/daemon/server/router/build/build_routes.go
@@ -200,13 +200,6 @@ func (br *buildRouter) postPrune(ctx context.Context, w http.ResponseWriter, r *
 		if bs, err := parseBytesFromFormValue("reserved-space"); err != nil {
 			return err
 		} else {
-			if bs == 0 {
-				// Deprecated parameter. Only checked if reserved-space is not used.
-				bs, err = parseBytesFromFormValue("keep-storage")
-				if err != nil {
-					return err
-				}
-			}
 			opts.ReservedSpace = bs
 		}
 


### PR DESCRIPTION
## What I did

Remove the deprecated `keep-storage` query parameter from the `/build/prune` endpoint, as scheduled in the API changelog.

## How I did it

- **`daemon/server/router/build/build_routes.go`**: Remove the fallback that accepted `keep-storage` as an alias for `reserved-space` in API v1.48+. The pre-1.48 code path still accepts `keep-storage` for backward compatibility.
- **`daemon/config/builder.go`**: Remove deprecated `KeepStorage` and `DefaultKeepStorage` fields from the JSON unmarshalling of `BuilderGCRule` and `BuilderGCConfig`.
- **`daemon/config/builder_test.go`**: Update `TestBuilderGC_DeprecatedKeepStorage` to verify that `keepStorage` in config is now ignored instead of mapped to `ReservedSpace`.

## How to verify it

Build and run config tests:
```
GOOS=linux go build ./daemon/config/ ./daemon/server/router/build/
GOOS=linux go test ./daemon/config/ -run TestBuilderGC
```

Closes #50131