### PR TITLE
daemon/logger/journald: remove outdated comment

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -139,8 +139,6 @@ func newJournald(info logger.Info) (*journald, error) {
 	}, nil
 }
 
-// We don't actually accept any options, but we have to supply a callback for
-// the factory to pass the (probably empty) configuration map to.
 func validateLogOpt(cfg map[string]string) error {
 	for key := range cfg {
 		switch key {


### PR DESCRIPTION
The validateLogOpt function was added in e611a189cb3147cd79ccabfe8ba61ae3e3e28459 at which time there were no options for this driver, but that changed since.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

