### PR TITLE
image list: match reference filter against canonical names

### DIFF
--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"runtime"
 	"sort"
 	"strings"
@@ -641,13 +642,26 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 			if err != nil {
 				return false
 			}
+			// Match the filter pattern against both the familiar and
+			// canonical forms of the image reference (with and
+			// without tag), so that e.g. "alpine" and
+			// "docker.io/library/alpine" (and their glob variants)
+			// both match.
+			targets := []string{
+				reference.FamiliarString(ref),
+				reference.FamiliarName(ref),
+				reference.TagNameOnly(ref).String(),
+				ref.Name(),
+			}
 			for _, value := range refs {
-				found, err := reference.FamiliarMatch(value, ref)
-				if err != nil {
-					return false
-				}
-				if found {
-					return found
+				for _, target := range targets {
+					matched, err := path.Match(value, target)
+					if err != nil {
+						return false
+					}
+					if matched {
+						return true
+					}
 				}
 			}
 			return false

--- a/daemon/containerd/image_list.go
+++ b/daemon/containerd/image_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"runtime"
 	"sort"
 	"strings"
@@ -647,7 +648,16 @@ func (i *ImageService) setupFilters(ctx context.Context, imageFilters filters.Ar
 					return false
 				}
 				if found {
-					return found
+					return true
+				}
+				// Also match against the full canonical reference,
+				// so that e.g. "docker.io/library/alpine" matches
+				// an image stored as "docker.io/library/alpine:latest".
+				if matched, _ := path.Match(value, reference.TagNameOnly(ref).String()); matched {
+					return true
+				}
+				if matched, _ := path.Match(value, ref.Name()); matched {
+					return true
 				}
 			}
 			return false

--- a/daemon/containerd/image_list_test.go
+++ b/daemon/containerd/image_list_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/platforms"
 	imagetypes "github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/v2/daemon/container"
+	"github.com/moby/moby/v2/daemon/internal/filters"
 	"github.com/moby/moby/v2/daemon/server/imagebackend"
 	"github.com/moby/moby/v2/internal/testutil/specialimage"
 	"github.com/opencontainers/go-digest"
@@ -453,6 +454,75 @@ func TestImageList(t *testing.T) {
 			})
 
 			tc.check(t, all)
+		})
+	}
+}
+
+func TestImageListReferenceFilter(t *testing.T) {
+	ctx := namespaces.WithNamespace(t.Context(), "testing")
+
+	blobsDir := t.TempDir()
+
+	toContainerdImage := func(t *testing.T, imageFunc specialimage.SpecialImageFunc) c8dimages.Image {
+		idx, err := imageFunc(blobsDir)
+		assert.NilError(t, err)
+		return imagesFromIndex(idx)[0]
+	}
+
+	multilayer := toContainerdImage(t, specialimage.MultiLayer)
+
+	cs := &blobsDirContentStore{blobs: filepath.Join(blobsDir, "blobs/sha256")}
+
+	for _, tc := range []struct {
+		name      string
+		reference string
+		expected  int
+	}{
+		{
+			name:      "familiar short name",
+			reference: "multilayer",
+			expected:  1,
+		},
+		{
+			name:      "familiar name with tag",
+			reference: "multilayer:latest",
+			expected:  1,
+		},
+		{
+			name:      "canonical name without tag",
+			reference: "docker.io/library/multilayer",
+			expected:  1,
+		},
+		{
+			name:      "canonical name with tag",
+			reference: "docker.io/library/multilayer:latest",
+			expected:  1,
+		},
+		{
+			name:      "canonical name with glob tag",
+			reference: "docker.io/library/multilayer:*",
+			expected:  1,
+		},
+		{
+			name:      "no match",
+			reference: "nomatch",
+			expected:  0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := logtest.WithT(ctx, t)
+			service := fakeImageService(t, ctx, cs)
+
+			_, err := service.images.Create(ctx, multilayer)
+			assert.NilError(t, err)
+
+			opts := imagebackend.ListOptions{
+				Filters: filters.NewArgs(filters.Arg("reference", tc.reference)),
+			}
+			all, err := service.Images(ctx, opts)
+			assert.NilError(t, err)
+
+			assert.Check(t, is.Len(all, tc.expected), "reference filter %q returned %d images, expected %d", tc.reference, len(all), tc.expected)
 		})
 	}
 }

