### PR TITLE
daemon/logger/loggerutils: ParseLogTag: fix panic and image ID format, improve test-coverage

### DIFF
--- a/daemon/logger/loggerutils/log_tag.go
+++ b/daemon/logger/loggerutils/log_tag.go
@@ -10,6 +10,17 @@ import (
 // DefaultTemplate defines the defaults template logger should use.
 const DefaultTemplate = "{{.ID}}"
 
+const (
+	ctrShortID = "{{.ID}}"
+	ctrFullID  = "{{.FullID}}"
+	ctrName    = "{{.Name}}"
+	ctrCommand = "{{.Command}}"
+	imgShortID = "{{.ImageID}}"
+	imgFullID  = "{{.ImageFullID}}"
+	imgName    = "{{.ImageName}}"
+	hostName   = "{{.Hostname}}"
+)
+
 // ParseLogTag generates a context aware tag for consistency across different
 // log drivers based on the context of the running container.
 func ParseLogTag(info logger.Info, defaultTemplate string) (string, error) {

--- a/daemon/logger/loggerutils/log_tag.go
+++ b/daemon/logger/loggerutils/log_tag.go
@@ -29,14 +29,36 @@ func ParseLogTag(info logger.Info, defaultTemplate string) (string, error) {
 		tagTemplate = defaultTemplate
 	}
 
-	tmpl, err := templates.NewParse("log-tag", tagTemplate)
-	if err != nil {
-		return "", err
-	}
-	buf := new(bytes.Buffer)
-	if err := tmpl.Execute(buf, &info); err != nil {
-		return "", err
-	}
+	// Fast-path for common / basic templates.
+	switch tagTemplate {
+	case "":
+		return "", nil
+	case ctrShortID:
+		return info.ID(), nil
+	case ctrFullID:
+		return info.FullID(), nil
+	case ctrName:
+		return info.Name(), nil
+	case ctrCommand:
+		return info.Command(), nil
+	case imgShortID:
+		return info.ImageID(), nil
+	case imgFullID:
+		return info.ImageFullID(), nil
+	case imgName:
+		return info.ImageName(), nil
+	case hostName:
+		return info.Hostname()
+	default:
+		tmpl, err := templates.NewParse("log-tag", tagTemplate)
+		if err != nil {
+			return "", err
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, &info); err != nil {
+			return "", err
+		}
 
-	return buf.String(), nil
+		return buf.String(), nil
+	}
 }

--- a/daemon/logger/loggerutils/log_tag_test.go
+++ b/daemon/logger/loggerutils/log_tag_test.go
@@ -1,47 +1,132 @@
 package loggerutils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/moby/moby/v2/daemon/logger"
+	"gotest.tools/v3/assert"
 )
 
