### PR TITLE
api/types/network: fix handling of unmapped ports (ephemeral ports)

### DIFF
--- a/api/types/network/port.go
+++ b/api/types/network/port.go
@@ -328,9 +328,11 @@ func (pr PortRange) Range() PortRange {
 //	}
 func (pr PortRange) All() iter.Seq[Port] {
 	return func(yield func(Port) bool) {
-		if pr.proto == protoZero {
-			return
-		}
+		// Do not skip zero values here, because a zero-value means
+		// "map the port to an ephemeral host port".
+		//
+		// For example, "--port 80" is shorthand for "--port 0:80"
+		// ("--port <ephemeral port>:80").
 		for i := uint32(pr.Start()); i <= uint32(pr.End()); i++ {
 			if !yield(Port{num: uint16(i), proto: pr.proto}) {
 				return

--- a/api/types/network/port_test.go
+++ b/api/types/network/port_test.go
@@ -278,7 +278,8 @@ func TestPortRange(t *testing.T) {
 		assert.Equal(t, pr.End(), uint16(0))
 		assert.Equal(t, pr.Proto(), network.IPProtocol(""))
 		assert.Equal(t, pr.Range(), pr)
-		assert.Check(t, slices.Equal(slices.Collect(pr.All()), []network.Port{}))
+		var ephemeralPort network.Port
+		assert.Check(t, slices.Equal(slices.Collect(pr.All()), []network.Port{ephemeralPort}))
 
 		t.Run("Marshal Unmarshal", func(t *testing.T) {
 			var pr network.PortRange

--- a/vendor/github.com/moby/moby/api/types/network/port.go
+++ b/vendor/github.com/moby/moby/api/types/network/port.go
@@ -328,9 +328,11 @@ func (pr PortRange) Range() PortRange {
 //	}
 func (pr PortRange) All() iter.Seq[Port] {
 	return func(yield func(Port) bool) {
-		if pr.proto == protoZero {
-			return
-		}
+		// Do not skip zero values here, because a zero-value means
+		// "map the port to an ephemeral host port".
+		//
+		// For example, "--port 80" is shorthand for "--port 0:80"
+		// ("--port <ephemeral port>:80").
 		for i := uint32(pr.Start()); i <= uint32(pr.End()); i++ {
 			if !yield(Port{num: uint16(i), proto: pr.proto}) {
 				return


### PR DESCRIPTION
- relates to / introduced in https://github.com/moby/moby/pull/52165
- relates to https://github.com/docker/cli/pull/6893#issuecomment-4170435817


commit 4c24542e95980cb3e81570ef5f43ed46d4ffa6ce changed `PortRange.All()` to omit zero values for ports, but this caused a regression; the zero-value is used in some places to assign an ephemeral port, e.g.: `--port 80` is an implicit `--port 0:80`, or `--port <ephemeral port>:80`, where the daemon picks a random port number from the ephemeral port range as host-port.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