--- a/daemon/images/image_list.go
+++ b/daemon/images/image_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"sort"
 	"time"
 
@@ -156,12 +157,28 @@ func (i *ImageService) Images(ctx context.Context, opts imagebackend.ListOptions
 
 		for _, ref := range i.referenceStore.References(id.Digest()) {
 			if opts.Filters.Contains("reference") {
+				// Match the filter pattern against both the familiar
+				// and canonical forms of the image reference (with
+				// and without tag), so that e.g. "alpine" and
+				// "docker.io/library/alpine" (and their glob
+				// variants) both match.
+				targets := []string{
+					reference.FamiliarString(ref),
+					reference.FamiliarName(ref),
+					reference.TagNameOnly(ref).String(),
+					ref.Name(),
+				}
 				var found bool
-				var matchErr error
 				for _, pattern := range opts.Filters.Get("reference") {
-					found, matchErr = reference.FamiliarMatch(pattern, ref)
-					if matchErr != nil {
-						return nil, matchErr
+					for _, target := range targets {
+						matched, err := path.Match(pattern, target)
+						if err != nil {
+							return nil, err
+						}
+						if matched {
+							found = true
+							break
+						}
 					}
 					if found {
 						break

--- a/integration/image/list_test.go
+++ b/integration/image/list_test.go
@@ -175,6 +175,24 @@ func TestAPIImagesFilters(t *testing.T) {
 			expectedImages:   1,
 			expectedRepoTags: 1,
 		},
+		{
+			name:             "canonical name without a tag",
+			filters:          make(client.Filters).Add("reference", "docker.io/library/utest"),
+			expectedImages:   1,
+			expectedRepoTags: 1,
+		},
+		{
+			name:             "canonical name with glob tag",
+			filters:          make(client.Filters).Add("reference", "docker.io/library/utest:*"),
+			expectedImages:   1,
+			expectedRepoTags: 1,
+		},
+		{
+			name:             "canonical namespaced name",
+			filters:          make(client.Filters).Add("reference", "docker.io/utest/docker"),
+			expectedImages:   1,
+			expectedRepoTags: 1,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
## Summary

- Fix the `reference` filter on `GET /images/json` to also match against the full canonical image reference (e.g., `docker.io/library/alpine`), not only the familiar short form (e.g., `alpine`)
- The existing `FamiliarMatch` strips `docker.io/library/` before comparing, so filtering with a canonical name never matched
- After `FamiliarMatch`, also try matching the pattern against the full canonical name (with and without tag)

## Motivation

When interacting with the Docker HTTP API using fully qualified image names (e.g., `docker.io/library/alpine`), the `reference` filter on the image list endpoint fails to find images. This is because `FamiliarMatch` converts the stored image name to its "familiar" short form before matching, so canonical name patterns never match.

Other API endpoints like inspect (`/images/{name}/json`) correctly handle canonical names via `resolveImage()`, making this inconsistency confusing for API consumers.

## Test plan

- [x] Added `TestImageListReferenceFilter` covering:
  - Familiar short name (`multilayer`)
  - Familiar name with tag (`multilayer:latest`)
  - Canonical name without tag (`docker.io/library/multilayer`)
  - Canonical name with tag (`docker.io/library/multilayer:latest`)
  - Canonical name with glob tag (`docker.io/library/multilayer:*`)
  - Non-matching reference (`nomatch`)
- [x] All existing `TestImageList` tests continue to pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)


```markdown changelog
Fix `docker image ls --filter reference=...` (`GET /images/json`) to also match fully qualified canonical image names (e.g. `docker.io/library/alpine`), not only the familiar short form.
```