### PR TITLE
daemon/logger: use uniform location for registering drivers

### DIFF
--- a/daemon/logger/awslogs/cloudwatchlogs.go
+++ b/daemon/logger/awslogs/cloudwatchlogs.go
@@ -112,16 +112,6 @@ type wrappedEvent struct {
 }
 type byTimestamp []wrappedEvent
 
-// init registers the awslogs driver
-func init() {
-	if err := logger.RegisterLogDriver(name, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		panic(err)
-	}
-}
-
 // eventBatch holds the events that are batched for submission and the
 // associated data about it.
 //

--- a/daemon/logger/awslogs/register.go
+++ b/daemon/logger/awslogs/register.go
@@ -1,0 +1,12 @@
+package awslogs
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/etwlogs/etwlogs_windows.go
+++ b/daemon/logger/etwlogs/etwlogs_windows.go
@@ -44,17 +44,10 @@ var (
 )
 
 var (
-	providerHandle windows.Handle
+	providerHandle = windows.InvalidHandle
 	refCount       int
 	mu             sync.Mutex
 )
-
-func init() {
-	providerHandle = windows.InvalidHandle
-	if err := logger.RegisterLogDriver(name, New); err != nil {
-		panic(err)
-	}
-}
 
 // New creates a new etwLogs logger for the given container and registers the EWT provider.
 func New(info logger.Info) (logger.Logger, error) {

--- a/daemon/logger/etwlogs/register.go
+++ b/daemon/logger/etwlogs/register.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package etwlogs
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -68,15 +68,6 @@ const (
 	readTimeoutKey = "fluentd-read-timeout"
 )
 
-func init() {
-	if err := logger.RegisterLogDriver(name, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		panic(err)
-	}
-}
-
 // New creates a fluentd logger using the configuration passed in on
 // the context. The supported context configuration variable is
 // fluentd-address.

--- a/daemon/logger/fluentd/register.go
+++ b/daemon/logger/fluentd/register.go
@@ -1,0 +1,12 @@
+package fluentd
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/gcplogs/gcplogging.go
+++ b/daemon/logger/gcplogs/gcplogging.go
@@ -43,16 +43,6 @@ var (
 	instanceID   string
 )
 
-func init() {
-	if err := logger.RegisterLogDriver(name, New); err != nil {
-		panic(err)
-	}
-
-	if err := logger.RegisterLogOptValidator(name, ValidateLogOpts); err != nil {
-		panic(err)
-	}
-}
-
 type gcplogs struct {
 	client    *logging.Client
 	logger    *logging.Logger

--- a/daemon/logger/gcplogs/register.go
+++ b/daemon/logger/gcplogs/register.go
@@ -1,0 +1,13 @@
+package gcplogs
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		panic(err)
+	}
+
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpts); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -26,15 +26,6 @@ type gelfLogger struct {
 	rawExtra json.RawMessage
 }
 
