### PR TITLE
Fix typos and misspellings in comments, tests, and docs

### DIFF
--- a/client/image_import.go
+++ b/client/image_import.go
@@ -39,7 +39,7 @@ func (cli *Client) ImageImport(ctx context.Context, source ImageImportSource, re
 		query.Set("message", options.Message)
 	}
 	if p := formatPlatform(options.Platform); p != "unknown" {
-		// TODO(thaJeztah): would we ever support mutiple platforms here? (would require multiple rootfs tars as well?)
+		// TODO(thaJeztah): would we ever support multiple platforms here? (would require multiple rootfs tars as well?)
 		query.Set("platform", p)
 	}
 	for _, change := range options.Changes {

--- a/client/service_logs.go
+++ b/client/service_logs.go
@@ -34,7 +34,7 @@ type ServiceLogsResult interface {
 //
 // The underlying [io.ReadCloser] is automatically closed if the context is canceled,
 func (cli *Client) ServiceLogs(ctx context.Context, serviceID string, options ServiceLogsOptions) (ServiceLogsResult, error) {
-	// TODO(thaJeztah): this function needs documentation about the format of ths stream (similar to for container logs)
+	// TODO(thaJeztah): this function needs documentation about the format of the stream (similar to for container logs)
 	// TODO(thaJeztah): migrate CLI utilities to the client where suitable; https://github.com/docker/cli/blob/v29.0.0-rc.1/cli/command/service/logs.go#L73-L348
 
 	serviceID, err := trimID("service", serviceID)

--- a/client/task_logs.go
+++ b/client/task_logs.go
@@ -32,7 +32,7 @@ type TaskLogsResult interface {
 //
 // The underlying [io.ReadCloser] is automatically closed if the context is canceled,
 func (cli *Client) TaskLogs(ctx context.Context, taskID string, options TaskLogsOptions) (TaskLogsResult, error) {
-	// TODO(thaJeztah): this function needs documentation about the format of ths stream (similar to for container logs)
+	// TODO(thaJeztah): this function needs documentation about the format of the stream (similar to for container logs)
 	// TODO(thaJeztah): migrate CLI utilities to the client where suitable; https://github.com/docker/cli/blob/v29.0.0-rc.1/cli/command/service/logs.go#L73-L348
 
 	query := url.Values{}

--- a/contrib/otel/README.md
+++ b/contrib/otel/README.md
@@ -19,7 +19,7 @@ The `contrib/otel` directory contains the compose file with the services configu
 5. Browse Jaeger at `http://localhost:16686` or the Aspire Dashboard at `http://localhost:18888/traces`;
 6. To see some traces from the engine, select `dockerd` in the top left dropdown
 
-> **Note**: The precise steps may vary based on how you're working on the codebase (buiding a binary and executing natively, running/debugging in a devcontainer, etc... )
+> **Note**: The precise steps may vary based on how you're working on the codebase (building a binary and executing natively, running/debugging in a devcontainer, etc... )
 
 ## Cleanup?
 

--- a/daemon/cluster/controllers/plugin/controller_test.go
+++ b/daemon/cluster/controllers/plugin/controller_test.go
@@ -121,7 +121,7 @@ func TestWaitCancel(t *testing.T) {
 			t.Fatal(err)
 		}
 	case <-time.After(10 * time.Second):
-		t.Fatal("timeout waiting for cancelation")
+		t.Fatal("timeout waiting for cancellation")
 	}
 }
 

--- a/daemon/cluster/convert/network.go
+++ b/daemon/cluster/convert/network.go
@@ -88,7 +88,7 @@ func ipamFromGRPC(i *swarmapi.IPAMOptions) *types.IPAMOptions {
 		}
 
 		for _, config := range i.Configs {
-			// Best-effort parse of user suppplied values that have
+			// Best-effort parse of user supplied values that have
 			// been round-tripped through Swarm's Raft store. It is
 			// far too late to reject bogus values.
 			subnet, _ := netiputil.ParseCIDR(config.Subnet)
@@ -162,7 +162,7 @@ func BasicNetworkFromGRPC(n swarmapi.Network) network.Network {
 		}
 		ipam.Config = make([]network.IPAMConfig, 0, len(n.IPAM.Configs))
 		for _, ic := range n.IPAM.Configs {
-			// Best-effort parse of user suppplied values that have
+			// Best-effort parse of user supplied values that have
 			// been round-tripped through Swarm's Raft store. It is
 			// far too late to reject bogus values.
 			subnet, _ := netiputil.ParseCIDR(ic.Subnet)

--- a/daemon/cluster/executor/container/executor.go
+++ b/daemon/cluster/executor/container/executor.go
@@ -186,7 +186,7 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 	// or has just had its IP changed (false)
 	removeAttachments := make(map[string]bool)
 
-	// the first time we Configure, nodeObj wil be nil, because it will not be
+	// the first time we Configure, nodeObj will be nil, because it will not be
 	// set yet. in that case, skip this check.
 	if e.nodeObj != nil {
 		for _, na := range e.nodeObj.Attachments {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -268,7 +268,7 @@ func (daemon *Daemon) restore(ctx context.Context, cfg *configStore, containers 
 	log.G(ctx).Info("Restoring containers: start.")
 
 	// parallelLimit is the maximum number of parallel startup jobs that we
-	// allow (this is the limited used for all startup semaphores). The multipler
+	// allow (this is the limited used for all startup semaphores). The multiplier
 	// (128) was chosen after some fairly significant benchmarking -- don't change
 	// it unless you've tested it significantly (this value is adjusted if
 	// RLIMIT_NOFILE is small to avoid EMFILE).

--- a/daemon/images/image.go
+++ b/daemon/images/image.go
@@ -141,7 +141,7 @@ func (i *ImageService) manifestMatchesPlatform(ctx context.Context, img *image.I
 			}
 
 			if err := json.Unmarshal(data, &m); err != nil {
-				logger.WithError(err).Error("Error desserializing manifest")
+				logger.WithError(err).Error("Error deserializing manifest")
 				continue
 			}
 

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -193,7 +193,7 @@ func (daemon *Daemon) Kill(container *containerpkg.Container) error {
 		return err
 	}
 
-	// wait for container to exit one last time, if it doesn't then kill didnt work, so return error
+	// wait for container to exit one last time, if it doesn't then kill didn't work, so return error
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel2()
 

--- a/daemon/logger/loggerutils/logfile_test.go
+++ b/daemon/logger/loggerutils/logfile_test.go
@@ -133,7 +133,7 @@ func TestTailFiles(t *testing.T) {
 		f1 := bytes.NewBuffer(nil)
 		writeMsg(f1, msg1)
 
-		_, err := f1.WriteString("some randome garbage")
+		_, err := f1.WriteString("some random garbage")
 		assert.NilError(t, err, "error writing garbage to log stream")
 
 		writeMsg(f1, msg2) // This won't be seen due to garbage written above

--- a/daemon/migration_test.go
+++ b/daemon/migration_test.go
@@ -93,7 +93,7 @@ func TestContainerMigrateOS(t *testing.T) {
 			},
 		},
 		{
-			name: "gd with an image thats no longer available",
+			name: "gd with missing image",
 			ctr: Container{
 				ImageManifest: graphdrivers,
 				ImageID:       "notfound",
@@ -119,7 +119,7 @@ func TestContainerMigrateOS(t *testing.T) {
 			},
 		},
 		{
-			name: "c8d with an image thats no longer available",
+			name: "c8d with missing image",
 			ctr: Container{
 				ImageManifest: &ocispec.Descriptor{
 					Digest: "notfound",

--- a/integration-cli/docker_api_swarm_service_test.go
+++ b/integration-cli/docker_api_swarm_service_test.go
@@ -185,7 +185,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdate(c *testing.T) {
 	// 2nd batch
 	poll.WaitOn(c, pollCheck(c, daemons[0].CheckRunningTaskImages(ctx), checker.DeepEquals(map[string]int{image1: instances - 2*parallelism, image2: 2 * parallelism})), poll.WithTimeout(defaultReconciliationTimeout))
 
-	// 3nd batch
+	// 3rd batch
 	poll.WaitOn(c, pollCheck(c, daemons[0].CheckRunningTaskImages(ctx), checker.DeepEquals(map[string]int{image2: instances})), poll.WithTimeout(defaultReconciliationTimeout))
 
 	// Roll back to the previous version. This uses the CLI because
@@ -277,7 +277,7 @@ func (s *DockerSwarmSuite) TestAPISwarmServicesUpdateStartFirst(c *testing.T) {
 
 	poll.WaitOn(c, pollCheck(c, d.CheckRunningTaskImages(ctx), checker.DeepEquals(map[string]int{image1: instances - 2*parallelism, image2: 2 * parallelism})), poll.WithTimeout(defaultReconciliationTimeout))
 
-	// 3nd batch
+	// 3rd batch
 
 	// The old tasks should be running, and the new ones should be starting.
 	startingTasks = checkStartingTasks(1)

--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -508,7 +508,7 @@ func testLiveRestoreAutoRemove(t *testing.T) {
 		return d, finishContainer, cID
 	}
 
-	t.Run("engine restart shouldnt kill alive containers", func(t *testing.T) {
+	t.Run("engine restart shouldn't kill alive containers", func(t *testing.T) {
 		d, finishContainer, cID := run(t)
 
 		d.Restart(t, "--live-restore", "--iptables=false", "--ip6tables=false")

--- a/integration/volume/mount_test.go
+++ b/integration/volume/mount_test.go
@@ -210,7 +210,7 @@ func TestRunMountImage(t *testing.T) {
 				assert.ErrorContains(t, removeErr, fmt.Sprintf(`container %s is using its referenced image %s`, id[:12], imgId[:12]))
 			}
 
-			// Test that the container servives a restart when mounted image is removed
+			// Test that the container survives a restart when mounted image is removed
 			if tc.name == "image_remove_force" {
 				_, stopErr := apiClient.ContainerStop(ctx, id, client.ContainerStopOptions{})
 				assert.NilError(t, stopErr)

--- a/pkg/plugins/pluginrpc-gen/parser.go
+++ b/pkg/plugins/pluginrpc-gen/parser.go
@@ -93,7 +93,7 @@ func Parse(filePath string, objName string) (*ParsedPkg, error) {
 		return nil, fmt.Errorf("could not find object %s in %s", objName, filePath)
 	}
 	if obj.Kind != ast.Typ {
-		return nil, fmt.Errorf("exected type, got %s", obj.Kind)
+		return nil, fmt.Errorf("expected type, got %s", obj.Kind)
 	}
 	spec, ok := obj.Decl.(*ast.TypeSpec)
 	if !ok {

--- a/pkg/pools/pools_test.go
+++ b/pkg/pools/pools_test.go
@@ -116,7 +116,7 @@ func TestBufioWriterPoolPutAndGet(t *testing.T) {
 	// recover it
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("Trying to flush the writter should have 'panicked', did not.")
+			t.Fatal("Trying to flush the writer should have 'panicked', did not.")
 		}
 	}()
 	writer.Flush()

--- a/vendor/github.com/moby/moby/client/image_import.go
+++ b/vendor/github.com/moby/moby/client/image_import.go
@@ -39,7 +39,7 @@ func (cli *Client) ImageImport(ctx context.Context, source ImageImportSource, re
 		query.Set("message", options.Message)
 	}
 	if p := formatPlatform(options.Platform); p != "unknown" {
-		// TODO(thaJeztah): would we ever support mutiple platforms here? (would require multiple rootfs tars as well?)
+		// TODO(thaJeztah): would we ever support multiple platforms here? (would require multiple rootfs tars as well?)
 		query.Set("platform", p)
 	}
 	for _, change := range options.Changes {

--- a/vendor/github.com/moby/moby/client/service_logs.go
+++ b/vendor/github.com/moby/moby/client/service_logs.go
@@ -34,7 +34,7 @@ type ServiceLogsResult interface {
 //
 // The underlying [io.ReadCloser] is automatically closed if the context is canceled,
 func (cli *Client) ServiceLogs(ctx context.Context, serviceID string, options ServiceLogsOptions) (ServiceLogsResult, error) {
-	// TODO(thaJeztah): this function needs documentation about the format of ths stream (similar to for container logs)
+	// TODO(thaJeztah): this function needs documentation about the format of the stream (similar to for container logs)
 	// TODO(thaJeztah): migrate CLI utilities to the client where suitable; https://github.com/docker/cli/blob/v29.0.0-rc.1/cli/command/service/logs.go#L73-L348
 
 	serviceID, err := trimID("service", serviceID)

--- a/vendor/github.com/moby/moby/client/task_logs.go
+++ b/vendor/github.com/moby/moby/client/task_logs.go
@@ -32,7 +32,7 @@ type TaskLogsResult interface {
 //
 // The underlying [io.ReadCloser] is automatically closed if the context is canceled,
 func (cli *Client) TaskLogs(ctx context.Context, taskID string, options TaskLogsOptions) (TaskLogsResult, error) {
-	// TODO(thaJeztah): this function needs documentation about the format of ths stream (similar to for container logs)
+	// TODO(thaJeztah): this function needs documentation about the format of the stream (similar to for container logs)
 	// TODO(thaJeztah): migrate CLI utilities to the client where suitable; https://github.com/docker/cli/blob/v29.0.0-rc.1/cli/command/service/logs.go#L73-L348
 
 	query := url.Values{}


### PR DESCRIPTION
## What I did

Fixed 20 spelling mistakes across 17 files in the codebase, found using `codespell`.

## How I did it

Ran `codespell` across the repo (excluding vendor directories), manually verified each finding to exclude false positives, and corrected only clear misspellings.

## Changes

| File | Typo | Fix |
|------|------|-----|
| `daemon/daemon.go` | multipler | multiplier |
| `daemon/cluster/convert/network.go` (x2) | suppplied | supplied |
| `daemon/images/image.go` | desserializing | deserializing |
| `daemon/cluster/executor/container/executor.go` | wil | will |
| `daemon/kill.go` | didnt | didn't |
| `daemon/migration_test.go` (x2) | thats | that's |
| `daemon/cluster/controllers/plugin/controller_test.go` | cancelation | cancellation |
| `daemon/logger/loggerutils/logfile_test.go` | randome | random |
| `client/image_import.go` | mutiple | multiple |
| `client/service_logs.go` | ths | the |
| `client/task_logs.go` | ths | the |
| `contrib/otel/README.md` | buiding | building |
| `integration/volume/mount_test.go` | servives | survives |
| `integration-cli/docker_api_swarm_service_test.go` (x2) | 3nd | 3rd |
| `integration/daemon/daemon_test.go` | shouldnt | shouldn't |
| `pkg/pools/pools_test.go` | writter | writer |
| `pkg/plugins/pluginrpc-gen/parser.go` | exected | expected |

## How to verify it

All changes are in comments, string literals in tests, and documentation - no functional code is affected.

## Description for the changelog

Fix various typos and misspellings in comments, tests, and documentation.
