### PR TITLE
transport: enable HTTP keep-alive for registry connections

### DIFF
--- a/daemon/internal/distribution/registry.go
+++ b/daemon/internal/distribution/registry.go
@@ -83,14 +83,12 @@ func newRepository(
 		KeepAlive: 30 * time.Second,
 	}
 
-	// TODO(dmcgowan): Call close idle connections when complete, use keep alive
 	base := &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		DialContext:         direct.DialContext,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     endpoint.TLSConfig,
-		// TODO(dmcgowan): Call close idle connections when complete and use keep alive
-		DisableKeepAlives: true,
+		IdleConnTimeout:     30 * time.Second,
 	}
 
 	modifiers := registry.Headers(dockerversion.DockerUserAgent(ctx), metaHeaders)

--- a/daemon/pkg/registry/registry.go
+++ b/daemon/pkg/registry/registry.go
@@ -141,8 +141,7 @@ func newTransport(tlsConfig *tls.Config) http.RoundTripper {
 			}).DialContext,
 			TLSHandshakeTimeout: 10 * time.Second,
 			TLSClientConfig:     tlsConfig,
-			// TODO(dmcgowan): Call close idle connections when complete and use keep alive
-			DisableKeepAlives: true,
+			IdleConnTimeout:     30 * time.Second,
 		},
 	)
 }


### PR DESCRIPTION
- supersedes, closes https://github.com/moby/moby/pull/40305

**- What I did**

Enabled HTTP keep-alive for registry connections by replacing `DisableKeepAlives: true` with `IdleConnTimeout: 30 * time.Second` in two files:

- `daemon/internal/distribution/registry.go` (image pull/push)
- `daemon/pkg/registry/registry.go` (registry auth/search)

**- How I did it**

Previously, both HTTP transports had `DisableKeepAlives: true` set, which forced a new TCP + TLS handshake for every HTTP request to the registry. Two TODO comments (`TODO(dmcgowan)`) indicated the intent to enable keep-alive but noted the need for idle connection cleanup.

By setting `IdleConnTimeout: 30 * time.Second`, idle connections are automatically closed by Go's `http.Transport` after 30 seconds of inactivity. This allows connection reuse during active pull/push operations (where requests are seconds apart) while ensuring cleanup after the operation completes — without requiring the caller to explicitly close the transport.

This approach is already used in `daemon/pkg/plugin/registry.go`:

```go
// daemon/pkg/plugin/registry.go (existing code)
Transport: &http.Transport{
    ...
    IdleConnTimeout: 30 * time.Second,
    // no DisableKeepAlives
}
```

Aligning the distribution and registry transports with this existing pattern for consistency.

**- How to verify it**

- Existing integration tests for pull/push should continue to pass.
- Connection reuse can be observed by monitoring TCP connections during a multi-layer image pull (e.g., fewer connections established with keep-alive enabled).

**- Human readable description for the release notes**

```markdown changelog
Improved image pull and push performance by enabling HTTP keep-alive for registry connections, avoiding redundant TCP and TLS handshakes.
```

**- A picture of a cute animal (not mandatory but encouraged)**