### PR TITLE
Fix CONTAINER_PARTIAL_LAST always false on EOF

### DIFF
--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -151,9 +151,9 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 					} else {
 						msg.Timestamp = partialTS
 					}
-					msg.PLogMetaData = &types.PartialLogMetaData{ID: partialid, Ordinal: ordinal, Last: false}
+					msg.PLogMetaData = &types.PartialLogMetaData{ID: partialid, Ordinal: ordinal, Last: eof}
 					ordinal++
-					hasMorePartial = true
+					hasMorePartial = !eof
 
 					if logErr := c.dst.Log(msg); logErr != nil {
 						logDriverError(c.dst.Name(), string(msg.Line), logErr)

--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -93,7 +93,7 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 				n += read
 			}
 			// If we have no data to log, and there's no more coming, we're done.
-			if n == 0 && eof {
+			if n == 0 && eof && !hasMorePartial {
 				return
 			}
 			// Break up the data that we've buffered up into lines, and log each in turn.
@@ -133,7 +133,7 @@ func (c *Copier) copySrc(name string, src io.Reader) {
 			// has no newlines, log whatever we haven't logged yet,
 			// noting that it's a partial log line.
 			if eof || (p == 0 && n == len(buf)) {
-				if p < n {
+				if p < n || (eof && hasMorePartial) {
 					msg := NewMessage()
 					msg.Source = name
 					msg.Line = append(msg.Line, buf[p:n]...)

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -263,15 +263,19 @@ func testCopierWithSized(t *testing.T, loggerFactory func(SizedLogger) SizedLogg
 			t.Fatal(err)
 		}
 		if msg.Source != "stdout" {
-			t.Fatalf("Wrong Source: %q, should be %q", msg.Source, "stdout")
+			t.Errorf("Line %d: wrong Source: %q, should be %q", recvdMsgs, msg.Source, "stdout")
+		}
+		if recvdMsgs == expectedMsgs && len(msg.Line) == 0 && msg.PLogMetaData != nil && msg.PLogMetaData.Last {
+			// Don't count the empty message that terminates the partial sequence.
+			continue
 		}
 		if len(msg.Line) != sizedLogger.BufSize() {
-			t.Fatalf("Line was not of expected max length %d, was %d", sizedLogger.BufSize(), len(msg.Line))
+			t.Errorf("Line %d was not of expected max length %d, was %d", recvdMsgs, sizedLogger.BufSize(), len(msg.Line))
 		}
 		recvdMsgs++
 	}
 	if recvdMsgs != expectedMsgs {
-		t.Fatalf("expected to receive %d messages, actually received %d %q", expectedMsgs, recvdMsgs, jsonBuf.String())
+		t.Errorf("expected to receive %d messages, actually received %d %q", expectedMsgs, recvdMsgs, jsonBuf.String())
 	}
 }
 
@@ -411,71 +415,90 @@ func TestCopierWithPartial(t *testing.T) {
 // PLogMetaData.Last set to true when the stream ends with EOF and there
 // is no trailing newline.
 func TestCopierPartialLastOnEOF(t *testing.T) {
-	// Create a long line that exceeds the buffer size so it gets split
-	// into partials, but do NOT end with a newline so the last chunk
-	// is triggered by EOF.
-	longLine := strings.Repeat("x", defaultBufSize)
-	trailingData := "trailing-no-newline"
-
-	var input bytes.Buffer
-	// Write enough data to produce multiple partial messages.
-	for range 2 {
-		input.WriteString(longLine)
-	}
-	input.WriteString(trailingData)
-	// Deliberately no trailing '\n'.
-
-	var jsonBuf bytes.Buffer
-	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf)}
-
-	c := NewCopier(map[string]io.Reader{"stdout": &input}, jsonLog)
-	c.Run()
-	wait := make(chan struct{})
-	go func() {
-		c.Wait()
-		close(wait)
-	}()
-	select {
-	case <-time.After(1 * time.Second):
-		t.Fatal("Copier failed to do its work in 1 second")
-	case <-wait:
+	tests := []struct {
+		name         string
+		trailingData string
+	}{
+		{
+			name:         "with trailing data",
+			trailingData: "trailing-no-newline",
+		},
+		{
+			name:         "exact buffer boundary",
+			trailingData: "",
+		},
 	}
 
-	dec := json.NewDecoder(&jsonBuf)
-	var msgs []Message
-	for {
-		var msg Message
-		if err := dec.Decode(&msg); err != nil {
-			if err == io.EOF {
-				break
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a long line that exceeds the buffer size so it gets split
+			// into partials, but do NOT end with a newline so the last chunk
+			// is triggered by EOF.
+			longLine := strings.Repeat("x", defaultBufSize)
+
+			var input bytes.Buffer
+			// Write enough data to produce multiple partial messages.
+			for range 2 {
+				input.WriteString(longLine)
 			}
-			t.Fatal(err)
-		}
-		msgs = append(msgs, msg)
-	}
+			input.WriteString(tc.trailingData)
 
-	if len(msgs) < 2 {
-		t.Fatalf("Expected at least 2 partial messages, got %d", len(msgs))
-	}
+			// Deliberately no trailing '\n'.
 
-	// All messages should be partial.
-	for i, msg := range msgs {
-		if msg.PLogMetaData == nil {
-			t.Errorf("Message %d: expected PLogMetaData to be set", i)
-		}
-	}
+			var jsonBuf bytes.Buffer
+			jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf)}
+			c := NewCopier(map[string]io.Reader{"stdout": &input}, jsonLog)
+			c.Run()
 
-	// All messages except the last should have Last == false.
-	for i := 0; i < len(msgs)-1; i++ {
-		if msgs[i].PLogMetaData.Last {
-			t.Errorf("Message %d: expected Last to be false, got true", i)
-		}
-	}
+			wait := make(chan struct{})
+			go func() {
+				c.Wait()
+				close(wait)
+			}()
 
-	// The last message should have Last == true.
-	last := msgs[len(msgs)-1]
-	if !last.PLogMetaData.Last {
-		t.Errorf("Last message: expected Last to be true, got false (line=%q)", last.Line)
+			select {
+			case <-time.After(1 * time.Second):
+				t.Fatal("Copier failed to do its work in 1 second")
+			case <-wait:
+			}
+
+			dec := json.NewDecoder(&jsonBuf)
+			var msgs []Message
+			for {
+				var msg Message
+				if err := dec.Decode(&msg); err != nil {
+					if err == io.EOF {
+						break
+					}
+					t.Fatal(err)
+				}
+				msgs = append(msgs, msg)
+			}
+
+			if len(msgs) < 2 {
+				t.Fatalf("Expected at least 2 partial messages, got %d", len(msgs))
+			}
+
+			// All messages should be partial.
+			for i, msg := range msgs {
+				if msg.PLogMetaData == nil {
+					t.Errorf("Message %d: expected PLogMetaData to be set", i)
+				}
+			}
+
+			// All messages except the last should have Last == false.
+			for i := 0; i < len(msgs)-1; i++ {
+				if msgs[i].PLogMetaData.Last {
+					t.Errorf("Message %d: expected Last to be false, got true", i)
+				}
+			}
+
+			// The last message should have Last == true.
+			last := msgs[len(msgs)-1]
+			if !last.PLogMetaData.Last {
+				t.Errorf("Last message: expected Last to be true, got false (line=%q)", last.Line)
+			}
+		})
 	}
 }
 

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -407,6 +407,78 @@ func TestCopierWithPartial(t *testing.T) {
 	}
 }
 
