### PR TITLE
daemon/logger/jsonfilelog: be more explicit on handling optional "tag"

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -30,7 +30,6 @@ var buffersPool = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte
 // JSONFileLogger is Logger implementation for default Docker logging.
 type JSONFileLogger struct {
 	writer *loggerutils.LogFile
-	tag    string // tag values requested by the user to log
 	extra  json.RawMessage
 }
 
@@ -111,7 +110,6 @@ func New(info logger.Info) (logger.Logger, error) {
 
 	return &JSONFileLogger{
 		writer: writer,
-		tag:    tag,
 		extra:  extra,
 	}, nil
 }

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -85,13 +85,13 @@ func New(info logger.Info) (logger.Logger, error) {
 		return nil, err
 	}
 
-	// no default template. only use a tag if the user asked for it
-	tag, err := loggerutils.ParseLogTag(info, "")
-	if err != nil {
-		return nil, err
-	}
-	if tag != "" {
-		extraAttrs["tag"] = tag
+	if v, ok := info.Config["tag"]; ok && v != "" {
+		// no default template. and only use a tag if the user asked for it.
+		if tag, err := loggerutils.ParseLogTag(info, ""); err != nil {
+			return nil, err
+		} else if tag != "" {
+			extraAttrs["tag"] = tag
+		}
 	}
 
 	var extra json.RawMessage


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/35949
- (carry of https://github.com/moby/moby/pull/34248)
- https://github.com/moby/moby/issues/19803

### daemon/logger/jsonfilelog: JSONFileLogger: remove unused "tag" field

This field was added in 5f50f4f511cd84e79bf005817af346b1764df27f, but that patch was carried and updated in e77267c5a682e2c5aaa32469f2c83c2479d57566, which merged the "tag" field into the extra-attributes instead of using a separate field.

### daemon/logger/jsonfilelog: be more explicit on handling optional "tag"

Prevent parsing an empty template if the user didn't request for a tag
to be included.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

