### PR TITLE
libnetwork: expose proxy information in FirewallInfo

### DIFF
--- a/daemon/libnetwork/controller_linux.go
+++ b/daemon/libnetwork/controller_linux.go
@@ -13,7 +13,8 @@ import (
 	"github.com/moby/moby/v2/daemon/libnetwork/osl"
 )
 
-// FirewallBackend returns the name of the firewall backend for "docker info".
+// FirewallBackend returns FirewallInfo for "docker info".
+// Despite the name, FirewallInfo may include information about the userland proxy as well.
 func (c *Controller) FirewallBackend() *system.FirewallInfo {
 	var info system.FirewallInfo
 	info.Driver = "iptables"
@@ -24,6 +25,15 @@ func (c *Controller) FirewallBackend() *system.FirewallInfo {
 		info.Driver += "+firewalld"
 		if reloadedAt := iptables.FirewalldReloadedAt(); !reloadedAt.IsZero() {
 			info.Info = [][2]string{{"ReloadedAt", reloadedAt.Format(time.RFC3339)}}
+		}
+	}
+	if c.cfg.EnableUserlandProxy {
+		// EnableUserlandProxy is exposed in FirewallInfo since Docker v29.5.
+		// In older versions, EnableUserlandProxy is not included in FirewallInfo,
+		// but it is still used in most cases as it is enabled by default.
+		info.Info = append(info.Info, [2]string{"EnableUserlandProxy", "true"})
+		if c.cfg.UserlandProxyPath != "" {
+			info.Info = append(info.Info, [2]string{"UserlandProxyPath", c.cfg.UserlandProxyPath})
 		}
 	}
 	return &info


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://github.com/moby/moby/blob/master/docs/contributing/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Exposed userland proxy info ` in `/info` API.

This will help users analyze whether they are using the proxy.

Preparation for:
- https://github.com/moby/moby/issues/14856

**- How I did it**
Updated the API and the implementation.

**- How to verify it**
```console
$ docker info
[...]
Firewall Backend: iptables
  EnableUserlandProxy: true
  UserlandProxyPath: /usr/local/bin/docker-proxy
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Expose diagnostic data about userland proxy in `docker info`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

