### PR TITLE
client: WithHTTPHeaders: improve doc, add test coverage, and error on duplicate headers

### DIFF
--- a/client/client_options.go
+++ b/client/client_options.go
@@ -194,11 +194,25 @@ func WithUserAgent(ua string) Opt {
 }
 
 // WithHTTPHeaders appends custom HTTP headers to the client's default headers.
-// It does not allow for built-in headers (such as "User-Agent", if set) to
-// be overridden. Also see [WithUserAgent].
+// It does not allow overriding built-in headers (such as "User-Agent").
+// Also see [WithUserAgent].
+//
+// It replaces any existing custom headers. Keys are case-insensitive and
+// canonicalized using [http.CanonicalHeaderKey]. If multiple entries map
+// to the same canonical key, the resulting value is undefined and may vary
+// between runs due to map iteration order.
 func WithHTTPHeaders(headers map[string]string) Opt {
 	return func(c *clientConfig) error {
-		c.customHTTPHeaders = headers
+		c.customHTTPHeaders = make(map[string]string)
+		for k, v := range headers {
+			k = http.CanonicalHeaderKey(k)
+			_, ok := c.customHTTPHeaders[k]
+			if ok {
+				// TODO(thaJeztah): consider returning an error on duplicates
+				continue
+			}
+			c.customHTTPHeaders[k] = v
+		}
 		return nil
 	}
 }

--- a/client/client_options.go
+++ b/client/client_options.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -199,8 +200,7 @@ func WithUserAgent(ua string) Opt {
 //
 // It replaces any existing custom headers. Keys are case-insensitive and
 // canonicalized using [http.CanonicalHeaderKey]. If multiple entries map
-// to the same canonical key, the resulting value is undefined and may vary
-// between runs due to map iteration order.
+// to the same canonical key, a [cerrdefs.ErrInvalidArgument] is returned.
 func WithHTTPHeaders(headers map[string]string) Opt {
 	return func(c *clientConfig) error {
 		c.customHTTPHeaders = make(map[string]string)
@@ -208,8 +208,7 @@ func WithHTTPHeaders(headers map[string]string) Opt {
 			k = http.CanonicalHeaderKey(k)
 			_, ok := c.customHTTPHeaders[k]
 			if ok {
-				// TODO(thaJeztah): consider returning an error on duplicates
-				continue
+				return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("duplicate custom HTTP header (%s)", k))
 			}
 			c.customHTTPHeaders[k] = v
 		}

--- a/client/client_options_test.go
+++ b/client/client_options_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -380,15 +381,9 @@ func TestWithHTTTPHeaders(t *testing.T) {
 				"CUSTOM-HEADER": "custom-value-C",
 			}),
 		)
