### PR TITLE
client: fix TestNewClientWithOpsFromEnv

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,7 +48,7 @@ func TestNewClientWithOpsFromEnv(t *testing.T) {
 			envs: map[string]string{
 				"DOCKER_CERT_PATH": "invalid/path",
 			},
-			expectedError: "could not load X509 key pair: open invalid/path/cert.pem: no such file or directory",
+			expectedError: `configure TLS from "DOCKER_CERT_PATH=invalid/path": could not load X509 key pair: open invalid/path/cert.pem: no such file or directory`,
 		},
 		{
 			doc: "default api version with cert path",


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/52202

This broken in 760f375400e7500c6e10669340ea7c77ae514861, which initially only updated the GoDoc, but also changed the error-message (whoops!).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

