### PR TITLE
bridge: protect bridge subnet from direct external access in raw PREROUTING

### DIFF
--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
@@ -74,10 +74,12 @@ func (ic iptablesCleaner) DelNetwork(ctx context.Context, nc firewaller.NetworkC
 	if ic.config.IPv4 && nc.Config4.Prefix.IsValid() {
 		_ = deleteLegacyFilterRules(iptables.IPv4, nc.IfName)
 		_ = n.setupNonInternalNetworkRules(ctx, iptables.IPv4, nc.Config4, false)
+		_ = n.setSubnetProtection(ctx, iptables.IPv4, nc.Config4, false)
 	}
 	if ic.config.IPv6 && nc.Config6.Prefix.IsValid() {
 		_ = deleteLegacyFilterRules(iptables.IPv6, nc.IfName)
 		_ = n.setupNonInternalNetworkRules(ctx, iptables.IPv6, nc.Config6, false)
+		_ = n.setSubnetProtection(ctx, iptables.IPv6, nc.Config6, false)
 	}
 }
 

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/cleaner.go
@@ -87,10 +87,10 @@ func (ic iptablesCleaner) DelEndpoint(ctx context.Context, nc firewaller.Network
 		ipt:    &Iptabler{config: ic.config},
 	}
 	if n.ipt.config.IPv4 && epIPv4.IsValid() {
-		_ = n.filterDirectAccess(ctx, iptables.IPv4, n.config.Config4, epIPv4, false)
+		_ = n.deleteLegacyDirectAccess(ctx, iptables.IPv4, n.config.Config4, epIPv4)
 	}
 	if n.ipt.config.IPv6 && epIPv6.IsValid() {
-		_ = n.filterDirectAccess(ctx, iptables.IPv6, n.config.Config6, epIPv6, false)
+		_ = n.deleteLegacyDirectAccess(ctx, iptables.IPv6, n.config.Config6, epIPv6)
 	}
 }
 

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
@@ -10,54 +10,23 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/iptables"
 )
 