-		assert.NilError(t, err)
-
-		// Check customHTTPHeaders directly for this test because we canonicalize
-		// headers before sending requests. Ultimately, we should produce an
-		// error if duplicate headers are provided.
-		assert.Check(t, c.customHTTPHeaders["Custom-Header"] != "", "canonical header should be set")
-		assert.Check(t, c.customHTTPHeaders["custom-header"] == "", "non-canonical header should not be set")
-		assert.Check(t, c.customHTTPHeaders["CUSTOM-HEADER"] == "", "non-canonical header should not be set")
-		assert.NilError(t, c.Close())
+		assert.Check(t, is.ErrorIs(err, cerrdefs.ErrInvalidArgument))
+		assert.Check(t, is.Error(err, "duplicate custom HTTP header (Custom-Header)"))
+		assert.Check(t, is.Nil(c))
 	})
 	t.Run("multiple", func(t *testing.T) {
 		c, err := New(

--- a/client/client_options_test.go
+++ b/client/client_options_test.go
@@ -371,6 +371,44 @@ func TestWithUserAgent(t *testing.T) {
 	})
 }
 
+func TestWithHTTTPHeaders(t *testing.T) {
+	t.Run("duplicates", func(t *testing.T) {
+		c, err := New(
+			WithHTTPHeaders(map[string]string{
+				"custom-header": "custom-value-A",
+				"Custom-Header": "custom-value-B",
+				"CUSTOM-HEADER": "custom-value-C",
+			}),
+		)
+		assert.NilError(t, err)
+
+		// Check customHTTPHeaders directly for this test because we canonicalize
+		// headers before sending requests. Ultimately, we should produce an
+		// error if duplicate headers are provided.
+		assert.Check(t, c.customHTTPHeaders["Custom-Header"] != "", "canonical header should be set")
+		assert.Check(t, c.customHTTPHeaders["custom-header"] == "", "non-canonical header should not be set")
+		assert.Check(t, c.customHTTPHeaders["CUSTOM-HEADER"] == "", "non-canonical header should not be set")
+		assert.NilError(t, c.Close())
+	})
+	t.Run("multiple", func(t *testing.T) {
+		c, err := New(
+			WithHTTPHeaders(map[string]string{"custom-header-1": "hello"}),
+			WithHTTPHeaders(map[string]string{"custom-header-2": "custom-value-A"}),
+			WithHTTPHeaders(map[string]string{"Custom-Header-2": "custom-value-B"}),
+			WithHTTPHeaders(map[string]string{"CUSTOM-HEADER-2": "custom-value-C"}),
+			WithBaseMockClient(func(req *http.Request) (*http.Response, error) {
+				assert.Check(t, is.Equal(req.Header.Get("Custom-Header-1"), ""), "custom-header-1 should've been replaced")
+				assert.Check(t, is.Equal(req.Header.Get("Custom-Header-2"), "custom-value-C"))
+				return &http.Response{StatusCode: http.StatusOK}, nil
+			}),
+		)
+		assert.NilError(t, err)
+		_, err = c.Ping(t.Context(), PingOptions{})
+		assert.NilError(t, err)
+		assert.NilError(t, c.Close())
+	})
+}
+
 func TestWithHTTPClient(t *testing.T) {
 	cookieJar, err := cookiejar.New(nil)
 	assert.NilError(t, err)

--- a/vendor/github.com/moby/moby/client/client_options.go
+++ b/vendor/github.com/moby/moby/client/client_options.go
@@ -194,11 +194,25 @@ func WithUserAgent(ua string) Opt {
 }
 
 // WithHTTPHeaders appends custom HTTP headers to the client's default headers.
-// It does not allow for built-in headers (such as "User-Agent", if set) to
-// be overridden. Also see [WithUserAgent].
+// It does not allow overriding built-in headers (such as "User-Agent").
+// Also see [WithUserAgent].
+//
+// It replaces any existing custom headers. Keys are case-insensitive and
+// canonicalized using [http.CanonicalHeaderKey]. If multiple entries map
+// to the same canonical key, the resulting value is undefined and may vary
+// between runs due to map iteration order.
 func WithHTTPHeaders(headers map[string]string) Opt {
 	return func(c *clientConfig) error {
-		c.customHTTPHeaders = headers
+		c.customHTTPHeaders = make(map[string]string)
+		for k, v := range headers {
+			k = http.CanonicalHeaderKey(k)
+			_, ok := c.customHTTPHeaders[k]
+			if ok {
+				// TODO(thaJeztah): consider returning an error on duplicates
+				continue
+			}
+			c.customHTTPHeaders[k] = v
+		}
 		return nil
 	}
 }

--- a/vendor/github.com/moby/moby/client/client_options.go
+++ b/vendor/github.com/moby/moby/client/client_options.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/go-connections/sockets"
 	"github.com/docker/go-connections/tlsconfig"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -199,8 +200,7 @@ func WithUserAgent(ua string) Opt {
 //
 // It replaces any existing custom headers. Keys are case-insensitive and
 // canonicalized using [http.CanonicalHeaderKey]. If multiple entries map
-// to the same canonical key, the resulting value is undefined and may vary
-// between runs due to map iteration order.
+// to the same canonical key, a [cerrdefs.ErrInvalidArgument] is returned.
 func WithHTTPHeaders(headers map[string]string) Opt {
 	return func(c *clientConfig) error {
 		c.customHTTPHeaders = make(map[string]string)
@@ -208,8 +208,7 @@ func WithHTTPHeaders(headers map[string]string) Opt {
 			k = http.CanonicalHeaderKey(k)
 			_, ok := c.customHTTPHeaders[k]
 			if ok {
-				// TODO(thaJeztah): consider returning an error on duplicates
-				continue
+				return cerrdefs.ErrInvalidArgument.WithMessage(fmt.Sprintf("duplicate custom HTTP header (%s)", k))
 			}
 			c.customHTTPHeaders[k] = v
 		}


### PR DESCRIPTION
The behavior of this option was under-documented, and there's an issue with duplicate headers leading to unexpected behavior; changing that is probably not suitable for a patch release, so let's start with adding test-coverage, and adding a TODO for a future release.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: client.WithHTTPHeaders now detects if duplicate headers are set, and produces an error. Previously, duplicate errors would be randomized, resulting in undefined behavior.
```

**- A picture of a cute animal (not mandatory but encouraged)**

