### PR TITLE
client/pkg/jsonmessage: add DisplayStream and DisplayMessages utils

### DIFF
--- a/client/pkg/jsonmessage/jsonmessage.go
+++ b/client/pkg/jsonmessage/jsonmessage.go
@@ -140,10 +140,20 @@ func Display(jm jsonstream.Message, out io.Writer, isTerminal bool, width uint16
 
 type JSONMessagesStream = iter.Seq2[jsonstream.Message, error]
 
-// DisplayJSONMessagesStream reads a JSON message stream from in, and writes
-// each [JSONMessage] to out.
-// see DisplayJSONMessages for details
+// DisplayJSONMessagesStream is like [DisplayStream], but allows the caller to
+// explicitly provide the terminal file descriptor and whether out is a terminal.
 func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
+	return displayJSONMessagesStream(in, out, terminalFd, isTerminal, auxCallback)
+}
+
+// DisplayStream reads a JSON message stream from in, and writes each
+// [jsonstream.Message] to out. See [DisplayMessages] for details.
+func DisplayStream(in io.Reader, out io.Writer, auxCallback func(jsonstream.Message)) error {
+	terminalFd, isTerminal := term.GetFdInfo(out)
+	return displayJSONMessagesStream(in, out, terminalFd, isTerminal, auxCallback)
+}
+
+func displayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	dec := json.NewDecoder(in)
 	f := func(yield func(jsonstream.Message, error) bool) {
 		for {
@@ -158,26 +168,33 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 		}
 	}
 
-	return DisplayJSONMessages(f, out, terminalFd, isTerminal, auxCallback)
+	return displayJSONMessages(f, out, terminalFd, isTerminal, auxCallback)
 }
 
-// DisplayJSONMessages writes each [JSONMessage] from stream to out.
-// It returns an error if an invalid JSONMessage is received, or if
-// a JSONMessage containers a non-zero [JSONMessage.Error].
-//
-// Presentation of the JSONMessage depends on whether a terminal is attached,
-// and on the terminal width. Progress bars ([JSONProgress]) are suppressed
-// on narrower terminals (< 110 characters).
-//
-//   - isTerminal describes if out is a terminal, in which case it prints
-//     a newline ("\n") at the end of each line and moves the cursor while
-//     displaying.
-//   - terminalFd is the fd of the current terminal (if any), and used
-//     to get the terminal width.
-//   - auxCallback allows handling the [JSONMessage.Aux] field. It is
-//     called if a JSONMessage contains an Aux field, in which case
-//     DisplayJSONMessagesStream does not present the JSONMessage.
+// DisplayJSONMessages is like [DisplayMessages], but allows the caller to
+// explicitly provide the terminal file descriptor and whether out is a terminal.
 func DisplayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
