### PR TITLE
ci: fix bin-image workflow

### DIFF
--- a/.github/workflows/bin-image.yml
+++ b/.github/workflows/bin-image.yml
@@ -32,7 +32,7 @@ jobs:
 
   build:
     if: ${{ !failure() && !cancelled() && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci/validate-only')) }}
-    uses: docker/github-builder@70313223e2665c3211b454b3fea6534624e78d64 # v1.4.0
+    uses: docker/github-builder/.github/workflows/bake.yml@70313223e2665c3211b454b3fea6534624e78d64 # v1.4.0
     needs:
       - validate-dco
     permissions:


### PR DESCRIPTION
- introduced in https://github.com/moby/moby/pull/52220

<img width="1310" height="249" alt="Screenshot 2026-04-04 at 18 15 08" src="https://github.com/user-attachments/assets/1a9dc414-bc46-4eff-a284-f39798a530e8" />


Looks like zizmor messed this one up as well in b588d1a59474dff83e2b6b78aa5211d13ef8cf41

<img width="654" height="141" alt="Screenshot 2026-04-04 at 18 24 46" src="https://github.com/user-attachments/assets/95ceecef-8e15-4d46-8697-4d762d688d04" />



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

