### PR TITLE
Update RootlessKit (3.0.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
 # It must be a valid tag in the docker.io/tonistiigi/xx image repository.
 ARG XX_VERSION=1.9.0
 
-# VPNKIT_VERSION is the version of the vpnkit binary which is used as a fallback
-# network driver for rootless.
-ARG VPNKIT_VERSION=0.6.0
-
 # DOCKERCLI_VERSION is the version of the CLI to install in the dev-container.
 ARG DOCKERCLI_VERSION=v29.4.0
 ARG DOCKERCLI_REPOSITORY="https://github.com/docker/cli.git"
@@ -328,7 +324,7 @@ FROM tini-${TARGETOS} AS tini
 # rootlesskit
 FROM base AS rootlesskit-src
 WORKDIR /usr/src/rootlesskit
-ARG ROOTLESSKIT_VERSION=v2.3.6
+ARG ROOTLESSKIT_VERSION=v3.0.0
 ADD https://github.com/rootless-containers/rootlesskit.git?ref=${ROOTLESSKIT_VERSION}&keep-git-dir=1 .
 
 FROM base AS rootlesskit-build
@@ -388,19 +384,6 @@ RUN ./autogen.sh && \
     ./configure --bindir=/build && \
     make -j install
 
-# vpnkit
-# use dummy scratch stage to avoid build to fail for unsupported platforms
-FROM scratch AS vpnkit-windows
-FROM scratch AS vpnkit-linux-386
-FROM scratch AS vpnkit-linux-arm
-FROM scratch AS vpnkit-linux-ppc64le
-FROM scratch AS vpnkit-linux-riscv64
-FROM scratch AS vpnkit-linux-s390x
-FROM moby/vpnkit-bin:${VPNKIT_VERSION} AS vpnkit-linux-amd64
-FROM moby/vpnkit-bin:${VPNKIT_VERSION} AS vpnkit-linux-arm64
-FROM vpnkit-linux-${TARGETARCH} AS vpnkit-linux
-FROM vpnkit-${TARGETOS} AS vpnkit
-
 # containerutility
 FROM base AS containerutil-src
 WORKDIR /usr/src/containerutil
@@ -449,7 +432,6 @@ COPY --link --from=shfmt         /build/ /usr/local/bin/
 COPY --link --from=runc          /build/ /usr/local/bin/
 COPY --link --from=containerd    /build/ /usr/local/bin/
 COPY --link --from=rootlesskit   /build/ /usr/local/bin/
-COPY --link --from=vpnkit        /       /usr/local/bin/
 COPY --link --from=containerutil /build/ /usr/local/bin/
 COPY --link --from=crun          /build/ /usr/local/bin/
 COPY --link hack/dockerfile/etc/docker/  /etc/docker/
@@ -628,7 +610,6 @@ COPY --link --from=runc          /build/ /
 COPY --link --from=containerd    /build/ /
 COPY --link --from=rootlesskit   /build/ /
 COPY --link --from=containerutil /build/ /
-COPY --link --from=vpnkit        /       /
 COPY --link --from=build         /build  /
 
 # smoke tests

--- a/contrib/dockerd-rootless-setuptool.sh
+++ b/contrib/dockerd-rootless-setuptool.sh
@@ -298,7 +298,6 @@ init() {
 	# TODO: support printing non-essential but recommended instructions:
 	# - sysctl: "net.ipv4.ping_group_range"
 	# - sysctl: "net.ipv4.ip_unprivileged_port_start"
-	# - external binary: slirp4netns
 	# - external binary: fuse-overlayfs
 }
 

--- a/contrib/dockerd-rootless.sh
+++ b/contrib/dockerd-rootless.sh
@@ -6,16 +6,15 @@
 # External dependencies:
 # * newuidmap and newgidmap needs to be installed.
 # * /etc/subuid and /etc/subgid needs to be configured for the current user.
-# * Either one of slirp4netns (>= v0.4.0), VPNKit, lxc-user-nic needs to be installed.
 #
 # Recognized environment variables:
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=DIR: the rootlesskit state dir.
 #   * Defaults to "$XDG_RUNTIME_DIR/dockerd-rootless".
-# * DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|pasta|lxc-user-nic): the rootlesskit network driver.
-#   * Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed, else "pasta", else "vpnkit".
+# * DOCKERD_ROOTLESS_ROOTLESSKIT_NET=(slirp4netns|vpnkit|pasta|gvisor-tap-vsock|lxc-user-nic): the rootlesskit network driver.
+#   * Defaults to "slirp4netns" if slirp4netns (>= v0.4.0) is installed, else "pasta", else "vpnkit", else "gvisor-tap-vsock".
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_MTU=NUM: the MTU value for the rootlesskit network driver.
-#   * Defaults to 65520 for slirp4netns and pasta, 1500 for other rootlesskit network drivers.
-# * DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|implicit): the rootlesskit port driver.
+#   * Defaults to 65520 for slirp4netns, pasta, and gvisor-tap-vsock. Defaults to 1500 for other rootlesskit network drivers.
+# * DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=(builtin|slirp4netns|implicit|gvisor-tap-vsock): the rootlesskit port driver.
 #   * Defaults to "implicit" for "pasta", "builtin" for other rootlesskit network drivers.
 # * DOCKERD_ROOTLESS_ROOTLESSKIT_SLIRP4NETNS_SANDBOX=(auto|true|false): whether to protect slirp4netns with a dedicated mount namespace.
 #   * Defaults to "auto".
@@ -34,14 +33,18 @@
 
 # Guide to choose the network driver and the port driver:
 #
-#  Network driver | Port driver    | Net throughput | Port throughput | Src IP | No SUID | Note
-#  ---------------|----------------|----------------|-----------------|--------|---------|---------------------------------------------------------
-#  slirp4netns    | builtin        | Slow           | Fast ✅         | ❌     | ✅      | Default in typical setup
-#  vpnkit         | builtin        | Slow           | Fast ✅         | ❌     | ✅      | Default when slirp4netns is not installed
-#  slirp4netns    | slirp4netns    | Slow           | Slow            | ✅     | ✅      |
-#  pasta          | implicit       | Slow           | Fast ✅         | ✅     | ✅      | Experimental; Needs recent version of pasta (2023_12_04)
-#  lxc-user-nic   | builtin        | Fast ✅        | Fast ✅         | ❌     | ❌      | Experimental
-#  (bypass4netns) | (bypass4netns) | Fast ✅        | Fast ✅         | ✅     | ✅      | (Not integrated to RootlessKit)
+#  Network driver   | Port driver      | Net throughput | Port throughput | Src IP | No SUID | Note
+#  -----------------|------------------|----------------|-----------------|--------|---------|---------------------------------------------------------
+#  gvisor-tap-vsock | builtin          | Slow           | Fast ✅         | ✅ (*) | ✅      | Default when slirp4netns is not installed
+#  slirp4netns      | builtin          | Slow           | Fast ✅         | ✅ (*) | ✅      | Default when slirp4netns is installed
+#  vpnkit           | builtin          | Slow           | Fast ✅         | ✅ (*) | ✅      | Legacy
+#  gvisor-tap-vsock | gvisor-tap-vsock | Slow           | Slow            | ❌     | ✅      | Not recommended. Use `builtin` port driver instead.
+#  slirp4netns      | slirp4netns      | Slow           | Slow            | ✅     | ✅      |
+#  pasta            | implicit         | Slow           | Fast ✅         | ✅     | ✅      | Experimental; Needs recent version of pasta (2023_12_04)
+#  lxc-user-nic     | builtin          | Fast ✅        | Fast ✅         | ✅ (*) | ❌      | Experimental
+#  (bypass4netns)   | (bypass4netns)   | Fast ✅        | Fast ✅         | ✅     | ✅      | (Not integrated to RootlessKit)
+#
+# (*) Applicable since RootlessKit v3.0. Also requires userland-proxy to be disabled.
 
 # See the documentation for the further information: https://docs.docker.com/go/rootless/
 
@@ -134,8 +137,7 @@ if [ -z "$net" ]; then
 		fi
 	fi
 	if [ -z "$net" ]; then
-		echo "One of slirp4netns (>= v0.4.0), pasta (passt >= 2023_12_04), or vpnkit needs to be installed"
-		exit 1
+		net=gvisor-tap-vsock
 	fi
 fi
 if [ "$net" = host ]; then
@@ -143,11 +145,14 @@ if [ "$net" = host ]; then
 	exit 1
 fi
 if [ -z "$mtu" ]; then
-	if [ "$net" = slirp4netns -o "$net" = pasta ]; then
-		mtu=65520
-	else
-		mtu=1500
-	fi
+	case "$net" in
+		slirp4netns | pasta | gvisor-tap-vsock)
+			mtu=65520
+			;;
+		*)
+			mtu=1500
+			;;
+	esac
 fi
 if [ -z "$port_driver" ]; then
 	if [ "$net" = pasta ]; then