-func (n *network) AddEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
-	return n.modEndpoint(ctx, epIPv4, epIPv6, true)
-}
-
-func (n *network) DelEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
-	return n.modEndpoint(ctx, epIPv4, epIPv6, false)
-}
-
-func (n *network) modEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr, enable bool) error {
-	if n.ipt.config.IPv4 && epIPv4.IsValid() {
-		if err := n.filterDirectAccess(ctx, iptables.IPv4, n.config.Config4, epIPv4, enable); err != nil {
-			return err
-		}
-	}
-	if n.ipt.config.IPv6 && epIPv6.IsValid() {
-		if err := n.filterDirectAccess(ctx, iptables.IPv6, n.config.Config6, epIPv6, enable); err != nil {
-			return err
-		}
-	}
+func (n *network) AddEndpoint(_ context.Context, _, _ netip.Addr) error {
 	return nil
 }
 
-// filterDirectAccess drops packets addressed directly to the container's IP address,
-// when direct routing is not permitted by network configuration.
-//
-// It is a no-op if:
-//   - the network is internal
-//   - gateway mode is "nat-unprotected" or "routed".
-//   - direct routing is enabled at the daemon level.
-//   - "raw" rules are disabled (possibly because the host doesn't have the necessary
-//     kernel support).
-//
-// Packets originating on the bridge's own interface and addressed directly to the
-// container are allowed - the host always has direct access to its own containers
-// (it doesn't need to use the port mapped to its own addresses, although it can).
-//
-// "Trusted interfaces" are treated in the same way as the bridge itself.
-func (n *network) filterDirectAccess(ctx context.Context, ipv iptables.IPVersion, config firewaller.NetworkConfigFam, epIP netip.Addr, enable bool) error {
+func (n *network) DelEndpoint(_ context.Context, _, _ netip.Addr) error {
+	return nil
+}
+
+// deleteLegacyDirectAccess removes per-container raw PREROUTING rules that may
+// have been created by an older daemon version. Current versions use a single
+// subnet-level rule per network instead (see setSubnetProtection).
+func (n *network) deleteLegacyDirectAccess(ctx context.Context, ipv iptables.IPVersion, config firewaller.NetworkConfigFam, epIP netip.Addr) error {
 	if n.config.Internal || config.Unprotected || config.Routed {
 		return nil
 	}
-	// For config that may change between daemon restarts, make sure rules are
-	// removed - if the container was left running when the daemon stopped, and
-	// direct routing has since been disabled, the rules need to be deleted when
-	// cleanup happens on restart. This also means a change in config over a
-	// live-restore restart will take effect.
 	if n.ipt.config.AllowDirectRouting || rawRulesDisabled(ctx) {
-		enable = false
+		return nil
 	}
 	for _, ifName := range n.config.TrustedHostInterfaces {
 		accept := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
@@ -65,14 +34,14 @@ func (n *network) filterDirectAccess(ctx context.Context, ipv iptables.IPVersion
 			"-i", ifName,
 			"-j", "ACCEPT",
 		}}
-		if err := appendOrDelChainRule(accept, "DIRECT ACCESS FILTERING - ACCEPT", enable); err != nil {
+		if err := appendOrDelChainRule(accept, "DIRECT ACCESS FILTERING - ACCEPT", false); err != nil {
 			return err
 		}
 	}
-	accept := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
+	drop := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
 		"-d", epIP.String(),
 		"!", "-i", n.config.IfName,
 		"-j", "DROP",
 	}}
-	return appendOrDelChainRule(accept, "DIRECT ACCESS FILTERING - DROP", enable)
+	return appendOrDelChainRule(drop, "DIRECT ACCESS FILTERING - DROP", false)
 }

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
@@ -25,9 +25,6 @@ func (n *network) deleteLegacyDirectAccess(ctx context.Context, ipv iptables.IPV
 	if n.config.Internal || config.Unprotected || config.Routed {
 		return nil
 	}
-	if n.ipt.config.AllowDirectRouting || rawRulesDisabled(ctx) {
-		return nil
-	}
 	for _, ifName := range n.config.TrustedHostInterfaces {
 		accept := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
 			"-d", epIP.String(),

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/endpoint.go
@@ -10,7 +10,17 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/iptables"
 )
 
-func (n *network) AddEndpoint(_ context.Context, _, _ netip.Addr) error {
+func (n *network) AddEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
+	if n.ipt.config.IPv4 && epIPv4.IsValid() {
+		if err := n.deleteLegacyDirectAccess(ctx, iptables.IPv4, n.config.Config4, epIPv4); err != nil {
+			return err
+		}
+	}
+	if n.ipt.config.IPv6 && epIPv6.IsValid() {
+		if err := n.deleteLegacyDirectAccess(ctx, iptables.IPv6, n.config.Config6, epIPv6); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/network.go
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/network.go
@@ -97,6 +97,13 @@ func (n *network) setupIPTables(ctx context.Context, ipVersion iptables.IPVersio
 			return n.setupNonInternalNetworkRules(ctx, ipVersion, config, false)
 		})
 
+		if err := n.setSubnetProtection(ctx, ipVersion, config, true); err != nil {
+			return fmt.Errorf("Failed to setup subnet protection: %w", err)
+		}
+		n.registerCleanFunc(func() error {
+			return n.setSubnetProtection(ctx, ipVersion, config, false)
+		})
+
 		if err := deleteLegacyFilterRules(ipVersion, n.config.IfName); err != nil {
 			return fmt.Errorf("failed to delete legacy rules in filter-FORWARD: %w", err)
 		}
@@ -358,6 +365,47 @@ func (n *network) setupNonInternalNetworkRules(ctx context.Context, ipVer iptabl
 	}
 
 	return nil
+}
+
+// setSubnetProtection drops packets addressed directly to any IP in the bridge
+// subnet from interfaces other than the bridge or loopback. This prevents external
+// hosts that have a route to the bridge subnet from accessing containers on
+// unpublished ports, or services on the host bound to the gateway address.
+//
+// It is a no-op if:
+//   - gateway mode is "nat-unprotected" or "routed" (direct access is intentional).
+//   - direct routing is enabled at the daemon level.
+//   - "raw" rules are disabled.
+func (n *network) setSubnetProtection(ctx context.Context, ipv iptables.IPVersion, config firewaller.NetworkConfigFam, enable bool) error {
+	if config.Unprotected || config.Routed || !config.Prefix.IsValid() {
+		return nil
+	}
+	if n.ipt.config.AllowDirectRouting || rawRulesDisabled(ctx) {
+		enable = false
+	}
+	subnet := config.Prefix.String()
+	// Accept loopback traffic to the subnet. This is needed for host-local access
+	// to the gateway IP, which is assigned to the bridge and reachable via lo.
+	loAccept := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
+		"-d", subnet, "-i", "lo", "-j", "ACCEPT",
+	}}
+	if err := appendOrDelChainRule(loAccept, "SUBNET PROTECTION - ACCEPT LO", enable); err != nil {
+		return err
+	}
+	// Accept traffic from trusted interfaces (e.g. flannel.1 in VXLAN setups).
+	for _, ifName := range n.config.TrustedHostInterfaces {
+		accept := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
+			"-d", subnet, "-i", ifName, "-j", "ACCEPT",
+		}}
+		if err := appendOrDelChainRule(accept, "SUBNET PROTECTION - ACCEPT TRUSTED", enable); err != nil {
+			return err
+		}
+	}
+	// Drop traffic from any other non-bridge interface to the subnet.
+	extDrop := iptables.Rule{IPVer: ipv, Table: iptables.Raw, Chain: "PREROUTING", Args: []string{
+		"-d", subnet, "!", "-i", n.config.IfName, "-j", "DROP",
+	}}
+	return appendOrDelChainRule(extDrop, "SUBNET PROTECTION - DROP", enable)
 }
 
 func setIcc(ctx context.Context, version iptables.IPVersion, bridgeIface string, iccEnable, internal, insert bool) error {

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 -i loopback0 -p tcp -m tcp --dport 8080 -j ACCEPT
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6tables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d fd49:efd7:54aa::1/128 ! -i br-dummy -j DROP
+-A PREROUTING -d fd49:efd7:54aa::/64 -i lo -j ACCEPT
+-A PREROUTING -d fd49:efd7:54aa::/64 ! -i br-dummy -j DROP
 COMMIT
 *filter
 :INPUT ACCEPT [0:0]

--- a/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/iptabler/testdata/TestIptabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__iptables.golden
@@ -1,7 +1,8 @@
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
--A PREROUTING -d 192.168.0.2/32 ! -i br-dummy -j DROP
+-A PREROUTING -d 192.168.0.0/24 -i lo -j ACCEPT
+-A PREROUTING -d 192.168.0.0/24 ! -i br-dummy -j DROP
 -A PREROUTING -d 127.0.0.1/32 ! -i lo -p tcp -m tcp --dport 8080 -j DROP
 COMMIT
 *filter

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/endpoint.go
@@ -4,76 +4,16 @@ package nftabler
 
 import (
 	"context"
-	"fmt"
 	"net/netip"
-	"strings"
-
-	"github.com/moby/moby/v2/daemon/libnetwork/drivers/bridge/internal/firewaller"
-	"github.com/moby/moby/v2/daemon/libnetwork/internal/nftables"
 )
 
 func (n *network) AddEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
 	if n.fw.cleaner != nil {
 		n.fw.cleaner.DelEndpoint(ctx, n.config, epIPv4, epIPv6)
 	}
-	return n.modEndpoint(ctx, epIPv4, epIPv6, true)
-}
-
-func (n *network) DelEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr) error {
-	return n.modEndpoint(ctx, epIPv4, epIPv6, false)
-}
-
-func (n *network) modEndpoint(ctx context.Context, epIPv4, epIPv6 netip.Addr, enable bool) error {
-	if n.fw.config.IPv4 && epIPv4.IsValid() {
-		tm := nftables.Modifier{}
-		updater := tm.Create
-		if !enable {
-			updater = tm.Delete
-		}
-		n.filterDirectAccess(updater, nftables.IPv4, n.config.Config4, epIPv4)
-		if err := n.fw.table4.Apply(ctx, tm); err != nil {
-			return fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
-		}
-	}
-	if n.fw.config.IPv6 && epIPv6.IsValid() {
-		tm := nftables.Modifier{}
-		updater := tm.Create
-		if !enable {
-			updater = tm.Delete
-		}
-		n.filterDirectAccess(updater, nftables.IPv6, n.config.Config6, epIPv6)
-		if err := n.fw.table6.Apply(ctx, tm); err != nil {
-			return fmt.Errorf("adding rules for bridge %s: %w", n.config.IfName, err)
-		}
-	}
 	return nil
 }
 
