### PR TITLE
internal/testutil/daemon.New: cleanup test paths

### DIFF
--- a/internal/testutil/daemon/daemon.go
+++ b/internal/testutil/daemon/daemon.go
@@ -218,7 +218,7 @@ func New(t testing.TB, ops ...Option) *Daemon {
 		dest = os.Getenv("DEST")
 	}
 	assert.Assert(t, dest != "", "Please set the DOCKER_INTEGRATION_DAEMON_DEST or the DEST environment variable")
-	dest = filepath.Join(dest, t.Name())
+	dest = filepath.Join(dest, sanitizedTestName(t))
 
 	if os.Getenv("DOCKER_ROOTLESS") != "" {
 		if os.Getenv("DOCKER_REMAP_ROOT") != "" {
@@ -240,6 +240,53 @@ func New(t testing.TB, ops ...Option) *Daemon {
 	}
 
 	return d
+}
+
+// sanitizedTestName removes special characters (like double or single quotes)
+// from name to prevent creating filesystem paths that can cause
+// errors when parsing through scripts.
+//
+// Test-names (t.Name()) for sub-tests allow free-form names to be used,
+// for example:
+//
+//	t.Run("engine restart shouldn't kill alive containers", func(t *testing.T) {
+//
+// Which would result in the quote (') to be included in the filename,
+// which is valid, but can cause issues when processing with shell scripts;
+//
+//	find bundles -path '*/root/*overlay2' -prune -o -type f \( -name '*-report.json' -o -name '*.log' -o -name '*.out' -o -name '*.prof' -o -name '*-report.xml' \) -print | xargs sudo tar -czf /tmp/reports.tar.gz
+//	[...]
+//	xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
+//
+// sanitizedTestName replaces special characters with an underscore to prevent
+// such issues.
+func sanitizedTestName(t testing.TB) string {
+	t.Helper()
+	parts := strings.Split(t.Name(), "/")
+	for i := range parts {
+		parts[i] = sanitizePathComponent(parts[i])
+	}
+	return filepath.Join(parts...)
+}
+
+func sanitizePathComponent(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '-' || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+
+	out := strings.TrimLeft(strings.TrimSpace(b.String()), "-")
+	if out == "" {
+		return "_"
+	}
+	return out
 }
 
 // BinaryPath returns the binary and its arguments.

--- a/internal/testutil/daemon/daemon_test.go
+++ b/internal/testutil/daemon/daemon_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// regression test for https://github.com/moby/moby/issues/52300
+func TestSanitizeTestName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "shouldn't do something",
+			want: "TestSanitizeTestName/shouldn_t_do_something",
+		},
+		{
+			name: `double "quotes"`,
+			want: "TestSanitizeTestName/double__quotes_",
+		},
+		{
+			name: "contains spaces",
+			want: "TestSanitizeTestName/contains_spaces",
+		},
+		{
+			name: "contains ..dots",
+			want: "TestSanitizeTestName/contains___dots",
+		},
+		{
+			name: "..starts-with-dots",
+			want: "TestSanitizeTestName/__starts-with-dots",
+		},
+		{
+			name: ".starts-with-dot",
+			want: "TestSanitizeTestName/_starts-with-dot",
+		},
+		{
+			name: "ends-with-dot.",
+			want: "TestSanitizeTestName/ends-with-dot_",
+		},
+		{
+			name: "--starts-with-dash",
+			want: "TestSanitizeTestName/starts-with-dash",
+		},
+		{
+			name: "_starts-with-underscore",
+			want: "TestSanitizeTestName/_starts-with-underscore",
+		},
+		{
+			name: "ends-with-dash-",
+			want: "TestSanitizeTestName/ends-with-dash-",
+		},
+		{
+			name: "foo/bar",
+			want: "TestSanitizeTestName/foo/bar",
+		},
+		{
+			name: `foo/"bar"`,
+			want: "TestSanitizeTestName/foo/_bar_",
+		},
+		{
+			name: "foo/..bar",
+			want: "TestSanitizeTestName/foo/__bar",
+		},
+		{
+			name: "../foo",
+			want: "TestSanitizeTestName/__/foo",
+		},
+		{
+			name: "foo/..",
+			want: "TestSanitizeTestName/foo/__",
+		},
+		{
+			name: "'",
+			want: "TestSanitizeTestName/_",
+		},
+		{
+			name: "...",
+			want: "TestSanitizeTestName/___",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out := sanitizedTestName(t)
+			want := filepath.FromSlash(tc.want) // let's be nice to Windows.
+			if out != want {
+				t.Errorf("got %q, want %q", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
relates to:

- fixes https://github.com/moby/moby/issues/52300
- relates to https://github.com/moby/moby/pull/52310
- relates to https://github.com/moby/moby/pull/52277#discussion_r3026380616
- relates to https://github.com/moby/moby/pull/52308#issuecomment-4188541852


remove special characters (like double or single quotes) from name to prevent creating filesystem paths that can cause errors when parsing through scripts.

Test-names (t.Name()) for sub-tests allow free-form names to be used, for example:

    t.Run("engine restart shouldn't kill alive containers", func(t *testing.T) {

Which would result in the quote (') to be included in the filename, which is valid, but can cause issues when processing with shell scripts;

    find bundles -path '*/root/*overlay2' -prune -o -type f \( -name '*-report.json' -o -name '*.log' -o -name '*.out' -o -name '*.prof' -o -name '*-report.xml' \) -print | xargs sudo tar -czf /tmp/reports.tar.gz
    [...]
    xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option

This patch adds a `sanitizedTestName` utility that replaces special characters with an underscore to prevent such issues.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

