### PR TITLE
daemon/logger/local: refactor and improve tests

### DIFF
--- a/daemon/logger/local/config.go
+++ b/daemon/logger/local/config.go
@@ -1,6 +1,10 @@
 package local
 
 import (
+	"fmt"
+	"strconv"
+
+	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 )
 
@@ -11,26 +15,52 @@ type CreateConfig struct {
 	MaxFileCount       int
 }
 
-func newDefaultConfig() *CreateConfig {
-	return &CreateConfig{
+func newConfig(opts map[string]string) (*CreateConfig, error) {
+	cfg := &CreateConfig{
 		MaxFileSize:        defaultMaxFileSize,
 		MaxFileCount:       defaultMaxFileCount,
 		DisableCompression: !defaultCompressLogs,
 	}
+	if v, ok := opts["max-size"]; ok {
+		maxSize, err := units.FromHumanSize(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max-size: %s: %w", v, err)
+		}
+		cfg.MaxFileSize = maxSize
+	}
+
+	if v, ok := opts["max-file"]; ok {
+		maxFile, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max-file: %s: %w", v, err)
+		}
+		cfg.MaxFileCount = maxFile
+	}
+
+	if v, ok := opts["compress"]; ok {
+		compressLogs, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid boolean value for compress: %w", err)
+		}
+		cfg.DisableCompression = !compressLogs
+	}
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
 func validateConfig(cfg *CreateConfig) error {
 	if cfg.MaxFileSize < 0 {
-		return errors.New("max size should be a positive number")
+		return errors.New("max-size must not be negative")
 	}
 	if cfg.MaxFileCount < 0 {
-		return errors.New("max file count cannot be less than 0")
+		return errors.New("max-file must not be negative")
 	}
-
-	if !cfg.DisableCompression {
-		if cfg.MaxFileCount <= 1 {
-			return errors.New("compression cannot be enabled when max file count is 1")
-		}
+	if !cfg.DisableCompression && cfg.MaxFileCount <= 1 {
+		// compression is applied to rotated files, so doesn't apply if rotation is not used.
+		return errors.New("compression cannot be enabled when max file count is 1")
 	}
 	return nil
 }

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -4,11 +4,9 @@ import (
 	"encoding/binary"
 	"io"
 	"math/bits"
-	"strconv"
 	"sync"
 	"time"
 
-	"github.com/docker/go-units"
 	"github.com/moby/moby/v2/daemon/logger"
 	"github.com/moby/moby/v2/daemon/logger/internal/logdriver"
 	"github.com/moby/moby/v2/daemon/logger/loggerutils"
@@ -63,31 +61,8 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, errdefs.System(errors.New("log path is missing -- this is a bug and should not happen"))
 	}
 
-	cfg := newDefaultConfig()
-	if capacity, ok := info.Config["max-size"]; ok {
-		var err error
-		cfg.MaxFileSize, err = units.FromHumanSize(capacity)
-		if err != nil {
-			return nil, errdefs.InvalidParameter(errors.Wrapf(err, "invalid value for max-size: %s", capacity))
-		}
-	}
-
-	if userMaxFileCount, ok := info.Config["max-file"]; ok {
-		var err error
-		cfg.MaxFileCount, err = strconv.Atoi(userMaxFileCount)
-		if err != nil {
-			return nil, errdefs.InvalidParameter(errors.Wrapf(err, "invalid value for max-file: %s", userMaxFileCount))
-		}
-	}
-
-	if userCompress, ok := info.Config["compress"]; ok {
-		compressLogs, err := strconv.ParseBool(userCompress)
-		if err != nil {
-			return nil, errdefs.InvalidParameter(errors.Wrap(err, "error reading compress log option"))
-		}
-		cfg.DisableCompression = !compressLogs
-	}
-	if err := validateConfig(cfg); err != nil {
+	cfg, err := newConfig(info.Config)
+	if err != nil {
 		return nil, errdefs.InvalidParameter(err)
 	}
 

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -87,7 +87,18 @@ func New(info logger.Info) (logger.Logger, error) {
 		}
 		cfg.DisableCompression = !compressLogs
 	}
-	return newDriver(info.LogPath, cfg)
+	if err := validateConfig(cfg); err != nil {
+		return nil, errdefs.InvalidParameter(err)
+	}
+
+	lf, err := loggerutils.NewLogFile(info.LogPath, cfg.MaxFileSize, cfg.MaxFileCount, !cfg.DisableCompression, decodeFunc, 0o640, getTailReader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &driver{
+		logfile: lf,
+	}, nil
 }
 
 func marshal(m *logger.Message, buffer *[]byte) error {
@@ -122,20 +133,6 @@ func marshal(m *logger.Message, buffer *[]byte) error {
 	}
 	binary.BigEndian.PutUint32(buf[writeLen-encodeBinaryLen:writeLen], uint32(protoSize))
 	return nil
-}
-
-func newDriver(logPath string, cfg *CreateConfig) (logger.Logger, error) {
-	if err := validateConfig(cfg); err != nil {
-		return nil, errdefs.InvalidParameter(err)
-	}
-
-	lf, err := loggerutils.NewLogFile(logPath, cfg.MaxFileSize, cfg.MaxFileCount, !cfg.DisableCompression, decodeFunc, 0o640, getTailReader)
-	if err != nil {
-		return nil, err
-	}
-	return &driver{
-		logfile: lf,
-	}, nil
 }
 
 func (d *driver) Name() string {

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -181,11 +181,11 @@ func protoToMessage(proto *logdriver.LogEntry) *logger.Message {
 		Timestamp: time.Unix(0, proto.TimeNano).UTC(),
 	}
 	if proto.Partial {
-		var md backend.PartialLogMetaData
-		md.Last = proto.GetPartialLogMetadata().GetLast()
-		md.ID = proto.GetPartialLogMetadata().GetId()
-		md.Ordinal = int(proto.GetPartialLogMetadata().GetOrdinal())
-		msg.PLogMetaData = &md
+		msg.PLogMetaData = &backend.PartialLogMetaData{
+			Last:    proto.GetPartialLogMetadata().GetLast(),
+			ID:      proto.GetPartialLogMetadata().GetId(),
+			Ordinal: int(proto.GetPartialLogMetadata().GetOrdinal()),
+		}
 	}
 	msg.Line = append(msg.Line[:0], proto.Line...)
 	return msg

--- a/daemon/logger/local/local_test.go
+++ b/daemon/logger/local/local_test.go
@@ -22,60 +22,51 @@ import (
 func TestWriteLog(t *testing.T) {
 	t.Parallel()
 
-	dir, err := os.MkdirTemp("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(dir)
-
-	logPath := filepath.Join(dir, "test.log")
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
 
 	l, err := New(logger.Info{LogPath: logPath})
 	assert.NilError(t, err)
-	defer l.Close()
+	t.Cleanup(func() { assert.NilError(t, l.Close()) })
 
-	m1 := logger.Message{Source: "stdout", Timestamp: time.Now().Add(-1 * 30 * time.Minute), Line: []byte("message 1")}
-	m2 := logger.Message{Source: "stdout", Timestamp: time.Now().Add(-1 * 20 * time.Minute), Line: []byte("message 2"), PLogMetaData: &backend.PartialLogMetaData{Last: true, ID: "0001", Ordinal: 1}}
-	m3 := logger.Message{Source: "stderr", Timestamp: time.Now().Add(-1 * 10 * time.Minute), Line: []byte("message 3")}
+	now := time.Now()
+	messages := []logger.Message{
+		{Source: "stdout", Timestamp: now.Add(-30 * time.Minute), Line: []byte("message 1")},
+		{Source: "stdout", Timestamp: now.Add(-20 * time.Minute), Line: []byte("message 2"), PLogMetaData: &backend.PartialLogMetaData{Last: true, ID: "0001", Ordinal: 1}},
+		{Source: "stderr", Timestamp: now.Add(-10 * time.Minute), Line: []byte("message 3")},
+	}
 
-	// copy the log message because the underlying log writer resets the log message and returns it to a buffer pool
-	err = l.Log(copyLogMessage(&m1))
-	assert.NilError(t, err)
-	err = l.Log(copyLogMessage(&m2))
-	assert.NilError(t, err)
-	err = l.Log(copyLogMessage(&m3))
-	assert.NilError(t, err)
+	for i := range messages {
+		// copy the log message because the underlying log writer resets the log message and returns it to a buffer pool
+		err = l.Log(copyLogMessage(&messages[i]))
+		assert.NilError(t, err)
+	}
 
 	f, err := os.Open(logPath)
 	assert.NilError(t, err)
-	defer f.Close()
+	t.Cleanup(func() { assert.NilError(t, f.Close()) })
 	dec := protoio.NewUint32DelimitedReader(f, binary.BigEndian, 1e6)
-
-	var (
-		proto     logdriver.LogEntry
-		testProto logdriver.LogEntry
-		partial   logdriver.PartialLogEntryMetadata
-	)
 
 	lenBuf := make([]byte, encodeBinaryLen)
 	seekMsgLen := func() {
-		io.ReadFull(f, lenBuf)
+		_, err := io.ReadFull(f, lenBuf)
+		assert.NilError(t, err)
 	}
 
-	err = dec.ReadMsg(&proto)
-	assert.NilError(t, err)
-	messageToProto(&m1, &testProto, &partial)
-	assert.Check(t, is.DeepEqual(testProto, proto), "expected:\n%+v\ngot:\n%+v", testProto, proto)
-	seekMsgLen()
+	for i := range messages {
+		var got logdriver.LogEntry
+		err = dec.ReadMsg(&got)
+		assert.NilError(t, err)
 
-	err = dec.ReadMsg(&proto)
-	assert.NilError(t, err)
-	messageToProto(&m2, &testProto, &partial)
-	assert.Check(t, is.DeepEqual(testProto, proto))
-	seekMsgLen()
+		var want logdriver.LogEntry
+		var partial logdriver.PartialLogEntryMetadata
+		messageToProto(&messages[i], &want, &partial)
+		assert.Check(t, is.DeepEqual(want, got), "msg %d: expected:\n%+v\ngot:\n%+v", i, want, got)
 
-	err = dec.ReadMsg(&proto)
-	assert.NilError(t, err)
-	messageToProto(&m3, &testProto, &partial)
-	assert.Check(t, is.DeepEqual(testProto, proto), "expected:\n%+v\ngot:\n%+v", testProto, proto)
+		if i < len(messages)-1 {
+			seekMsgLen()
+		}
+	}
 }
 
 func TestReadLog(t *testing.T) {
@@ -95,14 +86,10 @@ func TestReadLog(t *testing.T) {
 }
 
 func BenchmarkLogWrite(b *testing.B) {
-	f, err := os.CreateTemp("", b.Name())
-	assert.Assert(b, err)
-	defer os.Remove(f.Name())
-	f.Close()
-
-	local, err := New(logger.Info{LogPath: f.Name()})
-	assert.Assert(b, err)
-	defer local.Close()
+	tmpDir := b.TempDir()
+	l, err := New(logger.Info{LogPath: filepath.Join(tmpDir, "test.log")})
+	assert.NilError(b, err)
+	b.Cleanup(func() { assert.NilError(b, l.Close()) })
 
 	t := time.Now().UTC()
 	for _, data := range [][]byte{
@@ -114,13 +101,12 @@ func BenchmarkLogWrite(b *testing.B) {
 		b.Run(strconv.Itoa(len(data)), func(b *testing.B) {
 			entry := &logdriver.LogEntry{Line: data, Source: "stdout", TimeNano: t.UnixNano()}
 			b.SetBytes(int64(entry.Size() + encodeBinaryLen + encodeBinaryLen))
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				msg := logger.NewMessage()
 				msg.Line = data
 				msg.Timestamp = t
 				msg.Source = "stdout"
-				if err := local.Log(msg); err != nil {
+				if err := l.Log(msg); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -3,48 +3,54 @@ package local
 import (
 	"io"
 	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/moby/moby/v2/daemon/logger"
 	"gotest.tools/v3/assert"
 )
 
-func TestDecode(t *testing.T) {
+// TestDecodeIncompleteRecord verifies that Decode returns io.EOF when the
+// underlying file ends in the middle of a record, and that decoding succeeds
+// once the remainder of the record is appended.
+func TestDecodeIncompleteRecord(t *testing.T) {
 	buf := make([]byte, 0)
 
 	err := marshal(&logger.Message{Line: []byte("hello")}, &buf)
 	assert.NilError(t, err)
 
-	for i := 0; i < len(buf); i++ {
-		testDecode(t, buf, i)
+	tmpDir := t.TempDir()
+	for split := range len(buf) {
+		t.Run("split="+strconv.Itoa(split), func(t *testing.T) {
+			logFile := filepath.Join(tmpDir, "log_"+strconv.Itoa(split)+".log")
+			fw, err := os.Create(logFile)
+			assert.NilError(t, err)
+			t.Cleanup(func() { assert.NilError(t, fw.Close()) })
+
+			fr, err := os.Open(logFile)
+			assert.NilError(t, err)
+			t.Cleanup(func() { assert.NilError(t, fr.Close()) })
+
+			d := &decoder{rdr: fr}
+
+			if split > 0 {
+				_, err = fw.Write(buf[0:split])
+				assert.NilError(t, err)
+
+				_, err = d.Decode()
+				assert.ErrorIs(t, err, io.EOF)
+
+				_, err = fw.Write(buf[split:])
+				assert.NilError(t, err)
+			} else {
+				_, err = fw.Write(buf)
+				assert.NilError(t, err)
+			}
+
+			msg, err := d.Decode()
+			assert.NilError(t, err)
+			assert.Equal(t, "hello\n", string(msg.Line))
+		})
 	}
-}
-
-func testDecode(t *testing.T, buf []byte, split int) {
-	fw, err := os.CreateTemp("", t.Name())
-	assert.NilError(t, err)
-	defer os.Remove(fw.Name())
-
-	fr, err := os.Open(fw.Name())
-	assert.NilError(t, err)
-
-	d := &decoder{rdr: fr}
-
-	if split > 0 {
-		_, err = fw.Write(buf[0:split])
-		assert.NilError(t, err)
-
-		_, err = d.Decode()
-		assert.ErrorIs(t, err, io.EOF)
-
-		_, err = fw.Write(buf[split:])
-		assert.NilError(t, err)
-	} else {
-		_, err = fw.Write(buf)
-		assert.NilError(t, err)
-	}
-
-	message, err := d.Decode()
-	assert.NilError(t, err)
-	assert.Equal(t, "hello\n", string(message.Line))
 }

--- a/daemon/logger/local/read_test.go
+++ b/daemon/logger/local/read_test.go
@@ -50,7 +50,7 @@ func TestDecodeIncompleteRecord(t *testing.T) {
 
 			msg, err := d.Decode()
 			assert.NilError(t, err)
-			assert.Equal(t, "hello\n", string(msg.Line))
+			assert.Equal(t, string(msg.Line), "hello\n")
 		})
 	}
 }


### PR DESCRIPTION
### daemon/logger/local: use struct-literal for pmetadata

### daemon/logger/local: improve TestDecode, rename to TestDecodeIncompleteRecord

This test is testing decoding logs that are partially written;

- rename the test to better cover that intent, and add a short godoc
- use sub-tests for each step
- use t.TempDir to help cleaning up and not writing to global temp
- make sure files are closed

### daemon/logger/local: test cleanups

- use t.TempDir() where possible
- fix some unhandled errors
- reduce some repetition in TestWriteLog

### daemon/logger/local: unify constructors

Inline the `newDriver` constructor into the exported `New` constructor.


### daemon/logger/local: add a constructor for config

The driver's constructor was creating a default config, then patched
it in place, after which it validated the result; create a constructor
for the config instead to encapsulate the steps.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

