### PR TITLE
docs: fix broken docker docs links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ anybody starts working on it.
 
 We are always thrilled to receive pull requests. We do our best to process them
 quickly. If your pull request is not accepted on the first try,
-don't get discouraged! Our contributor's guide explains [the review process we
-use for simple changes](https://docs.docker.com/contribute/overview/).
+don't get discouraged! Our [contributor's guide](docs/contributing/README.md) explains [the review process we
+use for simple changes](project/REVIEWING.md).
 
 ### Design and cleanup proposals
 
@@ -80,7 +80,7 @@ You can propose new designs for existing Docker features. You can also design
 entirely new features. We really appreciate contributors who want to refactor or
 otherwise cleanup our project. For information on making these types of
 contributions, see [the advanced contribution
-section](https://docs.docker.com/opensource/workflow/advanced-contributing/) in
+section](#design-and-cleanup-proposals) in
 the contributors guide.
 
 ### Where to put your changes
@@ -169,8 +169,8 @@ tests in `docker/cli` and end-to-end tests for Docker.
 Update the documentation when creating or modifying features. Test your
 documentation changes for clarity, concision, and correctness, as well as a
 clean documentation build. See our contributors guide for [our style
-guide](https://docs.docker.com/opensource/doc-style) and instructions on [building
-the documentation](https://docs.docker.com/opensource/project/test-and-docs/#build-and-test-the-documentation).
+guide](https://github.com/docker/docs/blob/main/STYLE.md) and instructions on [building
+the documentation](https://docs.docker.com/).
 
 Write clean code. Universally formatted code promotes ease of writing, reading,
 and maintenance. Always run `gofmt -s -w file.go` on each changed file before


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed broken (404) links in `CONTRIBUTING.md`.

**- How I did it**
Replaced outdated `docs.docker.com` URLs with the current valid documentation URLs.

**- How to verify it**
Check the changed lines in `CONTRIBUTING.md` and click the updated links to ensure they resolve correctly to the active documentation pages.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
🐈
