### PR TITLE
gracefully handle invalid "extra-hosts" for containers

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -74,10 +74,10 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 	}
 
 	for _, extraHost := range ctr.HostConfig.ExtraHosts {
-		// allow IPv6 addresses in extra hosts; only split on first ":"
 		if _, err := opts.ValidateExtraHost(extraHost); err != nil {
 			return nil, err
 		}
+		// allow IPv6 addresses in extra hosts; only split on first ":"
 		host, ip, _ := strings.Cut(extraHost, ":")
 		// If the IP Address is the literal string "host-gateway", replace this
 		// value with the IP address(es) stored in the daemon level HostGatewayIP
@@ -90,7 +90,21 @@ func buildSandboxOptions(cfg *config.Config, ctr *container.Container) ([]libnet
 				sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, gip.Unmap()))
 			}
 		} else {
-			sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, netip.MustParseAddr(ip).Unmap()))
+			if ipAddr, err := netip.ParseAddr(ip); err != nil {
+				// Value should already be validated if we arrive here, but
+				// handle invalid IP-addresses gracefully: they may be part
+				// of an existing container-config created by docker < v29.0.0.
+				//
+				// See https://github.com/moby/moby/issues/52274
+				// See https://github.com/moby/moby/pull/50956
+				log.G(context.TODO()).WithFields(log.Fields{
+					"error":      err,
+					"extra_host": extraHost,
+					"container":  ctr.ID,
+				}).Warn("buildSandboxOptions: failed to parse IP address for extra hosts")
+			} else {
+				sboxOptions = append(sboxOptions, libnetwork.OptionExtraHost(host, ipAddr.Unmap()))
+			}
 		}
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -381,6 +382,19 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 						c.HostConfig.LogConfig.Config["fluentd-async"] = v
 					}
 					delete(c.HostConfig.LogConfig.Config, "fluentd-async-connect")
+				}
+				if len(c.HostConfig.ExtraHosts) > 0 {
+					// Daemon versions before v29.0.0 were more permissive when handling whitespace in the IP-address:
+					//
+					// See https://github.com/moby/moby/issues/52274
+					// See https://github.com/moby/moby/pull/50956
+					//
+					// TODO(thaJeztah): remove this migration when we no longer need migration for docker < v29.0.0
+					for i, h := range c.HostConfig.ExtraHosts {
+						if host, ip, ok := strings.Cut(h, ":"); ok {
+							c.HostConfig.ExtraHosts[i] = strings.TrimSpace(host) + ":" + strings.TrimSpace(ip)
+						}
+					}
 				}
 			}
 

--- a/daemon/pkg/opts/opts.go
+++ b/daemon/pkg/opts/opts.go
@@ -3,7 +3,7 @@ package opts
 import (
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"path"
 	"slices"
 	"strings"
@@ -302,11 +302,11 @@ type ValidatorFctListType func(val string) ([]string, error)
 //
 // Refer to [net.ParseIP] for accepted formats.
 func ValidateIPAddress(val string) (string, error) {
-	ip := net.ParseIP(strings.TrimSpace(val))
-	if ip != nil {
-		return ip.String(), nil
+	ip, err := netip.ParseAddr(val)
+	if err != nil {
+		return "", fmt.Errorf("IP address is not correctly formatted: %w", err)
 	}
-	return "", fmt.Errorf("IP address is not correctly formatted: %s", val)
+	return ip.String(), nil
 }
 
 // ValidateDNSSearch validates domain for resolvconf search configuration.

--- a/daemon/pkg/opts/opts_test.go
+++ b/daemon/pkg/opts/opts_test.go
@@ -24,7 +24,7 @@ func TestValidateIPAddress(t *testing.T) {
 		{
 			doc:         "IPv4 loopback with whitespace",
 			input:       ` 127.0.0.1 `,
-			expectedOut: `127.0.0.1`,
+			expectedErr: `IP address is not correctly formatted: ParseAddr(" 127.0.0.1 "): unexpected character (at " 127.0.0.1 ")`,
 		},
 		{
 			doc:         "IPv6 loopback long form",
@@ -39,7 +39,7 @@ func TestValidateIPAddress(t *testing.T) {
 		{
 			doc:         "IPv6 loopback with whitespace",
 			input:       ` ::1 `,
-			expectedOut: `::1`,
+			expectedErr: `IP address is not correctly formatted: ParseAddr(" ::1 "): each colon-separated field must have at least one digit (at " ::1 ")`,
 		},
 		{
 			doc:         "IPv6 lowercase",
@@ -54,17 +54,17 @@ func TestValidateIPAddress(t *testing.T) {
 		{
 			doc:         "IPv6 with brackets",
 			input:       `[::1]`,
-			expectedErr: `IP address is not correctly formatted: [::1]`,
+			expectedErr: `IP address is not correctly formatted: ParseAddr("[::1]"): each colon-separated field must have at least one digit (at "[::1]")`,
 		},
 		{
 			doc:         "IPv4 partial",
 			input:       `127`,
-			expectedErr: `IP address is not correctly formatted: 127`,
+			expectedErr: `IP address is not correctly formatted: ParseAddr("127"): unable to parse IP`,
 		},
 		{
 			doc:         "random invalid string",
 			input:       `random invalid string`,
-			expectedErr: `IP address is not correctly formatted: random invalid string`,
+			expectedErr: `IP address is not correctly formatted: ParseAddr("random invalid string"): unable to parse IP`,
 		},
 	}
 


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/52274
- relates to https://github.com/moby/moby/pull/50956

### daemon/pkg/opts: ValidateIPAddress: use netip.Parse

Make sure we use the same function to validate as we use to parse
the IP-address.


### daemon: Daemon.restore: trim whitespace in extra-hosts

Older daemons were more permissive when handling whitespace, which
can cause the daemon to panic when handling existing container-configs;

```
goroutine 767 [running]:
net/netip.MustParseAddr(...)
        /usr/local/go/src/net/netip/netip.go:136
github.com/moby/moby/v2/daemon.buildSandboxOptions(0xc0009c2008, 0xc000b8c588)
        /root/build-deb/engine/daemon/container_operations.go:93 +0x1994
github.com/moby/moby/v2/daemon.(*Daemon).initializeNetworking(0xc0009a4c88, {0x5563cdcda848, 0xc000f6e810}, 0xc0009c2008, 0xc000b8c588)
        /root/build-deb/engine/daemon/container_operations.go:473 +0x33c
github.com/moby/moby/v2/daemon.(*Daemon).containerStart(0xc0009a4c88, {0x5563cdcda810, 0x5563cf72ec20}, 0xc0009c2008, 0xc000b8c588, {0x0, 0x0}, {0x0, 0x0}, 0x1)
        /root/build-deb/engine/daemon/start.go:134 +0x8d8
github.com/moby/moby/v2/daemon.(*Daemon).restore.func4(0xc000b8c588, 0xc000312d90)
        /root/build-deb/engine/daemon/daemon.go:632 +0x430
created by github.com/moby/moby/v2/daemon.(*Daemon).restore in goroutine 1
        /root/build-deb/engine/daemon/daemon.go:606 +0x7ff
```

Migrate existing configs to more gracefully handle startup after upgrading
from an older version of the daemon.


### daemon: buildSandboxOptions: warn, not panic on invalid extra host

This is mostly a defense in-depth for handling containers that were
created with an older version of docker. Log a warning instead of
panicking on invalid values.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Prevent a daemon crash during startup after upgrading if a container config containers a malformed IP-address.
```

**- A picture of a cute animal (not mandatory but encouraged)**

