### PR TITLE
daemon: respect explicit AppArmor profile on privileged containers

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
-	container.AppArmorProfile = "" // we don't care about the previous value.
+	container.AppArmorProfile = "" // reset; parseSecurityOpt re-derives it from HostConfig.SecurityOpt.
 
 	if !daemon.RawSysInfo().AppArmor {
 		return nil // if apparmor is disabled there is nothing to do here.
@@ -18,10 +18,12 @@ func (daemon *Daemon) saveAppArmorConfig(container *container.Container) error {
 		return errdefs.InvalidParameter(err)
 	}
 
-	if container.HostConfig.Privileged {
-		container.AppArmorProfile = unconfinedAppArmorProfile
-	} else if container.AppArmorProfile == "" {
-		container.AppArmorProfile = defaultAppArmorProfile
+	if container.AppArmorProfile == "" {
+		if container.HostConfig.Privileged {
+			container.AppArmorProfile = unconfinedAppArmorProfile
+		} else {
+			container.AppArmorProfile = defaultAppArmorProfile
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## What I did

Fixed `saveAppArmorConfig` unconditionally overwriting a user-specified AppArmor profile with `"unconfined"` on privileged containers. This caused containers with an explicit `--security-opt apparmor=<profile>` to lose their intended AppArmor policy after a restart (stop+start, host reboot, or daemon restart).

- Fixes #38075
- Fixes #51242

## How I did it

Inverted the condition nesting in `saveAppArmorConfig` (`daemon/container_linux.go`) so that `"unconfined"` (privileged default) and `"docker-default"` are only applied when no explicit profile was set via `SecurityOpt`. Previously the `Privileged` check came first and unconditionally overwrote any profile parsed from `SecurityOpt`.

The bug manifests as follows:

1. On first `docker start`, `createSpec` → `WithApparmor` builds the OCI spec    using the correct in-memory `AppArmorProfile` value (set during `docker create`).
2. `saveAppArmorConfig` then runs **after** spec creation and overwrites    `AppArmorProfile` to `"unconfined"` for privileged containers.
3. `CheckpointTo` persists this incorrect `"unconfined"` value to disk. 
4. On subsequent starts, the container loads with `AppArmorProfile = "unconfined"`, and `WithApparmor` picks up that stale value — the container runs without its intended AppArmor policy.

The fix makes `saveAppArmorConfig` consistent with the existing precedence in both `WithApparmor` (`oci_linux.go`) and `execSetPlatformOpt` (`exec_linux.go`), which already give explicit profiles priority over the privileged default.

The bug was introduced in d97a00df (Docker 17.04, #27083) and survived a refactor in 483aa629 (#43130).

## How to verify it

1. Load a custom AppArmor profile on the host (e.g. `apparmor_parser -r /path/to/my-profile`)
2. Create a privileged container with an explicit profile:
   ```
   docker create --privileged --security-opt apparmor=my-profile --name test alpine sleep infinity
   ```
3. Start the container:
   ```
   docker start test
   ```
4. Verify the profile is applied:
   ```
   docker inspect test --format '{{.AppArmorProfile}}'
   # should show: my-profile
   cat /proc/$(docker inspect test --format '{{.State.Pid}}')/attr/apparmor/current
   # should show: my-profile (enforce)
   ```
6. Restart the container:
   ```
   docker restart test
   ```
7. Verify the profile is **still** applied (this was the broken path):
   ```
   docker inspect test --format '{{.AppArmorProfile}}'
   # should show: my-profile (previously showed: unconfined)
   cat /proc/$(docker inspect test --format '{{.State.Pid}}')/attr/apparmor/current
   # should show: my-profile (enforce) (previously showed: unconfined)
   ```

## Human readable description for the release notes

```markdown changelog
- Fixed privileged containers losing their explicit AppArmor profile (`--security-opt apparmor=<profile>`) after a container restart.
```

## A picture of a cute animal (not mandatory but encouraged)

<img width="500" height="333" alt="image" src="https://github.com/user-attachments/assets/b057f0f6-805d-4e05-ac95-6bce416b09e6" />

From: https://en.wikipedia.org/wiki/File:9-banded-armadillo.jpg

*An armadillo — because it knows a thing or two about wearing proper armor at all times* 🛡️