-func TestParseLogTagDefaultTag(t *testing.T) {
-	info := buildContext(map[string]string{})
-	tag, e := ParseLogTag(info, "{{.ID}}")
-	assertTag(t, e, tag, info.ID())
-}
-
 func TestParseLogTag(t *testing.T) {
-	info := buildContext(map[string]string{"tag": "{{.ImageName}}/{{.Name}}/{{.ID}}"})
-	tag, e := ParseLogTag(info, "{{.ID}}")
-	assertTag(t, e, tag, "test-image/test-container/container-ab")
-}
+	tests := []struct {
+		doc             string
+		customTag       string
+		defaultTemplate string
+		expected        string
+	}{
+		{
+			doc: "empty tag without default",
+		},
+		{
+			doc:             "non-template tag",
+			customTag:       "my-custom-tag",
+			defaultTemplate: "{{.ID}}",
+			expected:        "my-custom-tag",
+		},
+		{
+			doc:             "empty tag with default template",
+			defaultTemplate: "{{.Name}}/{{.ID}}",
+			expected:        "test-container/abcdef012345",
+		},
+		{
+			doc:             "custom tag overrides default",
+			customTag:       "{{.Name}}/{{.ID}}",
+			defaultTemplate: "{{.ID}}",
+			expected:        "test-container/abcdef012345",
+		},
+		{
+			doc:       "short ID",
+			customTag: ctrShortID,
+			expected:  "abcdef012345",
+		},
+		{
+			doc:       "full ID",
+			customTag: ctrFullID,
+			expected:  "abcdef01234567890abcdef01234567890abcdef01234567890abcdef0123456",
+		},
+		{
+			// TODO(thaJeztah): not documented: https://docs.docker.com/engine/logging/log_tags/
+			doc:       "container command",
+			customTag: ctrCommand,
+			expected:  "/bin/sh -c hello",
+		},
+		{
+			doc:       "short image ID",
+			customTag: imgShortID,
+			expected:  "sha256:582c4", // FIXME(thaJeztah): short-ID should trim algorithm
+		},
+		{
+			doc:       "full image ID",
+			customTag: imgFullID,
+			expected:  "sha256:582c496ccf79d8aa6f8203a79d32aaf7ffd8b13362c60a701a2f9ac64886c93d",
+		},
+		{
+			// Image name is currently formatted as specified by the user, and not
+			// normalized (i.e., not made "Familiar" or "Canonical").
+			doc:       "image name",
+			customTag: imgName,
+			expected:  "docker.io/library/hello-world:alpine",
+		},
+		{
+			// TODO(thaJeztah): not documented: https://docs.docker.com/engine/logging/log_tags/
+			doc:       "hostname",
+			customTag: hostName,
+			expected:  func() string { h, _ := os.Hostname(); return h }(),
+		},
 
-func TestParseLogTagEmptyTag(t *testing.T) {
-	info := buildContext(map[string]string{})
-	tag, e := ParseLogTag(info, "{{.DaemonName}}/{{.ID}}")
-	assertTag(t, e, tag, "test-dockerd/container-ab")
-}
+		// Direct use of exported Info fields.
+		{
+			doc:       "DaemonName",
+			customTag: "{{.DaemonName}}",
+			expected:  "test-dockerd",
+		},
 
-// Helpers
+		// TODO(thaJeztah): these are undocumented: consider removing or exposing through methods
+		// see: https://docs.docker.com/engine/logging/log_tags/
+		{
+			doc:       "ContainerID",
+			customTag: "{{.ContainerID}}",
+			expected:  "abcdef01234567890abcdef01234567890abcdef01234567890abcdef0123456",
+		},
+		{
+			doc:       "ContainerName",
+			customTag: "{{.ContainerName}}",
+			expected:  "/test-container",
+		},
+		{
+			doc:       "ContainerImageID",
+			customTag: "{{.ContainerImageID}}",
+			expected:  "sha256:582c496ccf79d8aa6f8203a79d32aaf7ffd8b13362c60a701a2f9ac64886c93d",
+		},
+		{
+			doc:       "ContainerImageName",
+			customTag: "{{.ContainerImageName}}",
+			expected:  "docker.io/library/hello-world:alpine",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			attrs := map[string]string{}
+			if tc.customTag != "" {
+				attrs["tag"] = tc.customTag
+			}
+			tag, err := ParseLogTag(buildContext(attrs), tc.defaultTemplate)
+			assert.NilError(t, err)
+			assert.Equal(t, tag, tc.expected)
+		})
+	}
+}
 
 func buildContext(cfg map[string]string) logger.Info {
 	return logger.Info{
-		ContainerID:        "container-abcdefghijklmnopqrstuvwxyz01234567890",
-		ContainerName:      "/test-container",
-		ContainerImageID:   "image-abcdefghijklmnopqrstuvwxyz01234567890",
-		ContainerImageName: "test-image",
-		Config:             cfg,
-		DaemonName:         "test-dockerd",
-	}
-}
-
-func assertTag(t *testing.T, e error, tag string, expected string) {
-	if e != nil {
-		t.Fatalf("Error generating tag: %q", e)
-	}
-	if tag != expected {
-		t.Fatalf("Wrong tag: %q, should be %q", tag, expected)
+		ContainerID:         "abcdef01234567890abcdef01234567890abcdef01234567890abcdef0123456",
+		ContainerName:       "/test-container",
+		ContainerImageID:    "sha256:582c496ccf79d8aa6f8203a79d32aaf7ffd8b13362c60a701a2f9ac64886c93d",
+		ContainerImageName:  "docker.io/library/hello-world:alpine",
+		ContainerEntrypoint: "/bin/sh",
+		ContainerArgs:       []string{"-c", "hello"},
+		Config:              cfg,
+		DaemonName:          "test-dockerd",
 	}
 }

