### PR TITLE
Dockerfile: use set -x in here-docs for visibility in build-logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ ARG TARGETPLATFORM
 RUN --mount=from=delve-src,src=/usr/src/delve,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=delve-build-$TARGETPLATFORM \
     --mount=type=cache,target=/go/pkg/mod <<EOT
-  set -e
+  set -ex
   xx-go build -o /build/dlv ./cmd/dlv
   xx-verify /build/dlv
 EOT
@@ -163,13 +163,22 @@ ARG DOCKER_STATIC
 RUN --mount=from=containerd-src,src=/usr/src/containerd,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=containerd-build-$TARGETPLATFORM <<EOT
   set -e
-  export CC=$(xx-info)-gcc
-  export CGO_ENABLED=$([ "$DOCKER_STATIC" = "1" ] && echo "0" || echo "1")
+
+  make_flags=
+  verify_flags=
+  cgo_enabled=1
+  if [ "$DOCKER_STATIC" = "1" ]; then
+      make_flags=STATIC=1
+      verify_flags=--static
+      cgo_enabled=0
+  fi
+
+  set -x
   xx-go --wrap
-  make $([ "$DOCKER_STATIC" = "1" ] && echo "STATIC=1") binaries
-  xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") bin/containerd
-  xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") bin/containerd-shim-runc-v2
-  xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") bin/ctr
+  CC="$(xx-info)-gcc" CGO_ENABLED=$cgo_enabled make $make_flags binaries
+  xx-verify $verify_flags bin/containerd
+  xx-verify $verify_flags bin/containerd-shim-runc-v2
+  xx-verify $verify_flags bin/ctr
   mkdir /build
   mv bin/containerd bin/containerd-shim-runc-v2 bin/ctr /build
 EOT
@@ -257,8 +266,17 @@ RUN --mount=from=runc-src,src=/usr/src/runc,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=runc-build-$TARGETPLATFORM <<EOT
   set -e
   xx-go --wrap
-  CGO_ENABLED=1 make "$([ "$DOCKER_STATIC" = "1" ] && echo "static" || echo "runc")"
-  xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") runc
+
+  target=runc
+  verify_flags=
+  if [ "$DOCKER_STATIC" = "1" ]; then
+    target=static
+    verify_flags=--static
+  fi
+
+  set -x
+  CGO_ENABLED=1 make "$target"
+  xx-verify $verify_flags runc
   mkdir /build
   mv runc /build/
 EOT
@@ -290,7 +308,7 @@ RUN --mount=type=cache,sharing=locked,id=moby-tini-aptlib,target=/var/lib/apt \
             pkg-config
 RUN --mount=from=tini-src,src=/usr/src/tini,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=tini-build-$TARGETPLATFORM <<EOT
-  set -e
+  set -ex
   CC=$(xx-info)-gcc cmake .
   make tini-static
   xx-verify --static tini-static
@@ -323,9 +341,18 @@ RUN --mount=from=rootlesskit-src,src=/usr/src/rootlesskit,rw \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build,id=rootlesskit-build-$TARGETPLATFORM <<EOT
   set -e
-  export CGO_ENABLED=$([ "$DOCKER_STATIC" = "1" ] && echo "0" || echo "1")
-  xx-go build -o /build/rootlesskit -ldflags="$([ "$DOCKER_STATIC" != "1" ] && echo "-linkmode=external")" ./cmd/rootlesskit
-  xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") /build/rootlesskit
+
+  if [ "$DOCKER_STATIC" = "1" ]; then
+      set -x
+      export CGO_ENABLED=0
+      xx-go build -o /build/rootlesskit ./cmd/rootlesskit
+      xx-verify --static /build/rootlesskit
+  else
+      set -x
+      export CGO_ENABLED=1
+      xx-go build -o /build/rootlesskit -ldflags='-linkmode=external' ./cmd/rootlesskit
+      xx-verify /build/rootlesskit
+  fi
 EOT
 COPY --link ./contrib/dockerd-rootless.sh /build/
 COPY --link ./contrib/dockerd-rootless-setuptool.sh /build/
