### PR TITLE
client: fix race in cancelReadCloser

### DIFF
--- a/client/utils.go
+++ b/client/utils.go
@@ -136,7 +136,7 @@ func newCancelReadCloser(ctx context.Context, rc io.ReadCloser) io.ReadCloser {
 		rc:    rc,
 		close: sync.OnceValue(rc.Close),
 	}
-	crc.stop = context.AfterFunc(ctx, func() { _ = crc.Close() })
+	crc.stop = context.AfterFunc(ctx, func() { _ = crc.close() })
 	return crc
 }
 

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"context"
+	"io"
+	"strings"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -53,5 +56,14 @@ func TestEncodePlatforms(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Check(t, is.DeepEqual(out, tc.expected))
 		})
+	}
+}
+
+func TestNewCancelReadCloserRace(t *testing.T) {
+	for range 1000 {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_ = newCancelReadCloser(ctx, io.NopCloser(strings.NewReader("")))
 	}
 }

--- a/vendor/github.com/moby/moby/client/utils.go
+++ b/vendor/github.com/moby/moby/client/utils.go
@@ -136,7 +136,7 @@ func newCancelReadCloser(ctx context.Context, rc io.ReadCloser) io.ReadCloser {
 		rc:    rc,
 		close: sync.OnceValue(rc.Close),
 	}
-	crc.stop = context.AfterFunc(ctx, func() { _ = crc.Close() })
+	crc.stop = context.AfterFunc(ctx, func() { _ = crc.close() })
 	return crc
 }
 


### PR DESCRIPTION
- relates to https://github.com/testcontainers/testcontainers-go/pull/3591

```
=== RUN   TestNewCancelReadCloserRace
==================
WARNING: DATA RACE
Read at 0x00c0003cc018 by goroutine 74:
  github.com/moby/moby/client.(*cancelReadCloser).Close()
      /go/src/github.com/docker/docker/client/utils.go:152 +0x30
  github.com/moby/moby/client.newCancelReadCloser.func1()
      /go/src/github.com/docker/docker/client/utils.go:139 +0x2c

Previous write at 0x00c0003cc018 by goroutine 8:
  github.com/moby/moby/client.newCancelReadCloser()
      /go/src/github.com/docker/docker/client/utils.go:139 +0x1d8
  github.com/moby/moby/client.TestNewCancelReadCloserRace()
      /go/src/github.com/docker/docker/client/utils_test.go:67 +0x40
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x3c

Goroutine 74 (running) created at:
  context.(*afterFuncCtx).cancel.func1()
      /usr/local/go/src/context/context.go:358 +0x40
  sync.(*Once).doSlow()
      /usr/local/go/src/sync/once.go:78 +0x94
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:69 +0x40
  context.(*afterFuncCtx).cancel()
      /usr/local/go/src/context/context.go:357 +0xb8
  context.(*cancelCtx).propagateCancel()
      /usr/local/go/src/context/context.go:486 +0x1d8
  context.AfterFunc()
      /usr/local/go/src/context/context.go:329 +0xcc
  github.com/moby/moby/client.newCancelReadCloser()
      /go/src/github.com/docker/docker/client/utils.go:139 +0x1c8
  github.com/moby/moby/client.TestNewCancelReadCloserRace()
      /go/src/github.com/docker/docker/client/utils_test.go:67 +0x40
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x3c

Goroutine 8 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1997 +0x6e0
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2477 +0x74
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x164
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2475 +0x734
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2337 +0xaf4
  main.main()
      _testmain.go:651 +0x100
==================
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x69c11c]

goroutine 246 [running]:
github.com/moby/moby/client.(*cancelReadCloser).Close(0xc00070ab80)
	/go/src/github.com/docker/docker/client/utils.go:152 +0x3c
github.com/moby/moby/client.newCancelReadCloser.func1()
	/go/src/github.com/docker/docker/client/utils.go:139 +0x30
created by context.(*afterFuncCtx).cancel.func1 in goroutine 7
	/usr/local/go/src/context/context.go:358 +0x44
exit status 2
FAIL	github.com/moby/moby/client	0.035s
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

