### PR TITLE
[docker-29.x] dockerd-rootless.sh: check containerd-rootless.sh conflict

### DIFF
--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -108,6 +108,14 @@ init() {
 		XDG_RUNTIME_DIR_CREATED=1
 	fi
 
+	: "${CONTAINERD_ROOTLESS_ROOTLESSKIT_STATE_DIR:=$XDG_RUNTIME_DIR/containerd-rootless}"
+	if [ -e "$CONTAINERD_ROOTLESS_ROOTLESSKIT_STATE_DIR" ]; then
+		# https://github.com/moby/moby/issues/52171
+		# Hard requirement, not bypassable with --force
+		ERROR "dockerd-rootless.sh conflicts with containerd-rootless.sh. Stop containerd-rootless.sh if it's running, and remove $CONTAINERD_ROOTLESS_ROOTLESSKIT_STATE_DIR if it still exists."
+		exit 1
+	fi
+
 	instructions=""
 	# instruction: uidmap dependency check
 	if ! command -v newuidmap > /dev/null 2>&1; then

--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -97,6 +97,13 @@ if [ -z "$rootlesskit" ]; then
 	exit 1
 fi
 
+: "${CONTAINERD_ROOTLESS_ROOTLESSKIT_STATE_DIR:=$XDG_RUNTIME_DIR/containerd-rootless}"
+if [ -e "$CONTAINERD_ROOTLESS_ROOTLESSKIT_STATE_DIR" ]; then
+	# https://github.com/moby/moby/issues/52171
+	echo "dockerd-rootless.sh conflicts with containerd-rootless.sh. Stop containerd-rootless.sh if it's running, and remove $CONTAINERD_ROOTLESS_ROOTLESSKIT_STATE_DIR if it still exists."
+	exit 1
+fi
+
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR:=$XDG_RUNTIME_DIR/dockerd-rootless}"
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_NET:=}"
 : "${DOCKERD_ROOTLESS_ROOTLESSKIT_MTU:=}"


### PR DESCRIPTION
Cherry-pick (clean)
- #52175 
- - -

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
dockerd-rootless.sh: check containerd-rootless.sh conflict

fixes #52171

Prior to this fix, Rootless Docker could fail with cryptic errors when Rootless containerd is running too

**- How I did it**
Check if `$XDG_RUNTIME_DIR/containerd-rootless` exists

**- How to verify it**

```console
$ containerd-rootless-setuptool.sh install
$ dockerd-rootless-setuptool.sh install
[ERROR] dockerd-rootless.sh conflicts with containerd-rootless.sh. Stop containerd-rootless.sh if it's running, and remove /run/user/1000/containerd-rootless if it still exists.
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
dockerd-rootless.sh: check containerd-rootless.sh conflict
```

**- A picture of a cute animal (not mandatory but encouraged)**