-func init() {
-	if err := logger.RegisterLogDriver(name, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		panic(err)
-	}
-}
-
 // New creates a gelf logger using the configuration passed in on the
 // context. The supported context configuration variable is gelf-address.
 func New(info logger.Info) (logger.Logger, error) {

--- a/daemon/logger/gelf/register.go
+++ b/daemon/logger/gelf/register.go
@@ -1,0 +1,12 @@
+package gelf
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -46,6 +46,7 @@ const (
 	fieldLogOrdinal = "CONTAINER_LOG_ORDINAL"
 )
 
+// waitUntilFlushed is set if read support is enabled and a no-op otherwise.
 var waitUntilFlushed func(*journald) error
 
 type journald struct {
@@ -66,15 +67,6 @@ type journald struct {
 	sendToJournal   func(message string, priority journal.Priority, vars map[string]string) error
 	journalReadDir  string        //nolint:unused // Referenced in read.go, which has more restrictive build constraints.
 	readSyncTimeout time.Duration //nolint:unused // Referenced in read.go, which has more restrictive build constraints.
-}
-
-func init() {
-	if err := logger.RegisterLogDriver(name, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(name, validateLogOpt); err != nil {
-		panic(err)
-	}
 }
 
 // sanitizeKeyMod returns the sanitized string so that it could be used in journald.

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -15,6 +15,10 @@ import (
 	"github.com/moby/moby/v2/daemon/server/backend"
 )
 
+func init() {
+	waitUntilFlushed = waitUntilFlushedImpl
+}
+
 const (
 	closedDrainTimeout = 5 * time.Second
 	waitInterval       = 250 * time.Millisecond
@@ -548,8 +552,4 @@ func waitUntilFlushedImpl(s *journald) error {
 			Warn("journald: deadline exceeded waiting for logs to be committed to journal")
 	}()
 	return <-flushed
-}
-
-func init() {
-	waitUntilFlushed = waitUntilFlushedImpl
 }

--- a/daemon/logger/journald/register.go
+++ b/daemon/logger/journald/register.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package journald
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, validateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -34,15 +34,6 @@ type JSONFileLogger struct {
 	extra  json.RawMessage
 }
 
-func init() {
-	if err := logger.RegisterLogDriver(Name, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(Name, ValidateLogOpt); err != nil {
-		panic(err)
-	}
-}
-
 // New creates new JSONFileLogger which writes to filename passed in
 // on given context.
 func New(info logger.Info) (logger.Logger, error) {

--- a/daemon/logger/jsonfilelog/register.go
+++ b/daemon/logger/jsonfilelog/register.go
@@ -1,0 +1,12 @@
+package jsonfilelog
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(Name, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(Name, ValidateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/local/local.go
+++ b/daemon/logger/local/local.go
@@ -52,15 +52,6 @@ func ValidateLogOpt(cfg map[string]string) error {
 	return nil
 }
 
-func init() {
-	if err := logger.RegisterLogDriver(Name, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(Name, ValidateLogOpt); err != nil {
-		panic(err)
-	}
-}
-
 type driver struct {
 	logfile *loggerutils.LogFile
 }

--- a/daemon/logger/local/register.go
+++ b/daemon/logger/local/register.go
@@ -1,0 +1,12 @@
+package local
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(Name, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(Name, ValidateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/splunk/register.go
+++ b/daemon/logger/splunk/register.go
@@ -1,0 +1,12 @@
+package splunk
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(driverName, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(driverName, ValidateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/splunk/splunk.go
+++ b/daemon/logger/splunk/splunk.go
@@ -140,15 +140,6 @@ const (
 	splunkFormatInline = "inline"
 )
 
-func init() {
-	if err := logger.RegisterLogDriver(driverName, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(driverName, ValidateLogOpt); err != nil {
-		panic(err)
-	}
-}
-
 // New creates splunk logger driver using configuration passed in context
 func New(info logger.Info) (logger.Logger, error) {
 	hostname, err := info.Hostname()

--- a/daemon/logger/syslog/register.go
+++ b/daemon/logger/syslog/register.go
@@ -1,0 +1,12 @@
+package syslog
+
+import "github.com/moby/moby/v2/daemon/logger"
+
+func init() {
+	if err := logger.RegisterLogDriver(name, New); err != nil {
+		panic(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
+		panic(err)
+	}
+}

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -51,15 +51,6 @@ type syslogger struct {
 	writer *syslog.Writer
 }
 
-func init() {
-	if err := logger.RegisterLogDriver(name, New); err != nil {
-		panic(err)
-	}
-	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
-		panic(err)
-	}
-}
-
 // rsyslog uses appname part of syslog message to fill in an %syslogtag% template
 // attribute in rsyslog.conf. In order to be backward compatible to rfc3164
 // tag will be also used as an appname


### PR DESCRIPTION
Logging-drivers are registered through an init function, but they were burried deep in the implementation files; move the driver-registration call to a separate file, consistent between all drivers.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

