### PR TITLE
fix: return 400 instead of 500 for invalid request parameters

### DIFF
--- a/daemon/internal/image/tarexport/save.go
+++ b/daemon/internal/image/tarexport/save.go
@@ -24,6 +24,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/ioutils"
 	"github.com/moby/moby/v2/daemon/internal/layer"
 	"github.com/moby/moby/v2/daemon/internal/system"
+	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/sys/sequential"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
@@ -104,7 +105,7 @@ func (l *tarexporter) parseNames(ctx context.Context, names []string) (desc map[
 
 		ref, err := reference.ParseAnyReference(name)
 		if err != nil {
-			return nil, err
+			return nil, errdefs.InvalidParameter(err)
 		}
 		namedRef, ok := ref.(reference.Named)
 		if !ok {

--- a/daemon/server/router/container/container_routes.go
+++ b/daemon/server/router/container/container_routes.go
@@ -112,7 +112,7 @@ func (c *containerRouter) getContainersJSON(ctx context.Context, w http.Response
 	if tmpLimit := r.Form.Get("limit"); tmpLimit != "" {
 		val, err := strconv.Atoi(tmpLimit)
 		if err != nil {
-			return err
+			return errdefs.InvalidParameter(err)
 		}
 		limit = val
 	}
@@ -293,7 +293,7 @@ func (c *containerRouter) postContainersStop(ctx context.Context, w http.Respons
 	if tmpSeconds := r.Form.Get("t"); tmpSeconds != "" {
 		valSeconds, err := strconv.Atoi(tmpSeconds)
 		if err != nil {
-			return err
+			return errdefs.InvalidParameter(err)
 		}
 		options.Timeout = &valSeconds
 	}

--- a/daemon/server/router/plugin/plugin_routes.go
+++ b/daemon/server/router/plugin/plugin_routes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moby/moby/v2/daemon/internal/streamformatter"
 	"github.com/moby/moby/v2/daemon/server/backend"
 	"github.com/moby/moby/v2/daemon/server/httputils"
+	"github.com/moby/moby/v2/errdefs"
 	"github.com/moby/moby/v2/pkg/ioutils"
 	"github.com/pkg/errors"
 )
@@ -40,7 +41,7 @@ func parseRemoteRef(remote string) (reference.Named, string, error) {
 	// Parse remote reference, supporting remotes with name and tag
 	remoteRef, err := reference.ParseNormalizedNamed(remote)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errdefs.InvalidParameter(err)
 	}
 
 	type canonicalWithTag interface {
@@ -205,7 +206,7 @@ func (pr *pluginRouter) enablePlugin(ctx context.Context, w http.ResponseWriter,
 
 	timeout, err := strconv.Atoi(r.Form.Get("timeout"))
 	if err != nil {
-		return err
+		return errdefs.InvalidParameter(err)
 	}
 
 	name := vars["name"]


### PR DESCRIPTION
## Description

Several API endpoints return HTTP 500 for invalid user input (bad reference format, non-integer query params, missing required params) when they should return HTTP 400. This is because the errors are returned without `errdefs` wrapping, so the API error handler defaults to 500.

## Changes

Wrap plain errors with `errdefs.InvalidParameter()` in 4 files:

| Endpoint | Error | Was | Now |
|----------|-------|-----|-----|
| `GET /images/get`, `GET /images/{name}/get` | invalid reference format | 500 | 400 |
| `POST /containers/{id}/stop?t=string` | invalid integer | 500 | 400 |
| `GET /containers/json?limit=string` | invalid integer | 500 | 400 |
| `GET /plugins/privileges?remote=A` | invalid reference format | 500 | 400 |
| `POST /plugins/{name}/enable?timeout=string` | invalid integer | 500 | 400 |
| `GET /services/{id}/logs`, `GET /tasks/{id}/logs` | missing stream param | 500 | 400 |

This makes them consistent with other endpoints that already return 400 for the same error types (e.g., `POST /images/{name}/tag`, `GET /images/{name}/json`).

Fixes #48173