### PR TITLE
Fix testsuite when running directly as rootless

### DIFF
--- a/integration/container/mounts_linux_test.go
+++ b/integration/container/mounts_linux_test.go
@@ -74,6 +74,7 @@ func TestContainerMultipleMountsSamePath(t *testing.T) {
 func TestContainerNetworkMountsNoChown(t *testing.T) {
 	// chown only applies to Linux bind mounted volumes; must be same host to verify
 	skip.If(t, testEnv.IsRemoteDaemon)
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 
 	ctx := setupTest(t)
 
@@ -603,6 +604,7 @@ func TestContainerBindMountReadOnlyDefault(t *testing.T) {
 func TestContainerBindMountRecursivelyReadOnly(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, versions.LessThan(testEnv.DaemonAPIVersion(), "1.44"), "requires API v1.44")
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 
 	ctx := setupTest(t)
 

--- a/integration/container/pidmode_linux_test.go
+++ b/integration/container/pidmode_linux_test.go
@@ -15,6 +15,7 @@ import (
 func TestPIDModeHost(t *testing.T) {
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
 	skip.If(t, testEnv.IsRemoteDaemon())
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 
 	hostPid, err := os.Readlink("/proc/1/ns/pid")
 	assert.NilError(t, err)

--- a/integration/container/run_linux_test.go
+++ b/integration/container/run_linux_test.go
@@ -134,6 +134,7 @@ func TestPrivilegedHostDevices(t *testing.T) {
 	// so needs to be same host.
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 
 	ctx := setupTest(t)
 	apiClient := testEnv.APIClient()
@@ -207,6 +208,7 @@ func TestRunConsoleSize(t *testing.T) {
 func TestRunWithAlternativeContainerdShim(t *testing.T) {
 	skip.If(t, testEnv.IsRemoteDaemon)
 	skip.If(t, testEnv.DaemonInfo.OSType != "linux")
+	skip.If(t, os.Getuid() != 0, "skipping test that requires root")
 
 	ctx := testutil.StartSpan(baseContext, t)
 

--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -474,6 +474,7 @@ func (d *Daemon) StartWithLogFile(out *os.File, providedArgs ...string) error {
 			"--preserve-env=PATH", // Pass through PATH, overriding secure_path.
 			"XDG_RUNTIME_DIR="+d.rootlessXDGRuntimeDir,
 			"HOME="+d.rootlessUser.HomeDir,
+			"DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR="+filepath.Join(d.rootlessXDGRuntimeDir, "rootless"),
 			"--",
 			defaultDockerdRootlessBinary,
 		)

--- a/internal/testutil/daemon/daemon_linux.go
+++ b/internal/testutil/daemon/daemon_linux.go
@@ -30,7 +30,10 @@ func cleanupNetworkNamespace(t testing.TB, d *Daemon) {
 
 // CgroupNamespace returns the cgroup namespace the daemon is running in
 func (d *Daemon) CgroupNamespace(t testing.TB) string {
-	link, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/cgroup", d.Pid()))
+	pidBytes, err := os.ReadFile(d.pidFile)
+	assert.NilError(t, err)
+
+	link, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/cgroup", strings.TrimSpace(string(pidBytes))))
 	assert.NilError(t, err)
 
 	return strings.TrimSpace(link)


### PR DESCRIPTION
- testutil/daemon: fix CgroupNamespace reading wrong process's ns
In rootless mode, `d.Pid()` returns the PID of the outermost process started by the test framework (e.g., sudo), not dockerd itself. Even without sudo, reading the shell's cgroup namespace instead of dockerd's is incorrect.
dockerd always writes its own PID to the `--pidfile` passed by the test framework, so read that instead. This gives the actual dockerd PID.
- testutil/daemon: Set rootlesskit `--state-dir` on rootless tests
This is done to avoid colliding with another instance set up via dockerd-rootless.sh
- integration: Skip some tests when not run as root
 These tests pass when `DOCKER_ROOTLESS` is set when run on privileged containers but fail otherwise as they call mknod on `/dev/`, or try to read `/proc/1/ns/pid`, etc.

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

