### PR TITLE
daemon/containerd: register Sigstore media type prefixes to suppress …

### DIFF
--- a/daemon/containerd/image_pull.go
+++ b/daemon/containerd/image_pull.go
@@ -97,6 +97,13 @@ func (i *ImageService) PullImage(ctx context.Context, baseRef reference.Named, o
 }
 
 func (i *ImageService) pullTag(ctx context.Context, ref reference.Named, platform *ocispec.Platform, metaHeaders map[string][]string, authConfig *registrytypes.AuthConfig, out progress.Output) error {
+	// Register media types used by Sigstore bundles and OCI referrers so that
+	// MakeRefKey can assign a proper ref-key prefix instead of logging
+	// "reference for unknown type" warnings.
+	ctx = remotes.WithMediaTypeKeyPrefix(ctx, ocispec.MediaTypeEmptyJSON, "empty")
+	ctx = remotes.WithMediaTypeKeyPrefix(ctx, policyimage.ArtifactTypeCosignSignature, "cosign-signature")
+	ctx = remotes.WithMediaTypeKeyPrefix(ctx, policyimage.ArtifactTypeSigstoreBundle, "sigstore-bundle")
+
 	var opts []containerd.RemoteOpt
 	if platform != nil {
 		opts = append(opts, containerd.WithPlatform(platforms.FormatAll(*platform)))


### PR DESCRIPTION
- What I did

Fix "reference for unknown type" warnings logged when pulling images with Sigstore bundles (e.g. `moby/buildkit:latest`).

Fixes #52158

- How I did it

Register Sigstore and OCI empty media types using `WithMediaTypeKeyPrefix` in pull context in `pullTag()`, so that `MakeRefKey` returns a ref-key prefix instead of falling through in a default case which is the cause of the warning.

This follows the same structure that is in:
- `daemon/pkg/plugin/fetch_linux.go:74` 
- buildkit's `RegisterContentPayloadTypes` 

The three media types:
- `application/vnd.oci.empty.v1+json` : `"empty"`
- `application/vnd.dev.cosign.artifact.sig.v1+json` : `"cosign-signature"`
- `application/vnd.dev.sigstore.bundle.v0.3+json` : `"sigstore-bundle"`

- How to verify it

Pull an image with Sigstore bundles and look at the daemon logs:
```
docker image pull moby/buildkit:latest
```
There is no more "reference for unknown type" warnings.
