### PR TITLE
daemon/libnetwork/ns: cleanups and refactor

### DIFF
--- a/daemon/libnetwork/ns/init_linux.go
+++ b/daemon/libnetwork/ns/init_linux.go
@@ -14,48 +14,55 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-var (
-	initNs   = netns.None()
-	initNl   nlwrap.Handle
-	initOnce sync.Once
-	// NetlinkSocketsTimeout represents the default timeout duration for the sockets
-	NetlinkSocketsTimeout = 3 * time.Second
-)
+// NetlinkSocketsTimeout represents the default timeout duration for the sockets.
+var NetlinkSocketsTimeout = 3 * time.Second
+
+// initNamespace initializes a new network namespace.
+var initNamespace = sync.OnceValues(initHandles)
 
 // initHandles initializes a new network namespace
-func initHandles() {
-	var err error
-	initNs, err = netns.Get()
+func initHandles() (netns.NsHandle, nlwrap.Handle) {
+	initNs, err := netns.Get()
 	if err != nil {
-		log.G(context.TODO()).Errorf("could not get initial namespace: %v", err)
+		log.G(context.Background()).WithError(err).Error("could not get initial namespace: falling back to using netns.None")
+		initNs = netns.None()
 	}
-	initNl, err = nlwrap.NewHandle(getSupportedNlFamilies()...)
+	initNl, err := nlwrap.NewHandle(getSupportedNlFamilies()...)
 	if err != nil {
 		// Fail fast to keep the invariant: NlHandle must be a valid handle
 		panic(fmt.Errorf("could not create netlink handle on initial (host) namespace: %w", err))
 	}
 	err = initNl.SetSocketTimeout(NetlinkSocketsTimeout)
 	if err != nil {
-		log.G(context.TODO()).Warnf("Failed to set the timeout on the default netlink handle sockets: %v", err)
+		log.G(context.Background()).WithError(err).Warn("failed to set the timeout on the default netlink handle sockets")
 	}
+
+	return initNs, initNl
 }
 
 // ResetHandles resets the initial namespace and netlink handles.
 // This is useful for testing to ensure a clean state. It will
 // panic if called outside a test.
+//
+// Note: This function is not safe for concurrent use with callers
+// that are using handles obtained from this package. It may close
+// handles while they are still in use.
 func ResetHandles() {
 	if !testing.Testing() {
 		panic("ResetHandles should only be called from tests")
 	}
+	initNs, initNl := initNamespace()
+	// Reset the initNamespace sync.OnceValues. This may race with
+	// concurrent callers still calling the old initNamespace (and
+	// values), but adding a [sync.RWMutex] only for the test-case
+	// is probably too much (unless things are racy).
+	initNamespace = sync.OnceValues(initHandles)
 	if initNs.IsOpen() {
 		_ = initNs.Close()
-		initNs = netns.None()
 	}
 	if initNl.Handle != nil {
 		initNl.Close()
-		initNl = nlwrap.Handle{}
 	}
-	initOnce = sync.Once{}
 }
 
 // ParseHandlerInt transforms the namespace handler into an integer
@@ -65,14 +72,14 @@ func ParseHandlerInt() int {
 
 // GetHandler returns the namespace handler
 func getHandler() netns.NsHandle {
-	initOnce.Do(initHandles)
-	return initNs
+	ns, _ := initNamespace()
+	return ns
 }
 
 // NlHandle returns the netlink handler
 func NlHandle() nlwrap.Handle {
-	initOnce.Do(initHandles)
-	return initNl
+	_, nl := initNamespace()
+	return nl
 }
 
 func getSupportedNlFamilies() []int {

--- a/daemon/libnetwork/ns/init_linux.go
+++ b/daemon/libnetwork/ns/init_linux.go
@@ -15,7 +15,7 @@ import (
 )
 
 // NetlinkSocketsTimeout represents the default timeout duration for the sockets.
-var NetlinkSocketsTimeout = 3 * time.Second
+const NetlinkSocketsTimeout = 3 * time.Second
 
 // initNamespace initializes a new network namespace.
 var initNamespace = sync.OnceValues(initHandles)

--- a/daemon/libnetwork/ns/init_linux.go
+++ b/daemon/libnetwork/ns/init_linux.go
@@ -65,18 +65,13 @@ func ResetHandles() {
 	}
 }
 
-// ParseHandlerInt transforms the namespace handler into an integer
-func ParseHandlerInt() int {
-	return int(getHandler())
-}
-
-// GetHandler returns the namespace handler
-func getHandler() netns.NsHandle {
+// NsHandle returns the network namespace handle for the initial (host) namespace.
+func NsHandle() netns.NsHandle {
 	ns, _ := initNamespace()
 	return ns
 }
 
-// NlHandle returns the netlink handler
+// NlHandle returns the netlink handle.
 func NlHandle() nlwrap.Handle {
 	_, nl := initNamespace()
 	return nl

--- a/daemon/libnetwork/ns/init_linux.go
+++ b/daemon/libnetwork/ns/init_linux.go
@@ -48,7 +48,7 @@ func ResetHandles() {
 		panic("ResetHandles should only be called from tests")
 	}
 	if initNs.IsOpen() {
-		initNs.Close()
+		_ = initNs.Close()
 		initNs = netns.None()
 	}
 	if initNl.Handle != nil {
@@ -99,7 +99,7 @@ func checkXfrmSocket() error {
 	if err != nil {
 		return err
 	}
-	syscall.Close(fd)
+	_ = syscall.Close(fd)
 	return nil
 }
 
@@ -109,6 +109,6 @@ func checkNfSocket() error {
 	if err != nil {
 		return err
 	}
-	syscall.Close(fd)
+	_ = syscall.Close(fd)
 	return nil
 }

--- a/daemon/libnetwork/ns/init_windows.go
+++ b/daemon/libnetwork/ns/init_windows.go
@@ -1,3 +1,0 @@
-package ns
-
-// File is present so that go build ./... is closer to working on Windows from repo root.

--- a/daemon/libnetwork/osl/interface_linux.go
+++ b/daemon/libnetwork/osl/interface_linux.go
@@ -262,7 +262,7 @@ func (n *Namespace) AddInterface(ctx context.Context, srcName, dstPrefix, dstNam
 		if nerr := n.nlHandle.LinkSetName(iface, i.SrcName()); nerr != nil {
 			log.G(ctx).Errorf("renaming interface (%s->%s) failed, %v after config error %v", i.DstName(), i.SrcName(), nerr, err)
 		}
-		if nerr := n.nlHandle.LinkSetNsFd(iface, ns.ParseHandlerInt()); nerr != nil {
+		if nerr := n.nlHandle.LinkSetNsFd(iface, int(ns.NsHandle())); nerr != nil {
 			log.G(ctx).Errorf("moving interface %s to host ns failed, %v, after config error %v", i.SrcName(), nerr, err)
 		}
 		return err
@@ -845,8 +845,9 @@ func (n *Namespace) RemoveInterface(i *Interface) error {
 		}
 	} else if !n.isDefault {
 		// Move the network interface to caller namespace.
+		//
 		// TODO(aker): What's this really doing? There are no calls to LinkDel in this package: is this code really used? (Interface.Remove() has 3 callers); see https://github.com/moby/moby/pull/46315/commits/108595c2fe852a5264b78e96f9e63cda284990a6#r1331265335
-		if err := n.nlHandle.LinkSetNsFd(iface, ns.ParseHandlerInt()); err != nil {
+		if err := n.nlHandle.LinkSetNsFd(iface, int(ns.NsHandle())); err != nil {
 			log.G(context.TODO()).Debugf("LinkSetNsFd failed for interface %s: %v", i.SrcName(), err)
 			return err
 		}


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/51488

### daemon/libnetwork/ns: suppress some unhandled errors

### daemon/libnetwork/ns: remove windows stub

This reverts commit 40b6ebfe754d6efe839f89ecfd4727ccdbbea359 ([libnetwork@d82ceca]),
which added it to make compile work on Windows, but this package contains
no Windows code, so shouldn't be imported in any file compiled on Windows.

[libnetwork@d82ceca]: https://github.com/moby/libnetwork/commit/d82ceca3f6ba685e0e709e9f15800353ecad03a4

### daemon/libnetwork/ns: use sync.OnceValues

This avoids depending on global state in the package, and "forces"
consumers to go through the initHandles() func to get the handles.

A slight change in behavior is that `ResetHandles()` may now initialize
a new namespace only to reset it, but this is likely an "OK" trade-off.


### daemon/libnetwork/ns: remove ParseHandlerInt, add NsHandle

It's more transparent for the caller to handle conversion.


### daemon/libnetwork/ns: make NetlinkSocketsTimeout a const

It's never updated, so let's make it clear that that's the case.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

