### PR TITLE
daemon/pkg/opts: fix ValidateIPAddress docstring

### DIFF
--- a/daemon/pkg/opts/opts.go
+++ b/daemon/pkg/opts/opts.go
@@ -296,11 +296,8 @@ type ValidatorFctType func(val string) (string, error)
 type ValidatorFctListType func(val string) ([]string, error)
 
 // ValidateIPAddress validates if the given value is a correctly formatted
-// IP address, and returns the value in normalized form. Leading and trailing
-// whitespace is allowed, but it does not allow IPv6 addresses surrounded by
-// square brackets ("[::1]").
-//
-// Refer to [net.ParseIP] for accepted formats.
+// IP address, and returns the value in normalized form.
+// Leading and trailing whitespace is not allowed.
 func ValidateIPAddress(val string) (string, error) {
 	ip, err := netip.ParseAddr(val)
 	if err != nil {


### PR DESCRIPTION
Update the docstring to accurately reflect the behavior of netip.ParseAddr, which does not allow leading/trailing whitespace and does not support IPv6 addresses in square brackets.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

