### PR TITLE
daemon/pkg/registry We should not set loopback_addr as default insecu…

### DIFF
--- a/daemon/pkg/registry/config.go
+++ b/daemon/pkg/registry/config.go
@@ -143,7 +143,6 @@ func (config *serviceConfig) loadMirrors(mirrors []string) error {
 func (config *serviceConfig) loadInsecureRegistries(registries []string) error {
 	// Localhost is by default considered as an insecure registry. This is a
 	// stop-gap for people who are running a private registry on localhost.
-	registries = append(registries, "::1/128", "127.0.0.0/8")
 
 	var (
 		insecureRegistryCIDRs = make(map[netip.Prefix]struct{})


### PR DESCRIPTION
…re registry

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed the loopback addresses (::1/128 and 127.0.0.0/8) from the default insecure registry list. Local registry endpoints now require TLS and CA certificate validation by default, improving security and aligning with the behavior of other container runtimes like Podman and containerd.

**- How I did it**
Updated the default insecure registry CIDR configuration in the registry package to no longer include 127.0.0.0/8 and ::1/128. Docker daemon will no longer treat these addresses as secure (HTTP) endpoints without explicit user configuration.

**- How to verify it**
Start a local registry that listens only on HTTP (e.g., docker run -d -p 5000:5000 --name registry registry:2).

Attempt to push an image to that registry (e.g., docker tag alpine localhost:5000/test && docker push localhost:5000/test).

The push should fail with an error similar to http: server gave HTTP response to HTTPS client, indicating that the connection is no longer implicitly trusted.

To allow the HTTP connection, users must explicitly add the registry address to the insecure-registries list in /etc/docker/daemon.json.

**- Human readable description for the release notes**
<!--
Remove default insecure registry entries for local loopback addresses (`127.0.0.0/8` and `::1/128`). Local registries now require TLS and CA certificate validation by default, aligning with other container runtimes like podman and containerd.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

