### PR TITLE
libnetwork: always delete endpoint driver info on sbLeave error

### DIFF
--- a/daemon/libnetwork/endpoint.go
+++ b/daemon/libnetwork/endpoint.go
@@ -841,17 +841,23 @@ func (ep *Endpoint) sbLeave(ctx context.Context, sb *Sandbox, n *Network, force 
 		}
 	}
 
+	var errs []error
+
 	// Update the store about the sandbox detach only after we
 	// have completed sb.clearNetworkResources above to avoid
 	// spurious logs when cleaning up the sandbox when the daemon
 	// ungracefully exits and restarts before completing sandbox
 	// detach but after store has been updated.
 	if err := n.getController().storeEndpoint(ctx, ep); err != nil {
-		return err
+		errs = append(errs, fmt.Errorf("failed to store endpoint: %w", err))
+		// Do not return early and continue with deleting driver info from the
+		// cluster (NetworkDB) so that remote nodes learn about the endpoint
+		// deletion and don't accumulate stale PERMANENT ARP/FDB entries in
+		// overlay network namespaces.
 	}
 
-	if e := ep.deleteDriverInfoFromCluster(); e != nil {
-		log.G(ctx).WithError(e).Error("Failed to delete endpoint state for endpoint from cluster")
+	if err := ep.deleteDriverInfoFromCluster(); err != nil {
+		log.G(ctx).WithError(err).Error("Failed to delete endpoint state for endpoint from cluster")
 	}
 
 	// When a container is connected to a network, it gets /etc/hosts
@@ -871,7 +877,9 @@ func (ep *Endpoint) sbLeave(ctx context.Context, sb *Sandbox, n *Network, force 
 	sb.deleteHostsEntries(etcHostsAddrs)
 
 	if !sbInDelete && sb.needDefaultGW() && sb.getEndpointInGWNetwork() == nil {
-		return sb.setupDefaultGW()
+		if err := sb.setupDefaultGW(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to set default gateway: %w", err))
+		}
 	}
 
 	// Disable upstream forwarding if the sandbox lost external connectivity.
@@ -902,7 +910,7 @@ func (ep *Endpoint) sbLeave(ctx context.Context, sb *Sandbox, n *Network, force 
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // Delete deletes and detaches this endpoint from the network.


### PR DESCRIPTION
- fix: https://github.com/moby/moby/issues/52265

In Swarm overlay networks, remote nodes program VXLAN FDB and neighbor entries from the overlay driver’s NetworkDB table (overlay_peer_table). Those entries are installed as static/permanent neighbors (and corresponding bridge FDB entries) and are removed only when the endpoint’s driver table entries are deleted from NetworkDB and the delete event is gossiped to peers.

Endpoint.sbLeave() updates the local endpoint object in the store via storeEndpoint(). If that store update fails (notably datastore.ErrKeyModified from a boltDB CAS conflict during concurrent endpoint operations), sbLeave() returned early and never called deleteDriverInfoFromCluster(). As a result, the endpoint’s overlay_peer_table record was left behind in NetworkDB, no DELETE gossip event was emitted, and remote nodes never executed the corresponding peer delete handler. This causes stale/permanent ARP/FDB entries to accumulate in overlay network namespaces, eventually blackholing TCP traffic and producing intermittent 502/504 until the service is redeployed.

By deleting the endpoint’s driver info from NetworkDB even when the store update fails, we ensure the DELETE event is always propagated to remote nodes, allowing them to remove the programmed neighbor/FDB state and preventing stale overlay ARP entries from persisting.

**Note**: This was heavily assisted by GPT-5.2