### PR TITLE
daemon: retry secrets dir remount on transient EBUSY

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/containerd/log"
 	"github.com/moby/moby/v2/daemon/config"
@@ -437,12 +438,24 @@ func (daemon *Daemon) remountSecretDir(ctr *container.Container) error {
 	uid, gid := daemon.idMapping.RootPair()
 	tmpfsOwnership := fmt.Sprintf("uid=%d,gid=%d", uid, gid)
 
-	// remount secrets ro
-	if err := mount.Mount("tmpfs", dir, "tmpfs", "remount,ro,"+tmpfsOwnership); err != nil {
-		return errors.Wrap(err, "unable to remount dir as readonly")
+	// Remount secrets as read-only, retrying on transient EBUSY errors.
+	// On busy hosts the tmpfs mount can momentarily be held by other
+	// processes (e.g. container runtime) right after writing secret/config
+	// files, causing the remount to fail. Retrying resolves the race.
+	// See https://github.com/moby/moby/issues/48783
+	var mountErr error
+	for retry := range 5 {
+		mountErr = mount.Mount("tmpfs", dir, "tmpfs", "remount,ro,"+tmpfsOwnership)
+		if mountErr == nil {
+			return nil
+		}
+		if !errors.Is(mountErr, syscall.EBUSY) {
+			return errors.Wrap(mountErr, "unable to remount dir as readonly")
+		}
+		log.G(context.TODO()).WithError(mountErr).WithField("dir", dir).Debug("Transient EBUSY on secrets remount, retrying")
+		time.Sleep(10*time.Millisecond + time.Duration(retry)*25*time.Millisecond)
 	}
-
-	return nil
+	return errors.Wrap(mountErr, "unable to remount dir as readonly")
 }
 
 func (daemon *Daemon) cleanupSecretDir(ctr *container.Container) {


### PR DESCRIPTION
**- What I did**

Added retry logic to `remountSecretDir` for transient `EBUSY` errors when remounting the secrets/configs tmpfs as read-only.

**- How I did it**

Wrapped the `mount.Mount("tmpfs", dir, "tmpfs", "remount,ro,...")` call in a retry loop (up to 5 attempts, 100ms apart). Only `EBUSY` triggers a retry; other errors fail immediately. A debug-level log is emitted on each retry for observability.

This follows the existing retry-on-EBUSY pattern from `EnsureRemoveAll` in `daemon/internal/containerfs/rm.go`.

**- How to verify it**

1. Set up a Docker Swarm node running many services that use configs or secrets
2. Deploy a service with `update_config: { order: start-first }` and Docker configs
3. Trigger repeated service updates — the `EBUSY` race during secrets remount should now be retried instead of failing the container start

The issue is a race condition that occurs intermittently on busy hosts, so verification requires a loaded environment. See #48783 for reproduction details.

**- Description**

The race condition in `remountSecretDir` has existed for a long time, but became noticeably worse after the containerd v1.7 → v2.x bump (Docker 28.x/29.x). The major containerd upgrade appears to have changed container lifecycle timing enough to widen the window where the tmpfs mount is held during secret/config setup, making the `EBUSY` collision significantly more likely on busy hosts. We observe this consistently on Docker 29.3.0 (containerd v2.2.1) but not on Docker 27.5.0 (containerd v1.7.25) with comparable workloads (~100 containers).

**- Human readable description for the release notes**

```markdown changelog
Fix intermittent container start failures (`EBUSY` on secrets/configs remount) on busy Swarm nodes by retrying the read-only remount.
```

Fixes #48783

Signed-off-by: Mads Jon Nielsen <madsjon@gmail.com>