### PR TITLE
client/internal: fix Streams.Wait error handling, fix RSFilterReader error handling 

### DIFF
--- a/client/internal/json-stream.go
+++ b/client/internal/json-stream.go
@@ -12,8 +12,9 @@ const rs = 0x1E
 
 type DecoderFn func(v any) error
 
-// NewJSONStreamDecoder builds adequate DecoderFn to read json records formatted with specified content-type
-func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
+// NewJSONStreamDecoder builds a DecoderFn to read a stream of JSON records
+// formatted with the specified content-type.
+func NewJSONStreamDecoder(r io.Reader, contentType types.MediaType) DecoderFn {
 	switch contentType {
 	case types.MediaTypeJSONSequence:
 		return json.NewDecoder(NewRSFilterReader(r)).Decode

--- a/client/internal/json-stream.go
+++ b/client/internal/json-stream.go
@@ -24,22 +24,16 @@ func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
 	}
 }
 
-// RSFilterReader wraps an io.Reader and filters out ASCII RS characters
-type RSFilterReader struct {
+type rsFilterReader struct {
 	reader io.Reader
-	buffer []byte
 }
 
-// NewRSFilterReader creates a new RSFilterReader that filters out RS characters
-func NewRSFilterReader(r io.Reader) *RSFilterReader {
-	return &RSFilterReader{
-		reader: r,
-		buffer: make([]byte, 4096), // Internal buffer for reading chunks
-	}
+// NewRSFilterReader creates an [io.Reader] that filters out ASCII Record Separators (RS).
+func NewRSFilterReader(r io.Reader) io.Reader {
+	return &rsFilterReader{reader: r}
 }
 
-// Read implements the io.Reader interface, filtering out RS characters
-func (r *RSFilterReader) Read(p []byte) (n int, err error) {
+func (r *rsFilterReader) Read(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}

--- a/client/internal/json-stream.go
+++ b/client/internal/json-stream.go
@@ -33,12 +33,29 @@ func NewRSFilterReader(r io.Reader) io.Reader {
 	return &rsFilterReader{reader: r}
 }
 
-func (r *rsFilterReader) Read(p []byte) (n int, err error) {
+func (r *rsFilterReader) Read(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
 
-	n, err = r.reader.Read(p)
-	filtered := slices.DeleteFunc(p[:n], func(b byte) bool { return b == rs })
-	return len(filtered), err
+	for {
+		n, err := r.reader.Read(p)
+		if n == 0 {
+			return 0, err
+		}
+
+		filtered := slices.DeleteFunc(p[:n], func(b byte) bool { return b == rs })
+		n = len(filtered)
+		if err != nil {
+			if err == io.EOF && n > 0 {
+				return n, nil
+			}
+			return n, err
+		}
+		if n == 0 {
+			// Avoid returning (0, nil) after consuming input; keep reading until data or an error (e.g., EOF).
+			continue
+		}
+		return n, nil
+	}
 }

--- a/client/internal/json-stream_test.go
+++ b/client/internal/json-stream_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -9,9 +10,9 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func Test_JsonSeqDecoder(t *testing.T) {
-	separator := string(rune(rs))
-	lf := "\n"
+func TestJSONStreamDecode_JSONSequence(t *testing.T) {
+	const separator = string(rune(rs))
+	const lf = "\n"
 	input := fmt.Sprintf(`%s{"hello":"world"}%s%s{ "hello": "again" }%s`, separator, lf, separator, lf)
 	decoder := NewJSONStreamDecoder(strings.NewReader(input), types.MediaTypeJSONSequence)
 	type Hello struct {
@@ -26,4 +27,48 @@ func Test_JsonSeqDecoder(t *testing.T) {
 	err = decoder(&again)
 	assert.NilError(t, err)
 	assert.Equal(t, "again", again.Hello)
+}
+
+// TestRSFilterReader_SkipsRSOnlyRead verifies that RSFilterReader does not
+// return (0, nil) when the underlying reader produces only RS bytes in a read.
+// It must continue reading until it can return actual data or an error.
+func TestRSFilterReader_SkipsRSOnlyRead(t *testing.T) {
+	r := NewRSFilterReader(&chunkedReader{
+		reads: [][]byte{
+			{rs},
+			[]byte(`{"hello":"world"}`),
+		},
+	})
+
+	buf := make([]byte, 64)
+	n, err := r.Read(buf)
+	assert.NilError(t, err)
+	assert.Equal(t, `{"hello":"world"}`, string(buf[:n]))
+}
+
+// TestRSFilterReader_SkipsRSBeforeEOF verifies that RSFilterReader correctly
+// skips RS-only input and propagates io.EOF when no non-RS data is available.
+func TestRSFilterReader_SkipsRSBeforeEOF(t *testing.T) {
+	r := NewRSFilterReader(&chunkedReader{
+		reads: [][]byte{{rs}},
+	})
+
+	buf := make([]byte, 64)
+	n, err := r.Read(buf)
+	assert.Assert(t, err == io.EOF)
+	assert.Equal(t, 0, n)
+}
+
+type chunkedReader struct {
+	reads [][]byte
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if len(r.reads) == 0 {
+		return 0, io.EOF
+	}
+
+	n := copy(p, r.reads[0])
+	r.reads = r.reads[1:]
+	return n, nil
 }

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -75,9 +75,14 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 
 // Wait waits for operation to complete and detects errors reported as JSONMessage
 func (r Stream) Wait(ctx context.Context) error {
-	for _, err := range r.JSONMessages(ctx) {
+	for jm, err := range r.JSONMessages(ctx) {
 		if err != nil {
+			// decode, transport and context cancellation errors.
 			return err
+		}
+		if jm.Error != nil {
+			// push/pull failures.
+			return jm.Error
 		}
 	}
 	return nil

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -46,8 +46,9 @@ func (r Stream) Close() error {
 
 var _ io.ReadCloser = Stream{}
 
-// JSONMessages decodes the response stream as a sequence of JSONMessages.
-// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
+// JSONMessages decodes the response stream as a sequence of [jsonstream.Message].
+// The underlying [io.Reader] is closed when the stream ends or if the context
+// is cancelled.
 func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error] {
 	stop := context.AfterFunc(ctx, func() {
 		_ = r.Close()
@@ -82,7 +83,11 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 	}
 }
 
-// Wait waits for operation to complete and detects errors reported as JSONMessage
+// Wait consumes the stream until completion.
+//
+// It returns nil if the operation completes successfully. Errors are
+// returned if the context is canceled, a decoding/transport failure
+// occurs, or a JSON message reports an error ([jsonstream.Message.Error]).
 func (r Stream) Wait(ctx context.Context) error {
 	for jm, err := range r.JSONMessages(ctx) {
 		if err != nil {

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -8,6 +8,8 @@ import (
 	"iter"
 	"sync"
 
+	"github.com/containerd/errdefs/pkg/errhttp"
+
 	"github.com/moby/moby/api/types/jsonstream"
 )
 
@@ -82,8 +84,40 @@ func (r Stream) Wait(ctx context.Context) error {
 		}
 		if jm.Error != nil {
 			// push/pull failures.
-			return jm.Error
+			return httpErrorFromStatusCode(jm.Error, jm.Error.Code)
 		}
 	}
 	return nil
+}
+
+type httpError struct {
+	err    error
+	errdef error
+}
+
+func (e *httpError) Error() string {
+	return e.err.Error()
+}
+
+func (e *httpError) Unwrap() error {
+	return e.err
+}
+
+func (e *httpError) Is(target error) bool {
+	return errors.Is(e.errdef, target)
+}
+
+// httpErrorFromStatusCode creates an errdef error, based on the provided HTTP status-code
+//
+// TODO(thaJeztah): unify with the implementation in client and move to an internal package
+// see https://github.com/moby/moby/blob/client/v0.4.0/client/errors.go#L76-L114
+func httpErrorFromStatusCode(err error, statusCode int) error {
+	if err == nil {
+		return nil
+	}
+
+	return &httpError{
+		err:    err,
+		errdef: errhttp.ToNative(statusCode),
+	}
 }

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -61,15 +61,21 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 		dec := json.NewDecoder(r)
 		for {
 			var jm jsonstream.Message
-			err := dec.Decode(&jm)
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if ctx.Err() != nil {
-				yield(jm, ctx.Err())
+			if err := dec.Decode(&jm); err != nil {
+				if errors.Is(err, io.EOF) {
+					return
+				}
+				if err := ctx.Err(); err != nil {
+					// Do not return decoding errors if the context was
+					// cancelled, because the decoding errors may be due
+					// to the context being cancelled.
+					yield(jsonstream.Message{}, err)
+					return
+				}
+				yield(jsonstream.Message{}, err)
 				return
 			}
-			if !yield(jm, err) {
+			if !yield(jm, nil) {
 				return
 			}
 		}

--- a/client/internal/jsonmessages.go
+++ b/client/internal/jsonmessages.go
@@ -52,12 +52,13 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 	stop := context.AfterFunc(ctx, func() {
 		_ = r.Close()
 	})
-	dec := json.NewDecoder(r)
 	return func(yield func(jsonstream.Message, error) bool) {
 		defer func() {
 			stop() // unregister AfterFunc
-			r.Close()
+			_ = r.Close()
 		}()
+
+		dec := json.NewDecoder(r)
 		for {
 			var jm jsonstream.Message
 			err := dec.Decode(&jm)

--- a/client/internal/jsonmessages_test.go
+++ b/client/internal/jsonmessages_test.go
@@ -1,0 +1,82 @@
+package internal_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/moby/moby/client/internal"
+)
+
+func TestStreamWait(t *testing.T) {
+	tests := []struct {
+		doc      string
+		input    string
+		expError string
+	}{
+		{
+			doc:   "success",
+			input: `{"status":"ok"}`,
+		},
+		{
+			doc:      "internal server error",
+			input:    `{"errorDetail": {"code": 500, "message": "something went wrong"}}`,
+			expError: "something went wrong",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			r := io.NopCloser(strings.NewReader(tc.input))
+			s := internal.NewJSONMessageStream(r)
+
+			err := s.Wait(t.Context())
+			if tc.expError == "" {
+				assert.NilError(t, err)
+				return
+			}
+			assert.Check(t, is.ErrorContains(err, tc.expError))
+		})
+	}
+}
+
+func TestStreamWait_ContextCanceled(t *testing.T) {
+	rc := newBlockingReadCloser()
+	s := internal.NewJSONMessageStream(rc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Wait(ctx)
+	}()
+	cancel()
+
+	err := <-done
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+type blockingReadCloser struct {
+	done chan struct{}
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{done: make(chan struct{})}
+}
+
+func (r *blockingReadCloser) Read([]byte) (int, error) {
+	<-r.done
+	return 0, io.ErrClosedPipe
+}
+
+func (r *blockingReadCloser) Close() error {
+	select {
+	case <-r.done:
+	default:
+		close(r.done)
+	}
+	return nil
+}

--- a/client/internal/jsonmessages_test.go
+++ b/client/internal/jsonmessages_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -17,6 +18,7 @@ func TestStreamWait(t *testing.T) {
 		doc      string
 		input    string
 		expError string
+		expType  func(error) bool
 	}{
 		{
 			doc:   "success",
@@ -26,6 +28,13 @@ func TestStreamWait(t *testing.T) {
 			doc:      "internal server error",
 			input:    `{"errorDetail": {"code": 500, "message": "something went wrong"}}`,
 			expError: "something went wrong",
+			expType:  cerrdefs.IsInternal,
+		},
+		{
+			doc:      "access error",
+			input:    `{"errorDetail": {"code": 403, "message": "access denied"}}`,
+			expError: "access denied",
+			expType:  cerrdefs.IsPermissionDenied,
 		},
 	}
 
@@ -40,6 +49,7 @@ func TestStreamWait(t *testing.T) {
 				return
 			}
 			assert.Check(t, is.ErrorContains(err, tc.expError))
+			assert.Check(t, is.ErrorType(err, tc.expType))
 		})
 	}
 }

--- a/vendor/github.com/moby/moby/client/internal/json-stream.go
+++ b/vendor/github.com/moby/moby/client/internal/json-stream.go
@@ -12,8 +12,9 @@ const rs = 0x1E
 
 type DecoderFn func(v any) error
 
-// NewJSONStreamDecoder builds adequate DecoderFn to read json records formatted with specified content-type
-func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
+// NewJSONStreamDecoder builds a DecoderFn to read a stream of JSON records
+// formatted with the specified content-type.
+func NewJSONStreamDecoder(r io.Reader, contentType types.MediaType) DecoderFn {
 	switch contentType {
 	case types.MediaTypeJSONSequence:
 		return json.NewDecoder(NewRSFilterReader(r)).Decode

--- a/vendor/github.com/moby/moby/client/internal/json-stream.go
+++ b/vendor/github.com/moby/moby/client/internal/json-stream.go
@@ -24,22 +24,16 @@ func NewJSONStreamDecoder(r io.Reader, contentType string) DecoderFn {
 	}
 }
 
-// RSFilterReader wraps an io.Reader and filters out ASCII RS characters
-type RSFilterReader struct {
+type rsFilterReader struct {
 	reader io.Reader
-	buffer []byte
 }
 
-// NewRSFilterReader creates a new RSFilterReader that filters out RS characters
-func NewRSFilterReader(r io.Reader) *RSFilterReader {
-	return &RSFilterReader{
-		reader: r,
-		buffer: make([]byte, 4096), // Internal buffer for reading chunks
-	}
+// NewRSFilterReader creates an [io.Reader] that filters out ASCII Record Separators (RS).
+func NewRSFilterReader(r io.Reader) io.Reader {
+	return &rsFilterReader{reader: r}
 }
 
-// Read implements the io.Reader interface, filtering out RS characters
-func (r *RSFilterReader) Read(p []byte) (n int, err error) {
+func (r *rsFilterReader) Read(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}

--- a/vendor/github.com/moby/moby/client/internal/json-stream.go
+++ b/vendor/github.com/moby/moby/client/internal/json-stream.go
@@ -33,12 +33,29 @@ func NewRSFilterReader(r io.Reader) io.Reader {
 	return &rsFilterReader{reader: r}
 }
 
-func (r *rsFilterReader) Read(p []byte) (n int, err error) {
+func (r *rsFilterReader) Read(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
 
-	n, err = r.reader.Read(p)
-	filtered := slices.DeleteFunc(p[:n], func(b byte) bool { return b == rs })
-	return len(filtered), err
+	for {
+		n, err := r.reader.Read(p)
+		if n == 0 {
+			return 0, err
+		}
+
+		filtered := slices.DeleteFunc(p[:n], func(b byte) bool { return b == rs })
+		n = len(filtered)
+		if err != nil {
+			if err == io.EOF && n > 0 {
+				return n, nil
+			}
+			return n, err
+		}
+		if n == 0 {
+			// Avoid returning (0, nil) after consuming input; keep reading until data or an error (e.g., EOF).
+			continue
+		}
+		return n, nil
+	}
 }

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -75,9 +75,14 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 
 // Wait waits for operation to complete and detects errors reported as JSONMessage
 func (r Stream) Wait(ctx context.Context) error {
-	for _, err := range r.JSONMessages(ctx) {
+	for jm, err := range r.JSONMessages(ctx) {
 		if err != nil {
+			// decode, transport and context cancellation errors.
 			return err
+		}
+		if jm.Error != nil {
+			// push/pull failures.
+			return jm.Error
 		}
 	}
 	return nil

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -46,8 +46,9 @@ func (r Stream) Close() error {
 
 var _ io.ReadCloser = Stream{}
 
-// JSONMessages decodes the response stream as a sequence of JSONMessages.
-// if stream ends or context is cancelled, the underlying [io.Reader] is closed.
+// JSONMessages decodes the response stream as a sequence of [jsonstream.Message].
+// The underlying [io.Reader] is closed when the stream ends or if the context
+// is cancelled.
 func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, error] {
 	stop := context.AfterFunc(ctx, func() {
 		_ = r.Close()
@@ -82,7 +83,11 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 	}
 }
 
-// Wait waits for operation to complete and detects errors reported as JSONMessage
+// Wait consumes the stream until completion.
+//
+// It returns nil if the operation completes successfully. Errors are
+// returned if the context is canceled, a decoding/transport failure
+// occurs, or a JSON message reports an error ([jsonstream.Message.Error]).
 func (r Stream) Wait(ctx context.Context) error {
 	for jm, err := range r.JSONMessages(ctx) {
 		if err != nil {

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -8,6 +8,8 @@ import (
 	"iter"
 	"sync"
 
+	"github.com/containerd/errdefs/pkg/errhttp"
+
 	"github.com/moby/moby/api/types/jsonstream"
 )
 
@@ -82,8 +84,40 @@ func (r Stream) Wait(ctx context.Context) error {
 		}
 		if jm.Error != nil {
 			// push/pull failures.
-			return jm.Error
+			return httpErrorFromStatusCode(jm.Error, jm.Error.Code)
 		}
 	}
 	return nil
+}
+
+type httpError struct {
+	err    error
+	errdef error
+}
+
+func (e *httpError) Error() string {
+	return e.err.Error()
+}
+
+func (e *httpError) Unwrap() error {
+	return e.err
+}
+
+func (e *httpError) Is(target error) bool {
+	return errors.Is(e.errdef, target)
+}
+
+// httpErrorFromStatusCode creates an errdef error, based on the provided HTTP status-code
+//
+// TODO(thaJeztah): unify with the implementation in client and move to an internal package
+// see https://github.com/moby/moby/blob/client/v0.4.0/client/errors.go#L76-L114
+func httpErrorFromStatusCode(err error, statusCode int) error {
+	if err == nil {
+		return nil
+	}
+
+	return &httpError{
+		err:    err,
+		errdef: errhttp.ToNative(statusCode),
+	}
 }

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -61,15 +61,21 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 		dec := json.NewDecoder(r)
 		for {
 			var jm jsonstream.Message
-			err := dec.Decode(&jm)
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if ctx.Err() != nil {
-				yield(jm, ctx.Err())
+			if err := dec.Decode(&jm); err != nil {
+				if errors.Is(err, io.EOF) {
+					return
+				}
+				if err := ctx.Err(); err != nil {
+					// Do not return decoding errors if the context was
+					// cancelled, because the decoding errors may be due
+					// to the context being cancelled.
+					yield(jsonstream.Message{}, err)
+					return
+				}
+				yield(jsonstream.Message{}, err)
 				return
 			}
-			if !yield(jm, err) {
+			if !yield(jm, nil) {
 				return
 			}
 		}

--- a/vendor/github.com/moby/moby/client/internal/jsonmessages.go
+++ b/vendor/github.com/moby/moby/client/internal/jsonmessages.go
@@ -52,12 +52,13 @@ func (r Stream) JSONMessages(ctx context.Context) iter.Seq2[jsonstream.Message, 
 	stop := context.AfterFunc(ctx, func() {
 		_ = r.Close()
 	})
-	dec := json.NewDecoder(r)
 	return func(yield func(jsonstream.Message, error) bool) {
 		defer func() {
 			stop() // unregister AfterFunc
-			r.Close()
+			_ = r.Close()
 		}()
+
+		dec := json.NewDecoder(r)
 		for {
 			var jm jsonstream.Message
 			err := dec.Decode(&jm)


### PR DESCRIPTION
relates to:

- https://github.com/docker/buildx/pull/3777#discussion_r3032694878
- https://github.com/docker/buildx/pull/2988
- https://github.com/moby/moby/issues/49453
- https://github.com/moby/moby/pull/50953#discussion_r2399903667

### go.mod: add back replace rules

### client/internal: Stream.Wait: fix missing error-handling

The intent of the Wait method is to allow consumers to handle a stream
synchronously; block until the push/pull/build completes (or is cancelled)
but report errors happening during the stream (e.g. failures to pull the
image).

Wait previously ignored errors reported via jsonstream.Message.Error,
causing push/pull failures to be treated as success. Update it to return
these in-band errors while preserving existing handling for decode,
transport, and context cancellation errors.


### client/internal: Stream.Wait: return errdefs errors


### client/internal: Stream.JSONMessages: move reader inside the func

Just slightly cleaner on scope.


### client/internal: Stream.JSONMessages: improve error handling

- explicitly return zero-values on error to prevent any potential "garbage"
  decoded message from being returned.
- do not return decoding errors if the context was cancelled; decoding may
  fail due to the context being cancelled (and reader closed), which could
  produce unexpected errors.
- consolidate all error-handling within a single `err != nil` block.


### client/internal: RSFilterReader: un-export, and remove unused buffer

This buffer was added as part of the initial implementation, but during
review it was decided it's not needed; https://github.com/moby/moby/pull/50953#discussion_r2399903667

Remove the buffer as it's not used, and un-export the RSFilterReader
implementation.

### client/internal: improve test-coverage for rsFilterReader

### client/internal: fix RSFilterReader returning (0, nil) after filtering

RSFilterReader could consume input consisting only of RS bytes and return
(0, nil), violating io.Reader expectations. This can cause callers to loop
indefinitely waiting for progress.

For example, a caller like:

    for {
        n, err := r.Read(buf)
        if err != nil {
            return err
        }
        if n == 0 {
            continue
        }
        process(buf[:n])
    }

would loop forever if Read returns (0, nil) after consuming input.

Fix by continuing to read until either filtered data is available or an
error (including EOF) is returned.


### client/internal: touch-up godoc

Also change NewJSONStreamDecoder to use use types.MediaType as argument. The
MediaType type-alias that was added in 0e7c8176e87e5d61aa6b9ba64f5f11d83a91040d
to help discoverability of accepted media/content-types.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
client: fix `ImagePullResponse.Wait`, `ImagePushResponse.Wait` not returning an error if pull/push errors happend during the pull operation.
```

**- A picture of a cute animal (not mandatory but encouraged)**