--- a/daemon/logger/loggerutils/log_tag_test.go
+++ b/daemon/logger/loggerutils/log_tag_test.go
@@ -8,6 +8,16 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestParseLogTagZeroValues(t *testing.T) {
+	out, err := ParseLogTag(logger.Info{}, "")
+	assert.NilError(t, err)
+	assert.Assert(t, out == "")
+
+	out, err = ParseLogTag(logger.Info{}, DefaultTemplate)
+	assert.NilError(t, err)
+	assert.Assert(t, out == "")
+}
+
 func TestParseLogTag(t *testing.T) {
 	tests := []struct {
 		doc             string
@@ -54,7 +64,7 @@ func TestParseLogTag(t *testing.T) {
 		{
 			doc:       "short image ID",
 			customTag: imgShortID,
-			expected:  "sha256:582c4", // FIXME(thaJeztah): short-ID should trim algorithm
+			expected:  "582c496ccf79",
 		},
 		{
 			doc:       "full image ID",

--- a/daemon/logger/loginfo.go
+++ b/daemon/logger/loginfo.go
@@ -116,32 +116,32 @@ func (info *Info) Command() string {
 	return command
 }
 
-// ID Returns the Container ID shortened to 12 characters.
+// ID returns the container ID-prefix (truncated ID).
 func (info *Info) ID() string {
 	return info.ContainerID[:12]
 }
 
-// FullID is an alias of ContainerID.
+// FullID returns the container ID.
 func (info *Info) FullID() string {
 	return info.ContainerID
 }
 
-// Name returns the ContainerName without a preceding '/'.
+// Name returns the container name.
 func (info *Info) Name() string {
 	return strings.TrimPrefix(info.ContainerName, "/")
 }
 
-// ImageID returns the ContainerImageID shortened to 12 characters.
+// ImageID returns the ID-prefix (truncated ID) of the image the container was created from.
 func (info *Info) ImageID() string {
 	return info.ContainerImageID[:12]
 }
 
-// ImageFullID is an alias of ContainerImageID.
+// ImageFullID returns the ID (digest) of the image the container was created from.
 func (info *Info) ImageFullID() string {
 	return info.ContainerImageID
 }
 
-// ImageName is an alias of ContainerImageName
+// ImageName returns the name of the image the container was created from.
 func (info *Info) ImageName() string {
 	return info.ContainerImageName
 }

--- a/daemon/logger/loginfo.go
+++ b/daemon/logger/loginfo.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/moby/moby/v2/daemon/internal/stringid"
 )
 
 // Info provides enough information for a logging driver to do its function.
@@ -118,7 +120,7 @@ func (info *Info) Command() string {
 
 // ID returns the container ID-prefix (truncated ID).
 func (info *Info) ID() string {
-	return info.ContainerID[:12]
+	return stringid.TruncateID(info.ContainerID)
 }
 
 // FullID returns the container ID.
@@ -133,7 +135,7 @@ func (info *Info) Name() string {
 
 // ImageID returns the ID-prefix (truncated ID) of the image the container was created from.
 func (info *Info) ImageID() string {
-	return info.ContainerImageID[:12]
+	return stringid.TruncateID(info.ContainerImageID)
 }
 
 // ImageFullID returns the ID (digest) of the image the container was created from.


### PR DESCRIPTION
### daemon/logger: Info: touch-up godoc

Update the GoDoc for various methods to be less specific about the underlying
implementation. This struct is currently passed as-is to loggers to allow
setting a templated "tag", but holds various fields that are not documented
for this purpose, and which do not have an explicit method or template-function.

We may want to reimplement that code to be more deliberate on fields and/or
methods intended for templating, but let's start with updating the docs.


### daemon/logger/loggerutils: ParseLogTag: improve test-coverage

- add consts for well-known templating options
- improve test coverage, and use more realistic values in tests


### daemon/logger/loggerutils: ParseLogTag: fix panic and image ID

- fix a potential panic when using `ID()` / `{{.ID}}` or `ImageID()` / `{{.ImagID}}`
  if the Info was empty. In practice, this shouldn't happen because it's always
  initialized.
- fix `ImageID()` / `{{.ImageID}}` ("short ID") not trimming the algorithm.


### daemon/logger/loggerutils: ParseLogTag: add fast path

Add fast-path for well-known options and skip templating.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `--log-opt "tag={{.ImageID}}"` not stripping the digest's algorithm.
```

**- A picture of a cute animal (not mandatory but encouraged)**

