### PR TITLE
client/internal/mod: swap order of "ok" bool

### DIFF
--- a/client/internal/mod/mod.go
+++ b/client/internal/mod/mod.go
@@ -49,13 +49,13 @@ func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
 	}
 
 	// Check if we're the main module.
-	if ok, v := getVersion(name, &bi.Main); ok {
+	if v, ok := getVersion(name, &bi.Main); ok {
 		return v
 	}
 
 	// iterate over all dependencies and find name
 	for _, dep := range bi.Deps {
-		if ok, v := getVersion(name, dep); ok {
+		if v, ok := getVersion(name, dep); ok {
 			return v
 		}
 	}
@@ -63,9 +63,9 @@ func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
 	return ""
 }
 
-func getVersion(name string, dep *debug.Module) (bool, string) {
+func getVersion(name string, dep *debug.Module) (string, bool) {
 	if dep == nil || dep.Path != name {
-		return false, ""
+		return "", false
 	}
 
 	v := dep.Version
@@ -73,10 +73,10 @@ func getVersion(name string, dep *debug.Module) (bool, string) {
 		v = dep.Replace.Version
 	}
 	if v == "" || v == "(devel)" {
-		return true, ""
+		return "", true
 	}
 
-	return true, normalize(v)
+	return normalize(v), true
 }
 
 // normalize converts a Go module version into a display-friendly form:

--- a/vendor/github.com/moby/moby/client/internal/mod/mod.go
+++ b/vendor/github.com/moby/moby/client/internal/mod/mod.go
@@ -49,13 +49,13 @@ func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
 	}
 
 	// Check if we're the main module.
-	if ok, v := getVersion(name, &bi.Main); ok {
+	if v, ok := getVersion(name, &bi.Main); ok {
 		return v
 	}
 
 	// iterate over all dependencies and find name
 	for _, dep := range bi.Deps {
-		if ok, v := getVersion(name, dep); ok {
+		if v, ok := getVersion(name, dep); ok {
 			return v
 		}
 	}
@@ -63,9 +63,9 @@ func moduleVersion(name string, bi *debug.BuildInfo) (modVersion string) {
 	return ""
 }
 
-func getVersion(name string, dep *debug.Module) (bool, string) {
+func getVersion(name string, dep *debug.Module) (string, bool) {
 	if dep == nil || dep.Path != name {
-		return false, ""
+		return "", false
 	}
 
 	v := dep.Version
@@ -73,10 +73,10 @@ func getVersion(name string, dep *debug.Module) (bool, string) {
 		v = dep.Replace.Version
 	}
 	if v == "" || v == "(devel)" {
-		return true, ""
+		return "", true
 	}
 
-	return true, normalize(v)
+	return normalize(v), true
 }
 
 // normalize converts a Go module version into a display-friendly form:


### PR DESCRIPTION
Not sure why I used this order; let's change to a more logical one.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