@@ -389,7 +416,7 @@ RUN xx-apt-get install -y --no-install-recommends \
         pkg-config
 RUN --mount=from=containerutil-src,src=/usr/src/containerutil,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=containerutil-build-$TARGETPLATFORM <<EOT
-  set -e
+  set -ex
   CC="$(xx-info)-gcc" CXX="$(xx-info)-g++" make
   xx-verify --static containerutility.exe
   mkdir /build
@@ -551,6 +578,7 @@ ARG PACKAGER_NAME
 # read only mount in current work dir
 ENV PREFIX=/tmp
 RUN <<EOT
+  set -ex
   # in bullseye arm64 target does not link with lld so configure it to use ld instead
   if [ "$(xx-info arch)" = "arm64" ]; then
     XX_CC_PREFER_LINKER=ld xx-clang --setup-target-triple
@@ -559,11 +587,25 @@ EOT
 RUN --mount=type=bind,target=.,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=moby-build-$TARGETPLATFORM <<EOT
   set -e
-  target=$([ "$DOCKER_STATIC" = "1" ] && echo "binary" || echo "dynbinary")
+
+  target=dynbinary
+  verify_flags=
+  exe_suffix=
+  if [ "$DOCKER_STATIC" = "1" ]; then
+      target=binary
+      verify_flags=--static
+  fi
+  if [ "$(xx-info os)" = "windows" ]; then
+      exe_suffix=.exe
+  fi
+
+  set -x
   xx-go --wrap
-  PKG_CONFIG=$(xx-go env PKG_CONFIG) ./hack/make.sh $target
-  xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") /tmp/bundles/${target}-daemon/dockerd$([ "$(xx-info os)" = "windows" ] && echo ".exe")
-  [ "$(xx-info os)" != "linux" ] || xx-verify $([ "$DOCKER_STATIC" = "1" ] && echo "--static") /tmp/bundles/${target}-daemon/docker-proxy
+  PKG_CONFIG=$(xx-go env PKG_CONFIG) ./hack/make.sh "$target"
+  xx-verify $verify_flags "/tmp/bundles/${target}-daemon/dockerd${exe_suffix}"
+  if [ "$(xx-info os)" = "linux" ]; then
+      xx-verify $verify_flags "/tmp/bundles/${target}-daemon/docker-proxy"
+  fi
   mkdir /build
   mv /tmp/bundles/${target}-daemon/* /build/
 EOT


### PR DESCRIPTION
relates to;

- https://github.com/moby/buildkit/issues/2167
- https://github.com/moby/buildkit/pull/2201#discussion_r660933251
- https://github.com/moby/buildkit/issues/1412

The plain-text build-logs do not show the content of here-docs, which makes it invisible what commands are run:

    #66 [runc-build 3/3] RUN --mount=from=runc-src,src=/usr/src/runc,rw     --mount=type=cache,target=/root/.cache/go-build,id=runc-build-linux/arm64 <<EOT (set -e...)

This patch updates some of the here-docs to use `set -x` to print the commands that were run. It's not a full replacement, but at least shows what commands are executed;

    #46 [runc-build 3/3] RUN --mount=from=runc-src,src=/usr/src/runc,rw     --mount=type=cache,target=/root/.cache/go-build,id=runc-build-linux/arm64 <<EOT (set -e...)
    #46 0.774 + CGO_ENABLED=1 make static
    #46 1.810 go build -trimpath -buildmode=pie  -tags "seccomp urfave_cli_no_docs netgo osusergo" -ldflags "-X main.gitCommit=v1.3.4-0-gd6d73eb  -linkmode external -extldflags -static-pie " -o runc .
    #46 ...
    #46 [runc-build 3/3] RUN --mount=from=runc-src,src=/usr/src/runc,rw     --mount=type=cache,target=/root/.cache/go-build,id=runc-build-linux/arm64 <<EOT (set -e...)
    #46 6.409 + xx-verify --static runc
    #46 6.429 + mkdir /build
    #46 6.430 + mv runc /build/
    #46 DONE 6.5s

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

