### PR TITLE
daemon/volume/service: deprecate OpErr.Cause (Causer interface)

### DIFF
--- a/daemon/volume/service/errors.go
+++ b/daemon/volume/service/errors.go
@@ -59,9 +59,13 @@ func (e *OpErr) Error() string {
 	return s
 }
 
-// Cause returns the error the caused this error
+// Cause returns the error the caused this error.
+//
+// Deprecated: use [OpErr.Unwrap] instead.
+//
+//go:fix inline
 func (e *OpErr) Cause() error {
-	return e.Err
+	return e.Unwrap()
 }
 
 // Unwrap returns the error the caused this error
@@ -87,20 +91,14 @@ func IsNameConflict(err error) bool {
 }
 
 func isErr(err error, expected error) bool {
-	switch pe := err.(type) {
-	case nil:
-		return false
-	case interface{ Cause() error }:
-		return isErr(pe.Cause(), expected)
-	case interface{ Unwrap() error }:
-		return isErr(pe.Unwrap(), expected)
-	case interface{ Unwrap() []error }:
-		for _, ue := range pe.Unwrap() {
-			if isErr(ue, expected) {
-				return true
-			}
-		}
-		return false
+	if errors.Is(err, expected) {
+		return true
 	}
-	return errors.Is(err, expected)
+
+	type causer interface{ Cause() error }
+	if e, ok := err.(causer); ok {
+		return isErr(e.Cause(), expected)
+	}
+
+	return false
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

