### PR TITLE
Dockerfile: update runc binary to v1.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -248,7 +248,7 @@ WORKDIR /usr/src/runc
 # This version should usually match the version that is used by the containerd version
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged.
-ARG RUNC_VERSION=v1.4.3
+ARG RUNC_VERSION=v1.5.1
 ADD https://github.com/opencontainers/runc.git?ref=${RUNC_VERSION}&keep-git-dir=1 .
 
 FROM base AS runc-build
@@ -275,7 +275,7 @@ RUN --mount=from=runc-src,src=/usr/src/runc,rw \
   fi
 
   set -x
-  CGO_ENABLED=1 make "$target"
+  CGO_ENABLED=1 make RUNC_BUILDTAGS="-libpathrs" "$target"
   xx-verify $verify_flags runc
   mkdir /build
   mv runc /build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -248,7 +248,7 @@ WORKDIR /usr/src/runc
 # This version should usually match the version that is used by the containerd version
 # that is used. If you need to update runc, open a pull request in the containerd
 # project first, and update both after that is merged.
-ARG RUNC_VERSION=v1.4.3
+ARG RUNC_VERSION=v1.5.1
 ADD https://github.com/opencontainers/runc.git?ref=${RUNC_VERSION}&keep-git-dir=1 .
 
 FROM base AS runc-build
@@ -276,7 +276,7 @@ RUN --mount=from=runc-src,src=/usr/src/runc,rw \
   fi
 
   set -x
-  CGO_ENABLED=1 make "$target"
+  CGO_ENABLED=1 make RUNC_BUILDTAGS="-libpathrs" "$target"
   xx-verify $verify_flags runc
   mkdir /build
   mv runc /build/


### PR DESCRIPTION
- [x] stacked on https://github.com/moby/moby/pull/50960


### release v1.5.1

- There was a regression reported in with the maskPaths optimisation added in
  1.5.0-rc.3. On Ubuntu Focal (20.04), attempts to mount tmpfs with
  the nr_inodes=1 option will fail due to a downstream kernel patch
  (ironically originating from AUFS). We now have a fallback path using
  nr_inodes=2 instead if the operation fails.
- Properly handle EINVAL for seccomp SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
  when trying to rewrite the filter. This appears to only happen if you compile
  runc with libseccomp >= 2.6.0 and then run it with an < 2.6.0 libseccomp.

### release v1.5.0

New:

- User-namespaced containers can now configure `user.*` sysctls.
- Intel RDT: the RDT subdirectory is now only removed if runc created it, matching the updated runtime-spec guidance.

Added

- `runc version` and `runc features` now provide version information about
  libpathrs (when runc is built with the `libpathrs` build tag).

Fixed

- Since runc 1.3.0, the org.opencontainers.runc.version annotation included
  in runc features contained an extraneous `\n`, possibly causing issues with
  tools that parse the output. It is now properly stripped.

Changed

- runc (when built with the `libpathrs` build tag) now depends on libpathrs
  v0.2.5 or later, and attempting to build with older versions will cause
  compilation errors.
- Switched to go-criu v8.3.0, which reduces our binary size from ~16MB to ~14MB.


release notes: https://github.com/opencontainers/runc/releases/tag/v1.5.1
full diff: https://github.com/opencontainers/runc/compare/v1.4.3...v1.5.1

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update runc (in static binaries) to [v1.5.1](https://github.com/opencontainers/runc/releases/tag/v1.5.1)
```

**- A picture of a cute animal (not mandatory but encouraged)**

