### PR TITLE
use private time-namespace for containers on supported kernels

### DIFF
--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -276,6 +276,12 @@ func WithNamespaces(daemon *Daemon, c *container.Container) coci.SpecOpts {
 			}
 		}
 
+		// Remove time-namespace if not supported. We can remove this once we
+		// drop support for kernel < 5.6.
+		if !daemon.RawSysInfo().TimeNamespaces {
+			oci.RemoveNamespace(s, specs.TimeNamespace)
+		}
+
 		// ipc
 		ipcMode := c.HostConfig.IpcMode
 		if !ipcMode.Valid() {

--- a/daemon/pkg/oci/defaults.go
+++ b/daemon/pkg/oci/defaults.go
@@ -117,6 +117,7 @@ func DefaultLinuxSpec() specs.Spec {
 			Namespaces: []specs.LinuxNamespace{
 				{Type: specs.MountNamespace},
 				{Type: specs.NetworkNamespace},
+				{Type: specs.TimeNamespace},
 				{Type: specs.UTSNamespace},
 				{Type: specs.PIDNamespace},
 				{Type: specs.IPCNamespace},

--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -26,6 +26,7 @@ func newV2(options ...Opt) *SysInfo {
 		applyAppArmorInfo,
 		applySeccompInfo,
 		applyCgroupNsInfo,
+		applyTimeNsInfo,
 	}
 
 	m, err := cgroupsV2.Load(sysInfo.cg2GroupPath)

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -21,6 +21,9 @@ type SysInfo struct {
 	// Whether the kernel supports cgroup namespaces or not
 	CgroupNamespaces bool
 
+	// TimeNamespaces indicates whether the kernel supports time namespaces.
+	TimeNamespaces bool
+
 	// Whether IPv4 forwarding is supported or not, if this was disabled, networking will not work
 	IPv4ForwardingDisabled bool
 

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -105,6 +105,7 @@ func newV1() *SysInfo {
 		applyAppArmorInfo,
 		applySeccompInfo,
 		applyCgroupNsInfo,
+		applyTimeNsInfo,
 	}
 
 	sysInfo.cgMounts, err = findCgroupV1Mountpoints()
@@ -283,6 +284,11 @@ func applyCgroupNsInfo(info *SysInfo) {
 	info.CgroupNamespaces = cgroupnsSupported()
 }
 
+// applyTimeNsInfo adds whether time namespaces are supported to the info.
+func applyTimeNsInfo(info *SysInfo) {
+	info.TimeNamespaces = timeNsSupported()
+}
+
 // applySeccompInfo checks if Seccomp is supported, via CONFIG_SECCOMP.
 func applySeccompInfo(info *SysInfo) {
 	info.Seccomp = seccomp.IsEnabled()
@@ -301,6 +307,14 @@ func apparmorSupported() bool {
 // cgroupnsSupported adds whether cgroup namespaces are supported.
 func cgroupnsSupported() bool {
 	if _, err := os.Stat("/proc/self/ns/cgroup"); !os.IsNotExist(err) {
+		return true
+	}
+	return false
+}
+
+// timeNsSupported checks whether time namespaces are supported.
+func timeNsSupported() bool {
+	if _, err := os.Stat("/proc/self/ns/time"); !os.IsNotExist(err) {
 		return true
 	}
 	return false

--- a/pkg/sysinfo/sysinfo_linux_test.go
+++ b/pkg/sysinfo/sysinfo_linux_test.go
@@ -64,6 +64,9 @@ func TestNew(t *testing.T) {
 	if expected := cgroupnsSupported(); sysInfo.CgroupNamespaces != expected {
 		t.Errorf("got CgroupNamespaces %v, wanted %v", sysInfo.CgroupNamespaces, expected)
 	}
+	if expected := timeNsSupported(); sysInfo.TimeNamespaces != expected {
+		t.Errorf("got TimeNamespaces %v, wanted %v", sysInfo.TimeNamespaces, expected)
+	}
 }
 
 func TestIsCpusetListAvailable(t *testing.T) {


### PR DESCRIPTION
- addresses https://github.com/moby/moby/issues/39163
- relates to https://github.com/opencontainers/runtime-spec/pull/1151
- relates to https://github.com/opencontainers/runc/issues/2345 / https://github.com/opencontainers/runc/pull/3876
- related https://github.com/containerd/containerd/pull/12564
- related https://github.com/containerd/containerd/issues/12517
- relates to https://h4x0r.org/funreliable/


### use private time-namespace for containers on supported kernels

Time namespaces were introduced in [Linux Kernel 5.6], and are supported by
[OCI runtime spec v1.1.0] and up. This patch updates the default OCI spec for
containers to use a private time-namespace if the host support it. We do not
yet provide options to customize this option (e.g. to allow switching between
"private", "host", or to join another container's time-namespace), which can be
added in a future update (but requires API changes).
With this patch applied:

    docker run -dq nginx:alpine
    54220be49a47d09f74ee918e65233365e94ecb306e4104a4468ab50221262bf7

    ctr -n moby c info 54220be49a47d09f74ee918e65233365e94ecb306e4104a4468ab50221262bf7 | jq .Spec.linux.namespaces
    [
      {"type": "mount"},
      {"type": "network"},
      {"type": "uts"},
      {"type": "pid"},
      {"type": "ipc"},
      {"type": "time"},
      {"type": "cgroup"}
    ]

[Linux Kernel 5.6]: https://lwn.net/Articles/779104/
[OCI runtime spec v1.1.0]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.1.0

### daemon: explicitly mark some arguments as unused

### pkg/sysinfo: add detection for time-namespaces support


### pkg/sysinfo: TestNew: fix copy/paste mistake





**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Enable private time namespace for containers by default on supported kernels
```

**- A picture of a cute animal (not mandatory but encouraged)**