+	return displayJSONMessages(messages, out, terminalFd, isTerminal, auxCallback)
+}
+
+// DisplayMessages writes each [jsonstream.Message] from stream to out.
+// It returns an error if an invalid [jsonstream.Message] is received, or if
+// a message contains a non-zero [jsonstream.Message.Error].
+//
+// Presentation of the message depends on whether out is a terminal, and on the
+// terminal width. Progress bars ([jsonstream.Progress]) are suppressed on
+// narrower terminals (< 110 characters). If out is a terminal, it prints a
+// newline ("\n") at the end of each line and moves the cursor while displaying.
+//
+// auxCallback allows handling the [jsonstream.Message.Aux] field. It is called
+// if a message contains an Aux field, in which case DisplayMessages does not
+// present the message.
+func DisplayMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, auxCallback func(jsonstream.Message)) error {
+	terminalFd, isTerminal := term.GetFdInfo(out)
+	return displayJSONMessages(messages, out, terminalFd, isTerminal, auxCallback)
+}
+
+func displayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	ids := make(map[string]uint)
 	var width uint16 = 200
 	if isTerminal {

--- a/client/pkg/jsonmessage/jsonmessage_test.go
+++ b/client/pkg/jsonmessage/jsonmessage_test.go
@@ -8,12 +8,11 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/jsonstream"
-	"github.com/moby/term"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
-func TestProgressString(t *testing.T) {
+func TestRenderTUIProgress(t *testing.T) {
 	type expected struct {
 		short string
 		long  string
@@ -112,7 +111,7 @@ func TestProgressString(t *testing.T) {
 	}
 }
 
-func TestJSONMessageDisplay(t *testing.T) {
+func TestDisplay(t *testing.T) {
 	messages := map[jsonstream.Message][]string{
 		// Empty
 		{}: {"\n", "\n"},
@@ -171,8 +170,8 @@ func TestJSONMessageDisplay(t *testing.T) {
 	}
 }
 
-// Test JSONMessage with an Error. It returns an error with the given text, not the meaning of the HTTP code.
-func TestJSONMessageDisplayWithJSONError(t *testing.T) {
+// Test jsonstream.Message with an Error. It returns an error with the given text, not the meaning of the HTTP code.
+func TestDisplayWithJSONError(t *testing.T) {
 	data := bytes.NewBuffer([]byte{})
 	jsonMessage := jsonstream.Message{Error: &jsonstream.Error{Code: 404, Message: "Can't find it"}}
 
@@ -186,21 +185,16 @@ func TestJSONMessageDisplayWithJSONError(t *testing.T) {
 	assert.Check(t, is.Error(err, "Anything"))
 }
 
-func TestDisplayJSONMessagesStreamInvalidJSON(t *testing.T) {
-	var inFd uintptr
+func TestDisplayStreamInvalidJSON(t *testing.T) {
 	data := bytes.NewBuffer([]byte{})
 	reader := strings.NewReader("This is not a 'valid' JSON []")
-	inFd, _ = term.GetFdInfo(reader)
-
 	exp := "invalid character "
-	if err := DisplayJSONMessagesStream(reader, data, inFd, false, nil); err == nil || !strings.HasPrefix(err.Error(), exp) {
+	if err := DisplayStream(reader, data, nil); err == nil || !strings.HasPrefix(err.Error(), exp) {
 		t.Fatalf("Expected error (%s...), got %q", exp, err)
 	}
 }
 
 func TestDisplayJSONMessagesStream(t *testing.T) {
-	var inFd uintptr
-
 	messages := map[string][]string{
 		// empty string
 		"": {
@@ -231,20 +225,19 @@ func TestDisplayJSONMessagesStream(t *testing.T) {
 	for jsonMessage, expectedMessages := range messages {
 		data := bytes.NewBuffer([]byte{})
 		reader := strings.NewReader(jsonMessage)
-		inFd, _ = term.GetFdInfo(reader)
 
 		// Without terminal
-		if err := DisplayJSONMessagesStream(reader, data, inFd, false, nil); err != nil {
+		if err := DisplayStream(reader, data, nil); err != nil {
 			t.Fatal(err)
 		}
 		if data.String() != expectedMessages[0] {
 			t.Fatalf("Expected an %q, got %q", expectedMessages[0], data.String())
 		}
 
-		// With terminal
+		// With terminal (forcing terminal mode)
 		data = bytes.NewBuffer([]byte{})
 		reader = strings.NewReader(jsonMessage)
-		if err := DisplayJSONMessagesStream(reader, data, inFd, true, nil); err != nil {
+		if err := DisplayJSONMessagesStream(reader, data, 0, true, nil); err != nil {
 			t.Fatal(err)
 		}
 		if data.String() != expectedMessages[1] {

--- a/integration/build/build_userns_linux_test.go
+++ b/integration/build/build_userns_linux_test.go
@@ -70,7 +70,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	defer resp.Body.Close()
 
 	buf := bytes.NewBuffer(nil)
-	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, buf, 0, false, nil)
+	err = jsonmessage.DisplayStream(resp.Body, buf, nil)
 	assert.NilError(t, err)
 
 	reader, err := clientUserRemap.ImageSave(ctx, []string{imageTag})
@@ -107,7 +107,7 @@ func TestBuildUserNamespaceValidateCapabilitiesAreV2(t *testing.T) {
 	assert.NilError(t, err, "failed to load image tar file")
 	defer loadResp.Close()
 	var buf2 bytes.Buffer
-	err = jsonmessage.DisplayJSONMessagesStream(loadResp, &buf2, 0, false, nil)
+	err = jsonmessage.DisplayStream(loadResp, &buf2, nil)
 	assert.NilError(t, err)
 
 	cid := container.Run(ctx, t, clientNoUserRemap,

--- a/integration/container/copy_test.go
+++ b/integration/container/copy_test.go
@@ -215,7 +215,7 @@ func makeTestImage(ctx context.Context, t *testing.T) (imageID string) {
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
-	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonstream.Message) {
+	err = jsonmessage.DisplayStream(resp.Body, io.Discard, func(msg jsonstream.Message) {
 		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID
@@ -290,7 +290,7 @@ func TestCopyFromContainer(t *testing.T) {
 	defer resp.Body.Close()
 
 	var imageID string
-	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, io.Discard, 0, false, func(msg jsonstream.Message) {
+	err = jsonmessage.DisplayStream(resp.Body, io.Discard, func(msg jsonstream.Message) {
 		var r build.Result
 		assert.NilError(t, json.Unmarshal(*msg.Aux, &r))
 		imageID = r.ID

--- a/integration/plugin/common/plugin_test.go
+++ b/integration/plugin/common/plugin_test.go
@@ -139,7 +139,6 @@ func TestPluginInstall(t *testing.T) {
 		assert.NilError(t, err)
 		defer res.Close()
 
-		buf := &strings.Builder{}
 		assert.NilError(t, err)
 		var digest string
 
@@ -153,7 +152,8 @@ func TestPluginInstall(t *testing.T) {
 			Digest string
 			Size   int
 		}
-		assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(res, buf, 0, false, func(j jsonstream.Message) {
+		var buf strings.Builder
+		assert.NilError(t, jsonmessage.DisplayStream(res, &buf, func(j jsonstream.Message) {
 			if j.Aux != nil {
 				var r pushResult
 				assert.NilError(t, json.Unmarshal(*j.Aux, &r))
@@ -349,8 +349,8 @@ func TestPluginBackCompatMediaTypes(t *testing.T) {
 	assert.NilError(t, err)
 	defer res.Close()
 
-	buf := &strings.Builder{}
-	assert.NilError(t, jsonmessage.DisplayJSONMessagesStream(res, buf, 0, false, nil), buf)
+	var buf strings.Builder
+	assert.NilError(t, jsonmessage.DisplayStream(res, &buf, nil), buf)
 
 	// Use custom header here because older versions of the registry do not
 	// parse the accept header correctly and does not like the accept header

--- a/internal/testutil/fixtures/load/frozen.go
+++ b/internal/testutil/fixtures/load/frozen.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/jsonmessage"
-	"github.com/moby/term"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -115,8 +114,7 @@ func loadFrozenImages(ctx context.Context, apiClient client.APIClient) error {
 		return errors.Wrap(err, "failed to load frozen images")
 	}
 	defer resp.Close()
-	fd, isTerminal := term.GetFdInfo(os.Stdout)
-	return jsonmessage.DisplayJSONMessagesStream(resp, os.Stdout, fd, isTerminal, nil)
+	return jsonmessage.DisplayStream(resp, os.Stdout, nil)
 }
 
 func pullImages(ctx context.Context, client client.APIClient, images []string) error {
@@ -166,8 +164,7 @@ func pullTagAndRemove(ctx context.Context, apiClient client.APIClient, ref strin
 		return errors.Wrapf(err, "failed to pull %s", ref)
 	}
 	defer resp.Close()
-	fd, isTerminal := term.GetFdInfo(os.Stdout)
-	if err := jsonmessage.DisplayJSONMessagesStream(resp, os.Stdout, fd, isTerminal, nil); err != nil {
+	if err := jsonmessage.DisplayStream(resp, os.Stdout, nil); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/moby/moby/client/pkg/jsonmessage/jsonmessage.go
@@ -140,10 +140,20 @@ func Display(jm jsonstream.Message, out io.Writer, isTerminal bool, width uint16
 
 type JSONMessagesStream = iter.Seq2[jsonstream.Message, error]
 
-// DisplayJSONMessagesStream reads a JSON message stream from in, and writes
-// each [JSONMessage] to out.
-// see DisplayJSONMessages for details
+// DisplayJSONMessagesStream is like [DisplayStream], but allows the caller to
+// explicitly provide the terminal file descriptor and whether out is a terminal.
 func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
+	return displayJSONMessagesStream(in, out, terminalFd, isTerminal, auxCallback)
+}
+
+// DisplayStream reads a JSON message stream from in, and writes each
+// [jsonstream.Message] to out. See [DisplayMessages] for details.
+func DisplayStream(in io.Reader, out io.Writer, auxCallback func(jsonstream.Message)) error {
+	terminalFd, isTerminal := term.GetFdInfo(out)
+	return displayJSONMessagesStream(in, out, terminalFd, isTerminal, auxCallback)
+}
+
+func displayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	dec := json.NewDecoder(in)
 	f := func(yield func(jsonstream.Message, error) bool) {
 		for {
@@ -158,26 +168,33 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 		}
 	}
 
-	return DisplayJSONMessages(f, out, terminalFd, isTerminal, auxCallback)
+	return displayJSONMessages(f, out, terminalFd, isTerminal, auxCallback)
 }
 
-// DisplayJSONMessages writes each [JSONMessage] from stream to out.
-// It returns an error if an invalid JSONMessage is received, or if
-// a JSONMessage containers a non-zero [JSONMessage.Error].
-//
-// Presentation of the JSONMessage depends on whether a terminal is attached,
-// and on the terminal width. Progress bars ([JSONProgress]) are suppressed
-// on narrower terminals (< 110 characters).
-//
-//   - isTerminal describes if out is a terminal, in which case it prints
-//     a newline ("\n") at the end of each line and moves the cursor while
-//     displaying.
-//   - terminalFd is the fd of the current terminal (if any), and used
-//     to get the terminal width.
-//   - auxCallback allows handling the [JSONMessage.Aux] field. It is
-//     called if a JSONMessage contains an Aux field, in which case
-//     DisplayJSONMessagesStream does not present the JSONMessage.
+// DisplayJSONMessages is like [DisplayMessages], but allows the caller to
+// explicitly provide the terminal file descriptor and whether out is a terminal.
 func DisplayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
+	return displayJSONMessages(messages, out, terminalFd, isTerminal, auxCallback)
+}
+
+// DisplayMessages writes each [jsonstream.Message] from stream to out.
+// It returns an error if an invalid [jsonstream.Message] is received, or if
+// a message contains a non-zero [jsonstream.Message.Error].
+//
+// Presentation of the message depends on whether out is a terminal, and on the
+// terminal width. Progress bars ([jsonstream.Progress]) are suppressed on
+// narrower terminals (< 110 characters). If out is a terminal, it prints a
+// newline ("\n") at the end of each line and moves the cursor while displaying.
+//
+// auxCallback allows handling the [jsonstream.Message.Aux] field. It is called
+// if a message contains an Aux field, in which case DisplayMessages does not
+// present the message.
+func DisplayMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, auxCallback func(jsonstream.Message)) error {
+	terminalFd, isTerminal := term.GetFdInfo(out)
+	return displayJSONMessages(messages, out, terminalFd, isTerminal, auxCallback)
+}
+
+func displayJSONMessages(messages iter.Seq2[jsonstream.Message, error], out io.Writer, terminalFd uintptr, isTerminal bool, auxCallback func(jsonstream.Message)) error {
 	ids := make(map[string]uint)
 	var width uint16 = 200
 	if isTerminal {


### PR DESCRIPTION
These can replace the existing DisplayJSONMessagesStream and DisplayJSONMessages functions, not requiring the caller to perform terminal detection.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client/pkg/jsonmessage: add `DisplayStream` and `DisplayMessages` utils.
```

**- A picture of a cute animal (not mandatory but encouraged)**