-// filterDirectAccess drops packets addressed directly to the container's IP address,
-// when direct routing is not permitted by network configuration.
-//
-// It is a no-op if:
-//   - gateway mode is "nat-unprotected" or "routed".
-//   - direct routing is enabled at the daemon level.
-//   - "raw" rules are disabled (possibly because the host doesn't have the necessary
-//     kernel support).
-//
-// Packets originating on the bridge's own interface and addressed directly to the
-// container are allowed - the host always has direct access to its own containers.
-// (It doesn't need to use the port mapped to its own addresses, although it can.)
-//
-// "Trusted interfaces" are treated in the same way as the bridge itself.
-func (n *network) filterDirectAccess(updater func(nftables.Obj), fam nftables.Family, conf firewaller.NetworkConfigFam, epIP netip.Addr) {
-	if n.config.Internal || conf.Unprotected || conf.Routed || n.fw.config.AllowDirectRouting {
-		return
-	}
-	ifNames := strings.Join(n.config.TrustedHostInterfaces, ", ")
-	updater(nftables.Rule{
-		Chain: rawPreroutingChain,
-		Group: rawPreroutingPortsRuleGroup,
-		Rule: []string{
-			string(fam), "daddr", epIP.String(),
-			"iifname != {", n.config.IfName, ",", ifNames, `} counter drop comment "DROP DIRECT ACCESS"`,
-		},
-	})
+func (n *network) DelEndpoint(_ context.Context, _, _ netip.Addr) error {
+	return nil
 }

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/network.go
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/network.go
@@ -174,6 +174,24 @@ func (n *network) configure(ctx context.Context, table nftables.Table, conf fire
 			})
 		}
 
