### PR TITLE
fix: use t.Cleanup to prevent goroutine leak in TestCancelledUpload

### DIFF
--- a/daemon/internal/distribution/xfer/upload_test.go
+++ b/daemon/internal/distribution/xfer/upload_test.go
@@ -116,6 +116,11 @@ func TestCancelledUpload(t *testing.T) {
 		close(progressDone)
 	}()
 
+	t.Cleanup(func() {
+		close(progressChan)
+		<-progressDone
+	})
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
@@ -128,7 +133,4 @@ func TestCancelledUpload(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal("expected upload to be cancelled")
 	}
-
-	close(progressChan)
-	<-progressDone
 }


### PR DESCRIPTION
## Description

Fix goroutine leak in TestCancelledUpload. When the error check fails and t.Fatal runs, close(progressChan) never executes, leaving the goroutine blocked on `for range progressChan` forever.

## Changes

Move `close(progressChan)` and the wait on `progressDone` into `t.Cleanup` so they always run regardless of how the test exits.

## Testing

`go test ./daemon/internal/distribution/xfer/ -count=1` passes.

Fixes #52271