### PR TITLE
daemon: Daemon.SystemVersion: align fields with api type

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -108,6 +108,14 @@ func (daemon *Daemon) SystemVersion(ctx context.Context) (system.VersionResponse
 	cfg := daemon.config()
 
 	v := system.VersionResponse{
+		Platform: system.PlatformInfo{
+			Name: dockerversion.PlatformName,
+		},
+		Version:       dockerversion.Version,
+		APIVersion:    config.MaxAPIVersion,
+		MinAPIVersion: cfg.MinAPIVersion,
+		Os:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
 		Components: []system.ComponentVersion{
 			{
 				Name:    "Engine",
@@ -126,20 +134,19 @@ func (daemon *Daemon) SystemVersion(ctx context.Context) (system.VersionResponse
 			},
 		},
 
-		// Populate deprecated fields for older clients
-		Version:       dockerversion.Version,
+		// Populate deprecated fields for older clients.
+		//
+		// These fields were (soft) deprecated in API v1.35 in favor of the
+		// per-component build-info, but kept for backward-compatibility, see:
+		//
+		// - https://github.com/moby/moby/pull/35705
+		// - https://github.com/moby/moby/pull/51359
 		GitCommit:     dockerversion.GitCommit,
-		APIVersion:    config.MaxAPIVersion,
-		MinAPIVersion: cfg.MinAPIVersion,
 		GoVersion:     runtime.Version(),
-		Os:            runtime.GOOS,
-		Arch:          runtime.GOARCH,
-		BuildTime:     dockerversion.BuildTime,
 		KernelVersion: kernelVer,
 		Experimental:  cfg.Experimental,
+		BuildTime:     dockerversion.BuildTime,
 	}
-
-	v.Platform.Name = dockerversion.PlatformName
 
 	if err := daemon.fillPlatformVersion(ctx, &v, cfg); err != nil {
 		return v, err


### PR DESCRIPTION
These fields were "soft" deprecated in [moby@9152e63] (API v1.35) in favor of the build-information provided for each component, but kept for backward compatibility. Some fields were un-deprecated in [moby@12c9de3], as they were widely used.

This patch aligns the daemon code with the API definition to more clearly indicate which fields are still considered deprecated; https://github.com/moby/moby/blob/api/v1.54.0/api/types/system/version_response.go#L29-L35

[moby@9152e63]: https://github.com/moby/moby/commit/9152e63290e4a4e586b811cce39082efc649b912
[moby@12c9de3]: https://github.com/moby/moby/commit/12c9de37e9ea6fc2f2fb752fb9d3fe387d3dd06a


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

