### PR TITLE
api/docs: lower deprecation heading to a h4

### DIFF
--- a/api/docs/CHANGELOG.md
+++ b/api/docs/CHANGELOG.md
@@ -275,7 +275,7 @@ keywords: "API, Docker, rcli, REST, documentation"
 * `GET /events` now supports image `create` event that is emitted when a new
   image is built regardless if it was tagged or not.
 
-### Deprecated Config fields in `GET /images/{name}/json` response
+#### Deprecated Config fields in `GET /images/{name}/json` response
 
 The `Config` field returned by this endpoint (used for "image inspect") returns
 additional fields that are not part of the image's configuration and not part of


### PR DESCRIPTION
Prevent the heading to show up in the TOC on docs.docker.com

<img width="490" height="242" alt="Screenshot 2026-04-06 at 00 53 20" src="https://github.com/user-attachments/assets/3e1b5a5c-6cbb-4e41-8a53-dba88b17cfff" />


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

