### PR TITLE
ci: CodeQL: set CGO_ENABLED=0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,14 @@ on:
 env:
   GO_VERSION: "1.25.8"
 
+  # CodeQL AutoBuild runs "docker bake binary", which produces a static
+  # binary, and CodeQL has trouble with cgo; ideally, we'd run CodeQL
+  # analysis inside our "make shell" environment, but that would require
+  # an image to be pushed.
+  #
+  # Let's try if making it just analyze the "static build" files works.
+  CGO_ENABLED: "0"
+  GOFLAGS: "-tags=netgo,osusergo,static_build,nri_no_wasm"
 jobs:
   codeql:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
ci: CodeQL: set CGO_ENABLED=0

It looks like CodeQL gets confused due to CGO not being enabled when
analyzing, as it may be using `go list` and skipping files;

    Go files were found but not processed (1 result)
        * [Specify a custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-sca>


CodeQL AutoBuild runs "docker bake binary", which produces a static
binary, and CodeQL has trouble with cgo; ideally, we'd run CodeQL
analysis inside our "make shell" (or .devcontainer) environment,
and use the `container:` option but that would require an image to
be pushed to a registry between steps.

Let's try if making it just analyze the "static build" files works.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

