### PR TITLE
fix: cap health check start interval by remaining start period

### DIFF
--- a/daemon/health.go
+++ b/daemon/health.go
@@ -263,7 +263,8 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 	c.Unlock()
 
 	getInterval := func() time.Duration {
-		if time.Since(started) >= startPeriod {
+		sinceStart := time.Since(started)
+		if sinceStart >= startPeriod {
 			return probeInterval
 		}
 		c.Lock()
@@ -271,6 +272,13 @@ func monitor(d *Daemon, c *container.Container, stop chan struct{}, probe probe)
 		c.Unlock()
 
 		if status == containertypes.Starting {
+			// Cap the interval so we don't sleep past the end of the
+			// start period. Without this, a large StartInterval would
+			// delay the transition to the regular probe cadence.
+			remaining := startPeriod - sinceStart
+			if startInterval > remaining {
+				return remaining
+			}
 			return startInterval
 		}
 		return probeInterval


### PR DESCRIPTION
- Fixes: https://github.com/moby/moby/issues/46747

## Summary

When `HealthStartPeriod` < `HealthStartInterval`, the health monitor waited for the full start interval before the next probe even after the start period ended. This delayed the transition to the regular probe cadence.

Cap the interval returned during the start period to the remaining start-period time so the monitor wakes up when the start period ends rather than sleeping past it.

## Release notes (optional)

```markdown changelog
Fix health checks being delayed for too long when the start interval is longer than the start period.
```