### PR TITLE
docs: fix remaining broken links in contributing docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ https://github.com/moby/moby/blob/master/CONTRIBUTING.md
 ** Make sure all your commits include a signature generated with `git commit -s` **
 
 For additional information on our contributing process, read our contributing
-guide https://docs.docker.com/opensource/code/
+guide https://github.com/moby/moby/blob/master/docs/contributing/
 
 If this is a bug fix, make sure your description includes "fixes #xxxx", or
 "closes #xxxx"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Want to hack on the Moby Project? Awesome! We have a contributor's guide that ex
 [setting up a development environment and the contribution
 process](docs/contributing/). 
 
-[![Contributors guide](docs/static_files/contributors.png)](https://docs.docker.com/opensource/project/who-written-for/)
+[![Contributors guide](docs/static_files/contributors.png)](docs/contributing/who-written-for.md)
 
 This page contains information about reporting issues as well as some tips and
 guidelines useful to experienced open source contributors. Finally, make sure


### PR DESCRIPTION
## Summary

- Fix broken image link in `CONTRIBUTING.md` (line 7): the `docs.docker.com/opensource/project/who-written-for/` URL returns 404. Replaced with the in-repo path `docs/contributing/who-written-for.md`.
- Fix broken contributing guide link in `.github/PULL_REQUEST_TEMPLATE.md` (line 8): the `docs.docker.com/opensource/code/` URL returns 404. Replaced with the GitHub URL for `docs/contributing/`.

Follow-up to #52228 which fixed most broken links but missed these two.

Fixes #45024