### PR TITLE
integration: ignore container Status field in DiskUsage test comparisons

### DIFF
--- a/integration/system/disk_usage_test.go
+++ b/integration/system/disk_usage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
+	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/v2/integration/internal/container"
 	"github.com/moby/moby/v2/internal/testutil"
@@ -284,7 +285,10 @@ func TestDiskUsage(t *testing.T) {
 
 					du, err := apiClient.DiskUsage(ctx, tc.options)
 					assert.NilError(t, err)
-					assert.DeepEqual(t, du, tc.expected, cmpopts.EquateComparable(netip.Addr{}, netip.Prefix{}))
+					assert.DeepEqual(t, du, tc.expected,
+						cmpopts.EquateComparable(netip.Addr{}, netip.Prefix{}),
+						cmpopts.IgnoreFields(containertypes.Summary{}, "Status"),
+					)
 				})
 			}
 		})


### PR DESCRIPTION
integration: ignore container Status field in DiskUsage test comparisons

The Status field is a human-readable uptime string (e.g. "Up Less than a second" vs "Up 1 second"), which is racy.

Use cmpopts.IgnoreFields to exclude Status from the DeepEqual comparison in the type-filter sub-tests. The field is already implicitly covered by the State and Created assertions in the parent step.

Otherwise we get failures like this:

https://openqa-assets.opensuse.org/tests/5768388/file/docker_engine-report.txt

```
        - 				Status:     "Up 1 second",
        + 				Status:     "Up Less than a second",
```

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

![nikita](https://i.imgur.com/g3J5At3.jpeg)