### PR TITLE
`builder-next: replace duplicated oneOffProgress with progress.OneOff`

### DIFF
--- a/daemon/internal/builder-next/adapters/containerimage/pull.go
+++ b/daemon/internal/builder-next/adapters/containerimage/pull.go
@@ -347,7 +347,7 @@ func (p *puller) resolveLocal() {
 
 func (p *puller) resolve(ctx context.Context, jobCtx solver.JobContext) error {
 	_, err := p.g.Do(ctx, "", func(ctx context.Context) (_ struct{}, retErr error) {
-		resolveProgressDone := oneOffProgress(ctx, "resolve "+p.src.Reference.String())
+		resolveProgressDone := progress.OneOff(ctx, "resolve "+p.src.Reference.String())
 		defer func() {
 			_ = resolveProgressDone(retErr)
 		}()
@@ -899,23 +899,6 @@ type statusInfo struct {
 	Total     int64
 	StartedAt time.Time
 	UpdatedAt time.Time
-}
-
-func oneOffProgress(ctx context.Context, id string) func(err error) error {
-	pw, _, _ := progress.NewFromContext(ctx)
-	s := time.Now()
-	st := progress.Status{
-		Started: &s,
-	}
-	_ = pw.Write(id, st)
-	return func(err error) error {
-		// TODO: set error on status
-		c := time.Now()
-		st.Completed = &c
-		_ = pw.Write(id, st)
-		_ = pw.Close()
-		return err
-	}
 }
 
 // cacheKeyFromConfig returns a stable digest from image config. If image config

--- a/daemon/internal/builder-next/exporter/mobyexporter/export.go
+++ b/daemon/internal/builder-next/exporter/mobyexporter/export.go
@@ -15,6 +15,7 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/util/leaseutil"
+	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/moby/v2/daemon/internal/image"
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/opencontainers/go-digest"
@@ -137,7 +138,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 	var diffs []digest.Digest
 	if ref != nil {
-		layersDone := oneOffProgress(ctx, "exporting layers")
+		layersDone := progress.OneOff(ctx, "exporting layers")
 
 		if err := ref.Finalize(ctx); err != nil {
 			return nil, nil, nil, layersDone(err)
@@ -193,7 +194,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp *exporter.Source
 
 	configDigest := digest.FromBytes(config)
 
-	configDone := oneOffProgress(ctx, fmt.Sprintf("writing image %s", configDigest))
+	configDone := progress.OneOff(ctx, fmt.Sprintf("writing image %s", configDigest))
 	id, err := e.opt.ImageStore.Create(config)
 	if err != nil {
 		return nil, nil, nil, configDone(err)
@@ -204,7 +205,7 @@ func (e *imageExporterInstance) Export(ctx context.Context, inp *exporter.Source
 	for _, targetName := range e.targetNames {
 		names = append(names, targetName.String())
 		if e.opt.ImageTagger != nil {
-			tagDone := oneOffProgress(ctx, "naming to "+targetName.String())
+			tagDone := progress.OneOff(ctx, "naming to "+targetName.String())
 			if err := e.opt.ImageTagger.TagImage(ctx, image.ID(digest.Digest(id)), targetName); err != nil {
 				return nil, nil, nil, tagDone(err)
 			}

--- a/daemon/internal/builder-next/exporter/mobyexporter/writer.go
+++ b/daemon/internal/builder-next/exporter/mobyexporter/writer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/cache"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
-	"github.com/moby/buildkit/util/progress"
 	"github.com/moby/buildkit/util/system"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -204,21 +203,4 @@ func getRefMetadata(ref cache.ImmutableRef, limit int) []refMetadata {
 		meta.createdAt = &createdAt
 	}
 	return metas
-}
-
-func oneOffProgress(ctx context.Context, id string) func(err error) error {
-	pw, _, _ := progress.NewFromContext(ctx)
-	now := time.Now()
-	st := progress.Status{
-		Started: &now,
-	}
-	_ = pw.Write(id, st)
-	return func(err error) error {
-		// TODO: set error on status
-		now := time.Now()
-		st.Completed = &now
-		_ = pw.Write(id, st)
-		_ = pw.Close()
-		return err
-	}
 }

--- a/daemon/internal/builder-next/worker/worker.go
+++ b/daemon/internal/builder-next/worker/worker.go
@@ -603,7 +603,7 @@ func (ld *layerDescriptor) DiffID() (layer.DiffID, error) {
 }
 
 func (ld *layerDescriptor) Download(ctx context.Context, progressOutput pkgprogress.Output) (io.ReadCloser, int64, error) {
-	done := oneOffProgress(ld.pctx, fmt.Sprintf("pulling %s", ld.desc.Digest))
+	done := progress.OneOff(ld.pctx, fmt.Sprintf("pulling %s", ld.desc.Digest))
 
 	// TODO should this write output to progressOutput? Or use something similar to loggerFromContext()? see https://github.com/moby/buildkit/commit/aa29e7729464f3c2a773e27795e584023c751cb8
 	discardLogs := func(_ []byte) {}
@@ -651,23 +651,6 @@ func getLayers(ctx context.Context, descs []ocispec.Descriptor) ([]rootfs.Layer,
 		}
 	}
 	return layers, nil
-}
-
-func oneOffProgress(ctx context.Context, id string) func(err error) error {
-	pw, _, _ := progress.NewFromContext(ctx)
-	s := time.Now()
-	st := progress.Status{
-		Started: &s,
-	}
-	_ = pw.Write(id, st)
-	return func(err error) error {
-		// TODO: set error on status
-		c := time.Now()
-		st.Completed = &c
-		_ = pw.Write(id, st)
-		_ = pw.Close()
-		return err
-	}
 }
 
 type emptyProvider struct{}


### PR DESCRIPTION
Three identical copies of oneOffProgress existed in the worker, containerimage adapter, and mobyexporter packages. Replace them with progress.OneOff from the buildkit/util/progress package, which has the same implementation.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Replaced three duplicated copies of `oneOffProgress` with `progress.OneOff` from `github.com/moby/buildkit/util/progress`.

**- How I did it**
The same `oneOffProgress` function was copy-pasted in three packages:
- `daemon/internal/builder-next/worker/`
- `daemon/internal/builder-next/adapters/containerimage/`
- `daemon/internal/builder-next/exporter/mobyexporter/`

All three had identical implementations and the same `// TODO: set error on status` comment. BuildKit already provides `progress.OneOff` with the same signature and behavior, so replaced all call sites and removed the local copies.

**- How to verify it**
- Confirm that `progress.OneOff` has the same signature: `func(ctx context.Context, id string) func(err error) error`
- Run existing tests: `go test ./daemon/internal/builder-next/...`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="259" height="194" alt="image" src="https://github.com/user-attachments/assets/8b7a8c14-6189-4a7d-93a7-55a7ea551dfe" />
