### PR TITLE
client: New: ignore nil-Opt instead of panicking

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -207,6 +207,9 @@ func New(ops ...Opt) (*Client, error) {
 	cfg := &c.clientConfig
 
 	for _, op := range ops {
+		if op == nil {
+			continue
+		}
 		if err := op(cfg); err != nil {
 			return nil, err
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -13,6 +13,22 @@ import (
 	"gotest.tools/v3/skip"
 )
 
+func TestNewClientWithNilOpt(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("should not panic on nil Opt: %v", r)
+		}
+	}()
+
+	client, err := New(nil)
+	assert.NilError(t, err)
+	assert.Check(t, client != nil)
+
+	client, err = New(Opt(nil))
+	assert.NilError(t, err)
+	assert.Check(t, client != nil)
+}
+
 func TestNewClientWithOpsFromEnv(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows")
 

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -207,6 +207,9 @@ func New(ops ...Opt) (*Client, error) {
 	cfg := &c.clientConfig
 
 	for _, op := range ops {
+		if op == nil {
+			continue
+		}
 		if err := op(cfg); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: prevent panic when passing `nil` Opts to `client.New`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