+		// Drop packets destined to any IP in the bridge subnet from interfaces
+		// other than the bridge, loopback, or any trusted host interfaces. This
+		// protects containers on unpublished ports and the host's gateway address
+		// from external hosts that have a direct route to the bridge subnet.
+		if conf.Prefix.IsValid() && !n.fw.config.AllowDirectRouting {
+			family := string(table.Family())
+			ifNames := strings.Join(append([]string{n.config.IfName, "lo"}, n.config.TrustedHostInterfaces...), ", ")
+			tm.Create(nftables.Rule{
+				Chain: rawPreroutingChain,
+				Group: initialRuleGroup,
+				Rule: []string{
+					family, "daddr", conf.Prefix.String(),
+					"iifname != {", ifNames, `}`,
+					`counter drop comment "SUBNET DROP EXTERNAL"`,
+				},
+			})
+		}
+
 		// ICMP
 		if conf.Routed {
 			rule := "ip protocol icmp"

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,7 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -48,6 +48,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=false,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=false,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=false,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=false,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=false__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip.golden
@@ -47,7 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr 192.168.0.2 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat,bindlh=true__ip6.golden
@@ -47,7 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
-		ip6 daddr fd49:efd7:54aa::1 iifname != "br-dummy" counter packets 0 bytes 0 drop comment "DROP DIRECT ACCESS"
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=nat-unprotected,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=false__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true,wsl2mirrored=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname "loopback0" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 accept comment "ACCEPT WSL2 LOOPBACK"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip.golden
@@ -47,6 +47,7 @@ table ip docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip daddr 192.168.0.0/24 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 		iifname != "lo" ip daddr 127.0.0.1 tcp dport 8080 counter packets 0 bytes 0 drop comment "DROP REMOTE LOOPBACK"
 	}
 