--- a/docs/contributing/ctn-build.md
+++ b/docs/contributing/ctn-build.md
@@ -30,7 +30,7 @@ docker buildx bake binary-cross
 # build binaries for a specific platform
 docker buildx bake --set *.platform=linux/arm64
 
-# build "complete" binaries (including containerd, runc, vpnkit, etc.)
+# build "complete" binaries (including containerd, runc, etc.)
 docker buildx bake all
 
 # build "complete" binaries for all supported platforms

--- a/hack/dockerfile/install/rootlesskit.installer
+++ b/hack/dockerfile/install/rootlesskit.installer
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # When updating, also update go.mod and Dockerfile accordingly.
-: "${ROOTLESSKIT_VERSION:=v2.3.6}"
+: "${ROOTLESSKIT_VERSION:=v3.0.0}"
 
 install_rootlesskit() {
 	case "$1" in

--- a/hack/make/binary-daemon
+++ b/hack/make/binary-daemon
@@ -17,11 +17,6 @@ copy_binaries() {
 	for file in containerd containerd-shim-runc-v2 ctr runc docker-init rootlesskit dockerd-rootless.sh dockerd-rootless-setuptool.sh; do
 		cp -f "$(command -v "$file")" "$dir/"
 	done
-	# vpnkit might not be available for the target platform, see vpnkit stage in
-	# the Dockerfile for more information.
-	if command -v vpnkit > /dev/null 2>&1; then
-		cp -f "$(command -v vpnkit)" "$dir/"
-	fi
 }
 
 [ -z "$KEEPDEST" ] && rm -rf "$DEST"

--- a/hack/make/install-binary
+++ b/hack/make/install-binary
@@ -17,7 +17,4 @@ source "${MAKEDIR}/.install"
 	install_binary "${DEST}/rootlesskit"
 	install_binary "${DEST}/dockerd-rootless.sh"
 	install_binary "${DEST}/dockerd-rootless-setuptool.sh"
-	if [ -f "${DEST}/vpnkit" ]; then
-		install_binary "${DEST}/vpnkit"
-	fi
 )


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Updated RootlessKit to v3.0. https://github.com/rootless-containers/rootlesskit/releases/tag/v3.0.0

- slirp4netns/vpnkit/pasta is no longer needed as gvisor-tap-vsock is now embedded in RootlessKit.
  slirp4netns/vpnkit/pasta is still used when installed.
- The `builtin` port driver can now correctly propagate the source IP, when
  `userland-proxy` is disabled.

**- How I did it**

- Updated RootlessKit to v3.0 https://github.com/rootless-containers/rootlesskit/compare/v2.3.6...v3.0.0
- Removed vpnkit

**- How to verify it**

```bash
dockerd-rootless-setuptool.sh install
docker run -d -p 8080:80 nginx:alpine
```

- It should no longer requires one of slirp4netns, vpnkit, or pasta to be installed
- The src IP should be propagated properly, when `userland-proxy` is disabled:
```
sudo modprobe br_netfilter
echo '{"userland-proxy":false}' >~/.config/docker/daemon.json
systemctl --user restart docker
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Update RootlessKit to [v3.0.0](https://github.com/rootless-containers/rootlesskit/releases/tag/v3.0.0).
```

**- A picture of a cute animal (not mandatory but encouraged)**


- - -

Relevant:
- https://github.com/containerd/nerdctl/pull/4827