+// TestCopierPartialLastOnEOF tests that the last partial message has
+// PLogMetaData.Last set to true when the stream ends with EOF and there
+// is no trailing newline.
+func TestCopierPartialLastOnEOF(t *testing.T) {
+	// Create a long line that exceeds the buffer size so it gets split
+	// into partials, but do NOT end with a newline so the last chunk
+	// is triggered by EOF.
+	longLine := strings.Repeat("x", defaultBufSize)
+	trailingData := "trailing-no-newline"
+
+	var input bytes.Buffer
+	// Write enough data to produce multiple partial messages.
+	for range 2 {
+		input.WriteString(longLine)
+	}
+	input.WriteString(trailingData)
+	// Deliberately no trailing '\n'.
+
+	var jsonBuf bytes.Buffer
+	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf)}
+
+	c := NewCopier(map[string]io.Reader{"stdout": &input}, jsonLog)
+	c.Run()
+	wait := make(chan struct{})
+	go func() {
+		c.Wait()
+		close(wait)
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatal("Copier failed to do its work in 1 second")
+	case <-wait:
+	}
+
+	dec := json.NewDecoder(&jsonBuf)
+	var msgs []Message
+	for {
+		var msg Message
+		if err := dec.Decode(&msg); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		msgs = append(msgs, msg)
+	}
+
+	if len(msgs) < 2 {
+		t.Fatalf("Expected at least 2 partial messages, got %d", len(msgs))
+	}
+
+	// All messages should be partial.
+	for i, msg := range msgs {
+		if msg.PLogMetaData == nil {
+			t.Errorf("Message %d: expected PLogMetaData to be set", i)
+		}
+	}
+
+	// All messages except the last should have Last == false.
+	for i := 0; i < len(msgs)-1; i++ {
+		if msgs[i].PLogMetaData.Last {
+			t.Errorf("Message %d: expected Last to be false, got true", i)
+		}
+	}
+
+	// The last message should have Last == true.
+	last := msgs[len(msgs)-1]
+	if !last.PLogMetaData.Last {
+		t.Errorf("Last message: expected Last to be true, got false (line=%q)", last.Line)
+	}
+}
+
 type BenchmarkLoggerDummy struct{}
 
 func (l *BenchmarkLoggerDummy) Log(m *Message) error { PutMessage(m); return nil }