--- a/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
+++ b/daemon/libnetwork/drivers/bridge/internal/nftabler/testdata/TestNftabler/hairpin=true,internal=false,icc=true,masq=true,snat=true,gwm=routed,bindlh=true__ip6.golden
@@ -47,6 +47,7 @@ table ip6 docker-bridges {
 
 	chain raw-PREROUTING {
 		type filter hook prerouting priority raw; policy accept;
+		ip6 daddr fd49:efd7:54aa::/64 iifname != { "lo", "br-dummy" } counter packets 0 bytes 0 drop comment "SUBNET DROP EXTERNAL"
 	}
 
 	chain filter-forward-in__br-dummy {


### PR DESCRIPTION
**- What I did**

Added a per-network rule to the `raw PREROUTING` chain that drops packets destined to any address in the bridge subnet from interfaces other than the bridge itself, loopback, or configured trusted host interfaces. This protects both containers on unpublished ports and the bridge's own gateway address (the host-side bridge IP, e.g. `172.17.0.1` on the default `docker0` bridge) from external hosts that have a direct route to the bridge subnet.

**- How I did it**

Replaced the previous per-container direct access filtering rules (`filterDirectAccess` in `endpoint.go`) with a single subnet-level rule created at network setup time.

For iptables, the following rules are added per bridge (plus one ACCEPT per trusted interface):
```
-t raw -A PREROUTING -d <subnet> -i lo -j ACCEPT
-t raw -A PREROUTING -d <subnet> ! -i <bridge> -j DROP
```

For nftables, a single compound rule:
```
<family> daddr <subnet> iifname != { <bridge>, lo, ... } counter drop
```

Loopback is always permitted because the gateway IP is a valid host address reachable from local processes via `lo`. The rules are not added for gateway modes `routed` or `nat-unprotected`, nor when `--allow-direct-routing` is set, consistent with the intent of those options. `DOCKER_INSECURE_NO_IPTABLES_RAW=1` disables the iptables rules.

Related upstream work:
- #45610 — motivating issue (LAN hosts accessing published ports)
- #49325 — introduced per-port raw PREROUTING rules
- #49829 — consolidated to per-container rules
- #49832 — added trusted host interfaces support
- #49621 — added raw rules opt-out

This PR further consolidates from per-container to per-subnet, and extends coverage to the bridge gateway address.

**- How to verify it**

1. Create a bridge network: `docker network create --subnet 172.17.0.0/16 testnet`
2. Verify the raw PREROUTING rules are present: `iptables -t raw -L PREROUTING -n -v`
3. Confirm loopback traffic to the gateway IP (`172.17.0.1`) still works from the host.
4. From a neighbor host with a route to `172.17.0.0/16`, verify that direct connections to addresses in the subnet are dropped.
5. Verify rules are cleaned up on `docker network rm testnet`.
6. Verify no rules are added when using `--gateway-mode=routed` or `--allow-direct-routing`.

**- Human readable description for the release notes**

```markdown changelog
Bridge networks now drop packets from external interfaces destined to any address in the bridge subnet using a single network-level raw PREROUTING rule, protecting both containers and the bridge gateway address from direct external access.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<a title="Opoterser, CC BY-SA 3.0 &lt;https://creativecommons.org/licenses/by-sa/3.0&gt;, via Wikimedia Commons" href="https://commons.wikimedia.org/wiki/File:Phidippus_audax_male.jpg"><img width="960" alt="Phidippus audax male" src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Phidippus_audax_male.jpg/960px-Phidippus_audax_male.jpg"></a>

<a href="https://commons.wikimedia.org/wiki/File:Phidippus_audax_male.jpg">Opoterser</a>, <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a>, via Wikimedia Commons