### PR TITLE
daemon, client: diskUsage: explicitly exclude "-1" for containers

### DIFF
--- a/client/system_disk_usage.go
+++ b/client/system_disk_usage.go
@@ -244,12 +244,15 @@ func imageDiskUsageFromLegacyAPI(du *legacyDiskUsage) ImagesDiskUsage {
 		Items:      du.Images,
 	}
 
-	for _, i := range idu.Items {
-		if i.Containers > 0 {
+	for _, img := range idu.Items {
+		switch {
+		case img.Containers < 0:
+			// No container-count information available; skip (assume it's in use).
+		case img.Containers > 0:
 			idu.ActiveCount++
-		} else if i.Size != -1 && i.SharedSize != -1 {
-			// Only count reclaimable size if we have size information
-			idu.Reclaimable += (i.Size - i.SharedSize)
+		case img.Containers == 0 && img.Size != -1 && img.SharedSize != -1:
+			reclaimable := img.Size - img.SharedSize
+			idu.Reclaimable += reclaimable
 		}
 	}
 

--- a/daemon/disk_usage.go
+++ b/daemon/disk_usage.go
@@ -78,12 +78,15 @@ func (daemon *Daemon) imageDiskUsage(ctx context.Context, verbose bool) (*backen
 			TotalSize:  totalSize,
 		}
 
-		for _, i := range images {
-			if i.Containers > 0 {
+		for _, img := range images {
+			switch {
+			case img.Containers < 0:
+				// No container-count information available; skip (assume it's in use).
+			case img.Containers > 0:
 				du.ActiveCount++
-			} else if i.Size != -1 && i.SharedSize != -1 {
-				// Only count reclaimable size if we have size information
-				du.Reclaimable += (i.Size - i.SharedSize)
+			case img.Containers == 0 && img.Size != -1 && img.SharedSize != -1:
+				reclaimable := img.Size - img.SharedSize
+				du.Reclaimable += reclaimable
 			}
 		}
 

--- a/vendor/github.com/moby/moby/client/system_disk_usage.go
+++ b/vendor/github.com/moby/moby/client/system_disk_usage.go
@@ -244,12 +244,15 @@ func imageDiskUsageFromLegacyAPI(du *legacyDiskUsage) ImagesDiskUsage {
 		Items:      du.Images,
 	}
 
-	for _, i := range idu.Items {
-		if i.Containers > 0 {
+	for _, img := range idu.Items {
+		switch {
+		case img.Containers < 0:
+			// No container-count information available; skip (assume it's in use).
+		case img.Containers > 0:
 			idu.ActiveCount++
-		} else if i.Size != -1 && i.SharedSize != -1 {
-			// Only count reclaimable size if we have size information
-			idu.Reclaimable += (i.Size - i.SharedSize)
+		case img.Containers == 0 && img.Size != -1 && img.SharedSize != -1:
+			reclaimable := img.Size - img.SharedSize
+			idu.Reclaimable += reclaimable
 		}
 	}
 


### PR DESCRIPTION
- follow-up to https://github.com/moby/moby/pull/51778#discussion_r2963227801
- relates to https://github.com/moby/moby/issues/51775


The Containers field is set to "-1" if no information was collected; in
practice this should not happen when we collect diskusage information,
but let's be explicit.

Also rename the "i" variable to prevent it from being mistaken for the
slice's index value.

Follow-up to 46dba49ec8eff07a77f70479f4b32745e67a4e5d

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