### PR DESCRIPTION
**- What I did**

Fixed a bug where `CONTAINER_PARTIAL_LAST` (and `PLogMetaData.Last` in general) was always `false` for partial log messages, even for the final partial chunk when the log stream ends with EOF and no trailing newline.

Fixes #52085

**- How I did it**

In `daemon/logger/copier.go`, the `copySrc` method handles splitting oversized log lines into partial messages. When the buffer is full without a newline, or when EOF is reached with remaining data, a partial message is emitted. Previously, this partial was unconditionally created with `Last: false`:

```go
msg.PLogMetaData = &types.PartialLogMetaData{ID: partialid, Ordinal: ordinal, Last: false}
ordinal++
hasMorePartial = true
```

This is correct when the buffer is full and more data is expected, but incorrect when we've reached EOF — the final partial should have `Last: true`. The fix uses the `eof` flag:

```go
msg.PLogMetaData = &types.PartialLogMetaData{ID: partialid, Ordinal: ordinal, Last: eof}
ordinal++
hasMorePartial = !eof
```

- When `eof == false` (buffer full, more data coming): `Last: false`, `hasMorePartial: true` — unchanged behavior
- When `eof == true` (stream ended): `Last: true`, `hasMorePartial: false` — the final partial is correctly marked

**- How to verify it**

1. Run the new unit test:
   ```
   go test ./daemon/logger/ -run TestCopierPartialLastOnEOF -v
   ```

2. Reproduce the original issue scenario:
   ```bash
   docker run --name=numbers_4k --rm --log-driver=journald alpine sh -c "seq 1 3500 | tr '\n' ' '"
   journalctl --no-pager CONTAINER_NAME=numbers_4k --lines=2 --output=json | jq '.CONTAINER_PARTIAL_LAST'
   ```
   The last partial message should now show `"true"` instead of `"false"`.

**- Human readable description for the release notes**
```markdown changelog
Fix partial log metadata: the last partial message now correctly sets `CONTAINER_PARTIAL_LAST=true` when the log stream ends without a trailing newline.
```

**- A picture of a cute animal (not mandatory but encouraged)**

🐳