### PR TITLE
integration/daemon: TestLiveRestore remove quote from test-name

### DIFF
--- a/integration/daemon/daemon_test.go
+++ b/integration/daemon/daemon_test.go
@@ -508,7 +508,7 @@ func testLiveRestoreAutoRemove(t *testing.T) {
 		return d, finishContainer, cID
 	}
 
-	t.Run("engine restart shouldn't kill alive containers", func(t *testing.T) {
+	t.Run("engine restart should not kill alive containers", func(t *testing.T) {
 		d, finishContainer, cID := run(t)
 
 		d.Restart(t, "--live-restore", "--iptables=false", "--ip6tables=false")


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/52300
- relates to https://github.com/moby/moby/pull/52277#discussion_r3026380616
- relates to https://github.com/moby/moby/pull/52308#issuecomment-4188541852

Names of tests are used as storage location for test-results, and using a quote in the test-name resulted in CI failing to collect the results. Commit 07a5e924ce0a1ae7f376b2932355e0a2c62c71b3 updated a grammar issue in a sub-test, introducing a quote;

```patch
-	t.Run("engine restart shouldnt kill alive containers", func(t *testing.T) {
+	t.Run("engine restart shouldn't kill alive containers", func(t *testing.T) {
```

Which caused CI to fail when collecting the files:

    find bundles -path '*/root/*overlay2' -prune -o -type f \( -name '*-report.json' -o -name '*.log' -o -name '*.out' -o -name '*.prof' -o -name '*-report.xml' \) -print | xargs sudo tar -czf /tmp/reports.tar.gz
    [...]
    xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option

We should make collecting reports less brittle, and probably consider having some extra handling for the storage locations, but let's start with changing this test name.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

