### PR TITLE
gha/labeler: Only assign Windows to Windows-only changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -168,7 +168,7 @@ area/ci:
 platform/windows:
   - all:
     - changed-files:
-      - any-glob-to-any-file:
+      - any-glob-to-all-files:
         - '**/*_windows.go'
         - 'Dockerfile.windows'
       - all-globs-to-all-files: '!vendor/**'


### PR DESCRIPTION
### gha/labeler: Only assign Windows to Windows-only changes

  The platform/windows label was incorrectly being applied when any file in a PR was Windows-specific, even if the PR also contained non-Windows changes. This caused a lot of non-Windows-specific changes to be mislabeled as Windows-only.

  Changed from `any-glob-to-any-file` to `any-glob-to-all-files` so that the windows label is only applied when ALL changed files match the windows-specific patterns (like `*_windows.go` or `Dockerfile.windows`).

  This ensures that mixed PRs containing both Windows and cross-platform changes are not incorrectly tagged as Windows-only.