### PR TITLE
internal/testutil/daemon: only run sudo as root

### DIFF
--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -467,16 +467,20 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 		if d.dockerdBinary != defaultDockerdBinary {
 			return errors.Errorf("[%s] DOCKER_ROOTLESS doesn't support non-default dockerd binary path %q", d.id, d.dockerdBinary)
 		}
-		dockerdBinary = "sudo"
-		d.args = append(d.args,
-			"-u", d.rootlessUser.Username,
-			"--preserve-env",
-			"--preserve-env=PATH", // Pass through PATH, overriding secure_path.
-			"XDG_RUNTIME_DIR="+d.rootlessXDGRuntimeDir,
-			"HOME="+d.rootlessUser.HomeDir,
-			"--",
-			defaultDockerdRootlessBinary,
-		)
+		if os.Geteuid() == 0 {
+			dockerdBinary = "sudo"
+			d.args = append(d.args,
+				"-u", d.rootlessUser.Username,
+				"--preserve-env",
+				"--preserve-env=PATH", // Pass through PATH, overriding secure_path.
+				"XDG_RUNTIME_DIR="+d.rootlessXDGRuntimeDir,
+				"HOME="+d.rootlessUser.HomeDir,
+				"--",
+				defaultDockerdRootlessBinary,
+			)
+		} else {
+			dockerdBinary = defaultDockerdRootlessBinary
+		}
 	}
 
 	d.args = append(d.args,


### PR DESCRIPTION

**- What I did**

Only run sudo as root.

When DOCKER_ROOTLESS is set, run sudo only if we are root so we can run the testsuite directly as rootless.

We're running the testsuite directly and we encountered some issues listed in https://github.com/moby/moby/pull/51263

This is an attempt to tackle those in a different way.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

